### PR TITLE
docs: update READMEs and architecture docs for tenant/SCIM/RLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ A self-hosted password manager with SSO authentication, end-to-end encryption, a
 - **Account Lockout** - Progressive lockout (5→15min, 10→1h, 15→24h) with audit logging
 - **Rate Limiting** - Redis-backed vault unlock rate limiting
 - **CSP & Security Headers** - Content Security Policy with nonce, CSP violation reporting
+- **SCIM 2.0 Provisioning** - Tenant-scoped user/group sync (RFC 7644) with Bearer token auth
+- **Multi-Tenant Isolation** - PostgreSQL FORCE ROW LEVEL SECURITY on 28 tables with IdP claim-based tenant resolution
 - **Self-Hosted** - Docker Compose with PostgreSQL, SAML Jackson, and Redis
 - **Browser Extension (Chrome/Edge, MV3)** - Manual autofill, inline suggestions, and AWS 3-field fill (Account ID/Alias + IAM username + password)
 
@@ -249,6 +251,7 @@ src/
 │   ├── emergency-access/     # Emergency access workflows
 │   ├── watchtower/           # Security audit (HIBP, analysis)
 │   ├── health/               # Health check (liveness + readiness)
+│   ├── scim/v2/              # SCIM 2.0 provisioning (Users / Groups)
 │   └── csp-report/           # CSP violation reporting
 ├── components/
 │   ├── layout/               # Header, Sidebar, SearchBar
@@ -309,6 +312,8 @@ extension/
 - **Rate limiting** - Redis-backed rate limiting on sensitive endpoints (including vault unlock)
 - **CSRF defense** - JSON body + SameSite cookie + CSP + Origin header validation on destructive endpoints
 - **CSP** - Content Security Policy with nonce-based script control and violation reporting
+- **Multi-tenant isolation** - PostgreSQL FORCE RLS on 28 tables with CI guard scripts to prevent accidental RLS bypass
+- **SCIM 2.0** - Tenant-scoped Bearer tokens, Users/Groups endpoints (RFC 7644)
 
 ## Deployment Guides
 

--- a/docs/architecture/feature-comparison.md
+++ b/docs/architecture/feature-comparison.md
@@ -81,8 +81,17 @@ Because competitor capabilities vary by plan and deployment model, always verify
 | Feature | passwd-sso | 1Password | Bitwarden | Notes |
 |---|---|---|---|---|
 | Self-hosted | Done | No | Yes | Docker/Terraform |
-| API / integration | Done | Varies | Yes | Webhook/SCIM not yet implemented |
+| SCIM 2.0 provisioning | Done | Yes | Yes | Tenant-scoped tokens, team-level group mapping |
+| API / integration | Done | Varies | Yes | SCIM implemented; Webhook not yet |
+
+## 9. Multi-Tenant / Isolation
+
+| Feature | passwd-sso | 1Password | Bitwarden | Notes |
+|---|---|---|---|---|
+| Tenant isolation | Done | Yes | Yes | FORCE ROW LEVEL SECURITY on 28 tables |
+| Bootstrap tenant migration | Done | N/A | N/A | Auto-migrate from personal to IdP tenant |
+| CI RLS guard scripts | Done | N/A | N/A | Prevent accidental RLS bypass |
 
 ---
 
-*Last updated: 2026-02-14*
+*Last updated: 2026-02-27*

--- a/docs/architecture/production-readiness.md
+++ b/docs/architecture/production-readiness.md
@@ -1,6 +1,6 @@
 # passwd-sso Production-Readiness ToDo
 
-Last updated: 2026-02-17  
+Last updated: 2026-02-27
 Baseline: `main` branch
 
 ---
@@ -79,8 +79,8 @@ Areas already considered at production level.
 
 - Crypto design: PBKDF2 600k + HKDF domain separation + AAD binding
 - Type safety: `any` count 0, `as any` count 1, `@ts-ignore` count 0, `strict: true`
-- Test ratio: app 38,646 LOC vs tests 20,280 LOC (~52%, 119 files / 1,152 tests)
-- Security review: all 6 sections PASS in `../security/security-review.md`
+- Test ratio: app ~50k LOC vs tests ~30k LOC (295 files / 2,575 tests)
+- Security review: all 7 sections PASS in `../security/security-review.md` (Section 7: tenant RLS added 2026-02-27)
 - CSP + nonce enforcement + violation reporting
 - Rate limiting (Redis + in-memory fallback)
 - i18n (en/ja 884-key parity, APP_NAME env support)
@@ -91,7 +91,7 @@ Areas already considered at production level.
 - Audit logs (personal + team, filter/export supported)
 - External audit-log forwarding (pino + Fluent Bit sidecar)
 - Environment validation (26 vars, startup-time schema check)
-- CI/CD pipeline (4 parallel GitHub Actions jobs, ESLint + Vitest + Next.js build)
+- CI/CD pipeline (4 parallel GitHub Actions jobs, ESLint + Vitest + Next.js build + RLS guard scripts)
 - Structured app logging (pino + withRequestLog + CSP-report sanitization)
 - Health checks (`/api/health/live` liveness + `/api/health/ready` readiness, DB/Redis checks, timeout protection)
 - Monitoring/alerting (CloudWatch metric filters + alarms + ECS stop EventBridge + SNS)
@@ -103,6 +103,8 @@ Areas already considered at production level.
 - DB connection pool tuning (env tuning + maxLifetimeSeconds + graceful shutdown + RDS connection alarm)
 - Load testing (k6 6 scenarios, triple-guard seed script, initial SLOs, threshold pass/fail)
 - Dependency license audit (allowlist JSON 17 entries, strict CI enforcement, expiry checks, policy docs)
+- Multi-tenant isolation (FORCE RLS on 28 tables, `withBypassRls` CI allowlist guard, nested auth CI guard)
+- SCIM 2.0 provisioning (Users + Groups, tenant-scoped tokens, RFC 7644)
 - Production code `console.log`: 0, `TODO/FIXME`: 0
 
 ---


### PR DESCRIPTION
## Summary

- **README.ja.md**: Rename 組織→チーム (6 occurrences), add SCIM 2.0 and multi-tenant isolation features
- **README.md**: Add SCIM 2.0 Provisioning and Multi-Tenant Isolation to Features, Security Model, and Project Structure
- **feature-comparison.md**: Add SCIM row and Section 9 (Multi-Tenant/Isolation)
- **feature-gap-analysis.md**: Mark B-1 SCIM as implemented (2026-02-27), update score 8/11→9/11
- **production-readiness.md**: Update test ratio (295 files / 2,575 tests), add RLS/SCIM to completed areas
- **tenant-team-migration-plan.md**: Mark all phases 0-9 as complete
- **security-review.md**: Add Section 7 (Multi-Tenant RLS, 5-point checklist, all PASS)

## Test plan

- [x] Documentation-only changes, no code impact
- [x] Verify all links and formatting render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)