### PR TITLE
docs(e2e): add test guidelines and PR safety checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,13 @@
 - [ ] CI checks pass
 - [ ] Manually tested in browser
 
-<!-- IMPROVE(#36): add E2E safety checklist below when e2e guidelines are ready -->
+## E2E Safety (if applicable)
+
+- [ ] Destructive tests use a dedicated user (not shared `vaultReady`)
+- [ ] No conditional assertion skip (`if (visible) { expect(...) }`)
+- [ ] Cleanup scope is limited to `e2e-*` / `E2E` prefixed resources
+
+See [docs/e2e-guidelines.md](../docs/e2e-guidelines.md) for details.
 
 ## Related Issues
 

--- a/docs/e2e-guidelines.md
+++ b/docs/e2e-guidelines.md
@@ -1,0 +1,50 @@
+# E2E Test Guidelines
+
+## 1. Test Isolation
+
+- Each test file should be independent of other test files.
+- Shared state between tests within a file (e.g., CRUD chain in `password-crud.spec.ts`) must run with `workers: 1` and be documented.
+- Prefer `test.step()` or independent `beforeEach` data setup over cross-test dependencies.
+- Never assume data created by another test file exists.
+
+## 2. Destructive Tests
+
+Destructive tests (vault reset, account deletion, data purge, etc.) **must** use a dedicated test user.
+
+| Test type | User requirement |
+|-----------|-----------------|
+| Read-only (view, list) | Shared user OK (`vaultReady`) |
+| Non-destructive write (create, edit) | Shared user OK if cleaned up |
+| Destructive (reset, delete account) | **Dedicated user required** |
+
+- Dedicated users are created in `e2e/global-setup.ts`.
+- Name dedicated users clearly: `e2e-reset-*`, `e2e-delete-*`, etc.
+
+## 3. Cleanup Scope
+
+- Tests must only clean up resources with the `e2e-*` or `E2E` prefix.
+- Never delete or modify resources that could belong to other test suites or manual testing.
+- Use `afterEach` / `afterAll` for cleanup when creating persistent data.
+
+## 4. Assertions
+
+- **No conditional assertion skip.** Never wrap `expect()` in `if` blocks:
+
+  ```typescript
+  // BAD — silently passes when element is absent
+  if (await element.isVisible()) {
+    await expect(element).toHaveText("expected");
+  }
+
+  // GOOD — fails explicitly when element is absent
+  await expect(element).toBeVisible();
+  await expect(element).toHaveText("expected");
+  ```
+
+- Use Playwright's built-in auto-waiting (`toBeVisible`, `toHaveText`, etc.) instead of manual waits.
+
+## 5. Naming Conventions
+
+- Test data: prefix with `E2E` or `e2e-` (e.g., `E2E Test Entry`, `e2e-user@example.com`).
+- Test files: `<feature>.spec.ts` in `e2e/tests/`.
+- Page objects: `<feature>.page.ts` in `e2e/page-objects/`.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,4 +1,3 @@
-// IMPROVE(#35): add docs/e2e-guidelines.md (test isolation, destructive-test rules)
 // IMPROVE(#37): add ESLint rule to forbid conditional assertion skip in e2e/tests
 import { defineConfig, devices } from "@playwright/test";
 


### PR DESCRIPTION
## Summary

Closes #35, Closes #36

- Add `docs/e2e-guidelines.md` covering test isolation, destructive test rules, cleanup scope, and assertion patterns
- Update `.github/PULL_REQUEST_TEMPLATE.md` with E2E safety checklist (3 items)
- Remove resolved `IMPROVE(#35)` annotation from `e2e/playwright.config.ts`

## Test plan

- [x] Docs only — no code changes, no test/lint/build impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)