### PR TITLE
feat: UI/UX improvements - theme toggle, passkey badge, extension bypass, dark theme

### DIFF
--- a/docs/archive/review/ui-ux-improvements-plan.md
+++ b/docs/archive/review/ui-ux-improvements-plan.md
@@ -1,0 +1,218 @@
+# UI/UX Improvements Plan
+
+## Objective
+Fix three UI/UX issues: (1) add dark/light theme toggle, (2) hide misleading passkey sign-in badge for OIDC/SAML2 users, (3) suppress extension passkey save banner on own app pages.
+
+## Requirements
+- Theme toggle must work on all pages (dashboard, admin, settings)
+- Passkey badge must correctly reflect whether the user can actually use passkey sign-in
+- Extension must not offer to save passkeys when on passwd-sso's own WebAuthn registration page
+
+---
+
+## Issue 1: Theme Toggle (Dark/Light Mode)
+
+### Background
+The app has full dark mode CSS support (CSS variables in `globals.css`, 112+ `dark:` Tailwind classes) and `next-themes` v0.4.6 installed, but no ThemeProvider or UI toggle exists.
+
+### Plan
+
+#### 1a. Create ThemeProvider component
+- **File**: `src/components/providers/theme-provider.tsx`
+- Wrap `next-themes` `ThemeProvider` with:
+  - `attribute="class"`
+  - `defaultTheme="system"`
+  - `enableSystem`
+  - `disableTransitionOnChange`
+- Export as `"use client"` component
+
+#### 1b. Add ThemeProvider to locale layout
+- **File**: `src/app/[locale]/layout.tsx`
+- Provider nesting order (critical — Toaster uses `useTheme()` and must be inside ThemeProvider):
+  ```
+  NextIntlClientProvider
+    ThemeProvider          ← NEW
+      SessionProvider
+        VaultProvider
+          {children}
+          <Toaster />     ← inside ThemeProvider context
+  ```
+
+#### 1c. Create ThemeToggle component
+- **File**: `src/components/layout/theme-toggle.tsx`
+- Three-state toggle: light / dark / system
+- Use `DropdownMenu` (consistent with existing header dropdowns)
+- Icons: `Sun`, `Moon`, `Monitor` from lucide-react
+- Use `useTheme()` from `next-themes`
+- Use `useTranslations("Common")` for labels (Common is in NS_GLOBAL, available on all pages)
+
+#### 1d. Add ThemeToggle to Header
+- **File**: `src/components/layout/header.tsx`
+- Place between `LanguageSwitcher` and `NotificationBell`
+- Guard with `mounted` state (same pattern as LanguageSwitcher)
+
+#### 1e. Add i18n translations
+- **Files**: `messages/ja/Common.json`, `messages/en/Common.json`
+- Keys: `theme`, `themeLight`, `themeDark`, `themeSystem`
+- Rationale: Common namespace is in NS_GLOBAL, ensuring translations are available on all pages including admin
+
+---
+
+## Issue 2: Passkey Sign-in Capability Check for OIDC/SAML2 Users
+
+### Background
+When a user authenticates via OIDC (Google) or SAML2 (BoxyHQ Jackson), passkey sign-in is not available as a login method. The "パスキーログイン" (Passkey sign-in) badge on registered passkeys is misleading because:
+- OIDC/SAML2 users cannot use passkeys to sign in
+- The badge implies the passkey can be used for login when it cannot
+- Passkeys for these users are only useful for vault unlock (PRF) and offline backup
+
+### Plan
+
+#### 2a. Create API endpoint to check passkey sign-in capability
+- **File**: `src/app/api/user/auth-provider/route.ts`
+- **Auth**: Use `auth()` for session check (route-handler auth pattern)
+- **Proxy protection**: Add `USER_AUTH_PROVIDER = "/api/user/auth-provider"` to `API_PATH` in `src/lib/constants.ts` and add `pathname.startsWith(API_PATH.USER_AUTH_PROVIDER)` to `src/proxy.ts` protected route list
+- **DB query**: Use `withBypassRls(prisma, fn, BYPASS_PURPOSE.AUTH_FLOW)` to query `Account` table (same purpose as `auth-adapter.ts` Account queries)
+- **Multi-account handling**: Query ALL accounts for the user (`findMany` with `userId`), then determine:
+  - If user has ONLY OIDC/SAML providers (google, saml-jackson) → `canPasskeySignIn: false`
+  - If user has any local auth provider (passkey, nodemailer) → `canPasskeySignIn: true`
+- **Response**: `{ canPasskeySignIn: boolean }` (not raw provider string — avoid leaking internal implementation details)
+
+#### 2b. Add conditional badge rendering to PasskeyCredentialsCard
+- **File**: `src/components/settings/passkey-credentials-card.tsx`
+- Fetch `/api/user/auth-provider` on mount
+- When `canPasskeySignIn === false`:
+  - Show "パスキーログイン" badge as disabled (grayed out, line-through) with tooltip explaining the limitation
+- When `canPasskeySignIn === true` (or fetch fails — fail open for UX):
+  - Show badge normally (existing behavior)
+
+#### 2c. Update i18n translations
+- **Files**: `messages/ja/WebAuthn.json`, `messages/en/WebAuthn.json`
+- Add key: `discoverableDisabledOidc` — "OIDC/SAML認証ではパスキーログインは利用できません" / "Passkey sign-in is not available with OIDC/SAML authentication"
+
+#### 2d. Decision: Don't hide entire passkey registration
+- Passkeys are still useful for: vault unlock via PRF, offline backup via largeBlob
+- Only the "sign-in" badge needs adjustment
+
+---
+
+## Issue 3: Browser Extension Passkey Save Banner on Own App
+
+### Background
+The browser extension suppresses ID/password save banners on passwd-sso's own pages via `isOwnAppPage()` check (`extension/src/background/index.ts:2104`, `:2221`). However, the passkey message handlers (`PASSKEY_GET_MATCHES`, `PASSKEY_CHECK_DUPLICATE`, `PASSKEY_CREATE_CREDENTIAL` at lines 2346-2391) lack this check. When a user registers a passkey on passwd-sso's own WebAuthn page, the extension's WebAuthn interceptor triggers `showPasskeySaveBanner()` — offering to save the passkey as a vault entry, which is meaningless (passkeys are device-bound, not storable credentials).
+
+### Plan
+
+#### 3a. Add `isOwnAppPage()` check to passkey message handlers
+- **File**: `extension/src/background/index.ts`
+- For `PASSKEY_GET_MATCHES` (line 2346): check `_sender.tab?.url` with `isOwnAppPage()`, return `{ entries: [], suppressed: true }`
+- For `PASSKEY_CHECK_DUPLICATE` (line 2352): return `{ exists: false, suppressed: true }` if own app
+- For `PASSKEY_CREATE_CREDENTIAL` (line 2373): return `{ ok: false, suppressed: true }` if own app
+- Note: `isOwnAppPage()` is for UX suppression only; `isSenderAuthorizedForRpId` in `passkey-provider.ts` remains the security boundary (add code comment to clarify)
+
+#### 3b. Handle suppression in content script bridge
+- **File**: `extension/src/content/webauthn-bridge-lib.ts`
+- `handleConfirmCreate()` (line 109): in the `PASSKEY_CHECK_DUPLICATE` response handling, check for `suppressed: true` BEFORE checking `entries`/`vaultLocked`. When suppressed, call `respond(requestId, { action: "platform" })` immediately to fall through to native WebAuthn without showing the save banner
+- `handleGetMatches()`: when background returns `{ entries: [], suppressed: true }`, skip showing passkey dropdown and respond with empty selection
+
+#### 3c. Suppression response convention
+- All suppressed passkey responses include `suppressed: true` field
+- Content script checks `suppressed` flag first in all passkey response handlers
+- WebAuthn interceptor in MAIN world falls through to browser's native `navigator.credentials.create()` seamlessly (existing "platform" action already does this)
+
+---
+
+## Testing Strategy
+
+### Issue 1 Tests
+- `src/components/layout/theme-toggle.test.tsx` (`// @vitest-environment jsdom`)
+  - Mock `next-themes` `useTheme()`: `vi.mock("next-themes", () => ({ useTheme: vi.fn().mockReturnValue({ theme: "light", setTheme: vi.fn(), resolvedTheme: "light" }), ThemeProvider: ({ children }) => children }))`
+  - Test: renders three options (light/dark/system)
+  - Test: calls `setTheme()` on selection
+- Update `src/components/layout/header.test.tsx`
+  - Add mock for `./theme-toggle` (same pattern as existing `./language-switcher` and `notification-bell` mocks)
+  - Verify ThemeToggle renders in header
+
+### Issue 2 Tests
+- `src/app/api/user/auth-provider/route.test.ts`
+  - Follow existing pattern (mockAuth, mockPrisma, createRequest helpers)
+  - Mock `withBypassRls`: `vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()), withBypassRls: vi.fn((_prisma, fn) => fn()) }))`
+  - Test: 401 without session
+  - Test: 200 with canPasskeySignIn=true (user has passkey provider)
+  - Test: 200 with canPasskeySignIn=false (user has only google provider)
+  - Test: 200 with canPasskeySignIn=true (user has both google + nodemailer)
+  - Test: DB error → 500
+
+### Issue 3 Tests
+- Update `extension/src/background/background.test.ts`
+  - Add describe block "PASSKEY handlers suppress on own app"
+  - Prerequisite: existing `installChromeMock` sets `serverUrl: "https://localhost:3000"` in `chrome.storage.local.get`. Use sender URL `https://localhost:3000/dashboard/settings/security/passkey` to trigger `isOwnAppPage() → true`
+  - Test: PASSKEY_GET_MATCHES returns `{ entries: [], suppressed: true }` on own app URL
+  - Test: PASSKEY_CHECK_DUPLICATE returns `{ exists: false, suppressed: true }` on own app URL
+- Update `extension/src/content/__tests__/webauthn-bridge-lib.test.ts`
+  - Test: handleConfirmCreate with suppressed dupResponse (`{ suppressed: true }`) → responds with `{ action: "platform" }` without showing banner
+
+All new test files must include `// @vitest-environment jsdom` when testing DOM components.
+
+---
+
+## Considerations & Constraints
+- Theme preference stored in localStorage only (via next-themes default). No DB persistence needed.
+- `isOwnAppPage()` depends on `serverUrl` being set in chrome.storage.local. If unset, returns false (banner shows — acceptable UX degradation, not a security issue).
+- Fail-open for passkey badge: if `/api/user/auth-provider` fetch fails, show badge normally (don't degrade existing UX).
+
+---
+
+## User Operation Scenarios
+
+### Scenario 1: Theme Toggle
+1. User opens dashboard → header shows theme toggle button (sun/moon icon)
+2. User clicks toggle → dropdown shows Light / Dark / System options
+3. User selects Dark → page immediately switches to dark mode
+4. User navigates to admin settings → dark mode persists (localStorage)
+5. User refreshes page → dark mode persists (no flash)
+
+### Scenario 2: OIDC User Views Passkey Settings
+1. User signed in via Google OIDC → navigates to Settings > Security > Passkey
+2. User has registered a passkey (for PRF vault unlock)
+3. "パスキーログイン" badge shows as grayed out with line-through
+4. User hovers badge → tooltip: "OIDC/SAML認証ではパスキーログインは利用できません"
+5. "保管庫のロック解除" badge shows normally (PRF still works)
+
+### Scenario 3: User with Multiple Auth Providers
+1. User originally signed up via Magic Link, later linked Google account
+2. User has both "nodemailer" and "google" Account records
+3. API returns `canPasskeySignIn: true` (has local auth)
+4. Badge shows normally
+
+### Scenario 4: Extension on Own App
+1. User opens passwd-sso WebAuthn settings page in browser
+2. User clicks "Register new passkey" → browser's native WebAuthn dialog appears
+3. Extension detects `navigator.credentials.create()` call
+4. Extension background checks `isOwnAppPage()` → true
+5. Extension returns suppressed response → NO save banner shown
+6. Native WebAuthn registration completes normally
+
+---
+
+## Files to Create
+1. `src/components/providers/theme-provider.tsx`
+2. `src/components/layout/theme-toggle.tsx`
+3. `src/app/api/user/auth-provider/route.ts`
+4. `src/app/api/user/auth-provider/route.test.ts`
+5. `src/components/layout/theme-toggle.test.tsx`
+
+## Files to Modify
+1. `src/app/[locale]/layout.tsx` — add ThemeProvider (provider nesting order)
+2. `src/components/layout/header.tsx` — add ThemeToggle
+3. `src/components/settings/passkey-credentials-card.tsx` — conditional badge
+4. `src/lib/constants/api-path.ts` — add USER_AUTH_PROVIDER to API_PATH
+5. `src/proxy.ts` — add auth-provider to protected routes
+6. `messages/ja/Common.json` — theme translations
+7. `messages/en/Common.json` — theme translations
+8. `messages/ja/WebAuthn.json` — OIDC disclaimer
+9. `messages/en/WebAuthn.json` — OIDC disclaimer
+10. `extension/src/background/index.ts` — add isOwnAppPage() check to passkey handlers
+11. `extension/src/content/webauthn-bridge-lib.ts` — handle suppression response
+12. `extension/src/background/background.test.ts` — passkey suppression tests
+13. `extension/src/content/__tests__/webauthn-bridge-lib.test.ts` — suppression test

--- a/docs/archive/review/ui-ux-improvements-plan.md
+++ b/docs/archive/review/ui-ux-improvements-plan.md
@@ -195,6 +195,42 @@ All new test files must include `// @vitest-environment jsdom` when testing DOM 
 
 ---
 
+## Implementation Checklist
+
+### Shared utilities to reuse
+- `withBypassRls(prisma, fn, BYPASS_PURPOSE.AUTH_FLOW)` from `src/lib/tenant-rls.ts`
+- `auth()` from `@/auth` for session check
+- `unauthorized()` / `errorResponse()` from `src/lib/api-helpers.ts`
+- `withRequestLog()` wrapper for route handlers
+- `API_PATH` object in `src/lib/constants/api-path.ts`
+- `isOwnAppPage()` in `extension/src/background/index.ts`
+- `EXT_MSG` constants in `extension/src/lib/constants.ts`
+
+### Files that must be modified
+- [ ] `src/components/providers/theme-provider.tsx` — CREATE
+- [ ] `src/components/layout/theme-toggle.tsx` — CREATE
+- [ ] `src/app/api/user/auth-provider/route.ts` — CREATE
+- [ ] `src/app/[locale]/layout.tsx` — add ThemeProvider in correct nesting order
+- [ ] `src/components/layout/header.tsx` — add ThemeToggle
+- [ ] `src/components/settings/passkey-credentials-card.tsx` — conditional badge
+- [ ] `src/lib/constants/api-path.ts` — add USER_AUTH_PROVIDER
+- [ ] `src/proxy.ts` — add auth-provider to protected routes
+- [ ] `messages/ja/Common.json` — theme translations
+- [ ] `messages/en/Common.json` — theme translations
+- [ ] `messages/ja/WebAuthn.json` — OIDC disclaimer
+- [ ] `messages/en/WebAuthn.json` — OIDC disclaimer
+- [ ] `extension/src/background/index.ts` — isOwnAppPage checks for passkey handlers
+- [ ] `extension/src/content/webauthn-bridge-lib.ts` — suppression handling
+
+### Patterns to follow
+- API route: `auth()` → `session?.user?.id` check → `withBypassRls` → `NextResponse.json`
+- API_PATH: `USER_AUTH_PROVIDER: "/api/user/auth-provider"` in api-path.ts
+- Proxy: `pathname.startsWith(API_PATH.USER_AUTH_PROVIDER)` in protected list
+- Translation keys: simple camelCase in Common.json/WebAuthn.json
+- Extension: follow LOGIN_DETECTED isOwnAppPage pattern for PASSKEY_* handlers
+
+---
+
 ## Files to Create
 1. `src/components/providers/theme-provider.tsx`
 2. `src/components/layout/theme-toggle.tsx`

--- a/docs/archive/review/ui-ux-theme-passkey-badge-code-review.md
+++ b/docs/archive/review/ui-ux-theme-passkey-badge-code-review.md
@@ -1,0 +1,54 @@
+# Code Review: ui-ux-theme-passkey-badge
+Date: 2026-04-07
+Review round: 1 (final)
+
+## Architecture Evaluation: WebAuthn Interceptor Bypass
+
+All three experts agreed the approach is correct:
+- **postMessage from ISOLATED→MAIN world** is the standard Chrome Extension pattern for cross-world communication
+- **Two-layer defense** (MAIN world `ownAppBypass` flag + background `isOwnAppPage()` suppression) provides proper defense-in-depth
+- **Race condition** is mitigated by user interaction timing (chrome.storage.local resolves in <1ms, user click + server round-trip takes seconds)
+- **postMessage spoofing** is possible but harmless — attacker only gets native WebAuthn (no access to vault or stored passkeys)
+
+## Functionality Findings
+
+### F7 [Minor]: ThemeToggle placed before LanguageSwitcher
+- Plan says "between LanguageSwitcher and NotificationBell"
+- Implementation: ThemeToggle → LanguageSwitcher → NotificationBell
+- Decision: Keep current order — theme toggle is a global action and placing it leftmost is natural UX
+
+No Critical or Major findings.
+
+## Security Findings
+
+### S-F01 [Minor]: `ownAppBypass` flag is one-way (cannot be reset)
+- Once set to `true`, stays `true` for the page lifetime
+- XSS could trigger the bypass via postMessage
+- Impact: None — bypass only causes native WebAuthn fallback, no privilege escalation
+- Decision: Acceptable. Added comment documenting design intent.
+
+### S-F04 [Minor]: No rate limiter on /api/user/auth-provider
+- Returns only `{ canPasskeySignIn: boolean }` — minimal information
+- Proxy layer requires session authentication
+- Consistent with existing /api/user/locale pattern
+- Decision: Acceptable for now. Can add rate limiter if needed later.
+
+No Critical or Major findings.
+
+## Testing Findings
+
+### T-F1 [Major]: PasskeyCredentialsCard conditional badge untested
+- Decision: Deferred — component requires extensive mocking, logic is simple (ternary), API route test covers all provider combinations
+
+### T-F2 [Major]: PASSKEY_CREATE_CREDENTIAL suppression test missing
+- Resolution: Added test case in background.test.ts
+
+### T-F3 [Minor]: MCP truncation untested — Deferred (low risk)
+### T-F4 [Minor]: ThemeToggle dark icon untested — Deferred (low risk)
+### T-F5 [Minor]: Sidebar admin mock effectiveness — Deferred (low risk)
+
+## Resolution Status
+
+### T-F2 [Major] PASSKEY_CREATE_CREDENTIAL suppression test
+- Action: Added test case "returns suppressed for PASSKEY_CREATE_CREDENTIAL on own app"
+- Modified file: extension/src/__tests__/background.test.ts

--- a/docs/archive/review/ui-ux-theme-passkey-badge-deviation.md
+++ b/docs/archive/review/ui-ux-theme-passkey-badge-deviation.md
@@ -1,0 +1,16 @@
+# Coding Deviation Log: ui-ux-theme-passkey-badge
+Created: 2026-04-06
+
+## Deviations from Plan
+
+### D1: API_ERROR.INTERNAL → API_ERROR.INTERNAL_ERROR
+- **Plan description**: Use `API_ERROR.INTERNAL` for catch block error response
+- **Actual implementation**: Used `API_ERROR.INTERNAL_ERROR` — the correct key name in the codebase
+- **Reason**: `API_ERROR.INTERNAL` does not exist; the actual enum key is `INTERNAL_ERROR`
+- **Impact scope**: `src/app/api/user/auth-provider/route.ts` only
+
+### D2: Theme translation key "themeSystem" (ja) changed
+- **Plan description**: `"themeSystem": "システム"`
+- **Actual implementation**: `"themeSystem": "システム設定に従う"`
+- **Reason**: User requested alignment with browser extension terminology. Extension uses "システム設定に従う" for the system theme option.
+- **Impact scope**: `messages/ja/Common.json` only

--- a/docs/archive/review/ui-ux-theme-passkey-badge-review.md
+++ b/docs/archive/review/ui-ux-theme-passkey-badge-review.md
@@ -1,0 +1,102 @@
+# Plan Review: ui-ux-theme-passkey-badge
+Date: 2026-04-06
+Review round: 2
+
+## Changes from Previous Round
+Initial review
+
+## Functionality Findings
+
+### F1 [Critical] ThemeProvider placement causes Toaster to lose theme context
+- **File**: `src/app/[locale]/layout.tsx`
+- **Problem**: Plan says "wrap children inside NextIntlClientProvider, outside SessionProvider" which is ambiguous. ThemeProvider must be placed INSIDE NextIntlClientProvider so that Toaster (which calls `useTheme()` in `src/components/ui/sonner.tsx`) is within ThemeProvider context.
+- **Impact**: Toaster won't reflect theme changes; potential hydration mismatch.
+- **Recommended action**: Specify provider order explicitly:
+  ```
+  NextIntlClientProvider > ThemeProvider > SessionProvider > VaultProvider > {children} + Toaster
+  ```
+
+### F2 [Major] Multi-account provider query undefined
+- **File**: `src/app/api/user/auth-provider/route.ts` (new)
+- **Problem**: Users can have multiple Account records (e.g., Google + Magic Link). Plan doesn't define how to determine "is this user OIDC/SAML2-only". Single `findFirst` query returns arbitrary provider. Also needs `withBypassRls` for Account table access.
+- **Impact**: Incorrect badge display for multi-provider users.
+- **Recommended action**: Query all accounts for the user. Return a boolean `canPasskeySignIn` (true if user has no OIDC/SAML-only constraint) rather than raw provider string. Use `withBypassRls` as in `auth-adapter.ts`.
+
+### F3 [Major] Extension suppression flow incomplete in handleConfirmCreate
+- **File**: `extension/src/content/webauthn-bridge-lib.ts:109-150`
+- **Problem**: `handleConfirmCreate` branches on `dupResponse` fields (entries, vaultLocked) but won't handle new `suppressed` field. Banner will still show.
+- **Impact**: Passkey save banner still appears on own app despite background suppression.
+- **Recommended action**: Add `suppressed` handling to `handleConfirmCreate` — when `PASSKEY_CHECK_DUPLICATE` returns `{ suppressed: true }`, call `respond(requestId, { action: "platform" })` immediately.
+
+### F4 [Minor] Theme translation namespace not in NS_GLOBAL
+- **File**: `src/i18n/namespace-groups.ts`, `messages/*/Dashboard.json`
+- **Problem**: Dashboard namespace is not in NS_GLOBAL. ThemeToggle in Header needs translations on all pages (including admin).
+- **Impact**: Theme labels show as raw keys on admin pages.
+- **Recommended action**: Add theme keys to a namespace already in NS_GLOBAL (e.g., Common.json), or create a new ThemeToggle-specific namespace and add it to NS_GLOBAL.
+
+## Security Findings
+
+### S1 [Major] Proxy middleware protection gap for /api/user/auth-provider
+- **File**: `src/proxy.ts`, `src/lib/constants.ts`
+- **Problem**: `/api/user/auth-provider` not in proxy protected routes list. IP access restriction policies won't apply.
+- **Impact**: Endpoint bypasses proxy-level access restriction (tenant IP policy).
+- **Recommended action**: Add `USER_AUTH_PROVIDER` to `API_PATH` and `src/proxy.ts` protection list.
+
+### S2 [Minor] Raw provider string exposure
+- **Problem**: Returning raw DB strings (e.g., "saml-jackson") leaks implementation details.
+- **Recommended action**: Return normalized values or boolean `canPasskeySignIn` instead.
+
+### S3 [Minor] isOwnAppPage() documentation
+- **Problem**: `isOwnAppPage()` is UX suppression, not security guard.
+- **Recommended action**: Add code comment clarifying `isSenderAuthorizedForRpId` is the security boundary.
+
+## Testing Findings
+
+### T1 [Critical] No route test for /api/user/auth-provider
+- **File**: `src/app/api/user/auth-provider/route.test.ts` (missing)
+- **Problem**: Existing pattern (e.g., `/api/user/locale/route.test.ts`) covers 401, 200, DB error cases.
+- **Impact**: Auth bypass, RLS issues undetected.
+- **Recommended action**: Create route.test.ts following existing pattern.
+
+### T2 [Major] No next-themes mock pattern for ThemeToggle tests
+- **File**: new `src/components/layout/theme-toggle.test.tsx`
+- **Problem**: `useTheme` mock not established in project.
+- **Recommended action**: Establish mock: `vi.mock("next-themes", ...)` and add ThemeToggle render/interaction tests.
+
+### T3 [Major] No PasskeyCredentialsCard conditional badge test
+- **File**: new `src/components/settings/passkey-credentials-card.test.tsx`
+- **Problem**: Conditional badge rendering for OIDC/SAML2 untested.
+- **Recommended action**: Test badge visibility with mocked auth-provider response.
+
+### T4 [Major] No PASSKEY_* suppression tests in background.test.ts
+- **File**: `extension/src/background/background.test.ts`
+- **Problem**: LOGIN_DETECTED suppression tested; PASSKEY_* handlers not.
+- **Recommended action**: Add describe block for passkey own-app suppression.
+
+### T5 [Major] No webauthn-bridge-lib suppression test
+- **File**: `extension/src/content/__tests__/webauthn-bridge-lib.test.ts`
+- **Problem**: Bridge handling of suppressed response untested.
+- **Recommended action**: Test handleConfirmCreate with suppressed dupResponse.
+
+### T6 [Minor] jsdom environment annotation for new tests
+- **Recommended action**: New component tests must include `// @vitest-environment jsdom`.
+
+## Round 2 Results
+
+All Round 1 findings (F1-F4, S1-S3, T1-T6) resolved in plan update.
+
+New findings from Round 2:
+- F5 [Minor] BYPASS_PURPOSE value unspecified → RESOLVED (AUTH_FLOW added to plan)
+- F6 [Major] handleGetMatches MAIN world suppressed handling → REJECTED (false finding: MAIN world interceptor already falls through to origGet when entries is empty, no change needed)
+- F7/F8 [Major/Minor] File path error: src/lib/constants.ts → src/lib/constants/api-path.ts → RESOLVED (path corrected)
+- T7 [Major] Test-implementation correspondence unclear → RESOLVED (test plan clarified with implementation dependencies)
+- T8 [Major] isOwnAppPage mock trigger conditions → RESOLVED (serverUrl + sender URL prerequisites documented)
+- T9 [Minor] header.test.tsx theme-toggle mock → RESOLVED (mock added to plan)
+- T10 [Minor] withBypassRls mock pattern → RESOLVED (mock pattern added to plan)
+- N1/Security [Minor] BYPASS_PURPOSE unspecified → RESOLVED (same as F5)
+
+## Adjacent Findings
+None.
+
+## Quality Warnings
+None.

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -1968,6 +1968,102 @@ describe("LOGIN_DETECTED suppresses on own app", () => {
   });
 });
 
+describe("PASSKEY handlers suppress on own app", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    chromeMock = installChromeMock();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes(EXT_API_PATH.EXTENSION_TOKEN_REFRESH)) {
+          return {
+            ok: true,
+            json: async () => ({
+              token: "refreshed-tok",
+              expiresAt: new Date(Date.now() + 900_000).toISOString(),
+              scope: ["passwords:read", "vault:unlock-data"],
+            }),
+          };
+        }
+        if (url.includes(EXT_API_PATH.VAULT_UNLOCK_DATA)) {
+          return {
+            ok: true,
+            json: async () => ({
+              userId: "user-1",
+              accountSalt: "00",
+              encryptedSecretKey: "aa",
+              secretKeyIv: "bb",
+              secretKeyAuthTag: "cc",
+              verificationArtifact: { ciphertext: "11", iv: "22", authTag: "33" },
+            }),
+          };
+        }
+        if (url.includes(EXT_API_PATH.PASSWORDS)) {
+          return {
+            ok: true,
+            json: async () => [
+              {
+                id: "pw-1",
+                encryptedOverview: { ciphertext: "11", iv: "22", authTag: "33" },
+                entryType: EXT_ENTRY_TYPE.LOGIN,
+                aadVersion: 1,
+              },
+            ],
+          };
+        }
+        return { ok: false, json: async () => ({}) };
+      }),
+    );
+
+    await loadBackground();
+
+    await sendMessage({
+      type: "SET_TOKEN",
+      token: "t",
+      expiresAt: Date.now() + 60_000,
+    });
+    await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
+  });
+
+  it("returns suppressed for PASSKEY_GET_MATCHES on own app", async () => {
+    const res = await sendMessageWithSender(
+      { type: "PASSKEY_GET_MATCHES", rpId: "localhost" },
+      { tab: { id: 200, url: "https://localhost:3000/ja/dashboard/settings/security/passkey" } },
+    );
+    expect(res).toEqual(
+      expect.objectContaining({
+        type: "PASSKEY_GET_MATCHES",
+        entries: [],
+        suppressed: true,
+      }),
+    );
+  });
+
+  it("returns suppressed for PASSKEY_CHECK_DUPLICATE on own app", async () => {
+    const res = await sendMessageWithSender(
+      { type: "PASSKEY_CHECK_DUPLICATE", rpId: "localhost", userName: "user@example.com" },
+      { tab: { id: 201, url: "https://localhost:3000/ja/dashboard/settings/security/passkey" } },
+    );
+    expect(res).toEqual(
+      expect.objectContaining({
+        type: "PASSKEY_CHECK_DUPLICATE",
+        exists: false,
+        suppressed: true,
+      }),
+    );
+  });
+
+  it("does not suppress PASSKEY_GET_MATCHES on external URLs", async () => {
+    const res = await sendMessageWithSender(
+      { type: "PASSKEY_GET_MATCHES", rpId: "external.com" },
+      { tab: { id: 202, url: "https://external.com/login" } },
+    );
+    expect(res).not.toHaveProperty("suppressed", true);
+  });
+});
+
 describe("tab event badge updates", () => {
   beforeEach(async () => {
     vi.resetModules();

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -2062,6 +2062,29 @@ describe("PASSKEY handlers suppress on own app", () => {
     );
     expect(res).not.toHaveProperty("suppressed", true);
   });
+
+  it("returns suppressed for PASSKEY_CREATE_CREDENTIAL on own app", async () => {
+    const res = await sendMessageWithSender(
+      {
+        type: "PASSKEY_CREATE_CREDENTIAL",
+        rpId: "localhost",
+        rpName: "passwd-sso",
+        userId: "dXNlci0x",
+        userName: "user@example.com",
+        userDisplayName: "User",
+        excludeCredentialIds: [],
+        clientDataJSON: "{}",
+      },
+      { tab: { id: 203, url: "https://localhost:3000/ja/dashboard/settings/security/passkey" } },
+    );
+    expect(res).toEqual(
+      expect.objectContaining({
+        type: "PASSKEY_CREATE_CREDENTIAL",
+        ok: false,
+        suppressed: true,
+      }),
+    );
+  });
 });
 
 describe("tab event badge updates", () => {

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -2049,7 +2049,7 @@ describe("PASSKEY handlers suppress on own app", () => {
     expect(res).toEqual(
       expect.objectContaining({
         type: "PASSKEY_CHECK_DUPLICATE",
-        exists: false,
+        entries: [],
         suppressed: true,
       }),
     );

--- a/extension/src/__tests__/webauthn-bridge-lib.test.ts
+++ b/extension/src/__tests__/webauthn-bridge-lib.test.ts
@@ -443,4 +443,32 @@ describe("webauthn-bridge-lib handleWebAuthnMessage", () => {
       }),
     );
   });
+
+  it("falls through to platform when PASSKEY_CHECK_DUPLICATE returns suppressed:true", () => {
+    const postedMessages: unknown[] = [];
+    vi.spyOn(window, "postMessage").mockImplementation((data) => {
+      postedMessages.push(data);
+    });
+    sendMessageMock.mockImplementation((_msg: unknown, cb: (r: unknown) => void) => {
+      cb({ suppressed: true });
+    });
+
+    const event = makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-confirm-suppressed",
+        action: "PASSKEY_CONFIRM_CREATE",
+        payload: { rpId: "example.com", rpName: "Example", userName: "alice", userDisplayName: "Alice" },
+      },
+    });
+    handleWebAuthnMessage(event);
+
+    expect(postedMessages).toContainEqual(
+      expect.objectContaining({
+        type: WEBAUTHN_BRIDGE_RESP,
+        requestId: "req-confirm-suppressed",
+        response: { action: "platform" },
+      }),
+    );
+  });
 });

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -2344,13 +2344,25 @@ async function handleMessage(
     }
 
     case EXT_MSG.PASSKEY_GET_MATCHES: {
-      const result = await handlePasskeyGetMatches(message.rpId, _sender.tab?.url);
+      // UX suppression only — isSenderAuthorizedForRpId in passkey-provider.ts
+      // remains the security boundary for passkey operations.
+      const senderUrl = _sender.tab?.url;
+      if (senderUrl && await isOwnAppPage(senderUrl)) {
+        sendResponse({ type: EXT_MSG.PASSKEY_GET_MATCHES, entries: [], suppressed: true } as ExtensionResponse);
+        return;
+      }
+      const result = await handlePasskeyGetMatches(message.rpId, senderUrl);
       sendResponse({ type: EXT_MSG.PASSKEY_GET_MATCHES, ...result } as ExtensionResponse);
       return;
     }
 
     case EXT_MSG.PASSKEY_CHECK_DUPLICATE: {
-      const result = await handlePasskeyCheckDuplicate(message.rpId, message.userName, _sender.tab?.url);
+      const senderUrl = _sender.tab?.url;
+      if (senderUrl && await isOwnAppPage(senderUrl)) {
+        sendResponse({ type: EXT_MSG.PASSKEY_CHECK_DUPLICATE, exists: false, suppressed: true } as ExtensionResponse);
+        return;
+      }
+      const result = await handlePasskeyCheckDuplicate(message.rpId, message.userName, senderUrl);
       sendResponse({ type: EXT_MSG.PASSKEY_CHECK_DUPLICATE, ...result } as ExtensionResponse);
       return;
     }
@@ -2371,6 +2383,11 @@ async function handleMessage(
     }
 
     case EXT_MSG.PASSKEY_CREATE_CREDENTIAL: {
+      const senderUrl = _sender.tab?.url;
+      if (senderUrl && await isOwnAppPage(senderUrl)) {
+        sendResponse({ type: EXT_MSG.PASSKEY_CREATE_CREDENTIAL, ok: false, suppressed: true } as ExtensionResponse);
+        return;
+      }
       try {
         const result = await handlePasskeyCreateCredential({
           rpId: message.rpId,
@@ -2381,7 +2398,7 @@ async function handleMessage(
           excludeCredentialIds: message.excludeCredentialIds,
           clientDataJSON: message.clientDataJSON,
           replaceEntryId: message.replaceEntryId,
-          senderUrl: _sender.tab?.url,
+          senderUrl,
         });
         sendResponse({ type: EXT_MSG.PASSKEY_CREATE_CREDENTIAL, ...result } as ExtensionResponse);
       } catch {

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -2348,7 +2348,7 @@ async function handleMessage(
       // remains the security boundary for passkey operations.
       const senderUrl = _sender.tab?.url;
       if (senderUrl && await isOwnAppPage(senderUrl)) {
-        sendResponse({ type: EXT_MSG.PASSKEY_GET_MATCHES, entries: [], suppressed: true } as ExtensionResponse);
+        sendResponse({ type: EXT_MSG.PASSKEY_GET_MATCHES, entries: [], vaultLocked: false, suppressed: true } as ExtensionResponse);
         return;
       }
       const result = await handlePasskeyGetMatches(message.rpId, senderUrl);
@@ -2359,7 +2359,7 @@ async function handleMessage(
     case EXT_MSG.PASSKEY_CHECK_DUPLICATE: {
       const senderUrl = _sender.tab?.url;
       if (senderUrl && await isOwnAppPage(senderUrl)) {
-        sendResponse({ type: EXT_MSG.PASSKEY_CHECK_DUPLICATE, exists: false, suppressed: true } as ExtensionResponse);
+        sendResponse({ type: EXT_MSG.PASSKEY_CHECK_DUPLICATE, entries: [], suppressed: true } as ExtensionResponse);
         return;
       }
       const result = await handlePasskeyCheckDuplicate(message.rpId, message.userName, senderUrl);

--- a/extension/src/content/webauthn-bridge-lib.ts
+++ b/extension/src/content/webauthn-bridge-lib.ts
@@ -143,7 +143,10 @@ function handleConfirmCreate(
     (dupResponse) => {
       clearTimeout(fallback);
       if (chrome.runtime.lastError || dupResponse?.vaultLocked || dupResponse?.suppressed) {
-        // Vault locked, own app suppression, or SW error — fall through to platform authenticator
+        // All three cases fall through to the platform authenticator, but for different reasons:
+        //   vaultLocked: vault is locked, cannot access stored passkeys
+        //   suppressed:  on own app page, extension should not intercept WebAuthn
+        //   lastError:   service worker error, cannot communicate with background
         fallthrough();
         return;
       }

--- a/extension/src/content/webauthn-bridge-lib.ts
+++ b/extension/src/content/webauthn-bridge-lib.ts
@@ -142,8 +142,8 @@ function handleConfirmCreate(
     { type: EXT_MSG.PASSKEY_CHECK_DUPLICATE, rpId: payload.rpId, userName: payload.userName },
     (dupResponse) => {
       clearTimeout(fallback);
-      if (chrome.runtime.lastError || dupResponse?.vaultLocked) {
-        // Vault locked or SW error — fall through to platform authenticator
+      if (chrome.runtime.lastError || dupResponse?.vaultLocked || dupResponse?.suppressed) {
+        // Vault locked, own app suppression, or SW error — fall through to platform authenticator
         fallthrough();
         return;
       }

--- a/extension/src/content/webauthn-bridge.ts
+++ b/extension/src/content/webauthn-bridge.ts
@@ -7,4 +7,19 @@ const GUARD_KEY = "__pssoWebAuthnBridge";
 if (!(window as unknown as Record<string, boolean>)[GUARD_KEY]) {
   (window as unknown as Record<string, boolean>)[GUARD_KEY] = true;
   window.addEventListener("message", handleWebAuthnMessage);
+
+  // Tell MAIN world interceptor to bypass all WebAuthn interception on own app pages.
+  // This must happen early so the flag is set before any WebAuthn API call.
+  chrome.storage.local.get("serverUrl", ({ serverUrl }) => {
+    if (typeof serverUrl !== "string" || !serverUrl) return;
+    try {
+      const base = new URL(serverUrl);
+      const page = new URL(window.location.href);
+      if (page.origin !== base.origin) return;
+      const bp = base.pathname || "/";
+      if (page.pathname === bp || page.pathname.startsWith(bp.endsWith("/") ? bp : `${bp}/`)) {
+        window.postMessage({ type: "PASSWD_SSO_OWN_APP_BYPASS" }, window.location.origin);
+      }
+    } catch { /* invalid URL — ignore */ }
+  });
 }

--- a/extension/src/content/webauthn-interceptor.js
+++ b/extension/src/content/webauthn-interceptor.js
@@ -26,6 +26,15 @@
   var origGet = navigator.credentials.get.bind(navigator.credentials);
   var origCreate = navigator.credentials.create.bind(navigator.credentials);
 
+  // Own-app bypass: when the ISOLATED world detects this is the passwd-sso app,
+  // it posts this message so the interceptor skips all WebAuthn interception.
+  var ownAppBypass = false;
+  window.addEventListener("message", function (event) {
+    if (event.source === window && event.data && event.data.type === "PASSWD_SSO_OWN_APP_BYPASS") {
+      ownAppBypass = true;
+    }
+  });
+
   var pendingRequests = {};
 
   window.addEventListener("message", function (event) {
@@ -59,7 +68,7 @@
   }
 
   navigator.credentials.get = function (options) {
-    if (!options || !options.publicKey) {
+    if (ownAppBypass || !options || !options.publicKey) {
       return origGet(options);
     }
 
@@ -154,7 +163,7 @@
   };
 
   navigator.credentials.create = function (options) {
-    if (!options || !options.publicKey) {
+    if (ownAppBypass || !options || !options.publicKey) {
       return origCreate(options);
     }
 

--- a/extension/src/types/messages.ts
+++ b/extension/src/types/messages.ts
@@ -137,6 +137,7 @@ export type ExtensionResponse =
       type: typeof EXT_MSG.PASSKEY_GET_MATCHES;
       entries: PasskeyMatchEntry[];
       vaultLocked: boolean;
+      suppressed?: boolean;
     }
   | {
       type: typeof EXT_MSG.PASSKEY_SIGN_ASSERTION;
@@ -148,12 +149,14 @@ export type ExtensionResponse =
       type: typeof EXT_MSG.PASSKEY_CHECK_DUPLICATE;
       entries: PasskeyMatchEntry[];
       vaultLocked?: boolean;
+      suppressed?: boolean;
     }
   | {
       type: typeof EXT_MSG.PASSKEY_CREATE_CREDENTIAL;
       ok: boolean;
       response?: SerializedAttestationResponse;
       error?: string;
+      suppressed?: boolean;
     };
 
 export interface AutofillPayload {

--- a/messages/en/Common.json
+++ b/messages/en/Common.json
@@ -12,5 +12,9 @@
   "yes": "Yes",
   "no": "No",
   "statusUnsaved": "Unsaved changes",
-  "statusSaved": "All changes saved"
+  "statusSaved": "All changes saved",
+  "theme": "Theme",
+  "themeLight": "Light",
+  "themeDark": "Dark",
+  "themeSystem": "System"
 }

--- a/messages/en/WebAuthn.json
+++ b/messages/en/WebAuthn.json
@@ -59,5 +59,6 @@
   "pinPolicyError": "Security key PIN length does not meet tenant policy requirements. Please set a longer PIN.",
   "pinLength": "PIN: {length} digits",
   "largeBlobLabel": "Offline backup",
-  "largeBlobSupported": "Offline backup capable"
+  "largeBlobSupported": "Offline backup capable",
+  "discoverableDisabledOidc": "Passkey sign-in is not available with OIDC/SAML authentication"
 }

--- a/messages/ja/Common.json
+++ b/messages/ja/Common.json
@@ -12,5 +12,9 @@
   "yes": "はい",
   "no": "いいえ",
   "statusUnsaved": "未保存の変更があります",
-  "statusSaved": "変更は保存済みです"
+  "statusSaved": "変更は保存済みです",
+  "theme": "テーマ",
+  "themeLight": "ライト",
+  "themeDark": "ダーク",
+  "themeSystem": "システム設定に従う"
 }

--- a/messages/ja/WebAuthn.json
+++ b/messages/ja/WebAuthn.json
@@ -59,5 +59,6 @@
   "pinPolicyError": "セキュリティキーのPIN長がテナントポリシーの要件を満たしていません。より長いPINを設定してください。",
   "pinLength": "PIN: {length}桁",
   "largeBlobLabel": "オフラインバックアップ",
-  "largeBlobSupported": "オフラインバックアップ対応"
+  "largeBlobSupported": "オフラインバックアップ対応",
+  "discoverableDisabledOidc": "OIDC/SAML認証ではパスキーログインは利用できません"
 }

--- a/scripts/check-bypass-rls.mjs
+++ b/scripts/check-bypass-rls.mjs
@@ -84,6 +84,8 @@ const ALLOWED_USAGE = new Map([
   // MCP Connections: user's own token listing + revocation (userId + tenantId in WHERE)
   ["src/app/api/user/mcp-tokens/route.ts", ["mcpAccessToken", "mcpClient"]],
   ["src/app/api/user/mcp-tokens/[id]/route.ts", ["mcpAccessToken", "mcpRefreshToken", "delegationSession", "auditLog"]],
+  // Auth provider check: userId-scoped Account query for passkey sign-in capability
+  ["src/app/api/user/auth-provider/route.ts", ["account"]],
 ]);
 
 // Regex to match prisma model access: prisma.modelName.method(...) or tx.modelName.method(...)

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import {
 } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { SessionProvider } from "@/components/providers/session-provider";
+import { ThemeProvider } from "@/components/providers/theme-provider";
 import { VaultProvider } from "@/lib/vault-context";
 import { Toaster } from "@/components/ui/sonner";
 import { routing } from "@/i18n/routing";
@@ -53,12 +54,14 @@ export default async function LocaleLayout({ children, params }: Props) {
 
   return (
     <NextIntlClientProvider messages={pickMessages(messages, NS_GLOBAL)}>
-      <SessionProvider>
-        <VaultProvider>
-          {children}
-          <Toaster />
-        </VaultProvider>
-      </SessionProvider>
+      <ThemeProvider>
+        <SessionProvider>
+          <VaultProvider>
+            {children}
+            <Toaster />
+          </VaultProvider>
+        </SessionProvider>
+      </ThemeProvider>
     </NextIntlClientProvider>
   );
 }

--- a/src/app/api/user/auth-provider/route.test.ts
+++ b/src/app/api/user/auth-provider/route.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequest } from "@/__tests__/helpers/request-builder";
+
+const { mockAuth, mockPrismaAccount, mockWithBypassRls } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockPrismaAccount: { findMany: vi.fn() },
+  mockWithBypassRls: vi.fn(
+    async (_prisma: unknown, fn: () => unknown) => fn(),
+  ),
+}));
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/prisma", () => ({
+  prisma: { account: mockPrismaAccount },
+}));
+vi.mock("@/lib/tenant-rls", async (importOriginal) => ({
+  ...(await importOriginal()) as Record<string, unknown>,
+  withBypassRls: mockWithBypassRls,
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/user/auth-provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await GET(
+      createRequest("GET", "http://localhost/api/user/auth-provider"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns canPasskeySignIn: true for passkey-only user (no accounts)", async () => {
+    mockPrismaAccount.findMany.mockResolvedValue([]);
+    const res = await GET(
+      createRequest("GET", "http://localhost/api/user/auth-provider"),
+    );
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.canPasskeySignIn).toBe(true);
+  });
+
+  it("returns canPasskeySignIn: false for google-only user", async () => {
+    mockPrismaAccount.findMany.mockResolvedValue([
+      { provider: "google" },
+    ]);
+    const res = await GET(
+      createRequest("GET", "http://localhost/api/user/auth-provider"),
+    );
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.canPasskeySignIn).toBe(false);
+  });
+
+  it("returns canPasskeySignIn: false for saml-jackson-only user", async () => {
+    mockPrismaAccount.findMany.mockResolvedValue([
+      { provider: "saml-jackson" },
+    ]);
+    const res = await GET(
+      createRequest("GET", "http://localhost/api/user/auth-provider"),
+    );
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.canPasskeySignIn).toBe(false);
+  });
+
+  it("returns canPasskeySignIn: true for user with google + nodemailer", async () => {
+    mockPrismaAccount.findMany.mockResolvedValue([
+      { provider: "google" },
+      { provider: "nodemailer" },
+    ]);
+    const res = await GET(
+      createRequest("GET", "http://localhost/api/user/auth-provider"),
+    );
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.canPasskeySignIn).toBe(true);
+  });
+
+  it("returns canPasskeySignIn: true for nodemailer-only user", async () => {
+    mockPrismaAccount.findMany.mockResolvedValue([
+      { provider: "nodemailer" },
+    ]);
+    const res = await GET(
+      createRequest("GET", "http://localhost/api/user/auth-provider"),
+    );
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.canPasskeySignIn).toBe(true);
+  });
+
+  it("returns 500 on DB error", async () => {
+    mockPrismaAccount.findMany.mockRejectedValue(new Error("DB error"));
+    const res = await GET(
+      createRequest("GET", "http://localhost/api/user/auth-provider"),
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it("uses withBypassRls with AUTH_FLOW purpose", async () => {
+    mockPrismaAccount.findMany.mockResolvedValue([]);
+    await GET(
+      createRequest("GET", "http://localhost/api/user/auth-provider"),
+    );
+    expect(mockWithBypassRls).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(Function),
+      "auth_flow",
+    );
+  });
+});

--- a/src/app/api/user/auth-provider/route.ts
+++ b/src/app/api/user/auth-provider/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { unauthorized, errorResponse } from "@/lib/api-response";
+import { API_ERROR } from "@/lib/api-error-codes";
+import { withRequestLog } from "@/lib/with-request-log";
+import { prisma } from "@/lib/prisma";
+import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+
+// Providers that do NOT support passkey-based sign-in
+const OIDC_SAML_PROVIDERS = new Set(["google", "saml-jackson"]);
+
+// GET /api/user/auth-provider — Check if user can use passkey sign-in
+async function handleGET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return unauthorized();
+  }
+
+  try {
+    const accounts = await withBypassRls(prisma, () =>
+      prisma.account.findMany({
+        where: { userId: session.user.id },
+        select: { provider: true },
+      }),
+      BYPASS_PURPOSE.AUTH_FLOW,
+    );
+
+    // User can use passkey sign-in if:
+    // - They have no Account records (passkey-only user — no OAuth/email link), OR
+    // - They have at least one non-OIDC/SAML provider (e.g., nodemailer)
+    const canPasskeySignIn =
+      accounts.length === 0 ||
+      accounts.some((a) => !OIDC_SAML_PROVIDERS.has(a.provider));
+
+    return NextResponse.json({ canPasskeySignIn });
+  } catch {
+    return errorResponse(API_ERROR.INTERNAL_ERROR, 500);
+  }
+}
+
+export const GET = withRequestLog(handleGET);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,36 +83,36 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: oklch(0.178 0 0);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
+  --card: oklch(0.230 0 0);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
+  --popover: oklch(0.230 0 0);
   --popover-foreground: oklch(0.985 0 0);
   --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
+  --primary-foreground: oklch(0.230 0 0);
+  --secondary: oklch(0.295 0 0);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
+  --muted: oklch(0.295 0 0);
   --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
+  --accent: oklch(0.295 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
+  --border: oklch(1 0 0 / 12%);
+  --input: oklch(1 0 0 / 17%);
   --ring: oklch(0.556 0 0);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
+  --sidebar: oklch(0.230 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent: oklch(0.295 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-border: oklch(1 0 0 / 12%);
   --sidebar-ring: oklch(0.556 0 0);
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,37 +83,37 @@
 }
 
 .dark {
-  --background: oklch(0.178 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.230 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.230 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.230 0 0);
-  --secondary: oklch(0.295 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.295 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.295 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 12%);
-  --input: oklch(1 0 0 / 17%);
-  --ring: oklch(0.556 0 0);
+  --background: #2d2d2d;
+  --foreground: #f5f5f5;
+  --card: #363636;
+  --card-foreground: #f5f5f5;
+  --popover: #363636;
+  --popover-foreground: #f5f5f5;
+  --primary: #e5e5e5;
+  --primary-foreground: #2d2d2d;
+  --secondary: #424242;
+  --secondary-foreground: #f5f5f5;
+  --muted: #424242;
+  --muted-foreground: #a8a8a8;
+  --accent: #424242;
+  --accent-foreground: #f5f5f5;
+  --destructive: #ef4444;
+  --border: rgba(255, 255, 255, 0.14);
+  --input: rgba(255, 255, 255, 0.20);
+  --ring: #808080;
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.230 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar: #363636;
+  --sidebar-foreground: #f5f5f5;
   --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.295 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 12%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar-primary-foreground: #f5f5f5;
+  --sidebar-accent: #424242;
+  --sidebar-accent-foreground: #f5f5f5;
+  --sidebar-border: rgba(255, 255, 255, 0.14);
+  --sidebar-ring: #808080;
 }
 
 @layer base {

--- a/src/components/layout/header.test.tsx
+++ b/src/components/layout/header.test.tsx
@@ -55,6 +55,9 @@ vi.mock("@/components/vault/recovery-key-dialog", () => ({
 vi.mock("@/components/notifications/notification-bell", () => ({
   NotificationBell: () => <div data-testid="notification-bell" />,
 }));
+vi.mock("./theme-toggle", () => ({
+  ThemeToggle: () => <div data-testid="theme-toggle" />,
+}));
 
 vi.mock("@/hooks/use-travel-mode", () => ({
   useTravelMode: () => ({ active: false, loading: false, enable: vi.fn(), disable: vi.fn() }),

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -16,6 +16,7 @@ import {
 import { UserAvatar } from "@/components/auth/user-avatar";
 import { SignOutButton } from "@/components/auth/signout-button";
 import { LanguageSwitcher } from "./language-switcher";
+import { ThemeToggle } from "./theme-toggle";
 import { NotificationBell } from "@/components/notifications/notification-bell";
 import { useVault } from "@/lib/vault-context";
 import { APP_NAME, VAULT_STATUS } from "@/lib/constants";
@@ -106,6 +107,7 @@ export function Header({ onMenuToggle }: HeaderProps) {
           </div>
         )}
 
+        {mounted && <ThemeToggle />}
         {mounted && <LanguageSwitcher />}
         {mounted && <NotificationBell />}
 

--- a/src/components/layout/sidebar-content.test.tsx
+++ b/src/components/layout/sidebar-content.test.tsx
@@ -100,11 +100,11 @@ describe("SidebarContent", () => {
     expect(props.onCreateFolder).toHaveBeenCalledWith("team-1");
   });
 
-  it("does not render SettingsNavSection for team vault", () => {
+  it("renders SettingsNavSection for team vault (admin console stays accessible)", () => {
     const props = baseProps({ vaultContext: { type: "team", teamId: "team-1", teamRole: "ADMIN" } });
     render(<SidebarContent {...props} />);
 
-    expect(screen.queryByText("settings-nav")).toBeNull();
+    expect(screen.queryByText("settings-nav")).not.toBeNull();
   });
 
   it("does not render SecuritySection for team Viewer", () => {

--- a/src/components/layout/sidebar-content.tsx
+++ b/src/components/layout/sidebar-content.tsx
@@ -198,18 +198,16 @@ export function SidebarContent({
         />
       )}
 
-      {vaultContext.type !== "team" && (
-        <SettingsNavSection
-          isOpen={isOpen("settingsNav")}
-          onOpenChange={toggleSection("settingsNav")}
-          t={t}
-          selectedTeam={selectedTeam}
-          isAdminActive={isAdminActive}
-          isSettingsActive={isSettingsActive}
-          isAdmin={isAdmin}
-          onNavigate={onNavigate}
-        />
-      )}
+      <SettingsNavSection
+        isOpen={isOpen("settingsNav")}
+        onOpenChange={toggleSection("settingsNav")}
+        t={t}
+        selectedTeam={selectedTeam}
+        isAdminActive={isAdminActive}
+        isSettingsActive={isSettingsActive}
+        isAdmin={isAdmin}
+        onNavigate={onNavigate}
+      />
 
       <ToolsSection
         isOpen={isOpen("tools")}

--- a/src/components/layout/sidebar-section-security.tsx
+++ b/src/components/layout/sidebar-section-security.tsx
@@ -126,22 +126,20 @@ export function SettingsNavSection({
       <CollapsibleContent>
         <div className="ml-3 border-l pl-3 space-y-0.5">
           {!scopedTeam && (
-            <>
-              <Button variant={isSettingsActive ? "secondary" : "ghost"} className="w-full justify-start gap-2" asChild>
-                <Link href="/dashboard/settings" onClick={onNavigate}>
-                  <UserRound className="h-4 w-4" />
-                  {t("settings")}
-                </Link>
-              </Button>
-              {isAdmin && (
-                <Button variant={isAdminActive ? "secondary" : "ghost"} className="w-full justify-start gap-2" asChild>
-                  <Link href="/admin" onClick={onNavigate}>
-                    <LayoutDashboard className="h-4 w-4" />
-                    {t("adminConsole")}
-                  </Link>
-                </Button>
-              )}
-            </>
+            <Button variant={isSettingsActive ? "secondary" : "ghost"} className="w-full justify-start gap-2" asChild>
+              <Link href="/dashboard/settings" onClick={onNavigate}>
+                <UserRound className="h-4 w-4" />
+                {t("settings")}
+              </Link>
+            </Button>
+          )}
+          {isAdmin && (
+            <Button variant={isAdminActive ? "secondary" : "ghost"} className="w-full justify-start gap-2" asChild>
+              <Link href="/admin" onClick={onNavigate}>
+                <LayoutDashboard className="h-4 w-4" />
+                {t("adminConsole")}
+              </Link>
+            </Button>
           )}
         </div>
       </CollapsibleContent>

--- a/src/components/layout/theme-toggle.test.tsx
+++ b/src/components/layout/theme-toggle.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockSetTheme = vi.fn();
+const mockUseTheme = vi.fn();
+
+vi.mock("next-themes", () => ({
+  useTheme: () => mockUseTheme(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const map: Record<string, string> = {
+      theme: "Theme",
+      themeLight: "Light",
+      themeDark: "Dark",
+      themeSystem: "System",
+    };
+    return map[key] ?? key;
+  },
+}));
+
+import { ThemeToggle } from "./theme-toggle";
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseTheme.mockReturnValue({
+      theme: "light",
+      setTheme: mockSetTheme,
+      resolvedTheme: "light",
+    });
+  });
+
+  it("renders toggle button with aria-label", () => {
+    render(<ThemeToggle />);
+    expect(screen.getByRole("button", { name: "Theme" })).toBeDefined();
+  });
+
+  it("shows three options when clicked", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    await user.click(screen.getByRole("button", { name: "Theme" }));
+
+    expect(screen.getByText("Light")).toBeDefined();
+    expect(screen.getByText("Dark")).toBeDefined();
+    expect(screen.getByText("System")).toBeDefined();
+  });
+
+  it("calls setTheme('dark') when Dark is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    await user.click(screen.getByRole("button", { name: "Theme" }));
+    await user.click(screen.getByText("Dark"));
+
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("calls setTheme('light') when Light is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    await user.click(screen.getByRole("button", { name: "Theme" }));
+    await user.click(screen.getByText("Light"));
+
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("calls setTheme('system') when System is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    await user.click(screen.getByRole("button", { name: "Theme" }));
+    await user.click(screen.getByText("System"));
+
+    expect(mockSetTheme).toHaveBeenCalledWith("system");
+  });
+});

--- a/src/components/layout/theme-toggle.tsx
+++ b/src/components/layout/theme-toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useTranslations } from "next-intl";
+import { Moon, Sun, Monitor } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function ThemeToggle() {
+  const { setTheme, resolvedTheme } = useTheme();
+  const t = useTranslations("Common");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label={t("theme")}>
+          {resolvedTheme === "dark" ? (
+            <Moon className="h-4 w-4" />
+          ) : (
+            <Sun className="h-4 w-4" />
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="h-4 w-4" />
+          {t("themeLight")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="h-4 w-4" />
+          {t("themeDark")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor className="h-4 w-4" />
+          {t("themeSystem")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/settings/mcp-client-card.tsx
+++ b/src/components/settings/mcp-client-card.tsx
@@ -339,8 +339,10 @@ export function McpClientCard() {
             </Badge>
           )}
         </div>
-        <p className="text-xs text-muted-foreground font-mono">
-          {client.clientId}
+        <p className="text-xs text-muted-foreground font-mono truncate" title={client.clientId}>
+          {client.clientId.length > 16
+            ? `${client.clientId.slice(0, 16)}…`
+            : client.clientId}
         </p>
         <ScopeBadges scopes={client.allowedScopes} />
         {client.connectedUsers && client.connectedUsers.length > 0 && (

--- a/src/components/settings/mcp-connections-card.tsx
+++ b/src/components/settings/mcp-connections-card.tsx
@@ -186,21 +186,23 @@ export function McpConnectionsCard() {
                 className="flex items-start justify-between border rounded-md p-3"
               >
                 <div className="space-y-1.5 min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium truncate">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-sm font-medium truncate max-w-[12rem]">
                       {client.name}
                     </span>
-                    <span className="text-xs text-muted-foreground font-mono">
-                      {client.clientId}
+                    <span className="text-xs text-muted-foreground font-mono truncate max-w-[10rem]" title={client.clientId}>
+                      {client.clientId.length > 16
+                        ? `${client.clientId.slice(0, 16)}…`
+                        : client.clientId}
                     </span>
                     {client.isDcr && (
-                      <Badge variant="outline" className="text-xs">
+                      <Badge variant="outline" className="text-xs shrink-0">
                         DCR
                       </Badge>
                     )}
                     <Badge
                       variant={client.connection ? "default" : "secondary"}
-                      className="text-xs"
+                      className="text-xs shrink-0"
                     >
                       {client.connection ? t("connected") : t("notConnected")}
                     </Badge>

--- a/src/components/settings/passkey-credentials-card.tsx
+++ b/src/components/settings/passkey-credentials-card.tsx
@@ -86,6 +86,9 @@ export function PasskeyCredentialsCard() {
   const [registering, setRegistering] = useState(false);
   const [nickname, setNickname] = useState("");
 
+  // Auth provider check — whether user can use passkey for sign-in
+  const [canPasskeySignIn, setCanPasskeySignIn] = useState(true); // fail-open
+
   // Inline rename state
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
@@ -114,6 +117,17 @@ export function PasskeyCredentialsCard() {
   useEffect(() => {
     fetchCredentials();
   }, [fetchCredentials]);
+
+  useEffect(() => {
+    fetchApi(API_PATH.USER_AUTH_PROVIDER)
+      .then(async (res) => {
+        if (res.ok) {
+          const data = await res.json();
+          setCanPasskeySignIn(data.canPasskeySignIn);
+        }
+      })
+      .catch(() => {}); // fail-open: keep default true
+  }, []);
 
   const handleRegister = async () => {
     if (!webAuthnAvailable || !vaultUnlocked || registering) return;
@@ -424,11 +438,17 @@ export function PasskeyCredentialsCard() {
                       {/* Discoverable (passkey sign-in) */}
                       <span
                         className={`text-xs px-1.5 py-0.5 rounded ${
-                          isNonDiscoverable(cred)
+                          isNonDiscoverable(cred) || !canPasskeySignIn
                             ? "text-muted-foreground/50 line-through"
                             : "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
                         }`}
-                        title={isNonDiscoverable(cred) ? t("notDiscoverableDescription") : t("discoverableDescription")}
+                        title={
+                          !canPasskeySignIn
+                            ? t("discoverableDisabledOidc")
+                            : isNonDiscoverable(cred)
+                              ? t("notDiscoverableDescription")
+                              : t("discoverableDescription")
+                        }
                       >
                         {t("discoverable")}
                       </span>

--- a/src/lib/constants/api-path.ts
+++ b/src/lib/constants/api-path.ts
@@ -77,6 +77,7 @@ export const API_PATH = {
   TENANT_ACCESS_REQUESTS: "/api/tenant/access-requests",
   VAULT_DELEGATION: "/api/vault/delegation",
   USER_MCP_TOKENS: "/api/user/mcp-tokens",
+  USER_AUTH_PROVIDER: "/api/user/auth-provider",
 } as const;
 
 export const apiPath = {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -178,6 +178,7 @@ async function handleApiAuth(request: NextRequest) {
     pathname.startsWith(API_PATH.NOTIFICATIONS) ||
     pathname.startsWith(API_PATH.USER_LOCALE) ||
     pathname.startsWith(API_PATH.USER_MCP_TOKENS) ||
+    pathname.startsWith(API_PATH.USER_AUTH_PROVIDER) ||
     pathname.startsWith(API_PATH.EXTENSION) ||
     pathname.startsWith(API_PATH.TENANT) ||
     pathname.startsWith(API_PATH.API_KEYS) ||


### PR DESCRIPTION
## Summary
- Add dark/light/system theme toggle to the header using next-themes
- Show passkey sign-in badge as disabled for OIDC/SAML-only users via new `/api/user/auth-provider` endpoint
- Bypass WebAuthn interceptor entirely on own app pages (two-layer: MAIN world flag + background suppression)
- Soften dark theme colors (hex values to work around Tailwind v4 oklch cache bug)
- Truncate long MCP client IDs (`mcpc_XXXX`) to prevent overflow in settings UI
- Show admin console link in sidebar when team vault is selected

## Changes

### Theme Toggle
- New `ThemeProvider` wrapping next-themes (`src/components/providers/theme-provider.tsx`)
- New `ThemeToggle` component with light/dark/system dropdown (`src/components/layout/theme-toggle.tsx`)
- Added to header and locale layout with correct provider nesting order
- Theme translations in `Common.json` (NS_GLOBAL) for all-page availability
- Dark theme CSS variables switched to hex to work around Tailwind v4 oklch build cache issue

### Passkey Badge for OIDC/SAML Users
- New `GET /api/user/auth-provider` endpoint returning `{ canPasskeySignIn: boolean }`
- Multi-account handling: passkey-only (no Account records) → true, OIDC-only → false, mixed → true
- Proxy protection added (`API_PATH.USER_AUTH_PROVIDER` + `src/proxy.ts`)
- Badge shows as disabled with explanatory tooltip for OIDC/SAML users
- Added to `check-bypass-rls.mjs` allowlist

### Extension WebAuthn Bypass on Own App
- ISOLATED world (`webauthn-bridge.ts`) detects own app via `serverUrl` and posts `PASSWD_SSO_OWN_APP_BYPASS` to MAIN world
- MAIN world interceptor (`webauthn-interceptor.js`) skips all interception when bypass flag is set
- Background handlers (`PASSKEY_GET_MATCHES`, `PASSKEY_CHECK_DUPLICATE`, `PASSKEY_CREATE_CREDENTIAL`) also suppress via `isOwnAppPage()` as defense-in-depth
- `suppressed` field added to `ExtensionResponse` types
- Fallthrough reason comments added to bridge code

### MCP Client ID Overflow
- Truncate `mcpc_XXXX` IDs to 16 chars with ellipsis in both `mcp-connections-card.tsx` and `mcp-client-card.tsx`
- Full ID available via `title` attribute on hover
- Added `flex-wrap` to badge container

### Admin Console Navigation
- Admin console link now visible in sidebar when team vault is selected
- Decoupled from `SettingsNavSection` team vault guard
- Personal settings link remains hidden in team vault context

## Test plan
- [ ] `npx vitest run` — 6805 tests pass (545 files)
- [ ] `npx next build` — production build succeeds
- [ ] `npm run lint` — no lint errors
- [ ] `scripts/pre-pr.sh` — all 8 checks pass
- [ ] Theme toggle: switch between light/dark/system, verify persistence across page navigation
- [ ] OIDC/SAML user: verify passkey badge shows as disabled with tooltip
- [ ] Passkey-only user: verify badge shows normally
- [ ] Extension: register passkey on own app — native WebAuthn dialog appears without extension banner
- [ ] Extension: register passkey on external site — extension save banner appears normally
- [ ] MCP connections: verify long client IDs are truncated with hover tooltip
- [ ] Team vault: verify admin console link is visible in sidebar
- [ ] Dark theme: verify softer gray tones (not pure black)

🤖 Generated with [Claude Code](https://claude.com/claude-code)