### PR TITLE
docs: refine postMessage risk, audit durability, and cross-references

### DIFF
--- a/docs/security/cors-policy.md
+++ b/docs/security/cors-policy.md
@@ -28,7 +28,7 @@ CORS is a **browser-enforced constraint only**. Non-browser clients (curl, scrip
 The browser extension communicates with the API via its **Background Service Worker** using **Bearer token** authentication. Chrome extension service workers are not subject to browser CORS restrictions, so no cross-origin CORS headers are needed for extension access.
 
 Communication flow:
-1. Extension obtains a Bearer token via the token bridge (same-origin DOM injection)
+1. Extension obtains a Bearer token via the token bridge (`window.postMessage` with strict origin and schema validation)
 2. Background Service Worker makes `fetch()` calls with `Authorization: Bearer <token>`
 3. Service Worker network requests bypass browser CORS checks entirely
 

--- a/docs/security/cryptography-whitepaper.md
+++ b/docs/security/cryptography-whitepaper.md
@@ -2,6 +2,7 @@
 
 This document describes the cryptographic architecture of passwd-sso.
 For the full domain separation ledger, see [crypto-domain-ledger.md](crypto-domain-ledger.md).
+For threat assumptions and non-cryptographic trust boundaries, see [threat-model.md](threat-model.md).
 
 Last updated: 2026-04-09
 

--- a/docs/security/security-review.md
+++ b/docs/security/security-review.md
@@ -209,7 +209,8 @@ Evidence:
 - Entries exceeding max retries or dropped due to buffer overflow are logged to a dead-letter logger (`_logType: "audit-dead-letter"`) for external collection.
 
 ### Notes / residual risk
-- The retry buffer is in-memory and not durable. A process crash loses buffered entries (they will appear in dead-letter logs if the logger flushed before crash).
+- The retry buffer is memory-resident only and does not survive process restart, pod eviction, or crash. Entries in flight at the time of termination are lost (they will appear in dead-letter logs only if the logger flushed before termination).
+  Therefore this mechanism improves availability but does not provide durable audit guarantees.
 - If strict compliance requires guaranteed delivery, a durable queue or transactional outbox would be needed.
 
 ### Conclusion (Section 5)

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -50,6 +50,9 @@ TB4: Server <-> SAML Jackson
 TB5: Extension <-> Web App
      Extension communicates with web app via extension token (Bearer).
      Token issued via Auth.js session, validated server-side per request.
+     Token delivery uses window.postMessage (ISOLATED world content script).
+     Because postMessage is observable by same-origin main-world scripts,
+     this channel is treated as exposure-minimized but not confidentiality-isolated.
 
 TB6: Client <-> WebAuthn Authenticator
      Browser mediates credential creation/assertion via navigator.credentials API.


### PR DESCRIPTION
## Summary
- Follow-up to #353: address remaining documentation gaps identified during review
- Fix outdated "DOM injection" reference, add postMessage observability caveat, clarify audit retry durability limits, and add cross-document references

## Changes

**cors-policy.md**
- Fix "same-origin DOM injection" → `window.postMessage` with strict origin and schema validation

**threat-model.md**
- Add token delivery mechanism description to TB5 (Extension ↔ Web App trust boundary)
- Explicitly note that `postMessage` is exposure-minimized but not confidentiality-isolated

**security-review.md**
- Clarify audit retry buffer does not survive process restart, pod eviction, or crash
- Add explicit statement: mechanism improves availability but does not provide durable audit guarantees

**cryptography-whitepaper.md**
- Add cross-reference to threat-model.md for non-cryptographic trust boundaries

## Test plan
- [x] Verify `cors-policy.md` token bridge description matches `extension/src/content/token-bridge-lib.ts` (postMessage, not DOM injection)
- [x] Verify `threat-model.md` TB5 postMessage observability note is accurate per content script isolation model
- [x] Verify `security-review.md` audit durability wording matches `src/lib/audit-retry.ts` (in-memory only, no persistence)
- [x] Verify `cryptography-whitepaper.md` cross-reference link resolves to existing `threat-model.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)