### PR TITLE
fix: force node24 runtime for release-please-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ jobs:
     name: "Release Please"
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      # Workaround: force node24 runtime for actions still pinned to node20.
+      # Remove after upgrading to release-please-action v5 (node24-native).
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:


### PR DESCRIPTION
## Summary
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to the Release Please job to suppress the Node.js 20 deprecation warning
- Temporary workaround until `googleapis/release-please-action` v5 ships with native node24 support (upstream PR #1188)
- GitHub will force node24 on 2026-06-02; this change opts in early

## Test plan
- [ ] Verify the Release Please workflow runs without the Node.js 20 deprecation warning
- [ ] Verify release-please still creates/updates Release PRs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)