### PR TITLE
docs: align security docs with current implementation

### DIFF
--- a/docs/security/cryptography-whitepaper.md
+++ b/docs/security/cryptography-whitepaper.md
@@ -3,7 +3,7 @@
 This document describes the cryptographic architecture of passwd-sso.
 For the full domain separation ledger, see [crypto-domain-ledger.md](crypto-domain-ledger.md).
 
-Last updated: 2026-03-07
+Last updated: 2026-04-09
 
 ---
 
@@ -164,6 +164,14 @@ Server stores: HMAC(serverPepper, verifierHash)
 
 All encryption uses the Web Crypto API (`crypto.subtle`). CryptoKey objects are created with `extractable: false` where possible.
 
+### 4.1 HKDF Usage Notes
+
+HKDF (RFC 5869) is used for all key derivation from high-entropy input key material (IKM). Design rationale:
+
+- **Zero salt**: Personal vault HKDF derivations use an empty (zero-length) salt. This is acceptable under RFC 5869 §3.1 when the IKM is uniformly random (256-bit `secretKey`). Domain separation is achieved exclusively via distinct `info` labels.
+- **Non-zero salt**: Team key wrapping and recovery key wrapping use a random salt per operation. The salt is stored alongside the wrapped key and serves as a domain separator in addition to the `info` label.
+- **Info labels**: Each derivation path uses a unique info string (e.g., `passwd-sso-enc-v1`, `passwd-sso-auth-v1`). The full ledger is maintained in [crypto-domain-ledger.md](crypto-domain-ledger.md).
+
 ## 5. AAD (Additional Authenticated Data) Binding
 
 Every ciphertext is bound to its context via AAD. This prevents:
@@ -233,9 +241,15 @@ For entries with `itemKeyVersion = 0` (legacy, no ItemKey):
 
 ### 7.3 Extension compromised
 
-**Attacker can**: Access vault secret key in chrome.storage.session during active session.
+**Attacker can**: Access vault secret key in memory during an active session. Stored ciphertext in `chrome.storage.session` is not directly usable without the ephemeral wrapping key.
 
-**Mitigations**: chrome.storage.session is scoped to browser session (cleared on browser close). Token TTL limits exposure window. Content scripts run in isolated worlds.
+**Mitigations**:
+- Sensitive session fields are encrypted with an ephemeral AES-256-GCM key before storage. The wrapping key is non-extractable and held only in memory.
+- On service worker full restart, the ephemeral key is lost and stored ciphertext becomes undecryptable, forcing re-authentication.
+- `chrome.storage.session` is scoped to browser session (cleared on browser close) and restricted to `TRUSTED_CONTEXTS`.
+- Token TTL limits exposure window. Content scripts run in isolated worlds.
+
+**Residual risk**: An attacker with arbitrary code execution in the extension context can read the in-memory secret key during an active session. This is an inherent limitation of browser extension architecture.
 
 ### 7.4 IdP compromised (Google/SAML)
 

--- a/docs/security/security-review.md
+++ b/docs/security/security-review.md
@@ -1,6 +1,6 @@
 # Security Review
 
-Last updated: 2026-02-27
+Last updated: 2026-04-09
 Branch baseline: `main` (includes merged fixes from `fix/security-review-proxy-import` and `feat/tenant-team-scim-spec`)
 
 ## 1. Authentication / Authorization Boundary
@@ -103,14 +103,16 @@ Evidence:
 - `extension/src/__tests__/background.test.ts:211` verifies relock on token change.
 
 ### Notes / residual risk
-- `vaultSecretKey` is persisted in `chrome.storage.session` (`extension/src/lib/session-storage.ts:12`).  
-  This is a deliberate UX/security trade-off (survive MV3 SW restarts).  
-  **Decision:** keep `chrome.storage.session` persistence for extension `vaultSecretKey` to preserve UX.
-  Security controls remain: browser-session scoped storage, token TTL/refresh, explicit lock/clear flows.
+- Sensitive session fields (`token`, `vaultSecretKey`) are encrypted with an ephemeral AES-256-GCM key before being persisted to `chrome.storage.session` (`extension/src/lib/session-crypto.ts`, `extension/src/lib/session-storage.ts`).
+  - The wrapping key is generated via `crypto.subtle.generateKey()` with `extractable: false` and held only in memory.
+  - On service worker restart, the ephemeral key is lost, rendering stored ciphertext undecryptable. This forces re-authentication rather than allowing silent secret recovery.
+  - `chrome.storage.session.setAccessLevel({ accessLevel: "TRUSTED_CONTEXTS" })` further restricts access to trusted extension contexts.
+- This is a deliberate UX/security trade-off: secrets survive transient SW idle shutdowns (where the key remains in memory) but are irrecoverable after a full restart.
+  **Decision:** keep `chrome.storage.session` with envelope encryption for extension `vaultSecretKey` to preserve UX.
 
 ### Conclusion (Section 2)
 - No immediate logic bug found.
-- Current implementation is consistent with the chosen model: token/session continuity across SW restarts.
+- Current implementation is consistent with the chosen model: envelope-encrypted token/session continuity across SW idle shutdowns, with forced re-authentication after full restarts.
 
 ## 3. Input / Metadata Sanitization
 
@@ -172,12 +174,12 @@ Evidence:
 - Extension unlock zeroes temporary secret: `extension/src/background/index.ts:798`.
 
 ### Notes / residual risk
-- Extension keeps `vaultSecretKey` hex in memory and session storage (`extension/src/background/index.ts:39`, `extension/src/background/index.ts:127`).  
-  This is the highest-sensitivity residual risk in current design.
+- Extension `vaultSecretKey` is held in memory and persisted to `chrome.storage.session` via envelope encryption (AES-256-GCM with a non-extractable ephemeral key; see Section 2 notes).
+  Plaintext secret is never written to storage. The residual risk is limited to in-memory exposure during an active session.
 
 ### Conclusion (Section 4)
 - Crypto primitives and AAD usage are solid.
-- Main remaining risk is persistence/handling policy for extension vault secret continuity.
+- Extension vault secret persistence uses envelope encryption; residual risk is limited to in-memory exposure.
 
 ## 5. Audit Log Integrity / Traceability
 
@@ -202,15 +204,17 @@ Evidence:
 3. Audit write failures do not break primary operation  
 Status: `PASS`  
 Evidence:
-- `src/lib/audit.ts:57` catches DB write errors by design (fire-and-forget).
+- `src/lib/audit.ts` catches DB write errors and enqueues failed entries for retry (`src/lib/audit-retry.ts`).
+- Retry mechanism: in-memory FIFO buffer (max 100 entries), piggyback flush on subsequent `logAudit()` calls (drains up to 10 entries per call), bounded at 3 retries per entry.
+- Entries exceeding max retries or dropped due to buffer overflow are logged to a dead-letter logger (`_logType: "audit-dead-letter"`) for external collection.
 
 ### Notes / residual risk
-- Fire-and-forget means potential audit loss under DB outage.
-- If strict compliance is required, move to durable queue/transactional outbox.
+- The retry buffer is in-memory and not durable. A process crash loses buffered entries (they will appear in dead-letter logs if the logger flushed before crash).
+- If strict compliance requires guaranteed delivery, a durable queue or transactional outbox would be needed.
 
 ### Conclusion (Section 5)
-- Current audit model is consistent with availability-first design.
-- Compliance-hardening would require architectural change, not patch-level fixes.
+- Current audit model is best-effort with bounded retry, reducing audit loss compared to pure fire-and-forget.
+- Compliance-hardening beyond this would require a durable delivery mechanism.
 
 ## 6. Test Coverage Review (Current Security Findings)
 


### PR DESCRIPTION
## Summary
- Update security-review.md and cryptography-whitepaper.md to reflect current implementation, closing gaps where documentation described outdated behavior
- Document envelope encryption for extension session storage (ephemeral AES-256-GCM wrapping key, non-extractable, lost on SW restart)
- Document bounded audit retry mechanism (in-memory FIFO buffer, piggyback flush, dead-letter fallback), replacing outdated fire-and-forget description
- Add HKDF usage notes with RFC 5869 zero-salt rationale and salt strategy per derivation context

## Changes

**cryptography-whitepaper.md**
- Add Section 4.1 HKDF Usage Notes: zero-salt rationale for personal vault, random-salt for team/recovery keys, info label requirements
- Update Section 7.3 (extension compromise threat): describe envelope encryption mitigations and residual risk limited to in-memory exposure

**security-review.md**
- Update Section 2 Notes: describe AES-256-GCM envelope encryption for session storage, ephemeral key lifecycle, TRUSTED_CONTEXTS access level
- Update Section 4 Notes: clarify that plaintext secret is never written to storage; residual risk limited to in-memory exposure
- Update Section 5 Item 3 + Notes: document retry buffer (max 100 entries, 3 retries, piggyback flush, dead-letter logging), replace fire-and-forget description
- Update date stamps to 2026-04-09

## Test plan
- [x] HKDF usage notes in `cryptography-whitepaper.md` match implementation in `src/lib/crypto-client.ts` (zero-salt for personal vault, random salt for team/recovery)
- [x] Envelope encryption description in `security-review.md` Section 2 matches `extension/src/lib/session-crypto.ts` and `extension/src/lib/session-storage.ts`
- [x] Audit retry description in `security-review.md` Section 5 matches `src/lib/audit-retry.ts` (buffer size 100, drain batch 10, max retries 3, dead-letter logger)
- [x] Extension threat model in `cryptography-whitepaper.md` Section 7.3 aligns with envelope encryption design
- [ ] Verify no markdown link breakage or syntax errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)