### PR TITLE
Align extension input focus styles with web app

### DIFF
--- a/extension/src/options/App.tsx
+++ b/extension/src/options/App.tsx
@@ -91,7 +91,7 @@ export function App() {
               value={serverUrl}
               onChange={(e) => setServerUrl(e.target.value)}
               placeholder={t("options.serverUrlPlaceholder")}
-              className="h-9 px-3 rounded-md border border-gray-200 bg-gray-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+              className="h-9 px-3 rounded-md border border-gray-300 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-gray-900 transition-shadow"
             />
             <span className="text-xs text-gray-400">
               {t("options.httpsRequired")}
@@ -108,7 +108,7 @@ export function App() {
             <select
               value={autoLockMinutes}
               onChange={(e) => setAutoLockMinutes(Number(e.target.value))}
-              className="h-9 px-3 rounded-md border border-gray-200 bg-gray-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+              className="h-9 px-3 rounded-md border border-gray-300 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-gray-900 transition-shadow"
             >
               <option value={0}>{t("options.never")}</option>
               <option value={1}>1</option>

--- a/extension/src/popup/components/MatchList.tsx
+++ b/extension/src/popup/components/MatchList.tsx
@@ -155,7 +155,7 @@ export function MatchList({ tabUrl, onLock }: Props) {
             placeholder={t("popup.searchPlaceholder")}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="h-9 px-3 rounded-md border border-gray-300 text-sm"
+            className="h-9 px-3 rounded-md border border-gray-300 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-gray-900 transition-shadow"
           />
 
           {query && filteredMatched.length === 0 && filteredUnmatched.length === 0 && (
@@ -177,7 +177,7 @@ export function MatchList({ tabUrl, onLock }: Props) {
               {filteredMatched.map((e) => (
                 <li
                   key={e.id}
-                  className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2"
+                  className="rounded-md border border-gray-200 bg-gray-50 hover:bg-gray-100 transition-colors px-3 py-2"
                 >
                   <div className="flex items-center justify-between gap-2">
                     <div className="text-sm font-medium text-gray-900">

--- a/extension/src/popup/components/VaultUnlock.tsx
+++ b/extension/src/popup/components/VaultUnlock.tsx
@@ -48,7 +48,7 @@ export function VaultUnlock({ onUnlocked, tabUrl }: Props) {
         {t("popup.unlockDescription")}
       </p>
       {tabHost && (
-        <div className="flex items-center gap-2 px-3 py-2 text-xs text-gray-600 bg-gray-50 border border-gray-200 rounded-md">
+        <div className="flex items-center gap-2 px-3 py-2 text-xs text-gray-600 bg-gray-100 border border-gray-200 rounded-md">
           <span className="shrink-0">🌐</span>
           <span>{t("popup.unlockSite", { host: tabHost })}</span>
         </div>
@@ -59,7 +59,7 @@ export function VaultUnlock({ onUnlocked, tabUrl }: Props) {
           value={passphrase}
           onChange={(e) => setPassphrase(e.target.value)}
           placeholder={t("popup.passphrasePlaceholder")}
-          className="h-10 flex-1 px-3 rounded-md border border-gray-300 text-sm"
+          className="h-10 flex-1 px-3 rounded-md border border-gray-300 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-gray-900 transition-shadow"
           autoFocus
         />
         <button


### PR DESCRIPTION
## Summary\n- align popup passphrase/search focus styles to web app tone\n- align options server URL/auto-lock focus styles to the same scheme\n\n## Files\n- extension/src/popup/components/VaultUnlock.tsx\n- extension/src/popup/components/MatchList.tsx\n- extension/src/options/App.tsx\n