### PR TITLE
fix(ci): add Redis service to app-ci, fix pExpire precision, add jsdom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ jobs:
     name: "App: Lint → Test → Build"
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    services:
+      redis:
+        image: redis:7-alpine
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
     env:
       DATABASE_URL: "postgresql://ci:ci@localhost:5432/ci"
       ORG_MASTER_KEY: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -97,6 +106,9 @@ jobs:
       VERIFIER_PEPPER_KEY: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       REDIS_URL: "redis://localhost:6379"
       E2E_ALLOW_DB_MUTATION: "true"
+      # Dummy auth provider — production env validation requires at least one
+      AUTH_GOOGLE_ID: "ci-google-id.apps.googleusercontent.com"
+      AUTH_GOOGLE_SECRET: "ci-google-secret"
     steps:
       - uses: actions/checkout@v4
 

--- a/extension/src/__tests__/lib/error-messages.test.ts
+++ b/extension/src/__tests__/lib/error-messages.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { humanizeError } from "../../lib/error-messages";
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -26,10 +26,9 @@ export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
     const redis = getRedis();
     if (!redis) return null;
     try {
-      const windowSec = Math.ceil(windowMs / 1000);
       const count = await redis.incr(key);
       if (count === 1) {
-        await redis.expire(key, windowSec);
+        await redis.pExpire(key, windowMs);
       }
       return count <= max;
     } catch {


### PR DESCRIPTION
## Summary
- Add Redis service container to `app-ci` job so `rate-limit.test.ts` and route handler tests exercise the actual Redis code path (`incr`/`pExpire`/`del`)
- Fix `rate-limit.ts`: use `pExpire` (millisecond precision) instead of `expire` (second precision) — `Math.ceil(50/1000) = 1s` caused the "window expires" test to fail when Redis was actually available
- Add `@vitest-environment jsdom` to `extension/error-messages.test.ts` — `navigator.language` requires jsdom, not the default node environment

These are pre-existing failures visible in all recent CI runs.

## Test plan
- [x] `npm test` — 1,168 unit tests pass (with Redis running)
- [x] `REDIS_URL=redis://localhost:6379 npx vitest run src/__tests__/lib/rate-limit.test.ts` — 9/9 pass
- [x] Extension `npm test` — 195 tests pass (21 files)
- [ ] CI `app-ci` + `extension-ci` + `e2e` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)