### PR TITLE
fix(security): use AUTH_URL for CSRF origin check, eliminate as any

### DIFF
--- a/src/__tests__/api/audit-logs.test.ts
+++ b/src/__tests__/api/audit-logs.test.ts
@@ -26,8 +26,7 @@ describe("GET /api/audit-logs", () => {
     mockAuth.mockResolvedValue(null);
 
     const req = createRequest("GET", "http://localhost/api/audit-logs");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any);
+    const res = await GET(req);
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(401);
@@ -52,8 +51,8 @@ describe("GET /api/audit-logs", () => {
     mockFindMany.mockResolvedValue(logs);
 
     const req = createRequest("GET", "http://localhost/api/audit-logs");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any);
+
+    const res = await GET(req);
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(200);
@@ -93,8 +92,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       "http://localhost/api/audit-logs?limit=3"
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any);
+
+    const res = await GET(req);
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(200);
@@ -110,8 +109,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       `http://localhost/api/audit-logs?action=${AUDIT_ACTION.AUTH_LOGIN}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any);
+
+    await GET(req);
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -130,8 +129,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       `http://localhost/api/audit-logs?actions=${AUDIT_ACTION.AUTH_LOGIN},${AUDIT_ACTION.ENTRY_CREATE}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any);
+
+    await GET(req);
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -150,8 +149,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       "http://localhost/api/audit-logs?from=2025-01-01T00:00:00Z&to=2025-12-31T23:59:59Z"
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any);
+
+    await GET(req);
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -173,8 +172,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       `http://localhost/api/audit-logs?actions=${AUDIT_ACTION.ENTRY_IMPORT}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any);
+
+    await GET(req);
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -193,8 +192,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       `http://localhost/api/audit-logs?actions=${AUDIT_ACTION.ENTRY_BULK_TRASH}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any);
+
+    await GET(req);
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -213,8 +212,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       `http://localhost/api/audit-logs?actions=${AUDIT_ACTION.ENTRY_BULK_ARCHIVE}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any);
+
+    await GET(req);
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -233,8 +232,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       `http://localhost/api/audit-logs?actions=${AUDIT_ACTION.ENTRY_BULK_UNARCHIVE}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any);
+
+    await GET(req);
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -253,8 +252,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       `http://localhost/api/audit-logs?actions=${AUDIT_ACTION.ENTRY_BULK_RESTORE}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any);
+
+    await GET(req);
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -273,8 +272,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       "http://localhost/api/audit-logs?action=INVALID_ACTION"
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any);
+
+    await GET(req);
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -292,8 +291,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       `http://localhost/api/audit-logs?actions=${AUDIT_ACTION.AUTH_LOGIN},INVALID_ACTION`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any);
+
+    const res = await GET(req);
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(400);
@@ -309,8 +308,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       "http://localhost/api/audit-logs?limit=999"
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any);
+
+    await GET(req);
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -327,8 +326,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       "http://localhost/api/audit-logs?cursor=abc123"
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any);
+
+    await GET(req);
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -346,8 +345,8 @@ describe("GET /api/audit-logs", () => {
       "GET",
       "http://localhost/api/audit-logs?cursor=invalid-cursor-id"
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any);
+
+    const res = await GET(req);
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(400);
@@ -377,8 +376,8 @@ describe("GET /api/audit-logs", () => {
     ]);
 
     const req = createRequest("GET", "http://localhost/api/audit-logs");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any);
+
+    const res = await GET(req);
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(200);

--- a/src/__tests__/api/orgs/audit-logs.test.ts
+++ b/src/__tests__/api/orgs/audit-logs.test.ts
@@ -44,8 +44,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    const res = await GET(req, createParams({ orgId: ORG_ID }));
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(401);
@@ -62,8 +62,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    const res = await GET(req, createParams({ orgId: ORG_ID }));
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(403);
@@ -95,8 +95,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    const res = await GET(req, createParams({ orgId: ORG_ID }));
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(200);
@@ -131,8 +131,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs?action=${AUDIT_ACTION.ORG_MEMBER_INVITE}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    await GET(req, createParams({ orgId: ORG_ID }));
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -152,8 +152,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs?actions=${AUDIT_ACTION.ENTRY_CREATE},${AUDIT_ACTION.ENTRY_UPDATE}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    await GET(req, createParams({ orgId: ORG_ID }));
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -173,8 +173,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs?actions=${AUDIT_ACTION.ENTRY_BULK_TRASH}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    await GET(req, createParams({ orgId: ORG_ID }));
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -194,8 +194,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs?actions=${AUDIT_ACTION.ENTRY_BULK_ARCHIVE}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    await GET(req, createParams({ orgId: ORG_ID }));
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -215,8 +215,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs?actions=${AUDIT_ACTION.ENTRY_BULK_UNARCHIVE}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    await GET(req, createParams({ orgId: ORG_ID }));
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -236,8 +236,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs?actions=${AUDIT_ACTION.ENTRY_BULK_RESTORE}`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    await GET(req, createParams({ orgId: ORG_ID }));
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -256,8 +256,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs?actions=${AUDIT_ACTION.ENTRY_CREATE},NOPE`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    const res = await GET(req, createParams({ orgId: ORG_ID }));
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(400);
@@ -275,8 +275,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs?from=2025-01-01T00:00:00Z&to=2025-06-30T23:59:59Z`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    await GET(req, createParams({ orgId: ORG_ID }));
 
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -313,8 +313,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs?limit=5`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    const res = await GET(req, createParams({ orgId: ORG_ID }));
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(200);
@@ -331,8 +331,8 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
       "GET",
       `http://localhost/api/orgs/${ORG_ID}/audit-logs?cursor=bad-cursor`
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await GET(req as any, createParams({ orgId: ORG_ID }));
+
+    const res = await GET(req, createParams({ orgId: ORG_ID }));
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(400);
@@ -349,8 +349,7 @@ describe("GET /api/orgs/[orgId]/audit-logs", () => {
     );
 
     await expect(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      GET(req as any, createParams({ orgId: ORG_ID }))
+      GET(req, createParams({ orgId: ORG_ID }))
     ).rejects.toThrow("Unexpected");
   });
 });

--- a/src/__tests__/audit.test.ts
+++ b/src/__tests__/audit.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 
 const { mockCreate, mockAuditInfo } = vi.hoisted(() => ({
@@ -291,54 +292,50 @@ describe("sanitizeMetadata", () => {
 
 describe("extractRequestMeta", () => {
   it("extracts IP from x-forwarded-for header", () => {
-    const req = new Request("http://localhost/api/test", {
+    const req = new NextRequest("http://localhost/api/test", {
       headers: {
         "x-forwarded-for": "203.0.113.1, 10.0.0.1",
         "user-agent": "Mozilla/5.0",
       },
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = extractRequestMeta(req as any);
+    const result = extractRequestMeta(req);
 
     expect(result.ip).toBe("203.0.113.1");
     expect(result.userAgent).toBe("Mozilla/5.0");
   });
 
   it("falls back to x-real-ip when no x-forwarded-for", () => {
-    const req = new Request("http://localhost/api/test", {
+    const req = new NextRequest("http://localhost/api/test", {
       headers: {
         "x-real-ip": "198.51.100.10",
         "user-agent": "TestAgent",
       },
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = extractRequestMeta(req as any);
+    const result = extractRequestMeta(req);
 
     expect(result.ip).toBe("198.51.100.10");
     expect(result.userAgent).toBe("TestAgent");
   });
 
   it("returns null IP when no proxy headers", () => {
-    const req = new Request("http://localhost/api/test", {
+    const req = new NextRequest("http://localhost/api/test", {
       headers: {
         "user-agent": "TestAgent",
       },
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = extractRequestMeta(req as any);
+    const result = extractRequestMeta(req);
 
     expect(result.ip).toBeNull();
     expect(result.userAgent).toBe("TestAgent");
   });
 
   it("returns null userAgent when no user-agent header", () => {
-    const req = new Request("http://localhost/api/test");
+    const req = new NextRequest("http://localhost/api/test");
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = extractRequestMeta(req as any);
+    const result = extractRequestMeta(req);
 
     expect(result.ip).toBeNull();
     expect(result.userAgent).toBeNull();

--- a/src/__tests__/helpers/mock-prisma.ts
+++ b/src/__tests__/helpers/mock-prisma.ts
@@ -12,6 +12,15 @@ const MODEL_METHODS = [
   "upsert",
 ] as const;
 
+type MockModel = Record<
+  (typeof MODEL_METHODS)[number],
+  ReturnType<typeof vi.fn>
+>;
+
+export type MockPrisma = Record<string, MockModel> & {
+  $transaction: ReturnType<typeof vi.fn>;
+};
+
 /**
  * Creates a deeply proxied mock where any model property access returns
  * an object whose methods are all vi.fn().
@@ -55,6 +64,5 @@ export function createMockPrisma() {
   };
 
   const proxy = new Proxy({}, handler);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return proxy as any;
+  return proxy as MockPrisma;
 }

--- a/src/app/api/orgs/[orgId]/passwords/[id]/route.ts
+++ b/src/app/api/orgs/[orgId]/passwords/[id]/route.ts
@@ -79,8 +79,7 @@ export async function GET(_req: NextRequest, { params }: Params) {
     ? Buffer.from(buildOrgEntryAAD(orgId, entry.id, "blob"))
     : undefined;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let blob: Record<string, any>;
+  let blob: Record<string, unknown>;
   try {
     blob = JSON.parse(
       decryptServerData(
@@ -224,8 +223,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
     ? Buffer.from(buildOrgEntryAAD(orgId, id, "blob"))
     : undefined;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let currentBlob: Record<string, any>;
+  let currentBlob: Record<string, unknown>;
   try {
     currentBlob = JSON.parse(
       decryptServerData(
@@ -264,8 +262,8 @@ export async function PUT(req: NextRequest, { params }: Params) {
     isArchived = parsed.data.isArchived;
 
     const updatedBlob = {
-      title: parsed.data.title ?? currentBlob.title,
-      content: parsed.data.content ?? currentBlob.content,
+      title: (parsed.data.title ?? currentBlob.title) as string,
+      content: (parsed.data.content ?? currentBlob.content) as string,
     };
     responseTitle = updatedBlob.title;
 
@@ -285,7 +283,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
     isArchived = parsed.data.isArchived;
 
     const updatedBlob = {
-      title: parsed.data.title ?? currentBlob.title,
+      title: (parsed.data.title ?? currentBlob.title) as string,
       cardholderName:
         parsed.data.cardholderName !== undefined
           ? parsed.data.cardholderName || null
@@ -318,7 +316,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
     responseTitle = updatedBlob.title;
 
     const lastFour = updatedBlob.cardNumber
-      ? updatedBlob.cardNumber.slice(-4)
+      ? (updatedBlob.cardNumber as string).slice(-4)
       : null;
     updatedBlobStr = JSON.stringify(updatedBlob);
     overviewBlobStr = JSON.stringify({
@@ -345,7 +343,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
         : currentBlob[field];
 
     const updatedBlob = {
-      title: parsed.data.title ?? currentBlob.title,
+      title: (parsed.data.title ?? currentBlob.title) as string,
       fullName: mergeField("fullName"),
       address: mergeField("address"),
       phone: mergeField("phone"),

--- a/src/app/api/orgs/[orgId]/passwords/route.ts
+++ b/src/app/api/orgs/[orgId]/passwords/route.ts
@@ -125,8 +125,7 @@ export async function GET(req: NextRequest, { params }: Params) {
   }
 
   const entries: OrgPasswordListEntry[] = [];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  for (const entry of passwords as any[]) {
+  for (const entry of passwords) {
     try {
       const aad = entry.aadVersion >= 1
         ? Buffer.from(buildOrgEntryAAD(orgId, entry.id, "overview"))

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -23,7 +23,7 @@ import { API_ERROR } from "./api-error-codes";
  */
 export function assertOrigin(request: Request): NextResponse | null {
   const origin = request.headers.get("origin");
-  const appUrl = process.env.APP_URL || process.env.NEXTAUTH_URL;
+  const appUrl = process.env.APP_URL || process.env.AUTH_URL;
 
   if (!appUrl) {
     // If APP_URL is not configured, skip check (dev convenience)

--- a/src/lib/org-auth.test.ts
+++ b/src/lib/org-auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { MockPrisma } from "@/__tests__/helpers/mock-prisma";
 
 // vi.mock is hoisted — factory must not reference outer variables
 vi.mock("@/lib/prisma", () => {
@@ -34,8 +35,7 @@ import {
   OrgAuthError,
 } from "./org-auth";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockPrisma = prisma as any;
+const mockPrisma = prisma as unknown as MockPrisma;
 
 describe("hasOrgPermission", () => {
   it("OWNER has all permissions", () => {

--- a/src/lib/with-request-log.ts
+++ b/src/lib/with-request-log.ts
@@ -14,6 +14,12 @@
 import { type NextRequest } from "next/server";
 import logger, { requestContext } from "@/lib/logger";
 
+// Route handlers have varying signatures:
+//   (request: NextRequest) => Promise<Response>                    — static routes
+//   (request: NextRequest, context: { params: Promise<P> }) => …  — dynamic routes
+// TypeScript's contravariant function params prevent a single non-any
+// constraint from accepting both shapes while preserving H's concrete type.
+// The `as unknown as H` cast (L53) is the actual type boundary.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RouteHandler = (...args: any[]) => Promise<Response>;
 


### PR DESCRIPTION
## Summary

Fix CSRF origin validation using dead `NEXTAUTH_URL` fallback, and eliminate all `as any` casts from production and test code.

## Changes

**Security**
- `csrf.ts`: Replace `NEXTAUTH_URL` (Auth.js v4 legacy, not in env.ts schema) with `AUTH_URL` so Origin validation is active in production

**Type safety (src/)**
- `as any`: 38 → **0**
- `no-explicit-any` suppressions: 5 → **1** (with-request-log.ts — documented why TypeScript contravariance prevents a non-any constraint for route handler wrappers)
- `orgs/passwords/route.ts`: Remove unnecessary `passwords as any[]` cast
- `orgs/passwords/[id]/route.ts`: `Record<string, any>` → `Record<string, unknown>` with targeted `as string` assertions at merge points
- `mock-prisma.ts`: Add exported `MockPrisma` type, replace `as any` return
- `org-auth.test.ts`: Use `MockPrisma` type instead of `as any`
- `audit-logs.test.ts` (2 files): Remove 30 unnecessary `req as any` casts
- `audit.test.ts`: Use `NextRequest` instead of `Request` + `as any`

## Testing

- [x] CI checks pass
- [x] Manually tested in browser

## Related Issues

Addresses security finding from codebase evaluation (CSRF Origin check silently disabled in production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)