### PR TITLE
fix(security): resolve CodeQL code scanning alerts

### DIFF
--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -592,9 +592,12 @@ async function performAutofillForEntry(
       const inputs = Array.from(
         document.querySelectorAll("input"),
       ) as HTMLInputElement[];
+      const host = window.location.hostname.toLowerCase();
       const isAwsSignInPage =
-        window.location.hostname.includes("signin.aws.amazon.com") ||
-        window.location.hostname.includes("sign-in.aws.amazon.com");
+        host === "signin.aws.amazon.com" ||
+        host.endsWith(".signin.aws.amazon.com") ||
+        host === "sign-in.aws.amazon.com" ||
+        host.endsWith(".sign-in.aws.amazon.com");
 
       const findInputByHint = () => {
         if (!targetHintArg) return null;

--- a/extension/src/content/autofill-lib.ts
+++ b/extension/src/content/autofill-lib.ts
@@ -166,9 +166,12 @@ export function performAutofill(payload: AutofillPayload) {
     hintedUsernameInput ??
     findUsernameInput(inputs, passwordInput);
 
+  const host = window.location.hostname.toLowerCase();
   const isAwsSignInPage =
-    window.location.hostname.includes("signin.aws.amazon.com") ||
-    window.location.hostname.includes("sign-in.aws.amazon.com");
+    host === "signin.aws.amazon.com" ||
+    host.endsWith(".signin.aws.amazon.com") ||
+    host === "sign-in.aws.amazon.com" ||
+    host.endsWith(".sign-in.aws.amazon.com");
 
   const getHints = (input: HTMLInputElement): string => {
     const id = input.id;

--- a/src/lib/password-generator.ts
+++ b/src/lib/password-generator.ts
@@ -110,7 +110,12 @@ function randomChar(charset: string): string {
 }
 
 function secureRandomInt(max: number): number {
-  const bytes = randomBytes(4);
-  const value = bytes.readUInt32BE(0);
+  if (max <= 0 || max > 0x100000000) throw new RangeError("max must be in (0, 2^32]");
+  // Rejection sampling to eliminate modulo bias.
+  const limit = Math.floor(0x100000000 / max) * max;
+  let value: number;
+  do {
+    value = randomBytes(4).readUInt32BE(0);
+  } while (value >= limit);
   return value % max;
 }


### PR DESCRIPTION
## Summary
- Fix modulo bias in `secureRandomInt` using rejection sampling with upper bound guard (#7)
- Fix hostname matching for AWS sign-in: exact match + dot-prefixed `endsWith` to prevent subdomain spoofing (#3, #4, #5, #6)
- Dismiss alerts #1, #2 (`insufficient-password-hash`) as false positive — `authHash` is pre-derived via PBKDF2 (600k iterations) on the client side; server-side SHA-256 is domain separation only

## Test plan
- [x] `password-generator.test.ts` — 15 tests pass
- [x] `background.test.ts` — 49 tests pass
- [x] `autofill.test.ts` — 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)