### PR TITLE
fix(docker): patch HIGH CVEs flagged by Trivy container scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: Install dependencies
 # Pin base image to digest for reproducible builds (update with: docker pull node:20-alpine)
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS deps
-RUN apk add --no-cache libc6-compat && apk upgrade --no-cache zlib
+RUN apk add --no-cache libc6-compat && apk upgrade --no-cache zlib libcrypto3 libssl3
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts
@@ -9,7 +9,7 @@ RUN npm ci --ignore-scripts
 # Stage 2: Build the application
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS builder
 WORKDIR /app
-RUN apk upgrade --no-cache zlib
+RUN apk upgrade --no-cache zlib libcrypto3 libssl3
 ARG DATABASE_URL
 ENV DATABASE_URL=$DATABASE_URL
 COPY --from=deps /app/node_modules ./node_modules
@@ -20,7 +20,7 @@ RUN npx next build
 # Stage 3: Production image
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS runner
 WORKDIR /app
-RUN apk upgrade --no-cache zlib
+RUN apk upgrade --no-cache zlib libcrypto3 libssl3
 
 ENV NODE_ENV=production
 
@@ -35,9 +35,24 @@ COPY --from=builder /app/prisma.config.ts ./prisma.config.ts
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/dotenv ./node_modules/dotenv
 
-# Install prisma CLI + all deps for migrate deploy
-# Patch npm-bundled tar to >=7.5.11 (CVE-2026-31802)
+# Upgrade npm and patch npm-bundled CVE deps in a single layer.
+# - npm 11.12.1: drops bundled cross-spawn entirely and ships glob 13.x /
+#   minimatch 10.x, closing CVE-2024-21538, CVE-2025-64756,
+#   CVE-2026-26996/27903/27904.
+# - tar >=7.5.11: closes CVE-2026-31802 (npm 11.12.1 already ships this; the
+#   patch block is a guarded no-op but kept as a tripwire if a future bump
+#   downgrades).
+# - picomatch >=4.0.4: closes CVE-2026-33671 (still bundled at 4.0.3 nested
+#   under tinyglobby in npm 11.12.1).
+# Patch blocks fail-closed (exit 1) when expected directories disappear, so a
+# silent npm-layout drift cannot reintroduce the CVEs.
+# `--ignore-scripts` on the global npm upgrade limits root-execution blast
+# radius if the registry is compromised. Cache is cleared at the end to avoid
+# shipping the downloaded tarballs in the final layer.
 RUN TAR_VER=7.5.11 && \
+    PICOMATCH_VER=4.0.4 && \
+    NPM_VER=11.12.1 && \
+    npm install -g "npm@${NPM_VER}" --loglevel=error --ignore-scripts && \
     npm install prisma --no-save --ignore-scripts && \
     TAR_DIR=/usr/local/lib/node_modules/npm/node_modules/tar && \
     if [ -d "$TAR_DIR" ]; then \
@@ -52,8 +67,30 @@ RUN TAR_VER=7.5.11 && \
         echo "tar ${CURRENT} already >= ${TAR_VER}, skipping patch"; \
       fi; \
     else \
-      echo "WARNING: tar directory not found at ${TAR_DIR}, skipping patch" >&2; \
-    fi
+      echo "ERROR: tar directory not found at ${TAR_DIR}; npm layout changed, re-verify patch path" >&2 && exit 1; \
+    fi && \
+    PICOMATCH_DIR=/usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch && \
+    if [ -d "$PICOMATCH_DIR" ]; then \
+      CURRENT=$(node -p "require('${PICOMATCH_DIR}/package.json').version") && \
+      if [ "$(printf '%s\n' "$PICOMATCH_VER" "$CURRENT" | sort -V | head -n1)" != "$PICOMATCH_VER" ]; then \
+        cd "$PICOMATCH_DIR" && \
+        npm pack "picomatch@${PICOMATCH_VER}" --quiet && \
+        tar xzf "picomatch-${PICOMATCH_VER}.tgz" --strip-components=1 && \
+        rm -f "picomatch-${PICOMATCH_VER}.tgz" && \
+        node -e "const v=require('./package.json').version;if(v!=='${PICOMATCH_VER}'){console.error('picomatch patch failed: got '+v);process.exit(1)}"; \
+      else \
+        echo "picomatch ${CURRENT} already >= ${PICOMATCH_VER}, skipping patch"; \
+      fi; \
+    else \
+      echo "ERROR: picomatch directory not found at ${PICOMATCH_DIR}; npm layout changed, re-verify patch path" >&2 && exit 1; \
+    fi && \
+    cd / && \
+    npm cache clean --force >/dev/null 2>&1 && \
+    rm -rf /root/.npm /tmp/* && \
+    # Post-patch invariant assertion: fail the build if any expected version is missing.
+    [ "$(npm -v)" = "${NPM_VER}" ] && \
+    node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tar/package.json').version;if(v<'${TAR_VER}'){console.error('tar still '+v);process.exit(1)}" && \
+    node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch/package.json').version;if(v<'${PICOMATCH_VER}'){console.error('picomatch still '+v);process.exit(1)}"
 
 # Copy @prisma runtime adapters (overlay on top of prisma's @prisma packages)
 COPY --from=builder /app/node_modules/@prisma/adapter-pg ./node_modules/@prisma/adapter-pg


### PR DESCRIPTION
## Summary

- Resolves the CI Trivy `container-scan` failure on the main branch (CVE-2026-28390 OpenSSL DoS, HIGH) reported at [run 24289271171](https://github.com/ngc-shj/passwd-sso/actions/runs/24289271171/job/70923804689?pr=364).
- Proactively closes 4 additional HIGH CVEs newly surfaced by the latest Trivy DB so the next PR doesn't fail unrelated to its diff.
- All patches live in the runner stage and are guarded fail-closed against future npm-layout drift.

## CVEs closed

| CVE | Component | Fix |
|---|---|---|
| CVE-2026-28390 | libcrypto3 / libssl3 (OpenSSL DoS) | `apk upgrade libcrypto3 libssl3` → 3.5.6-r0 in all 3 stages |
| CVE-2024-21538 | npm-bundled cross-spawn (ReDoS) | `npm install -g npm@11.12.1` (drops bundled cross-spawn) |
| CVE-2025-64756 | npm-bundled glob (command injection) | npm 11.12.1 ships glob 13.0.6 |
| CVE-2026-26996 / 27903 / 27904 | npm-bundled minimatch (DoS) | npm 11.12.1 ships minimatch 10.2.4 |
| CVE-2026-33671 | npm-bundled picomatch nested under tinyglobby (ReDoS) | in-place `npm pack picomatch@4.0.4` overlay |

## Hardening (review feedback applied)

- Single RUN layer for npm upgrade + all patches → no inter-layer bloat from overwritten files.
- `--ignore-scripts` on the global npm install → limits root-execution blast radius if the registry tarball is compromised.
- Patch blocks **fail-closed** (`exit 1`) when expected directories disappear → silent npm-layout drift cannot reintroduce the CVEs.
- Post-patch invariant assertion verifies npm/tar/picomatch versions before the layer is sealed.
- npm cache cleaned + `/root/.npm` + `/tmp/*` removed → patched tarballs do not ship in the final image.
- `--loglevel=error` instead of `--silent` → genuine install failures surface in CI logs.

## Out of scope (deferred to follow-up)

- `npm pack` supply-chain integrity pinning (sha512 floor) — would require a maintenance burden; deferred to a separate hardening PR.
- Pre-existing `ARG/ENV DATABASE_URL` leak into the builder stage — builder is intermediate, not COPYed to runner; CI uses a dummy value.
- Trivy DB pinning + scheduled nightly re-scan — CI workflow improvement, not Dockerfile.

## Test plan

- [x] `docker build --build-arg DATABASE_URL=postgresql://dummy:dummy@localhost:5432/dummy -t passwd-sso:scan .` — succeeds
- [x] `trivy image --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 passwd-sso:scan` — exit 0 (zero HIGH/CRITICAL)
- [x] Final image versions verified: npm 11.12.1, tar 7.5.11, picomatch 4.0.4, libcrypto3/libssl3 present
- [x] `npx next build` — succeeds
- [ ] CI `container-scan` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)