### PR TITLE
fix: restore dev server after Next.js 16.2.3 bump

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,9 +20,20 @@ if (rawBasePath && !/^\/[\w-]+(?:\/[\w-]+)*$/.test(rawBasePath)) {
   );
 }
 
+// Dev-only: allow HMR/chunk requests from the configured hostnames.
+// Next.js 16.2+ tightened cross-origin dev resource request enforcement, which
+// breaks access via reverse proxies / Tailscale / remote tunnels. Set
+// NEXT_DEV_ALLOWED_ORIGINS="host1,host2" in .env.local to allow them.
+// Production builds ignore this setting (allowedDevOrigins is dev-only).
+const devAllowedOrigins = (process.env.NEXT_DEV_ALLOWED_ORIGINS ?? "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
 const nextConfig: NextConfig = {
   basePath: rawBasePath || undefined,
   output: "standalone",
+  allowedDevOrigins: devAllowedOrigins.length > 0 ? devAllowedOrigins : undefined,
   serverExternalPackages: ["file-type", "argon2-browser", "@aws-sdk/client-secrets-manager", "@azure/keyvault-secrets", "@azure/identity", "@google-cloud/secret-manager"],
 
   env: {

--- a/proxy.ts
+++ b/proxy.ts
@@ -5,10 +5,25 @@ import { proxy as handleProxy } from "./src/proxy";
 // Pre-compute static CSP parts at module init time to avoid per-request work.
 // Only the nonce value is injected per-request.
 const _isProd = process.env.NODE_ENV === "production";
-const _cspMode = process.env.CSP_MODE ?? (_isProd ? "strict" : "dev");
+// Safety guard: in production, never allow CSP_MODE=dev to downgrade the CSP.
+// Ops mistakes (wrong .env.production, Docker env, etc.) must not silently
+// disable strict-dynamic + nonce in prod. Only "strict" is accepted in prod.
+const _rawCspMode = process.env.CSP_MODE ?? (_isProd ? "strict" : "dev");
+const _cspMode = _isProd && _rawCspMode !== "strict" ? "strict" : _rawCspMode;
+if (_isProd && _rawCspMode !== _cspMode) {
+  console.warn(
+    `[CSP] CSP_MODE="${_rawCspMode}" is ignored in production builds; using "strict"`,
+  );
+}
 const _reportUri = `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/api/csp-report`;
-const _scriptSrcSuffix = _isProd ? "" : " 'unsafe-eval'";
-// In dev mode style-src uses 'unsafe-inline'; in strict mode nonce is injected.
+// In dev mode style-src and script-src use 'unsafe-inline'; in strict mode
+// nonce + 'strict-dynamic' is injected. Dev uses 'unsafe-inline' because the
+// per-request nonce flow via cookie is not reliable for Next.js HMR/dev-overlay
+// inline scripts (Next.js 16.2+ tightened cookie propagation to server components).
+// Note: the per-request nonce is still generated and set as the `csp-nonce`
+// cookie in dev (read by `src/app/layout.tsx` for a <meta name="csp-nonce">),
+// but plays no CSP role in dev because the header uses 'unsafe-inline'.
+// Production never hits this branch.
 const _stylePrefix = _cspMode === "dev" ? "style-src 'self' 'unsafe-inline'" : "style-src 'self' 'nonce-";
 const _styleSuffix = _cspMode === "dev" ? "" : "'";
 const _staticDirectives = [
@@ -65,7 +80,19 @@ function generateNonce(): string {
 }
 
 function buildCspHeader(nonce: string): string {
-  const scriptSrc = `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'wasm-unsafe-eval'${_scriptSrcSuffix}`;
+  // Dev mode: 'unsafe-inline' + 'unsafe-eval' (no nonce, no strict-dynamic).
+  //   Necessary because Next.js HMR, Turbopack dev overlay, and React Fast Refresh
+  //   inject inline scripts that cannot receive the per-request CSP nonce.
+  //   This is the standard Next.js dev CSP configuration.
+  // Strict mode: per-request nonce + 'strict-dynamic'.
+  //   Inline scripts without the nonce are blocked. 'unsafe-eval' is intentionally
+  //   NOT included even when strict mode is selected via CSP_MODE=strict in a
+  //   non-prod NODE_ENV — strict mode approximates prod CSP and prod has no
+  //   need for 'unsafe-eval' (Turbopack dev overlay uses eval() and will be
+  //   blocked, but in that case the caller should use dev mode instead).
+  const scriptSrc = _cspMode === "dev"
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'"
+    : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'wasm-unsafe-eval'`;
   const styleSrc = _cspMode === "dev"
     ? _stylePrefix
     : `${_stylePrefix}${nonce}${_styleSuffix}`;


### PR DESCRIPTION
## Summary

Next.js 16.2.3 (merged via #356 earlier today) exposed two dev-only regressions that make the dev dashboard hang forever when accessed via a reverse proxy / Tailscale / remote tunnel. Production is **unaffected** — the strict CSP path is unchanged.

- **CSP nonce propagation broke in dev.** `src/app/layout.tsx` reads the per-request nonce from a `csp-nonce` cookie set by the middleware. Next.js 16.2.3 tightened cookie propagation so the cookie no longer reaches server components on the first request. Next.js HMR, Turbopack dev overlay, and React Fast Refresh inject inline `<script>` tags without the nonce attribute and get blocked by `script-src 'strict-dynamic' + nonce` → the page never hydrates.
- **`allowedDevOrigins` enforcement tightened.** `/_next/webpack-hmr` and `/_next/static/chunks/*` are now blocked when the Host header doesn't match `allowedDevOrigins`, which breaks the dev server behind any reverse proxy.

## Changes

### `proxy.ts` (root middleware) — CSP dev mode relaxation

- Dev mode `script-src` switched to `'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'` — the standard Next.js dev CSP.
- Strict (prod) `script-src` is **bit-identical to before**: `'self' 'nonce-\${nonce}' 'strict-dynamic' 'wasm-unsafe-eval'`.
- Added a **production safety guard**: `CSP_MODE=dev` is rejected when `NODE_ENV=production`, forcing strict mode and logging a warning. This prevents an ops mistake (wrong `.env.production`, Docker env, etc.) from silently downgrading the prod CSP.
- Dead code removal: unused `_scriptSrcSuffix` variable removed after the refactor.

### `next.config.ts` — env-driven `allowedDevOrigins`

- New env var `NEXT_DEV_ALLOWED_ORIGINS` (comma-separated hostname list).
- When set, passed to Next.js `allowedDevOrigins`; when unset, Next.js default behavior (no extra origins) is preserved.
- Production builds ignore this setting — `allowedDevOrigins` is dev-only in Next.js.

## Test plan

- [x] **Prod CSP unchanged**: `NODE_ENV=production npm run build` succeeds (verified: ✅ Compiled successfully in 8.4s).
- [x] **Dev dashboard loads**: Started `npm run dev`, set `NEXT_DEV_ALLOWED_ORIGINS=<host>` in `.env.local`, accessed the dashboard through Tailscale — spinner disappears and React hydrates.
- [x] **No CSP violation reports** in dev server logs when loading the dashboard.
- [x] **No HMR cross-origin block warning** in dev server logs.
- [ ] **Strict mode override still works**: `CSP_MODE=strict npm run dev` loads pages successfully (approximates prod CSP locally).
- [ ] **Prod guard works**: `NODE_ENV=production CSP_MODE=dev npm run start` logs the warning and still uses strict CSP.
- [x] **Pre-PR checks**: `bash scripts/pre-pr.sh` — all 8 checks pass ✅.

## Review

Two rounds of multi-agent review (functionality, security, testing) on this branch:

- **Round 1**: 4 Minor findings, all fixed
  - **S-1**: Added prod guard against `CSP_MODE=dev` downgrade (defense-in-depth)
  - **F1**: Clarified that dev still sets `csp-nonce` cookie (for layout) even though CSP header doesn't use it
  - **F2**: Corrected "Next.js 16" → "Next.js 16.2+" in comment
  - **T-1**: Documented why `'unsafe-eval'` is intentionally absent from strict mode even when overridden via `CSP_MODE=strict` in non-prod
- **Round 2**: No Critical findings — ready to commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)