### PR TITLE
chore: remove unused imports flagged by CodeQL

### DIFF
--- a/src/app/api/audit-logs/import/route.ts
+++ b/src/app/api/audit-logs/import/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
 import { z } from "zod/v4";
-import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
 import { AUDIT_ACTION, AUDIT_SCOPE, IMPORT_FORMAT_VALUES } from "@/lib/constants";
 import { requireTeamPermission } from "@/lib/team-auth";

--- a/src/app/api/passwords/route.ts
+++ b/src/app/api/passwords/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit";
 import { createE2EPasswordSchema } from "@/lib/validations";
-import { rateLimited, unauthorized, validationError } from "@/lib/api-response";
+import { rateLimited, validationError } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
 import { checkAuth } from "@/lib/check-auth";
 import { withRequestLog } from "@/lib/with-request-log";

--- a/src/app/api/scim/v2/ResourceTypes/route.ts
+++ b/src/app/api/scim/v2/ResourceTypes/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { scimResponse, scimError } from "@/lib/scim/response";
+import { scimResponse } from "@/lib/scim/response";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { prisma } from "@/lib/prisma";
 import { withRequestLog } from "@/lib/with-request-log";

--- a/src/app/api/scim/v2/Schemas/route.ts
+++ b/src/app/api/scim/v2/Schemas/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { scimResponse, scimError } from "@/lib/scim/response";
+import { scimResponse } from "@/lib/scim/response";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { prisma } from "@/lib/prisma";
 import { withRequestLog } from "@/lib/with-request-log";

--- a/src/app/api/scim/v2/ServiceProviderConfig/route.ts
+++ b/src/app/api/scim/v2/ServiceProviderConfig/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { scimResponse, scimError } from "@/lib/scim/response";
+import { scimResponse } from "@/lib/scim/response";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { prisma } from "@/lib/prisma";
 import { withRequestLog } from "@/lib/with-request-log";

--- a/src/app/api/teams/[teamId]/audit-logs/download/route.ts
+++ b/src/app/api/teams/[teamId]/audit-logs/download/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireTeamPermission } from "@/lib/team-auth";

--- a/src/app/api/teams/[teamId]/folders/route.ts
+++ b/src/app/api/teams/[teamId]/folders/route.ts
@@ -6,7 +6,6 @@ import { createFolderSchema } from "@/lib/validations";
 import {
   requireTeamMember,
   requireTeamPermission,
-  TeamAuthError,
 } from "@/lib/team-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
@@ -15,7 +14,7 @@ import { AUDIT_TARGET_TYPE, AUDIT_ACTION, TEAM_PERMISSION } from "@/lib/constant
 import { withTeamTenantRls } from "@/lib/tenant-context";
 import { ACTIVE_ENTRY_WHERE } from "@/lib/prisma-filters";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, notFound, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 
 type Params = { params: Promise<{ teamId: string }> };
 

--- a/src/app/api/teams/[teamId]/members/[memberId]/route.ts
+++ b/src/app/api/teams/[teamId]/members/[memberId]/route.ts
@@ -6,7 +6,6 @@ import { updateMemberRoleSchema } from "@/lib/validations";
 import {
   requireTeamPermission,
   isRoleAbove,
-  TeamAuthError,
 } from "@/lib/team-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";

--- a/src/app/api/teams/[teamId]/members/search/route.ts
+++ b/src/app/api/teams/[teamId]/members/search/route.ts
@@ -7,7 +7,7 @@ import { API_ERROR } from "@/lib/api-error-codes";
 import { TEAM_PERMISSION, INVITATION_STATUS } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 import { SEARCH_QUERY_MAX_LENGTH } from "@/lib/validations/common";
 import { TEAM_MEMBER_SEARCH_LIMIT } from "@/lib/validations/common.server";
 

--- a/src/app/api/teams/[teamId]/passwords/[id]/favorite/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/favorite/route.ts
@@ -6,7 +6,7 @@ import { requireTeamPermission } from "@/lib/team-auth";
 import { TEAM_PERMISSION } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, notFound, unauthorized } from "@/lib/api-response";
+import { handleAuthError, notFound, unauthorized } from "@/lib/api-response";
 
 type Params = { params: Promise<{ teamId: string; id: string }> };
 

--- a/src/app/api/teams/[teamId]/passwords/[id]/history/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/history/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { requireTeamMember } from "@/lib/team-auth";
 import { withTeamTenantRls } from "@/lib/tenant-context";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, notFound, unauthorized } from "@/lib/api-response";
+import { handleAuthError, notFound, unauthorized } from "@/lib/api-response";
 import { HISTORY_PAGE_SIZE } from "@/lib/validations/common.server";
 
 type Params = { params: Promise<{ teamId: string; id: string }> };

--- a/src/app/api/teams/[teamId]/passwords/[id]/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/route.ts
@@ -7,7 +7,6 @@ import {
   requireTeamPermission,
   requireTeamMember,
   hasTeamPermission,
-  TeamAuthError,
 } from "@/lib/team-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";

--- a/src/app/api/teams/[teamId]/passwords/bulk-archive/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-archive/route.ts
@@ -6,7 +6,7 @@ import { requireTeamPermission } from "@/lib/team-auth";
 import { withRequestLog } from "@/lib/with-request-log";
 import { TEAM_PERMISSION, AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
-import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
 import { bulkArchiveSchema } from "@/lib/validations";
 

--- a/src/app/api/teams/[teamId]/passwords/bulk-import/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-import/route.ts
@@ -4,7 +4,7 @@ import { logAuditAsync, logAuditBulkAsync, teamAuditBase } from "@/lib/audit";
 import { withRequestLog } from "@/lib/with-request-log";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE, TEAM_PERMISSION } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
-import { errorResponse, handleAuthError, rateLimited, unauthorized } from "@/lib/api-response";
+import { handleAuthError, rateLimited, unauthorized } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
 import { bulkTeamImportSchema } from "@/lib/validations";
 import { createRateLimiter } from "@/lib/rate-limit";

--- a/src/app/api/teams/[teamId]/passwords/bulk-restore/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-restore/route.ts
@@ -6,7 +6,7 @@ import { requireTeamPermission } from "@/lib/team-auth";
 import { withRequestLog } from "@/lib/with-request-log";
 import { TEAM_PERMISSION, AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
-import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
 import { bulkIdsSchema } from "@/lib/validations";
 

--- a/src/app/api/teams/[teamId]/passwords/bulk-trash/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-trash/route.ts
@@ -6,7 +6,7 @@ import { requireTeamPermission } from "@/lib/team-auth";
 import { withRequestLog } from "@/lib/with-request-log";
 import { TEAM_PERMISSION, AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
-import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
 import { bulkIdsSchema } from "@/lib/validations";
 

--- a/src/app/api/teams/[teamId]/passwords/empty-trash/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/empty-trash/route.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 
 type Params = { params: Promise<{ teamId: string }> };
 

--- a/src/app/api/teams/[teamId]/policy/route.ts
+++ b/src/app/api/teams/[teamId]/policy/route.ts
@@ -7,7 +7,6 @@ import {
   requireTeamPermission,
   TeamAuthError,
 } from "@/lib/team-auth";
-import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
 import { TEAM_PERMISSION, AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";

--- a/src/app/api/teams/[teamId]/tags/route.ts
+++ b/src/app/api/teams/[teamId]/tags/route.ts
@@ -5,7 +5,6 @@ import { createTeamTagSchema } from "@/lib/validations";
 import {
   requireTeamMember,
   requireTeamPermission,
-  TeamAuthError,
 } from "@/lib/team-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
@@ -19,7 +18,7 @@ import {
   TagTreeError,
 } from "@/lib/tag-tree";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, notFound, unauthorized } from "@/lib/api-response";
+import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
 
 type Params = { params: Promise<{ teamId: string }> };
 

--- a/src/app/api/teams/[teamId]/webhooks/[webhookId]/route.ts
+++ b/src/app/api/teams/[teamId]/webhooks/[webhookId]/route.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, notFound, unauthorized } from "@/lib/api-response";
+import { handleAuthError, notFound, unauthorized } from "@/lib/api-response";
 
 type Params = { params: Promise<{ teamId: string; webhookId: string }> };
 

--- a/src/app/api/teams/[teamId]/webhooks/route.ts
+++ b/src/app/api/teams/[teamId]/webhooks/route.ts
@@ -20,7 +20,7 @@ import { assertOrigin } from "@/lib/csrf";
 import { z } from "zod";
 import { TEAM_WEBHOOK_SUBSCRIBABLE_ACTIONS } from "@/lib/constants";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 import { MAX_WEBHOOKS, WEBHOOK_URL_MAX_LENGTH } from "@/lib/validations/common";
 import { isSsrfSafeWebhookUrl, SSRF_URL_VALIDATION_MESSAGE } from "@/lib/url-validation";
 

--- a/src/app/api/tenant/access-requests/[id]/approve/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.ts
@@ -9,7 +9,7 @@ import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTenantRls, withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, notFound, rateLimited, unauthorized } from "@/lib/api-response";
+import { handleAuthError, notFound, rateLimited, unauthorized } from "@/lib/api-response";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { SA_TOKEN_PREFIX, MAX_SA_TOKENS_PER_ACCOUNT } from "@/lib/constants/service-account";
 import { parseSaTokenScopes } from "@/lib/service-account-token";

--- a/src/app/api/tenant/access-requests/[id]/deny/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/deny/route.ts
@@ -8,7 +8,7 @@ import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, notFound, rateLimited, unauthorized } from "@/lib/api-response";
+import { handleAuthError, notFound, rateLimited, unauthorized } from "@/lib/api-response";
 import { createRateLimiter } from "@/lib/rate-limit";
 
 type Params = { params: Promise<{ id: string }> };

--- a/src/app/api/tenant/access-requests/[id]/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/route.ts
@@ -5,7 +5,7 @@ import { requireTenantPermission } from "@/lib/tenant-auth";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, notFound, unauthorized } from "@/lib/api-response";
+import { handleAuthError, notFound, unauthorized } from "@/lib/api-response";
 
 type Params = { params: Promise<{ id: string }> };
 

--- a/src/app/api/tenant/audit-delivery-targets/[id]/route.ts
+++ b/src/app/api/tenant/audit-delivery-targets/[id]/route.ts
@@ -11,7 +11,7 @@ import {
 } from "@/lib/constants";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, notFound, unauthorized } from "@/lib/api-response";
+import { handleAuthError, notFound, unauthorized } from "@/lib/api-response";
 import { z } from "zod";
 
 type Params = { params: Promise<{ id: string }> };

--- a/src/app/api/tenant/audit-delivery-targets/route.ts
+++ b/src/app/api/tenant/audit-delivery-targets/route.ts
@@ -19,7 +19,7 @@ import { AuditDeliveryTargetKind } from "@prisma/client";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 import { API_ERROR } from "@/lib/api-error-codes";
 import {
   MAX_AUDIT_DELIVERY_TARGETS,

--- a/src/app/api/tenant/audit-logs/download/route.ts
+++ b/src/app/api/tenant/audit-logs/download/route.ts
@@ -7,7 +7,7 @@ import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { errorResponse, handleAuthError, rateLimited, unauthorized, validationError } from "@/lib/api-response";
+import { handleAuthError, rateLimited, unauthorized, validationError } from "@/lib/api-response";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { parseActionsCsvParam } from "@/lib/audit-query";
 import type { AuditAction } from "@prisma/client";

--- a/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/revoke/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/revoke/route.ts
@@ -10,7 +10,6 @@ import { adminVaultResetRevokedEmail } from "@/lib/email/templates/admin-vault-r
 import { resolveUserLocale } from "@/lib/locale";
 import {
   requireTenantPermission,
-  TenantAuthError,
 } from "@/lib/tenant-auth";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { notificationTitle, notificationBody } from "@/lib/notification-messages";
@@ -18,7 +17,7 @@ import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
 import { AUDIT_ACTION } from "@/lib/constants";
 import { NOTIFICATION_TYPE } from "@/lib/constants/notification";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 
 export const runtime = "nodejs";
 

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.ts
@@ -13,7 +13,6 @@ import { resolveUserLocale } from "@/lib/locale";
 import {
   requireTenantPermission,
   isTenantRoleAbove,
-  TenantAuthError,
 } from "@/lib/tenant-auth";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { notificationTitle, notificationBody } from "@/lib/notification-messages";
@@ -21,7 +20,7 @@ import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
 import { AUDIT_ACTION } from "@/lib/constants";
 import { NOTIFICATION_TYPE } from "@/lib/constants/notification";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, forbidden, handleAuthError, notFound, rateLimited, unauthorized } from "@/lib/api-response";
+import { forbidden, handleAuthError, notFound, rateLimited, unauthorized } from "@/lib/api-response";
 import { MAX_PENDING_RESETS, VAULT_RESET_HISTORY_LIMIT } from "@/lib/validations/common.server";
 import { MS_PER_DAY } from "@/lib/constants/time";
 

--- a/src/app/api/tenant/members/[userId]/route.ts
+++ b/src/app/api/tenant/members/[userId]/route.ts
@@ -5,7 +5,6 @@ import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
 import { updateTenantMemberRoleSchema } from "@/lib/validations";
 import {
   requireTenantPermission,
-  TenantAuthError,
 } from "@/lib/tenant-auth";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";

--- a/src/app/api/tenant/members/route.ts
+++ b/src/app/api/tenant/members/route.ts
@@ -5,7 +5,7 @@ import { requireTenantPermission } from "@/lib/tenant-auth";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 
 export const runtime = "nodejs";
 

--- a/src/app/api/tenant/scim-tokens/route.ts
+++ b/src/app/api/tenant/scim-tokens/route.ts
@@ -13,7 +13,7 @@ import { withTenantRls } from "@/lib/tenant-rls";
 import { z } from "zod";
 import { SCIM_TOKEN_DESC_MAX_LENGTH } from "@/lib/validations";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, rateLimited, unauthorized } from "@/lib/api-response";
+import { handleAuthError, rateLimited, unauthorized } from "@/lib/api-response";
 import { createRateLimiter } from "@/lib/rate-limit";
 import {
   SCIM_TOKEN_EXPIRY_MIN_DAYS,

--- a/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
@@ -11,7 +11,7 @@ import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, notFound, unauthorized } from "@/lib/api-response";
+import { handleAuthError, notFound, unauthorized } from "@/lib/api-response";
 import {
   SA_TOKEN_PREFIX,
   MAX_SA_TOKENS_PER_ACCOUNT,

--- a/src/app/api/tenant/service-accounts/route.ts
+++ b/src/app/api/tenant/service-accounts/route.ts
@@ -10,7 +10,7 @@ import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, rateLimited, unauthorized } from "@/lib/api-response";
+import { handleAuthError, rateLimited, unauthorized } from "@/lib/api-response";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { MAX_SERVICE_ACCOUNTS_PER_TENANT } from "@/lib/constants/service-account";
 import { serviceAccountCreateSchema } from "@/lib/validations/service-account";

--- a/src/app/api/tenant/webhooks/[webhookId]/route.ts
+++ b/src/app/api/tenant/webhooks/[webhookId]/route.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/constants";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, notFound, unauthorized } from "@/lib/api-response";
+import { handleAuthError, notFound, unauthorized } from "@/lib/api-response";
 
 type Params = { params: Promise<{ webhookId: string }> };
 

--- a/src/app/api/tenant/webhooks/route.ts
+++ b/src/app/api/tenant/webhooks/route.ts
@@ -19,7 +19,7 @@ import {
 import { randomBytes } from "node:crypto";
 import { z } from "zod";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
+import { handleAuthError, unauthorized } from "@/lib/api-response";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { MAX_WEBHOOKS, WEBHOOK_URL_MAX_LENGTH } from "@/lib/validations/common";
 import { isSsrfSafeWebhookUrl, SSRF_URL_VALIDATION_MESSAGE } from "@/lib/url-validation";

--- a/src/app/api/vault/admin-reset/route.ts
+++ b/src/app/api/vault/admin-reset/route.ts
@@ -12,7 +12,7 @@ import { executeVaultReset } from "@/lib/vault-reset";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, forbidden, notFound, unauthorized, rateLimited } from "@/lib/api-response";
+import { forbidden, notFound, unauthorized, rateLimited } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { MS_PER_MINUTE } from "@/lib/constants/time";

--- a/src/app/api/watchtower/alert/route.ts
+++ b/src/app/api/watchtower/alert/route.ts
@@ -17,7 +17,7 @@ import { notificationTitle, notificationBody } from "@/lib/notification-messages
 import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants";
 import { NOTIFICATION_TYPE } from "@/lib/constants/notification";
 import { withRequestLog } from "@/lib/with-request-log";
-import { errorResponse, handleAuthError, rateLimited, unauthorized } from "@/lib/api-response";
+import { handleAuthError, rateLimited, unauthorized } from "@/lib/api-response";
 import { BREACH_COUNT_MAX } from "@/lib/validations/common.server";
 import { MS_PER_HOUR } from "@/lib/constants/time";
 

--- a/src/lib/ip-access.ts
+++ b/src/lib/ip-access.ts
@@ -336,18 +336,6 @@ export function extractClientIpFromHeaders(
   return leftmost || socketIp || null;
 }
 
-function formatCidr(parsed: ParsedCidr): string {
-  if (parsed.version === 4) {
-    return `${parsed.ip.join(".")}/${parsed.prefixLen}`;
-  }
-  // Format IPv6 bytes back to colon notation
-  const groups: string[] = [];
-  for (let i = 0; i < 16; i += 2) {
-    groups.push(((parsed.ip[i] << 8) | parsed.ip[i + 1]).toString(16));
-  }
-  return `${groups.join(":")}/${parsed.prefixLen}`;
-}
-
 // ─── Tailscale IP detection ──────────────────────────────────
 
 const TAILSCALE_IPV4_CIDR = "100.64.0.0/10";

--- a/src/lib/webhook-dispatcher.ts
+++ b/src/lib/webhook-dispatcher.ts
@@ -20,7 +20,6 @@ import { ACTOR_TYPE } from "@/lib/constants/audit";
 import { WEBHOOK_CONCURRENCY, WEBHOOK_MAX_RETRIES } from "@/lib/validations/common.server";
 import { Agent as UndiciAgent } from "undici";
 import {
-  EXTERNAL_DELIVERY_METADATA_BLOCKLIST,
   sanitizeForExternalDelivery,
   resolveAndValidateIps,
   createPinnedDispatcher,


### PR DESCRIPTION
## Summary

- Resolves 45 newly opened CodeQL `js/unused-local-variable` alerts (alerts 122–165) introduced by the recent simplify-codebase refactor
- Pure dead-code removal: 39 unused imports across API route handlers + the unused `formatCidr` helper in `src/lib/ip-access.ts`
- No behavior change — `npx vitest run` (565/7166) and `npx next build` pass

## Changes

- `src/lib/ip-access.ts`: drop `formatCidr` (dead helper)
- `src/lib/webhook-dispatcher.ts`: drop `EXTERNAL_DELIVERY_METADATA_BLOCKLIST` import
- `src/app/api/**/route.ts` (38 files): drop unused `errorResponse`, `TeamAuthError`, `TenantAuthError`, `notFound`, `API_ERROR`, `NextResponse`, `scimError`, `unauthorized` imports left behind after the auth-error handler unification

## Test plan

- [x] `npx vitest run` — 565 files / 7166 tests pass
- [x] `npx next build` — succeeds
- [x] `bash scripts/pre-pr.sh` — all 9 checks pass
- [ ] Confirm CodeQL re-scan closes alerts 122–165 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)