### PR TITLE
fix(security): bump hono to 4.12.14 and remove TLS bypass from manual test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12262,9 +12262,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "overrides": {
     "qs": "6.14.2",
-    "hono": "4.12.12",
+    "hono": "4.12.14",
     "@hono/node-server": "1.19.13",
     "lodash": "4.17.23",
     "cross-spawn": "7.0.6",

--- a/scripts/manual-tests/README.md
+++ b/scripts/manual-tests/README.md
@@ -26,6 +26,15 @@ DOTENV_CONFIG_PATH=.env.local npx tsx -r dotenv/config \
   scripts/manual-tests/<script-name>.ts
 ```
 
+For scripts that target the dev HTTPS endpoint at `https://localhost:3001`
+(self-signed cert), prepend `NODE_TLS_REJECT_UNAUTHORIZED=0`:
+
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED=0 \
+  DOTENV_CONFIG_PATH=.env.local npx tsx -r dotenv/config \
+  scripts/manual-tests/share-access-audit.ts
+```
+
 ## Scripts
 
 | Script | Verifies |

--- a/scripts/manual-tests/share-access-audit.ts
+++ b/scripts/manual-tests/share-access-audit.ts
@@ -67,8 +67,9 @@ async function main() {
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
   console.log(`Created test share id=${share.id} (tenant=${entry.tenantId})`);
 
+  // Local dev uses a self-signed cert. Set NODE_TLS_REJECT_UNAUTHORIZED=0 in
+  // the shell when invoking this script (see scripts/manual-tests/README.md).
   const baseUrl = "https://localhost:3001/passwd-sso/api/share-links/verify-access";
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
   const r1 = await fetch(baseUrl, {
     method: "POST",


### PR DESCRIPTION
## Summary

- **Dependabot alert 87** (GHSA-458j-xx4x-4375): Bump `overrides.hono` from `4.12.12` to `4.12.14` to patch JSX SSR HTML injection. Transitive via `prisma@7.6.0` (`@prisma/dev`) and `shadcn@3.8.4` (`@modelcontextprotocol/sdk`).
  - https://github.com/ngc-shj/passwd-sso/security/dependabot/87
- **Code-scanning alert 121** (`js/disabling-certificate-validation`): Remove `process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"` from `scripts/manual-tests/share-access-audit.ts:71`. Document setting it as a shell env var instead so the local self-signed cert workflow still works.
  - https://github.com/ngc-shj/passwd-sso/security/code-scanning/121

## Test plan

- [x] `npm ls hono` shows `4.12.14` on every path
- [x] `npx vitest run` — 565 files / 7166 tests pass
- [x] `npx next build` — succeeds
- [x] `bash scripts/pre-pr.sh` — all 9 checks pass
- [ ] Confirm CodeQL re-scan no longer flags `share-access-audit.ts`
- [ ] Confirm Dependabot alert auto-closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)