### PR TITLE
style: unify extension button colors with shadcn theme

### DIFF
--- a/extension/src/options/App.tsx
+++ b/extension/src/options/App.tsx
@@ -125,7 +125,7 @@ export function App() {
           <button
             type="button"
             onClick={handleSave}
-            className="px-5 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 active:bg-blue-800 transition-colors shadow-sm"
+            className="px-5 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 active:bg-gray-950 transition-colors shadow-sm"
           >
             {t("options.save")}
           </button>

--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -93,7 +93,7 @@ export function App() {
             <button
               type="button"
               onClick={handleDisconnect}
-              className="cursor-pointer text-xs font-semibold text-white bg-red-500 px-2.5 py-1.5 rounded-md hover:bg-red-600 active:bg-red-700 transition-colors"
+              className="cursor-pointer text-xs font-semibold text-white bg-red-600 px-2.5 py-1.5 rounded-md hover:bg-red-500 active:bg-red-700 transition-colors"
             >
               {t("popup.disconnect")}
             </button>

--- a/extension/src/popup/components/LoginPrompt.tsx
+++ b/extension/src/popup/components/LoginPrompt.tsx
@@ -27,7 +27,7 @@ export function LoginPrompt() {
       )}
       <button
         onClick={handleLogin}
-        className="cursor-pointer px-4 py-2 bg-blue-500 text-white text-sm font-medium rounded-md hover:bg-blue-600 active:bg-blue-700 transition-colors"
+        className="cursor-pointer px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-md hover:bg-gray-800 active:bg-gray-950 transition-colors"
       >
         {t("popup.openApp")}
       </button>

--- a/extension/src/popup/components/MatchList.tsx
+++ b/extension/src/popup/components/MatchList.tsx
@@ -134,7 +134,7 @@ export function MatchList({ tabUrl, onLock }: Props) {
         <h2 className="text-sm font-semibold text-gray-700">{t("popup.passwords")}</h2>
         <button
           onClick={handleLock}
-          className="cursor-pointer text-xs font-semibold text-white bg-black px-2.5 py-1.5 rounded-md hover:bg-gray-900 active:bg-gray-950 transition-colors"
+          className="cursor-pointer text-xs font-semibold text-white bg-gray-900 px-2.5 py-1.5 rounded-md hover:bg-gray-800 active:bg-gray-950 transition-colors"
         >
           {t("popup.lock")}
         </button>
@@ -188,13 +188,13 @@ export function MatchList({ tabUrl, onLock }: Props) {
                         <button
                           onClick={() => handleFill(e.id)}
                           disabled={filling}
-                          className="cursor-pointer text-xs font-semibold text-white bg-blue-500 px-2.5 py-1.5 rounded-md hover:bg-blue-600 active:bg-blue-700 transition-colors disabled:opacity-60"
+                          className="cursor-pointer text-xs font-semibold text-white bg-gray-900 px-2.5 py-1.5 rounded-md hover:bg-gray-800 active:bg-gray-950 transition-colors disabled:opacity-60"
                         >
                           {t("popup.fill")}
                         </button>
                         <button
                           onClick={() => handleCopy(e.id)}
-                          className="cursor-pointer text-xs font-semibold text-blue-800 bg-blue-100 border border-blue-200 px-2.5 py-1.5 rounded-md hover:bg-blue-200 active:bg-blue-300 transition-colors"
+                          className="cursor-pointer text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 px-2.5 py-1.5 rounded-md hover:bg-gray-200 active:bg-gray-300 transition-colors"
                         >
                           {t("popup.copy")}
                         </button>
@@ -232,13 +232,13 @@ export function MatchList({ tabUrl, onLock }: Props) {
                         <button
                           onClick={() => handleFill(e.id)}
                           disabled={filling}
-                          className="cursor-pointer text-xs font-semibold text-white bg-blue-500 px-2.5 py-1.5 rounded-md hover:bg-blue-600 active:bg-blue-700 transition-colors disabled:opacity-60"
+                          className="cursor-pointer text-xs font-semibold text-white bg-gray-900 px-2.5 py-1.5 rounded-md hover:bg-gray-800 active:bg-gray-950 transition-colors disabled:opacity-60"
                         >
                           {t("popup.fill")}
                         </button>
                         <button
                           onClick={() => handleCopy(e.id)}
-                          className="cursor-pointer text-xs font-semibold text-blue-800 bg-blue-100 border border-blue-200 px-2.5 py-1.5 rounded-md hover:bg-blue-200 active:bg-blue-300 transition-colors"
+                          className="cursor-pointer text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 px-2.5 py-1.5 rounded-md hover:bg-gray-200 active:bg-gray-300 transition-colors"
                         >
                           {t("popup.copy")}
                         </button>

--- a/extension/src/popup/components/VaultUnlock.tsx
+++ b/extension/src/popup/components/VaultUnlock.tsx
@@ -76,7 +76,7 @@ export function VaultUnlock({ onUnlocked, tabUrl }: Props) {
       <button
         type="submit"
         disabled={loading || !passphrase.trim()}
-        className="cursor-pointer px-4 py-2 bg-black text-white text-sm font-medium rounded-md hover:bg-gray-900 active:bg-gray-950 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        className="cursor-pointer px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-md hover:bg-gray-800 active:bg-gray-950 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {loading ? t("popup.unlocking") : t("popup.unlock")}
       </button>


### PR DESCRIPTION
## Summary
- Align all extension popup/options button colors with the web app's shadcn/ui theme
- Primary buttons: `blue-500`/`black` → `gray-900` (matching `--primary: oklch(0.205 0 0)`)
- Destructive button: `red-500` → `red-600` (matching `--destructive: oklch(0.577 0.245 27.325)`)
- Secondary/copy buttons: `blue-100` → `gray-100` for neutral outline style

## Test plan
- [x] All 34 extension popup/options tests pass
- [ ] Visual check: popup buttons render with consistent gray-900 primary styling
- [ ] Visual check: disconnect button renders with red-600 destructive styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)