### PR TITLE
fix(ui): improve layout consistency across dashboard pages

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -34,7 +34,7 @@
     "watchtower": "Watchtower",
     "tags": "Tags",
     "vault": "Vault",
-    "personalVault": "Vault",
+    "personalVault": "Personal Vault",
     "security": "Security",
     "auditLog": "Audit Log",
     "auditLogPersonal": "Account",

--- a/src/app/[locale]/dashboard/orgs/[orgId]/page.tsx
+++ b/src/app/[locale]/dashboard/orgs/[orgId]/page.tsx
@@ -381,15 +381,6 @@ export default function OrgDashboardPage({
           titleExtra={!isPrimaryScopeLabel && org ? <OrgRoleBadge role={org.role} /> : null}
           actions={
             <>
-              <EntrySortMenu
-                sortBy={sortBy}
-                onSortByChange={setSortBy}
-                labels={{
-                  updated: tDash("sortUpdated"),
-                  created: tDash("sortCreated"),
-                  title: tDash("sortTitle"),
-                }}
-              />
               {canCreate && !isOrgSpecialView && (
                 contextualEntryType ? (
                   <Button
@@ -439,8 +430,8 @@ export default function OrgDashboardPage({
           }
         />
 
-        <Card className="rounded-xl border bg-card/80 p-3">
-          <div className="relative">
+        <Card className="flex items-center gap-2 rounded-xl border bg-card/80 p-3">
+          <div className="relative flex-1">
             <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input
               className="pl-9"
@@ -449,6 +440,15 @@ export default function OrgDashboardPage({
               onChange={(e) => setSearchQuery(e.target.value)}
             />
           </div>
+          <EntrySortMenu
+            sortBy={sortBy}
+            onSortByChange={setSortBy}
+            labels={{
+              updated: tDash("sortUpdated"),
+              created: tDash("sortCreated"),
+              title: tDash("sortTitle"),
+            }}
+          />
         </Card>
 
         {isOrgArchive ? (

--- a/src/app/[locale]/dashboard/orgs/page.tsx
+++ b/src/app/[locale]/dashboard/orgs/page.tsx
@@ -59,7 +59,7 @@ export default function OrgsPage() {
             </div>
             <OrgCreateDialog
               trigger={
-                <Button size="sm">
+                <Button>
                   <Plus className="mr-2 h-4 w-4" />
                   {t("createOrg")}
                 </Button>
@@ -69,49 +69,47 @@ export default function OrgsPage() {
           </div>
         </Card>
 
-        <Card className="rounded-xl border bg-card/80 p-4">
-          {loading ? (
-            <div className="flex items-center justify-center py-12">
-              <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-            </div>
-          ) : orgs.length === 0 ? (
-            <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-center">
-              <Building2 className="mb-4 h-12 w-12 text-muted-foreground" />
-              <p className="text-muted-foreground">{t("noOrgs")}</p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                {t("noOrgsDesc")}
-              </p>
-            </div>
-          ) : (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {orgs.map((org) => (
-                <Link
-                  key={org.id}
-                  href={`/dashboard/orgs/${org.id}`}
-                  className="group block rounded-xl border bg-card/80 p-4 transition-colors hover:bg-accent"
-                >
-                  <div className="mb-2 flex items-start justify-between gap-2">
-                    <h3 className="truncate font-semibold">{org.name}</h3>
-                    <OrgRoleBadge role={org.role} />
-                  </div>
-                  {org.description && (
-                    <p className="mb-3 line-clamp-2 text-sm text-muted-foreground">
-                      {org.description}
-                    </p>
-                  )}
-                  <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                    <span className="flex items-center gap-1">
-                      <Users className="h-3 w-3" />
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <KeyRound className="h-3 w-3" />
-                    </span>
-                  </div>
-                </Link>
-              ))}
-            </div>
-          )}
-        </Card>
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          </div>
+        ) : orgs.length === 0 ? (
+          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-center">
+            <Building2 className="mb-4 h-12 w-12 text-muted-foreground" />
+            <p className="text-muted-foreground">{t("noOrgs")}</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {t("noOrgsDesc")}
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {orgs.map((org) => (
+              <Link
+                key={org.id}
+                href={`/dashboard/orgs/${org.id}`}
+                className="group block rounded-xl border bg-card/80 p-4 transition-colors hover:bg-accent"
+              >
+                <div className="mb-2 flex items-start justify-between gap-2">
+                  <h3 className="truncate font-semibold">{org.name}</h3>
+                  <OrgRoleBadge role={org.role} />
+                </div>
+                {org.description && (
+                  <p className="mb-3 line-clamp-2 text-sm text-muted-foreground">
+                    {org.description}
+                  </p>
+                )}
+                <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <Users className="h-3 w-3" />
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <KeyRound className="h-3 w-3" />
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
         </div>
     </div>
   );

--- a/src/components/emergency-access/create-grant-dialog.tsx
+++ b/src/components/emergency-access/create-grant-dialog.tsx
@@ -80,8 +80,8 @@ export function CreateGrantDialog({ onCreated }: CreateGrantDialogProps) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button size="sm">
-          <Plus className="mr-1 h-4 w-4" />
+        <Button>
+          <Plus className="mr-2 h-4 w-4" />
           {t("addTrustedContact")}
         </Button>
       </DialogTrigger>

--- a/src/components/passwords/password-dashboard.tsx
+++ b/src/components/passwords/password-dashboard.tsx
@@ -158,17 +158,6 @@ export function PasswordDashboard({ view, tagId, folderId, entryType }: Password
           actions={
             <>
               {!isTrash && !isArchive && (
-                <EntrySortMenu
-                  sortBy={sortBy}
-                  onSortByChange={setSortBy}
-                  labels={{
-                    updated: t("sortUpdated"),
-                    created: t("sortCreated"),
-                    title: t("sortTitle"),
-                  }}
-                />
-              )}
-              {!isTrash && !isArchive && (
                 contextualEntryType ? (
                   <Button
                     onClick={() => {
@@ -216,8 +205,21 @@ export function PasswordDashboard({ view, tagId, folderId, entryType }: Password
           }
         />
 
-        <div className="mb-4 rounded-xl border bg-card/80 p-3">
-          <SearchBar ref={searchRef} value={searchQuery} onChange={setSearchQuery} />
+        <div className="mb-4 flex items-center gap-2 rounded-xl border bg-card/80 p-3">
+          <div className="flex-1">
+            <SearchBar ref={searchRef} value={searchQuery} onChange={setSearchQuery} />
+          </div>
+          {!isTrash && !isArchive && (
+            <EntrySortMenu
+              sortBy={sortBy}
+              onSortByChange={setSortBy}
+              labels={{
+                updated: t("sortUpdated"),
+                created: t("sortCreated"),
+                title: t("sortTitle"),
+              }}
+            />
+          )}
         </div>
 
         <div className="space-y-4">


### PR DESCRIPTION
## Summary
- English sidebar label changed from "Vault" to "Personal Vault" for clarity
- Unified button sizes by removing `size="sm"` from Org create and Emergency Access add contact buttons
- Removed redundant outer `<Card>` wrapper from organization list (individual items already have card styling)
- Moved sort menu (`EntrySortMenu`) from header actions into search card for both personal and org dashboards

## Test plan
- [x] All 2186 existing tests pass (`npx vitest run`)
- [x] ESLint clean (`npm run lint`)
- [x] TypeScript: no new errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)