### PR TITLE
fix(ci): add explicit permissions to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- GitHub code scanning の `actions/missing-workflow-permissions` アラート 4 件を解消
- ワークフロー トップレベルに `permissions: contents: read` を追加 (最小権限)

## Changes

- `.github/workflows/ci.yml`: `permissions: contents: read` 追加

## Testing

- [ ] CI checks pass
- [ ] Manually tested in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)