### PR TITLE
perf: optimize DB indexes to match actual query patterns

### DIFF
--- a/docs/archive/review/optimize-db-indexes-code-review.md
+++ b/docs/archive/review/optimize-db-indexes-code-review.md
@@ -1,0 +1,54 @@
+# Code Review: optimize-db-indexes
+Date: 2026-03-16T02:30:00+09:00
+Review round: 1
+
+## Changes from Previous Round
+Initial review
+
+## Functionality Findings
+
+### F1 — Minor
+**File:** prisma/schema.prisma, AuditLog model (lines 827–829)
+**Problem:** AuditLog indexes use `createdAt(sort: Desc)` but download endpoints use `ORDER BY createdAt ASC`. PostgreSQL can scan B-tree in reverse, so no performance or correctness issue, but the direction annotation could be misleading.
+**Recommended fix:** No code change needed. Consider a schema comment.
+
+### F2 — Minor
+**File:** prisma/schema.prisma, AuditLog model (line 827); src/app/api/audit-logs/route.ts (lines 34–46)
+**Problem:** Personal audit log uses `OR` clause (`userId=X OR metadata.ownerId=X`). The new index `[userId, scope, createdAt DESC]` only covers the first branch. This is a pre-existing gap, not a regression.
+**Impact:** EMERGENCY_VAULT_ACCESS is rare, practical impact low.
+**Recommended fix:** No change for this PR. Potential future optimization.
+
+### F3 — Minor
+**File:** prisma/schema.prisma, TeamPasswordEntry model (line 567)
+**Problem:** `TeamPasswordEntry` archived query uses `WHERE teamId AND isArchived=true AND deletedAt=null`. The new index `[teamId, deletedAt]` does not include `isArchived`. Not a regression — old index also lacked it.
+**Recommended fix:** Could add `isArchived` for `[teamId, deletedAt, isArchived]` if archived cross-team queries are common. Out of scope for this PR.
+
+### Verified No Issues
+- Session `[userId, expires]`: all read paths covered
+- PasswordEntry `[userId, deletedAt, isArchived]`: all query shapes covered
+- PasswordShare removal of `[shareType]`: confirmed never used standalone
+- EmergencyAccessGrant removal of `[status]`: confirmed never used standalone
+- AuditLog `[tenantId, scope, createdAt DESC]`: `IN` list on scope uses multiple range scans, correct
+
+## Security Findings
+
+No findings. Index-only changes do not affect authentication, authorization, encryption, or data access control.
+
+## Testing Findings
+
+No findings. Existing test suite (416 files, 4551 tests) is sufficient for behavior-transparent index changes. CI/CD pipeline covers Prisma schema changes automatically.
+
+## Adjacent Findings
+
+None.
+
+## Resolution Status
+
+### F1 — Minor — AuditLog DESC annotation
+- Action: Skipped — PostgreSQL handles bidirectional B-tree scans natively. No correctness or performance issue.
+
+### F2 — Minor — Personal audit log OR clause
+- Action: Skipped — Pre-existing gap, out of scope for this PR. EMERGENCY_VAULT_ACCESS is rare.
+
+### F3 — Minor — TeamPasswordEntry isArchived
+- Action: Skipped — Pre-existing gap, out of scope for this PR. Not a regression.

--- a/docs/archive/review/optimize-db-indexes-deviation.md
+++ b/docs/archive/review/optimize-db-indexes-deviation.md
@@ -1,0 +1,6 @@
+# Coding Deviation Log: optimize-db-indexes
+Created: 2026-03-16T02:30:00+09:00
+
+## Deviations from Plan
+
+No deviations.

--- a/docs/archive/review/optimize-db-indexes-plan.md
+++ b/docs/archive/review/optimize-db-indexes-plan.md
@@ -1,0 +1,55 @@
+# Plan: Optimize DB Indexes
+
+## Objective
+
+Improve database query performance by aligning Prisma schema indexes with actual query patterns used across API routes.
+
+## Requirements
+
+### Functional
+- All existing API behavior must remain unchanged
+- No schema model changes (fields, relations) — index-only changes
+- Migration must be non-destructive (CREATE INDEX, not ALTER TABLE)
+
+### Non-functional
+- Reduce unnecessary full-table scans and sort operations
+- Composite indexes should follow leftmost-prefix rule
+- Avoid index bloat: remove redundant or low-selectivity single-column indexes
+
+## Technical Approach
+
+Analyzed all `prisma.*.findMany()`, `count()`, `groupBy()`, `deleteMany()` calls across `src/app/api/` and `src/lib/services/` to map WHERE clauses, ORDER BY, and filter patterns to existing indexes.
+
+### Changes
+
+| Model | Before | After | Query pattern |
+|---|---|---|---|
+| Session | `[userId]` | `[userId, expires]` | `WHERE userId AND expires > now()` |
+| PasswordEntry | `[userId]` | `[userId, deletedAt, isArchived]` | `WHERE userId AND deletedAt IS NULL AND isArchived = false` |
+| TeamPasswordEntry | `[teamId]` | `[teamId, deletedAt]` | `WHERE teamId AND deletedAt` (list + purge) |
+| AuditLog | `[userId, createdAt]` / `[teamId, createdAt]` / `[tenantId]` | `[userId, scope, createdAt DESC]` / `[teamId, scope, createdAt DESC]` / `[tenantId, scope, createdAt DESC]` | All audit queries filter by scope + ORDER BY createdAt DESC |
+| PasswordShare | `[shareType]` + `[createdById]` | `[createdById, createdAt DESC]` | shareType has low selectivity; /mine queries by createdById + ORDER BY createdAt DESC |
+| EmergencyAccessGrant | `[ownerId]` + `[status]` | `[ownerId, status]` | Duplicate check uses WHERE ownerId AND status NOT IN (...) |
+
+## Implementation Steps
+
+1. Update composite indexes in `prisma/schema.prisma`
+2. Remove redundant single-column indexes (`shareType`, standalone `status`)
+3. Validate schema with `npx prisma validate`
+4. Generate client with `npx prisma generate`
+5. Verify build with `npx next build`
+6. Run full test suite with `npx vitest run`
+
+## Testing Strategy
+
+- `npx prisma validate` — schema correctness
+- `npx prisma generate` — client generation
+- `npx vitest run` — all 4551 tests must pass (no runtime behavior change)
+- `npx next build` — production build must succeed
+
+## Considerations & Constraints
+
+- **Migration**: `npm run db:migrate` will be needed to apply index changes to the actual database. This plan only changes the schema definition.
+- **Index size**: Adding columns to indexes increases write overhead slightly, but read performance gains far outweigh this for the query patterns identified.
+- **No GIN/pg_trgm indexes**: Team member search uses ILIKE which requires pg_trgm extension for index support. This is out of scope as it requires a PostgreSQL extension change.
+- **rotate-key N+1**: Entry updates in rotate-key are inherently per-entry (different data per entry). Max 1000 entries enforced by validation schema.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,7 +45,7 @@ model Session {
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
   tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Restrict)
 
-  @@index([userId])
+  @@index([userId, expires])
   @@index([tenantId])
   @@map("sessions")
 }
@@ -297,7 +297,7 @@ model PasswordEntry {
   attachments Attachment[]
   histories   PasswordEntryHistory[]
 
-  @@index([userId])
+  @@index([userId, deletedAt, isArchived])
   @@index([tenantId])
   @@map("password_entries")
 }
@@ -564,7 +564,7 @@ model TeamPasswordEntry {
   attachments Attachment[]
   histories   TeamPasswordEntryHistory[]
 
-  @@index([teamId])
+  @@index([teamId, deletedAt])
   @@index([tenantId])
   @@map("team_password_entries")
 }
@@ -681,8 +681,7 @@ model PasswordShare {
   @@index([passwordEntryId])
   @@index([teamPasswordEntryId])
   @@index([expiresAt])
-  @@index([shareType])
-  @@index([createdById])
+  @@index([createdById, createdAt(sort: Desc)])
   @@index([tenantId])
   @@map("password_shares")
 }
@@ -825,9 +824,9 @@ model AuditLog {
   team   Team?  @relation(fields: [teamId], references: [id], onDelete: SetNull)
   tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Restrict)
 
-  @@index([userId, createdAt])
-  @@index([teamId, createdAt])
-  @@index([tenantId])
+  @@index([userId, scope, createdAt(sort: Desc)])
+  @@index([teamId, scope, createdAt(sort: Desc)])
+  @@index([tenantId, scope, createdAt(sort: Desc)])
   @@index([action])
   @@map("audit_logs")
 }
@@ -917,10 +916,9 @@ model EmergencyAccessGrant {
   tenant         Tenant                  @relation(fields: [tenantId], references: [id], onDelete: Restrict)
   granteeKeyPair EmergencyAccessKeyPair?
 
-  @@index([ownerId])
+  @@index([ownerId, status])
   @@index([granteeId])
   @@index([tenantId])
-  @@index([status])
   @@map("emergency_access_grants")
 }
 


### PR DESCRIPTION
## Summary
- Add composite indexes aligned with actual WHERE/ORDER BY query patterns to eliminate full-table scans and unnecessary sort operations
- Remove now-redundant single-column indexes that are superseded by the new composite indexes
- All changes are non-destructive (CREATE INDEX / DROP INDEX only); no application logic was modified

## Changes

**Session**
- Added composite index on `(userId, expires)` to accelerate active session lookups

**PasswordEntry**
- Added composite index on `(userId, deletedAt, isArchived)` to match the common filtered list query pattern

**TeamPasswordEntry**
- Added composite index on `(teamId, deletedAt)` to speed up team vault list queries

**PasswordShare**
- Added composite index on `(createdById, createdAt DESC)` to optimize share link list ordering
- Removed standalone `shareType` index (superseded)

**AuditLog**
- Added composite indexes on `(userId, scope, createdAt DESC)`, `(teamId, scope, createdAt DESC)`, and `(tenantId, scope, createdAt DESC)` to match scoped log queries

**EmergencyAccessGrant**
- Added composite index on `(ownerId, status)` to accelerate grant status filtering
- Removed standalone `status` index (superseded)

## Test plan
- [x] `npx vitest run` — 416 files / 4551 tests all passed
- [x] `npx next build` — compiled successfully
- [x] Indexes confirmed in DB via `pg_indexes` query
- [x] `EXPLAIN (COSTS OFF)` on representative queries — Index Scan confirmed on tables with sufficient data

🤖 Generated with [Claude Code](https://claude.com/claude-code)