### PR TITLE
refactor: unify audit paths with type-safe null userId for anonymous/SYSTEM events

### DIFF
--- a/docs/archive/review/unify-audit-outbox-path-code-review.md
+++ b/docs/archive/review/unify-audit-outbox-path-code-review.md
@@ -1,0 +1,89 @@
+# Code Review: unify-audit-outbox-path
+Date: 2026-04-14
+Review round: 1 (final — all findings resolved)
+
+## Changes from Previous Round
+Initial review of branch `refactor/unify-audit-outbox-path`.
+
+Pre-branch context: the large logAudit → logAuditAsync migration was already merged to main. This branch is a follow-up addressing the external reviewer's note that non-outbox paths remain in logAuditAsync. The fix changes `userId: "anonymous"` sentinel strings to type-safe `userId: null + actorType: SYSTEM`, which bypasses the outbox via direct write (matching the audit_logs CHECK constraint that allows `user_id IS NULL AND actor_type = 'SYSTEM'`).
+
+## Functionality Findings
+
+### F1 Major: structured JSON emit inconsistent with DB write when caller omits actorType — RESOLVED
+- Action: `buildOutboxPayload` now forces `actorType = SYSTEM` when `userId === null`, keeping structured log and DB write consistent regardless of caller input.
+- Modified file: src/lib/audit.ts
+
+### F2 Major: 4 callers passing non-UUID string fallbacks ("system"/"unknown") — RESOLVED
+- Action: Changed `?? "system"` / `?? "unknown"` → `?? null` in 4 callers. These now flow through the null userId direct-write path.
+- Modified files:
+  - src/app/api/mcp/token/route.ts:138
+  - src/lib/directory-sync/engine.ts:205
+  - src/lib/access-restriction.ts:159
+  - src/lib/team-policy.ts:204
+
+### F3 Minor: logAuditInTx accepts null userId but outbox rejects — ACCEPTED (latent, no current caller)
+- Anti-Deferral check: acceptable risk
+- Worst case: A future caller using logAuditInTx with userId:null will enqueue a row the worker rejects. Manifests as worker dead-letter, not app error.
+- Likelihood: low — all current logAuditInTx callers pass authenticated UUID userIds
+- Cost to fix: ~5 LOC but adding a second code path to logAuditInTx (direct write inside tx) has architectural implications (atomicity semantics). Better addressed when a real caller needs it.
+- TODO(unify-audit-outbox-path): Consider tightening logAuditInTx signature to `userId: string` (non-null) or adding a null-userId branch if needed.
+
+### F4 Minor: file-level JSDoc stale — RESOLVED
+- Action: Updated JSDoc to describe both routing paths (UUID → outbox, null → direct write) and design consequences (no chain, no SIEM fan-out for null path).
+- Modified file: src/lib/audit.ts (header comment)
+
+## Security Findings
+
+### S1 Info: SIEM/webhook fan-out bypass for SYSTEM+null events — DOCUMENTED
+- Action: Added explicit design note in JSDoc: `SHARE_ACCESS_VERIFY_*` events do NOT flow through audit_delivery fan-out (no outboxId → no delivery rows). This matches worker-emitted meta-events.
+- Rationale: anonymous share access is not a SIEM-level security event in the current threat model. If external SIEM forwarding is required later, move these actions to the outbox path with a sentinel user record.
+- Modified file: src/lib/audit.ts
+
+### S5 Minor: test fixture uses stale "anonymous" string — RESOLVED
+- Action: Renamed test "dead-letters non-UUID userId without tenantId" → "dead-letters UUID userId when user lookup returns null", and changed fixture from `userId: "anonymous"` to a real UUID string. Test now matches the current code path (resolveTenantId → user.findUnique returns null → dead-letter).
+- Modified file: src/__tests__/audit-fifo-flusher.test.ts
+
+## Testing Findings
+
+### T1 High: null userId test only verified negatives — RESOLVED
+- Action: Added positive assertion `expect(mockAuditLogCreate).toHaveBeenCalledWith(...)` verifying that prisma.auditLog.create is called with `userId: null, actorType: "SYSTEM", tenantId, action`. Captured `mockAuditLogCreate` via vi.hoisted for direct inspection.
+- Modified file: src/__tests__/audit-fifo-flusher.test.ts
+
+### T2 Medium: null userId + no tenantId dead-letter untested — RESOLVED
+- Action: Added test "dead-letters null userId when tenantId is absent" asserting `tenant_not_found` reason + no direct write.
+- Modified file: src/__tests__/audit-fifo-flusher.test.ts
+
+### T3 Medium: null userId + DB error never-throws untested — RESOLVED
+- Action: Added test "catches direct write failure and logs to dead letter (null userId path)" mocking `auditLog.create` rejection and asserting `resolves.toBeUndefined()` + dead-letter call.
+- Modified file: src/__tests__/audit-fifo-flusher.test.ts
+
+### T4 Info: test name no longer matches code path — RESOLVED (merged with S5)
+- See S5.
+
+### T5 Low: metadata.ip assertion missing — RESOLVED
+- Action: Extended `expect.objectContaining({ anonymousAccess: true })` to also require `ip: expect.any(String)` in both SHARE_ACCESS_VERIFY_FAILED and SUCCESS assertions.
+- Modified file: src/app/api/share-links/verify-access/route.test.ts
+
+### Also added (T1 follow-up): actorType forcing test
+- Action: Added test "forces actorType to SYSTEM when userId is null (even if caller omits it)" verifying F1 invariant in both structured log emit and DB write.
+- Modified file: src/__tests__/audit-fifo-flusher.test.ts
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1-R16: Checked — no issues introduced. R8 (stale magic strings) resolved by F2. R10 (actorType default mismatch) resolved by F1. R14 (stale JSDoc) resolved by F4.
+
+### Security expert
+- R1-R13, RS1-RS3: Checked — no issues. Direct-write path preserves RLS via withBypassRls. No spoofing risk (actorType forced to SYSTEM). Dead-letter sanitization intact.
+
+### Testing expert
+- R1-R16, RT1-RT3: Checked. RT1 (mock-reality divergence) resolved by T1 fix. RT2 (positive assertion coverage) resolved by T1/T2/T3 additions.
+
+## Resolution Status
+
+All Major and Critical findings resolved. One Minor (F3) accepted with documented Anti-Deferral justification (latent, no current caller, cost-benefit unfavorable for preemptive fix).
+
+Verification:
+- 563 test files / 7120 tests pass (+3 new tests)
+- Production build succeeds
+- No residual non-UUID userId strings in production code

--- a/scripts/manual-tests/README.md
+++ b/scripts/manual-tests/README.md
@@ -1,0 +1,33 @@
+# Manual Test Scripts
+
+End-to-end verification scripts for features that are hard to cover with unit
+or integration tests alone. Each script:
+
+- Sets up a minimal fixture in the running dev DB (bypassing RLS)
+- Calls the actual HTTP API on the running dev server
+- Inspects DB state to verify expected side effects
+- Cleans up the fixture on exit
+
+These are **not** run by CI. They are one-shot verification tools for
+reviewers to confirm behavior against a live stack.
+
+## Prerequisites
+
+- Dev server running at `https://localhost:3001/passwd-sso` (`npm run dev`)
+- PostgreSQL container running (`docker compose up -d db`)
+- `.env.local` populated with `DATABASE_URL`, `VERIFIER_PEPPER_KEY`,
+  `VAULT_MASTER_KEY_*`
+- At least one `PasswordEntry` row exists in the DB
+
+## How to run
+
+```bash
+DOTENV_CONFIG_PATH=.env.local npx tsx -r dotenv/config \
+  scripts/manual-tests/<script-name>.ts
+```
+
+## Scripts
+
+| Script | Verifies |
+|--------|----------|
+| `share-access-audit.ts` | Anonymous share-link access writes `audit_logs` directly (userId=NULL, actor_type=SYSTEM) and does **not** enter the outbox |

--- a/scripts/manual-tests/README.md
+++ b/scripts/manual-tests/README.md
@@ -31,3 +31,10 @@ DOTENV_CONFIG_PATH=.env.local npx tsx -r dotenv/config \
 | Script | Verifies |
 |--------|----------|
 | `share-access-audit.ts` | Anonymous share-link access writes `audit_logs` directly (userId=NULL, actor_type=SYSTEM) and does **not** enter the outbox |
+| `test-delivery-targets.sh` | Audit delivery target CRUD — grabs an active session token from the DB and exercises the `/api/tenant/audit-delivery-targets` endpoints |
+
+### `test-delivery-targets.sh` — additional prerequisites
+
+- At least one active session in the DB (log in via the UI first)
+- `.env.local` `AUTH_URL` set (used as `Origin` for CSRF check)
+- Run with `bash scripts/manual-tests/test-delivery-targets.sh`

--- a/scripts/manual-tests/share-access-audit.ts
+++ b/scripts/manual-tests/share-access-audit.ts
@@ -1,0 +1,161 @@
+/* eslint-disable no-console */
+/**
+ * Manual test: share-links/verify-access audit logging for anonymous access.
+ *
+ * Verifies that SHARE_ACCESS_VERIFY_FAILED / SHARE_ACCESS_VERIFY_SUCCESS
+ * events write directly to audit_logs (user_id=NULL, actor_type=SYSTEM)
+ * and do NOT enter the audit_outbox queue.
+ *
+ * See scripts/manual-tests/README.md for usage.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+import { hashToken, hashAccessPassword, encryptShareData } from "@/lib/crypto-server";
+import { randomBytes } from "node:crypto";
+
+async function main() {
+  const entry = await withBypassRls(prisma, () =>
+    prisma.passwordEntry.findFirst({
+      select: { id: true, userId: true, tenantId: true },
+      where: { deletedAt: null },
+    }),
+  BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+  if (!entry) {
+    console.error("No password entry found. Create one via UI first.");
+    process.exit(1);
+  }
+
+  const tokenPlain = randomBytes(32).toString("hex");
+  const tokenHash = hashToken(tokenPlain);
+  const accessPw = "test-password-12345";
+  const accessPwHash = hashAccessPassword(accessPw);
+
+  const enc = encryptShareData(JSON.stringify({ note: "audit-test" }));
+  const share = await withBypassRls(prisma, () =>
+    prisma.passwordShare.create({
+      data: {
+        tokenHash,
+        accessPasswordHash: accessPwHash,
+        tenantId: entry.tenantId,
+        createdById: entry.userId,
+        passwordEntryId: entry.id,
+        encryptedData: enc.ciphertext,
+        dataIv: enc.iv,
+        dataAuthTag: enc.authTag,
+        masterKeyVersion: enc.masterKeyVersion,
+        expiresAt: new Date(Date.now() + 60_000),
+        maxViews: 100,
+        viewCount: 0,
+      },
+    }),
+  BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+  console.log(`Created test share id=${share.id} (tenant=${entry.tenantId})`);
+
+  const baseUrl = "https://localhost:3001/passwd-sso/api/share-links/verify-access";
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+  const r1 = await fetch(baseUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token: tokenPlain, password: "wrong-password" }),
+  });
+  console.log(`\n[TEST 1] wrong password → HTTP ${r1.status}`);
+  console.log(`  body: ${(await r1.text()).slice(0, 200)}`);
+
+  const r2 = await fetch(baseUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token: tokenPlain, password: accessPw }),
+  });
+  console.log(`\n[TEST 2] correct password → HTTP ${r2.status}`);
+  console.log(`  body: ${(await r2.text()).slice(0, 200)}`);
+
+  await new Promise((r) => setTimeout(r, 500));
+
+  const logs = await withBypassRls(prisma, () =>
+    prisma.$queryRaw<
+      Array<{
+        action: string;
+        user_id: string | null;
+        actor_type: string;
+        anon: string | null;
+        ip: string | null;
+        outbox_id: string | null;
+        created_at: Date;
+      }>
+    >`
+      SELECT action, user_id, actor_type,
+             metadata->>'anonymousAccess' AS anon,
+             metadata->>'ip' AS ip,
+             outbox_id,
+             created_at
+      FROM audit_logs
+      WHERE tenant_id = ${entry.tenantId}::uuid
+        AND action IN ('SHARE_ACCESS_VERIFY_FAILED', 'SHARE_ACCESS_VERIFY_SUCCESS')
+        AND target_id = ${share.id}
+      ORDER BY created_at DESC
+      LIMIT 5
+    `,
+  BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+  console.log(`\n[AUDIT LOGS]`);
+  console.table(logs);
+
+  const outbox = await withBypassRls(prisma, () =>
+    prisma.$queryRaw<
+      Array<{ status: string; action: string; user_id: string | null; actor_type: string; created_at: Date }>
+    >`
+      SELECT status, payload->>'action' AS action,
+             payload->>'userId' AS user_id,
+             payload->>'actorType' AS actor_type,
+             created_at
+      FROM audit_outbox
+      WHERE tenant_id = ${entry.tenantId}::uuid
+        AND payload->>'action' IN ('SHARE_ACCESS_VERIFY_FAILED', 'SHARE_ACCESS_VERIFY_SUCCESS')
+        AND payload->>'targetId' = ${share.id}
+      ORDER BY created_at DESC
+      LIMIT 5
+    `,
+  BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+  console.log(`\n[OUTBOX (should be EMPTY — null userId bypasses outbox)]`);
+  console.table(outbox);
+
+  await withBypassRls(prisma, () =>
+    prisma.passwordShare.delete({ where: { id: share.id } }),
+  BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+  console.log(`\nCleaned up test share ${share.id}`);
+
+  const failedRow = logs.find((r) => r.action === "SHARE_ACCESS_VERIFY_FAILED");
+  const successRow = logs.find((r) => r.action === "SHARE_ACCESS_VERIFY_SUCCESS");
+  let ok = true;
+  const check = (cond: boolean, msg: string) => {
+    console.log(`  ${cond ? "✓" : "✗"} ${msg}`);
+    if (!cond) ok = false;
+  };
+  console.log(`\n[VERIFICATION]`);
+  check(r1.status === 403, "wrong password returns 403");
+  check(r2.status === 200, "correct password returns 200");
+  check(failedRow != null, "SHARE_ACCESS_VERIFY_FAILED row exists");
+  check(successRow != null, "SHARE_ACCESS_VERIFY_SUCCESS row exists");
+  if (failedRow) {
+    check(failedRow.user_id === null, "FAILED row: user_id IS NULL");
+    check(failedRow.actor_type === "SYSTEM", "FAILED row: actor_type = SYSTEM");
+    check(failedRow.anon === "true", "FAILED row: metadata.anonymousAccess = true");
+    check(failedRow.outbox_id === null, "FAILED row: outbox_id IS NULL (direct write)");
+  }
+  if (successRow) {
+    check(successRow.user_id === null, "SUCCESS row: user_id IS NULL");
+    check(successRow.actor_type === "SYSTEM", "SUCCESS row: actor_type = SYSTEM");
+    check(successRow.anon === "true", "SUCCESS row: metadata.anonymousAccess = true");
+    check(successRow.outbox_id === null, "SUCCESS row: outbox_id IS NULL (direct write)");
+  }
+  check(outbox.length === 0, "No rows in audit_outbox for these actions");
+
+  console.log(`\n${ok ? "✓ All checks passed" : "✗ Some checks FAILED"}`);
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/manual-tests/test-delivery-targets.sh
+++ b/scripts/manual-tests/test-delivery-targets.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Manual test script for audit delivery target CRUD
-# Usage: bash scripts/test-delivery-targets.sh
+# Usage: bash scripts/manual-tests/test-delivery-targets.sh
 set -euo pipefail
 
 BASE="https://localhost:3001/passwd-sso"

--- a/scripts/manual-tests/test-delivery-targets.sh
+++ b/scripts/manual-tests/test-delivery-targets.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Manual test script for audit delivery target CRUD
+# Usage: bash scripts/test-delivery-targets.sh
+set -euo pipefail
+
+BASE="https://localhost:3001/passwd-sso"
+
+# Get session token from DB
+TOKEN=$(docker compose -f docker-compose.yml exec -T db \
+  psql -U passwd_user -d passwd_sso -tA \
+  -c "SELECT session_token FROM sessions WHERE expires > NOW() ORDER BY expires DESC LIMIT 1;" | tr -d '\r\n')
+# HTTPS uses __Secure- prefix; plain HTTP uses authjs.session-token
+COOKIE="__Secure-authjs.session-token=$TOKEN"
+
+# Derive origin from AUTH_URL (CSRF check compares against APP_URL/AUTH_URL)
+ORIGIN=$(grep -m1 "^AUTH_URL=" .env.local | cut -d= -f2- | tr -d '\r\n')
+: "${ORIGIN:=https://localhost:3001}"
+api() {
+  local method=$1 path=$2; shift 2
+  curl -sk -X "$method" "$BASE$path" \
+    -H "Content-Type: application/json" \
+    -H "Origin: $ORIGIN" \
+    -H "X-Forwarded-Proto: https" \
+    -b "$COOKIE" "$@"
+}
+
+pass() { printf "\033[32m  ✓ %s\033[0m\n" "$1"; }
+fail() { printf "\033[31m  ✗ %s\033[0m\n" "$1"; FAILED=1; }
+
+FAILED=0
+echo "=== Audit Delivery Target CRUD Tests ==="
+
+# ── 1. SSRF rejection ────────────────────────────────────
+echo ""
+echo "▸ SSRF: private IP (192.168.1.1)"
+STATUS=$(api POST /api/tenant/audit-delivery-targets \
+  -d '{"kind":"WEBHOOK","url":"https://192.168.1.1/hook","secret":"test123"}' \
+  -o /dev/null -w "%{http_code}")
+[ "$STATUS" = "400" ] && pass "Rejected with 400" || fail "Expected 400, got $STATUS"
+
+echo "▸ SSRF: HTTP (not HTTPS)"
+STATUS=$(api POST /api/tenant/audit-delivery-targets \
+  -d '{"kind":"WEBHOOK","url":"http://example.com/hook","secret":"test123"}' \
+  -o /dev/null -w "%{http_code}")
+[ "$STATUS" = "400" ] && pass "Rejected with 400" || fail "Expected 400, got $STATUS"
+
+# ── 2. Deactivate / Reactivate (BEFORE limit test, outbox is quiet) ──
+FIRST_ID=$(api GET /api/tenant/audit-delivery-targets | python3 -c "
+import sys,json
+targets = json.load(sys.stdin).get('targets',[])
+active = [t for t in targets if t['isActive']]
+print(active[0]['id'] if active else '')
+" 2>/dev/null || echo "")
+
+if [ -n "$FIRST_ID" ]; then
+  echo ""
+  echo "▸ Deactivate target $FIRST_ID"
+  BODY=$(api PATCH "/api/tenant/audit-delivery-targets/$FIRST_ID" -d '{"isActive":false}')
+  IS_ACTIVE=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('target',{}).get('isActive',''))" 2>/dev/null)
+  [ "$IS_ACTIVE" = "False" ] && pass "Deactivated (isActive=false)" || fail "Expected isActive=false, got $IS_ACTIVE"
+
+  # Wait for outbox worker to drain (1s poll interval + processing)
+  sleep 5
+  DEACT_LOG=$(docker compose -f docker-compose.yml exec -T db \
+    psql -U passwd_user -d passwd_sso -tA \
+    -c "SELECT count(*) FROM audit_logs WHERE action::text='AUDIT_DELIVERY_TARGET_DEACTIVATE' AND metadata->>'targetId'='$FIRST_ID';" | tr -d '\r\n ')
+  [ "$DEACT_LOG" -ge 1 ] && pass "DEACTIVATE audit log recorded" || fail "No DEACTIVATE audit log found"
+
+  echo ""
+  echo "▸ Reactivate target $FIRST_ID"
+  BODY=$(api PATCH "/api/tenant/audit-delivery-targets/$FIRST_ID" -d '{"isActive":true}')
+  IS_ACTIVE=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('target',{}).get('isActive',''))" 2>/dev/null)
+  [ "$IS_ACTIVE" = "True" ] && pass "Reactivated (isActive=true)" || fail "Expected isActive=true, got $IS_ACTIVE"
+
+  sleep 5
+  REACT_LOG=$(docker compose -f docker-compose.yml exec -T db \
+    psql -U passwd_user -d passwd_sso -tA \
+    -c "SELECT count(*) FROM audit_logs WHERE action::text='AUDIT_DELIVERY_TARGET_REACTIVATE' AND metadata->>'targetId'='$FIRST_ID';" | tr -d '\r\n ')
+  [ "$REACT_LOG" -ge 1 ] && pass "REACTIVATE audit log recorded" || fail "No REACTIVATE audit log found"
+else
+  fail "No active target found to test deactivate/reactivate"
+fi
+
+# ── 3. Limit test (creates many targets → outbox flood, do this last) ──
+CURRENT_COUNT=$(api GET /api/tenant/audit-delivery-targets | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('targets',[])))" 2>/dev/null || echo 0)
+echo ""
+echo "▸ Current target count: $CURRENT_COUNT"
+
+CREATED_IDS=()
+NEED=$((10 - CURRENT_COUNT))
+if [ "$NEED" -gt 0 ]; then
+  echo "▸ Creating $NEED targets to reach limit..."
+  for i in $(seq 1 "$NEED"); do
+    BODY=$(api POST /api/tenant/audit-delivery-targets \
+      -d "{\"kind\":\"WEBHOOK\",\"url\":\"https://limit-test-$i.example.com/hook\",\"secret\":\"secret$i\"}")
+    TID=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('target',{}).get('id',''))" 2>/dev/null || echo "")
+    [ -n "$TID" ] && CREATED_IDS+=("$TID")
+  done
+fi
+
+echo ""
+echo "▸ Limit test: creating 11th target"
+STATUS=$(api POST /api/tenant/audit-delivery-targets \
+  -d '{"kind":"WEBHOOK","url":"https://overflow.example.com/hook","secret":"overflow"}' \
+  -o /dev/null -w "%{http_code}")
+[ "$STATUS" = "400" ] && pass "Rejected with 400 (limit reached)" || fail "Expected 400, got $STATUS"
+
+# Cleanup: deactivate test targets we created for limit test
+if [ ${#CREATED_IDS[@]} -gt 0 ]; then
+  echo ""
+  echo "▸ Cleaning up ${#CREATED_IDS[@]} limit-test targets..."
+  for TID in "${CREATED_IDS[@]}"; do
+    api PATCH "/api/tenant/audit-delivery-targets/$TID" -d '{"isActive":false}' >/dev/null 2>&1
+  done
+  pass "Cleanup done"
+fi
+
+echo ""
+echo "=== Results ==="
+[ "$FAILED" = "0" ] && echo -e "\033[32m✓ All manual tests passed\033[0m" || echo -e "\033[31m✗ Some tests failed\033[0m"
+exit "$FAILED"

--- a/src/__tests__/audit-fifo-flusher.test.ts
+++ b/src/__tests__/audit-fifo-flusher.test.ts
@@ -77,6 +77,22 @@ describe("logAuditAsync", () => {
     );
   });
 
+  it("bypasses outbox and writes directly for null userId (SYSTEM actor)", async () => {
+    await logAuditAsync({
+      scope: AUDIT_SCOPE.PERSONAL,
+      action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_SUCCESS,
+      userId: null,
+      actorType: "SYSTEM",
+      tenantId: "tenant-1",
+      metadata: { anonymousAccess: true },
+    });
+
+    // null userId must NOT enter the outbox — worker rejects it
+    expect(mockEnqueueAudit).not.toHaveBeenCalled();
+    // null userId must NOT trigger user lookup
+    expect(mockUserFindUnique).not.toHaveBeenCalled();
+  });
+
   it("resolves tenantId from userId when not provided", async () => {
     mockUserFindUnique.mockResolvedValue({
       id: "00000000-0000-4000-8000-000000000042",
@@ -138,7 +154,7 @@ describe("logAuditAsync", () => {
     );
   });
 
-  it("dead-letters non-UUID userId without tenantId", async () => {
+  it("dead-letters non-UUID userId without tenantId (tenant_not_found)", async () => {
     await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.AUTH_LOGIN,
@@ -147,7 +163,7 @@ describe("logAuditAsync", () => {
 
     expect(mockEnqueueAudit).not.toHaveBeenCalled();
     expect(mockDeadLetterWarn).toHaveBeenCalledWith(
-      expect.objectContaining({ reason: "non_uuid_userId_no_tenantId" }),
+      expect.objectContaining({ reason: "tenant_not_found" }),
       "audit.dead_letter",
     );
   });

--- a/src/__tests__/audit-fifo-flusher.test.ts
+++ b/src/__tests__/audit-fifo-flusher.test.ts
@@ -6,11 +6,13 @@ const {
   mockDeadLetterWarn,
   mockUserFindUnique,
   mockTeamFindUnique,
+  mockAuditLogCreate,
 } = vi.hoisted(() => ({
   mockEnqueueAudit: vi.fn().mockResolvedValue(undefined),
   mockDeadLetterWarn: vi.fn(),
   mockUserFindUnique: vi.fn(),
   mockTeamFindUnique: vi.fn(),
+  mockAuditLogCreate: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/lib/audit-outbox", () => ({
@@ -22,7 +24,7 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     team: { findUnique: mockTeamFindUnique },
     user: { findUnique: mockUserFindUnique },
-    auditLog: { create: vi.fn().mockResolvedValue(undefined) },
+    auditLog: { create: mockAuditLogCreate },
   },
 }));
 
@@ -91,6 +93,78 @@ describe("logAuditAsync", () => {
     expect(mockEnqueueAudit).not.toHaveBeenCalled();
     // null userId must NOT trigger user lookup
     expect(mockUserFindUnique).not.toHaveBeenCalled();
+    // Direct write MUST happen with SYSTEM actor + null userId
+    expect(mockAuditLogCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: null,
+          actorType: "SYSTEM",
+          tenantId: "tenant-1",
+          action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_SUCCESS,
+        }),
+      }),
+    );
+  });
+
+  it("forces actorType to SYSTEM when userId is null (even if caller omits it)", async () => {
+    await logAuditAsync({
+      scope: AUDIT_SCOPE.PERSONAL,
+      action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_FAILED,
+      userId: null,
+      // actorType intentionally omitted — buildOutboxPayload must force SYSTEM
+      tenantId: "tenant-1",
+    });
+
+    // Structured emit must also use SYSTEM (not HUMAN default)
+    expect(mockAuditInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: expect.objectContaining({ userId: null, actorType: "SYSTEM" }),
+      }),
+      expect.any(String),
+    );
+    // DB write must also use SYSTEM
+    expect(mockAuditLogCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId: null, actorType: "SYSTEM" }),
+      }),
+    );
+  });
+
+  it("dead-letters null userId when tenantId is absent", async () => {
+    await logAuditAsync({
+      scope: AUDIT_SCOPE.PERSONAL,
+      action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_FAILED,
+      userId: null,
+      // tenantId omitted
+    });
+
+    expect(mockAuditLogCreate).not.toHaveBeenCalled();
+    expect(mockEnqueueAudit).not.toHaveBeenCalled();
+    expect(mockDeadLetterWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "tenant_not_found" }),
+      "audit.dead_letter",
+    );
+  });
+
+  it("catches direct write failure and logs to dead letter (null userId path)", async () => {
+    mockAuditLogCreate.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(
+      logAuditAsync({
+        scope: AUDIT_SCOPE.PERSONAL,
+        action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_FAILED,
+        userId: null,
+        tenantId: "tenant-1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockDeadLetterWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "logAuditAsync_failed",
+        error: expect.stringContaining("db down"),
+      }),
+      "audit.dead_letter",
+    );
   });
 
   it("resolves tenantId from userId when not provided", async () => {
@@ -154,11 +228,14 @@ describe("logAuditAsync", () => {
     );
   });
 
-  it("dead-letters non-UUID userId without tenantId (tenant_not_found)", async () => {
+  it("dead-letters UUID userId when user lookup returns null (tenant_not_found)", async () => {
+    // UUID userId that doesn't exist in DB — resolveTenantId returns null
+    mockUserFindUnique.mockResolvedValue(null);
+
     await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.AUTH_LOGIN,
-      userId: "anonymous",
+      userId: "00000000-0000-4000-8000-00000000ffff",
     });
 
     expect(mockEnqueueAudit).not.toHaveBeenCalled();

--- a/src/app/api/mcp/token/route.ts
+++ b/src/app/api/mcp/token/route.ts
@@ -135,7 +135,7 @@ export async function POST(req: NextRequest) {
     await logAuditAsync({
       scope: AUDIT_SCOPE.TENANT,
       action: AUDIT_ACTION.MCP_REFRESH_TOKEN_ROTATE,
-      userId: result.userId ?? "system",
+      userId: result.userId ?? null,
       tenantId: result.tenantId,
       metadata: { clientId: clientIdValue },
     });

--- a/src/app/api/share-links/verify-access/route.test.ts
+++ b/src/app/api/share-links/verify-access/route.test.ts
@@ -229,7 +229,10 @@ describe("POST /api/share-links/verify-access", () => {
         tenantId: "tenant-1",
         userId: null,
         actorType: "SYSTEM",
-        metadata: expect.objectContaining({ anonymousAccess: true }),
+        metadata: expect.objectContaining({
+          anonymousAccess: true,
+          ip: expect.any(String),
+        }),
       }),
     );
   });
@@ -250,7 +253,10 @@ describe("POST /api/share-links/verify-access", () => {
         tenantId: "tenant-1",
         userId: null,
         actorType: "SYSTEM",
-        metadata: expect.objectContaining({ anonymousAccess: true }),
+        metadata: expect.objectContaining({
+          anonymousAccess: true,
+          ip: expect.any(String),
+        }),
       }),
     );
   });

--- a/src/app/api/share-links/verify-access/route.test.ts
+++ b/src/app/api/share-links/verify-access/route.test.ts
@@ -224,7 +224,13 @@ describe("POST /api/share-links/verify-access", () => {
     const { status } = await parseResponse(res);
     expect(status).toBe(403);
     expect(mockLogAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ action: "SHARE_ACCESS_VERIFY_FAILED", tenantId: "tenant-1" }),
+      expect.objectContaining({
+        action: "SHARE_ACCESS_VERIFY_FAILED",
+        tenantId: "tenant-1",
+        userId: null,
+        actorType: "SYSTEM",
+        metadata: expect.objectContaining({ anonymousAccess: true }),
+      }),
     );
   });
 
@@ -239,7 +245,13 @@ describe("POST /api/share-links/verify-access", () => {
     expect(json.accessToken).toBe("access-token-xyz");
     expect(mockCreateShareAccessToken).toHaveBeenCalledWith("share-1");
     expect(mockLogAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ action: "SHARE_ACCESS_VERIFY_SUCCESS", tenantId: "tenant-1" }),
+      expect.objectContaining({
+        action: "SHARE_ACCESS_VERIFY_SUCCESS",
+        tenantId: "tenant-1",
+        userId: null,
+        actorType: "SYSTEM",
+        metadata: expect.objectContaining({ anonymousAccess: true }),
+      }),
     );
   });
 

--- a/src/app/api/share-links/verify-access/route.ts
+++ b/src/app/api/share-links/verify-access/route.ts
@@ -11,6 +11,7 @@ import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, rateLimited, notFound } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
 import { AUDIT_TARGET_TYPE, AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
+import { ACTOR_TYPE } from "@/lib/constants/audit";
 import { withRequestLog } from "@/lib/with-request-log";
 
 const ipLimiter = createRateLimiter({ windowMs: 60_000, max: 5 });
@@ -69,32 +70,30 @@ async function handlePOST(req: NextRequest) {
   }
 
   if (!verifyAccessPassword(password, share.accessPasswordHash)) {
-    // Non-atomic audit: userId="anonymous" is not a valid UUID,
-    // so this cannot use logAuditInTx (worker INSERT would fail on ::uuid cast).
-    // Falls through the FIFO flusher path where tenantId is already resolved.
     await logAuditAsync({
       scope: AUDIT_SCOPE.PERSONAL,
       action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_FAILED,
-      userId: "anonymous",
+      userId: null,
+      actorType: ACTOR_TYPE.SYSTEM,
       tenantId: share.tenantId,
       targetType: AUDIT_TARGET_TYPE.PASSWORD_SHARE,
       targetId: share.id,
-      metadata: { ip },
+      metadata: { ip, anonymousAccess: true },
       ...reqMeta,
     });
 
     return errorResponse(API_ERROR.SHARE_PASSWORD_INCORRECT, 403);
   }
 
-  // Non-atomic audit: same userId="anonymous" limitation as above.
   await logAuditAsync({
     scope: AUDIT_SCOPE.PERSONAL,
     action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_SUCCESS,
-    userId: "anonymous",
+    userId: null,
+    actorType: ACTOR_TYPE.SYSTEM,
     tenantId: share.tenantId,
     targetType: AUDIT_TARGET_TYPE.PASSWORD_SHARE,
     targetId: share.id,
-    metadata: { ip },
+    metadata: { ip, anonymousAccess: true },
     ...reqMeta,
   });
 

--- a/src/lib/access-restriction.ts
+++ b/src/lib/access-restriction.ts
@@ -156,7 +156,7 @@ export async function checkAccessRestrictionWithAudit(
     await logAuditAsync({
       action: AUDIT_ACTION.ACCESS_DENIED,
       scope: AUDIT_SCOPE.TENANT,
-      userId: userId ?? "unknown",
+      userId: userId ?? null,
       tenantId,
       ip: clientIp,
       userAgent: req.headers.get("user-agent"),

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,8 +1,13 @@
 /**
  * Server-side audit logging helpers.
  *
- * logAuditAsync() writes audit events to the outbox. Awaitable, never throws.
- * Dual-write: PostgreSQL AuditLog table (via outbox) + structured JSON to stdout (via pino).
+ * logAuditAsync() writes audit events. Awaitable, never throws.
+ * Routing:
+ *   - userId = UUID → outbox (enqueueAudit) → worker → audit_logs (participates in chain, SIEM fan-out)
+ *   - userId = null → direct write to audit_logs with actorType=SYSTEM (bypasses outbox).
+ *     This path is for events without a user context (e.g. anonymous share-access).
+ *     By design: no chain entry, no SIEM/webhook fan-out (matches worker-emitted meta-events).
+ * Dual-write: PostgreSQL audit_logs + structured JSON to stdout (via pino).
  * extractRequestMeta() extracts IP and User-Agent from NextRequest headers.
  */
 
@@ -93,11 +98,17 @@ export function sanitizeMetadata(value: unknown): unknown {
 export function buildOutboxPayload(params: AuditLogParams): AuditOutboxPayload {
   const safeMetadata = truncateMetadata(params.metadata);
   const sanitized = sanitizeMetadata(safeMetadata) as Record<string, unknown> | null | undefined;
+  // Enforce CHECK constraint invariant: userId IS NULL requires actorType = SYSTEM.
+  // This keeps the structured JSON emit and the DB write consistent regardless of
+  // what the caller passed for actorType.
+  const actorType = params.userId === null
+    ? ACTOR_TYPE.SYSTEM
+    : (params.actorType ?? ACTOR_TYPE.HUMAN);
   return {
     scope: params.scope,
     action: params.action,
     userId: params.userId,
-    actorType: params.actorType ?? ACTOR_TYPE.HUMAN,
+    actorType,
     serviceAccountId: params.serviceAccountId ?? null,
     teamId: params.teamId ?? null,
     targetType: params.targetType ?? null,
@@ -223,7 +234,7 @@ export async function logAuditAsync(params: AuditLogParams): Promise<void> {
             scope: payload.scope,
             action: payload.action,
             userId: null,
-            actorType: ACTOR_TYPE.SYSTEM,
+            actorType: payload.actorType, // SYSTEM (forced by buildOutboxPayload when userId is null)
             serviceAccountId: payload.serviceAccountId,
             tenantId,
             teamId: payload.teamId,

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -16,7 +16,6 @@ import { auditLogger, METADATA_BLOCKLIST, deadLetterLogger } from "@/lib/audit-l
 import { safeRecord } from "@/lib/safe-keys";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { extractClientIp } from "@/lib/ip-access";
-import { getLogger } from "@/lib/logger";
 import { ACTOR_TYPE } from "@/lib/constants/audit";
 import type { AuditAction, AuditScope, ActorType, Prisma } from "@prisma/client";
 import type { NextRequest } from "next/server";

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -35,7 +35,7 @@ import { UUID_RE } from "@/lib/constants/app";
 export interface AuditLogParams {
   scope: AuditScope;
   action: AuditAction;
-  userId: string;
+  userId: string | null;
   actorType?: ActorType;
   serviceAccountId?: string | null;
   tenantId?: string;
@@ -126,7 +126,7 @@ async function resolveTenantId(params: AuditLogParams): Promise<string | null> {
       return team?.tenantId ?? null;
     }
 
-    if (UUID_RE.test(params.userId)) {
+    if (params.userId && UUID_RE.test(params.userId)) {
       const user = await prisma.user.findUnique({
         where: { id: params.userId },
         select: { tenantId: true },
@@ -201,40 +201,44 @@ export async function logAuditAsync(params: AuditLogParams): Promise<void> {
     // Never let forwarding break the app
   }
 
-  // Outbox enqueue — all errors caught (MF2: never throws)
+  // All errors caught (MF2: never throws)
   try {
-    // Non-UUID userId (e.g., "anonymous") bypasses the outbox
-    if (!UUID_RE.test(params.userId)) {
+    // SYSTEM-actor / null userId events bypass the outbox and write directly.
+    // Rationale: the outbox worker rejects null userId payloads (that path is
+    // reserved for worker-emitted meta-events via writeDirectAuditLog). Events
+    // without a user context (anonymous access, etc.) must write directly
+    // with user_id=NULL + actor_type=SYSTEM (allowed by audit_logs CHECK).
+    if (params.userId === null) {
       const tenantId = params.tenantId ?? null;
       if (!tenantId) {
         deadLetterLogger.warn(
-          deadLetterEntry(params, "non_uuid_userId_no_tenantId"),
+          deadLetterEntry(params, "tenant_not_found"),
           "audit.dead_letter",
         );
         return;
       }
-      try {
-        await withBypassRls(prisma, async () => {
-          await prisma.auditLog.create({
-            data: {
-              scope: payload.scope, action: payload.action, userId: payload.userId!,
-              actorType: payload.actorType, serviceAccountId: payload.serviceAccountId,
-              tenantId, teamId: payload.teamId, targetType: payload.targetType,
-              targetId: payload.targetId,
-              metadata: (payload.metadata as Prisma.InputJsonValue) ?? undefined,
-              ip: payload.ip, userAgent: payload.userAgent,
-            },
-          });
-        }, BYPASS_PURPOSE.AUDIT_WRITE);
-      } catch (err) {
-        deadLetterLogger.warn(
-          deadLetterEntry(params, "non_uuid_direct_write_failed", String(err)),
-          "audit.dead_letter",
-        );
-      }
+      await withBypassRls(prisma, async () => {
+        await prisma.auditLog.create({
+          data: {
+            scope: payload.scope,
+            action: payload.action,
+            userId: null,
+            actorType: ACTOR_TYPE.SYSTEM,
+            serviceAccountId: payload.serviceAccountId,
+            tenantId,
+            teamId: payload.teamId,
+            targetType: payload.targetType,
+            targetId: payload.targetId,
+            metadata: (payload.metadata as Prisma.InputJsonValue) ?? undefined,
+            ip: payload.ip,
+            userAgent: payload.userAgent,
+          },
+        });
+      }, BYPASS_PURPOSE.AUDIT_WRITE);
       return;
     }
 
+    // Normal path: UUID userId → outbox
     const tenantId = await resolveTenantId(params);
     if (!tenantId) {
       deadLetterLogger.warn(

--- a/src/lib/directory-sync/engine.ts
+++ b/src/lib/directory-sync/engine.ts
@@ -202,7 +202,7 @@ export async function runDirectorySync(
       await logAuditAsync({
         scope: AUDIT_SCOPE.TENANT,
         action: AUDIT_ACTION.DIRECTORY_SYNC_STALE_RESET,
-        userId: actorUserId ?? "system",
+        userId: actorUserId ?? null,
         tenantId,
         targetType: AUDIT_TARGET_TYPE.DIRECTORY_SYNC_CONFIG,
         targetId: configId,

--- a/src/lib/team-policy.ts
+++ b/src/lib/team-policy.ts
@@ -201,7 +201,7 @@ export async function checkTeamAccessRestriction(teamId: string, clientIp: strin
   await logAuditAsync({
     action: AUDIT_ACTION.ACCESS_DENIED,
     scope: AUDIT_SCOPE.TEAM,
-    userId: userId ?? "unknown",
+    userId: userId ?? null,
     teamId,
     ip: clientIp,
     metadata: { clientIp, reason: "IP not in team allowed CIDRs" },


### PR DESCRIPTION
## Summary

- Complete the "audit path unification" follow-up flagged by the external security assessment: replace the legacy `userId: "anonymous" / "system" / "unknown"` sentinel strings with type-safe `userId: null + actorType: SYSTEM`.
- `logAuditAsync` now has a dedicated direct-write branch for null userId (bypasses the outbox, satisfies the existing `audit_logs` CHECK constraint `(actor_type = 'SYSTEM' AND user_id IS NULL) OR (user_id IS NOT NULL)`).
- Fixes 4 pre-existing latent callers that were enqueuing non-UUID strings to the outbox (would fail at worker `::uuid` cast and accumulate retries until dead-lettered).
- No DB schema change. No change to the outbox worker.

## Changes

### Core audit routing (`src/lib/audit.ts`)
- `AuditLogParams.userId: string → string | null`
- `buildOutboxPayload`: forces `actorType = SYSTEM` when `userId === null`, keeping structured JSON emit and DB row consistent
- `logAuditAsync`: added null-userId branch that writes directly to `audit_logs` (`withBypassRls` + `ACTOR_TYPE.SYSTEM`)
- `resolveTenantId`: guards null userId before `UUID_RE.test`
- Updated JSDoc to document both routing paths and design trade-offs (no chain, no SIEM fan-out for null path)

### Callers migrated to null userId
- `src/app/api/share-links/verify-access/route.ts` — `"anonymous"` → `null` (+ `metadata.anonymousAccess: true`)
- `src/app/api/mcp/token/route.ts` — `result.userId ?? "system"` → `?? null`
- `src/lib/directory-sync/engine.ts` — `actorUserId ?? "system"` → `?? null`
- `src/lib/access-restriction.ts` — `userId ?? "unknown"` → `?? null`
- `src/lib/team-policy.ts` — same

### Tests
- `audit-fifo-flusher.test.ts`: +4 tests covering null userId direct-write, actorType enforcement, tenant_not_found dead-letter, never-throws on DB error
- `share-links/verify-access/route.test.ts`: strengthened assertions to check `userId=null, actorType=SYSTEM, metadata.{ip, anonymousAccess}`
- `scripts/manual-tests/share-access-audit.ts`: new end-to-end verification script (creates test share → hits API → inspects audit_logs & audit_outbox → cleans up). 13/13 checks pass on live dev stack.

## Test plan

- [x] `npm run pre-pr` — all 9 static/lint/test/build checks pass
- [x] Unit tests: 563 test files / 7120 tests pass (+4 new)
- [x] Production build succeeds
- [x] Manual E2E: ran `scripts/manual-tests/share-access-audit.ts` — verified on live stack that:
  - Wrong password → 403 + `SHARE_ACCESS_VERIFY_FAILED` row with `user_id=NULL, actor_type=SYSTEM, metadata.anonymousAccess=true, outbox_id=NULL`
  - Correct password → 200 + `SHARE_ACCESS_VERIFY_SUCCESS` row with same shape
  - `audit_outbox` contains NO rows for these actions (confirmed bypass)
- [x] Code review: 12 findings raised, 11 resolved, 1 accepted with documented Anti-Deferral justification. See `docs/archive/review/unify-audit-outbox-path-code-review.md`.

## Notes

- **SIEM/webhook fan-out**: null-userId events do NOT flow through `audit_delivery` (no `outboxId`). Intentional, matches worker meta-events. Documented in `src/lib/audit.ts` header JSDoc.
- **Latent (F3)**: `logAuditInTx` accepts null userId but the outbox worker rejects it. No current caller triggers this. Tracked via `TODO(unify-audit-outbox-path)` marker in the code review log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)