### PR TITLE
fix(docker): upgrade musl to close CVE-2026-40200

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: Install dependencies
 # Pin base image to digest for reproducible builds (update with: docker pull node:20-alpine)
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS deps
-RUN apk add --no-cache libc6-compat && apk upgrade --no-cache zlib libcrypto3 libssl3
+RUN apk add --no-cache libc6-compat && apk upgrade --no-cache zlib libcrypto3 libssl3 musl musl-utils
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts
@@ -9,7 +9,7 @@ RUN npm ci --ignore-scripts
 # Stage 2: Build the application
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS builder
 WORKDIR /app
-RUN apk upgrade --no-cache zlib libcrypto3 libssl3
+RUN apk upgrade --no-cache zlib libcrypto3 libssl3 musl musl-utils
 ARG DATABASE_URL
 ENV DATABASE_URL=$DATABASE_URL
 COPY --from=deps /app/node_modules ./node_modules
@@ -26,7 +26,7 @@ RUN npx esbuild scripts/audit-outbox-worker.ts \
 # Stage 3: Production image
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS runner
 WORKDIR /app
-RUN apk upgrade --no-cache zlib libcrypto3 libssl3
+RUN apk upgrade --no-cache zlib libcrypto3 libssl3 musl musl-utils
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Summary

- Adds `musl` + `musl-utils` to the `apk upgrade` list in all three Dockerfile stages to pull the fixed version (≥ 1.2.5-r23) from the Alpine package mirror at build time.
- Closes **CVE-2026-40200** (HIGH, musl libc — arbitrary code execution / DoS) that appeared on Trivy's CI scan starting today.

## Changes

- `Dockerfile` (3 stages: deps, builder, runner): append `musl musl-utils` to the existing `apk upgrade --no-cache zlib libcrypto3 libssl3` commands

The pinned base image digest (`sha256:b88333c4...`) stays the same — the fix is applied via `apk upgrade` rather than a digest bump to keep the change minimal and consistent with the existing zlib / libcrypto3 / libssl3 upgrade pattern.

## Test plan

- [x] Local `docker build` succeeds with the change
- [x] Local `trivy image --severity CRITICAL,HIGH --ignore-unfixed` on the built image reports **0 CVEs** (was 2 HIGH — both CVE-2026-40200 entries before this change)
- [ ] CI Trivy scan passes (verified post-push)

## Notes

CVE-2026-40200 was published 2026-04-14/15. It was not introduced by any application code change in this repo — the previous PR #374 and #375 passed Trivy scans before today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)