### PR TITLE
feat(db): add configurable connection pool with graceful shutdown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,3 +75,11 @@ BLOB_BACKEND=db
 # Use with Fluent Bit sidecar: docker compose -f docker-compose.yml -f docker-compose.logging.yml up
 # AUDIT_LOG_FORWARD=true
 # AUDIT_LOG_APP_NAME=passwd-sso
+
+# --- DB Connection Pool Tuning (optional) ---
+# All values have sensible defaults. Override only if needed.
+# DB_POOL_MAX=20
+# DB_POOL_CONNECTION_TIMEOUT_MS=5000
+# DB_POOL_IDLE_TIMEOUT_MS=30000
+# DB_POOL_MAX_LIFETIME_SECONDS=1800
+# DB_POOL_STATEMENT_TIMEOUT_MS=30000

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -45,7 +45,7 @@
 | # | 優先度 | 項目 | 状態 | 備考 |
 |---|--------|------|------|------|
 | 3.1 | 必須 | バックアップ・リカバリ戦略 | 対応済み | AWS Backup Vault Lock (WORM/Compliance) + S3 Object Lock + クロスリージョンコピー + EventBridge 失敗通知。RPO 1h / RTO 2h。PR #23 |
-| 3.2 | 強く推奨 | DB コネクションプール設定 | 未着手 | pg.Pool の max / idleTimeoutMillis / connectionTimeoutMillis をチューニング + 接続数監視 |
+| 3.2 | 強く推奨 | DB コネクションプール設定 | 対応済み | pg.Pool を環境変数で設定可能化 (max / connectionTimeoutMillis / idleTimeoutMillis / maxLifetimeSeconds / statement_timeout)。envInt() で厳密パース + 範囲ガード (production fail-fast)。pool.on("error") + SIGTERM graceful shutdown。CloudWatch RDS DatabaseConnections アラーム追加。#48 |
 | 3.3 | 強く推奨 | マイグレーション戦略の分離 | 対応済み | ECS one-off タスク定義 (Fargate RunTask) でマイグレーションをアプリ起動から完全分離。deploy.sh で migrate → 成功確認 → app 更新の順序を保証。docker-compose は profiles 分離。docs/deployment.md。#47 |
 | 3.4 | 推奨 | Redis 高可用性 | 未着手 | 現行は単一 Redis。Redis Sentinel / ElastiCache 等によるフェイルオーバー |
 
@@ -100,6 +100,7 @@
 - コンポーネントテスト基盤 (`@testing-library/react` + `jsdom`、signin / header / auto-extension-connect)
 - E2E テスト (Playwright 7 spec / 22 ケース、暗号互換性テスト 16 件、DB 二重ガード + スコープ限定クリーンアップ)
 - マイグレーション戦略の分離 (ECS one-off RunTask + deploy.sh 順序保証 + docker-compose profiles 分離)
+- DB コネクションプール設定 (環境変数チューニング + maxLifetimeSeconds + graceful shutdown + RDS 接続数アラーム)
 - 本番コード `console.log` 0 件、`TODO/FIXME` 0 件
 
 ---

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -151,6 +151,29 @@ resource "aws_cloudwatch_metric_alarm" "high_latency" {
   tags          = local.tags
 }
 
+# RDS connection count approaching max_connections limit
+resource "aws_cloudwatch_metric_alarm" "rds_connections" {
+  count               = var.enable_monitoring ? 1 : 0
+  alarm_name          = "${local.name_prefix}-rds-connections-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = var.alarm_rds_connections_threshold
+  alarm_description   = "RDS connection count approaching max_connections limit"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.main.identifier
+  }
+
+  alarm_actions = [aws_sns_topic.alarms[0].arn]
+  ok_actions    = [aws_sns_topic.alarms[0].arn]
+  tags          = local.tags
+}
+
 ################################################################################
 # EventBridge: ECS Task Stop Detection
 ################################################################################

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -288,6 +288,12 @@ variable "alarm_latency_threshold_ms" {
   description = "API latency threshold in milliseconds"
 }
 
+variable "alarm_rds_connections_threshold" {
+  type        = number
+  default     = 80
+  description = "RDS connection count alarm threshold. Default 80 assumes db.t4g.micro (max_connections ≈ 100). Review when changing instance type."
+}
+
 # ── Backup ─────────────────────────────────────────────
 
 variable "enable_backup" {

--- a/src/__tests__/lib/prisma.test.ts
+++ b/src/__tests__/lib/prisma.test.ts
@@ -1,0 +1,303 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+
+// ─── Mocks ──────────────────────────────────────────────────
+
+const { mockOn, mockEnd, mockPoolConstructor, mockWarn, mockError, mockInfo } =
+  vi.hoisted(() => ({
+    mockOn: vi.fn(),
+    mockEnd: vi.fn().mockResolvedValue(undefined),
+    mockPoolConstructor: vi.fn(),
+    mockWarn: vi.fn(),
+    mockError: vi.fn(),
+    mockInfo: vi.fn(),
+  }));
+
+vi.mock("pg", () => {
+  // Use regular function (not arrow) so it can be called with `new`
+  function Pool(this: Record<string, unknown>, ...args: unknown[]) {
+    mockPoolConstructor(...args);
+    this.on = mockOn;
+    this.end = mockEnd;
+  }
+  return { default: { Pool }, Pool };
+});
+
+vi.mock("@prisma/adapter-pg", () => {
+  function PrismaPg() {}
+  return { PrismaPg };
+});
+
+vi.mock("@prisma/client", () => {
+  function PrismaClient() {}
+  return { PrismaClient };
+});
+
+vi.mock("@/lib/logger", () => ({
+  getLogger: () => ({
+    warn: mockWarn,
+    error: mockError,
+    info: mockInfo,
+  }),
+}));
+
+// ─── Helpers ────────────────────────────────────────────────
+
+const originalEnv = { ...process.env };
+
+function resetEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key];
+    }
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+/** Clear globalForPrisma singleton cache (persists on globalThis across vi.resetModules) */
+function clearSingletonCache() {
+  const g = globalThis as unknown as Record<string, unknown>;
+  delete g.prisma;
+  delete g.pool;
+}
+
+// ─── Tests ──────────────────────────────────────────────────
+
+// Prevent MaxListenersExceededWarning from repeated process.once() calls across tests
+const originalMaxListeners = process.getMaxListeners();
+beforeAll(() => process.setMaxListeners(30));
+afterAll(() => process.setMaxListeners(originalMaxListeners));
+
+describe("prisma pool configuration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    clearSingletonCache();
+    resetEnv();
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+  });
+
+  afterEach(() => {
+    resetEnv();
+  });
+
+  it("creates pool with default config values", async () => {
+    await import("@/lib/prisma");
+
+    expect(mockPoolConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionString: "postgresql://test:test@localhost:5432/test",
+        max: 20,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 30_000,
+        maxLifetimeSeconds: 1800,
+        statement_timeout: 30_000,
+        application_name: "passwd-sso",
+      }),
+    );
+  });
+
+  it("uses custom env values for pool config", async () => {
+    process.env.DB_POOL_MAX = "50";
+    process.env.DB_POOL_CONNECTION_TIMEOUT_MS = "10000";
+    process.env.DB_POOL_IDLE_TIMEOUT_MS = "60000";
+    process.env.DB_POOL_MAX_LIFETIME_SECONDS = "3600";
+    process.env.DB_POOL_STATEMENT_TIMEOUT_MS = "15000";
+
+    await import("@/lib/prisma");
+
+    expect(mockPoolConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        max: 50,
+        connectionTimeoutMillis: 10000,
+        idleTimeoutMillis: 60000,
+        maxLifetimeSeconds: 3600,
+        statement_timeout: 15000,
+      }),
+    );
+  });
+
+  it("registers error handler on pool", async () => {
+    await import("@/lib/prisma");
+
+    expect(mockOn).toHaveBeenCalledWith("error", expect.any(Function));
+  });
+
+  it("pool error handler logs with structured logger", async () => {
+    await import("@/lib/prisma");
+
+    const errorHandler = mockOn.mock.calls.find(
+      (call) => call[0] === "error",
+    )![1];
+    const testErr = new Error("connection reset");
+    errorHandler(testErr);
+
+    expect(mockError).toHaveBeenCalledWith(
+      { err: testErr },
+      "pool.error.idle_client",
+    );
+  });
+
+  it("throws when DATABASE_URL is not set", async () => {
+    delete process.env.DATABASE_URL;
+
+    await expect(import("@/lib/prisma")).rejects.toThrow(
+      "DATABASE_URL environment variable is not set",
+    );
+  });
+});
+
+describe("prisma shutdown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    clearSingletonCache();
+    resetEnv();
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    process.removeAllListeners("SIGTERM");
+    process.removeAllListeners("SIGINT");
+  });
+
+  afterEach(() => {
+    process.removeAllListeners("SIGTERM");
+    process.removeAllListeners("SIGINT");
+    resetEnv();
+  });
+
+  it("registers SIGTERM and SIGINT handlers", async () => {
+    await import("@/lib/prisma");
+
+    expect(process.listenerCount("SIGTERM")).toBe(1);
+    expect(process.listenerCount("SIGINT")).toBe(1);
+  });
+
+  it("SIGTERM handler calls pool.end()", async () => {
+    await import("@/lib/prisma");
+
+    const handler = process.listeners("SIGTERM")[0] as () => Promise<void>;
+    await handler();
+
+    expect(mockInfo).toHaveBeenCalledWith("pool.shutdown.start");
+    expect(mockEnd).toHaveBeenCalled();
+    expect(mockInfo).toHaveBeenCalledWith("pool.shutdown.complete");
+  });
+
+  it("SIGTERM handler logs error when pool.end() fails", async () => {
+    const endError = new Error("pool end failed");
+    mockEnd.mockRejectedValueOnce(endError);
+
+    await import("@/lib/prisma");
+    const handler = process.listeners("SIGTERM")[0] as () => Promise<void>;
+    await handler();
+
+    expect(mockError).toHaveBeenCalledWith(
+      { err: endError },
+      "pool.shutdown.error",
+    );
+  });
+
+  it("calls pool.end() only once when both SIGTERM and SIGINT fire", async () => {
+    await import("@/lib/prisma");
+
+    const sigterm = process.listeners("SIGTERM")[0] as () => Promise<void>;
+    const sigint = process.listeners("SIGINT")[0] as () => Promise<void>;
+    await Promise.all([sigterm(), sigint()]);
+
+    expect(mockEnd).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("envInt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    clearSingletonCache();
+    resetEnv();
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+  });
+
+  afterEach(() => {
+    resetEnv();
+  });
+
+  it("returns default when env var is not set", async () => {
+    const { envInt } = await import("@/lib/prisma");
+    expect(envInt("NONEXISTENT_VAR", 42)).toBe(42);
+  });
+
+  it("returns default when env var is empty string", async () => {
+    process.env.TEST_ENVINT = "";
+    const { envInt } = await import("@/lib/prisma");
+    expect(envInt("TEST_ENVINT", 42)).toBe(42);
+  });
+
+  it("parses valid integer", async () => {
+    process.env.TEST_ENVINT = "100";
+    const { envInt } = await import("@/lib/prisma");
+    expect(envInt("TEST_ENVINT", 42, { min: 0, max: 200 })).toBe(100);
+  });
+
+  it("falls back on non-numeric value in dev/test", async () => {
+    process.env.TEST_ENVINT = "abc";
+    const { envInt } = await import("@/lib/prisma");
+    expect(envInt("TEST_ENVINT", 42, { min: 0, max: 200 })).toBe(42);
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ envVar: "TEST_ENVINT", raw: "abc" }),
+      "pool.env.invalid_number.fallback",
+    );
+  });
+
+  it("falls back on partial number like '20ms' in dev/test", async () => {
+    process.env.TEST_ENVINT = "20ms";
+    const { envInt } = await import("@/lib/prisma");
+    expect(envInt("TEST_ENVINT", 42, { min: 0, max: 200 })).toBe(42);
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it("falls back on negative value below min in dev/test", async () => {
+    process.env.TEST_ENVINT = "-1";
+    const { envInt } = await import("@/lib/prisma");
+    expect(envInt("TEST_ENVINT", 42, { min: 0, max: 200 })).toBe(42);
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it("falls back on value above max in dev/test", async () => {
+    process.env.TEST_ENVINT = "999";
+    const { envInt } = await import("@/lib/prisma");
+    expect(envInt("TEST_ENVINT", 42, { min: 0, max: 200 })).toBe(42);
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it("throws on invalid value in production", async () => {
+    process.env.TEST_ENVINT = "abc";
+    (process.env as Record<string, string | undefined>).NODE_ENV = "production";
+    const { envInt } = await import("@/lib/prisma");
+    expect(() => envInt("TEST_ENVINT", 42, { min: 0, max: 200 })).toThrow(
+      'Invalid DB pool config: TEST_ENVINT="abc"',
+    );
+  });
+
+  it("throws on out-of-range value in production", async () => {
+    process.env.TEST_ENVINT = "999";
+    (process.env as Record<string, string | undefined>).NODE_ENV = "production";
+    const { envInt } = await import("@/lib/prisma");
+    expect(() => envInt("TEST_ENVINT", 42, { min: 0, max: 200 })).toThrow(
+      'Invalid DB pool config: TEST_ENVINT="999"',
+    );
+  });
+
+  it("falls back on float value in dev/test", async () => {
+    process.env.TEST_ENVINT = "3.14";
+    const { envInt } = await import("@/lib/prisma");
+    expect(envInt("TEST_ENVINT", 42, { min: 0, max: 200 })).toBe(42);
+    expect(mockWarn).toHaveBeenCalled();
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -95,6 +95,33 @@ const envSchema = z
     AZURE_STORAGE_CONNECTION_STRING: nonEmpty.optional(),
     AZURE_STORAGE_SAS_TOKEN: nonEmpty.optional(),
     GCS_ATTACHMENTS_BUCKET: nonEmpty.optional(),
+
+    // --- DB connection pool tuning (optional) ---
+    DB_POOL_MAX: z.coerce.number().int().min(1).max(200).default(20),
+    DB_POOL_CONNECTION_TIMEOUT_MS: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .max(60000)
+      .default(5000),
+    DB_POOL_IDLE_TIMEOUT_MS: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .max(600000)
+      .default(30000),
+    DB_POOL_MAX_LIFETIME_SECONDS: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .max(86400)
+      .default(1800),
+    DB_POOL_STATEMENT_TIMEOUT_MS: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .max(300000)
+      .default(30000),
   })
   .superRefine((data, ctx) => {
     const isProd = data.NODE_ENV === "production";

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,28 +1,137 @@
 import { PrismaClient } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import pg from "pg";
+import { getLogger } from "@/lib/logger";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
+  pool: pg.Pool | undefined;
 };
 
-function createPrismaClient(): PrismaClient {
+// ─── envInt: defense-in-depth env var parser ──────────────────
+
+interface EnvIntOpts {
+  min?: number;
+  max?: number;
+}
+
+/**
+ * Parse env var as strict integer with range guard.
+ * Uses Number() (not parseInt) to reject partial numbers like "20ms" or "10abc".
+ * Throws in production, falls back to default in dev/test.
+ *
+ * Validation roles:
+ * - env.ts (Zod): startup-time schema validation (authoritative, runs in instrumentation.ts)
+ * - prisma.ts (envInt): defense-in-depth for module load order edge cases
+ *   (prisma.ts may load before instrumentation.ts triggers env.ts validation)
+ */
+export function envInt(
+  name: string,
+  defaultVal: number,
+  opts: EnvIntOpts = {},
+): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return defaultVal;
+  const parsed = Number(raw);
+  const { min = 0, max = Number.MAX_SAFE_INTEGER } = opts;
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(
+        `Invalid DB pool config: ${name}="${raw}" (expected integer ${min}\u2013${max})`,
+      );
+    }
+    getLogger().warn(
+      { envVar: name, raw, min, max },
+      "pool.env.invalid_number.fallback",
+    );
+    return defaultVal;
+  }
+  return parsed;
+}
+
+// ─── Pool creation ───────────────────────────────────────────
+
+function createPool(): pg.Pool {
   const connectionString = process.env.DATABASE_URL;
   if (!connectionString) {
     throw new Error("DATABASE_URL environment variable is not set");
   }
 
-  const pool = new pg.Pool({ connectionString });
-  const adapter = new PrismaPg(pool);
-
-  return new PrismaClient({
-    adapter,
-    log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"],
+  const pool = new pg.Pool({
+    connectionString,
+    max: envInt("DB_POOL_MAX", 20, { min: 1, max: 200 }),
+    connectionTimeoutMillis: envInt("DB_POOL_CONNECTION_TIMEOUT_MS", 5000, {
+      min: 0,
+      max: 60_000,
+    }),
+    idleTimeoutMillis: envInt("DB_POOL_IDLE_TIMEOUT_MS", 30_000, {
+      min: 0,
+      max: 600_000,
+    }),
+    maxLifetimeSeconds: envInt("DB_POOL_MAX_LIFETIME_SECONDS", 1800, {
+      min: 0,
+      max: 86_400,
+    }),
+    statement_timeout: envInt("DB_POOL_STATEMENT_TIMEOUT_MS", 30_000, {
+      min: 0,
+      max: 300_000,
+    }),
+    application_name: "passwd-sso",
   });
+
+  const log = getLogger();
+  pool.on("error", (err) => {
+    log.error({ err }, "pool.error.idle_client");
+  });
+
+  return pool;
 }
 
-export const prisma = globalForPrisma.prisma ?? createPrismaClient();
+// ─── Graceful shutdown ───────────────────────────────────────
+
+function registerShutdown(pool: pg.Pool): void {
+  let closing = false;
+  const shutdown = async () => {
+    if (closing) return;
+    closing = true;
+    const log = getLogger();
+    log.info("pool.shutdown.start");
+    try {
+      await pool.end();
+      log.info("pool.shutdown.complete");
+    } catch (err) {
+      log.error({ err }, "pool.shutdown.error");
+    }
+  };
+  process.once("SIGTERM", shutdown);
+  process.once("SIGINT", shutdown);
+}
+
+// ─── PrismaClient factory ────────────────────────────────────
+
+function createPrismaClient(): { client: PrismaClient; pool: pg.Pool } {
+  const pool = createPool();
+  registerShutdown(pool);
+
+  const adapter = new PrismaPg(pool);
+  const client = new PrismaClient({
+    adapter,
+    log:
+      process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"],
+  });
+
+  return { client, pool };
+}
+
+// ─── Singleton ───────────────────────────────────────────────
+
+const result = globalForPrisma.prisma
+  ? { client: globalForPrisma.prisma, pool: globalForPrisma.pool! }
+  : createPrismaClient();
+
+export const prisma = result.client;
 
 if (process.env.NODE_ENV !== "production") {
-  globalForPrisma.prisma = prisma;
+  globalForPrisma.prisma = result.client;
+  globalForPrisma.pool = result.pool;
 }


### PR DESCRIPTION
## Summary

Closes #48 (production-readiness 3.2)

- Configure `pg.Pool` via `DB_POOL_*` env vars (`max`, `connectionTimeoutMillis`, `idleTimeoutMillis`, `maxLifetimeSeconds`, `statement_timeout`, `application_name`)
- Add `envInt()` defense-in-depth parser (strict `Number()` + `Number.isInteger`, production fail-fast, dev/test fallback with warn log)
- Register `pool.on("error")` handler to prevent uncaught exceptions from idle connections
- Add graceful shutdown via `process.once("SIGTERM"/"SIGINT")` with `closing` guard for idempotency
- Add RDS `DatabaseConnections` CloudWatch alarm (`infra/terraform/monitoring.tf`)
- Align `env.ts` Zod ranges with `prisma.ts` `envInt` ranges (defense-in-depth consistency)

## Changed files

| File | Change |
|------|--------|
| `src/lib/env.ts` | 5 `DB_POOL_*` env vars with Zod coerce + range validation |
| `src/lib/prisma.ts` | Pool config, `envInt()`, error handler, graceful shutdown |
| `src/__tests__/lib/prisma.test.ts` | New: 19 tests (pool config, shutdown idempotency, envInt) |
| `src/__tests__/env.test.ts` | 9 new tests (pool defaults, custom, upper bound rejection) |
| `infra/terraform/monitoring.tf` | RDS `DatabaseConnections` alarm |
| `infra/terraform/variables.tf` | `alarm_rds_connections_threshold` variable |
| `.env.example` | `DB_POOL_*` documentation |
| `docs/production-readiness.md` | 3.2 marked done |

## Test plan

- [x] `npx vitest run` — 1214 tests pass (122 files)
- [x] `npm run lint` — clean
- [x] `npm run build` — success
- [x] `terraform -chdir=infra/terraform validate` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)