### PR TITLE
feat: P3 security hardening — session limits, idle timeout, vault auto-lock

### DIFF
--- a/docs/review/fix-audit-log-consistency-deviation.md
+++ b/docs/review/fix-audit-log-consistency-deviation.md
@@ -1,0 +1,12 @@
+# Coding Deviation Log: fix-audit-log-consistency
+Created: 2026-03-07T00:00:00+09:00
+
+## Deviations from Plan
+
+### D-1: SCIM_USER_UPDATE metadata not changed (Plan item 6)
+- **Plan description**: Verify SCIM_USER_UPDATE metadata differences are legitimate
+- **Actual implementation**: Confirmed PUT (full replace with externalId) vs PATCH (partial with patched fields only) is intentional. No code changes made.
+- **Reason**: The difference reflects semantic API behavior, not inconsistency
+- **Impact scope**: None
+
+No other deviations. All remaining plan items implemented as specified.

--- a/docs/review/fix-audit-log-consistency-plan.md
+++ b/docs/review/fix-audit-log-consistency-plan.md
@@ -1,0 +1,56 @@
+# Plan: fix-audit-log-consistency
+
+## Objective
+
+Standardize audit log output fields across all `logAudit()` call sites to ensure consistency in `targetType`, `targetId`, `metadata`, `ip`/`userAgent`, and constant usage.
+
+## Requirements
+
+### Functional
+1. Replace string literals (`"PERSONAL"`, `"RECOVERY_PASSPHRASE_RESET"`, etc.) with `AUDIT_SCOPE.*` / `AUDIT_ACTION.*` constants
+2. Add missing `ip`/`userAgent` via `extractRequestMeta(req)` where `req` is available
+3. Remove duplicate `ip` from metadata when already present as top-level field
+4. Add `USER` to `AUDIT_TARGET_TYPE` and replace `"User"` string literals
+5. Unify `EMERGENCY_ACCESS_ACTIVATE` metadata to always include `ownerId`, `granteeId`, and `earlyApproval`
+6. Verify SCIM_USER_UPDATE metadata differences are legitimate (PUT=full replace, PATCH=partial)
+7. Add `provider` to `AUTH_LOGIN` metadata for login source traceability
+
+### Non-functional
+- No runtime behavior changes beyond additional/corrected metadata fields
+- No new dependencies
+- All existing tests must continue to pass
+
+## Technical Approach
+
+- Direct edits to existing route handlers and `auth.ts`
+- Add `USER` constant to `src/lib/constants/audit-target.ts`
+- Add `AUDIT_SCOPE`, `AUDIT_ACTION`, `AUDIT_TARGET_TYPE` imports where missing
+- Use `extractRequestMeta(req)` spread pattern for ip/userAgent
+- Add `{ provider }` to AUTH_LOGIN metadata in both auth.ts (signIn event) and passkey verify route
+
+## Implementation Steps
+
+1. **vault/recovery-key/recover/route.ts**: Import constants, replace `"PERSONAL"` → `AUDIT_SCOPE.PERSONAL`, `"RECOVERY_PASSPHRASE_RESET"` → `AUDIT_ACTION.RECOVERY_PASSPHRASE_RESET`
+2. **vault/recovery-key/generate/route.ts**: Import constants, replace string literals for scope and action
+3. **vault/reset/route.ts**: Import constants, replace `"PERSONAL"` and `"VAULT_RESET_EXECUTED"` with constants
+4. **auth/passkey/verify/route.ts**: Import `extractRequestMeta`, add `...extractRequestMeta(req)` and `metadata: { provider: "passkey" }`
+5. **admin/rotate-master-key/route.ts**: Remove `ip` from metadata object (already in top-level), use `...extractRequestMeta(req)` to also capture `userAgent`
+6. **constants/audit-target.ts**: Add `USER: "User"` entry
+7. **vault/admin-reset/route.ts**: Import `AUDIT_TARGET_TYPE`, replace `"User"` → `AUDIT_TARGET_TYPE.USER`
+8. **tenant/members/[userId]/reset-vault/route.ts**: Same as above
+9. **tenant/members/[userId]/reset-vault/[resetId]/revoke/route.ts**: Same as above
+10. **emergency-access/[id]/approve/route.ts**: Add `ownerId` to metadata
+11. **emergency-access/[id]/vault/route.ts**: Add `granteeId` and `earlyApproval: false` to metadata
+12. **auth.ts**: Destructure `account` in signIn event, add `metadata: { provider: account?.provider ?? "unknown" }`
+
+## Testing Strategy
+
+- Run `npm run build` to verify no TypeScript compilation errors
+- Run existing test suite to ensure no regressions
+- Verify no new `"User"` or `"PERSONAL"` string literal usage in audit log calls via grep
+
+## Considerations & Constraints
+
+- Auth.js v5 `signIn` event does not provide `req` object, so `ip`/`userAgent` cannot be added there (known limitation, not addressed)
+- System events (`WEBHOOK_DELIVERY_FAILED`, `DIRECTORY_SYNC_STALE_RESET`) intentionally lack `ip`/`userAgent` as there is no HTTP request context
+- SCIM PUT vs PATCH metadata difference is legitimate and not changed

--- a/docs/review/fix-audit-log-consistency-review.md
+++ b/docs/review/fix-audit-log-consistency-review.md
@@ -1,0 +1,43 @@
+# Code Review: fix-audit-log-consistency
+
+Date: 2026-03-07T00:00:00+09:00
+Review round: 2
+
+## Changes from Previous Round
+
+Round 1 findings F-1, F-2, T-1 were fixed. F-3, S-2, T-2~T-5 were skipped (out of scope).
+
+### Round 1 → Round 2 Resolution
+
+- F-1 (destructure → spread pattern): **Resolved** — 3 files updated to `...extractRequestMeta(req)`
+- F-2 (auth.ts ip/userAgent comment): **Resolved** — Comment added at auth.ts L309-311
+- T-1 (passkey test assertions): **Resolved** — extractRequestMeta mock added, expect.objectContaining used
+
+## Functionality Findings
+
+No findings.
+
+## Security Findings
+
+No findings.
+
+## Testing Findings
+
+No findings.
+
+## Resolution Status
+
+### F-1: vault/recovery-key/generate, recover, reset destructure pattern
+
+- Action: Changed to `...extractRequestMeta(req)` spread pattern
+- Modified files: vault/recovery-key/generate/route.ts, vault/recovery-key/recover/route.ts, vault/reset/route.ts
+
+### F-2: auth.ts signIn ip/userAgent limitation
+
+- Action: Added comment explaining Auth.js event limitation
+- Modified file: src/auth.ts:309-311
+
+### T-1: passkey/verify test assertions
+
+- Action: Added extractRequestMeta mock, updated logAudit assertion to expect.objectContaining with metadata/ip/userAgent
+- Modified file: src/app/api/auth/passkey/verify/route.test.ts:48,172-181

--- a/src/app/api/admin/rotate-master-key/route.ts
+++ b/src/app/api/admin/rotate-master-key/route.ts
@@ -141,7 +141,6 @@ export async function POST(req: NextRequest) {
   }
 
   // Audit log (async nonblocking; logAudit handles errors internally)
-  const { ip } = extractRequestMeta(req);
   logAudit({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.MASTER_KEY_ROTATION,
@@ -149,9 +148,8 @@ export async function POST(req: NextRequest) {
     metadata: {
       targetVersion,
       revokedShares,
-      ip,
     },
-    ip,
+    ...extractRequestMeta(req),
   });
 
   return NextResponse.json({

--- a/src/app/api/auth/passkey/verify/route.test.ts
+++ b/src/app/api/auth/passkey/verify/route.test.ts
@@ -45,6 +45,7 @@ vi.mock("@/lib/session-meta", () => ({
 
 vi.mock("@/lib/audit", () => ({
   logAudit: mockLogAudit,
+  extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test-agent", acceptLanguage: null }),
 }));
 
 vi.mock("@/lib/constants", () => ({
@@ -168,11 +169,16 @@ describe("POST /api/auth/passkey/verify", () => {
     });
     await POST(req);
 
-    expect(mockLogAudit).toHaveBeenCalledWith({
-      scope: "PERSONAL",
-      action: "AUTH_LOGIN",
-      userId: "user-1",
-    });
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "PERSONAL",
+        action: "AUTH_LOGIN",
+        userId: "user-1",
+        metadata: { provider: "passkey" },
+        ip: "127.0.0.1",
+        userAgent: "test-agent",
+      }),
+    );
   });
 
   it("returns 403 when origin is invalid", async () => {

--- a/src/app/api/auth/passkey/verify/route.ts
+++ b/src/app/api/auth/passkey/verify/route.ts
@@ -8,7 +8,7 @@ import { assertOrigin } from "@/lib/csrf";
 import { authorizeWebAuthn } from "@/lib/webauthn-authorize";
 import { createCustomAdapter } from "@/lib/auth-adapter";
 import { sessionMetaStorage } from "@/lib/session-meta";
-import { logAudit } from "@/lib/audit";
+import { logAudit, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { prisma } from "@/lib/prisma";
 import { withBypassRls } from "@/lib/tenant-rls";
@@ -123,6 +123,8 @@ async function handlePOST(req: NextRequest) {
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.AUTH_LOGIN,
     userId: user.id,
+    metadata: { provider: "passkey" },
+    ...extractRequestMeta(req),
   });
 
   // Set session cookie

--- a/src/app/api/emergency-access/[id]/approve/route.ts
+++ b/src/app/api/emergency-access/[id]/approve/route.ts
@@ -55,7 +55,7 @@ export async function POST(
     userId: session.user.id,
     targetType: AUDIT_TARGET_TYPE.EMERGENCY_ACCESS_GRANT,
     targetId: id,
-    metadata: { granteeId: grant.granteeId, earlyApproval: true },
+    metadata: { ownerId: grant.ownerId, granteeId: grant.granteeId, earlyApproval: true },
     ...extractRequestMeta(req),
   });
 

--- a/src/app/api/emergency-access/[id]/vault/route.ts
+++ b/src/app/api/emergency-access/[id]/vault/route.ts
@@ -55,7 +55,7 @@ export async function GET(
       userId: session.user.id,
       targetType: AUDIT_TARGET_TYPE.EMERGENCY_ACCESS_GRANT,
       targetId: id,
-      metadata: { ownerId: grant.ownerId },
+      metadata: { ownerId: grant.ownerId, granteeId: grant.granteeId, earlyApproval: false },
       ...extractRequestMeta(req),
     });
   }

--- a/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/revoke/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/revoke/route.ts
@@ -15,7 +15,7 @@ import {
 import { withTenantRls } from "@/lib/tenant-rls";
 import { notificationTitle, notificationBody } from "@/lib/notification-messages";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
-import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants";
+import { AUDIT_SCOPE, AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { NOTIFICATION_TYPE } from "@/lib/constants/notification";
 
 export const runtime = "nodejs";
@@ -84,7 +84,7 @@ export async function POST(
     action: AUDIT_ACTION.ADMIN_VAULT_RESET_REVOKE,
     userId: session.user.id,
     tenantId: actor.tenantId,
-    targetType: "User",
+    targetType: AUDIT_TARGET_TYPE.USER,
     targetId: targetUserId,
     metadata: { revokedById: session.user.id, resetId },
     ...extractRequestMeta(req),

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.ts
@@ -19,7 +19,7 @@ import {
 import { withTenantRls } from "@/lib/tenant-rls";
 import { notificationTitle, notificationBody } from "@/lib/notification-messages";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
-import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants";
+import { AUDIT_SCOPE, AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { NOTIFICATION_TYPE } from "@/lib/constants/notification";
 
 export const runtime = "nodejs";
@@ -152,7 +152,7 @@ export async function POST(
     action: AUDIT_ACTION.ADMIN_VAULT_RESET_INITIATE,
     userId: session.user.id,
     tenantId: actor.tenantId,
-    targetType: "User",
+    targetType: AUDIT_TARGET_TYPE.USER,
     targetId: targetUserId,
     ...extractRequestMeta(req),
   });

--- a/src/app/api/vault/admin-reset/route.ts
+++ b/src/app/api/vault/admin-reset/route.ts
@@ -8,7 +8,7 @@ import { assertOrigin } from "@/lib/csrf";
 import { logAudit, extractRequestMeta } from "@/lib/audit";
 import { executeVaultReset } from "@/lib/vault-reset";
 import { withBypassRls } from "@/lib/tenant-rls";
-import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants";
+import { AUDIT_SCOPE, AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 
 export const runtime = "nodejs";
 
@@ -129,7 +129,7 @@ export async function POST(req: NextRequest) {
     userId: session.user.id,
     tenantId: resetRecord.tenantId,
     teamId: resetRecord.teamId ?? undefined,
-    targetType: "User",
+    targetType: AUDIT_TARGET_TYPE.USER,
     targetId: session.user.id,
     metadata: {
       deletedEntries,

--- a/src/app/api/vault/recovery-key/generate/route.ts
+++ b/src/app/api/vault/recovery-key/generate/route.ts
@@ -9,6 +9,7 @@ import { VERIFIER_VERSION } from "@/lib/crypto-client";
 import { assertOrigin } from "@/lib/csrf";
 import { withRequestLog } from "@/lib/with-request-log";
 import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { z } from "zod";
 
@@ -136,13 +137,11 @@ async function handlePOST(request: NextRequest) {
 
   // Audit log
   const isRegeneration = !!user.recoveryKeySetAt;
-  const { ip, userAgent } = extractRequestMeta(request);
   logAudit({
-    scope: "PERSONAL",
-    action: isRegeneration ? "RECOVERY_KEY_REGENERATED" : "RECOVERY_KEY_CREATED",
+    scope: AUDIT_SCOPE.PERSONAL,
+    action: isRegeneration ? AUDIT_ACTION.RECOVERY_KEY_REGENERATED : AUDIT_ACTION.RECOVERY_KEY_CREATED,
     userId: session.user.id,
-    ip,
-    userAgent,
+    ...extractRequestMeta(request),
   });
 
   return NextResponse.json({ success: true });

--- a/src/app/api/vault/recovery-key/recover/route.ts
+++ b/src/app/api/vault/recovery-key/recover/route.ts
@@ -8,6 +8,7 @@ import { API_ERROR } from "@/lib/api-error-codes";
 import { assertOrigin } from "@/lib/csrf";
 import { withRequestLog } from "@/lib/with-request-log";
 import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { z } from "zod";
 
@@ -207,18 +208,16 @@ async function handleReset(body: unknown, userId: string, request: NextRequest) 
     }),
   );
 
-  const { ip, userAgent } = extractRequestMeta(request);
   logAudit({
-    scope: "PERSONAL",
-    action: "RECOVERY_PASSPHRASE_RESET",
+    scope: AUDIT_SCOPE.PERSONAL,
+    action: AUDIT_ACTION.RECOVERY_PASSPHRASE_RESET,
     userId,
     metadata: {
       keyVersion: user.keyVersion,
       recoveryKeyRegenerated: true,
       lockoutReset: true,
     },
-    ip,
-    userAgent,
+    ...extractRequestMeta(request),
   });
 
   return NextResponse.json({ success: true });

--- a/src/app/api/vault/reset/route.ts
+++ b/src/app/api/vault/reset/route.ts
@@ -6,6 +6,7 @@ import { API_ERROR } from "@/lib/api-error-codes";
 import { assertOrigin } from "@/lib/csrf";
 import { withRequestLog } from "@/lib/with-request-log";
 import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants";
 import { executeVaultReset } from "@/lib/vault-reset";
 import { z } from "zod/v4";
 
@@ -76,17 +77,15 @@ async function handlePOST(request: NextRequest) {
   const { deletedEntries, deletedAttachments } =
     await executeVaultReset(userId);
 
-  const { ip, userAgent } = extractRequestMeta(request);
   logAudit({
-    scope: "PERSONAL",
-    action: "VAULT_RESET_EXECUTED",
+    scope: AUDIT_SCOPE.PERSONAL,
+    action: AUDIT_ACTION.VAULT_RESET_EXECUTED,
     userId,
     metadata: {
       deletedEntries,
       deletedAttachments,
     },
-    ip,
-    userAgent,
+    ...extractRequestMeta(request),
   });
 
   return NextResponse.json({ success: true });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -304,12 +304,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     },
   },
   events: {
-    async signIn({ user }) {
+    async signIn({ user, account }) {
       if (user.id) {
+        // NOTE: Auth.js events do not expose NextRequest, so ip/userAgent
+        // cannot be captured here. Passkey sign-in records them separately
+        // in /api/auth/passkey/verify.
         logAudit({
           scope: AUDIT_SCOPE.PERSONAL,
           action: AUDIT_ACTION.AUTH_LOGIN,
           userId: user.id,
+          metadata: { provider: account?.provider ?? "unknown" },
         });
       }
     },

--- a/src/lib/constants/audit-target.ts
+++ b/src/lib/constants/audit-target.ts
@@ -1,4 +1,5 @@
 export const AUDIT_TARGET_TYPE = {
+  USER: "User",
   ATTACHMENT: "Attachment",
   EMERGENCY_ACCESS_GRANT: "EmergencyAccessGrant",
   FOLDER: "Folder",


### PR DESCRIPTION
## Summary
- Enforce per-tenant concurrent session limits with server-side eviction (Serializable isolation)
- Add session idle timeout with server-side enforcement in `updateSession`
- Add tenant-configurable vault auto-lock (web + browser extension)
- Add history lazy re-encryption endpoints (personal + team) with TOCTOU-safe CAS
- Migrate Redis client to ioredis with Sentinel support
- Add security docs (reproducible builds, Redis HA)

## Key changes
- **Session eviction**: `$transaction` with `isolationLevel: "Serializable"` prevents race conditions
- **History re-encrypt**: `updateMany` with `keyVersion` optimistic lock prevents TOCTOU
- **Idle timeout**: Read `lastActiveAt` before updating, `updateAge: 30` for timely detection
- **Vault auto-lock**: 30s check interval (web `setInterval`, extension `chrome.alarms`)
- **Validation**: 1MB blob size limit, hex format checks, `req.json()` error handling

## Code review
3-agent review (functionality, security, testing) completed in 2 rounds.  
All Critical/Major findings resolved. 5 Minor items deferred (Sentinel config, test dedup).  
See `docs/archive/review/p3-security-hardening-code-review-r2.md` for details.

## Test plan
- [x] 3828 tests pass (`npm test`)
- [x] Production build succeeds (`npm run build`)
- [x] Manual: session idle timeout triggers sign-out
- [x] Manual: vault auto-lock triggers lock screen (web + extension)
- [x] Manual: concurrent session eviction works
- [x] Manual: history re-encryption via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)