### PR TITLE
refactor: migrate all logAudit/logAuditBatch to logAuditAsync

### DIFF
--- a/docs/archive/review/migrate-log-audit-code-review.md
+++ b/docs/archive/review/migrate-log-audit-code-review.md
@@ -21,17 +21,13 @@ Initial review — all findings addressed in single round.
 
 ## Security Findings
 
-### S4 Minor: deadLetterLogger の stale redact パス — ACCEPTED
-- Anti-Deferral check: acceptable risk
-- Worst case: redact パスは no-op（存在しないパスに適用）、データ漏洩リスクなし
-- Likelihood: low — deadLetterEntry() が metadata を含まないため漏洩は発生しない
-- Cost to fix: 低（5行削除）だがリグレッションリスクもあるため別 PR で対応
+### S4 Minor: deadLetterLogger の stale redact パス — RESOLVED
+- Action: stale redact 設定を削除、コメントで deadLetterEntry() の設計を説明
+- Modified file: src/lib/audit-logger.ts
 
-### S6 Minor: non-UUID direct write の error reason 汎用化 — ACCEPTED
-- Anti-Deferral check: acceptable risk
-- Worst case: dead letter ログの reason が "logAuditAsync_failed" に統一され、non-UUID 直接書込み失敗と outbox 失敗の区別が困難
-- Likelihood: low — non-UUID 直接書込みパスは share-links の anonymous アクセスのみ
-- Cost to fix: 低（reason 文字列の分岐追加）だがコード複雑化のため別 PR で対応
+### S6 Minor: non-UUID direct write の error reason 汎用化 — RESOLVED
+- Action: 専用 reason "non_uuid_direct_write_failed" を追加、inner try/catch で分離
+- Modified file: src/lib/audit.ts
 
 ## Testing Findings
 
@@ -47,18 +43,18 @@ Initial review — all findings addressed in single round.
 - Action: dead catch 削除に合わせてテストを「logAuditAsync が呼ばれること」の検証に変更
 - Modified file: src/lib/account-lockout.test.ts
 
-### T3 Minor: テスト説明文の陳腐化 — PARTIALLY RESOLVED (same as F3)
+### T3 Minor: テスト説明文の陳腐化 — RESOLVED
+- Action: 11 ファイル・15 箇所のテスト説明文を logAuditAsync に更新
+- Modified files: 11 test files
 
-### T5 Minor: coverage.include に audit.ts 未追加 — ACCEPTED (out of scope)
-- Anti-Deferral check: out of scope (different feature)
-- TODO(migrate-log-audit): vitest.config.ts の coverage.include に audit.ts, audit-outbox.ts を追加
+### T5 Minor: coverage.include に audit.ts 未追加 — RESOLVED
+- Action: vitest.config.ts の coverage.include に audit.ts, audit-outbox.ts を追加
+- Modified file: vitest.config.ts
 
-### T6 Minor: bulk テストに toHaveBeenCalledTimes なし — ACCEPTED
-- Anti-Deferral check: acceptable risk
-- Worst case: 余分な logAuditAsync 呼び出しが検出されない
-- Likelihood: low — bulk 操作のコードパスは固定的
-- Cost to fix: 低だが 8 ファイル × 複数テストの計算が必要で間違いやすい
+### T6 Minor: bulk テストに toHaveBeenCalledTimes なし — RESOLVED
+- Action: 2 team bulk test files に toHaveBeenCalledTimes(3) を追加（残り 6 ファイルは既に完備済み）
+- Modified files: teams/bulk-archive/route.test.ts, teams/bulk-trash/route.test.ts
 
 ## Resolution Status
 
-All Major findings resolved. Minor findings: 3 resolved, 4 accepted with justification.
+All findings resolved. No skipped or accepted findings.

--- a/docs/archive/review/migrate-log-audit-code-review.md
+++ b/docs/archive/review/migrate-log-audit-code-review.md
@@ -1,0 +1,64 @@
+# Code Review: migrate-log-audit
+Date: 2026-04-14
+Review round: 1 (final)
+
+## Changes from Previous Round
+Initial review — all findings addressed in single round.
+
+## Functionality Findings
+
+### F1 Minor: pre-pr.sh に残存 logAudit チェック未追加 — RESOLVED
+- Action: `scripts/pre-pr.sh` に `no-deprecated-logAudit` チェック追加
+- Modified file: scripts/pre-pr.sh
+
+### F2 Minor: account-lockout.ts の dead catch + stale comment — RESOLVED
+- Action: lock_timeout パスの try/catch 削除、コメント更新
+- Modified file: src/lib/account-lockout.ts
+
+### F3 Minor: テスト説明文の陳腐化 — PARTIALLY RESOLVED
+- Action: audit-and-isolation.test.ts の5テスト名更新、account-lockout.test.ts の3テスト名更新
+- Remaining: 他のテストファイルの説明文は cosmetic change のみのため次回機会に対応
+
+## Security Findings
+
+### S4 Minor: deadLetterLogger の stale redact パス — ACCEPTED
+- Anti-Deferral check: acceptable risk
+- Worst case: redact パスは no-op（存在しないパスに適用）、データ漏洩リスクなし
+- Likelihood: low — deadLetterEntry() が metadata を含まないため漏洩は発生しない
+- Cost to fix: 低（5行削除）だがリグレッションリスクもあるため別 PR で対応
+
+### S6 Minor: non-UUID direct write の error reason 汎用化 — ACCEPTED
+- Anti-Deferral check: acceptable risk
+- Worst case: dead letter ログの reason が "logAuditAsync_failed" に統一され、non-UUID 直接書込み失敗と outbox 失敗の区別が困難
+- Likelihood: low — non-UUID 直接書込みパスは share-links の anonymous アクセスのみ
+- Cost to fix: 低（reason 文字列の分岐追加）だがコード複雑化のため別 PR で対応
+
+## Testing Findings
+
+### T1 Major: audit.mocked.test.ts enqueueAudit rejection test が偽陽性 — RESOLVED
+- Action: userId を UUID 形式に修正
+- Modified file: src/__tests__/audit.mocked.test.ts
+
+### T2 Major: audit-and-isolation.test.ts の 5 テストが async/await なし — RESOLVED
+- Action: async + await 追加、テスト名更新
+- Modified file: src/__tests__/integration/audit-and-isolation.test.ts
+
+### T4 Major: account-lockout.test.ts の lock_timeout error-swallow テスト — RESOLVED
+- Action: dead catch 削除に合わせてテストを「logAuditAsync が呼ばれること」の検証に変更
+- Modified file: src/lib/account-lockout.test.ts
+
+### T3 Minor: テスト説明文の陳腐化 — PARTIALLY RESOLVED (same as F3)
+
+### T5 Minor: coverage.include に audit.ts 未追加 — ACCEPTED (out of scope)
+- Anti-Deferral check: out of scope (different feature)
+- TODO(migrate-log-audit): vitest.config.ts の coverage.include に audit.ts, audit-outbox.ts を追加
+
+### T6 Minor: bulk テストに toHaveBeenCalledTimes なし — ACCEPTED
+- Anti-Deferral check: acceptable risk
+- Worst case: 余分な logAuditAsync 呼び出しが検出されない
+- Likelihood: low — bulk 操作のコードパスは固定的
+- Cost to fix: 低だが 8 ファイル × 複数テストの計算が必要で間違いやすい
+
+## Resolution Status
+
+All Major findings resolved. Minor findings: 3 resolved, 4 accepted with justification.

--- a/docs/archive/review/migrate-log-audit-deviation.md
+++ b/docs/archive/review/migrate-log-audit-deviation.md
@@ -1,0 +1,24 @@
+# Coding Deviation Log: migrate-log-audit
+Created: 2026-04-14
+
+## Deviations from Plan
+
+### D1: webhook-dispatcher.ts TENANT scope userId also changed to NIL_UUID
+- **Plan description**: MF6 specified fixing only TEAM scope (L231) `userId: "system"` → `NIL_UUID`. TENANT scope (L302) was to keep `userId: "system"` since `tenantId` is provided.
+- **Actual implementation**: Both TEAM and TENANT scope changed to `userId: NIL_UUID` for consistency.
+- **Reason**: User decision — "揃えた方が良いのであれば揃えましょう" (if it's better to align them, let's do it).
+- **Impact scope**: Both webhook delivery failure audit entries now use `NIL_UUID` instead of `"system"` for `userId`. TENANT scope still works via the normal outbox path (UUID passes the `UUID_RE` check).
+
+### D2: src/lib/mcp/tools.ts `auditDelegationAccess` made async
+- **Plan description**: Plan only specified mechanical `logAudit` → `await logAuditAsync` replacement.
+- **Actual implementation**: The helper function `auditDelegationAccess` was not `async`, so adding `await` required making it `async` and adding `await` at both call sites (`toolListCredentials`, `toolSearchCredentials`).
+- **Reason**: TypeScript requires `await` only inside `async` functions. The function signature had to change to accommodate the migration.
+- **Impact scope**: `auditDelegationAccess` and its 2 callers. No behavioral change beyond making the audit call awaitable.
+
+### D3: Bulk test assertions rewritten (not just renamed)
+- **Plan description**: Plan Step 10d said "grep for logAuditBatch in all test files — update imports and calls".
+- **Actual implementation**: Bulk operation tests (8 files) required significant assertion restructuring because `logAuditBatch(entries)` (single call with array) became `for (const entry of entries) { await logAuditAsync(entry); }` (multiple individual calls). The `mockLogAuditBatch` variable was removed entirely and assertions were rewritten to check individual `mockLogAudit` calls.
+- **Reason**: The test assertion pattern fundamentally changed — a single batch call became multiple per-entry calls.
+- **Impact scope**: 8 bulk operation test files (personal + team).
+
+---

--- a/docs/archive/review/migrate-log-audit-plan.md
+++ b/docs/archive/review/migrate-log-audit-plan.md
@@ -1,0 +1,456 @@
+# Plan: Bulk Migration of logAudit → logAuditAsync / logAuditInTx
+
+## Project context
+
+- **Type**: web app + service (Next.js 16 / Prisma 7 / PostgreSQL 16)
+- **Test infrastructure**: unit tests (vitest) + integration tests (real Postgres) + CI/CD
+- **Test obligations apply**: Major/Critical findings recommending tests are in scope.
+
+## Objective
+
+Complete the Phase 1 follow-up sweep: migrate all remaining `logAudit()` (fire-and-forget, void) and `logAuditBatch()` call sites to the durable audit path, then delete the deprecated functions.
+
+**Why this matters**: `logAudit()` is fire-and-forget (`void logAuditAsync(...).catch(...)`) — if the process crashes or the event loop stalls before the outbox write completes, the audit entry is silently lost. The durable audit outbox (Phase 1) was introduced to guarantee F1 atomicity (business write ⇔ audit row), but only ~15 security-critical call sites were migrated. The remaining ~160 call sites still use the lossy path, leaving the Phase 1 objective incomplete.
+
+**Parent design document**: [`durable-audit-outbox-plan.md`](./durable-audit-outbox-plan.md) (F10, L1058-1066, L925)
+
+## Background — call site inventory
+
+A full codebase survey identified the following categories:
+
+| Category | Count | Migration target | Notes |
+|----------|-------|-------------------|-------|
+| A — Inside `prisma.$transaction` | **0** | `logAuditInTx(tx, tenantId, params)` | None found — all call sites fire after tx commits |
+| B — Outside transaction (route handlers, lib) | **~152** | `await logAuditAsync(params)` | Main migration target |
+| B2 — `logAuditBatch` call sites | **8** | Loop with `await logAuditAsync()` | Personal + team bulk ops |
+| C — auth.ts (NextAuth callbacks) | **2** | `await logAuditAsync(params)` | AUTH_LOGIN / AUTH_LOGOUT — NextAuth events support async |
+| D — Test files | **11** | Update to test new API | `audit.mocked.test.ts`, integration tests |
+| E — webhook-dispatcher.ts | **2** | `await logAuditAsync()` via dynamic import | Preserve lazy import for circular dep |
+
+**Key finding**: No `logAudit()` calls exist inside `prisma.$transaction()` callbacks. Every call follows the pattern: transaction completes → `logAudit()` fires outside. Therefore the bulk migration target is `logAuditAsync`, not `logAuditInTx`.
+
+## Requirements
+
+### Functional
+
+| # | Requirement |
+|---|---|
+| MF1 | Enhance `logAuditAsync` to emit structured JSON to `auditLogger` (currently only `logAudit` does this). After migration, structured log forwarding must continue working. **tenantId handling**: emit `params.tenantId ?? null` (pre-resolution value) in structured JSON. This preserves emit-first ordering while including tenantId when the caller provides it. Callers that already pass `tenantId` (tenant/admin endpoints) will have it in the emit; callers that rely on `resolveTenantId` will emit `null` (same as current `logAudit` behavior). |
+| MF2 | `logAuditAsync` must catch all errors internally and log to `deadLetterLogger` — callers should not need try/catch. The function never throws. **Dead letter sanitization**: before logging to `deadLetterLogger`, apply `sanitizeMetadata(params.metadata)` to prevent raw metadata (which may contain sensitive data) from reaching stdout. Log only `{ scope, action, userId, tenantId, reason, error }` — not the full `auditEntry: params`. |
+| MF3 | Replace all ~152 `logAudit(params)` calls with `await logAuditAsync(params)`. |
+| MF4 | Replace all 8 `logAuditBatch(list)` calls with `for (const p of list) { await logAuditAsync(p); }` or equivalent. |
+| MF5 | Delete `logAudit()` and `logAuditBatch()` from `src/lib/audit.ts`. Remove `@deprecated` annotations. |
+| MF6 | Update 2 webhook-dispatcher.ts call sites: change dynamic import target from `logAudit` to `logAuditAsync`, add `await`. Preserve the lazy `await import(...)` pattern to avoid circular dependency. **Fix TEAM scope site** (L231): change `userId: "system"` to `userId: NIL_UUID` so the call follows the normal outbox path (avoids dead letter when `tenantId` is not provided for TEAM-scope webhook failures). Import `NIL_UUID` from `@/lib/constants/app`. |
+| MF7 | Migrate auth.ts AUTH_LOGIN / AUTH_LOGOUT (2 sites) to `await logAuditAsync(params)`. NextAuth v5 `events` callbacks accept async functions — the `await` ensures the outbox write completes before the callback returns. This is strictly better than fire-and-forget and resolves the original DEFERRED status. |
+| MF8 | Update test files to test `logAuditAsync` instead of `logAudit`. |
+| MF9 | Remove `logAuditBatch` export and any re-exports. |
+| MF10 | Any call site using string literals for `scope` or `action` instead of enum constants must be fixed during migration. |
+
+### Non-functional
+
+| # | Requirement |
+|---|---|
+| MN1 | No behavioral change to end users — audit events continue to be written to the outbox and forwarded. |
+| MN2 | Response latency impact: `await logAuditAsync()` adds ~1-5ms per request (single outbox INSERT). Acceptable for all endpoints. |
+| MN3 | All existing tests must pass after migration. Build must succeed. |
+| MN4 | The structured JSON emit to `auditLogger` must remain synchronous within `logAuditAsync` — it must not depend on the outbox write succeeding. |
+
+## Technical approach
+
+### 1. Enhance `logAuditAsync` in `src/lib/audit.ts`
+
+Current `logAuditAsync`:
+```typescript
+export async function logAuditAsync(params: AuditLogParams): Promise<void> {
+  const payload = buildOutboxPayload(params);
+  // ... tenantId resolution, outbox enqueue
+  // Does NOT emit structured JSON
+  // Does NOT catch errors
+}
+```
+
+After enhancement:
+```typescript
+export async function logAuditAsync(params: AuditLogParams): Promise<void> {
+  const payload = buildOutboxPayload(params);
+
+  // Structured JSON emit FIRST (synchronous, never fails the caller)
+  // tenantId uses pre-resolution value (params.tenantId ?? null)
+  try {
+    auditLogger.info(
+      {
+        audit: {
+          scope: payload.scope,
+          action: payload.action,
+          userId: payload.userId,
+          actorType: payload.actorType,
+          serviceAccountId: payload.serviceAccountId,
+          tenantId: params.tenantId ?? null,
+          teamId: payload.teamId,
+          targetType: payload.targetType,
+          targetId: payload.targetId,
+          metadata: sanitizeMetadata(payload.metadata),
+          ip: payload.ip,
+          userAgent: payload.userAgent,
+        },
+      },
+      `audit.${payload.action}`,
+    );
+  } catch {
+    // Never let forwarding break the app
+  }
+
+  // Outbox enqueue (awaited, ALL errors caught — MF2 "never throws")
+  try {
+    // Non-UUID userId path — dead letter output also sanitized
+    if (!UUID_RE.test(params.userId)) {
+      const tenantId = params.tenantId ?? null;
+      if (!tenantId) {
+        deadLetterLogger.warn(
+          { scope: params.scope, action: params.action, userId: params.userId,
+            reason: "non_uuid_userId_no_tenantId" },
+          "audit.dead_letter",
+        );
+        return;
+      }
+      // ... direct auditLog.create (unchanged)
+      return;
+    }
+
+    // Normal path: resolve tenantId, enqueue to outbox
+    const tenantId = await resolveTenantId(params);
+    if (!tenantId) {
+      deadLetterLogger.warn(
+        { scope: params.scope, action: params.action, userId: params.userId,
+          reason: "tenant_not_found" },
+        "audit.dead_letter",
+      );
+      return;
+    }
+    await enqueueAudit(tenantId, payload);
+  } catch (err) {
+    // Outer catch: resolveTenantId or enqueueAudit failure
+    deadLetterLogger.warn(
+      { scope: params.scope, action: params.action, userId: params.userId,
+        tenantId: params.tenantId ?? null,
+        reason: "logAuditAsync_failed", error: String(err) },
+      "audit.dead_letter",
+    );
+  }
+}
+```
+
+**Design decisions**:
+- Structured JSON is emitted FIRST (synchronous, no await) so it's never lost even if outbox write fails
+- `tenantId` in structured emit uses `params.tenantId ?? null` (pre-resolution) — callers that pass `tenantId` will have it; callers that rely on `resolveTenantId` will emit `null` (matches current `logAudit` behavior)
+- Dead letter output is sanitized: only `{ scope, action, userId, tenantId, reason, error }` — raw `metadata` is never logged to prevent sensitive data leakage
+- Error catching is inside `logAuditAsync` so callers don't need try/catch
+- The function never throws — `await logAuditAsync()` always resolves
+
+### 2. Migration patterns
+
+#### Pattern B1: Simple replacement (majority of call sites)
+
+```typescript
+// Before
+logAudit({
+  scope: AUDIT_SCOPE.PERSONAL,
+  action: AUDIT_ACTION.ENTRY_CREATE,
+  userId, ip, userAgent,
+  ...
+});
+
+// After
+await logAuditAsync({
+  scope: AUDIT_SCOPE.PERSONAL,
+  action: AUDIT_ACTION.ENTRY_CREATE,
+  userId, ip, userAgent,
+  ...
+});
+```
+
+#### Pattern B2: logAuditBatch replacement
+
+```typescript
+// Before
+logAuditBatch(auditEntries);
+
+// After
+for (const entry of auditEntries) {
+  await logAuditAsync(entry);
+}
+```
+
+Note: Sequential await is preferred over `Promise.all` because:
+- Each `logAuditAsync` opens its own transaction to the outbox
+- Sequential writes are more predictable under load
+- Count is small (typically < 50 entries in bulk ops)
+
+#### Pattern B3: Dual-scope audit (delegation, MCP tools)
+
+```typescript
+// Before
+logAudit({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL });
+logAudit({ ...auditBase, scope: AUDIT_SCOPE.TENANT });
+
+// After
+await logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL });
+await logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.TENANT });
+```
+
+#### Pattern E: Webhook dispatcher (dynamic import)
+
+```typescript
+// Before
+const { logAudit } = await import("@/lib/audit");
+logAudit({ ... });
+
+// After
+const { logAuditAsync } = await import("@/lib/audit");
+await logAuditAsync({ ... });
+```
+
+The lazy `await import(...)` MUST be preserved — it breaks the circular dependency between `audit.ts` ↔ `webhook-dispatcher.ts`.
+
+### 3. Deletion of deprecated functions
+
+After all call sites are migrated:
+
+1. Delete `logAudit()` function (L213-263)
+2. Delete `logAuditBatch()` function (L273-279)
+3. Remove `@deprecated` JSDoc from `logAuditAsync` if present
+4. Clean up any unused imports that were only needed by the deleted functions
+
+### 4. Test updates
+
+#### `src/__tests__/audit.mocked.test.ts`
+
+- Replace all `logAudit(...)` calls with `await logAuditAsync(...)`
+- Test that `logAuditAsync` emits structured JSON to `auditLogger`
+- Test that `logAuditAsync` catches errors and logs to `deadLetterLogger`
+- Test that `logAuditAsync` never throws
+
+#### `src/__tests__/integration/audit-and-isolation.test.ts`
+
+- Replace all `logAudit(...)` calls with `await logAuditAsync(...)`
+- Integration tests already verify outbox behavior — migration should be transparent
+
+### 5. Special cases
+
+| Call site | Handling |
+|-----------|----------|
+| `src/auth.ts:338,350` | Migrate to `await logAuditAsync()` — NextAuth v5 events support async callbacks |
+| `src/app/api/share-links/verify-access/route.ts:75,90` | `userId: "anonymous"` (non-UUID) — `logAuditAsync` already handles this path |
+| `src/lib/account-lockout.ts:284,317,366` | Fallback paths where tenantId is null — `logAuditAsync` handles via `resolveTenantId` |
+| `src/app/api/mcp/register/route.ts:172` | `userId: NIL_UUID`, `actorType: "SYSTEM"` — `logAuditAsync` handles non-UUID path |
+| `src/app/api/internal/audit-emit/route.ts:46` | Dynamic action — works with `logAuditAsync` as-is |
+| `src/lib/webhook-dispatcher.ts:231,302` | Dynamic import — change import target, add await. **L231 (TEAM scope)**: fix `userId: "system"` → `NIL_UUID` to avoid dead letter (non-UUID + no tenantId → dropped). **L302 (TENANT scope)**: keep `userId: "system"` — `tenantId: event.tenantId` is provided, so the non-UUID direct-write path works correctly. `AuditLog.userId` is nullable with no FK constraint, so `userId: "system"` is stored as-is. |
+| `src/app/api/vault/setup/route.ts` etc. | String literals for scope/action — fix to use constants (MF10) |
+
+## Implementation steps
+
+### Step 1: Enhance `logAuditAsync` (src/lib/audit.ts)
+
+1. Add structured JSON emit to `logAuditAsync` (move from `logAudit`) — emit FIRST before outbox write
+2. Wrap the **entire body** (including `resolveTenantId` + `enqueueAudit`) in a single outer try/catch with `deadLetterLogger` — MF2 "never throws" requires catching ALL errors, not just `enqueueAudit`
+3. Sanitize all dead letter outputs (3 paths: `non_uuid_userId_no_tenantId`, `tenant_not_found`, outer catch) — log only `{ scope, action, userId, tenantId, reason, error }`, never raw `metadata`
+4. Ensure the function never throws
+
+**Step 1 and Step 10a/10b MUST be in the same commit** — modifying `logAuditAsync` to never-throw will break `audit-fifo-flusher.test.ts` L153-168 (`rejects.toThrow`). Both the implementation change and the test update must land atomically.
+
+### Step 2: Migrate `src/lib/` call sites (~15 files)
+
+Migrate in order:
+1. `src/lib/access-restriction.ts` (3 sites)
+2. `src/lib/team-policy.ts` (1 site)
+3. `src/lib/auth-adapter.ts` (2 sites)
+4. `src/lib/account-lockout.ts` (3 sites)
+5. `src/lib/delegation.ts` (4 sites)
+6. `src/lib/directory-sync/engine.ts` (1 site)
+7. `src/lib/mcp/tools.ts` (2 sites)
+8. `src/lib/webhook-dispatcher.ts` (2 sites — dynamic import pattern)
+
+### Step 3: Migrate personal route handlers (~50 files)
+
+Migrate all `src/app/api/` route handlers that use PERSONAL scope:
+- passwords (CRUD, bulk, attachments, history)
+- folders, tags
+- vault (setup, reset, rotate-key, recovery-key, delegation)
+- sessions
+- api-keys
+- webauthn
+- emergency-access
+- travel-mode
+- audit-logs (export, download, import)
+- sends
+- watchtower
+- extension
+- auth/passkey/verify
+
+### Step 4: Migrate tenant/admin route handlers (~25 files)
+
+- tenant/policy, tenant/members, tenant/breakglass
+- tenant/service-accounts (CRUD, tokens)
+- tenant/access-requests (CRUD, approve, deny)
+- tenant/webhooks
+- tenant/scim-tokens
+- tenant/mcp-clients
+- tenant/audit-delivery-targets
+- tenant/audit-logs/download
+- admin/rotate-master-key
+- maintenance/* (purge-audit-logs, purge-history, dcr-cleanup, audit-outbox-*, audit-chain-verify)
+- scim/v2 (Users, Groups)
+- directory-sync (CRUD, run)
+- mcp (register, token, authorize/consent)
+- internal/audit-emit
+
+### Step 5: Migrate team route handlers (~20 files)
+
+- teams/[teamId]/passwords (CRUD, bulk, attachments, history)
+- teams/[teamId]/folders
+- teams/[teamId]/members
+- teams/[teamId]/invitations
+- teams/[teamId]/webhooks
+- teams/[teamId]/policy
+- teams/[teamId]/rotate-key
+- teams/[teamId]/audit-logs/download
+
+### Step 6: Migrate logAuditBatch call sites (8 files)
+
+- passwords/bulk-import, bulk-restore, bulk-trash, bulk-archive
+- teams/[teamId]/passwords/bulk-import, bulk-restore, bulk-trash, bulk-archive
+
+### Step 7: Update import statements
+
+- Change `import { logAudit, ... }` to `import { logAuditAsync, ... }` in all migrated files
+- Remove `logAuditBatch` from all imports
+
+### Step 8: Delete deprecated functions
+
+- Remove `logAudit()` from `src/lib/audit.ts`
+- Remove `logAuditBatch()` from `src/lib/audit.ts`
+- Clean up unused imports in `audit.ts`
+
+### Step 9: Migrate auth.ts (AUTH_LOGIN / AUTH_LOGOUT)
+
+- Replace `logAudit(params)` with `await logAuditAsync(params)` in both `events.signIn` and `events.signOut` callbacks
+- NextAuth v5 `events` callbacks support async functions — `await` ensures the outbox write completes
+- Import `logAuditAsync` from `@/lib/audit`, remove `logAudit` import
+- This resolves the original DEFERRED status from Phase 1 (design doc L1065-1066)
+
+### Step 10: Update tests (immediately after Step 1)
+
+**NOTE**: Test updates for `logAuditAsync` behavior (Step 10a) must run immediately after Step 1 to verify MF1/MF2 implementation before proceeding with bulk migration.
+
+#### Step 10a: `src/__tests__/audit.mocked.test.ts` (same commit as Step 1)
+
+- **Rewrite** the existing `describe("logAudit", ...)` block (L36-183) to test `logAuditAsync` instead — these tests must be converted, not merely supplemented, because `logAudit` will be deleted in Step 8
+- Replace all `logAudit(...)` calls with `await logAuditAsync(...)`
+- Add/update test cases:
+  1. `logAuditAsync` calls `auditLogger.info` with structured audit payload (MF1)
+  2. `logAuditAsync` includes `tenantId` in structured emit when provided
+  3. `enqueueAudit` throws → `logAuditAsync` resolves (not rejects) + `deadLetterLogger` called (MF2)
+  4. `auditLogger.info` throws → `logAuditAsync` still resolves (MN4)
+  5. Dead letter output does not contain raw `metadata` (S2 fix)
+  6. `expect(mockEnqueueAudit).toHaveBeenCalled()` for normal flow (T3 fix)
+
+#### Step 10b: `src/__tests__/audit-fifo-flusher.test.ts` (same commit as Step 1)
+
+- **Rewrite L153-168**: change `rejects.toThrow(...)` to `expect(logAuditAsync(...)).resolves.toBeUndefined()` + `expect(deadLetterLogger.warn).toHaveBeenCalled()` (T4 fix — current test contradicts MF2)
+- Add `auditLogger.info` mock and assertion (change mock `enabled: true` if needed — no guard in code, but pino may check it)
+
+#### Step 10c: `src/__tests__/integration/audit-and-isolation.test.ts` (after Step 8)
+
+- Replace `logAudit` mock with `logAuditAsync` mock
+- Note: this file uses mocks and does not test real outbox behavior. Real outbox testing is in `src/__tests__/db-integration/` tests (out of scope for this migration).
+
+#### Step 10d: Other test files (after Step 6)
+
+- Grep for `logAuditBatch` in all test files including `bulk-*.route.test.ts` — update imports and calls
+- Verify no remaining `logAudit` or `logAuditBatch` imports in any test file
+
+### Step 11: Verification
+
+1. `npx vitest run` — all tests pass
+2. `npx next build` — production build succeeds
+3. Grep for remaining `logAudit(` calls — should only find `logAuditAsync` and `logAuditInTx`
+4. Add residual-logAudit check to `scripts/pre-pr.sh`: use `if grep -rn 'logAudit(' src/ --include='*.ts' | grep -v 'logAuditAsync\|logAuditInTx' | grep -v test | grep -q .; then echo "ERROR: residual logAudit calls found"; exit 1; fi` pattern (not bare grep, which fails with exit code 1 on zero matches under `set -euo pipefail`)
+
+## Testing strategy
+
+| Test | Type | What it verifies |
+|------|------|-----------------|
+| `audit.mocked.test.ts` | Unit (mocked) | `logAuditAsync` emits structured JSON (MF1), catches errors (MF2), dead letter sanitized (S2), never throws (MN4), outbox called (T3) |
+| `audit-fifo-flusher.test.ts` | Unit (mocked) | `logAuditAsync` error → resolves (not rejects) + deadLetter (T4 rewrite), auditLogger emit |
+| `audit-and-isolation.test.ts` | Unit (mocked) | Mock-based isolation verification (note: does NOT test real outbox) |
+| Build verification | `next build` | All imports resolve, no type errors |
+| Grep verification | `pre-pr.sh` + manual | No remaining `logAudit(` calls (except `logAuditAsync`/`logAuditInTx`) |
+
+## Considerations & constraints
+
+### Performance impact
+
+- `await logAuditAsync()` adds ~1-5ms per request for the outbox INSERT
+- For batch operations (bulk-import with many entries), sequential awaits may add noticeable latency
+- Mitigation: batch operations already have high latency; audit overhead is negligible relative to the business operation
+
+### auth.ts — fully migrated (no longer DEFERRED)
+
+- Original plan deferred AUTH_LOGIN/AUTH_LOGOUT because `logAuditInTx` requires a transaction scope
+- Since we're using `logAuditAsync` (self-contained transaction), we CAN fully migrate these sites
+- NextAuth v5 `events` callbacks accept async functions — `await logAuditAsync(params)` ensures the outbox write completes before the callback returns
+- This is strictly better than `logAudit()` because: (1) outbox write is awaited (no silent loss on process shutdown), (2) errors go to `deadLetterLogger` instead of being silently swallowed
+- AUTH_LOGIN / AUTH_LOGOUT are the most audit-critical events — fire-and-forget is unacceptable for compliance (SOC 2, ISO 27001)
+
+### Webhook dispatcher circular dependency
+
+- `audit.ts` imports from `webhook-dispatcher.ts` (for webhook dispatch on audit events)
+- `webhook-dispatcher.ts` imports from `audit.ts` (to log delivery failures)
+- The lazy `await import("@/lib/audit")` in webhook-dispatcher.ts breaks this cycle
+- This pattern MUST be preserved during migration
+
+### Out of scope
+
+- Moving any call site INTO a `prisma.$transaction` for atomicity (that's a separate future effort)
+- Changing the `logAuditInTx` API or behavior
+- Modifying the outbox worker
+- Adding new audit actions or changing existing ones
+
+## User operation scenarios
+
+### Scenario 1: Normal API request with audit
+
+1. User creates a password entry via POST /api/passwords
+2. Route handler creates the entry in a transaction
+3. After transaction commits, `await logAuditAsync(params)` writes to outbox
+4. Response is sent to user
+5. Worker picks up outbox row and writes to audit_logs
+
+**Change from current**: Step 3 now awaits instead of fire-and-forget. If the outbox write fails, the error is logged to deadLetterLogger but the response still succeeds.
+
+### Scenario 2: Bulk operation with multiple audit entries
+
+1. User bulk-imports 50 password entries via POST /api/passwords/bulk-import
+2. Entries are created in a transaction
+3. 50 `await logAuditAsync()` calls execute sequentially
+4. Response is sent
+
+**Performance**: ~50-250ms additional latency from sequential outbox writes. Acceptable for a bulk operation.
+
+### Scenario 3: Auth login (NextAuth callback)
+
+1. User signs in via Google OIDC
+2. NextAuth triggers `events.signIn` callback (async)
+3. `await logAuditAsync(params)` writes AUTH_LOGIN to outbox
+4. Callback returns, auth flow completes
+
+**Change from current**: Now awaits `logAuditAsync` (durable, errors caught) instead of `logAudit` (fire-and-forget, errors swallowed). Auth events are fully durable.
+
+### Scenario 4: Webhook delivery failure audit
+
+1. Webhook delivery fails
+2. webhook-dispatcher.ts dynamically imports `logAuditAsync`
+3. `await logAuditAsync({ action: WEBHOOK_DELIVERY_FAILED, ... })` writes to outbox
+4. The action is in `OUTBOX_BYPASS_AUDIT_ACTIONS` — worker writes directly to audit_logs, skipping re-dispatch
+
+**Change from current**: Same behavior but with `await` for durability.

--- a/docs/archive/review/migrate-log-audit-review.md
+++ b/docs/archive/review/migrate-log-audit-review.md
@@ -1,0 +1,156 @@
+# Plan Review: migrate-log-audit
+Date: 2026-04-14
+Review round: 2
+
+## Changes from Previous Round (Round 1 → 2)
+
+Round 1 findings addressed:
+- F1/S5/F4: tenantId in structured emit → `params.tenantId ?? null` pre-resolution
+- F2: webhook-dispatcher TEAM scope → `userId: NIL_UUID`
+- F3/T7: Test file lists expanded, audit-fifo-flusher.test.ts added
+- S1: auth.ts → `await logAuditAsync` (NextAuth v5 async events)
+- S2: dead letter sanitization — sanitized output only
+- T1-T5: Test strategy rewritten with substeps 10a-10d
+- T6: pre-pr.sh grep check added
+
+Round 2 new findings addressed:
+- F5: try/catch wraps entire body including resolveTenantId
+- F6: TENANT scope userId:"system" decision documented explicitly
+- F7: NOT an issue — AuditLog.userId is nullable, no FK
+- S6 (M1): All 3 dead letter paths sanitized (not just catch block)
+- G1: logAudit test blocks explicitly rewritten (not supplemented)
+- G4/T4: Step 1 + Step 10a/10b in same commit
+- T6 impl note: grep with `if/then` pattern for pipefail safety
+- G2: NOT an issue — no auditLogger.enabled guard in code
+- G3: Deferred to implementation (grep during Step 10d)
+
+## Functionality Findings
+
+### F1 Major: structured JSON emit に tenantId が欠落 — 明示的決定が必要
+- Problem: 計画の Step 1 で `logAuditAsync` に `auditLogger.info` emit を移植するが、tenantId を含めるか否かが未定義。現行 `logAudit` も tenantId を emit していないが、移行を機に方針を明確にすべき。
+- Impact: SIEM 等の外部転送先でテナント別フィルタリングが不完全になる。
+- Recommended action: MF1 に「tenantId を structured JSON に含めるか否かを明示的に決定」を追記。含める場合は `resolveTenantId()` の結果を emit に渡す。
+
+### F2 Major: webhook-dispatcher.ts TEAM scope の `userId: "system"` + tenantId 欠落 → dead letter
+- Problem: `webhook-dispatcher.ts:231` の TEAM scope 呼び出しは `userId: "system"` (非UUID) かつ `tenantId` なし。`logAuditAsync` の non-UUID userId 分岐では `params.tenantId ?? null` が null → dead letter に落ちる。
+- Impact: `WEBHOOK_DELIVERY_FAILED` (TEAM) イベントが監査ログに記録されない。
+- Recommended action: TEAM scope 呼び出しに `tenantId` を追加するか、`userId` を `NIL_UUID` に変更して通常の outbox パスを使う。MF6 の作業範囲に含める。
+
+### F3 Minor: テストファイル網羅性の不完全
+- Problem: logAuditBatch を参照するテストファイル（bulk-*.route.test.ts 等）が計画の Step 10 に明示されていない。
+- Recommended action: Step 10 に「logAuditBatch を参照する全テストファイル」を明示的にリストアップ。
+
+### F4 Minor: emit-first と tenantId 解決の順序矛盾
+- Problem: MN4（structured emit は同期的）と tenantId を emit に含める場合の矛盾。
+- Recommended action: 「structured emit は tenantId を含まない（emit first 優先）」 or 「emit は tenantId 解決後（MN4 を "outbox 成功に非依存" と再解釈）」を明記。
+
+## Security Findings
+
+### S1 Major: AUTH_LOGIN/AUTH_LOGOUT の `void logAuditAsync` — Graceful shutdown 時の監査消失
+- Problem: `void logAuditAsync(params)` は await されないため、プロセス終了直前に発火した場合、outbox 書き込みが完了しないまま終了する。認証イベントは最も監査価値の高い操作。
+- Impact: 攻撃者のアカウント乗っ取り後のフォレンジック品質が低下。SOC 2 / ISO 27001 の監査証跡完全性違反。
+- Recommended action: NextAuth `events` callback は async function を受け付ける。`void` ではなく `await` に変更するか、SIGTERM ハンドラで保留中 outbox 書き込み完了を保証する仕組みを計画に追記。
+
+### S2 Major: dead letter ログへの raw `params.metadata` 出力 — sanitize 前データ漏洩
+- Problem: `deadLetterLogger.warn({ auditEntry: params, ... })` は `sanitizeMetadata()` 適用前の生 `metadata` を出力する。
+- Impact: 業務データが stdout 経由でログ集約基盤に流出するリスク。
+- Recommended action: dead letter 書き込み前に `sanitizeMetadata(params.metadata)` を適用するか、出力を `{ scope, action, userId, reason }` に限定。Step 1 で明示的にカバー。
+
+### S3 Minor: `internal/audit-emit` の never-throws 保証がテスト未担保
+- Problem: 動的 action エンドポイントで `logAuditAsync` が想定外に throw した場合 500 を返す可能性。
+- Recommended action: MF2 の never-throws をユニットテストで担保。
+
+### S4 Minor: concurrent enqueueAudit での RLS session-local 設定の並行安全性
+- Problem: `set_config(..., true)` (is_local=true) が Prisma `$transaction` のコネクションプール内で適切にリセットされるか未検証。
+- Recommended action: インテグレーションテストで concurrent enqueueAudit が tenantId を混入しないことを検証。
+
+### S5 Minor: structured JSON emit に tenantId 欠落 (F1 と重複)
+- Merged with F1.
+
+## Testing Findings
+
+### T1 Critical: `logAuditAsync` の auditLogger emit テストがゼロ
+- Problem: 現在の `audit.mocked.test.ts` は `logAudit` のみテスト。`logAuditAsync` の structured JSON emit、エラーキャッチ、never-throws をテストするケースが存在しない。
+- Impact: MF1/MF2 の回帰を検出不能。
+- Recommended action: Step 10 に以下を追加：
+  1. `logAuditAsync` が `auditLogger.info` を呼び出すこと
+  2. `enqueueAudit` が throw しても `logAuditAsync` が throw しないこと
+  3. `auditLogger.info` が throw しても `logAuditAsync` が throw しないこと
+
+### T2 Critical: MF1 実装が現コードに存在せず — テスト駆動の順序を計画に明記すべき
+- Problem: 現在の `logAuditAsync` (L161-203) は `auditLogger.info` を呼び出す行がない。計画の Step 1 で追加する予定だが、テスト更新 (Step 10) との順序関係が不明確。
+- Impact: Step 1 が正しく実装されたかの検証手段がない。
+- Recommended action: Step 1 の直後にテスト更新を配置するか、TDD 的にテストを先に書くことを計画に明記。
+
+### T3 Major: `mockEnqueueAudit` の呼び出しアサーション欠落
+- Problem: `audit.mocked.test.ts` の `mockEnqueueAudit` は `vi.hoisted` で定義済みだが、どのテストも `expect(mockEnqueueAudit)` でアサートしていない。
+- Recommended action: 書き直し時に正常系で `expect(mockEnqueueAudit).toHaveBeenCalled()` を追加。
+
+### T4 Major: `audit-fifo-flusher.test.ts` の「propagates rejection」テストが MF2 と矛盾
+- Problem: L153-168 のテストは `logAuditAsync` が reject を伝播することを `rejects.toThrow` でアサート。MF2「never throws」と正反対。
+- Impact: MF2 を正しく実装するとこのテストが fail する。
+- Recommended action: Step 10 に「`rejects.toThrow` を `not.rejects` + `deadLetterLogger` 呼び出しアサーションに書き換え」を明記。
+
+### T5 Major: `audit-and-isolation.test.ts` がモック中心で実 outbox 書き込みを未検証
+- Problem: `vi.mock("@/lib/audit", ...)` で `logAudit` をモックに差し替え、呼び出しのみアサート。実際の outbox 動作は未検証。
+- Recommended action: Step 10 に「モックを `logAuditAsync` に置き換えるが、outbox 書き込みの実検証は db-integration テストへの昇格を検討」と明記。
+
+### T6 Minor: grep 検証が手動依存で CI 未組み込み
+- Recommended action: pre-pr.sh 等に残留 `logAudit(` 検出を追加。
+
+### T7 Minor: `audit-fifo-flusher.test.ts` が Testing strategy テーブルに記載漏れ
+- Recommended action: テーブルに追加し、変更内容（propagation 反転、auditLogger emit 追加）を明記。
+
+## Adjacent Findings
+- [Adjacent from T2] RT2: `logAuditAsync` の型シグネチャは変わらないが never-throws 保証という仕様変化が ~152 ファイルのレビューで漏れるリスク — Functionality expert scope
+
+## Quality Warnings
+None (local LLM pre-screening found no issues)
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1 (Shared utility reimplementation): Checked — no issue (logAuditAsync is the existing shared utility)
+- R2 (Constants hardcoded): Checked — MF10 addresses string literal → constant migration
+- R3 (Pattern propagation): Checked — all ~160 call sites covered
+- R4 (Event dispatch gaps): Checked — F2 found webhook-dispatcher TEAM scope issue
+- R5 (Missing transactions): N/A — migration keeps calls outside transactions
+- R6 (Cascade delete orphans): N/A — no deletes
+- R7 (E2E selector breakage): N/A — no UI changes
+- R8 (UI pattern inconsistency): N/A — no UI changes
+- R9 (Transaction boundary for fire-and-forget): Checked — auth.ts `void logAuditAsync` is intentional, not inside tx
+- R10 (Circular module dependency): Checked — lazy import in webhook-dispatcher preserved
+- R11 (Display group ≠ subscription group): N/A — no event grouping changes
+- R12 (Enum/action group coverage gap): N/A — no new audit actions
+- R13 (Re-entrant dispatch loop): N/A — no dispatch changes
+- R14 (DB role grant completeness): N/A — no new DB roles
+- R15 (Hardcoded env values in migrations): N/A — no migrations
+- R16 (Dev/CI environment parity): N/A — no DB role/privilege tests
+
+### Security expert
+- R1-R5: Not applicable (no raw queries, XSS, CSRF, auth bypass, IDOR)
+- R6 (Sensitive data in logs): S2 — raw params.metadata in dead letter logs
+- R7-R8: Not applicable (no crypto, no access control changes)
+- R9 (Security misconfiguration): S4 — RLS session-local parallel safety
+- R10 (Audit/logging gaps): S1, S5 — auth event fire-and-forget, tenantId in emit
+- R11-R14: Not applicable
+- R15 (Business logic vulnerabilities): S1 — audit completeness violation
+- R16: Not applicable
+- RS1 (Multi-tenant isolation): S4 — concurrent enqueueAudit tenantId contamination
+- RS2 (E2E encryption integrity): Not applicable
+- RS3 (Outbox atomicity): Addressed by plan design, residual risk is S1
+
+### Testing expert
+- R1 (False-positive tests): T5 — mock-only assertion in audit-and-isolation
+- R2 (Missing tests for critical path): T1, T2 — logAuditAsync emit untested
+- R3 (Flaky tests): No issue
+- R4 (Mock inconsistency): T4 — propagation spec contradicts MF2
+- R5 (Coverage gaps): T3 — outbox assertion missing
+- R6-R8: No issue
+- R9 (CI integration): T6 — grep verification manual only
+- R10 (Integration test as unit test): T5 — audit-and-isolation uses mocks
+- R11-R15: No issue
+- R16 (Documentation-test mismatch): T7 — testing strategy table incomplete
+- RT1 (Write-read consistency): T5 — mock write, mock assert
+- RT2 (Type checking): Adjacent finding — never-throws spec change across 152 files
+- RT3 (Test validation): T4 — existing test contradicts plan requirement

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -35,7 +35,7 @@ run_step "Static: team-auth-rls"  node scripts/check-team-auth-rls.mjs
 run_step "Static: bypass-rls"     node scripts/check-bypass-rls.mjs
 run_step "Static: crypto-domains" node scripts/check-crypto-domains.mjs
 run_step "Static: migration-drift" node scripts/check-migration-drift.mjs
-run_step "Static: no-deprecated-logAudit" bash -c 'if grep -rn "logAudit(" src/ --include="*.ts" --include="*.tsx" | grep -v "logAuditAsync\|logAuditInTx" | grep -v "\.test\." | grep -q .; then echo "Residual logAudit() calls found:"; grep -rn "logAudit(" src/ --include="*.ts" --include="*.tsx" | grep -v "logAuditAsync\|logAuditInTx" | grep -v "\.test\."; exit 1; fi'
+run_step "Static: no-deprecated-logAudit" bash -c 'if grep -rn "logAudit(" src/ --include="*.ts" --include="*.tsx" | grep -v "logAuditAsync\|logAuditInTx" | grep -v "\.test\." | grep -v "^\s*//" | grep -v "^\s*\*" | grep -q .; then echo "Residual logAudit() calls found:"; grep -rn "logAudit(" src/ --include="*.ts" --include="*.tsx" | grep -v "logAuditAsync\|logAuditInTx" | grep -v "\.test\." | grep -v "^\s*//" | grep -v "^\s*\*"; exit 1; fi'
 # Clear vitest cache to match CI's clean environment
 rm -rf node_modules/.vitest extension/node_modules/.vitest 2>/dev/null || true
 run_step "Test"                   npx vitest run

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -35,6 +35,7 @@ run_step "Static: team-auth-rls"  node scripts/check-team-auth-rls.mjs
 run_step "Static: bypass-rls"     node scripts/check-bypass-rls.mjs
 run_step "Static: crypto-domains" node scripts/check-crypto-domains.mjs
 run_step "Static: migration-drift" node scripts/check-migration-drift.mjs
+run_step "Static: no-deprecated-logAudit" bash -c 'if grep -rn "logAudit(" src/ --include="*.ts" --include="*.tsx" | grep -v "logAuditAsync\|logAuditInTx" | grep -v "\.test\." | grep -q .; then echo "Residual logAudit() calls found:"; grep -rn "logAudit(" src/ --include="*.ts" --include="*.tsx" | grep -v "logAuditAsync\|logAuditInTx" | grep -v "\.test\."; exit 1; fi'
 # Clear vitest cache to match CI's clean environment
 rm -rf node_modules/.vitest extension/node_modules/.vitest 2>/dev/null || true
 run_step "Test"                   npx vitest run

--- a/src/__tests__/api/folders/folder-by-id.test.ts
+++ b/src/__tests__/api/folders/folder-by-id.test.ts
@@ -33,7 +33,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/folder-utils", () => ({

--- a/src/__tests__/api/passwords/attachments.test.ts
+++ b/src/__tests__/api/passwords/attachments.test.ts
@@ -37,7 +37,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/with-request-log", () => ({

--- a/src/__tests__/api/passwords/history-reencrypt.test.ts
+++ b/src/__tests__/api/passwords/history-reencrypt.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/__tests__/api/passwords/history-restore.test.ts
+++ b/src/__tests__/api/passwords/history-restore.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/__tests__/api/passwords/write-scope.test.ts
+++ b/src/__tests__/api/passwords/write-scope.test.ts
@@ -39,7 +39,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: vi.fn().mockReturnValue({}),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/__tests__/api/sends/file.test.ts
+++ b/src/__tests__/api/sends/file.test.ts
@@ -41,7 +41,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/__tests__/api/sends/route.test.ts
+++ b/src/__tests__/api/sends/route.test.ts
@@ -34,7 +34,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/__tests__/api/sessions/sessions-list.test.ts
+++ b/src/__tests__/api/sessions/sessions-list.test.ts
@@ -27,7 +27,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/__tests__/api/teams/team-attachment-download.test.ts
+++ b/src/__tests__/api/teams/team-attachment-download.test.ts
@@ -43,7 +43,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/blob-store", () => ({

--- a/src/__tests__/api/teams/team-attachments.test.ts
+++ b/src/__tests__/api/teams/team-attachments.test.ts
@@ -49,7 +49,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/blob-store", () => ({

--- a/src/__tests__/api/teams/team-empty-trash.test.ts
+++ b/src/__tests__/api/teams/team-empty-trash.test.ts
@@ -40,7 +40,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/__tests__/api/teams/team-folder-by-id.test.ts
+++ b/src/__tests__/api/teams/team-folder-by-id.test.ts
@@ -45,7 +45,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/folder-utils", () => ({

--- a/src/__tests__/api/teams/team-folders.test.ts
+++ b/src/__tests__/api/teams/team-folders.test.ts
@@ -51,7 +51,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/folder-utils", () => ({

--- a/src/__tests__/api/teams/team-history-reencrypt.test.ts
+++ b/src/__tests__/api/teams/team-history-reencrypt.test.ts
@@ -45,7 +45,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withTeamTenantRls: mockWithTeamTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/__tests__/api/teams/team-history-restore.test.ts
+++ b/src/__tests__/api/teams/team-history-restore.test.ts
@@ -40,7 +40,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/__tests__/api/teams/team-invitations.test.ts
+++ b/src/__tests__/api/teams/team-invitations.test.ts
@@ -48,7 +48,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("node:crypto", () => ({

--- a/src/__tests__/api/teams/team-policy.test.ts
+++ b/src/__tests__/api/teams/team-policy.test.ts
@@ -61,7 +61,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withTeamTenantRls: mockWithTeamTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/with-request-log", () => ({

--- a/src/__tests__/api/tenant/breakglass.test.ts
+++ b/src/__tests__/api/tenant/breakglass.test.ts
@@ -61,7 +61,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/__tests__/api/tenant/members.test.ts
+++ b/src/__tests__/api/tenant/members.test.ts
@@ -46,7 +46,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/with-request-log", () => ({

--- a/src/__tests__/api/tenant/scim-tokens.test.ts
+++ b/src/__tests__/api/tenant/scim-tokens.test.ts
@@ -58,7 +58,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/with-request-log", () => ({

--- a/src/__tests__/api/tenant/tenant-audit-logs.test.ts
+++ b/src/__tests__/api/tenant/tenant-audit-logs.test.ts
@@ -41,7 +41,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/__tests__/api/tenant/tenant-policy.test.ts
+++ b/src/__tests__/api/tenant/tenant-policy.test.ts
@@ -44,7 +44,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withBypassRls: mockWithBypassRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/__tests__/audit-fifo-flusher.test.ts
+++ b/src/__tests__/audit-fifo-flusher.test.ts
@@ -26,11 +26,13 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
+const mockAuditInfo = vi.hoisted(() => vi.fn());
+
 vi.mock("@/lib/audit-logger", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/audit-logger")>();
   return {
     ...actual,
-    auditLogger: { info: vi.fn(), enabled: false },
+    auditLogger: { info: mockAuditInfo, enabled: true },
     deadLetterLogger: { warn: mockDeadLetterWarn },
   };
 });
@@ -150,20 +152,64 @@ describe("logAuditAsync", () => {
     );
   });
 
-  it("propagates enqueueAudit rejection without throwing", async () => {
+  it("catches enqueueAudit rejection and logs to dead letter (never throws)", async () => {
     mockUserFindUnique.mockResolvedValue({
       id: "00000000-0000-4000-8000-000000000001",
       tenantId: "tenant-1",
     });
     mockEnqueueAudit.mockRejectedValueOnce(new Error("outbox write failed"));
 
-    // logAuditAsync should propagate the rejection (caller decides how to handle)
+    // logAuditAsync must never throw — errors go to deadLetterLogger
     await expect(
       logAuditAsync({
         scope: AUDIT_SCOPE.PERSONAL,
         action: AUDIT_ACTION.AUTH_LOGIN,
         userId: "00000000-0000-4000-8000-000000000001",
       }),
-    ).rejects.toThrow("outbox write failed");
+    ).resolves.toBeUndefined();
+
+    expect(mockDeadLetterWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "logAuditAsync_failed",
+        error: expect.stringContaining("outbox write failed"),
+      }),
+      "audit.dead_letter",
+    );
+  });
+
+  it("emits structured JSON to auditLogger before outbox write", async () => {
+    await logAuditAsync({
+      scope: AUDIT_SCOPE.PERSONAL,
+      action: AUDIT_ACTION.AUTH_LOGIN,
+      userId: "00000000-0000-4000-8000-000000000001",
+      tenantId: "tenant-1",
+    });
+
+    expect(mockAuditInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: expect.objectContaining({
+          scope: AUDIT_SCOPE.PERSONAL,
+          action: AUDIT_ACTION.AUTH_LOGIN,
+          tenantId: "tenant-1",
+        }),
+      }),
+      "audit.AUTH_LOGIN",
+    );
+  });
+
+  it("dead letter output does not contain raw metadata", async () => {
+    mockUserFindUnique.mockResolvedValue(null);
+
+    await logAuditAsync({
+      scope: AUDIT_SCOPE.PERSONAL,
+      action: AUDIT_ACTION.AUTH_LOGIN,
+      userId: "00000000-0000-4000-8000-0000000000ff",
+      metadata: { password: "secret", token: "bearer-xyz" },
+    });
+
+    const deadLetterCall = mockDeadLetterWarn.mock.calls[0][0];
+    expect(deadLetterCall).not.toHaveProperty("auditEntry");
+    expect(deadLetterCall).not.toHaveProperty("metadata");
+    expect(deadLetterCall).toHaveProperty("reason", "tenant_not_found");
   });
 });

--- a/src/__tests__/audit.mocked.test.ts
+++ b/src/__tests__/audit.mocked.test.ts
@@ -185,7 +185,7 @@ describe("logAuditAsync", () => {
       logAuditAsync({
         scope: AUDIT_SCOPE.PERSONAL,
         action: AUDIT_ACTION.AUTH_LOGIN,
-        userId: "user-1",
+        userId: "00000000-0000-4000-8000-000000000001",
         tenantId: "tenant-1",
       })
     ).resolves.toBeUndefined();

--- a/src/__tests__/audit.mocked.test.ts
+++ b/src/__tests__/audit.mocked.test.ts
@@ -31,19 +31,18 @@ vi.mock("@/lib/audit-logger", async (importOriginal) => {
   };
 });
 
-import { logAudit, sanitizeMetadata, extractRequestMeta, resolveActorType } from "@/lib/audit";
+import { logAuditAsync, sanitizeMetadata, extractRequestMeta, resolveActorType } from "@/lib/audit";
 
-describe("logAudit", () => {
-  it("pushes entry to FIFO and emits pino log synchronously", () => {
+describe("logAuditAsync", () => {
+  it("emits structured JSON to auditLogger", async () => {
     mockAuditInfo.mockReturnValue(undefined);
 
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.AUTH_LOGIN,
       userId: "user-1",
     });
 
-    // pino emit happens synchronously in logAudit
     expect(mockAuditInfo).toHaveBeenCalledWith(
       expect.objectContaining({
         audit: expect.objectContaining({
@@ -52,6 +51,7 @@ describe("logAudit", () => {
           userId: "user-1",
           actorType: "HUMAN",
           serviceAccountId: null,
+          tenantId: null,
           teamId: null,
           targetType: null,
           targetId: null,
@@ -63,10 +63,30 @@ describe("logAudit", () => {
     );
   });
 
-  it("passes optional fields to the pino logger", () => {
+  it("includes tenantId in structured emit when provided", async () => {
     mockAuditInfo.mockReturnValue(undefined);
 
-    logAudit({
+    await logAuditAsync({
+      scope: AUDIT_SCOPE.PERSONAL,
+      action: AUDIT_ACTION.AUTH_LOGIN,
+      userId: "user-1",
+      tenantId: "tenant-1",
+    });
+
+    expect(mockAuditInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: expect.objectContaining({
+          tenantId: "tenant-1",
+        }),
+      }),
+      "audit.AUTH_LOGIN",
+    );
+  });
+
+  it("passes optional fields to the auditLogger", async () => {
+    mockAuditInfo.mockReturnValue(undefined);
+
+    await logAuditAsync({
       scope: AUDIT_SCOPE.TEAM,
       action: AUDIT_ACTION.ENTRY_CREATE,
       userId: "user-1",
@@ -96,21 +116,20 @@ describe("logAudit", () => {
     );
   });
 
-  it("truncates metadata larger than 10KB before emitting pino log", () => {
+  it("truncates metadata larger than 10KB before emitting", async () => {
     mockAuditInfo.mockReturnValue(undefined);
 
     const largeMetadata: Record<string, unknown> = {
       data: "x".repeat(15_000),
     };
 
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.ENTRY_UPDATE,
       userId: "user-1",
       metadata: largeMetadata,
     });
 
-    // pino receives sanitized (truncated) metadata
     expect(mockAuditInfo).toHaveBeenCalledWith(
       expect.objectContaining({
         audit: expect.objectContaining({
@@ -124,11 +143,11 @@ describe("logAudit", () => {
     );
   });
 
-  it("truncates user-agent to 512 chars", () => {
+  it("truncates user-agent to 512 chars", async () => {
     mockAuditInfo.mockReturnValue(undefined);
     const longUA = "A".repeat(1000);
 
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.AUTH_LOGIN,
       userId: "user-1",
@@ -145,24 +164,54 @@ describe("logAudit", () => {
     );
   });
 
-  it("does not throw when auditLogger.info throws", () => {
+  it("does not throw when auditLogger.info throws", async () => {
     mockAuditInfo.mockImplementation(() => {
       throw new Error("pino error");
     });
 
-    expect(() =>
-      logAudit({
+    await expect(
+      logAuditAsync({
         scope: AUDIT_SCOPE.PERSONAL,
         action: AUDIT_ACTION.AUTH_LOGIN,
         userId: "user-1",
       })
-    ).not.toThrow();
+    ).resolves.toBeUndefined();
   });
 
-  it("passes actorType SERVICE_ACCOUNT and serviceAccountId to pino logger", () => {
+  it("does not throw when enqueueAudit rejects", async () => {
+    mockEnqueueAudit.mockRejectedValueOnce(new Error("outbox write failed"));
+
+    await expect(
+      logAuditAsync({
+        scope: AUDIT_SCOPE.PERSONAL,
+        action: AUDIT_ACTION.AUTH_LOGIN,
+        userId: "user-1",
+        tenantId: "tenant-1",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("calls enqueueAudit for normal UUID userId flow", async () => {
+    await logAuditAsync({
+      scope: AUDIT_SCOPE.PERSONAL,
+      action: AUDIT_ACTION.AUTH_LOGIN,
+      userId: "00000000-0000-4000-8000-000000000001",
+      tenantId: "tenant-1",
+    });
+
+    expect(mockEnqueueAudit).toHaveBeenCalledWith(
+      "tenant-1",
+      expect.objectContaining({
+        scope: AUDIT_SCOPE.PERSONAL,
+        action: AUDIT_ACTION.AUTH_LOGIN,
+      }),
+    );
+  });
+
+  it("passes actorType SERVICE_ACCOUNT and serviceAccountId", async () => {
     mockAuditInfo.mockReturnValue(undefined);
 
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.ENTRY_CREATE,
       userId: "user-1",

--- a/src/__tests__/db-integration/audit-logaudit-non-atomic.integration.test.ts
+++ b/src/__tests__/db-integration/audit-logaudit-non-atomic.integration.test.ts
@@ -9,7 +9,7 @@ import { randomUUID } from "node:crypto";
 import { createTestContext, setBypassRlsGucs, type TestContext } from "./helpers";
 import { enqueueAudit, type AuditOutboxPayload } from "@/lib/audit-outbox";
 
-describe("audit logAudit non-atomic (negative test)", () => {
+describe("audit logAuditAsync non-atomic (negative test)", () => {
   let ctx: TestContext;
   let tenantId: string;
   let userId: string;

--- a/src/__tests__/integration/audit-and-isolation.test.ts
+++ b/src/__tests__/integration/audit-and-isolation.test.ts
@@ -97,8 +97,8 @@ describe("Scenario 5: SA action audit logging", () => {
     expect(resolveActorType(auth)).toBe("HUMAN");
   });
 
-  it("logAudit writes actorType SERVICE_ACCOUNT and serviceAccountId when SA acts", () => {
-    logAuditAsync({
+  it("logAuditAsync writes actorType SERVICE_ACCOUNT and serviceAccountId when SA acts", async () => {
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.ENTRY_CREATE,
       userId: "sa-proxy-user-id",
@@ -118,10 +118,10 @@ describe("Scenario 5: SA action audit logging", () => {
     );
   });
 
-  it("logAudit emits actorType SERVICE_ACCOUNT to pino logger when SA acts", () => {
+  it("logAuditAsync emits actorType SERVICE_ACCOUNT to pino logger when SA acts", async () => {
     mockAuditInfo.mockReturnValue(undefined);
 
-    logAuditAsync({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.TENANT,
       action: AUDIT_ACTION.ENTRY_UPDATE,
       userId: "sa-proxy-user-id",
@@ -156,9 +156,9 @@ describe("Scenario 6: Existing audit unchanged — session produces HUMAN", () =
     expect(resolveActorType(auth)).toBe("HUMAN");
   });
 
-  it("logAudit defaults actorType to HUMAN when not provided", () => {
+  it("logAuditAsync defaults actorType to HUMAN when not provided", async () => {
     // No actorType passed — should default to HUMAN in DB write
-    logAuditAsync({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.AUTH_LOGIN,
       userId: "b0000000-0000-4000-8000-000000000001",
@@ -178,10 +178,10 @@ describe("Scenario 6: Existing audit unchanged — session produces HUMAN", () =
     expect(call.actorType).toBeUndefined();
   });
 
-  it("logAudit defaults actorType to HUMAN in pino emit when not provided", () => {
+  it("logAuditAsync defaults actorType to HUMAN in pino emit when not provided", async () => {
     mockAuditInfo.mockReturnValue(undefined);
 
-    logAuditAsync({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.AUTH_LOGOUT,
       userId: "b0000000-0000-4000-8000-000000000001",
@@ -196,8 +196,8 @@ describe("Scenario 6: Existing audit unchanged — session produces HUMAN", () =
     );
   });
 
-  it("session-based audit has no serviceAccountId in DB write", () => {
-    logAuditAsync({
+  it("session-based audit has no serviceAccountId in DB write", async () => {
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.ENTRY_VIEW,
       userId: "user-human",

--- a/src/__tests__/integration/audit-and-isolation.test.ts
+++ b/src/__tests__/integration/audit-and-isolation.test.ts
@@ -28,7 +28,7 @@ vi.mock("@/lib/audit", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/audit")>();
   return {
     ...actual,
-    logAudit: mockLogAudit,
+    logAuditAsync: mockLogAudit,
   };
 });
 vi.mock("@/lib/prisma", () => ({
@@ -62,7 +62,7 @@ vi.mock("@/auth", () => ({ auth: mockAuth }));
 
 // ─── Imports after mocks ───────────────────────────────────────────────────────
 
-import { logAudit, resolveActorType } from "@/lib/audit";
+import { logAuditAsync, resolveActorType } from "@/lib/audit";
 import type { AuthResult } from "@/lib/auth-or-token";
 
 // ─── Scenario 5: SA action audit logging ──────────────────────────────────────
@@ -98,7 +98,7 @@ describe("Scenario 5: SA action audit logging", () => {
   });
 
   it("logAudit writes actorType SERVICE_ACCOUNT and serviceAccountId when SA acts", () => {
-    logAudit({
+    logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.ENTRY_CREATE,
       userId: "sa-proxy-user-id",
@@ -121,7 +121,7 @@ describe("Scenario 5: SA action audit logging", () => {
   it("logAudit emits actorType SERVICE_ACCOUNT to pino logger when SA acts", () => {
     mockAuditInfo.mockReturnValue(undefined);
 
-    logAudit({
+    logAuditAsync({
       scope: AUDIT_SCOPE.TENANT,
       action: AUDIT_ACTION.ENTRY_UPDATE,
       userId: "sa-proxy-user-id",
@@ -158,7 +158,7 @@ describe("Scenario 6: Existing audit unchanged — session produces HUMAN", () =
 
   it("logAudit defaults actorType to HUMAN when not provided", () => {
     // No actorType passed — should default to HUMAN in DB write
-    logAudit({
+    logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.AUTH_LOGIN,
       userId: "b0000000-0000-4000-8000-000000000001",
@@ -181,7 +181,7 @@ describe("Scenario 6: Existing audit unchanged — session produces HUMAN", () =
   it("logAudit defaults actorType to HUMAN in pino emit when not provided", () => {
     mockAuditInfo.mockReturnValue(undefined);
 
-    logAudit({
+    logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.AUTH_LOGOUT,
       userId: "b0000000-0000-4000-8000-000000000001",
@@ -197,7 +197,7 @@ describe("Scenario 6: Existing audit unchanged — session produces HUMAN", () =
   });
 
   it("session-based audit has no serviceAccountId in DB write", () => {
-    logAudit({
+    logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.ENTRY_VIEW,
       userId: "user-human",

--- a/src/__tests__/integration/jit-workflow.test.ts
+++ b/src/__tests__/integration/jit-workflow.test.ts
@@ -83,7 +83,7 @@ vi.mock("@/lib/auth-or-token", () => ({
   authOrToken: mockAuthOrToken,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   resolveActorType: () => "HUMAN",
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));

--- a/src/__tests__/integration/mcp-oauth-flow.test.ts
+++ b/src/__tests__/integration/mcp-oauth-flow.test.ts
@@ -120,7 +120,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
 }));
 
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 

--- a/src/__tests__/integration/sa-lifecycle.test.ts
+++ b/src/__tests__/integration/sa-lifecycle.test.ts
@@ -97,7 +97,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
 }));
 
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 

--- a/src/__tests__/lib/access-restriction.test.ts
+++ b/src/__tests__/lib/access-restriction.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withBypassRls: mockWithBypassRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
 }));
 vi.mock("@/lib/tailscale-client", () => ({
   verifyTailscalePeer: mockVerifyTailscalePeer,

--- a/src/app/api/admin/rotate-master-key/route.test.ts
+++ b/src/app/api/admin/rotate-master-key/route.test.ts
@@ -32,7 +32,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "10.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,

--- a/src/app/api/admin/rotate-master-key/route.ts
+++ b/src/app/api/admin/rotate-master-key/route.ts
@@ -22,7 +22,7 @@ import {
   getMasterKeyByVersion,
 } from "@/lib/crypto-server";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -109,7 +109,7 @@ async function handlePOST(req: NextRequest) {
 
   // Audit log (async nonblocking; logAudit handles errors internally)
   const { ip } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.MASTER_KEY_ROTATION,
     userId: operatorId,

--- a/src/app/api/api-keys/[id]/route.test.ts
+++ b/src/app/api/api-keys/[id]/route.test.ts
@@ -35,7 +35,7 @@ vi.mock("@/lib/logger", () => {
   };
 });
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({}),
 }));
 

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { checkAuth } from "@/lib/check-auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, unauthorized } from "@/lib/api-response";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -47,7 +47,7 @@ async function handleDELETE(
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.API_KEY_REVOKE,
     userId,

--- a/src/app/api/api-keys/route.test.ts
+++ b/src/app/api/api-keys/route.test.ts
@@ -47,7 +47,7 @@ vi.mock("@/lib/logger", () => {
   };
 });
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({}),
 }));
 vi.mock("@/lib/constants/api-key", async (importOriginal) => {

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { checkAuth } from "@/lib/check-auth";
 import { prisma } from "@/lib/prisma";
 import { hashToken } from "@/lib/crypto-server";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { apiKeyCreateSchema } from "@/lib/validations";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, unauthorized, rateLimited } from "@/lib/api-response";
@@ -131,7 +131,7 @@ async function handlePOST(req: NextRequest) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.API_KEY_CREATE,
     userId: userId,

--- a/src/app/api/audit-logs/download/route.test.ts
+++ b/src/app/api/audit-logs/download/route.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/app/api/audit-logs/download/route.ts
+++ b/src/app/api/audit-logs/download/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { rateLimited, unauthorized, validationError } from "@/lib/api-response";
 import {
   AUDIT_ACTION,
@@ -82,7 +82,7 @@ async function handleGET(req: NextRequest) {
   }
 
   // Record the download itself
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.AUDIT_LOG_DOWNLOAD,
     userId: session.user.id,

--- a/src/app/api/audit-logs/export/route.test.ts
+++ b/src/app/api/audit-logs/export/route.test.ts
@@ -31,7 +31,7 @@ vi.mock("@/lib/team-auth", () => ({
   TeamAuthError,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/audit-logs/export/route.ts
+++ b/src/app/api/audit-logs/export/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { assertPolicyAllowsExport, PolicyViolationError } from "@/lib/team-policy";
 import { z } from "zod/v4";
@@ -60,7 +60,7 @@ async function handlePOST(req: NextRequest) {
     }
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: teamId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_EXPORT,
     userId: session.user.id,

--- a/src/app/api/audit-logs/import/route.test.ts
+++ b/src/app/api/audit-logs/import/route.test.ts
@@ -8,7 +8,7 @@ const { mockAuth, mockLogAudit } = vi.hoisted(() => ({
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 

--- a/src/app/api/audit-logs/import/route.ts
+++ b/src/app/api/audit-logs/import/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { z } from "zod/v4";
 import { errorResponse, unauthorized } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
@@ -43,7 +43,7 @@ async function handlePOST(req: NextRequest) {
     }
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: teamId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_IMPORT,
     userId: session.user.id,

--- a/src/app/api/auth/passkey/verify/route.test.ts
+++ b/src/app/api/auth/passkey/verify/route.test.ts
@@ -38,7 +38,7 @@ vi.mock("@/lib/webauthn-authorize", () => ({
 }));
 
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({
     ip: null,
     userAgent: null,

--- a/src/app/api/auth/passkey/verify/route.ts
+++ b/src/app/api/auth/passkey/verify/route.ts
@@ -5,7 +5,7 @@ import { withRequestLog } from "@/lib/with-request-log";
 import { rateLimited } from "@/lib/api-response";
 import { assertOrigin } from "@/lib/csrf";
 import { authorizeWebAuthn } from "@/lib/webauthn-authorize";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { extractClientIp, rateLimitKeyFromIp } from "@/lib/ip-access";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { prisma } from "@/lib/prisma";
@@ -121,7 +121,7 @@ async function handlePOST(req: NextRequest) {
 
   // Audit log
   if (evictedCount > 0) {
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.SESSION_REVOKE_ALL,
       userId: user.id,
@@ -129,7 +129,7 @@ async function handlePOST(req: NextRequest) {
       ...meta,
     });
   }
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.AUTH_LOGIN,
     userId: user.id,

--- a/src/app/api/directory-sync/[id]/route.test.ts
+++ b/src/app/api/directory-sync/[id]/route.test.ts
@@ -248,7 +248,7 @@ describe("PUT /api/directory-sync/[id]", () => {
     );
   });
 
-  it("calls logAudit after successful update", async () => {
+  it("calls logAuditAsync after successful update", async () => {
     const req = createRequest("PUT", ROUTE_URL, { body: { enabled: false } });
     await PUT(req, CTX);
 
@@ -317,7 +317,7 @@ describe("DELETE /api/directory-sync/[id]", () => {
     );
   });
 
-  it("calls logAudit after successful delete", async () => {
+  it("calls logAuditAsync after successful delete", async () => {
     const req = createRequest("DELETE", ROUTE_URL);
     await DELETE(req, CTX);
 

--- a/src/app/api/directory-sync/[id]/route.test.ts
+++ b/src/app/api/directory-sync/[id]/route.test.ts
@@ -42,7 +42,7 @@ vi.mock("@/lib/with-request-log", () => ({
   withRequestLog: (handler: (...args: unknown[]) => unknown) => handler,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/directory-sync/credentials", () => ({

--- a/src/app/api/directory-sync/[id]/route.ts
+++ b/src/app/api/directory-sync/[id]/route.ts
@@ -12,7 +12,7 @@ import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
 import { withRequestLog } from "@/lib/with-request-log";
 import { withUserTenantRls } from "@/lib/tenant-context";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { encryptCredentials } from "@/lib/directory-sync/credentials";
 import {
@@ -189,7 +189,7 @@ async function handlePUT(req: NextRequest, ctx: RouteContext) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.DIRECTORY_SYNC_CONFIG_UPDATE,
     userId: session.user.id,
@@ -248,7 +248,7 @@ async function handleDELETE(req: NextRequest, ctx: RouteContext) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.DIRECTORY_SYNC_CONFIG_DELETE,
     userId: session.user.id,

--- a/src/app/api/directory-sync/[id]/run/route.test.ts
+++ b/src/app/api/directory-sync/[id]/run/route.test.ts
@@ -213,7 +213,7 @@ describe("POST /api/directory-sync/[id]/run", () => {
     expect(json.usersDeactivated).toBe(0);
   });
 
-  it("calls logAudit with correct metadata on success", async () => {
+  it("calls logAuditAsync with correct metadata on success", async () => {
     const req = createRequest("POST", ROUTE_URL, { body: { dryRun: true } });
     await POST(req, CTX);
 

--- a/src/app/api/directory-sync/[id]/run/route.test.ts
+++ b/src/app/api/directory-sync/[id]/run/route.test.ts
@@ -38,7 +38,7 @@ vi.mock("@/lib/with-request-log", () => ({
   withRequestLog: (handler: (...args: unknown[]) => unknown) => handler,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/webhook-dispatcher", () => ({

--- a/src/app/api/directory-sync/[id]/run/route.ts
+++ b/src/app/api/directory-sync/[id]/run/route.ts
@@ -11,7 +11,7 @@ import { prisma } from "@/lib/prisma";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { withRequestLog } from "@/lib/with-request-log";
 import { withUserTenantRls } from "@/lib/tenant-context";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { runDirectorySync } from "@/lib/directory-sync/engine";
 import { createRateLimiter } from "@/lib/rate-limit";
@@ -98,7 +98,7 @@ async function handlePOST(req: NextRequest, ctx: RouteContext) {
     force,
   });
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.DIRECTORY_SYNC_RUN,
     userId: session.user.id,

--- a/src/app/api/directory-sync/directory-sync.test.ts
+++ b/src/app/api/directory-sync/directory-sync.test.ts
@@ -272,7 +272,7 @@ describe("POST /api/directory-sync", () => {
     );
   });
 
-  it("calls logAudit after successful creation", async () => {
+  it("calls logAuditAsync after successful creation", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockTenantMemberFindFirst.mockResolvedValue(MEMBER);
     mockConfigFindFirst.mockResolvedValue(null);

--- a/src/app/api/directory-sync/directory-sync.test.ts
+++ b/src/app/api/directory-sync/directory-sync.test.ts
@@ -42,7 +42,7 @@ vi.mock("@/lib/with-request-log", () => ({
   withRequestLog: (handler: (...args: unknown[]) => unknown) => handler,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/directory-sync/credentials", () => ({

--- a/src/app/api/directory-sync/route.ts
+++ b/src/app/api/directory-sync/route.ts
@@ -11,7 +11,7 @@ import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
 import { withRequestLog } from "@/lib/with-request-log";
 import { withUserTenantRls } from "@/lib/tenant-context";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { encryptCredentials } from "@/lib/directory-sync/credentials";
 import {
@@ -174,7 +174,7 @@ async function handlePOST(req: NextRequest) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.DIRECTORY_SYNC_CONFIG_CREATE,
     userId: session.user.id,

--- a/src/app/api/emergency-access/[id]/accept/route.test.ts
+++ b/src/app/api/emergency-access/[id]/accept/route.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/lib/prisma", () => ({
 }));
 vi.mock("@/lib/email", () => ({ sendEmail: mockSendEmail }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/app/api/emergency-access/[id]/accept/route.ts
+++ b/src/app/api/emergency-access/[id]/accept/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { acceptEmergencyGrantByIdSchema } from "@/lib/validations";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyGrantAcceptedEmail } from "@/lib/email/templates/emergency-access";
 import { createRateLimiter } from "@/lib/rate-limit";
@@ -86,7 +86,7 @@ async function handlePOST(
     ]),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.EMERGENCY_GRANT_ACCEPT,
     userId: session.user.id,

--- a/src/app/api/emergency-access/[id]/approve/route.test.ts
+++ b/src/app/api/emergency-access/[id]/approve/route.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/lib/prisma", () => ({
 }));
 vi.mock("@/lib/email", () => ({ sendEmail: mockSendEmail }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/emergency-access/[id]/approve/route.ts
+++ b/src/app/api/emergency-access/[id]/approve/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { canTransition } from "@/lib/emergency-access-state";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyAccessApprovedEmail } from "@/lib/email/templates/emergency-access";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -50,7 +50,7 @@ async function handlePOST(
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.EMERGENCY_ACCESS_ACTIVATE,
     userId: session.user.id,

--- a/src/app/api/emergency-access/[id]/confirm/route.test.ts
+++ b/src/app/api/emergency-access/[id]/confirm/route.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/crypto-emergency", () => ({

--- a/src/app/api/emergency-access/[id]/confirm/route.ts
+++ b/src/app/api/emergency-access/[id]/confirm/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { confirmEmergencyGrantSchema } from "@/lib/validations";
 import { canTransition } from "@/lib/emergency-access-state";
 import { SUPPORTED_KEY_ALGORITHMS } from "@/lib/crypto-emergency";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { EA_STATUS, AUDIT_TARGET_TYPE, AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { withUserTenantRls } from "@/lib/tenant-context";
@@ -79,7 +79,7 @@ async function handlePOST(
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.EMERGENCY_GRANT_CONFIRM,
     userId: session.user.id,

--- a/src/app/api/emergency-access/[id]/decline/route.test.ts
+++ b/src/app/api/emergency-access/[id]/decline/route.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/lib/prisma", () => ({
 }));
 vi.mock("@/lib/email", () => ({ sendEmail: mockSendEmail }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,

--- a/src/app/api/emergency-access/[id]/decline/route.ts
+++ b/src/app/api/emergency-access/[id]/decline/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyGrantDeclinedEmail } from "@/lib/email/templates/emergency-access";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -49,7 +49,7 @@ async function handlePOST(
     }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.EMERGENCY_GRANT_REJECT,
     userId: session.user.id,

--- a/src/app/api/emergency-access/[id]/request/route.test.ts
+++ b/src/app/api/emergency-access/[id]/request/route.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/lib/prisma", () => ({
 }));
 vi.mock("@/lib/email", () => ({ sendEmail: mockSendEmail }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/app/api/emergency-access/[id]/request/route.ts
+++ b/src/app/api/emergency-access/[id]/request/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { canTransition } from "@/lib/emergency-access-state";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyAccessRequestedEmail } from "@/lib/email/templates/emergency-access";
 import { createRateLimiter } from "@/lib/rate-limit";
@@ -61,7 +61,7 @@ async function handlePOST(
     }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.EMERGENCY_ACCESS_REQUEST,
     userId: session.user.id,

--- a/src/app/api/emergency-access/[id]/revoke/route.test.ts
+++ b/src/app/api/emergency-access/[id]/revoke/route.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/lib/prisma", () => ({
 }));
 vi.mock("@/lib/email", () => ({ sendEmail: mockSendEmail }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/emergency-access/[id]/revoke/route.ts
+++ b/src/app/api/emergency-access/[id]/revoke/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { revokeEmergencyGrantSchema } from "@/lib/validations";
 import { canTransition } from "@/lib/emergency-access-state";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyAccessRevokedEmail } from "@/lib/email/templates/emergency-access";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -64,7 +64,7 @@ async function handlePOST(
       }),
     );
 
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.EMERGENCY_ACCESS_REVOKE,
       userId: session.user.id,
@@ -108,7 +108,7 @@ async function handlePOST(
       }),
     );
 
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.EMERGENCY_ACCESS_REVOKE,
       userId: session.user.id,

--- a/src/app/api/emergency-access/[id]/vault/entries/route.test.ts
+++ b/src/app/api/emergency-access/[id]/vault/entries/route.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,

--- a/src/app/api/emergency-access/[id]/vault/entries/route.ts
+++ b/src/app/api/emergency-access/[id]/vault/entries/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { EA_STATUS, AUDIT_TARGET_TYPE, AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
@@ -69,7 +69,7 @@ async function handleGET(
     }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.EMERGENCY_VAULT_ACCESS,
     userId: session.user.id,

--- a/src/app/api/emergency-access/[id]/vault/route.test.ts
+++ b/src/app/api/emergency-access/[id]/vault/route.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/lib/prisma", () => ({
   prisma: { emergencyAccessGrant: mockPrismaGrant },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/app/api/emergency-access/[id]/vault/route.ts
+++ b/src/app/api/emergency-access/[id]/vault/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { EA_STATUS, AUDIT_TARGET_TYPE, AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
@@ -52,7 +52,7 @@ async function handleGET(
     BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
     grant.status = EA_STATUS.ACTIVATED;
 
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.EMERGENCY_ACCESS_ACTIVATE,
       userId: session.user.id,

--- a/src/app/api/emergency-access/accept/route.test.ts
+++ b/src/app/api/emergency-access/accept/route.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/lib/crypto-server", () => ({
   hashToken: (t: string) => `hashed-${t}`,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/app/api/emergency-access/accept/route.ts
+++ b/src/app/api/emergency-access/accept/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { acceptEmergencyGrantSchema } from "@/lib/validations";
 import { hashToken } from "@/lib/crypto-server";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyGrantAcceptedEmail } from "@/lib/email/templates/emergency-access";
 import { createRateLimiter } from "@/lib/rate-limit";
@@ -83,7 +83,7 @@ async function handlePOST(req: NextRequest) {
     ]),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.EMERGENCY_GRANT_ACCEPT,
     userId: session.user.id,

--- a/src/app/api/emergency-access/reject/route.test.ts
+++ b/src/app/api/emergency-access/reject/route.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/lib/crypto-server", () => ({
   hashToken: (t: string) => `hashed-${t}`,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,

--- a/src/app/api/emergency-access/reject/route.ts
+++ b/src/app/api/emergency-access/reject/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { rejectEmergencyGrantSchema } from "@/lib/validations";
 import { hashToken } from "@/lib/crypto-server";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyGrantDeclinedEmail } from "@/lib/email/templates/emergency-access";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -51,7 +51,7 @@ async function handlePOST(req: NextRequest) {
     }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.EMERGENCY_GRANT_REJECT,
     userId: session.user.id,

--- a/src/app/api/emergency-access/route.test.ts
+++ b/src/app/api/emergency-access/route.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/lib/crypto-server", () => ({
   hashToken: (t: string) => `hashed-${t}`,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/app/api/emergency-access/route.ts
+++ b/src/app/api/emergency-access/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { createEmergencyGrantSchema } from "@/lib/validations";
 import { generateShareToken, hashToken } from "@/lib/crypto-server";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyInviteEmail } from "@/lib/email/templates/emergency-access";
 import { createRateLimiter } from "@/lib/rate-limit";
@@ -80,7 +80,7 @@ async function handlePOST(req: NextRequest) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.EMERGENCY_GRANT_CREATE,
     userId: session.user.id,

--- a/src/app/api/extension/bridge-code/route.test.ts
+++ b/src/app/api/extension/bridge-code/route.test.ts
@@ -62,7 +62,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({
   withBypassRls: mockWithBypassRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "1.2.3.4", userAgent: "test" }),
 }));
 vi.mock("@/lib/ip-access", () => ({

--- a/src/app/api/extension/bridge-code/route.ts
+++ b/src/app/api/extension/bridge-code/route.ts
@@ -17,7 +17,7 @@ import { rateLimited, unauthorized } from "@/lib/api-response";
 import { assertOrigin } from "@/lib/csrf";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { withUserTenantRls } from "@/lib/tenant-context";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { withRequestLog } from "@/lib/with-request-log";
 import {
   AUDIT_ACTION,
@@ -102,7 +102,7 @@ async function handlePOST(req: NextRequest) {
   }, BYPASS_PURPOSE.TOKEN_LIFECYCLE);
 
   // Audit (success path uses logAudit; userId/tenantId both resolved)
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.EXTENSION_BRIDGE_CODE_ISSUE,
     userId,

--- a/src/app/api/extension/token/exchange/route.test.ts
+++ b/src/app/api/extension/token/exchange/route.test.ts
@@ -66,7 +66,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "1.2.3.4", userAgent: "test" }),
 }));
 vi.mock("@/lib/ip-access", () => ({

--- a/src/app/api/extension/token/exchange/route.ts
+++ b/src/app/api/extension/token/exchange/route.ts
@@ -35,7 +35,7 @@ import {
 import { issueExtensionToken } from "@/lib/extension-token";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { extractClientIp } from "@/lib/ip-access";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { getLogger } from "@/lib/logger";
 import { withRequestLog } from "@/lib/with-request-log";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
@@ -150,7 +150,7 @@ async function handlePOST(req: NextRequest) {
       scope: consumed.scope,
     });
   } catch (err) {
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.EXTENSION_TOKEN_EXCHANGE_FAILURE,
       userId: consumed.userId,
@@ -172,7 +172,7 @@ async function handlePOST(req: NextRequest) {
   }
 
   // Audit success: userId and tenantId both come from the consumed code record
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.EXTENSION_TOKEN_EXCHANGE_SUCCESS,
     userId: consumed.userId,

--- a/src/app/api/folders/[id]/route.test.ts
+++ b/src/app/api/folders/[id]/route.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/folders/[id]/route.ts
+++ b/src/app/api/folders/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { updateFolderSchema } from "@/lib/validations";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, unauthorized, notFound, forbidden } from "@/lib/api-response";
@@ -155,7 +155,7 @@ async function handlePUT(
     throw err;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.FOLDER_UPDATE,
     userId: session.user.id,
@@ -258,7 +258,7 @@ async function handleDELETE(
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.FOLDER_DELETE,
     userId: session.user.id,

--- a/src/app/api/folders/route.test.ts
+++ b/src/app/api/folders/route.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/folder-utils", async (importOriginal) => {

--- a/src/app/api/folders/route.ts
+++ b/src/app/api/folders/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createFolderSchema } from "@/lib/validations";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, unauthorized, notFound } from "@/lib/api-response";
@@ -137,7 +137,7 @@ async function handlePOST(req: NextRequest) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.FOLDER_CREATE,
     userId: session.user.id,

--- a/src/app/api/internal/audit-emit/route.test.ts
+++ b/src/app/api/internal/audit-emit/route.test.ts
@@ -85,7 +85,7 @@ describe("POST /api/internal/audit-emit", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 200 and calls logAudit with correct params for PASSKEY_ENFORCEMENT_BLOCKED", async () => {
+  it("returns 200 and calls logAuditAsync with correct params for PASSKEY_ENFORCEMENT_BLOCKED", async () => {
     const res = await POST(
       createRequest("POST", "http://localhost/api/internal/audit-emit", {
         body: { action: "PASSKEY_ENFORCEMENT_BLOCKED" },
@@ -113,7 +113,7 @@ describe("POST /api/internal/audit-emit", () => {
     expect(res.status).toBe(429);
   });
 
-  it("includes metadata in logAudit call", async () => {
+  it("includes metadata in logAuditAsync call", async () => {
     const meta = { redirectedPath: "/dashboard", reason: "no_passkey" };
     const res = await POST(
       createRequest("POST", "http://localhost/api/internal/audit-emit", {

--- a/src/app/api/internal/audit-emit/route.test.ts
+++ b/src/app/api/internal/audit-emit/route.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockRateLimiterCheck }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: mockExtractRequestMeta,
 }));
 vi.mock("@/lib/constants", async (importOriginal) => {

--- a/src/app/api/internal/audit-emit/route.ts
+++ b/src/app/api/internal/audit-emit/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { checkAuth } from "@/lib/check-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { createRateLimiter } from "@/lib/rate-limit";
 
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest) {
   const auditAction = AUDIT_ACTION[action as keyof typeof AUDIT_ACTION];
 
   const meta = extractRequestMeta(request);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: auditAction,
     userId,

--- a/src/app/api/maintenance/audit-chain-verify/route.ts
+++ b/src/app/api/maintenance/audit-chain-verify/route.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -294,7 +294,7 @@ async function handleGET(req: NextRequest) {
   const ok = firstTamperedSeq === null && firstGapAfterSeq === null && firstTimestampViolationSeq === null;
 
   const { ip, userAgent } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.AUDIT_CHAIN_VERIFY,
     userId: operatorId,

--- a/src/app/api/maintenance/audit-outbox-metrics/route.ts
+++ b/src/app/api/maintenance/audit-outbox-metrics/route.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -98,7 +98,7 @@ async function handleGET(req: NextRequest) {
   };
 
   const { ip, userAgent } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.AUDIT_OUTBOX_METRICS_VIEW,
     userId: operatorId,

--- a/src/app/api/maintenance/audit-outbox-purge-failed/route.ts
+++ b/src/app/api/maintenance/audit-outbox-purge-failed/route.ts
@@ -13,7 +13,7 @@ import { prisma } from "@/lib/prisma";
 import { parseBody } from "@/lib/parse-body";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -77,7 +77,7 @@ async function handlePOST(req: NextRequest) {
   const purged = Number(rows[0]?.purged ?? 0);
 
   const { ip, userAgent } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.AUDIT_OUTBOX_PURGE_EXECUTED,
     userId: operatorId,

--- a/src/app/api/maintenance/dcr-cleanup/route.ts
+++ b/src/app/api/maintenance/dcr-cleanup/route.ts
@@ -13,7 +13,7 @@ import { prisma } from "@/lib/prisma";
 import { parseBody } from "@/lib/parse-body";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants/audit";
 import { AUDIT_METADATA_KEY } from "@/lib/constants";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
@@ -75,7 +75,7 @@ async function handlePOST(req: NextRequest) {
 
   // Audit log
   const { ip, userAgent } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.MCP_CLIENT_DCR_CLEANUP,
     userId: operatorId,

--- a/src/app/api/maintenance/purge-audit-logs/route.test.ts
+++ b/src/app/api/maintenance/purge-audit-logs/route.test.ts
@@ -33,7 +33,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "10.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,

--- a/src/app/api/maintenance/purge-audit-logs/route.ts
+++ b/src/app/api/maintenance/purge-audit-logs/route.ts
@@ -13,7 +13,7 @@ import { prisma } from "@/lib/prisma";
 import { parseBody } from "@/lib/parse-body";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants/audit";
 import { AUDIT_METADATA_KEY } from "@/lib/constants";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
@@ -103,7 +103,7 @@ async function handlePOST(req: NextRequest) {
   }
 
   const { ip, userAgent } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.HISTORY_PURGE,
     userId: operatorId,

--- a/src/app/api/maintenance/purge-history/route.test.ts
+++ b/src/app/api/maintenance/purge-history/route.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "10.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,

--- a/src/app/api/maintenance/purge-history/route.ts
+++ b/src/app/api/maintenance/purge-history/route.ts
@@ -13,7 +13,7 @@ import { prisma } from "@/lib/prisma";
 import { parseBody } from "@/lib/parse-body";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants/audit";
 import { AUDIT_METADATA_KEY } from "@/lib/constants";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
@@ -83,7 +83,7 @@ async function handlePOST(req: NextRequest) {
 
   // Audit log
   const { ip, userAgent } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.HISTORY_PURGE,
     userId: operatorId,

--- a/src/app/api/mcp/authorize/consent/route.test.ts
+++ b/src/app/api/mcp/authorize/consent/route.test.ts
@@ -63,7 +63,7 @@ vi.mock("@/lib/mcp/oauth-server", () => ({
 }));
 
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: mockExtractRequestMeta,
 }));
 

--- a/src/app/api/mcp/authorize/consent/route.test.ts
+++ b/src/app/api/mcp/authorize/consent/route.test.ts
@@ -331,7 +331,7 @@ describe("POST /api/mcp/authorize/consent", () => {
     );
   });
 
-  it("calls logAudit after successful consent", async () => {
+  it("calls logAuditAsync after successful consent", async () => {
     const req = createFormRequest(
       "http://localhost/api/mcp/authorize/consent",
       VALID_FORM_FIELDS,
@@ -367,7 +367,7 @@ describe("POST /api/mcp/authorize/consent", () => {
     expect(location).toContain("code=");
   });
 
-  it("redirects with error=access_denied and calls logAudit on deny action", async () => {
+  it("redirects with error=access_denied and calls logAuditAsync on deny action", async () => {
     const req = createFormRequest(
       "http://localhost/api/mcp/authorize/consent",
       {

--- a/src/app/api/mcp/authorize/consent/route.ts
+++ b/src/app/api/mcp/authorize/consent/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { createAuthorizationCode } from "@/lib/mcp/oauth-server";
 import { MCP_SCOPES, MAX_MCP_CLIENTS_PER_TENANT } from "@/lib/constants/mcp";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants/audit";
 import { assertOrigin } from "@/lib/csrf";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -64,7 +64,7 @@ export async function POST(req: NextRequest) {
   // Handle deny action (before claiming — deny should not bind the client)
   if (action === "deny") {
     const { ip, userAgent } = extractRequestMeta(req);
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.TENANT,
       action: AUDIT_ACTION.MCP_CONSENT_DENY,
       userId: session.user.id,
@@ -149,7 +149,7 @@ export async function POST(req: NextRequest) {
     } else {
       // Freshly claimed
       const { ip: claimIp } = extractRequestMeta(req);
-      logAudit({
+      await logAuditAsync({
         scope: AUDIT_SCOPE.TENANT,
         action: AUDIT_ACTION.MCP_CLIENT_DCR_CLAIM,
         userId: session.user.id,
@@ -189,7 +189,7 @@ export async function POST(req: NextRequest) {
 
   // Audit the consent grant
   const { ip, userAgent } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.MCP_CONSENT_GRANT,
     userId: session.user.id,

--- a/src/app/api/mcp/register/route.test.ts
+++ b/src/app/api/mcp/register/route.test.ts
@@ -56,7 +56,7 @@ vi.mock("@/lib/ip-access", () => ({
 }));
 
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
 }));
 
 vi.mock("@/lib/crypto-server", () => ({

--- a/src/app/api/mcp/register/route.test.ts
+++ b/src/app/api/mcp/register/route.test.ts
@@ -300,7 +300,7 @@ describe("POST /api/mcp/register", () => {
     expect(json.token_endpoint_auth_method).toBe("none");
   });
 
-  it("calls logAudit after successful registration", async () => {
+  it("calls logAuditAsync after successful registration", async () => {
     const req = createRequest("POST", "http://localhost/api/mcp/register", {
       body: VALID_BODY,
     });

--- a/src/app/api/mcp/register/route.ts
+++ b/src/app/api/mcp/register/route.ts
@@ -6,7 +6,7 @@ import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { hashToken } from "@/lib/crypto-server";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { extractClientIp, rateLimitKeyFromIp } from "@/lib/ip-access";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants/audit";
 import { AUDIT_TARGET_TYPE } from "@/lib/constants/audit-target";
 import {
@@ -169,7 +169,7 @@ export async function POST(req: NextRequest) {
   }
 
   // Audit log — system-level, no tenant or user context
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.MCP_CLIENT_DCR_REGISTER,
     userId: NIL_UUID,

--- a/src/app/api/mcp/token/route.test.ts
+++ b/src/app/api/mcp/token/route.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockRateLimiterCheck }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn().mockReturnValue({ ip: "127.0.0.1", userAgent: "test-agent" }),
 }));
 

--- a/src/app/api/mcp/token/route.ts
+++ b/src/app/api/mcp/token/route.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/mcp/oauth-server";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { extractClientIp, rateLimitKeyFromIp } from "@/lib/ip-access";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants/audit";
 import { NIL_UUID } from "@/lib/constants/app";
 
@@ -118,7 +118,7 @@ export async function POST(req: NextRequest) {
 
     if (!result.ok) {
       if (result.reason === "replay" && result.tenantId) {
-        logAudit({
+        await logAuditAsync({
           scope: AUDIT_SCOPE.TENANT,
           action: AUDIT_ACTION.MCP_REFRESH_TOKEN_REPLAY,
           userId: NIL_UUID,
@@ -132,7 +132,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.TENANT,
       action: AUDIT_ACTION.MCP_REFRESH_TOKEN_ROTATE,
       userId: result.userId ?? "system",

--- a/src/app/api/passwords/[id]/attachments/[attachmentId]/route.ts
+++ b/src/app/api/passwords/[id]/attachments/[attachmentId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { getAttachmentBlobStore } from "@/lib/blob-store";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -117,7 +117,7 @@ async function handleDELETE(
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ATTACHMENT_DELETE,
     userId: session.user.id,

--- a/src/app/api/passwords/[id]/attachments/route.ts
+++ b/src/app/api/passwords/[id]/attachments/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import {
   ALLOWED_EXTENSIONS,
   ALLOWED_CONTENT_TYPES,
@@ -218,7 +218,7 @@ async function handlePOST(
     throw error;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ATTACHMENT_UPLOAD,
     userId: session.user.id,

--- a/src/app/api/passwords/[id]/history/[historyId]/restore/route.test.ts
+++ b/src/app/api/passwords/[id]/history/[historyId]/restore/route.test.ts
@@ -24,7 +24,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/passwords/[id]/history/[historyId]/restore/route.ts
+++ b/src/app/api/passwords/[id]/history/[historyId]/restore/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, forbidden, notFound, unauthorized } from "@/lib/api-response";
 import { AUDIT_TARGET_TYPE, AUDIT_SCOPE, AUDIT_ACTION, AUDIT_METADATA_KEY } from "@/lib/constants";
@@ -103,7 +103,7 @@ async function handlePOST(
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_HISTORY_RESTORE,
     userId: session.user.id,

--- a/src/app/api/passwords/[id]/history/[historyId]/route.test.ts
+++ b/src/app/api/passwords/[id]/history/[historyId]/route.test.ts
@@ -27,7 +27,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/app/api/passwords/[id]/history/[historyId]/route.ts
+++ b/src/app/api/passwords/[id]/history/[historyId]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createHash } from "node:crypto";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, rateLimited, forbidden, notFound, unauthorized } from "@/lib/api-response";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
@@ -149,7 +149,7 @@ async function handlePATCH(
   }
 
   const meta = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_HISTORY_REENCRYPT,
     userId: session.user.id,

--- a/src/app/api/passwords/[id]/restore/route.ts
+++ b/src/app/api/passwords/[id]/restore/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { withRequestLog } from "@/lib/with-request-log";
 import { AUDIT_TARGET_TYPE, AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
@@ -46,7 +46,7 @@ async function handlePOST(
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_RESTORE,
     userId: session.user.id,

--- a/src/app/api/passwords/[id]/route.test.ts
+++ b/src/app/api/passwords/[id]/route.test.ts
@@ -49,7 +49,7 @@ vi.mock("@/lib/audit", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/audit")>();
   return {
     ...actual,
-    logAudit: mockLogAudit,
+    logAuditAsync: mockLogAudit,
   };
 });
 import { NextResponse } from "next/server";

--- a/src/app/api/passwords/[id]/route.ts
+++ b/src/app/api/passwords/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { updateE2EPasswordSchema } from "@/lib/validations";
 import { notFound, forbidden, validationError } from "@/lib/api-response";
 import { checkAuth } from "@/lib/check-auth";
@@ -191,7 +191,7 @@ async function handlePUT(
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_UPDATE,
     userId,
@@ -260,7 +260,7 @@ async function handleDELETE(
     );
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: permanent
       ? AUDIT_ACTION.ENTRY_PERMANENT_DELETE

--- a/src/app/api/passwords/bulk-archive/route.test.ts
+++ b/src/app/api/passwords/bulk-archive/route.test.ts
@@ -229,6 +229,7 @@ describe("POST /api/passwords/bulk-archive", () => {
     await POST(createRequest("POST", URL, { body: { ids: [id1, id2] } }));
 
     // 1 parent log + 2 per-entry logs, all via logAuditAsync
+    expect(mockLogAudit).toHaveBeenCalledTimes(3);
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "ENTRY_BULK_ARCHIVE",
@@ -277,6 +278,7 @@ describe("POST /api/passwords/bulk-archive", () => {
     }));
 
     // 1 parent log + 1 per-entry log, all via logAuditAsync
+    expect(mockLogAudit).toHaveBeenCalledTimes(2);
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "ENTRY_BULK_UNARCHIVE",
@@ -314,6 +316,7 @@ describe("POST /api/passwords/bulk-archive", () => {
     }));
 
     // 1 parent + 3 per-entry logs, all via logAuditAsync
+    expect(mockLogAudit).toHaveBeenCalledTimes(4);
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "ENTRY_BULK_ARCHIVE",
@@ -350,6 +353,7 @@ describe("POST /api/passwords/bulk-archive", () => {
     );
 
     // Each per-entry call carries the same fields that individual logAudit calls produce
+    expect(mockLogAudit).toHaveBeenCalledTimes(4); // 1 parent + 3 per-entry
     for (const targetId of [id1, id2, id3]) {
       expect(mockLogAudit).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/app/api/passwords/bulk-archive/route.test.ts
+++ b/src/app/api/passwords/bulk-archive/route.test.ts
@@ -1,14 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockFindMany, mockUpdateMany, mockAuditCreate, mockAuditCreateMany, mockLogAudit, mockLogAuditBatch, mockPrismaUser, mockWithUserTenantRls, mockWithBypassRls, mockTransaction } = vi.hoisted(() => ({
+const { mockAuth, mockFindMany, mockUpdateMany, mockAuditCreate, mockAuditCreateMany, mockLogAudit, mockPrismaUser, mockWithUserTenantRls, mockWithBypassRls, mockTransaction } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockFindMany: vi.fn(),
   mockUpdateMany: vi.fn(),
   mockAuditCreate: vi.fn(),
   mockAuditCreateMany: vi.fn(),
   mockLogAudit: vi.fn(),
-  mockLogAuditBatch: vi.fn(),
   mockPrismaUser: { findUnique: vi.fn() },
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
   mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
@@ -40,8 +39,7 @@ vi.mock("@/lib/audit", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/audit")>();
   return {
     ...actual,
-    logAudit: mockLogAudit,
-    logAuditBatch: mockLogAuditBatch,
+    logAuditAsync: mockLogAudit,
   };
 });
 
@@ -230,8 +228,7 @@ describe("POST /api/passwords/bulk-archive", () => {
 
     await POST(createRequest("POST", URL, { body: { ids: [id1, id2] } }));
 
-    // 1 parent log via logAudit, per-entry logs via logAuditBatch
-    expect(mockLogAudit).toHaveBeenCalledTimes(1);
+    // 1 parent log + 2 per-entry logs, all via logAuditAsync
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "ENTRY_BULK_ARCHIVE",
@@ -247,27 +244,26 @@ describe("POST /api/passwords/bulk-archive", () => {
       })
     );
 
-    // Per-entry logs via a single logAuditBatch call
-    expect(mockLogAuditBatch).toHaveBeenCalledTimes(1);
-    expect(mockLogAuditBatch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          action: "ENTRY_UPDATE",
-          targetId: id1,
-          metadata: expect.objectContaining({
-            source: "bulk-archive",
-            parentAction: "ENTRY_BULK_ARCHIVE",
-          }),
+    // Per-entry logs via individual logAuditAsync calls
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "ENTRY_UPDATE",
+        targetId: id1,
+        metadata: expect.objectContaining({
+          source: "bulk-archive",
+          parentAction: "ENTRY_BULK_ARCHIVE",
         }),
-        expect.objectContaining({
-          action: "ENTRY_UPDATE",
-          targetId: id2,
-          metadata: expect.objectContaining({
-            source: "bulk-archive",
-            parentAction: "ENTRY_BULK_ARCHIVE",
-          }),
+      })
+    );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "ENTRY_UPDATE",
+        targetId: id2,
+        metadata: expect.objectContaining({
+          source: "bulk-archive",
+          parentAction: "ENTRY_BULK_ARCHIVE",
         }),
-      ])
+      })
     );
   });
 
@@ -280,8 +276,7 @@ describe("POST /api/passwords/bulk-archive", () => {
       body: { ids: [id1], operation: "unarchive" },
     }));
 
-    // 1 parent log via logAudit, per-entry logs via logAuditBatch
-    expect(mockLogAudit).toHaveBeenCalledTimes(1);
+    // 1 parent log + 1 per-entry log, all via logAuditAsync
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "ENTRY_BULK_UNARCHIVE",
@@ -293,18 +288,15 @@ describe("POST /api/passwords/bulk-archive", () => {
       })
     );
 
-    expect(mockLogAuditBatch).toHaveBeenCalledTimes(1);
-    expect(mockLogAuditBatch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          action: "ENTRY_UPDATE",
-          targetId: id1,
-          metadata: expect.objectContaining({
-            source: "bulk-archive",
-            parentAction: "ENTRY_BULK_UNARCHIVE",
-          }),
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "ENTRY_UPDATE",
+        targetId: id1,
+        metadata: expect.objectContaining({
+          source: "bulk-archive",
+          parentAction: "ENTRY_BULK_UNARCHIVE",
         }),
-      ])
+      })
     );
   });
 
@@ -321,8 +313,7 @@ describe("POST /api/passwords/bulk-archive", () => {
       body: { ids: [id1, id2, id3] },
     }));
 
-    // 1 parent via logAudit, 3 per-entry batched via logAuditBatch
-    expect(mockLogAudit).toHaveBeenCalledTimes(1);
+    // 1 parent + 3 per-entry logs, all via logAuditAsync
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "ENTRY_BULK_ARCHIVE",
@@ -332,18 +323,19 @@ describe("POST /api/passwords/bulk-archive", () => {
       })
     );
 
-    // All 3 per-entry logs in a single logAuditBatch call
-    expect(mockLogAuditBatch).toHaveBeenCalledTimes(1);
-    expect(mockLogAuditBatch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ action: "ENTRY_UPDATE", targetId: id1 }),
-        expect.objectContaining({ action: "ENTRY_UPDATE", targetId: id2 }),
-        expect.objectContaining({ action: "ENTRY_UPDATE", targetId: id3 }),
-      ])
+    // All 3 per-entry logs via individual logAuditAsync calls
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "ENTRY_UPDATE", targetId: id1 })
+    );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "ENTRY_UPDATE", targetId: id2 })
+    );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "ENTRY_UPDATE", targetId: id3 })
     );
   });
 
-  it("logAuditBatch receives per-entry data matching individual logAudit contract", async () => {
+  it("logAuditAsync receives per-entry data matching individual logAudit contract", async () => {
     const id1 = "00000000-0000-4000-a000-000000000001";
     const id2 = "00000000-0000-4000-a000-000000000002";
     const id3 = "00000000-0000-4000-a000-000000000003";
@@ -357,21 +349,15 @@ describe("POST /api/passwords/bulk-archive", () => {
       })
     );
 
-    await vi.waitFor(() => expect(mockLogAuditBatch).toHaveBeenCalled());
-
-    const batchData: Record<string, unknown>[] = mockLogAuditBatch.mock.calls[0][0];
-
-    // Exactly 3 per-entry records — one per processed entry
-    expect(batchData).toHaveLength(3);
-
-    // Every record must carry the fields that individual logAudit calls would produce
-    for (const entry of batchData) {
-      expect(entry).toEqual(
+    // Each per-entry call carries the same fields that individual logAudit calls produce
+    for (const targetId of [id1, id2, id3]) {
+      expect(mockLogAudit).toHaveBeenCalledWith(
         expect.objectContaining({
           scope: "PERSONAL",
           action: "ENTRY_UPDATE",
           userId: "user-1",
           targetType: "PasswordEntry",
+          targetId,
           metadata: expect.objectContaining({
             source: "bulk-archive",
             parentAction: "ENTRY_BULK_ARCHIVE",
@@ -379,10 +365,5 @@ describe("POST /api/passwords/bulk-archive", () => {
         })
       );
     }
-
-    // targetId is unique per entry — not all the same
-    const ids = batchData.map((e) => e.targetId);
-    expect(ids).toEqual(expect.arrayContaining([id1, id2, id3]));
-    expect(new Set(ids).size).toBe(3);
   });
 });

--- a/src/app/api/passwords/bulk-archive/route.ts
+++ b/src/app/api/passwords/bulk-archive/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, logAuditBatch, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { withRequestLog } from "@/lib/with-request-log";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withUserTenantRls } from "@/lib/tenant-context";
@@ -51,7 +51,7 @@ async function handlePOST(req: NextRequest) {
 
   const requestMeta = extractRequestMeta(req);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: toArchived
       ? AUDIT_ACTION.ENTRY_BULK_ARCHIVE
@@ -71,22 +71,23 @@ async function handlePOST(req: NextRequest) {
     ...requestMeta,
   });
 
-  logAuditBatch(
-    entryIds.map((entryId) => ({
-      scope: AUDIT_SCOPE.PERSONAL,
-      action: AUDIT_ACTION.ENTRY_UPDATE,
-      userId: session.user.id,
-      targetType: AUDIT_TARGET_TYPE.PASSWORD_ENTRY,
-      targetId: entryId,
-      metadata: {
-        source: "bulk-archive",
-        parentAction: toArchived
-          ? AUDIT_ACTION.ENTRY_BULK_ARCHIVE
-          : AUDIT_ACTION.ENTRY_BULK_UNARCHIVE,
-      },
-      ...requestMeta,
-    })),
-  );
+  const auditEntries = entryIds.map((entryId) => ({
+    scope: AUDIT_SCOPE.PERSONAL,
+    action: AUDIT_ACTION.ENTRY_UPDATE,
+    userId: session.user.id,
+    targetType: AUDIT_TARGET_TYPE.PASSWORD_ENTRY,
+    targetId: entryId,
+    metadata: {
+      source: "bulk-archive",
+      parentAction: toArchived
+        ? AUDIT_ACTION.ENTRY_BULK_ARCHIVE
+        : AUDIT_ACTION.ENTRY_BULK_UNARCHIVE,
+    },
+    ...requestMeta,
+  }));
+  for (const entry of auditEntries) {
+    await logAuditAsync(entry);
+  }
 
   return NextResponse.json({
     success: true,

--- a/src/app/api/passwords/bulk-import/route.test.ts
+++ b/src/app/api/passwords/bulk-import/route.test.ts
@@ -11,7 +11,6 @@ const {
   mockWithUserTenantRls,
   mockRateLimiterCheck,
   mockLogAudit,
-  mockLogAuditBatch,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockPrismaPasswordEntry: {
@@ -24,7 +23,6 @@ const {
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
   mockRateLimiterCheck: vi.fn(),
   mockLogAudit: vi.fn(),
-  mockLogAuditBatch: vi.fn(),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -44,8 +42,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockRateLimiterCheck, clear: vi.fn() }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
-  logAuditBatch: mockLogAuditBatch,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({}),
 }));
 vi.mock("@/lib/logger", () => {
@@ -181,7 +178,7 @@ describe("POST /api/passwords/bulk-import", () => {
     );
   });
 
-  it("calls logAuditBatch with ENTRY_CREATE for each created entry", async () => {
+  it("calls logAuditAsync with ENTRY_CREATE for each created entry", async () => {
     const entries = [
       makeEntry("550e8400-e29b-41d4-a716-000000000001"),
       makeEntry("550e8400-e29b-41d4-a716-000000000002"),
@@ -190,19 +187,37 @@ describe("POST /api/passwords/bulk-import", () => {
 
     await POST(createRequest("POST", URL, { body: { entries } }));
 
-    expect(mockLogAuditBatch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          action: AUDIT_ACTION.ENTRY_CREATE,
-          metadata: expect.objectContaining({
-            source: "bulk-import",
-            parentAction: AUDIT_ACTION.ENTRY_BULK_IMPORT,
-          }),
+    // logAuditAsync called once per entry with ENTRY_CREATE
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AUDIT_ACTION.ENTRY_CREATE,
+        targetId: "550e8400-e29b-41d4-a716-000000000001",
+        metadata: expect.objectContaining({
+          source: "bulk-import",
+          parentAction: AUDIT_ACTION.ENTRY_BULK_IMPORT,
         }),
-      ]),
+      }),
     );
-    const batchArg = mockLogAuditBatch.mock.calls[0][0];
-    expect(batchArg).toHaveLength(3);
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AUDIT_ACTION.ENTRY_CREATE,
+        targetId: "550e8400-e29b-41d4-a716-000000000002",
+        metadata: expect.objectContaining({
+          source: "bulk-import",
+          parentAction: AUDIT_ACTION.ENTRY_BULK_IMPORT,
+        }),
+      }),
+    );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AUDIT_ACTION.ENTRY_CREATE,
+        targetId: "550e8400-e29b-41d4-a716-000000000003",
+        metadata: expect.objectContaining({
+          source: "bulk-import",
+          parentAction: AUDIT_ACTION.ENTRY_BULK_IMPORT,
+        }),
+      }),
+    );
   });
 
   it("uses rate limiter key scoped to userId", async () => {

--- a/src/app/api/passwords/bulk-import/route.test.ts
+++ b/src/app/api/passwords/bulk-import/route.test.ts
@@ -157,7 +157,7 @@ describe("POST /api/passwords/bulk-import", () => {
     expect(json.failed).toBe(1);
   });
 
-  it("calls logAudit with ENTRY_BULK_IMPORT action", async () => {
+  it("calls logAuditAsync with ENTRY_BULK_IMPORT action", async () => {
     const entries = [
       makeEntry("550e8400-e29b-41d4-a716-000000000001"),
       makeEntry("550e8400-e29b-41d4-a716-000000000002"),
@@ -165,6 +165,7 @@ describe("POST /api/passwords/bulk-import", () => {
 
     await POST(createRequest("POST", URL, { body: { entries } }));
 
+    expect(mockLogAudit).toHaveBeenCalledTimes(3); // 1 parent + 2 per-entry
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: AUDIT_ACTION.ENTRY_BULK_IMPORT,
@@ -188,6 +189,7 @@ describe("POST /api/passwords/bulk-import", () => {
     await POST(createRequest("POST", URL, { body: { entries } }));
 
     // logAuditAsync called once per entry with ENTRY_CREATE
+    expect(mockLogAudit).toHaveBeenCalledTimes(4); // 1 parent + 3 per-entry
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: AUDIT_ACTION.ENTRY_CREATE,

--- a/src/app/api/passwords/bulk-import/route.ts
+++ b/src/app/api/passwords/bulk-import/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, logAuditBatch, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { withRequestLog } from "@/lib/with-request-log";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withUserTenantRls } from "@/lib/tenant-context";
@@ -122,7 +122,7 @@ async function handlePOST(req: NextRequest) {
 
   const requestMeta = extractRequestMeta(req);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_BULK_IMPORT,
     userId,
@@ -138,20 +138,21 @@ async function handlePOST(req: NextRequest) {
     ...requestMeta,
   });
 
-  logAuditBatch(
-    createdIds.map((entryId) => ({
-      scope: AUDIT_SCOPE.PERSONAL,
-      action: AUDIT_ACTION.ENTRY_CREATE,
-      userId,
-      targetType: AUDIT_TARGET_TYPE.PASSWORD_ENTRY,
-      targetId: entryId,
-      metadata: {
-        source: "bulk-import",
-        parentAction: AUDIT_ACTION.ENTRY_BULK_IMPORT,
-      },
-      ...requestMeta,
-    })),
-  );
+  const auditEntries = createdIds.map((entryId) => ({
+    scope: AUDIT_SCOPE.PERSONAL,
+    action: AUDIT_ACTION.ENTRY_CREATE,
+    userId,
+    targetType: AUDIT_TARGET_TYPE.PASSWORD_ENTRY,
+    targetId: entryId,
+    metadata: {
+      source: "bulk-import",
+      parentAction: AUDIT_ACTION.ENTRY_BULK_IMPORT,
+    },
+    ...requestMeta,
+  }));
+  for (const entry of auditEntries) {
+    await logAuditAsync(entry);
+  }
 
   return NextResponse.json(
     { success: createdIds.length, failed: failedCount },

--- a/src/app/api/passwords/bulk-restore/route.test.ts
+++ b/src/app/api/passwords/bulk-restore/route.test.ts
@@ -1,14 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockFindMany, mockUpdateMany, mockAuditCreate, mockAuditCreateMany, mockLogAudit, mockLogAuditBatch, mockPrismaUser, mockWithUserTenantRls, mockWithBypassRls, mockTransaction } = vi.hoisted(() => ({
+const { mockAuth, mockFindMany, mockUpdateMany, mockAuditCreate, mockAuditCreateMany, mockLogAudit, mockPrismaUser, mockWithUserTenantRls, mockWithBypassRls, mockTransaction } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockFindMany: vi.fn(),
   mockUpdateMany: vi.fn(),
   mockAuditCreate: vi.fn(),
   mockAuditCreateMany: vi.fn(),
   mockLogAudit: vi.fn(),
-  mockLogAuditBatch: vi.fn(),
   mockPrismaUser: { findUnique: vi.fn() },
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
   mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
@@ -40,8 +39,7 @@ vi.mock("@/lib/audit", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/audit")>();
   return {
     ...actual,
-    logAudit: mockLogAudit,
-    logAuditBatch: mockLogAuditBatch,
+    logAuditAsync: mockLogAudit,
   };
 });
 
@@ -183,8 +181,7 @@ describe("POST /api/passwords/bulk-restore", () => {
 
     await POST(createRequest("POST", URL, { body: { ids: [id1, id2] } }));
 
-    // 1 parent log via logAudit, per-entry logs via logAuditBatch
-    expect(mockLogAudit).toHaveBeenCalledTimes(1);
+    // 1 parent log + 2 per-entry logs, all via logAuditAsync
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "ENTRY_BULK_RESTORE",
@@ -198,27 +195,26 @@ describe("POST /api/passwords/bulk-restore", () => {
       })
     );
 
-    // Per-entry logs via a single logAuditBatch call
-    expect(mockLogAuditBatch).toHaveBeenCalledTimes(1);
-    expect(mockLogAuditBatch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          action: "ENTRY_RESTORE",
-          targetId: id1,
-          metadata: expect.objectContaining({
-            source: "bulk-restore",
-            parentAction: "ENTRY_BULK_RESTORE",
-          }),
+    // Per-entry logs via individual logAuditAsync calls
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "ENTRY_RESTORE",
+        targetId: id1,
+        metadata: expect.objectContaining({
+          source: "bulk-restore",
+          parentAction: "ENTRY_BULK_RESTORE",
         }),
-        expect.objectContaining({
-          action: "ENTRY_RESTORE",
-          targetId: id2,
-          metadata: expect.objectContaining({
-            source: "bulk-restore",
-            parentAction: "ENTRY_BULK_RESTORE",
-          }),
+      })
+    );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "ENTRY_RESTORE",
+        targetId: id2,
+        metadata: expect.objectContaining({
+          source: "bulk-restore",
+          parentAction: "ENTRY_BULK_RESTORE",
         }),
-      ])
+      })
     );
   });
 });

--- a/src/app/api/passwords/bulk-restore/route.test.ts
+++ b/src/app/api/passwords/bulk-restore/route.test.ts
@@ -182,6 +182,7 @@ describe("POST /api/passwords/bulk-restore", () => {
     await POST(createRequest("POST", URL, { body: { ids: [id1, id2] } }));
 
     // 1 parent log + 2 per-entry logs, all via logAuditAsync
+    expect(mockLogAudit).toHaveBeenCalledTimes(3);
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "ENTRY_BULK_RESTORE",

--- a/src/app/api/passwords/bulk-restore/route.ts
+++ b/src/app/api/passwords/bulk-restore/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, logAuditBatch, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { withRequestLog } from "@/lib/with-request-log";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withUserTenantRls } from "@/lib/tenant-context";
@@ -48,7 +48,7 @@ async function handlePOST(req: NextRequest) {
 
   const requestMeta = extractRequestMeta(req);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_BULK_RESTORE,
     userId: session.user.id,
@@ -64,20 +64,21 @@ async function handlePOST(req: NextRequest) {
     ...requestMeta,
   });
 
-  logAuditBatch(
-    entryIds.map((entryId) => ({
-      scope: AUDIT_SCOPE.PERSONAL,
-      action: AUDIT_ACTION.ENTRY_RESTORE,
-      userId: session.user.id,
-      targetType: AUDIT_TARGET_TYPE.PASSWORD_ENTRY,
-      targetId: entryId,
-      metadata: {
-        source: "bulk-restore",
-        parentAction: AUDIT_ACTION.ENTRY_BULK_RESTORE,
-      },
-      ...requestMeta,
-    })),
-  );
+  const auditEntries = entryIds.map((entryId) => ({
+    scope: AUDIT_SCOPE.PERSONAL,
+    action: AUDIT_ACTION.ENTRY_RESTORE,
+    userId: session.user.id,
+    targetType: AUDIT_TARGET_TYPE.PASSWORD_ENTRY,
+    targetId: entryId,
+    metadata: {
+      source: "bulk-restore",
+      parentAction: AUDIT_ACTION.ENTRY_BULK_RESTORE,
+    },
+    ...requestMeta,
+  }));
+  for (const entry of auditEntries) {
+    await logAuditAsync(entry);
+  }
 
   return NextResponse.json({ success: true, restoredCount: updateResult.count });
 }

--- a/src/app/api/passwords/bulk-trash/route.test.ts
+++ b/src/app/api/passwords/bulk-trash/route.test.ts
@@ -1,14 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockFindMany, mockUpdateMany, mockAuditCreate, mockAuditCreateMany, mockLogAudit, mockLogAuditBatch, mockPrismaUser, mockWithUserTenantRls, mockWithBypassRls, mockTransaction } = vi.hoisted(() => ({
+const { mockAuth, mockFindMany, mockUpdateMany, mockAuditCreate, mockAuditCreateMany, mockLogAudit, mockPrismaUser, mockWithUserTenantRls, mockWithBypassRls, mockTransaction } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockFindMany: vi.fn(),
   mockUpdateMany: vi.fn(),
   mockAuditCreate: vi.fn(),
   mockAuditCreateMany: vi.fn(),
   mockLogAudit: vi.fn(),
-  mockLogAuditBatch: vi.fn(),
   mockPrismaUser: { findUnique: vi.fn() },
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
   mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
@@ -40,8 +39,7 @@ vi.mock("@/lib/audit", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/audit")>();
   return {
     ...actual,
-    logAudit: mockLogAudit,
-    logAuditBatch: mockLogAuditBatch,
+    logAuditAsync: mockLogAudit,
   };
 });
 
@@ -204,8 +202,7 @@ describe("POST /api/passwords/bulk-trash", () => {
 
     await POST(createRequest("POST", URL, { body: { ids: [id1, id2] } }));
 
-    // 1 parent log via logAudit, per-entry logs via logAuditBatch
-    expect(mockLogAudit).toHaveBeenCalledTimes(1);
+    // 1 parent log + 2 per-entry logs, all via logAuditAsync
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "ENTRY_BULK_TRASH",
@@ -218,27 +215,26 @@ describe("POST /api/passwords/bulk-trash", () => {
       })
     );
 
-    // Per-entry logs via a single logAuditBatch call
-    expect(mockLogAuditBatch).toHaveBeenCalledTimes(1);
-    expect(mockLogAuditBatch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          action: "ENTRY_TRASH",
-          targetId: id1,
-          metadata: expect.objectContaining({
-            source: "bulk-trash",
-            parentAction: "ENTRY_BULK_TRASH",
-          }),
+    // Per-entry logs via individual logAuditAsync calls
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "ENTRY_TRASH",
+        targetId: id1,
+        metadata: expect.objectContaining({
+          source: "bulk-trash",
+          parentAction: "ENTRY_BULK_TRASH",
         }),
-        expect.objectContaining({
-          action: "ENTRY_TRASH",
-          targetId: id2,
-          metadata: expect.objectContaining({
-            source: "bulk-trash",
-            parentAction: "ENTRY_BULK_TRASH",
-          }),
+      })
+    );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "ENTRY_TRASH",
+        targetId: id2,
+        metadata: expect.objectContaining({
+          source: "bulk-trash",
+          parentAction: "ENTRY_BULK_TRASH",
         }),
-      ])
+      })
     );
   });
 });

--- a/src/app/api/passwords/bulk-trash/route.test.ts
+++ b/src/app/api/passwords/bulk-trash/route.test.ts
@@ -203,6 +203,7 @@ describe("POST /api/passwords/bulk-trash", () => {
     await POST(createRequest("POST", URL, { body: { ids: [id1, id2] } }));
 
     // 1 parent log + 2 per-entry logs, all via logAuditAsync
+    expect(mockLogAudit).toHaveBeenCalledTimes(3);
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "ENTRY_BULK_TRASH",

--- a/src/app/api/passwords/bulk-trash/route.ts
+++ b/src/app/api/passwords/bulk-trash/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, logAuditBatch, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { withRequestLog } from "@/lib/with-request-log";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withUserTenantRls } from "@/lib/tenant-context";
@@ -48,7 +48,7 @@ async function handlePOST(req: NextRequest) {
   );
   const requestMeta = extractRequestMeta(req);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_BULK_TRASH,
     userId: session.user.id,
@@ -63,20 +63,21 @@ async function handlePOST(req: NextRequest) {
     ...requestMeta,
   });
 
-  logAuditBatch(
-    entryIds.map((entryId) => ({
-      scope: AUDIT_SCOPE.PERSONAL,
-      action: AUDIT_ACTION.ENTRY_TRASH,
-      userId: session.user.id,
-      targetType: AUDIT_TARGET_TYPE.PASSWORD_ENTRY,
-      targetId: entryId,
-      metadata: {
-        source: "bulk-trash",
-        parentAction: AUDIT_ACTION.ENTRY_BULK_TRASH,
-      },
-      ...requestMeta,
-    })),
-  );
+  const auditEntries = entryIds.map((entryId) => ({
+    scope: AUDIT_SCOPE.PERSONAL,
+    action: AUDIT_ACTION.ENTRY_TRASH,
+    userId: session.user.id,
+    targetType: AUDIT_TARGET_TYPE.PASSWORD_ENTRY,
+    targetId: entryId,
+    metadata: {
+      source: "bulk-trash",
+      parentAction: AUDIT_ACTION.ENTRY_BULK_TRASH,
+    },
+    ...requestMeta,
+  }));
+  for (const entry of auditEntries) {
+    await logAuditAsync(entry);
+  }
 
   return NextResponse.json({ success: true, movedCount: updateResult.count });
 }

--- a/src/app/api/passwords/empty-trash/route.test.ts
+++ b/src/app/api/passwords/empty-trash/route.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/passwords/empty-trash/route.ts
+++ b/src/app/api/passwords/empty-trash/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { withRequestLog } from "@/lib/with-request-log";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withUserTenantRls } from "@/lib/tenant-context";
@@ -32,7 +32,7 @@ async function handlePOST(req: NextRequest) {
 
   const requestMeta = extractRequestMeta(req);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_EMPTY_TRASH,
     userId: session.user.id,
@@ -47,7 +47,7 @@ async function handlePOST(req: NextRequest) {
   });
 
   for (const entryId of entryIds) {
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.ENTRY_PERMANENT_DELETE,
       userId: session.user.id,

--- a/src/app/api/passwords/route.test.ts
+++ b/src/app/api/passwords/route.test.ts
@@ -75,7 +75,7 @@ vi.mock("@/lib/audit", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/audit")>();
   return {
     ...actual,
-    logAudit: mockLogAudit,
+    logAuditAsync: mockLogAudit,
   };
 });
 

--- a/src/app/api/passwords/route.ts
+++ b/src/app/api/passwords/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createE2EPasswordSchema } from "@/lib/validations";
 import { unauthorized, validationError } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
@@ -202,7 +202,7 @@ async function handlePOST(req: NextRequest) {
 
   const { entry } = createResult;
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_CREATE,
     userId,

--- a/src/app/api/scim/v2/Groups/[id]/route.test.ts
+++ b/src/app/api/scim/v2/Groups/[id]/route.test.ts
@@ -31,7 +31,7 @@ const {
 vi.mock("@/lib/scim-token", () => ({ validateScimToken: mockValidateScimToken }));
 vi.mock("@/lib/scim/rate-limit", () => ({ checkScimRateLimit: mockCheckScimRateLimit }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/prisma", () => ({

--- a/src/app/api/scim/v2/Groups/[id]/route.ts
+++ b/src/app/api/scim/v2/Groups/[id]/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { validateScimToken } from "@/lib/scim-token";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { scimResponse, scimError, getScimBaseUrl } from "@/lib/scim/response";
 import { scimPatchOpSchema, scimGroupSchema } from "@/lib/scim/validations";
 import { parseGroupPatchOps, PatchParseError } from "@/lib/scim/patch-parser";
@@ -102,7 +102,7 @@ async function handlePUT(req: NextRequest, { params }: Params): Promise<Response
     throw e;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.SCIM_GROUP_UPDATE,
     userId: auditUserId,
@@ -178,7 +178,7 @@ async function handlePATCH(req: NextRequest, { params }: Params): Promise<Respon
     throw e;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.SCIM_GROUP_UPDATE,
     userId: auditUserId,

--- a/src/app/api/scim/v2/Groups/route.test.ts
+++ b/src/app/api/scim/v2/Groups/route.test.ts
@@ -19,7 +19,7 @@ const {
 
 vi.mock("@/lib/scim-token", () => ({ validateScimToken: mockValidateScimToken }));
 vi.mock("@/lib/scim/rate-limit", () => ({ checkScimRateLimit: mockCheckScimRateLimit }));
-vi.mock("@/lib/audit", () => ({ logAudit: vi.fn(), extractRequestMeta: () => ({ ip: null, userAgent: null }) }));
+vi.mock("@/lib/audit", () => ({ logAuditAsync: vi.fn(), extractRequestMeta: () => ({ ip: null, userAgent: null }) }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     scimGroupMapping: mockScimGroupMapping,

--- a/src/app/api/scim/v2/Users/[id]/route.test.ts
+++ b/src/app/api/scim/v2/Users/[id]/route.test.ts
@@ -31,7 +31,7 @@ const {
 vi.mock("@/lib/scim-token", () => ({ validateScimToken: mockValidateScimToken }));
 vi.mock("@/lib/scim/rate-limit", () => ({ checkScimRateLimit: mockCheckScimRateLimit }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/prisma", () => ({

--- a/src/app/api/scim/v2/Users/[id]/route.ts
+++ b/src/app/api/scim/v2/Users/[id]/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from "next/server";
 import { validateScimToken } from "@/lib/scim-token";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { scimResponse, scimError, getScimBaseUrl } from "@/lib/scim/response";
 import { scimUserSchema, scimPatchOpSchema } from "@/lib/scim/validations";
 import { parseUserPatchOps, PatchParseError } from "@/lib/scim/patch-parser";
@@ -120,7 +120,7 @@ async function handlePUT(req: NextRequest, { params }: Params): Promise<Response
     }
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: auditAction,
     userId: auditUserId,
@@ -207,7 +207,7 @@ async function handlePATCH(req: NextRequest, { params }: Params): Promise<Respon
     }
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: auditAction,
     userId: auditUserId,
@@ -274,7 +274,7 @@ async function handleDELETE(req: NextRequest, { params }: Params): Promise<Respo
     }
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.SCIM_USER_DELETE,
     userId: auditUserId,

--- a/src/app/api/scim/v2/Users/route.test.ts
+++ b/src/app/api/scim/v2/Users/route.test.ts
@@ -25,7 +25,7 @@ const {
 vi.mock("@/lib/scim-token", () => ({ validateScimToken: mockValidateScimToken }));
 vi.mock("@/lib/scim/rate-limit", () => ({ checkScimRateLimit: mockCheckScimRateLimit }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/prisma", () => ({

--- a/src/app/api/scim/v2/Users/route.ts
+++ b/src/app/api/scim/v2/Users/route.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { validateScimToken } from "@/lib/scim-token";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import {
   scimResponse,
   scimError,
@@ -237,7 +237,7 @@ async function handlePOST(req: NextRequest) {
       }),
     );
 
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.TENANT,
       action: AUDIT_ACTION.SCIM_USER_CREATE,
       userId: auditUserId,

--- a/src/app/api/sends/file/route.test.ts
+++ b/src/app/api/sends/file/route.test.ts
@@ -51,7 +51,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/sends/file/route.ts
+++ b/src/app/api/sends/file/route.ts
@@ -15,7 +15,7 @@ import {
   generateAccessPassword,
   hashAccessPassword,
 } from "@/lib/crypto-server";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, rateLimited, unauthorized, validationError, zodValidationError } from "@/lib/api-response";
@@ -180,7 +180,7 @@ async function handlePOST(req: NextRequest) {
 
   // Audit log
   const { ip, userAgent } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.SEND_CREATE,
     userId: session.user.id,

--- a/src/app/api/sends/route.ts
+++ b/src/app/api/sends/route.ts
@@ -9,7 +9,7 @@ import {
   generateAccessPassword,
   hashAccessPassword,
 } from "@/lib/crypto-server";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { rateLimited, unauthorized } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
@@ -91,7 +91,7 @@ async function handlePOST(req: NextRequest) {
 
   // Audit log
   const { ip, userAgent } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.SEND_CREATE,
     userId: session.user.id,

--- a/src/app/api/sessions/[id]/route.test.ts
+++ b/src/app/api/sessions/[id]/route.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => mockRateLimiter,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { createRateLimiter } from "@/lib/rate-limit";
@@ -68,7 +68,7 @@ async function handleDELETE(
   }
 
   const meta = extractRequestMeta(request);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.SESSION_REVOKE,
     userId: session.user.id,

--- a/src/app/api/sessions/route.test.ts
+++ b/src/app/api/sessions/route.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => mockRateLimiter,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { createRateLimiter } from "@/lib/rate-limit";
@@ -105,7 +105,7 @@ async function handleDELETE(request: NextRequest) {
   );
 
   const meta = extractRequestMeta(request);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.SESSION_REVOKE_ALL,
     userId: session.user.id,

--- a/src/app/api/share-links/verify-access/route.test.ts
+++ b/src/app/api/share-links/verify-access/route.test.ts
@@ -48,7 +48,7 @@ vi.mock("@/lib/ip-access", () => ({
   rateLimitKeyFromIp: (ip: string) => ip,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/logger", () => {

--- a/src/app/api/share-links/verify-access/route.ts
+++ b/src/app/api/share-links/verify-access/route.ts
@@ -6,7 +6,7 @@ import { hashToken, verifyAccessPassword } from "@/lib/crypto-server";
 import { createShareAccessToken } from "@/lib/share-access-token";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { extractClientIp, rateLimitKeyFromIp } from "@/lib/ip-access";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, rateLimited, notFound } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
@@ -72,7 +72,7 @@ async function handlePOST(req: NextRequest) {
     // Non-atomic audit: userId="anonymous" is not a valid UUID,
     // so this cannot use logAuditInTx (worker INSERT would fail on ::uuid cast).
     // Falls through the FIFO flusher path where tenantId is already resolved.
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_FAILED,
       userId: "anonymous",
@@ -87,7 +87,7 @@ async function handlePOST(req: NextRequest) {
   }
 
   // Non-atomic audit: same userId="anonymous" limitation as above.
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_SUCCESS,
     userId: "anonymous",

--- a/src/app/api/teams/[teamId]/audit-logs/download/route.test.ts
+++ b/src/app/api/teams/[teamId]/audit-logs/download/route.test.ts
@@ -42,7 +42,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withTeamTenantRls: mockWithTeamTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: mockExtractRequestMeta,
 }));
 vi.mock("@/lib/team-policy", () => ({

--- a/src/app/api/teams/[teamId]/audit-logs/download/route.ts
+++ b/src/app/api/teams/[teamId]/audit-logs/download/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { assertPolicyAllowsExport } from "@/lib/team-policy";
 import { PolicyViolationError } from "@/lib/team-policy";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -124,7 +124,7 @@ async function handleGET(req: NextRequest, { params }: Params) {
   }
 
   // Record the download itself
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.AUDIT_LOG_DOWNLOAD,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/folders/[id]/route.test.ts
+++ b/src/app/api/teams/[teamId]/folders/[id]/route.test.ts
@@ -53,7 +53,7 @@ vi.mock("@/lib/team-auth", () => ({
   TeamAuthError,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/teams/[teamId]/folders/[id]/route.ts
+++ b/src/app/api/teams/[teamId]/folders/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { updateFolderSchema } from "@/lib/validations";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -170,7 +170,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
     throw err;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.FOLDER_UPDATE,
     userId: session.user.id,
@@ -271,7 +271,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.FOLDER_DELETE,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/folders/route.test.ts
+++ b/src/app/api/teams/[teamId]/folders/route.test.ts
@@ -38,7 +38,7 @@ vi.mock("@/lib/team-auth", () => ({
   TeamAuthError,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/teams/[teamId]/folders/route.ts
+++ b/src/app/api/teams/[teamId]/folders/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createFolderSchema } from "@/lib/validations";
 import {
   requireTeamMember,
@@ -174,7 +174,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.FOLDER_CREATE,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/invitations/route.ts
+++ b/src/app/api/teams/[teamId]/invitations/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { randomBytes } from "node:crypto";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { inviteSchema } from "@/lib/validations";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -139,7 +139,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.TEAM_MEMBER_INVITE,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/members/[memberId]/route.test.ts
+++ b/src/app/api/teams/[teamId]/members/[memberId]/route.test.ts
@@ -59,7 +59,7 @@ vi.mock("@/lib/logger", () => ({
   getLogger: () => mockLogger,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn().mockReturnValue({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 

--- a/src/app/api/teams/[teamId]/members/[memberId]/route.ts
+++ b/src/app/api/teams/[teamId]/members/[memberId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { updateMemberRoleSchema } from "@/lib/validations";
 import {
   requireTeamPermission,
@@ -79,7 +79,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
       ]),
     );
 
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.TEAM,
       action: AUDIT_ACTION.TEAM_ROLE_UPDATE,
       userId: session.user.id,
@@ -123,7 +123,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.TEAM_ROLE_UPDATE,
     userId: session.user.id,
@@ -209,7 +209,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     getLogger().error({ userId: target.userId, error }, "session-invalidation-failed");
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.TEAM_MEMBER_REMOVE,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/members/route.test.ts
+++ b/src/app/api/teams/[teamId]/members/route.test.ts
@@ -64,7 +64,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withBypassRls: mockWithBypassRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 

--- a/src/app/api/teams/[teamId]/members/route.ts
+++ b/src/app/api/teams/[teamId]/members/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { addMemberSchema } from "@/lib/validations";
 import { requireTeamMember, requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -184,7 +184,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     throw e;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.TEAM_MEMBER_ADD,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/passwords/[id]/attachments/[attachmentId]/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/attachments/[attachmentId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { getAttachmentBlobStore } from "@/lib/blob-store";
@@ -134,7 +134,7 @@ async function handleDELETE(
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ATTACHMENT_DELETE,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { getAttachmentBlobStore } from "@/lib/blob-store";
@@ -258,7 +258,7 @@ async function handlePOST(
     throw error;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ATTACHMENT_UPLOAD,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/restore/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/restore/route.test.ts
@@ -39,7 +39,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/restore/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/restore/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { AUDIT_TARGET_TYPE, AUDIT_SCOPE, AUDIT_ACTION, AUDIT_METADATA_KEY, TEAM_PERMISSION } from "@/lib/constants";
@@ -113,7 +113,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ENTRY_HISTORY_RESTORE,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/route.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireTeamMember, TeamAuthError } from "@/lib/team-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
@@ -174,7 +174,7 @@ async function handlePATCH(req: NextRequest, { params }: Params) {
   }
 
   const meta = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ENTRY_HISTORY_REENCRYPT,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/passwords/[id]/restore/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/restore/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { TEAM_PERMISSION, AUDIT_TARGET_TYPE, AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
@@ -51,7 +51,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ENTRY_RESTORE,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/passwords/[id]/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { checkAuth } from "@/lib/check-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { updateTeamE2EPasswordSchema } from "@/lib/validations";
 import {
   requireTeamPermission,
@@ -144,7 +144,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
     throw e;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ENTRY_UPDATE,
     userId: session.user.id,
@@ -195,7 +195,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     teamPasswordService.deleteTeamPassword(teamId, id, permanent),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ENTRY_DELETE,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/passwords/bulk-archive/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-archive/route.test.ts
@@ -162,6 +162,8 @@ describe("POST /api/teams/[teamId]/passwords/bulk-archive", () => {
       createParams({ teamId: TEAM_ID }),
     );
 
+    // 1 parent log + 2 per-entry logs, all via logAuditAsync
+    expect(mockLogAudit).toHaveBeenCalledTimes(3);
     // Parent log via logAudit
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -231,6 +233,8 @@ describe("POST /api/teams/[teamId]/passwords/bulk-archive", () => {
       }),
     );
 
+    // 1 parent log + 2 per-entry logs, all via logAuditAsync
+    expect(mockLogAudit).toHaveBeenCalledTimes(3);
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         scope: AUDIT_SCOPE.TEAM,

--- a/src/app/api/teams/[teamId]/passwords/bulk-archive/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-archive/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest, createParams } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockPrismaTeamPasswordEntry, mockPrismaTransaction, mockRequireTeamPermission, TeamAuthError, mockWithTeamTenantRls, mockLogAudit, mockLogAuditBatch } = vi.hoisted(() => {
+const { mockAuth, mockPrismaTeamPasswordEntry, mockPrismaTransaction, mockRequireTeamPermission, TeamAuthError, mockWithTeamTenantRls, mockLogAudit } = vi.hoisted(() => {
   class _TeamAuthError extends Error {
     status: number;
     constructor(message: string, status: number) {
@@ -21,7 +21,6 @@ const { mockAuth, mockPrismaTeamPasswordEntry, mockPrismaTransaction, mockRequir
     TeamAuthError: _TeamAuthError,
     mockWithTeamTenantRls: vi.fn(async (_teamId: string, fn: () => unknown) => fn()),
     mockLogAudit: vi.fn(),
-    mockLogAuditBatch: vi.fn(),
   };
 });
 
@@ -41,8 +40,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withTeamTenantRls: mockWithTeamTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
-  logAuditBatch: mockLogAuditBatch,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 
@@ -182,31 +180,30 @@ describe("POST /api/teams/[teamId]/passwords/bulk-archive", () => {
       }),
     );
 
-    // Per-entry logs batched via logAuditBatch
-    expect(mockLogAuditBatch).toHaveBeenCalledTimes(1);
-    expect(mockLogAuditBatch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          scope: AUDIT_SCOPE.TEAM,
-          action: "ENTRY_UPDATE",
-          teamId: TEAM_ID,
-          targetId: id1,
-          metadata: expect.objectContaining({
-            source: "bulk-archive",
-            parentAction: "ENTRY_BULK_ARCHIVE",
-          }),
+    // Per-entry logs via individual logAuditAsync calls
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: AUDIT_SCOPE.TEAM,
+        action: "ENTRY_UPDATE",
+        teamId: TEAM_ID,
+        targetId: id1,
+        metadata: expect.objectContaining({
+          source: "bulk-archive",
+          parentAction: "ENTRY_BULK_ARCHIVE",
         }),
-        expect.objectContaining({
-          scope: AUDIT_SCOPE.TEAM,
-          action: "ENTRY_UPDATE",
-          teamId: TEAM_ID,
-          targetId: id2,
-          metadata: expect.objectContaining({
-            source: "bulk-archive",
-            parentAction: "ENTRY_BULK_ARCHIVE",
-          }),
+      }),
+    );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: AUDIT_SCOPE.TEAM,
+        action: "ENTRY_UPDATE",
+        teamId: TEAM_ID,
+        targetId: id2,
+        metadata: expect.objectContaining({
+          source: "bulk-archive",
+          parentAction: "ENTRY_BULK_ARCHIVE",
         }),
-      ]),
+      }),
     );
   });
 
@@ -247,19 +244,16 @@ describe("POST /api/teams/[teamId]/passwords/bulk-archive", () => {
       }),
     );
 
-    expect(mockLogAuditBatch).toHaveBeenCalledTimes(1);
-    expect(mockLogAuditBatch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          scope: AUDIT_SCOPE.TEAM,
-          action: "ENTRY_UPDATE",
-          teamId: TEAM_ID,
-          metadata: expect.objectContaining({
-            source: "bulk-archive",
-            parentAction: "ENTRY_BULK_UNARCHIVE",
-          }),
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: AUDIT_SCOPE.TEAM,
+        action: "ENTRY_UPDATE",
+        teamId: TEAM_ID,
+        metadata: expect.objectContaining({
+          source: "bulk-archive",
+          parentAction: "ENTRY_BULK_UNARCHIVE",
         }),
-      ]),
+      }),
     );
   });
 });

--- a/src/app/api/teams/[teamId]/passwords/bulk-archive/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-archive/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, logAuditBatch, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { withRequestLog } from "@/lib/with-request-log";
 import { TEAM_PERMISSION, AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
@@ -64,7 +64,7 @@ async function handlePOST(
 
   const requestMeta = extractRequestMeta(req);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: toArchived
       ? AUDIT_ACTION.ENTRY_BULK_ARCHIVE
@@ -85,23 +85,24 @@ async function handlePOST(
     ...requestMeta,
   });
 
-  logAuditBatch(
-    entryIds.map((entryId) => ({
-      scope: AUDIT_SCOPE.TEAM,
-      action: AUDIT_ACTION.ENTRY_UPDATE,
-      userId: session.user.id,
-      teamId,
-      targetType: AUDIT_TARGET_TYPE.TEAM_PASSWORD_ENTRY,
-      targetId: entryId,
-      metadata: {
-        source: "bulk-archive",
-        parentAction: toArchived
-          ? AUDIT_ACTION.ENTRY_BULK_ARCHIVE
-          : AUDIT_ACTION.ENTRY_BULK_UNARCHIVE,
-      },
-      ...requestMeta,
-    })),
-  );
+  const auditEntries = entryIds.map((entryId) => ({
+    scope: AUDIT_SCOPE.TEAM,
+    action: AUDIT_ACTION.ENTRY_UPDATE,
+    userId: session.user.id,
+    teamId,
+    targetType: AUDIT_TARGET_TYPE.TEAM_PASSWORD_ENTRY,
+    targetId: entryId,
+    metadata: {
+      source: "bulk-archive",
+      parentAction: toArchived
+        ? AUDIT_ACTION.ENTRY_BULK_ARCHIVE
+        : AUDIT_ACTION.ENTRY_BULK_UNARCHIVE,
+    },
+    ...requestMeta,
+  }));
+  for (const entry of auditEntries) {
+    await logAuditAsync(entry);
+  }
 
   return NextResponse.json({
     success: true,

--- a/src/app/api/teams/[teamId]/passwords/bulk-import/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-import/route.test.ts
@@ -224,7 +224,7 @@ describe("POST /api/teams/[teamId]/passwords/bulk-import", () => {
     expect(json.failed).toBe(1);
   });
 
-  it("calls logAudit with ENTRY_BULK_IMPORT and TEAM scope", async () => {
+  it("calls logAuditAsync with ENTRY_BULK_IMPORT and TEAM scope", async () => {
     const entries = [
       makeEntry("660e8400-e29b-41d4-a716-000000000001"),
       makeEntry("660e8400-e29b-41d4-a716-000000000002"),
@@ -235,6 +235,7 @@ describe("POST /api/teams/[teamId]/passwords/bulk-import", () => {
       createParams({ teamId: TEAM_ID }),
     );
 
+    expect(mockLogAudit).toHaveBeenCalledTimes(3); // 1 parent + 2 per-entry
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: AUDIT_ACTION.ENTRY_BULK_IMPORT,
@@ -261,6 +262,7 @@ describe("POST /api/teams/[teamId]/passwords/bulk-import", () => {
     );
 
     // logAuditAsync called once per entry with ENTRY_CREATE
+    expect(mockLogAudit).toHaveBeenCalledTimes(3); // 1 parent + 2 per-entry
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: AUDIT_ACTION.ENTRY_CREATE,

--- a/src/app/api/teams/[teamId]/passwords/bulk-import/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-import/route.test.ts
@@ -9,7 +9,6 @@ const {
   mockWithTeamTenantRls,
   mockRateLimiterCheck,
   mockLogAudit,
-  mockLogAuditBatch,
   mockCreateTeamPassword,
   TeamPasswordServiceError,
 } = vi.hoisted(() => {
@@ -41,7 +40,6 @@ const {
     mockWithTeamTenantRls: vi.fn(async (_teamId: string, fn: () => unknown) => fn()),
     mockRateLimiterCheck: vi.fn(),
     mockLogAudit: vi.fn(),
-    mockLogAuditBatch: vi.fn(),
     mockCreateTeamPassword: vi.fn(),
     TeamPasswordServiceError: _TeamPasswordServiceError,
   };
@@ -64,8 +62,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockRateLimiterCheck, clear: vi.fn() }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
-  logAuditBatch: mockLogAuditBatch,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({}),
 }));
 vi.mock("@/lib/services/team-password-service", () => ({
@@ -252,7 +249,7 @@ describe("POST /api/teams/[teamId]/passwords/bulk-import", () => {
     );
   });
 
-  it("calls logAuditBatch with ENTRY_CREATE for each created team entry", async () => {
+  it("calls logAuditAsync with ENTRY_CREATE for each created team entry", async () => {
     const entries = [
       makeEntry("660e8400-e29b-41d4-a716-000000000001"),
       makeEntry("660e8400-e29b-41d4-a716-000000000002"),
@@ -263,19 +260,28 @@ describe("POST /api/teams/[teamId]/passwords/bulk-import", () => {
       createParams({ teamId: TEAM_ID }),
     );
 
-    expect(mockLogAuditBatch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          action: AUDIT_ACTION.ENTRY_CREATE,
-          teamId: TEAM_ID,
-          metadata: expect.objectContaining({
-            source: "bulk-import",
-            parentAction: AUDIT_ACTION.ENTRY_BULK_IMPORT,
-          }),
+    // logAuditAsync called once per entry with ENTRY_CREATE
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AUDIT_ACTION.ENTRY_CREATE,
+        targetId: "660e8400-e29b-41d4-a716-000000000001",
+        teamId: TEAM_ID,
+        metadata: expect.objectContaining({
+          source: "bulk-import",
+          parentAction: AUDIT_ACTION.ENTRY_BULK_IMPORT,
         }),
-      ]),
+      }),
     );
-    const batchArg = mockLogAuditBatch.mock.calls[0][0];
-    expect(batchArg).toHaveLength(2);
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AUDIT_ACTION.ENTRY_CREATE,
+        targetId: "660e8400-e29b-41d4-a716-000000000002",
+        teamId: TEAM_ID,
+        metadata: expect.objectContaining({
+          source: "bulk-import",
+          parentAction: AUDIT_ACTION.ENTRY_BULK_IMPORT,
+        }),
+      }),
+    );
   });
 });

--- a/src/app/api/teams/[teamId]/passwords/bulk-import/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-import/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
-import { logAudit, logAuditBatch, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { withRequestLog } from "@/lib/with-request-log";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE, TEAM_PERMISSION } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
@@ -84,7 +84,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
 
   const requestMeta = extractRequestMeta(req);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ENTRY_BULK_IMPORT,
     userId,
@@ -101,21 +101,22 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     ...requestMeta,
   });
 
-  logAuditBatch(
-    createdIds.map((entryId) => ({
-      scope: AUDIT_SCOPE.TEAM,
-      action: AUDIT_ACTION.ENTRY_CREATE,
-      userId,
-      teamId,
-      targetType: AUDIT_TARGET_TYPE.TEAM_PASSWORD_ENTRY,
-      targetId: entryId,
-      metadata: {
-        source: "bulk-import",
-        parentAction: AUDIT_ACTION.ENTRY_BULK_IMPORT,
-      },
-      ...requestMeta,
-    })),
-  );
+  const auditEntries = createdIds.map((entryId) => ({
+    scope: AUDIT_SCOPE.TEAM,
+    action: AUDIT_ACTION.ENTRY_CREATE,
+    userId,
+    teamId,
+    targetType: AUDIT_TARGET_TYPE.TEAM_PASSWORD_ENTRY,
+    targetId: entryId,
+    metadata: {
+      source: "bulk-import",
+      parentAction: AUDIT_ACTION.ENTRY_BULK_IMPORT,
+    },
+    ...requestMeta,
+  }));
+  for (const entry of auditEntries) {
+    await logAuditAsync(entry);
+  }
 
   return NextResponse.json(
     { success: createdIds.length, failed: failedCount },

--- a/src/app/api/teams/[teamId]/passwords/bulk-restore/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-restore/route.test.ts
@@ -160,6 +160,7 @@ describe("POST /api/teams/[teamId]/passwords/bulk-restore", () => {
     );
 
     // Parent log via logAudit
+    expect(mockLogAudit).toHaveBeenCalledTimes(3); // 1 parent + 2 per-entry
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         scope: AUDIT_SCOPE.TEAM,

--- a/src/app/api/teams/[teamId]/passwords/bulk-restore/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-restore/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest, createParams } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockPrismaTeamPasswordEntry, mockPrismaTransaction, mockRequireTeamPermission, TeamAuthError, mockWithTeamTenantRls, mockLogAudit, mockLogAuditBatch } = vi.hoisted(() => {
+const { mockAuth, mockPrismaTeamPasswordEntry, mockPrismaTransaction, mockRequireTeamPermission, TeamAuthError, mockWithTeamTenantRls, mockLogAudit } = vi.hoisted(() => {
   class _TeamAuthError extends Error {
     status: number;
     constructor(message: string, status: number) {
@@ -21,7 +21,6 @@ const { mockAuth, mockPrismaTeamPasswordEntry, mockPrismaTransaction, mockRequir
     TeamAuthError: _TeamAuthError,
     mockWithTeamTenantRls: vi.fn(async (_teamId: string, fn: () => unknown) => fn()),
     mockLogAudit: vi.fn(),
-    mockLogAuditBatch: vi.fn(),
   };
 });
 
@@ -41,8 +40,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withTeamTenantRls: mockWithTeamTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
-  logAuditBatch: mockLogAuditBatch,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 
@@ -178,31 +176,30 @@ describe("POST /api/teams/[teamId]/passwords/bulk-restore", () => {
       }),
     );
 
-    // Per-entry logs batched via logAuditBatch
-    expect(mockLogAuditBatch).toHaveBeenCalledTimes(1);
-    expect(mockLogAuditBatch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          scope: AUDIT_SCOPE.TEAM,
-          action: "ENTRY_RESTORE",
-          teamId: TEAM_ID,
-          targetId: id1,
-          metadata: expect.objectContaining({
-            source: "bulk-restore",
-            parentAction: "ENTRY_BULK_RESTORE",
-          }),
+    // Per-entry logs via individual logAuditAsync calls
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: AUDIT_SCOPE.TEAM,
+        action: "ENTRY_RESTORE",
+        teamId: TEAM_ID,
+        targetId: id1,
+        metadata: expect.objectContaining({
+          source: "bulk-restore",
+          parentAction: "ENTRY_BULK_RESTORE",
         }),
-        expect.objectContaining({
-          scope: AUDIT_SCOPE.TEAM,
-          action: "ENTRY_RESTORE",
-          teamId: TEAM_ID,
-          targetId: id2,
-          metadata: expect.objectContaining({
-            source: "bulk-restore",
-            parentAction: "ENTRY_BULK_RESTORE",
-          }),
+      }),
+    );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: AUDIT_SCOPE.TEAM,
+        action: "ENTRY_RESTORE",
+        teamId: TEAM_ID,
+        targetId: id2,
+        metadata: expect.objectContaining({
+          source: "bulk-restore",
+          parentAction: "ENTRY_BULK_RESTORE",
         }),
-      ]),
+      }),
     );
   });
 });

--- a/src/app/api/teams/[teamId]/passwords/bulk-restore/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-restore/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, logAuditBatch, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { withRequestLog } from "@/lib/with-request-log";
 import { TEAM_PERMISSION, AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
@@ -61,7 +61,7 @@ async function handlePOST(
 
   const requestMeta = extractRequestMeta(req);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ENTRY_BULK_RESTORE,
     userId: session.user.id,
@@ -78,21 +78,22 @@ async function handlePOST(
     ...requestMeta,
   });
 
-  logAuditBatch(
-    entryIds.map((entryId) => ({
-      scope: AUDIT_SCOPE.TEAM,
-      action: AUDIT_ACTION.ENTRY_RESTORE,
-      userId: session.user.id,
-      teamId,
-      targetType: AUDIT_TARGET_TYPE.TEAM_PASSWORD_ENTRY,
-      targetId: entryId,
-      metadata: {
-        source: "bulk-restore",
-        parentAction: AUDIT_ACTION.ENTRY_BULK_RESTORE,
-      },
-      ...requestMeta,
-    })),
-  );
+  const auditEntries = entryIds.map((entryId) => ({
+    scope: AUDIT_SCOPE.TEAM,
+    action: AUDIT_ACTION.ENTRY_RESTORE,
+    userId: session.user.id,
+    teamId,
+    targetType: AUDIT_TARGET_TYPE.TEAM_PASSWORD_ENTRY,
+    targetId: entryId,
+    metadata: {
+      source: "bulk-restore",
+      parentAction: AUDIT_ACTION.ENTRY_BULK_RESTORE,
+    },
+    ...requestMeta,
+  }));
+  for (const entry of auditEntries) {
+    await logAuditAsync(entry);
+  }
 
   return NextResponse.json({ success: true, restoredCount: updateResult.count });
 }

--- a/src/app/api/teams/[teamId]/passwords/bulk-trash/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-trash/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest, createParams } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockPrismaTeamPasswordEntry, mockPrismaTransaction, mockRequireTeamPermission, TeamAuthError, mockWithTeamTenantRls, mockLogAudit, mockLogAuditBatch } = vi.hoisted(() => {
+const { mockAuth, mockPrismaTeamPasswordEntry, mockPrismaTransaction, mockRequireTeamPermission, TeamAuthError, mockWithTeamTenantRls, mockLogAudit } = vi.hoisted(() => {
   class _TeamAuthError extends Error {
     status: number;
     constructor(message: string, status: number) {
@@ -21,7 +21,6 @@ const { mockAuth, mockPrismaTeamPasswordEntry, mockPrismaTransaction, mockRequir
     TeamAuthError: _TeamAuthError,
     mockWithTeamTenantRls: vi.fn(async (_teamId: string, fn: () => unknown) => fn()),
     mockLogAudit: vi.fn(),
-    mockLogAuditBatch: vi.fn(),
   };
 });
 
@@ -41,8 +40,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withTeamTenantRls: mockWithTeamTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
-  logAuditBatch: mockLogAuditBatch,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 
@@ -177,31 +175,30 @@ describe("POST /api/teams/[teamId]/passwords/bulk-trash", () => {
       }),
     );
 
-    // Per-entry logs batched via logAuditBatch
-    expect(mockLogAuditBatch).toHaveBeenCalledTimes(1);
-    expect(mockLogAuditBatch).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          scope: AUDIT_SCOPE.TEAM,
-          action: "ENTRY_TRASH",
-          teamId: TEAM_ID,
-          targetId: id1,
-          metadata: expect.objectContaining({
-            source: "bulk-trash",
-            parentAction: "ENTRY_BULK_TRASH",
-          }),
+    // Per-entry logs via individual logAuditAsync calls
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: AUDIT_SCOPE.TEAM,
+        action: "ENTRY_TRASH",
+        teamId: TEAM_ID,
+        targetId: id1,
+        metadata: expect.objectContaining({
+          source: "bulk-trash",
+          parentAction: "ENTRY_BULK_TRASH",
         }),
-        expect.objectContaining({
-          scope: AUDIT_SCOPE.TEAM,
-          action: "ENTRY_TRASH",
-          teamId: TEAM_ID,
-          targetId: id2,
-          metadata: expect.objectContaining({
-            source: "bulk-trash",
-            parentAction: "ENTRY_BULK_TRASH",
-          }),
+      }),
+    );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: AUDIT_SCOPE.TEAM,
+        action: "ENTRY_TRASH",
+        teamId: TEAM_ID,
+        targetId: id2,
+        metadata: expect.objectContaining({
+          source: "bulk-trash",
+          parentAction: "ENTRY_BULK_TRASH",
         }),
-      ]),
+      }),
     );
   });
 });

--- a/src/app/api/teams/[teamId]/passwords/bulk-trash/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-trash/route.test.ts
@@ -159,6 +159,8 @@ describe("POST /api/teams/[teamId]/passwords/bulk-trash", () => {
       createParams({ teamId: TEAM_ID }),
     );
 
+    // 1 parent log + 2 per-entry logs, all via logAuditAsync
+    expect(mockLogAudit).toHaveBeenCalledTimes(3);
     // Parent log via logAudit
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/app/api/teams/[teamId]/passwords/bulk-trash/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-trash/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, logAuditBatch, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { withRequestLog } from "@/lib/with-request-log";
 import { TEAM_PERMISSION, AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
@@ -61,7 +61,7 @@ async function handlePOST(
   );
   const requestMeta = extractRequestMeta(req);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ENTRY_BULK_TRASH,
     userId: session.user.id,
@@ -77,21 +77,22 @@ async function handlePOST(
     ...requestMeta,
   });
 
-  logAuditBatch(
-    entryIds.map((entryId) => ({
-      scope: AUDIT_SCOPE.TEAM,
-      action: AUDIT_ACTION.ENTRY_TRASH,
-      userId: session.user.id,
-      teamId,
-      targetType: AUDIT_TARGET_TYPE.TEAM_PASSWORD_ENTRY,
-      targetId: entryId,
-      metadata: {
-        source: "bulk-trash",
-        parentAction: AUDIT_ACTION.ENTRY_BULK_TRASH,
-      },
-      ...requestMeta,
-    })),
-  );
+  const auditEntries = entryIds.map((entryId) => ({
+    scope: AUDIT_SCOPE.TEAM,
+    action: AUDIT_ACTION.ENTRY_TRASH,
+    userId: session.user.id,
+    teamId,
+    targetType: AUDIT_TARGET_TYPE.TEAM_PASSWORD_ENTRY,
+    targetId: entryId,
+    metadata: {
+      source: "bulk-trash",
+      parentAction: AUDIT_ACTION.ENTRY_BULK_TRASH,
+    },
+    ...requestMeta,
+  }));
+  for (const entry of auditEntries) {
+    await logAuditAsync(entry);
+  }
 
   return NextResponse.json({ success: true, movedCount: updateResult.count });
 }

--- a/src/app/api/teams/[teamId]/passwords/empty-trash/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/empty-trash/route.test.ts
@@ -41,7 +41,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withTeamTenantRls: mockWithTeamTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/logger", () => ({

--- a/src/app/api/teams/[teamId]/passwords/empty-trash/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/empty-trash/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import {
   TEAM_PERMISSION,
   AUDIT_ACTION,
@@ -51,7 +51,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
 
   const requestMeta = extractRequestMeta(req);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ENTRY_EMPTY_TRASH,
     userId: session.user.id,
@@ -67,7 +67,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
   });
 
   for (const entryId of entryIds) {
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.TEAM,
       action: AUDIT_ACTION.ENTRY_PERMANENT_DELETE,
       userId: session.user.id,

--- a/src/app/api/teams/[teamId]/passwords/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/route.test.ts
@@ -50,7 +50,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withBypassRls: mockWithBypassRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({}),
 }));
 

--- a/src/app/api/teams/[teamId]/passwords/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { checkAuth } from "@/lib/check-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createTeamE2EPasswordSchema } from "@/lib/validations";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
 import { parseBody } from "@/lib/parse-body";
@@ -117,7 +117,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     throw e;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.ENTRY_CREATE,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/policy/route.test.ts
+++ b/src/app/api/teams/[teamId]/policy/route.test.ts
@@ -48,7 +48,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withTeamTenantRls: mockWithTeamTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/logger", () => ({

--- a/src/app/api/teams/[teamId]/policy/route.ts
+++ b/src/app/api/teams/[teamId]/policy/route.ts
@@ -11,7 +11,7 @@ import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
 import { TEAM_PERMISSION, AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { withRequestLog } from "@/lib/with-request-log";
 import { errorResponse, notFound, unauthorized } from "@/lib/api-response";
 
@@ -106,7 +106,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
   );
 
   const meta = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.POLICY_UPDATE,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/rotate-key/route.test.ts
+++ b/src/app/api/teams/[teamId]/rotate-key/route.test.ts
@@ -44,7 +44,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({
@@ -59,7 +59,7 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 
 import { POST } from "./route";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 
 function createRequest(body: unknown) {
   return new NextRequest("http://localhost/api/teams/team-1/rotate-key", {
@@ -255,7 +255,7 @@ describe("POST /api/teams/[teamId]/rotate-key", () => {
     expect(json.success).toBe(true);
     expect(json.teamKeyVersion).toBe(2);
     expect(mockTransaction).toHaveBeenCalled();
-    expect(vi.mocked(logAudit)).toHaveBeenCalledWith(
+    expect(vi.mocked(logAuditAsync)).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "TEAM_KEY_ROTATION",
         teamId: "team-1",

--- a/src/app/api/teams/[teamId]/rotate-key/route.ts
+++ b/src/app/api/teams/[teamId]/rotate-key/route.ts
@@ -4,7 +4,7 @@ import { auth } from "@/auth";
 import { assertOrigin } from "@/lib/csrf";
 import { prisma } from "@/lib/prisma";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
 import { TEAM_PERMISSION, AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
@@ -243,7 +243,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     throw e;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.TEAM_KEY_ROTATION,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/webhooks/[webhookId]/route.test.ts
+++ b/src/app/api/teams/[teamId]/webhooks/[webhookId]/route.test.ts
@@ -36,7 +36,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withTeamTenantRls: mockWithTeamTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: mockExtractRequestMeta,
 }));
 

--- a/src/app/api/teams/[teamId]/webhooks/[webhookId]/route.ts
+++ b/src/app/api/teams/[teamId]/webhooks/[webhookId]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import {
   TEAM_PERMISSION,
   AUDIT_ACTION,
@@ -47,7 +47,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     prisma.teamWebhook.delete({ where: { id: webhookId, teamId } }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.WEBHOOK_DELETE,
     userId: session.user.id,

--- a/src/app/api/teams/[teamId]/webhooks/route.test.ts
+++ b/src/app/api/teams/[teamId]/webhooks/route.test.ts
@@ -56,7 +56,7 @@ vi.mock("@/lib/tenant-context", () => ({
   withTeamTenantRls: mockWithTeamTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/crypto-server", () => ({

--- a/src/app/api/teams/[teamId]/webhooks/route.ts
+++ b/src/app/api/teams/[teamId]/webhooks/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireTeamPermission, TeamAuthError } from "@/lib/team-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
 import {
@@ -152,7 +152,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TEAM,
     action: AUDIT_ACTION.WEBHOOK_CREATE,
     userId: session.user.id,

--- a/src/app/api/tenant/access-requests/[id]/approve/route.test.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.test.ts
@@ -59,7 +59,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withBypassRls: mockWithBypassRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/with-request-log", () => ({

--- a/src/app/api/tenant/access-requests/[id]/approve/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { hashToken } from "@/lib/crypto-server";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
@@ -168,7 +168,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     throw err;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.ACCESS_REQUEST_APPROVE,
     userId: session.user.id,

--- a/src/app/api/tenant/access-requests/[id]/deny/route.test.ts
+++ b/src/app/api/tenant/access-requests/[id]/deny/route.test.ts
@@ -48,7 +48,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/with-request-log", () => ({

--- a/src/app/api/tenant/access-requests/[id]/deny/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/deny/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
@@ -69,7 +69,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     );
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.ACCESS_REQUEST_DENY,
     userId: session.user.id,

--- a/src/app/api/tenant/access-requests/route.test.ts
+++ b/src/app/api/tenant/access-requests/route.test.ts
@@ -61,7 +61,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withBypassRls: mockWithBypassRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   resolveActorType: () => "HUMAN",
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));

--- a/src/app/api/tenant/access-requests/route.ts
+++ b/src/app/api/tenant/access-requests/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta, resolveActorType } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta, resolveActorType } from "@/lib/audit";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { authOrToken } from "@/lib/auth-or-token";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -200,7 +200,7 @@ async function handlePOST(req: NextRequest) {
     }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.ACCESS_REQUEST_CREATE,
     userId,

--- a/src/app/api/tenant/audit-delivery-targets/[id]/route.test.ts
+++ b/src/app/api/tenant/audit-delivery-targets/[id]/route.test.ts
@@ -50,7 +50,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/csrf", () => ({

--- a/src/app/api/tenant/audit-delivery-targets/[id]/route.ts
+++ b/src/app/api/tenant/audit-delivery-targets/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { assertOrigin } from "@/lib/csrf";
 import { parseBody } from "@/lib/parse-body";
 import {
@@ -70,7 +70,7 @@ async function handlePATCH(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: data.isActive
       ? AUDIT_ACTION.AUDIT_DELIVERY_TARGET_REACTIVATE

--- a/src/app/api/tenant/audit-delivery-targets/route.test.ts
+++ b/src/app/api/tenant/audit-delivery-targets/route.test.ts
@@ -319,7 +319,7 @@ describe("POST /api/tenant/audit-delivery-targets", () => {
     expect(json).not.toHaveProperty("secret");
   });
 
-  it("calls logAudit with AUDIT_DELIVERY_TARGET_CREATE", async () => {
+  it("calls logAuditAsync with AUDIT_DELIVERY_TARGET_CREATE", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockRequireTenantPermission.mockResolvedValue(ACTOR);
     mockAuditDeliveryTargetCount.mockResolvedValue(0);

--- a/src/app/api/tenant/audit-delivery-targets/route.test.ts
+++ b/src/app/api/tenant/audit-delivery-targets/route.test.ts
@@ -59,7 +59,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/csrf", () => ({

--- a/src/app/api/tenant/audit-delivery-targets/route.ts
+++ b/src/app/api/tenant/audit-delivery-targets/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { assertOrigin } from "@/lib/csrf";
 import { parseBody } from "@/lib/parse-body";
 import {
@@ -167,7 +167,7 @@ async function handlePOST(req: NextRequest) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.AUDIT_DELIVERY_TARGET_CREATE,
     userId: session.user.id,

--- a/src/app/api/tenant/audit-logs/download/route.test.ts
+++ b/src/app/api/tenant/audit-logs/download/route.test.ts
@@ -43,7 +43,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/app/api/tenant/audit-logs/download/route.ts
+++ b/src/app/api/tenant/audit-logs/download/route.ts
@@ -5,7 +5,7 @@ import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { errorResponse, rateLimited, unauthorized, validationError } from "@/lib/api-response";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
@@ -96,7 +96,7 @@ async function handleGET(req: NextRequest) {
   };
 
   // Record the download itself
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.AUDIT_LOG_DOWNLOAD,
     userId: session.user.id,

--- a/src/app/api/tenant/breakglass/[id]/route.test.ts
+++ b/src/app/api/tenant/breakglass/[id]/route.test.ts
@@ -51,7 +51,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test-agent" }),
 }));
 vi.mock("@/lib/csrf", () => ({

--- a/src/app/api/tenant/breakglass/[id]/route.ts
+++ b/src/app/api/tenant/breakglass/[id]/route.ts
@@ -5,7 +5,7 @@ import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { assertOrigin } from "@/lib/csrf";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, unauthorized, notFound } from "@/lib/api-response";
@@ -94,7 +94,7 @@ async function handleDELETE(
 
   // Audit log (non-blocking)
   const { ip, userAgent } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.PERSONAL_LOG_ACCESS_REVOKE,
     userId,

--- a/src/app/api/tenant/breakglass/route.test.ts
+++ b/src/app/api/tenant/breakglass/route.test.ts
@@ -63,7 +63,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test-agent" }),
 }));
 vi.mock("@/lib/csrf", () => ({

--- a/src/app/api/tenant/breakglass/route.ts
+++ b/src/app/api/tenant/breakglass/route.ts
@@ -8,7 +8,7 @@ import type { GrantStatus } from "@/lib/constants/breakglass";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
 import { BREAKGLASS_USER_LIST_LIMIT } from "@/lib/validations/common.server";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { assertOrigin } from "@/lib/csrf";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { createNotification } from "@/lib/notification";
@@ -158,7 +158,7 @@ async function handlePOST(req: NextRequest) {
 
   // Audit log (non-blocking)
   const { ip, userAgent } = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.PERSONAL_LOG_ACCESS_REQUEST,
     userId,

--- a/src/app/api/tenant/mcp-clients/[id]/route.test.ts
+++ b/src/app/api/tenant/mcp-clients/[id]/route.test.ts
@@ -47,7 +47,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 

--- a/src/app/api/tenant/mcp-clients/[id]/route.ts
+++ b/src/app/api/tenant/mcp-clients/[id]/route.ts
@@ -4,7 +4,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants/audit";
 import { AUDIT_TARGET_TYPE } from "@/lib/constants/audit-target";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
@@ -128,7 +128,7 @@ export async function PUT(
     throw err;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.MCP_CLIENT_UPDATE,
     userId: session.user.id,
@@ -168,7 +168,7 @@ export async function DELETE(
     prisma.mcpClient.delete({ where: { id, tenantId: actor.tenantId } }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.MCP_CLIENT_DELETE,
     userId: session.user.id,

--- a/src/app/api/tenant/mcp-clients/route.test.ts
+++ b/src/app/api/tenant/mcp-clients/route.test.ts
@@ -59,7 +59,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/app/api/tenant/mcp-clients/route.ts
+++ b/src/app/api/tenant/mcp-clients/route.ts
@@ -5,7 +5,7 @@ import { withTenantRls } from "@/lib/tenant-rls";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { randomBytes } from "node:crypto";
 import { hashToken } from "@/lib/crypto-server";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants/audit";
 import { AUDIT_TARGET_TYPE } from "@/lib/constants/audit-target";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
@@ -172,7 +172,7 @@ export async function POST(req: NextRequest) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.MCP_CLIENT_CREATE,
     userId: session.user.id,

--- a/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/revoke/route.test.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/revoke/route.test.ts
@@ -54,7 +54,7 @@ vi.mock("@/lib/prisma", () => ({
 }));
 vi.mock("@/lib/csrf", () => ({ assertOrigin: vi.fn(() => null) }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/notification", () => ({ createNotification: mockCreateNotification }));

--- a/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/revoke/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/revoke/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { assertOrigin } from "@/lib/csrf";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createNotification } from "@/lib/notification";
 import { sendEmail } from "@/lib/email";
 import { adminVaultResetRevokedEmail } from "@/lib/email/templates/admin-vault-reset-revoked";
@@ -81,7 +81,7 @@ async function handlePOST(
   }
 
   // Audit log
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.ADMIN_VAULT_RESET_REVOKE,
     userId: session.user.id,

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
@@ -67,7 +67,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: vi.fn(() => ({ check: mockRateLimiterCheck })),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/notification", () => ({ createNotification: mockCreateNotification }));

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.ts
@@ -4,7 +4,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { assertOrigin } from "@/lib/csrf";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createNotification } from "@/lib/notification";
 import { sendEmail } from "@/lib/email";
 import { adminVaultResetEmail } from "@/lib/email/templates/admin-vault-reset";
@@ -143,7 +143,7 @@ async function handlePOST(
   );
 
   // Audit log
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.ADMIN_VAULT_RESET_INITIATE,
     userId: session.user.id,

--- a/src/app/api/tenant/members/[userId]/route.test.ts
+++ b/src/app/api/tenant/members/[userId]/route.test.ts
@@ -38,7 +38,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withBypassRls: vi.fn((_p: unknown, fn: () => unknown) => fn()),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn().mockReturnValue({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/logger", () => ({

--- a/src/app/api/tenant/members/[userId]/route.ts
+++ b/src/app/api/tenant/members/[userId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { updateTenantMemberRoleSchema } from "@/lib/validations";
 import {
   requireTenantPermission,
@@ -118,7 +118,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
       );
     }
 
-    logAudit({
+    await logAuditAsync({
       scope: AUDIT_SCOPE.TENANT,
       action: AUDIT_ACTION.TENANT_ROLE_UPDATE,
       userId: session.user.id,
@@ -158,7 +158,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.TENANT_ROLE_UPDATE,
     userId: session.user.id,

--- a/src/app/api/tenant/policy/route.test.ts
+++ b/src/app/api/tenant/policy/route.test.ts
@@ -67,7 +67,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
 }));
 
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null, acceptLanguage: null }),
 }));
 

--- a/src/app/api/tenant/policy/route.ts
+++ b/src/app/api/tenant/policy/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, rateLimited, unauthorized } from "@/lib/api-response";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
@@ -760,7 +760,7 @@ async function handlePATCH(req: NextRequest) {
   invalidateLockoutThresholdCache(membership.tenantId);
 
   const meta = extractRequestMeta(req);
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.POLICY_UPDATE,
     userId: session.user.id,

--- a/src/app/api/tenant/scim-tokens/[tokenId]/route.test.ts
+++ b/src/app/api/tenant/scim-tokens/[tokenId]/route.test.ts
@@ -42,7 +42,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 

--- a/src/app/api/tenant/scim-tokens/[tokenId]/route.ts
+++ b/src/app/api/tenant/scim-tokens/[tokenId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
@@ -58,7 +58,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.SCIM_TOKEN_REVOKE,
     userId: session.user.id,

--- a/src/app/api/tenant/scim-tokens/route.test.ts
+++ b/src/app/api/tenant/scim-tokens/route.test.ts
@@ -50,7 +50,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/crypto-server", () => ({

--- a/src/app/api/tenant/scim-tokens/route.ts
+++ b/src/app/api/tenant/scim-tokens/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { hashToken } from "@/lib/crypto-server";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { generateScimToken } from "@/lib/scim/token-utils";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -134,7 +134,7 @@ async function handlePOST(req: NextRequest) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.SCIM_TOKEN_CREATE,
     userId: session.user.id,

--- a/src/app/api/tenant/service-accounts/[id]/route.test.ts
+++ b/src/app/api/tenant/service-accounts/[id]/route.test.ts
@@ -61,7 +61,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/with-request-log", () => ({

--- a/src/app/api/tenant/service-accounts/[id]/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
@@ -140,7 +140,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
     throw err;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.SERVICE_ACCOUNT_UPDATE,
     userId: session.user.id,
@@ -194,7 +194,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.SERVICE_ACCOUNT_DELETE,
     userId: session.user.id,

--- a/src/app/api/tenant/service-accounts/[id]/tokens/[tokenId]/route.test.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/[tokenId]/route.test.ts
@@ -53,7 +53,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/with-request-log", () => ({

--- a/src/app/api/tenant/service-accounts/[id]/tokens/[tokenId]/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/[tokenId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
@@ -69,7 +69,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.SERVICE_ACCOUNT_TOKEN_REVOKE,
     userId: session.user.id,

--- a/src/app/api/tenant/service-accounts/[id]/tokens/route.test.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/route.test.ts
@@ -55,7 +55,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/with-request-log", () => ({

--- a/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { hashToken } from "@/lib/crypto-server";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
@@ -168,7 +168,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     throw err;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.SERVICE_ACCOUNT_TOKEN_CREATE,
     userId: session.user.id,

--- a/src/app/api/tenant/service-accounts/route.test.ts
+++ b/src/app/api/tenant/service-accounts/route.test.ts
@@ -51,7 +51,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/app/api/tenant/service-accounts/route.ts
+++ b/src/app/api/tenant/service-accounts/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
@@ -142,7 +142,7 @@ async function handlePOST(req: NextRequest) {
     throw err;
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.SERVICE_ACCOUNT_CREATE,
     userId: session.user.id,

--- a/src/app/api/tenant/webhooks/[webhookId]/route.test.ts
+++ b/src/app/api/tenant/webhooks/[webhookId]/route.test.ts
@@ -48,7 +48,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/with-request-log", () => ({

--- a/src/app/api/tenant/webhooks/[webhookId]/route.ts
+++ b/src/app/api/tenant/webhooks/[webhookId]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import {
   TENANT_PERMISSION,
   AUDIT_ACTION,
@@ -48,7 +48,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     prisma.tenantWebhook.delete({ where: { id: webhookId, tenantId: actor.tenantId } }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.TENANT_WEBHOOK_DELETE,
     userId: session.user.id,

--- a/src/app/api/tenant/webhooks/route.test.ts
+++ b/src/app/api/tenant/webhooks/route.test.ts
@@ -59,7 +59,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withTenantRls: mockWithTenantRls,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/csrf", () => ({

--- a/src/app/api/tenant/webhooks/route.ts
+++ b/src/app/api/tenant/webhooks/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireTenantPermission, TenantAuthError } from "@/lib/tenant-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { assertOrigin } from "@/lib/csrf";
 import { parseBody } from "@/lib/parse-body";
 import {
@@ -139,7 +139,7 @@ async function handlePOST(req: NextRequest) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.TENANT,
     action: AUDIT_ACTION.TENANT_WEBHOOK_CREATE,
     userId: session.user.id,

--- a/src/app/api/travel-mode/disable/route.ts
+++ b/src/app/api/travel-mode/disable/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { verifyPassphraseVerifier } from "@/lib/crypto-server";
 import { checkLockout, recordFailure } from "@/lib/account-lockout";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -83,7 +83,7 @@ async function handlePOST(request: NextRequest) {
   if (!valid) {
     await recordFailure(session.user.id, request);
 
-    logAudit({
+    await logAuditAsync({
       action: AUDIT_ACTION.TRAVEL_MODE_DISABLE_FAILED,
       scope: AUDIT_SCOPE.PERSONAL,
       userId: session.user.id,
@@ -103,7 +103,7 @@ async function handlePOST(request: NextRequest) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     action: AUDIT_ACTION.TRAVEL_MODE_DISABLE,
     scope: AUDIT_SCOPE.PERSONAL,
     userId: session.user.id,

--- a/src/app/api/travel-mode/enable/route.ts
+++ b/src/app/api/travel-mode/enable/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { withRequestLog } from "@/lib/with-request-log";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { unauthorized } from "@/lib/api-response";
@@ -29,7 +29,7 @@ async function handlePOST(request: NextRequest) {
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     action: AUDIT_ACTION.TRAVEL_MODE_ENABLE,
     scope: AUDIT_SCOPE.PERSONAL,
     userId: session.user.id,

--- a/src/app/api/travel-mode/travel-mode.test.ts
+++ b/src/app/api/travel-mode/travel-mode.test.ts
@@ -151,7 +151,7 @@ describe("POST /api/travel-mode/enable", () => {
     );
   });
 
-  it("calls logAudit after enabling travel mode", async () => {
+  it("calls logAuditAsync after enabling travel mode", async () => {
     await EnablePOST(
       createRequest("POST", "http://localhost:3000/api/travel-mode/enable"),
     );

--- a/src/app/api/travel-mode/travel-mode.test.ts
+++ b/src/app/api/travel-mode/travel-mode.test.ts
@@ -28,7 +28,7 @@ vi.mock("@/lib/account-lockout", () => ({
   recordFailure: mockRecordFailure,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/crypto-server", () => ({

--- a/src/app/api/v1/passwords/[id]/route.test.ts
+++ b/src/app/api/v1/passwords/[id]/route.test.ts
@@ -53,7 +53,7 @@ vi.mock("@/lib/prisma", () => ({
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>, withTenantRls: mockWithTenantRls }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 

--- a/src/app/api/v1/passwords/[id]/route.ts
+++ b/src/app/api/v1/passwords/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { updateE2EPasswordSchema } from "@/lib/validations";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
@@ -224,7 +224,7 @@ async function handlePUT(
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_UPDATE,
     userId,
@@ -296,7 +296,7 @@ async function handleDELETE(
     );
   }
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: permanent ? AUDIT_ACTION.ENTRY_PERMANENT_DELETE : AUDIT_ACTION.ENTRY_TRASH,
     userId,

--- a/src/app/api/v1/passwords/route.test.ts
+++ b/src/app/api/v1/passwords/route.test.ts
@@ -37,7 +37,7 @@ vi.mock("@/lib/prisma", () => ({
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>, withTenantRls: mockWithTenantRls }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/logger", () => {

--- a/src/app/api/v1/passwords/route.ts
+++ b/src/app/api/v1/passwords/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createE2EPasswordSchema } from "@/lib/validations";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
@@ -195,7 +195,7 @@ async function handlePOST(req: NextRequest) {
 
   const { entry } = createResult;
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.ENTRY_CREATE,
     userId,

--- a/src/app/api/vault/admin-reset/route.test.ts
+++ b/src/app/api/vault/admin-reset/route.test.ts
@@ -28,7 +28,7 @@ vi.mock("@/lib/csrf", () => ({
   assertOrigin: vi.fn(() => null),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/vault-reset", () => ({

--- a/src/app/api/vault/admin-reset/route.ts
+++ b/src/app/api/vault/admin-reset/route.ts
@@ -7,7 +7,7 @@ import { prisma } from "@/lib/prisma";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { assertOrigin } from "@/lib/csrf";
 import { getAppOrigin } from "@/lib/url-helpers";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { executeVaultReset } from "@/lib/vault-reset";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants";
@@ -137,7 +137,7 @@ async function handlePOST(req: NextRequest) {
 
   // Audit log — use TENANT scope for tenant-level resets (teamId is null)
   const auditScope = resetRecord.teamId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.TENANT;
-  logAudit({
+  await logAuditAsync({
     scope: auditScope,
     action: AUDIT_ACTION.ADMIN_VAULT_RESET_EXECUTE,
     userId: session.user.id,

--- a/src/app/api/vault/delegation/check/route.test.ts
+++ b/src/app/api/vault/delegation/check/route.test.ts
@@ -32,7 +32,7 @@ vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockRateLimiterCheck }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
 }));
 vi.mock("@/lib/ip-access", () => ({
   extractClientIp: vi.fn(() => "127.0.0.1"),

--- a/src/app/api/vault/delegation/check/route.ts
+++ b/src/app/api/vault/delegation/check/route.ts
@@ -12,7 +12,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { authOrToken, hasUserId } from "@/lib/auth-or-token";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants/audit";
 import { MCP_CLIENT_ID_PREFIX } from "@/lib/constants/mcp";
 import { createRateLimiter } from "@/lib/rate-limit";
@@ -89,7 +89,7 @@ export async function GET(request: NextRequest) {
   }
 
   // Lightweight audit (success only)
-  logAudit({
+  await logAuditAsync({
     action: AUDIT_ACTION.DELEGATION_CHECK,
     scope: AUDIT_SCOPE.PERSONAL,
     userId,

--- a/src/app/api/vault/delegation/route.test.ts
+++ b/src/app/api/vault/delegation/route.test.ts
@@ -49,7 +49,7 @@ vi.mock("@/lib/csrf", () => ({ assertOrigin: mockAssertOrigin }));
 vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockRateLimiterCheck }),
 }));
-vi.mock("@/lib/audit", () => ({ logAudit: mockLogAudit }));
+vi.mock("@/lib/audit", () => ({ logAuditAsync: mockLogAudit }));
 vi.mock("@/lib/ip-access", () => ({ extractClientIp: vi.fn(() => "127.0.0.1") }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>, withBypassRls: mockWithBypassRls }));
 vi.mock("@/lib/prisma", () => ({

--- a/src/app/api/vault/delegation/route.ts
+++ b/src/app/api/vault/delegation/route.ts
@@ -13,7 +13,7 @@ import { prisma } from "@/lib/prisma";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { resolveUserTenantId } from "@/lib/tenant-context";
 import { withRequestLog } from "@/lib/with-request-log";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { MCP_SCOPE } from "@/lib/constants/mcp";
 import { API_ERROR } from "@/lib/api-error-codes";
@@ -216,8 +216,8 @@ async function handlePOST(request: NextRequest) {
     ip: extractClientIp(request),
     userAgent: request.headers.get("user-agent"),
   };
-  logAudit({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL });
-  logAudit({ ...auditBase, scope: AUDIT_SCOPE.TENANT });
+  await logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL });
+  await logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.TENANT });
 
   return NextResponse.json({
     delegationSessionId: delegationSession.id,

--- a/src/app/api/vault/recovery-key/generate/route.test.ts
+++ b/src/app/api/vault/recovery-key/generate/route.test.ts
@@ -27,7 +27,7 @@ vi.mock("@/lib/csrf", () => ({
   assertOrigin: vi.fn(() => null),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/vault/recovery-key/generate/route.ts
+++ b/src/app/api/vault/recovery-key/generate/route.ts
@@ -9,7 +9,7 @@ import { VERIFIER_VERSION } from "@/lib/crypto-client";
 import { assertOrigin } from "@/lib/csrf";
 import { withRequestLog } from "@/lib/with-request-log";
 import { rateLimited, zodValidationError } from "@/lib/api-response";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { z } from "zod";
 import { hexIv, hexAuthTag, hexSalt, hexHash } from "@/lib/validations/common";
@@ -135,7 +135,7 @@ async function handlePOST(request: NextRequest) {
   // Audit log
   const isRegeneration = !!user.recoveryKeySetAt;
   const { ip, userAgent } = extractRequestMeta(request);
-  logAudit({
+  await logAuditAsync({
     scope: "PERSONAL",
     action: isRegeneration ? "RECOVERY_KEY_REGENERATED" : "RECOVERY_KEY_CREATED",
     userId: session.user.id,

--- a/src/app/api/vault/recovery-key/recover/route.test.ts
+++ b/src/app/api/vault/recovery-key/recover/route.test.ts
@@ -28,7 +28,7 @@ vi.mock("@/lib/csrf", () => ({
   assertOrigin: vi.fn(() => null),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/vault/recovery-key/recover/route.ts
+++ b/src/app/api/vault/recovery-key/recover/route.ts
@@ -8,7 +8,7 @@ import { API_ERROR } from "@/lib/api-error-codes";
 import { assertOrigin } from "@/lib/csrf";
 import { withRequestLog } from "@/lib/with-request-log";
 import { rateLimited, zodValidationError } from "@/lib/api-response";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { z } from "zod";
 import { hexIv, hexAuthTag, hexSalt, hexHash } from "@/lib/validations/common";
@@ -208,7 +208,7 @@ async function handleReset(body: unknown, userId: string, request: NextRequest) 
   );
 
   const { ip, userAgent } = extractRequestMeta(request);
-  logAudit({
+  await logAuditAsync({
     scope: "PERSONAL",
     action: "RECOVERY_PASSPHRASE_RESET",
     userId,

--- a/src/app/api/vault/reset/route.test.ts
+++ b/src/app/api/vault/reset/route.test.ts
@@ -46,7 +46,7 @@ vi.mock("@/lib/csrf", () => ({
   assertOrigin: vi.fn(() => null),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/vault-reset", () => ({

--- a/src/app/api/vault/reset/route.ts
+++ b/src/app/api/vault/reset/route.ts
@@ -6,7 +6,7 @@ import { API_ERROR } from "@/lib/api-error-codes";
 import { assertOrigin } from "@/lib/csrf";
 import { withRequestLog } from "@/lib/with-request-log";
 import { rateLimited } from "@/lib/api-response";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { executeVaultReset } from "@/lib/vault-reset";
 import { z } from "zod/v4";
 
@@ -76,7 +76,7 @@ async function handlePOST(request: NextRequest) {
     await executeVaultReset(userId);
 
   const { ip, userAgent } = extractRequestMeta(request);
-  logAudit({
+  await logAuditAsync({
     scope: "PERSONAL",
     action: "VAULT_RESET_EXECUTED",
     userId,

--- a/src/app/api/vault/rotate-key/route.test.ts
+++ b/src/app/api/vault/rotate-key/route.test.ts
@@ -61,7 +61,7 @@ vi.mock("@/lib/delegation", () => ({
   revokeAllDelegationSessions: vi.fn(async () => 0),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: vi.fn(() => ({})),
 }));
 

--- a/src/app/api/vault/rotate-key/route.ts
+++ b/src/app/api/vault/rotate-key/route.ts
@@ -11,7 +11,7 @@ import { createRateLimiter } from "@/lib/rate-limit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { withRequestLog } from "@/lib/with-request-log";
 import { getLogger } from "@/lib/logger";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { z } from "zod";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { errorResponse, rateLimited, unauthorized, validationError, zodValidationError } from "@/lib/api-response";
@@ -304,7 +304,7 @@ async function handlePOST(request: NextRequest) {
   // Revoke all delegation sessions (key rotation invalidates delegated plaintext)
   await revokeAllDelegationSessions(userId, user.tenantId, "KEY_ROTATION").catch(() => {});
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.VAULT_KEY_ROTATION,
     userId,

--- a/src/app/api/vault/setup/route.test.ts
+++ b/src/app/api/vault/setup/route.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/lib/logger", () => ({
   getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: vi.fn(),
+  logAuditAsync: vi.fn(),
   extractRequestMeta: vi.fn().mockReturnValue({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({

--- a/src/app/api/vault/setup/route.ts
+++ b/src/app/api/vault/setup/route.ts
@@ -7,7 +7,7 @@ import { hmacVerifier } from "@/lib/crypto-server";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { VERIFIER_VERSION } from "@/lib/crypto-client";
 import { withRequestLog } from "@/lib/with-request-log";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { getLogger } from "@/lib/logger";
 import { z } from "zod";
 import { withUserTenantRls } from "@/lib/tenant-context";
@@ -164,7 +164,7 @@ async function handlePOST(request: NextRequest) {
   );
 
   const { ip, userAgent } = extractRequestMeta(request);
-  logAudit({
+  await logAuditAsync({
     scope: "PERSONAL",
     action: "VAULT_SETUP",
     userId: session.user.id,

--- a/src/app/api/watchtower/alert/route.test.ts
+++ b/src/app/api/watchtower/alert/route.test.ts
@@ -33,7 +33,7 @@ vi.mock("@/lib/csrf", () => ({
   assertOrigin: vi.fn(() => null),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
 }));
 vi.mock("@/lib/notification", () => ({

--- a/src/app/api/watchtower/alert/route.ts
+++ b/src/app/api/watchtower/alert/route.ts
@@ -6,7 +6,7 @@ import { parseBody } from "@/lib/parse-body";
 import { assertOrigin } from "@/lib/csrf";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { requireTeamMember, TeamAuthError } from "@/lib/team-auth";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { createNotification } from "@/lib/notification";
 import { sendEmail } from "@/lib/email";
 import { watchtowerAlertEmail } from "@/lib/email/templates/watchtower-alert";
@@ -88,7 +88,7 @@ async function handlePOST(req: NextRequest) {
   });
 
   // Audit log
-  logAudit({
+  await logAuditAsync({
     scope: teamId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.WATCHTOWER_ALERT_SENT,
     userId: session.user.id,

--- a/src/app/api/webauthn/credentials/[id]/route.test.ts
+++ b/src/app/api/webauthn/credentials/[id]/route.test.ts
@@ -37,7 +37,7 @@ vi.mock("@/lib/with-request-log", () => ({
   withRequestLog: (fn: any) => fn,
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test" }),
 }));
 

--- a/src/app/api/webauthn/credentials/[id]/route.test.ts
+++ b/src/app/api/webauthn/credentials/[id]/route.test.ts
@@ -127,7 +127,7 @@ describe("DELETE /api/webauthn/credentials/[id]", () => {
     );
   });
 
-  it("calls logAudit with credential metadata", async () => {
+  it("calls logAuditAsync with credential metadata", async () => {
     const req = createRequest("DELETE", ROUTE_URL);
     await DELETE(req, CTX);
 

--- a/src/app/api/webauthn/credentials/[id]/route.ts
+++ b/src/app/api/webauthn/credentials/[id]/route.ts
@@ -6,7 +6,7 @@ import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
 import { withRequestLog } from "@/lib/with-request-log";
 import { withUserTenantRls } from "@/lib/tenant-context";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { WEBAUTHN_NICKNAME_MAX_LENGTH } from "@/lib/validations/common";
 
@@ -51,7 +51,7 @@ async function handleDELETE(
     }),
   );
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.WEBAUTHN_CREDENTIAL_DELETE,
     userId,

--- a/src/app/api/webauthn/register/verify/route.test.ts
+++ b/src/app/api/webauthn/register/verify/route.test.ts
@@ -50,7 +50,7 @@ vi.mock("@/lib/webauthn-server", () => ({
 }));
 
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null, acceptLanguage: null }),
 }));
 

--- a/src/app/api/webauthn/register/verify/route.ts
+++ b/src/app/api/webauthn/register/verify/route.ts
@@ -9,7 +9,7 @@ import { API_ERROR } from "@/lib/api-error-codes";
 import { withRequestLog } from "@/lib/with-request-log";
 import { rateLimited } from "@/lib/api-response";
 import { withUserTenantRls } from "@/lib/tenant-context";
-import { logAudit, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import {
   PIN_LENGTH_MIN,
@@ -210,7 +210,7 @@ async function handlePOST(req: NextRequest) {
     });
   });
 
-  logAudit({
+  await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.WEBAUTHN_CREDENTIAL_REGISTER,
     userId,

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -114,7 +114,7 @@ vi.mock("@/lib/auth-adapter", () => ({
 }));
 
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
 }));
 
 vi.mock("@/lib/session-meta", () => ({

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,7 +1,7 @@
 import NextAuth from "next-auth";
 import type { Account } from "next-auth";
 import { createCustomAdapter } from "@/lib/auth-adapter";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { prisma } from "@/lib/prisma";
 import { extractTenantClaimValue } from "@/lib/tenant-claim";
@@ -335,7 +335,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     async signIn({ user }) {
       if (user.id) {
         const meta = sessionMetaStorage.getStore();
-        logAudit({
+        await logAuditAsync({
           scope: AUDIT_SCOPE.PERSONAL,
           action: AUDIT_ACTION.AUTH_LOGIN,
           userId: user.id,
@@ -347,7 +347,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     async signOut(message) {
       if ("session" in message && message.session?.userId) {
         const meta = sessionMetaStorage.getStore();
-        logAudit({
+        await logAuditAsync({
           scope: AUDIT_SCOPE.PERSONAL,
           action: AUDIT_ACTION.AUTH_LOGOUT,
           userId: message.session.userId,

--- a/src/lib/access-restriction.ts
+++ b/src/lib/access-restriction.ts
@@ -10,7 +10,7 @@ import { prisma } from "@/lib/prisma";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { isIpAllowed, isTailscaleIp, extractClientIp } from "@/lib/ip-access";
 import { verifyTailscalePeer } from "@/lib/tailscale-client";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { resolveUserTenantId } from "@/lib/tenant-context";
 import { NextResponse } from "next/server";
@@ -153,7 +153,7 @@ export async function checkAccessRestrictionWithAudit(
 
   if (!result.allowed) {
     // Fire-and-forget audit log
-    logAudit({
+    await logAuditAsync({
       action: AUDIT_ACTION.ACCESS_DENIED,
       scope: AUDIT_SCOPE.TENANT,
       userId: userId ?? "unknown",
@@ -217,7 +217,7 @@ export async function enforceAccessRestriction(
   const result = await checkAccessRestriction(tenantId, clientIp);
 
   if (!result.allowed) {
-    logAudit({
+    await logAuditAsync({
       action: AUDIT_ACTION.ACCESS_DENIED,
       scope: AUDIT_SCOPE.TENANT,
       userId,
@@ -236,7 +236,7 @@ export async function enforceAccessRestriction(
   if (policy.tailscaleEnabled && policy.tailscaleTailnet && clientIp && isTailscaleIp(clientIp)) {
     const verified = await verifyTailscalePeer(clientIp, policy.tailscaleTailnet);
     if (!verified) {
-      logAudit({
+      await logAuditAsync({
         action: AUDIT_ACTION.ACCESS_DENIED,
         scope: AUDIT_SCOPE.TENANT,
         userId,

--- a/src/lib/account-lockout.test.ts
+++ b/src/lib/account-lockout.test.ts
@@ -410,7 +410,7 @@ describe("recordFailure", () => {
     expect(result!.lockedUntil).toEqual(activeLock);
   });
 
-  it("swallows logAudit error in VAULT_UNLOCK_FAILED block", async () => {
+  it("swallows logAuditAsync error in VAULT_UNLOCK_FAILED block", async () => {
     setupTransaction({
       failed_unlock_attempts: 0,
       last_failed_unlock_at: null,
@@ -429,7 +429,7 @@ describe("recordFailure", () => {
     );
   });
 
-  it("swallows logAudit error in VAULT_LOCKOUT_TRIGGERED block", async () => {
+  it("swallows logAuditAsync error in VAULT_LOCKOUT_TRIGGERED block", async () => {
     setupTransaction({
       failed_unlock_attempts: 4,
       last_failed_unlock_at: new Date(),
@@ -450,20 +450,19 @@ describe("recordFailure", () => {
     );
   });
 
-  it("swallows logAudit error in lock_timeout catch block", async () => {
+  it("calls logAuditAsync in lock_timeout path (never throws)", async () => {
     const lockTimeoutError = Object.assign(new Error("lock timeout"), {
       code: "55P03",
     });
     mockPrismaTransaction.mockRejectedValue(lockTimeoutError);
-    mockLogAudit.mockImplementationOnce(() => {
-      throw new Error("audit write failed on lock_timeout");
-    });
 
     const result = await recordFailure("user-1");
     expect(result).toBeNull();
-    expect(mockLoggerInstance.error).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: "user-1" }),
-      "audit.vaultUnlockFailed.lockTimeout.error",
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "VAULT_UNLOCK_FAILED",
+        metadata: { reason: "lock_timeout" },
+      }),
     );
   });
 });

--- a/src/lib/account-lockout.test.ts
+++ b/src/lib/account-lockout.test.ts
@@ -38,7 +38,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withBypassRls: vi.fn((_prisma: unknown, fn: () => unknown) => fn()),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
   extractRequestMeta: mockExtractRequestMeta,
 }));
 vi.mock("@/lib/logger", () => ({

--- a/src/lib/account-lockout.ts
+++ b/src/lib/account-lockout.ts
@@ -12,7 +12,7 @@
 
 import { prisma } from "@/lib/prisma";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
-import { logAudit, logAuditInTx, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, logAuditInTx, extractRequestMeta } from "@/lib/audit";
 import { getLogger } from "@/lib/logger";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { notifyAdminsOfLockout } from "@/lib/lockout-admin-notify";
@@ -281,7 +281,7 @@ export async function recordFailure(
           });
         }, BYPASS_PURPOSE.AUDIT_WRITE);
       } else {
-        logAudit({
+        await logAuditAsync({
           scope: AUDIT_SCOPE.PERSONAL,
           action: AUDIT_ACTION.VAULT_UNLOCK_FAILED,
           userId,
@@ -314,7 +314,7 @@ export async function recordFailure(
             });
           }, BYPASS_PURPOSE.AUDIT_WRITE);
         } else {
-          logAudit({
+          await logAuditAsync({
             scope: AUDIT_SCOPE.PERSONAL,
             action: AUDIT_ACTION.VAULT_LOCKOUT_TRIGGERED,
             userId,
@@ -363,7 +363,7 @@ export async function recordFailure(
       // NOTE: logAudit() swallows internally; catch kept as safety net.
       try {
         const meta = request ? extractRequestMeta(request) : { ip: null, userAgent: null };
-        logAudit({
+        await logAuditAsync({
           scope: AUDIT_SCOPE.PERSONAL,
           action: AUDIT_ACTION.VAULT_UNLOCK_FAILED,
           userId,

--- a/src/lib/account-lockout.ts
+++ b/src/lib/account-lockout.ts
@@ -359,21 +359,17 @@ export async function recordFailure(
     if (isLockTimeoutError(err)) {
       getLogger().warn({ userId }, "vault.unlock.lockTimeout");
 
-      // Record audit even on lock_timeout (async nonblocking, outside transaction)
-      // NOTE: logAudit() swallows internally; catch kept as safety net.
-      try {
-        const meta = request ? extractRequestMeta(request) : { ip: null, userAgent: null };
-        await logAuditAsync({
-          scope: AUDIT_SCOPE.PERSONAL,
-          action: AUDIT_ACTION.VAULT_UNLOCK_FAILED,
-          userId,
-          metadata: { reason: "lock_timeout" },
-          ip: meta.ip,
-          userAgent: meta.userAgent,
-        });
-      } catch (auditErr) {
-        getLogger().error({ err: auditErr, userId }, "audit.vaultUnlockFailed.lockTimeout.error");
-      }
+      // Record audit even on lock_timeout (outside transaction).
+      // logAuditAsync never throws — errors go to deadLetterLogger internally.
+      const meta = request ? extractRequestMeta(request) : { ip: null, userAgent: null };
+      await logAuditAsync({
+        scope: AUDIT_SCOPE.PERSONAL,
+        action: AUDIT_ACTION.VAULT_UNLOCK_FAILED,
+        userId,
+        metadata: { reason: "lock_timeout" },
+        ip: meta.ip,
+        userAgent: meta.userAgent,
+      });
 
       return null;
     }

--- a/src/lib/audit-logger.ts
+++ b/src/lib/audit-logger.ts
@@ -17,7 +17,7 @@ const DEFAULT_APP_NAME = process.env.AUDIT_LOG_APP_NAME ?? "passwd-sso";
  * Defense-in-depth: even if a caller accidentally passes sensitive data,
  * sanitizeMetadata() in audit.ts will remove these keys before pino sees them.
  *
- * Also used to generate pino redact paths for both auditLogger and deadLetterLogger.
+ * Also used to generate pino redact paths for auditLogger.
  */
 export const METADATA_BLOCKLIST = new Set([
   "password",
@@ -101,10 +101,8 @@ export const deadLetterLogger = pino({
     _logType: "audit-dead-letter",
     _app: DEFAULT_APP_NAME,
   },
-  redact: {
-    paths: [...METADATA_BLOCKLIST].map((k) => `auditEntry.metadata.${k}`),
-    censor: "[REDACTED]",
-  },
+  // No redact paths needed — deadLetterEntry() in audit.ts emits only
+  // { scope, action, userId, tenantId, reason, error }, never raw metadata.
   formatters: {
     level(label: string) {
       return { level: label };

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,7 +1,7 @@
 /**
  * Server-side audit logging helpers.
  *
- * logAudit() is async nonblocking — it never throws and never blocks the response.
+ * logAuditAsync() writes audit events to the outbox. Awaitable, never throws.
  * Dual-write: PostgreSQL AuditLog table (via outbox) + structured JSON to stdout (via pino).
  * extractRequestMeta() extracts IP and User-Agent from NextRequest headers.
  */
@@ -154,24 +154,65 @@ export async function logAuditInTx(
 
 // ─── logAuditAsync ──────────────────────────────────────────────
 
+/** Minimal dead-letter payload — never includes raw metadata. */
+function deadLetterEntry(params: AuditLogParams, reason: string, error?: string) {
+  return {
+    scope: params.scope,
+    action: params.action,
+    userId: params.userId,
+    tenantId: params.tenantId ?? null,
+    reason,
+    ...(error != null && { error }),
+  };
+}
+
 /**
- * Write an audit log entry via the outbox. Awaitable version.
- * Resolves tenantId if not provided, then enqueues to the outbox.
+ * Write an audit log entry via the outbox. Awaitable, never throws.
+ *
+ * 1. Emits structured JSON to auditLogger (synchronous, before outbox write).
+ * 2. Enqueues the entry to the outbox (awaited).
+ * 3. On any error, logs to deadLetterLogger — caller never needs try/catch.
  */
 export async function logAuditAsync(params: AuditLogParams): Promise<void> {
   const payload = buildOutboxPayload(params);
 
-  // Non-UUID userId (e.g., "anonymous") bypasses the outbox
-  if (!UUID_RE.test(params.userId)) {
-    const tenantId = params.tenantId ?? null;
-    if (!tenantId) {
-      deadLetterLogger.warn(
-        { auditEntry: params, reason: "non_uuid_userId_no_tenantId" },
-        "audit.dead_letter",
-      );
-      return;
-    }
-    try {
+  // Structured JSON emit FIRST (synchronous, never fails the caller)
+  try {
+    auditLogger.info(
+      {
+        audit: {
+          scope: payload.scope,
+          action: payload.action,
+          userId: payload.userId,
+          actorType: payload.actorType,
+          serviceAccountId: payload.serviceAccountId,
+          tenantId: params.tenantId ?? null,
+          teamId: payload.teamId,
+          targetType: payload.targetType,
+          targetId: payload.targetId,
+          metadata: sanitizeMetadata(payload.metadata),
+          ip: payload.ip,
+          userAgent: payload.userAgent,
+        },
+      },
+      `audit.${payload.action}`,
+    );
+  } catch {
+    // Never let forwarding break the app
+  }
+
+  // Outbox enqueue — all errors caught (MF2: never throws)
+  try {
+    // Non-UUID userId (e.g., "anonymous") bypasses the outbox
+    if (!UUID_RE.test(params.userId)) {
+      const tenantId = params.tenantId ?? null;
+      if (!tenantId) {
+        deadLetterLogger.warn(
+          deadLetterEntry(params, "non_uuid_userId_no_tenantId"),
+          "audit.dead_letter",
+        );
+        return;
+      }
       await withBypassRls(prisma, async () => {
         await prisma.auditLog.create({
           data: {
@@ -184,101 +225,28 @@ export async function logAuditAsync(params: AuditLogParams): Promise<void> {
           },
         });
       }, BYPASS_PURPOSE.AUDIT_WRITE);
-    } catch (err) {
-      getLogger().warn({ err }, "logAuditAsync: non-UUID direct write failed");
+      return;
     }
-    return;
-  }
 
-  const tenantId = await resolveTenantId(params);
-  if (!tenantId) {
+    const tenantId = await resolveTenantId(params);
+    if (!tenantId) {
+      deadLetterLogger.warn(
+        deadLetterEntry(params, "tenant_not_found"),
+        "audit.dead_letter",
+      );
+      return;
+    }
+
+    await enqueueAudit(tenantId, payload);
+  } catch (err) {
     deadLetterLogger.warn(
-      { auditEntry: params, reason: "tenant_not_found" },
+      deadLetterEntry(params, "logAuditAsync_failed", String(err)),
       "audit.dead_letter",
     );
-    return;
-  }
-
-  await enqueueAudit(tenantId, payload);
-}
-
-// ─── logAudit ───────────���────────────────────────────────────────
-
-/**
- * Write an audit log entry. Async nonblocking: errors are silently caught.
- *
- * @deprecated Use logAuditInTx(tx, tenantId, params) for atomicity guarantees,
- * or logAuditAsync(params) when atomicity is not required but you need to await.
- */
-export function logAudit(params: AuditLogParams): void {
-  const { scope, action, userId, actorType, serviceAccountId, tenantId, teamId, targetType, targetId, metadata, ip, userAgent } = params;
-
-  const safeMetadata = truncateMetadata(metadata);
-  const safeUserAgent = userAgent?.slice(0, USER_AGENT_MAX_LENGTH) ?? null;
-
-  // Fire-and-forget outbox enqueue
-  void logAuditAsync({
-    scope,
-    action,
-    userId,
-    actorType,
-    serviceAccountId,
-    tenantId,
-    teamId,
-    targetType,
-    targetId,
-    metadata: safeMetadata,
-    ip,
-    userAgent: safeUserAgent,
-  }).catch((err) => {
-    deadLetterLogger.warn(
-      { auditEntry: params, reason: "logAuditAsync_failed", error: String(err) },
-      "audit.dead_letter",
-    );
-  });
-
-  // --- Structured JSON emit for external forwarding ---
-  try {
-    auditLogger.info(
-      {
-        audit: {
-          scope,
-          action,
-          userId,
-          actorType: actorType ?? ACTOR_TYPE.HUMAN,
-          serviceAccountId: serviceAccountId ?? null,
-          teamId: teamId ?? null,
-          targetType: targetType ?? null,
-          targetId: targetId ?? null,
-          metadata: sanitizeMetadata(safeMetadata),
-          ip: ip ?? null,
-          userAgent: safeUserAgent,
-        },
-      },
-      `audit.${action}`,
-    );
-  } catch {
-    // Never let forwarding break the app
   }
 }
 
-// ─── logAuditBatch ───────────────────────────────────────────────
-
-/**
- * Write multiple audit log entries.
- * Async nonblocking: errors are silently caught.
- *
- * @deprecated Use logAuditInTx(tx, tenantId, params) per entry for atomicity guarantees.
- */
-export function logAuditBatch(paramsList: AuditLogParams[]): void {
-  if (paramsList.length === 0) return;
-
-  for (const params of paramsList) {
-    logAudit(params);
-  }
-}
-
-// ─── extractRequestMeta ───────��──────────────────────────────────
+// ─── extractRequestMeta ──────────────────────────────────────────
 
 /**
  * Extract IP address, User-Agent, and Accept-Language from a NextRequest.

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -213,18 +213,25 @@ export async function logAuditAsync(params: AuditLogParams): Promise<void> {
         );
         return;
       }
-      await withBypassRls(prisma, async () => {
-        await prisma.auditLog.create({
-          data: {
-            scope: payload.scope, action: payload.action, userId: payload.userId!,
-            actorType: payload.actorType, serviceAccountId: payload.serviceAccountId,
-            tenantId, teamId: payload.teamId, targetType: payload.targetType,
-            targetId: payload.targetId,
-            metadata: (payload.metadata as Prisma.InputJsonValue) ?? undefined,
-            ip: payload.ip, userAgent: payload.userAgent,
-          },
-        });
-      }, BYPASS_PURPOSE.AUDIT_WRITE);
+      try {
+        await withBypassRls(prisma, async () => {
+          await prisma.auditLog.create({
+            data: {
+              scope: payload.scope, action: payload.action, userId: payload.userId!,
+              actorType: payload.actorType, serviceAccountId: payload.serviceAccountId,
+              tenantId, teamId: payload.teamId, targetType: payload.targetType,
+              targetId: payload.targetId,
+              metadata: (payload.metadata as Prisma.InputJsonValue) ?? undefined,
+              ip: payload.ip, userAgent: payload.userAgent,
+            },
+          });
+        }, BYPASS_PURPOSE.AUDIT_WRITE);
+      } catch (err) {
+        deadLetterLogger.warn(
+          deadLetterEntry(params, "non_uuid_direct_write_failed", String(err)),
+          "audit.dead_letter",
+        );
+      }
       return;
     }
 

--- a/src/lib/auth-adapter.test.ts
+++ b/src/lib/auth-adapter.test.ts
@@ -72,7 +72,7 @@ vi.mock("@auth/prisma-adapter", () => ({
   }),
 }));
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
 }));
 vi.mock("@/lib/notification", () => ({
   createNotification: mockCreateNotification,

--- a/src/lib/auth-adapter.ts
+++ b/src/lib/auth-adapter.ts
@@ -9,7 +9,7 @@ import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { randomUUID } from "node:crypto";
 import { checkNewDeviceAndNotify } from "@/lib/new-device-detection";
 import { USER_AGENT_MAX_LENGTH, BOOTSTRAP_SLUG_HASH_LENGTH } from "@/lib/validations/common.server";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { createNotification } from "@/lib/notification";
 import { getStrictestSessionDuration } from "@/lib/team-policy";
@@ -315,7 +315,7 @@ export function createCustomAdapter(): Adapter {
           evicted: { id: string; ipAddress: string | null; userAgent: string | null }[];
         };
         for (const ev of evicted) {
-          logAudit({
+          await logAuditAsync({
             scope: AUDIT_SCOPE.PERSONAL,
             action: AUDIT_ACTION.SESSION_EVICTED,
             userId: session.userId,
@@ -471,7 +471,7 @@ export function createCustomAdapter(): Adapter {
                 () => prisma.session.delete({ where: { sessionToken: session.sessionToken } }),
                 BYPASS_PURPOSE.AUTH_FLOW,
               );
-              logAudit({
+              await logAuditAsync({
                 scope: AUDIT_SCOPE.PERSONAL,
                 action: AUDIT_ACTION.SESSION_REVOKE,
                 userId: current.userId,

--- a/src/lib/constants/audit.ts
+++ b/src/lib/constants/audit.ts
@@ -589,7 +589,7 @@ export const AUDIT_ACTION_GROUPS_TENANT: Record<string, AuditAction[]> = {
 /**
  * Event groups subscribable via tenant webhooks.
  * Derived from AUDIT_ACTION_GROUPS_TENANT minus self-referential and
- * privacy-sensitive groups. logAudit() dispatches webhooks automatically
+ * privacy-sensitive groups. logAuditAsync() dispatches webhooks automatically
  * for all audit actions, so every action here is guaranteed to fire.
  *
  * Intentionally excluded:

--- a/src/lib/delegation.test.ts
+++ b/src/lib/delegation.test.ts
@@ -50,7 +50,7 @@ vi.mock("@/lib/crypto-server", async () => {
 vi.mock("@/lib/prisma", () => ({ prisma: {} }));
 vi.mock("@/lib/redis", () => ({ getRedis: vi.fn(() => null) }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>, withBypassRls: vi.fn((_p: unknown, fn: () => unknown) => fn()) }));
-vi.mock("@/lib/audit", () => ({ logAudit: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ logAuditAsync: vi.fn() }));
 
 describe("delegation", () => {
   describe("Redis key builders", () => {

--- a/src/lib/delegation.ts
+++ b/src/lib/delegation.ts
@@ -17,7 +17,7 @@ import {
   getMasterKeyByVersion,
 } from "@/lib/crypto-server";
 import type { ServerEncryptedData } from "@/lib/crypto-server";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants/audit";
 
 // ─── Constants ─────────────────────────────────────────────────
@@ -250,8 +250,8 @@ export async function revokeAllDelegationSessions(
       tenantId,
       metadata: { revokedCount: result.count, reason: reason ?? "manual" },
     };
-    logAudit({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL });
-    logAudit({ ...auditBase, scope: AUDIT_SCOPE.TENANT });
+    await logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL });
+    await logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.TENANT });
   }
 
   return result.count;
@@ -285,8 +285,8 @@ export async function revokeDelegationSession(
       targetId: sessionId,
       metadata: { reason: "manual" },
     };
-    logAudit({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL });
-    logAudit({ ...auditBase, scope: AUDIT_SCOPE.TENANT });
+    await logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL });
+    await logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.TENANT });
   }
 
   return result.count > 0;

--- a/src/lib/directory-sync/engine.test.ts
+++ b/src/lib/directory-sync/engine.test.ts
@@ -56,7 +56,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
 }));
 
 vi.mock("@/lib/audit", () => ({
-  logAudit: mockLogAudit,
+  logAuditAsync: mockLogAudit,
 }));
 
 vi.mock("@/lib/webhook-dispatcher", () => ({

--- a/src/lib/directory-sync/engine.ts
+++ b/src/lib/directory-sync/engine.ts
@@ -12,7 +12,7 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { withTenantRls } from "@/lib/tenant-rls";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { dispatchTenantWebhook } from "@/lib/webhook-dispatcher";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE, TENANT_ROLE } from "@/lib/constants";
 import { decryptCredentials } from "./credentials";
@@ -199,7 +199,7 @@ export async function runDirectorySync(
 
     // Log stale-reset if we overrode a stale RUNNING lock
     if (acquired && wasStaleRunning) {
-      logAudit({
+      await logAuditAsync({
         scope: AUDIT_SCOPE.TENANT,
         action: AUDIT_ACTION.DIRECTORY_SYNC_STALE_RESET,
         userId: actorUserId ?? "system",

--- a/src/lib/mcp/tools.test.ts
+++ b/src/lib/mcp/tools.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/lib/delegation", () => ({
   getDelegatedEntryIdsForSession: mockGetDelegatedEntryIdsForSession,
 }));
 
-vi.mock("@/lib/audit", () => ({ logAudit: mockLogAudit }));
+vi.mock("@/lib/audit", () => ({ logAuditAsync: mockLogAudit }));
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {},

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -16,7 +16,7 @@ import {
   getDelegatedEntryIdsForSession,
   type DelegationMetadata,
 } from "@/lib/delegation";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants/audit";
 import { AUDIT_TARGET_TYPE } from "@/lib/constants/audit-target";
 
@@ -98,7 +98,7 @@ async function getSession(token: McpTokenData) {
   return { session };
 }
 
-function auditDelegationAccess(
+async function auditDelegationAccess(
   token: McpTokenData,
   tool: "list" | "search",
   sessionId: string,
@@ -120,8 +120,8 @@ function auditDelegationAccess(
     },
     ip: ip ?? undefined,
   };
-  logAudit({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL });
-  logAudit({ ...auditBase, scope: AUDIT_SCOPE.TENANT });
+  await logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL });
+  await logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.TENANT });
 }
 
 // ─── Tool handlers ────────────────────────────────────────────
@@ -157,7 +157,7 @@ export async function toolListCredentials(
   // Apply pagination
   const paginated = entries.slice(offset, offset + limit);
 
-  auditDelegationAccess(token, "list", session.id, ip, { entryCount: paginated.length });
+  await auditDelegationAccess(token, "list", session.id, ip, { entryCount: paginated.length });
 
   return { result: { entries: paginated, total: entries.length } };
 }
@@ -199,7 +199,7 @@ export async function toolSearchCredentials(
 
   const paginated = filtered.slice(offset, offset + limit);
 
-  auditDelegationAccess(token, "search", session.id, ip, { entryCount: paginated.length, query });
+  await auditDelegationAccess(token, "search", session.id, ip, { entryCount: paginated.length, query });
 
   return { result: { entries: paginated, total: filtered.length } };
 }

--- a/src/lib/notification.ts
+++ b/src/lib/notification.ts
@@ -2,7 +2,7 @@
  * Server-side notification helpers.
  *
  * createNotification() is async nonblocking — it never throws and never blocks
- * the response. Follows the same fire-and-forget pattern as logAudit().
+ * the response. Follows the same fire-and-forget pattern as logAuditAsync().
  *
  * Design rule: `body` and `metadata` must NEVER contain E2E-encrypted entry
  * content (titles, passwords, etc.). Only non-sensitive information is allowed:

--- a/src/lib/team-policy.ts
+++ b/src/lib/team-policy.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { withTeamTenantRls, resolveTeamTenantId } from "@/lib/tenant-context";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { isIpAllowed, extractClientIp } from "@/lib/ip-access";
-import { logAudit } from "@/lib/audit";
+import { logAuditAsync } from "@/lib/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import type { NextRequest } from "next/server";
 
@@ -198,7 +198,7 @@ export async function checkTeamAccessRestriction(teamId: string, clientIp: strin
     return;
   }
 
-  logAudit({
+  await logAuditAsync({
     action: AUDIT_ACTION.ACCESS_DENIED,
     scope: AUDIT_SCOPE.TEAM,
     userId: userId ?? "unknown",

--- a/src/lib/webhook-dispatcher.test.ts
+++ b/src/lib/webhook-dispatcher.test.ts
@@ -43,7 +43,7 @@ vi.mock("@/lib/audit", async () => {
   const actual = await vi.importActual<typeof import("@/lib/audit")>("@/lib/audit");
   return {
     ...actual,
-    logAudit: mockLogAudit,
+    logAuditAsync: mockLogAudit,
   };
 });
 vi.mock("@/lib/audit-logger", async () => {

--- a/src/lib/webhook-dispatcher.ts
+++ b/src/lib/webhook-dispatcher.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/crypto-server";
 import { createHmac } from "node:crypto";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
+import { NIL_UUID } from "@/lib/constants/app";
 import { WEBHOOK_CONCURRENCY, WEBHOOK_MAX_RETRIES } from "@/lib/validations/common.server";
 import { Agent as UndiciAgent } from "undici";
 import {
@@ -227,11 +228,11 @@ export function dispatchWebhook(event: TeamWebhookEvent): void {
         }, BYPASS_PURPOSE.WEBHOOK_DISPATCH);
 
         // Lazy import to break circular dependency: webhook-dispatcher.ts ↔ audit.ts
-        const { logAudit } = await import("@/lib/audit");
-        logAudit({
+        const { logAuditAsync } = await import("@/lib/audit");
+        await logAuditAsync({
           scope: AUDIT_SCOPE.TEAM,
           action: AUDIT_ACTION.WEBHOOK_DELIVERY_FAILED,
-          userId: "system",
+          userId: NIL_UUID,
           teamId: event.teamId,
           metadata: {
             webhookId: id,
@@ -298,11 +299,11 @@ export function dispatchTenantWebhook(event: TenantWebhookEvent): void {
           });
         }, BYPASS_PURPOSE.WEBHOOK_DISPATCH);
 
-        const { logAudit } = await import("@/lib/audit");
-        logAudit({
+        const { logAuditAsync } = await import("@/lib/audit");
+        await logAuditAsync({
           scope: AUDIT_SCOPE.TENANT,
           action: AUDIT_ACTION.TENANT_WEBHOOK_DELIVERY_FAILED,
-          userId: "system",
+          userId: NIL_UUID,
           tenantId: event.tenantId,
           metadata: {
             webhookId: id,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,6 +39,8 @@ export default defineConfig({
         "src/lib/access-restriction.ts",
         "src/lib/account-lockout.ts",
         "src/lib/webhook-dispatcher.ts",
+        "src/lib/audit.ts",
+        "src/lib/audit-outbox.ts",
         "src/lib/audit-query.ts",
         "src/proxy.ts",
         "src/components/**/*.{ts,tsx}",


### PR DESCRIPTION
## Summary

- Migrate all ~160 `logAudit()` (fire-and-forget, void) and 8 `logAuditBatch()` call sites to `await logAuditAsync()` (durable, never-throws)
- Enhance `logAuditAsync`: structured JSON emit (MF1), internal error catching with sanitized dead letter output (MF2), `tenantId` in structured emit
- Delete deprecated `logAudit()` and `logAuditBatch()` from `src/lib/audit.ts`
- Fix webhook-dispatcher `userId: "system"` → `NIL_UUID` for both TEAM and TENANT scope
- Migrate auth.ts `AUTH_LOGIN`/`AUTH_LOGOUT` to `await logAuditAsync()` (no longer DEFERRED)
- Update ~134 test file mocks and assertions

## Test plan

- [x] `npx vitest run` — 563 files, 7116 tests pass
- [x] `npx next build` — production build succeeds
- [x] `scripts/pre-pr.sh` — all 9 checks pass (including new `no-deprecated-logAudit` check)
- [x] Manual test: MCP OAuth flow → `AUTH_LOGIN`, `MCP_CONSENT_GRANT` written to `audit_outbox` → worker drains to `audit_logs` with correct `user_id` and `actor_type`
- [x] Zero residual `logAudit()` calls in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)