### PR TITLE
chore(security): apply npm overrides for dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3089,16 +3089,6 @@
         "zeptomatch": "2.1.0"
       }
     },
-    "node_modules/@prisma/dev/node_modules/hono": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/@prisma/driver-adapter-utils": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.3.0.tgz",
@@ -11022,9 +11012,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -12691,9 +12681,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,5 +57,10 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "5.9.3",
     "vitest": "^4.0.18"
+  },
+  "overrides": {
+    "qs": "6.14.2",
+    "hono": "4.11.9",
+    "lodash": "4.17.23"
   }
 }


### PR DESCRIPTION
## Summary
- Add `overrides` in package.json to resolve 5 Dependabot security alerts
- `qs` 6.14.1 → 6.14.2 (DoS via arrayLimit bypass)
- `hono` 4.11.4 → 4.11.9 (XSS, arbitrary key read, cache deception)
- `lodash` 4.17.21 → 4.17.23 (Prototype Pollution in _.unset/_.omit)
- All are transitive devDependencies (shadcn, prisma) — no production impact

## Test plan
- [x] `npm ls qs` / `npm ls hono` / `npm ls lodash` confirm patched versions
- [x] No `invalid` markers in dependency tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)