### PR TITLE
fix(ui): add consistent header icons across dashboard pages

### DIFF
--- a/src/app/[locale]/dashboard/orgs/[orgId]/page.tsx
+++ b/src/app/[locale]/dashboard/orgs/[orgId]/page.tsx
@@ -7,6 +7,7 @@ import { Link } from "@/i18n/navigation";
 import { PasswordCard } from "@/components/passwords/password-card";
 import { EntryListHeader } from "@/components/passwords/entry-list-header";
 import { EntrySortMenu } from "@/components/passwords/entry-sort-menu";
+import { SearchBar } from "@/components/layout/search-bar";
 import type { InlineDetailData } from "@/components/passwords/password-detail-inline";
 import { OrgPasswordForm } from "@/components/org/org-password-form";
 import { OrgArchivedList } from "@/components/org/org-archived-list";
@@ -14,14 +15,13 @@ import { OrgTrashList } from "@/components/org/org-trash-list";
 import { OrgRoleBadge } from "@/components/org/org-role-badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Plus, KeyRound, Search, FileText, CreditCard, IdCard, Fingerprint } from "lucide-react";
+import { Plus, KeyRound, FileText, CreditCard, IdCard, Fingerprint, Star, Archive, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { ORG_ROLE, ENTRY_TYPE, apiPath } from "@/lib/constants";
 import type { EntryTypeValue } from "@/lib/constants";
@@ -190,6 +190,24 @@ export default function OrgDashboardPage({
       : isOrgFavorites
         ? t("favorites")
       : (activeCategoryLabel ?? t("passwords"));
+  const ENTRY_TYPE_ICONS: Record<string, React.ReactNode> = {
+    LOGIN: <KeyRound className="h-6 w-6" />,
+    SECURE_NOTE: <FileText className="h-6 w-6" />,
+    CREDIT_CARD: <CreditCard className="h-6 w-6" />,
+    IDENTITY: <IdCard className="h-6 w-6" />,
+    PASSKEY: <Fingerprint className="h-6 w-6" />,
+  };
+
+  const headerIcon = isOrgTrash
+    ? <Trash2 className="h-6 w-6" />
+    : isOrgArchive
+      ? <Archive className="h-6 w-6" />
+      : isOrgFavorites
+        ? <Star className="h-6 w-6" />
+        : activeEntryType && ENTRY_TYPE_ICONS[activeEntryType]
+          ? ENTRY_TYPE_ICONS[activeEntryType]
+          : <KeyRound className="h-6 w-6" />;
+
   const isOrgAll =
     !isOrgTrash &&
     !isOrgArchive &&
@@ -375,6 +393,7 @@ export default function OrgDashboardPage({
     <div className="flex-1 overflow-auto p-4 md:p-6">
       <div className="mx-auto max-w-4xl space-y-6">
         <EntryListHeader
+          icon={headerIcon}
           title={isPrimaryScopeLabel ? subtitle : (org?.name ?? "...")}
           subtitle={subtitle}
           showSubtitle={!isPrimaryScopeLabel}
@@ -430,15 +449,9 @@ export default function OrgDashboardPage({
           }
         />
 
-        <Card className="flex items-center gap-2 rounded-xl border bg-card/80 p-3">
-          <div className="relative flex-1">
-            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-            <Input
-              className="pl-9"
-              placeholder={subtitle}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
+        <div className="flex items-center gap-2 rounded-xl border bg-card/80 p-3">
+          <div className="flex-1">
+            <SearchBar value={searchQuery} onChange={setSearchQuery} />
           </div>
           <EntrySortMenu
             sortBy={sortBy}
@@ -449,7 +462,7 @@ export default function OrgDashboardPage({
               title: tDash("sortTitle"),
             }}
           />
-        </Card>
+        </div>
 
         {isOrgArchive ? (
           <OrgArchivedList

--- a/src/app/[locale]/dashboard/watchtower/page.tsx
+++ b/src/app/[locale]/dashboard/watchtower/page.tsx
@@ -124,7 +124,8 @@ export default function WatchtowerPage() {
       <div className="mx-auto max-w-4xl space-y-6">
         <Card className="rounded-xl border bg-gradient-to-b from-muted/30 to-background p-4">
           <div className="flex items-center justify-between gap-3">
-            <div>
+            <div className="flex items-center gap-3">
+              <Shield className="h-6 w-6" />
               <h1 className="text-2xl font-bold">{t("title")}</h1>
             </div>
             <Button

--- a/src/components/layout/sidebar-sections.tsx
+++ b/src/components/layout/sidebar-sections.tsx
@@ -16,7 +16,6 @@ import { ENTRY_TYPE } from "@/lib/constants";
 import type { SidebarOrganizeTagItem } from "@/hooks/use-sidebar-data";
 import { type VaultContext } from "@/hooks/use-vault-context";
 import {
-  FolderOpen,
   Tag,
   Star,
   Archive,
@@ -56,7 +55,7 @@ export function VaultSection({
     <div className="space-y-1">
       <Button variant={isSelectedVaultAll ? "secondary" : "ghost"} className="w-full justify-start gap-2" asChild>
         <Link href={isOrg ? `/dashboard/orgs/${vaultContext.orgId}` : "/dashboard"} onClick={onNavigate}>
-          <FolderOpen className="h-4 w-4" />
+          <KeyRound className="h-4 w-4" />
           {t("passwords")}
         </Link>
       </Button>

--- a/src/components/passwords/entry-list-header.tsx
+++ b/src/components/passwords/entry-list-header.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { Card } from "@/components/ui/card";
 
 interface EntryListHeaderProps {
+  icon?: ReactNode;
   title: string;
   subtitle?: string;
   showSubtitle?: boolean;
@@ -12,6 +13,7 @@ interface EntryListHeaderProps {
 }
 
 export function EntryListHeader({
+  icon,
   title,
   subtitle,
   showSubtitle = false,
@@ -23,6 +25,7 @@ export function EntryListHeader({
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 space-y-1">
           <div className="flex min-w-0 items-center gap-3">
+            {icon}
             <h1 className="truncate text-2xl font-bold tracking-tight">{title}</h1>
             {titleExtra}
           </div>

--- a/src/components/passwords/password-dashboard.tsx
+++ b/src/components/passwords/password-dashboard.tsx
@@ -21,7 +21,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Plus, KeyRound, FileText, CreditCard, IdCard, Fingerprint } from "lucide-react";
+import { Plus, KeyRound, FileText, CreditCard, IdCard, Fingerprint, Star, Archive, Trash2 } from "lucide-react";
 import type { EntryTypeValue } from "@/lib/constants";
 import { ENTRY_TYPE } from "@/lib/constants";
 
@@ -70,6 +70,24 @@ export function PasswordDashboard({ view, tagId, folderId, entryType }: Password
         : entryType && ENTRY_TYPE_TITLES[entryType]
           ? ENTRY_TYPE_TITLES[entryType]
           : t("passwords");
+  const ENTRY_TYPE_ICONS: Record<string, React.ReactNode> = {
+    LOGIN: <KeyRound className="h-6 w-6" />,
+    SECURE_NOTE: <FileText className="h-6 w-6" />,
+    CREDIT_CARD: <CreditCard className="h-6 w-6" />,
+    IDENTITY: <IdCard className="h-6 w-6" />,
+    PASSKEY: <Fingerprint className="h-6 w-6" />,
+  };
+
+  const headerIcon = isTrash
+    ? <Trash2 className="h-6 w-6" />
+    : isFavorites
+      ? <Star className="h-6 w-6" />
+      : isArchive
+        ? <Archive className="h-6 w-6" />
+        : entryType && ENTRY_TYPE_ICONS[entryType]
+          ? ENTRY_TYPE_ICONS[entryType]
+          : <KeyRound className="h-6 w-6" />;
+
   const isPersonalAll = !isTrash && !isArchive && !isFavorites && !entryType && !tagId && !folderId;
   const isCategorySelected = !!(entryType && ENTRY_TYPE_TITLES[entryType]);
   const isFolderOrTagSelected = Boolean(tagId || folderId);
@@ -152,6 +170,7 @@ export function PasswordDashboard({ view, tagId, folderId, entryType }: Password
     <div className="flex-1 p-4 md:p-6">
       <div className="mx-auto max-w-4xl space-y-4">
         <EntryListHeader
+          icon={headerIcon}
           title={isPrimaryScopeLabel ? subtitle : t("personalVault")}
           subtitle={subtitle}
           showSubtitle={!isPrimaryScopeLabel}


### PR DESCRIPTION
## Summary
- Add `icon` prop to `EntryListHeader` component for header icon support
- Change sidebar "Passwords" icon from `FolderOpen` to `KeyRound`
- Add context-aware header icons to personal and org dashboards (KeyRound, Star, Archive, Trash2, category-specific icons)
- Add `Shield` icon to Watchtower page header
- Unify org search box to use `SearchBar` component (matching personal dashboard layout)

## Test plan
- [x] All 2186 existing tests pass (`npx vitest run`)
- [x] ESLint clean (`npm run lint`)
- [x] TypeScript: no new errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)