### PR TITLE
refactor(audit): enforce *AuditBase helper usage on logAudit calls

### DIFF
--- a/docs/archive/review/enforce-audit-base-helper-usage-code-review.md
+++ b/docs/archive/review/enforce-audit-base-helper-usage-code-review.md
@@ -1,0 +1,99 @@
+# Code Review: enforce-audit-base-helper-usage
+Date: 2026-04-19
+Review round: 1
+
+## Changes from Previous Round
+Initial review of refactor/enforce-audit-base-helper-usage branch (commit `f62bb988`, 43 files +376 -215).
+
+## Functionality Findings
+No findings. All 7 plan-specific obligations verified via targeted greps:
+1. Pattern 5 tenantId preservation on PERSONAL emit (vault/delegation/route.ts:211).
+2. Pattern 4 tenantId override on TEAM-scope (vault/admin-reset/route.ts:140).
+3. Pattern 6 pre-tx extractRequestMeta deletion (share-links/route.ts:185).
+4. Pattern 7 extractClientIp direct-use sites migrated (vault/delegation, vault/delegation/check).
+5. Bucket C exceptions unchanged (internal/audit-emit, mcp/register).
+6. Override ordering verified across 12 sampled sites.
+7. Forensic upgrade exceptions (admin/rotate-master-key, mcp/authorize/consent:152) intentional per plan §Functional 2 EXCEPTION.
+
+## Security Findings
+
+[S1] **Minor**: Theoretical scope-downgrade in share-link audit when `teamId` cannot be resolved
+- File: src/app/api/share-links/[id]/route.ts:59-61, src/app/api/share-links/route.ts:184-186
+- Evidence: New gate `teamPasswordEntryId && teamId ? teamAuditBase(...) : personalAuditBase(...)`. Pre-migration: `scope: teamPasswordEntryId ? TEAM : PERSONAL` with `teamId` passed unconditionally.
+- Problem: If `share.teamPasswordEntry?.teamId` is ever null while `teamPasswordEntryId` is set, the new code silently falls back to PERSONAL scope; the original would emit TEAM-scope with `teamId=undefined`.
+- Impact: Theoretical only — `teamPasswordEntryId` is a FK; referential integrity prevents the missing relation in normal operation. No exploit path; failure mode would be loss of forensic visibility for a single audit row in a DB-corruption scenario.
+- Fix: Optional defensive log/throw if `teamPasswordEntryId && !teamId` (FK invariant violation). Not blocking for merge.
+
+## Testing Findings
+
+[T1] **Major**: No isolated unit tests for `personalAuditBase`/`teamAuditBase`/`tenantAuditBase` helpers
+- File: src/lib/audit.ts (helpers near end of file)
+- Evidence: Greps across `src/__tests__/` and `src/lib/__tests__/` find zero direct invocations. Only mocked in 18 route tests.
+- Problem: The plan introduces these helpers as the canonical entry point for ~40 routes. Mocked-only coverage means a regression in the helper would not be caught.
+- Fix: Added `src/__tests__/lib/audit-helpers.test.ts` (10 tests) asserting scope value, required field presence, and forensic-meta propagation including `acceptLanguage`.
+
+[T2] **Minor**: Helper mocks omit `acceptLanguage`, diverging from real helper output shape
+- File: 18 modified test files (e.g., src/app/api/admin/rotate-master-key/route.test.ts:37-39)
+- Evidence: Real helper returns `{scope,userId,[teamId|tenantId],ip,userAgent,acceptLanguage}` — mocks returned only `{...,ip,userAgent}`.
+- Problem: No production code asserts `acceptLanguage` today, but a future test asserting full audit body via deep equality would falsely pass.
+- Fix: Added `acceptLanguage: null` to each helper mock across all 18 files.
+
+[T3] **Minor**: Dead `extractRequestMeta:` mock in routes fully migrated to helpers
+- File: 16 test files (e.g., src/app/api/admin/rotate-master-key/route.test.ts:36)
+- Evidence: Production route.ts files no longer reference `extractRequestMeta`, so the mock entry was unused.
+- Fix: Removed `extractRequestMeta` mock entries from 16 files. Also removed the unused `mockExtractRequestMeta` hoisted variable from `mcp/authorize/consent/route.test.ts`.
+
+## Adjacent Findings
+None.
+
+## Quality Warnings
+None.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R3 (pattern propagation): Verified — all 22 modified route.ts files in diff align with Bucket B inventory.
+- R10 (override ordering): Verified across 12 sampled sites — all helper-spread first, overrides after.
+- R12 (action group coverage): N/A — no new audit actions.
+- R1-R2, R4-R9, R11, R13-R30: N/A or verified clean.
+
+### Security expert
+- R3 (pattern propagation): Verified — every Bucket B route migrated.
+- R-multi-tenant isolation: Sample-checked admin/rotate-master-key, scim/v2/Users/[id], vault/admin-reset — no cross-tenant ID swaps.
+- R-anonymous actor (share-links/verify-access): ANONYMOUS_ACTOR_ID + ACTOR_TYPE.ANONYMOUS correctly placed AFTER helper spread.
+- R-system actor (Pattern 2): ACTOR_TYPE.SYSTEM after helper spread in all 7 Batch-1 sites.
+- R-Bucket C: internal/audit-emit and mcp/register unchanged; no security regression.
+- R-Pattern 5 dual-emit: tenantId preserved on PERSONAL emit.
+- R-forensic upgrade sites: userAgent ADDITION only behavior change.
+- R-CSRF/origin, R-rate-limit ordering: Preserved.
+- R29: No new spec citations.
+- RS1-RS3: metadata sanitization unchanged; no new sensitive fields.
+
+### Testing expert
+- R19/RT1 (mock alignment): Verified across 18 files; T2 acceptLanguage divergence FIXED.
+- RT2 (test coverage): Pattern 5 covered, D3 admin-reset test correct.
+- RT3 (regression risk): D3 change correctly preserves coverage via `lastCall?.teamId).toBeUndefined()`.
+- T1 (helper unit tests): FIXED — added src/__tests__/lib/audit-helpers.test.ts.
+
+## Resolution Status
+
+### [T1] Major: No isolated unit tests for *AuditBase helpers — FIXED
+- Action: Added `src/__tests__/lib/audit-helpers.test.ts` with 10 tests covering scope value, field presence, ip/userAgent/acceptLanguage propagation from request headers, and absence of cross-scope fields (e.g., teamId on PERSONAL).
+- Modified file: src/__tests__/lib/audit-helpers.test.ts (new file, 96 lines)
+
+### [T2] Minor: Helper mocks omit acceptLanguage — FIXED
+- Action: Added `acceptLanguage: null` to each of personalAuditBase/teamAuditBase/tenantAuditBase mock returns in all 18 test files.
+- Modified files: 18 test files under src/__tests__/api/share-links/ and src/app/api/
+
+### [T3] Minor: Dead extractRequestMeta mock — FIXED
+- Action: Removed dead `extractRequestMeta:` mock entries from 16 test files where the migrated production routes no longer reference the function. Also removed `mockExtractRequestMeta` hoisted variable from mcp/authorize/consent/route.test.ts.
+- Modified files: 16 test files + mcp/authorize/consent/route.test.ts (3 line removals beyond the mock entry)
+
+### [S1] Minor: Theoretical scope-downgrade in share-link audit — Skipped
+- **Anti-Deferral check**: "acceptable risk" — DB FK invariant prevents the failure mode in normal operation.
+- **Justification**:
+  - Worst case: One audit row mis-scoped (PERSONAL instead of TEAM with teamId=undefined) for a corrupted share record. Forensic visibility loss for that single row.
+  - Likelihood: Very low — `teamPasswordEntryId` is a foreign key with referential integrity to `TeamPasswordEntry`, which has a non-null `teamId`. Reaching the failure mode requires direct DB tampering or schema corruption.
+  - Cost to fix: ~10 LOC defensive log/throw in two files (share-links/route.ts and share-links/[id]/route.ts). Low.
+  - Decision: Original code had identical fragility (would have written `teamId: undefined` which is functionally identical for the persisted column — `null`). The new code's `PERSONAL` fallback is arguably MORE correct in the corrupted-data case (no broken TEAM-scope row in audit_logs). No regression introduced; the flaw is pre-existing.
+- **Orchestrator sign-off**: Confirmed acceptable risk per quantification above. Not introduced by this PR; pre-existing fragility under DB-corruption scenarios. Low cost-to-fix tracked but not addressed in this PR scope (refactoring) — a separate hardening PR could add the defensive check across all share-link mutations.

--- a/docs/archive/review/enforce-audit-base-helper-usage-deviation.md
+++ b/docs/archive/review/enforce-audit-base-helper-usage-deviation.md
@@ -1,0 +1,96 @@
+# Coding Deviation Log: enforce-audit-base-helper-usage
+
+## D1: mcp/register/route.ts moved to Bucket C (was Batch 2)
+
+**Plan**: Batch 2 listed `src/app/api/mcp/register/route.ts` for Pattern 2 migration.
+
+**Reality**: The route emits a TENANT-scope event WITHOUT `tenantId` (`audit.ts` lines around 174). The MCP DCR (Dynamic Client Registration) endpoint operates BEFORE the client is bound to a tenant — there is no tenantId available at the call site. `tenantAuditBase(req, userId, tenantId)` requires tenantId as the third arg. The current code relies on `resolveTenantId()` looking up by `SYSTEM_ACTOR_ID` (which returns null and dead-letters the event).
+
+**Decision**: Bucket C — same category as `internal/audit-emit/route.ts` (TENANT-scope without tenantId). Migration would require an unreviewed extra DB lookup.
+
+**Audit chain impact**: None — the event already dead-letters; no persisted audit_logs row exists pre- or post-migration.
+
+## D2: vault/admin-reset Pattern 4 — explicit tenantId override after helper spread
+
+**Plan**: Pattern 4 example showed `...(resetRecord.teamId ? teamAuditBase(...) : tenantAuditBase(req, userId, tenantId)), action, ...`.
+
+**Reality**: The TEAM-scope helper does NOT set `tenantId`, but the existing test `vault/admin-reset/route.test.ts:222-236` asserts `tenantId: "tenant-1"` on the TEAM-scope event. Without explicit override, the test fails (same root cause as F1/Pattern 5 in the plan).
+
+**Decision**: Add `tenantId: resetRecord.tenantId` after the helper spread. Behavior-preserving; matches the F1 mandatory-tenantId rule documented for Pattern 5.
+
+```ts
+await logAuditAsync({
+  ...(resetRecord.teamId
+    ? teamAuditBase(req, session.user.id, resetRecord.teamId)
+    : tenantAuditBase(req, session.user.id, resetRecord.tenantId)),
+  tenantId: resetRecord.tenantId,  // ← preserved for TEAM emit (helper omits it)
+  action: ...,
+});
+```
+
+**Lesson**: Pattern 4 (conditional team/tenant) needs the same mandatory tenantId-preservation rule as Pattern 5 (dual emit) — for the same reason (helper omits it on TEAM scope, but JSON log + tests need it). Plan should be updated for future references.
+
+## D3: vault/admin-reset test — TENANT-scope `teamId: undefined` assertion replaced
+
+**Plan**: "No new tests required."
+
+**Reality**: `vault/admin-reset/route.test.ts:249-255` test "uses TENANT scope when teamId is null" asserted `expect.objectContaining({ teamId: undefined })`. Pre-migration the code explicitly set `teamId: resetRecord.teamId ?? undefined` (key present with undefined value). Post-migration `tenantAuditBase()` does not include the `teamId` key at all. `objectContaining` is strict about key presence; the test failed.
+
+**Decision**: Replace the assertion with `lastCall?.teamId).toBeUndefined()` which matches absent-key semantics. The persisted `audit_logs.teamId` column is identical pre/post (always null for TENANT-scope), so behavior is preserved.
+
+```ts
+// Before:
+expect(mockLogAudit).toHaveBeenCalledWith(
+  expect.objectContaining({ scope: "TENANT", tenantId: "tenant-1", teamId: undefined }),
+);
+
+// After:
+expect(mockLogAudit).toHaveBeenCalledWith(
+  expect.objectContaining({ scope: "TENANT", tenantId: "tenant-1" }),
+);
+const lastCall = mockLogAudit.mock.calls[...]?.[0] as Record<string, unknown> | undefined;
+expect(lastCall?.teamId).toBeUndefined();
+```
+
+**Lesson**: `expect.objectContaining({ key: undefined })` asserts an implementation detail (key presence), not the persisted value. Future migrations should not preserve such assertions when they constrain helper-spread shape unnecessarily.
+
+## D4: 18 test mock files — added explicit helper mocks (R19, predicted in plan)
+
+**Plan**: §Testing strategy claimed "Existing `extractRequestMeta` mocks transparently apply to helper-using sites — no mock updates required."
+
+**Reality**: This was incorrect. `vi.mock("@/lib/audit", () => ({ ... }))` creates a flat mock — the helpers (which live in the same module) are NOT auto-exposed. Internal calls within the audit module to `extractRequestMeta` would also bypass the mock per JS module semantics, but the immediate breakage is `tenantAuditBase is not defined on the mock`.
+
+**Decision**: Updated 18 test files to explicitly include `personalAuditBase`, `teamAuditBase`, `tenantAuditBase` in the mock object, returning shapes matching the file's existing `extractRequestMeta` mock (e.g., `{ scope, userId, ip: "127.0.0.1", userAgent: "Test" }`).
+
+**Files affected**:
+- `src/__tests__/api/share-links/{delete,route}.test.ts`
+- `src/app/api/admin/rotate-master-key/route.test.ts`
+- `src/app/api/audit-logs/export/route.test.ts`
+- `src/app/api/extension/token/exchange/route.test.ts`
+- `src/app/api/maintenance/{purge-audit-logs,purge-history}/route.test.ts`
+- `src/app/api/mcp/authorize/consent/route.test.ts`
+- `src/app/api/scim/v2/{Groups/[id],Users/[id],Users}/route.test.ts`
+- `src/app/api/share-links/{[id],verify-access}/route.test.ts`
+- `src/app/api/tenant/access-requests/route.test.ts`
+- `src/app/api/vault/{admin-reset,delegation/check,delegation}/route.test.ts`
+- `src/app/api/watchtower/alert/route.test.ts`
+
+**Lesson**: R19 obligation in the recurring-issue checklist exists for exactly this reason. Plan §Testing strategy was wrong about mock transparency; future plans for helper migrations should plan for explicit mock updates upfront.
+
+## D5: extension/token/exchange — ip placeholder "unknown" → null
+
+**Plan**: §Functional 2 EXCEPTION enumerated only `MASTER_KEY_ROTATION` and `MCP_CLIENT_DCR_CLAIM` as forensic-upgrade sites.
+
+**Reality**: `extension/token/exchange/route.ts` lines 154/176 previously passed `ip` (a local variable that defaults to `"unknown"` for rate-limit purposes when extractClientIp returns null). After helper migration, `personalAuditBase()` calls `extractRequestMeta()` which returns the real IP or `null` — never the rate-limit placeholder.
+
+**Decision**: Treat as a small forensic correction. The persisted `audit_logs.ip` column transitions from `"unknown"` to `null` for events where the caller IP cannot be determined. `null` is the more accurate signal (no IP) than the misleading `"unknown"` string.
+
+**Audit chain impact**: One-event hash continuity transition for any pre-migration request that had no determinable IP. Negligible — most requests have IP headers set.
+
+## D6: Bucket B inventory final count
+
+**Plan**: 23 source files / ~55 calls (after moving `internal/audit-emit` to Bucket C).
+
+**Reality**: 22 source files / ~52 calls (after also moving `mcp/register` to Bucket C per D1).
+
+**Decision**: Plan inventory accurate-enough; final implementation reflects the live count. No re-scope needed.

--- a/docs/archive/review/enforce-audit-base-helper-usage-plan.md
+++ b/docs/archive/review/enforce-audit-base-helper-usage-plan.md
@@ -458,4 +458,68 @@ These scenarios cover the affected endpoints and are used to mentally validate b
    - Event with `actorType: SYSTEM`, `userId: SYSTEM_ACTOR_ID`, scope `TENANT`. Pattern 2.
 
 10. **Internal audit emit** (`POST /api/internal/audit-emit`):
-    - Internal helper endpoint. The route uses `request` (not `req`); migration must preserve the variable name.
+    - Internal helper endpoint. **MOVED to Bucket C** during plan review — `tenantId` is not available without an extra DB lookup; `resolveTenantId()` performs the lookup transparently. No migration applies.
+
+## Implementation Checklist
+
+Generated during Phase 2 Step 2-1 (impact analysis).
+
+### Files to modify (23 source files)
+
+**Batch 1 — Maintenance & admin (7 files)**
+- [ ] `src/app/api/admin/rotate-master-key/route.ts` — Pattern 2 (system actor), userAgent ADDED per Functional 2 EXCEPTION
+- [ ] `src/app/api/maintenance/audit-chain-verify/route.ts` — Pattern 2
+- [ ] `src/app/api/maintenance/audit-outbox-metrics/route.ts` — Pattern 2
+- [ ] `src/app/api/maintenance/audit-outbox-purge-failed/route.ts` — Pattern 2
+- [ ] `src/app/api/maintenance/dcr-cleanup/route.ts` — Pattern 2
+- [ ] `src/app/api/maintenance/purge-audit-logs/route.ts` — Pattern 2
+- [ ] `src/app/api/maintenance/purge-history/route.ts` — Pattern 2
+
+**Batch 2 — MCP & extension (3 files; `internal/audit-emit/route.ts` excluded → Bucket C)**
+- [ ] `src/app/api/mcp/authorize/consent/route.ts` — Pattern 2 (3 calls; line 152 userAgent ADDED per EXCEPTION)
+- [ ] `src/app/api/mcp/register/route.ts` — Pattern 2
+- [ ] `src/app/api/extension/token/exchange/route.ts` — Pattern 1 (2 calls)
+
+**Batch 3 — Audit-log meta + watchtower (3 files)**
+- [ ] `src/app/api/audit-logs/export/route.ts` — Pattern 3 (conditional team/personal)
+- [ ] `src/app/api/audit-logs/import/route.ts` — Pattern 3
+- [ ] `src/app/api/watchtower/alert/route.ts` — Pattern 3
+
+**Batch 4 — Vault + share-links (6 files)**
+- [ ] `src/app/api/vault/admin-reset/route.ts` — Pattern 4 (conditional team/tenant)
+- [ ] `src/app/api/vault/delegation/route.ts` — Pattern 5 (dual-emit; `tenantId` MUST be preserved on PERSONAL emit)
+- [ ] `src/app/api/vault/delegation/check/route.ts` — Pattern 7 (extractClientIp direct)
+- [ ] `src/app/api/share-links/route.ts` — Pattern 6 (logAuditInTx; delete pre-tx extractRequestMeta)
+- [ ] `src/app/api/share-links/[id]/route.ts` — Pattern 6 + Pattern 3 (logAuditInTx + conditional team/personal)
+- [ ] `src/app/api/share-links/verify-access/route.ts` — Pattern 1 (2 calls)
+
+**Batch 5 — SCIM + access-requests (4 files)**
+- [ ] `src/app/api/scim/v2/Users/route.ts` — Pattern 1
+- [ ] `src/app/api/scim/v2/Users/[id]/route.ts` — Pattern 1 (3 calls)
+- [ ] `src/app/api/scim/v2/Groups/[id]/route.ts` — Pattern 1 (2 calls)
+- [ ] `src/app/api/tenant/access-requests/route.ts` — Pattern 1
+
+**Batch 6 — Documentation update (after Batches 1-5)**
+- [ ] `src/lib/audit.ts` module-doc — mandate helper usage; document Bucket C exceptions
+
+### Shared utilities to reuse (NEVER reimplement)
+
+- `personalAuditBase(req, userId)` from `@/lib/audit` — PERSONAL scope helper
+- `teamAuditBase(req, userId, teamId)` from `@/lib/audit` — TEAM scope helper
+- `tenantAuditBase(req, userId, tenantId)` from `@/lib/audit` — TENANT scope helper
+
+### Imports to remove per file (if no remaining usage)
+
+After migration of each file, remove the following imports IF and only IF no other code in the file uses them:
+- `extractRequestMeta` from `@/lib/audit`
+- `extractClientIp` from `@/lib/ip-access`
+- `AUDIT_SCOPE` from `@/lib/constants`
+
+CI's zero-warning lint will catch unused imports automatically.
+
+### Verification gate (after every batch)
+
+1. `npx eslint .` — zero warnings
+2. `npx vitest run` — all tests pass
+3. `npx next build` — production build succeeds
+4. `npm run test:integration` — priority tests: `audit-and-isolation.test.ts`, `audit-logaudit-non-atomic.integration.test.ts`

--- a/docs/archive/review/enforce-audit-base-helper-usage-plan.md
+++ b/docs/archive/review/enforce-audit-base-helper-usage-plan.md
@@ -1,0 +1,461 @@
+# Plan: enforce-audit-base-helper-usage
+
+## Project context
+
+- **Type**: web app (Next.js 16 App Router) — TypeScript / Prisma / multi-tenant SaaS
+- **Test infrastructure**: unit tests (Vitest, mocked + real-DB integration suites) + CI/CD (next build, lint, vitest, integration tests against real Postgres)
+- **Scope of change**: refactor only — no new features, no schema change, no behavior change. Pure call-site migration to use existing `*AuditBase` helpers.
+
+## Objective
+
+Migrate every `logAudit*` call site that has `req: NextRequest` in scope to use one of the three `*AuditBase` helpers (`personalAuditBase` / `teamAuditBase` / `tenantAuditBase`) defined in [src/lib/audit.ts](src/lib/audit.ts).
+
+The helpers exist precisely to prevent the recurring class of bug where call sites forget `extractRequestMeta(req)` (losing forensic ip/userAgent capture) or set the wrong `scope`. The recent commit `9f5b287c fix(mcp): switch mcp/token audit calls to tenantAuditBase (forensic ip/userAgent capture)` is a concrete instance of that bug. This refactor closes the remaining surface area.
+
+## Requirements
+
+### Functional
+1. Every `logAudit{Async,InTx,BulkAsync}` call site in `src/app/api/**/route.ts` that has `req`/`request: NextRequest` in scope MUST use one of `personalAuditBase` / `teamAuditBase` / `tenantAuditBase`.
+2. Behavior preservation: each migration MUST produce an identical `AuditOutboxPayload` to the pre-migration call. Specifically:
+   - `scope` value identical (no scope drift)
+   - `userId` identical
+   - `teamId` / `tenantId` identical (including the conditional `teamId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.PERSONAL` patterns)
+   - `ip` identical (`extractClientIp` result; the helper calls `extractRequestMeta` which wraps `extractClientIp`)
+   - `userAgent` identical (raw header; helper passes the raw string, which `buildOutboxPayload` then truncates to `USER_AGENT_MAX_LENGTH`)
+   - `acceptLanguage` is captured by `extractRequestMeta` but is NOT included in `AuditOutboxPayload` — helper adds an extra discarded field, which is harmless. Confirm via reading `buildOutboxPayload`.
+
+   **EXCEPTION — pre-existing forensic-field omissions are CORRECTED, not preserved**: at the following Bucket B sites, the current code omits `userAgent` (or `ip`). The helper migration intentionally adds the missing field — this is a forensic upgrade, not a regression. Do NOT add `userAgent: null` after the helper spread to "preserve behavior":
+   - [src/app/api/admin/rotate-master-key/route.ts:113-124](src/app/api/admin/rotate-master-key/route.ts#L113-L124) — `MASTER_KEY_ROTATION` event currently omits `userAgent` (passes `ip` only).
+   - [src/app/api/mcp/authorize/consent/route.ts:152-161](src/app/api/mcp/authorize/consent/route.ts#L152-L161) — `MCP_CLIENT_DCR_CLAIM` event currently omits `userAgent` (passes `ip: claimIp` only).
+   The chain hash (verified via `/api/maintenance/audit-chain-verify`) hashes the persisted column shape; a populated `userAgent` post-migration is a hash-continuity event, NOT a chain break (each link references the prior event's hash, not its schema). See §Considerations/Risks for details.
+3. Call sites in non-route contexts (NextAuth callbacks, library functions without `req`, background workers, MCP tools) are out of scope and remain as-is.
+
+### Non-functional
+4. No new helpers introduced unless an existing one cannot fit a real call site. Justify any helper addition in the deviation log.
+5. All existing tests pass; no test changes required EXCEPT where a test's exact-shape assertion includes payload fields the helper happens to add (e.g., `acceptLanguage` is dropped by `buildOutboxPayload` so should not affect tests, but verify).
+6. Lint, `npx vitest run`, integration tests, and `npx next build` all pass per CLAUDE.md mandatory checks.
+
+## Technical approach
+
+### Helper API (no change)
+
+```ts
+personalAuditBase(req, userId)        // → { scope: PERSONAL, userId, ip, userAgent, acceptLanguage }
+teamAuditBase(req, userId, teamId)    // → { scope: TEAM, userId, teamId, ip, userAgent, acceptLanguage }
+tenantAuditBase(req, userId, tenantId) // → { scope: TENANT, userId, tenantId, ip, userAgent, acceptLanguage }
+```
+
+### Migration patterns
+
+**Pattern 1: simple (most cases)** — fixed scope, no conditional.
+
+Before:
+```ts
+const { ip, userAgent } = extractRequestMeta(req);
+await logAuditAsync({
+  scope: AUDIT_SCOPE.TENANT,
+  userId,
+  tenantId,
+  action,
+  ip,
+  userAgent,
+});
+```
+
+After:
+```ts
+await logAuditAsync({
+  ...tenantAuditBase(req, userId, tenantId),
+  action,
+});
+```
+
+**Pattern 2: spread `extractRequestMeta(req)`** — same as pattern 1, the spread call is replaced by the helper spread.
+
+Before:
+```ts
+await logAuditAsync({
+  scope: AUDIT_SCOPE.TENANT,
+  userId: SYSTEM_ACTOR_ID,
+  actorType: ACTOR_TYPE.SYSTEM,
+  tenantId,
+  action,
+  ...extractRequestMeta(req),
+});
+```
+
+After:
+```ts
+await logAuditAsync({
+  ...tenantAuditBase(req, SYSTEM_ACTOR_ID, tenantId),
+  actorType: ACTOR_TYPE.SYSTEM,
+  action,
+});
+```
+
+**Pattern 3: conditional team-vs-personal scope** — common in `audit-logs/export`, `audit-logs/import`, `watchtower/alert`, `share-links/[id]`.
+
+Before:
+```ts
+await logAuditAsync({
+  scope: teamId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.PERSONAL,
+  userId,
+  teamId: teamId ?? undefined,
+  ...extractRequestMeta(req),
+  action,
+});
+```
+
+After:
+```ts
+await logAuditAsync({
+  ...(teamId ? teamAuditBase(req, userId, teamId) : personalAuditBase(req, userId)),
+  action,
+});
+```
+
+**Pattern 4: conditional team-vs-tenant scope** — `vault/admin-reset/route.ts` is the only known instance.
+
+Before:
+```ts
+const auditScope = resetRecord.teamId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.TENANT;
+await logAuditAsync({
+  scope: auditScope,
+  userId,
+  ...(resetRecord.teamId ? { teamId: resetRecord.teamId } : { tenantId }),
+  ...extractRequestMeta(req),
+  action,
+});
+```
+
+After:
+```ts
+await logAuditAsync({
+  ...(resetRecord.teamId
+    ? teamAuditBase(req, userId, resetRecord.teamId)
+    : tenantAuditBase(req, userId, tenantId)),
+  action,
+});
+```
+
+**Pattern 5: dual-scope emit** — `vault/delegation/route.ts:213-216` emits the SAME event under both PERSONAL and TENANT scopes via `Promise.all`. The helper applies cleanly by extracting the shared body.
+
+Before:
+```ts
+const auditBase = { action, userId, tenantId, targetId, metadata, ip, userAgent };
+await Promise.all([
+  logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL }),
+  logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.TENANT }),
+]);
+```
+
+After:
+```ts
+const auditBody = { action, targetId, metadata };
+await Promise.all([
+  // tenantId MUST be preserved on the PERSONAL emit — see note below.
+  logAuditAsync({ ...personalAuditBase(request, userId), tenantId, ...auditBody }),
+  logAuditAsync({ ...tenantAuditBase(request, userId, tenantId), ...auditBody }),
+]);
+```
+
+Note: `request` (not `req`) — preserve the variable name from the source.
+
+**`tenantId` preservation on PERSONAL emit (mandatory)**: The `personalAuditBase` helper does NOT set `tenantId` (PERSONAL scope is per-user). However, the existing test `vault/delegation/route.test.ts:350-359` explicitly asserts `tenantId: TENANT_ID` on the PERSONAL emit, AND the structured JSON log line emitted by `auditLogger.info` reads `params.tenantId ?? null`. Pre-migration the field is set; post-migration it would become `null` if dropped. Both the test and the JSON log shape require `tenantId` to remain explicit. The `tenantId` placement AFTER the helper spread (correct override ordering) is mandatory.
+
+**Pattern 6: in-transaction calls (`logAuditInTx`)** — the helper return type is the same shape, spreads cleanly into the params argument. The fact that `tenantId` may also be passed as the explicit second arg is harmless (the params-object `tenantId` is not used by `enqueueAuditInTx`).
+
+Before:
+```ts
+const { ip, userAgent } = extractRequestMeta(req);
+await prisma.$transaction(async (tx) => {
+  // ...
+  await logAuditInTx(tx, share.tenantId, {
+    scope: teamPasswordEntryId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.PERSONAL,
+    userId,
+    teamId,
+    targetId,
+    action,
+    ip,
+    userAgent,
+  });
+});
+```
+
+After:
+```ts
+// IMPORTANT: delete the pre-tx `const { ip, userAgent } = extractRequestMeta(req)` line
+// when its only consumer was the migrated audit call. The helper handles extraction internally.
+await prisma.$transaction(async (tx) => {
+  // ...
+  await logAuditInTx(tx, share.tenantId, {
+    ...(teamPasswordEntryId ? teamAuditBase(req, userId, teamId) : personalAuditBase(req, userId)),
+    targetId,
+    action,
+  });
+});
+```
+
+**Pattern 7: direct `extractClientIp(req)` (without `extractRequestMeta`)** — two Bucket B sites use `extractClientIp(request)` directly: `vault/delegation/check/route.ts:98` and `vault/delegation/route.ts:210`. These are functionally equivalent to `extractRequestMeta(request).ip` (the latter wraps the former). The helper migration replaces both forms identically.
+
+Before:
+```ts
+await logAuditAsync({
+  scope: AUDIT_SCOPE.PERSONAL,
+  userId,
+  ip: extractClientIp(request),
+  userAgent: request.headers.get("user-agent"),
+  // ...
+});
+```
+
+After:
+```ts
+await logAuditAsync({
+  ...personalAuditBase(request, userId),
+  // ...
+});
+```
+
+### Import updates (mandatory per file)
+
+Every migrated file MUST update its import from `@/lib/audit`:
+
+- Add the helper(s) used: `personalAuditBase` and/or `teamAuditBase` and/or `tenantAuditBase`.
+- Remove `extractRequestMeta` from the import IF and only IF no remaining call site in the file still calls `extractRequestMeta(req)` directly. Several files (e.g., `auth/passkey/verify/route.ts`) call `extractRequestMeta` for purposes other than audit (e.g., session metadata, lockout context) — leave those imports intact.
+- `AUDIT_SCOPE` import from `@/lib/constants` may be removable IF no remaining usage of `AUDIT_SCOPE` exists in the file after migration. Several files use `AUDIT_SCOPE` in non-audit-emit contexts (notification scope, query filters) — leave imports intact in those cases.
+
+Reviewer obligation: per-file, run `npx tsc --noEmit` mentally (or actually) by checking that no orphan imports remain. Lint will catch unused imports as warnings; CI is configured for zero warnings (per CLAUDE.md mandatory checks), so this is enforced.
+
+### Variable name preservation
+
+Source files use either `req` or `request` for the `NextRequest` parameter. Migrations MUST preserve the source variable name — do NOT rename to a global convention. Examples:
+- `src/app/api/internal/audit-emit/route.ts` uses `request`
+- `src/app/api/vault/delegation/route.ts` uses `request`
+- Most others use `req`
+
+### Equivalence verification
+
+For each migration, confirm the helper's return shape matches the manually-built object. The helper drops the manual setup of:
+- `scope` (helper supplies)
+- `userId` (helper supplies)
+- `teamId` / `tenantId` (helper supplies for team/tenant variants)
+- `ip` (helper supplies via `extractRequestMeta`)
+- `userAgent` (helper supplies via `extractRequestMeta`)
+
+The helper adds `acceptLanguage`, which `buildOutboxPayload` does NOT include in the outbox payload — confirmed by reading [src/lib/audit.ts](src/lib/audit.ts) lines 101-118. So no behavior change in the persisted audit record or downstream JSON log.
+
+## Inventory completeness
+
+The Bucket B target list is the result of a full enumeration over `src/` (excluding `__tests__/`, `*.test.ts`, and `src/lib/audit.ts` itself). Total `logAudit{Async,InTx,BulkAsync}` call sites in production code: **315 across 132 files**. Breakdown:
+
+- Bucket A (already uses helpers): 220 sites
+- Bucket B (this plan migrates): 56 sites across 24 files
+- Bucket C (out of scope, see "Considerations"): 39 sites across 13 files
+
+Every file in `src/app/api/**/route.ts` that emits audit events is accounted for in exactly one bucket. Common false alarms to verify against:
+- `src/app/api/vault/reset/**` — Bucket A (already uses helpers, verified by grep `AuditBase(req`)
+- `src/app/api/vault/setup/**` — Bucket A
+- `src/app/api/teams/[teamId]/**/route.ts` — Bucket A across all subroutes
+- `src/app/api/passwords/**/route.ts` — Bucket A across all subroutes
+
+If during implementation a new Bucket B site is found that is not listed in any batch, STOP and add it to the inventory + appropriate batch + record in the deviation log.
+
+**`logAuditBulkAsync` coverage**: Verified by grep — every `logAuditBulkAsync` call site in `src/app/api/**/route.ts` already imports and uses `personalAuditBase` or `teamAuditBase`. No Bucket B site uses the bulk variant, so no separate migration pattern is needed for it. The `logAuditBulkAsync` accepts an array of `AuditLogParams`; each element is built using a helper spread the same way as `logAuditAsync`.
+
+## Implementation steps
+
+Step batches are designed to be independently reviewable; any failing batch can be reverted without affecting others.
+
+1. **Batch 1 — Maintenance & admin endpoints (system-emitted, TENANT scope)** — 6 files:
+   - [src/app/api/admin/rotate-master-key/route.ts](src/app/api/admin/rotate-master-key/route.ts)
+   - [src/app/api/maintenance/audit-chain-verify/route.ts](src/app/api/maintenance/audit-chain-verify/route.ts)
+   - [src/app/api/maintenance/audit-outbox-metrics/route.ts](src/app/api/maintenance/audit-outbox-metrics/route.ts)
+   - [src/app/api/maintenance/audit-outbox-purge-failed/route.ts](src/app/api/maintenance/audit-outbox-purge-failed/route.ts)
+   - [src/app/api/maintenance/dcr-cleanup/route.ts](src/app/api/maintenance/dcr-cleanup/route.ts)
+   - [src/app/api/maintenance/purge-audit-logs/route.ts](src/app/api/maintenance/purge-audit-logs/route.ts)
+   - [src/app/api/maintenance/purge-history/route.ts](src/app/api/maintenance/purge-history/route.ts)
+
+2. **Batch 2 — Internal & MCP & extension endpoints** — 3 files / multiple call sites:
+   - ~~[src/app/api/internal/audit-emit/route.ts](src/app/api/internal/audit-emit/route.ts)~~ — **MOVED to Bucket C** (no `tenantId` available without an extra DB lookup; see Considerations).
+   - [src/app/api/mcp/authorize/consent/route.ts](src/app/api/mcp/authorize/consent/route.ts) (3 calls)
+   - [src/app/api/mcp/register/route.ts](src/app/api/mcp/register/route.ts)
+   - [src/app/api/extension/token/exchange/route.ts](src/app/api/extension/token/exchange/route.ts) (2 calls)
+
+3. **Batch 3 — Audit-log meta endpoints (conditional team/personal)** — 3 files:
+   - [src/app/api/audit-logs/export/route.ts](src/app/api/audit-logs/export/route.ts)
+   - [src/app/api/audit-logs/import/route.ts](src/app/api/audit-logs/import/route.ts)
+   - [src/app/api/watchtower/alert/route.ts](src/app/api/watchtower/alert/route.ts)
+
+4. **Batch 4 — Vault & share-link endpoints (mixed including tx)** — 5 files:
+   - [src/app/api/vault/admin-reset/route.ts](src/app/api/vault/admin-reset/route.ts) (conditional team/tenant)
+   - [src/app/api/vault/delegation/route.ts](src/app/api/vault/delegation/route.ts) (dual emit personal+tenant)
+   - [src/app/api/vault/delegation/check/route.ts](src/app/api/vault/delegation/check/route.ts)
+   - [src/app/api/share-links/route.ts](src/app/api/share-links/route.ts) (logAuditInTx)
+   - [src/app/api/share-links/[id]/route.ts](src/app/api/share-links/[id]/route.ts) (logAuditInTx, conditional)
+   - [src/app/api/share-links/verify-access/route.ts](src/app/api/share-links/verify-access/route.ts) (2 calls)
+
+5. **Batch 5 — SCIM & access-requests endpoints (TENANT scope)** — 4 files:
+   - SCIM endpoints authenticate via SCIM token bound to a tenant admin user; that user's id is the audit actor (preserved from pre-migration behavior).
+   - [src/app/api/scim/v2/Users/route.ts](src/app/api/scim/v2/Users/route.ts)
+   - [src/app/api/scim/v2/Users/[id]/route.ts](src/app/api/scim/v2/Users/[id]/route.ts) (3 calls)
+   - [src/app/api/scim/v2/Groups/[id]/route.ts](src/app/api/scim/v2/Groups/[id]/route.ts) (2 calls)
+   - [src/app/api/tenant/access-requests/route.ts](src/app/api/tenant/access-requests/route.ts)
+
+6. **Batch 6 — Documentation update** (must run AFTER Batches 1-5 land) — extend [src/lib/audit.ts](src/lib/audit.ts) module-doc to:
+   - Mandate helper usage in route-handler context
+   - Document Bucket C exceptions (auth callbacks, lib/, workers, mcp tools, `internal/audit-emit` due to no-tenantId-without-DB-lookup)
+   - This batch references the migration completed in Batches 1-5; do NOT execute it ahead of order.
+
+7. **Batch 7 — Verification**:
+   - Run `npx vitest run`
+   - Run `npm run test:integration` against local Postgres
+   - Run `npx eslint .` (zero warnings)
+   - Run `npx next build`
+   - Run `scripts/pre-pr.sh` if available
+
+## Testing strategy
+
+### Existing test coverage
+
+No new tests are required. The migration is behavior-preserving. Existing tests cover the call sites — they will catch any drift.
+
+**Existing `extractRequestMeta` mocks transparently apply to helper-using sites — no mock updates required.** Many test files (e.g., `vault/reset/route.test.ts`, `auth/passkey/verify/route.test.ts`, `tenant/policy/route.test.ts`) mock `extractRequestMeta` at the module boundary. Helpers internally call `extractRequestMeta`, so the mocks apply transparently after migration.
+
+**Audit payload assertion patterns** (verified by grep): Bucket B test files use `expect.objectContaining(...)` (partial match) for `logAuditAsync` arg assertions, NOT `toEqual`/`toStrictEqual` (exact shape). Helper additions like `acceptLanguage` therefore do not break existing tests. **Exception**: `vault/delegation/route.test.ts:350-359` explicitly asserts `tenantId: TENANT_ID` on the PERSONAL emit — Pattern 5 migration MUST preserve `tenantId` after the helper spread (see Pattern 5 mandatory note).
+
+**Priority integration tests**: when running `npm run test:integration`, prioritize:
+- `src/__tests__/integration/audit-and-isolation.test.ts` — queries `audit_logs` directly; catches column-shape regressions
+- `src/__tests__/db-integration/audit-logaudit-non-atomic.integration.test.ts` — exercises non-tx audit write path
+
+Specifically:
+- `src/app/api/mcp/token/route.test.ts` — covers tenantAuditBase migration done in `9f5b287c`.
+- `src/app/api/audit-logs/{export,import}/route.test.ts` — exists and exercises the conditional scope branch.
+- `src/app/api/vault/delegation/route.test.ts` — covers the dual-emit pattern.
+- `src/app/api/share-links/{route,[id]/route,verify-access/route}.test.ts` — covers tx variant.
+- Most other Bucket B files have a corresponding `.test.ts`.
+
+### Test red flags to watch (R19 / RT1)
+
+Search every file under change for exact-shape assertions on the audit log payload. Specifically grep test files for:
+- `expect(...).toEqual({` followed by an `audit:` or `scope:` field — exact-shape assertion that may need updating if helper's `acceptLanguage` reaches the assertion (it shouldn't, since `buildOutboxPayload` discards it before persistence/log emit, but verify).
+- Mock `enqueueAudit` / `enqueueAuditInTx` / `enqueueAuditBulk` setups — confirm they don't assume a specific param-key order.
+
+If any test fails after migration, do not "fix" the test by accommodating the new shape — investigate whether the helper produces a different effective payload. If yes, the helper is the bug, not the test.
+
+### Manual verification
+
+For one representative call per pattern (Patterns 1, 3, 5, 6), add a Vitest inline snapshot of the payload passed to `logAuditAsync` / `logAuditInTx`. Use `expect(mockLogAudit.mock.calls[0][0]).toMatchInlineSnapshot()`. The snapshot lives in the PR diff, persists across PRs, and breaks loudly on any future shape drift. Estimated cost: 4 snapshot blocks, ~20 LOC total.
+
+Do NOT use `console.log` + revert: that pattern reliably leaks debug prints into production code.
+
+## Considerations & constraints
+
+### Out of scope
+
+The following call sites are explicitly Bucket C and remain unchanged:
+
+| File | Reason |
+|------|--------|
+| `src/auth.ts` (3 calls) | NextAuth event/jwt callbacks — no `NextRequest` in scope, uses `sessionMetaStorage.getStore()` |
+| `src/lib/auth-adapter.ts` | NextAuth adapter — no `NextRequest` in scope |
+| `src/lib/access-restriction.ts` | Library function called from multiple contexts including non-HTTP |
+| `src/lib/account-lockout.ts` | Library function with optional `request?: NextRequest` — already conditionally uses `extractRequestMeta` when available |
+| `src/lib/delegation.ts` | Library function called after HTTP response (post-revoke cleanup) |
+| `src/lib/directory-sync/engine.ts` | Background sync engine (cron / polling) |
+| `src/lib/extension-token.ts` | Library function for token validation |
+| `src/lib/mcp/tools.ts` | MCP tool execution context — no NextRequest |
+| `src/lib/notification.ts` | Notification emission library |
+| `src/lib/team-policy.ts` | Policy library |
+| `src/lib/webhook-dispatcher.ts` | Webhook delivery callback (async loop) |
+| `src/lib/constants/audit.ts` | Constants file (one validation event) |
+| `src/workers/audit-outbox-worker.ts` | Background worker process |
+| `src/app/api/internal/audit-emit/route.ts` | TENANT-scope route where `tenantId` is not available at the call site without an extra DB lookup. `checkAuth` returns `userId` only; current code relies on `resolveTenantId()` for tenant resolution. Adding a User.findUnique purely for the helper would introduce an unreviewed extra DB roundtrip per call. Bucket C until a `tenantAuditBaseLazy(req, userId)` variant (which lets `resolveTenantId` continue to work) is introduced as a separate plan. |
+
+The Bucket C list is FROZEN by this plan. Any addition to it during implementation must be recorded in the deviation log with a concrete reason that maps to one of the categories above (or explains why a new category is justified).
+
+### Risks
+
+- **Risk 1 (low)**: Variable name mismatch — source uses `request` but migration uses `req`. Mitigation: each file's migration must preserve the source variable name. Reviewer must spot-check.
+- **Risk 2 (low)**: Helper accidentally drops `acceptLanguage` from a downstream consumer that reads it. Mitigation: confirmed via reading `buildOutboxPayload` that `acceptLanguage` is not part of `AuditOutboxPayload` — this risk is theoretical.
+- **Risk 3 (very low)**: A test asserts the param-key order or includes `acceptLanguage`. Mitigation: existing test runs catch this immediately; revert the helper migration for the affected file if needed.
+- **Risk 4 (medium)**: A Bucket B file actually has subtly different params that the helper doesn't capture (e.g., a custom `actorType: SYSTEM` overlay). Mitigation: keep the override fields explicit AFTER the helper spread (`...tenantAuditBase(req, ...), actorType: ACTOR_TYPE.SYSTEM`). Order matters — overrides go last.
+- **Risk 5 (low — informational)**: At the migration boundary, `audit_logs.userAgent` for `MASTER_KEY_ROTATION` and `MCP_CLIENT_DCR_CLAIM` events transitions from null to populated (per Functional 2 EXCEPTION). The audit hash chain (verified via `/api/maintenance/audit-chain-verify`) links each event to the previous event's hash, NOT to its schema — so this is a hash-continuity event for the very first post-migration event of each action, NOT a chain break. Older events remain valid; newer events hash correctly going forward. No code mitigation required; documented for incident-response clarity.
+- **Risk 6 (low — informational)**: User-Agent strings persisted by the helper-driven audit events are the same strings already captured for HUMAN-actor events across the system. They are not PII per se but may include browser version, OS version, and extension fingerprints. No new threat surface is introduced — the strings flow into `audit_logs.userAgent`, which is already tenant-scoped via RLS and not exposed outside the audit log read endpoints (which are tenant-admin gated). No mitigation required; documented for completeness.
+
+### Per-call-site override checklist (Batches 2 and 5)
+
+To prevent override-field omission, the per-call-site override fields are pre-listed below. Implementer copy-pastes the post-spread block.
+
+**Batch 2:**
+- `mcp/authorize/consent/route.ts:67` — overrides: `action`, `targetType`, `targetId`, `metadata`. NO `actorType` override (helper default HUMAN is correct).
+- `mcp/authorize/consent/route.ts:152` — overrides: `action`, `targetType`, `targetId`, `metadata`. Per Functional 2 EXCEPTION, `userAgent` is added by helper (deliberate).
+- `mcp/authorize/consent/route.ts:192` — overrides: `action`, `targetType`, `targetId`, `metadata`.
+- `mcp/register/route.ts:174` — overrides: `action`, `targetType`, `targetId`, `metadata`.
+- `extension/token/exchange/route.ts:154` (failure) — overrides: `action`, `tenantId` (already passed, helper covers via tenantAuditBase third arg), `metadata`.
+- `extension/token/exchange/route.ts:176` (success) — overrides: `action`, `tenantId` (helper covers).
+
+**Batch 5:**
+- `scim/v2/Users/route.ts:220` — overrides: `action`, `targetType`, `targetId`, `metadata`.
+- `scim/v2/Users/[id]/route.ts:103/182/241` — overrides: `action`, `targetType`, `targetId`, `metadata` per call.
+- `scim/v2/Groups/[id]/route.ts:85/153` — overrides: `action`, `targetType`, `targetId`, `metadata` per call.
+- `tenant/access-requests/route.ts:200` — overrides: `action`, `targetType`, `targetId`, `metadata`. Verify if any `actorType` override is needed (current code may set HUMAN explicitly — preserve as-is).
+
+For all other batches, follow the same pattern: enumerate overrides per call site BEFORE writing the helper-spread call.
+
+### Override ordering invariant
+
+The helper spread MUST come FIRST; any explicit overrides come AFTER:
+
+```ts
+// CORRECT: helper sets defaults, explicit override wins
+{ ...tenantAuditBase(req, userId, tenantId), actorType: ACTOR_TYPE.SYSTEM, action, targetId }
+
+// WRONG: helper would overwrite the actorType override
+{ actorType: ACTOR_TYPE.SYSTEM, ...tenantAuditBase(req, userId, tenantId), action, targetId }
+```
+
+Reviewer (and implementer) MUST verify this order on every migration.
+
+### Anti-patterns to flag during implementation
+
+If during implementation a helper needs to be modified or extended (new helper variant, new field), STOP and:
+1. Add an entry to the deviation log explaining why.
+2. Surface to the user before continuing.
+This refactor is intended to use the helpers AS-IS. Any helper change is a scope expansion that requires explicit approval.
+
+## User operation scenarios
+
+These scenarios cover the affected endpoints and are used to mentally validate behavior preservation. They are NOT new test additions — they are existing user flows that must keep working.
+
+1. **Tenant admin rotates master key** (`POST /api/admin/rotate-master-key`):
+   - Audit event: `MASTER_KEY_ROTATE` with `actorType: SYSTEM`, `userId: SYSTEM_ACTOR_ID`, scope `TENANT`, `tenantId` set, `ip` from caller.
+   - Migration target: Pattern 2 with explicit `actorType: SYSTEM` override.
+
+2. **User exports their personal audit log** (`POST /api/audit-logs/export`):
+   - Audit event: `AUDIT_LOG_EXPORT` with scope `PERSONAL`, `userId`, no `teamId`, `ip` + `userAgent` captured.
+   - Migration target: Pattern 3 (conditional team-vs-personal) with `teamId === undefined`.
+
+3. **Team admin exports team audit log** (`POST /api/audit-logs/export?teamId=…`):
+   - Same as #2 but scope `TEAM`, `teamId` set.
+
+4. **MCP client OAuth consent grant** (`POST /api/mcp/authorize/consent`):
+   - Three sequential events: `MCP_AUTHORIZE_INIT` (PERSONAL on first call?), `MCP_CONSENT_GRANT` / `MCP_CONSENT_DENY` (PERSONAL), and a TENANT-scope summary event. Verify each call's scope post-migration matches pre-migration.
+
+5. **Vault admin reset for tenant member** (`POST /api/vault/admin-reset`):
+   - When the user belongs to a team: event scope `TEAM` with `teamId`. When tenant-only: scope `TENANT` with `tenantId`. Pattern 4.
+
+6. **Delegation create** (`POST /api/vault/delegation`):
+   - Two events emitted in `Promise.all`: `DELEGATION_CREATE` PERSONAL + `DELEGATION_CREATE` TENANT. Both with same `targetId` (the delegation session id). Pattern 5.
+
+7. **Share link create** (`POST /api/share-links`) and **revoke** (`DELETE /api/share-links/[id]`):
+   - Inside Prisma transaction: event scope conditional on whether the share is for a team password entry. Pattern 6.
+
+8. **SCIM user provisioning** (`POST /api/scim/v2/Users`, `PATCH /api/scim/v2/Users/[id]`, `DELETE /api/scim/v2/Users/[id]`):
+   - All events scope `TENANT`. The `userId` field is the SCIM-token-bound user, which already exists at the call site.
+
+9. **Maintenance: purge audit logs** (`POST /api/maintenance/purge-audit-logs`):
+   - Event with `actorType: SYSTEM`, `userId: SYSTEM_ACTOR_ID`, scope `TENANT`. Pattern 2.
+
+10. **Internal audit emit** (`POST /api/internal/audit-emit`):
+    - Internal helper endpoint. The route uses `request` (not `req`); migration must preserve the variable name.

--- a/docs/archive/review/enforce-audit-base-helper-usage-review.md
+++ b/docs/archive/review/enforce-audit-base-helper-usage-review.md
@@ -1,0 +1,232 @@
+# Plan Review: enforce-audit-base-helper-usage
+Date: 2026-04-19
+Review round: 1
+
+## Changes from Previous Round
+Initial review.
+
+## Functionality Findings
+
+[F1] **Major**: Pattern 5 dual-emit drops explicit `tenantId` from PERSONAL-scope event, changing `auditLogger` JSON shape and breaking existing test
+- Problem: `vault/delegation/route.ts:204-216` original `auditBase` includes `tenantId` for BOTH PERSONAL+TENANT emits. Migration to `personalAuditBase(request, userId)` drops it from the params object. Existing test `vault/delegation/route.test.ts:350-359` explicitly asserts `tenantId: TENANT_ID` on the PERSONAL emit.
+- Impact: Test fails on Batch 4. Downstream JSON-log aggregation queries grouping by PERSONAL-scope `audit.tenantId` break.
+- Fix: Plan must show `{ ...personalAuditBase(request, userId), tenantId, ...auditBody }` for the PERSONAL emit.
+
+[F2] **Major**: `internal/audit-emit/route.ts` migration recipe missing — no `tenantId` available at call site
+- Problem: Current code passes only `userId` and relies on `resolveTenantId()` for tenant lookup. `tenantAuditBase(request, userId, tenantId)` requires `tenantId` as the third arg; `checkAuth` here returns `userId` only. No helper variant exists for "TENANT scope, lookup tenantId later".
+- Impact: Implementation ambiguity — implementer may invent an unreviewed extra DB lookup, or the file silently fails to compile.
+- Fix: Move `internal/audit-emit/route.ts` to Bucket C with documented exception ("TENANT-scope route where tenantId requires DB resolution by userId — no helper applies"). Document the new Bucket C category.
+
+[F3] **Major**: `share-links/route.ts` Pattern 6 recipe leaves orphan `extractRequestMeta` variables
+- Problem: `share-links/route.ts:186` calls `extractRequestMeta(req)` BEFORE the `withBypassRls(prisma, async (tx) => …)` block. Plan's Pattern 6 "after" example uses the helper INSIDE the tx callback. Both variables (`ip`/`userAgent`) become unused, triggering lint failures (zero-warning policy).
+- Impact: Lint failure; dead code.
+- Fix: Add explicit Pattern 6 step: "delete the pre-tx `const { ip, userAgent } = extractRequestMeta(req)` line when its only consumer was the migrated audit call."
+
+[F4] **Minor**: `mcp/authorize/consent/route.ts:152` — current `MCP_CLIENT_DCR_CLAIM` emit omits `userAgent` (only `ip: claimIp`); helper would re-add it
+- Problem: After migration, `userAgent` becomes populated where it was absent.
+- Impact: Behavior change — additive forensic field on persisted audit row.
+- Fix: Treat as deliberate forensic upgrade (per S1); document explicitly in plan that this site, along with `admin/rotate-master-key/route.ts:123`, intentionally CORRECTS the omission.
+
+[F5] **Minor**: Override-field enumeration not exhaustive for Batches 2/5
+- Problem: Plan's "additional fields" guidance is general. Implementer may forget required fields (`actorType`, `serviceAccountId`, `metadata`) per call site.
+- Fix: For Batches 2/5, pre-list every non-helper field per call site (action, targetType, targetId, metadata, actorType, serviceAccountId).
+
+[F6] **Minor**: Batch 6 (docs) implicitly depends on Batches 1-5
+- Problem: Plan claims batches are independently reviewable; Batch 6 documents helpers that the prior batches must already use.
+- Fix: Reorder Batch 6 to "Final docs after Batches 1-5 land" or merge into Batch 7.
+
+## Security Findings
+
+[S1] **Major**: `admin/rotate-master-key/route.ts:113-124` migration is a forensic UPGRADE (current code OMITS `userAgent`)
+- Problem: Plan states "behavior preservation" but migration adds `userAgent` to a previously-null field. This is a desired upgrade, but plan currently labels it as forbidden.
+- Impact: Over-cautious implementer might add `userAgent: null` after the helper spread to "preserve behavior", losing the forensic upgrade.
+- Fix: Plan §Functional 2 must add an exception clause: "EXCEPTION: pre-existing forensic-field omissions (ip OR userAgent) at any Bucket B call site are intentionally CORRECTED by the migration." Enumerate affected sites: `admin/rotate-master-key/route.ts:123`, `mcp/authorize/consent/route.ts:152`.
+
+[S2] **Minor**: Plan does not enumerate Bucket B sites that use `extractClientIp(...)` directly instead of `extractRequestMeta(...)`
+- Problem: `vault/delegation/check/route.ts:98` and `vault/delegation/route.ts:210` use `extractClientIp(request)` directly. Implementer may mis-recognize these as "not Bucket B" and skip them.
+- Fix: Add note under "Migration patterns" that `extractClientIp(req)` (without `extractRequestMeta`) is also a Bucket B antipattern — the helper replaces both forms.
+
+[S3] **Minor**: SCIM endpoint actor attribution undocumented
+- Problem: SCIM endpoints authenticate via SCIM token; the bound user's id IS the audit actor. This is non-obvious convention.
+- Fix: Add sentence to Batch 5 description: "SCIM endpoints authenticate via SCIM token bound to a tenant admin user; that user's id is the audit actor (preserved from pre-migration behavior)."
+
+[S4] **Minor**: Audit chain integrity — document hash continuity at migration boundary
+- Problem: When a previously-null `userAgent` becomes populated post-migration, the chain has a one-event hash continuity transition (not a chain break — chain links to previous hash, not previous schema).
+- Fix: Document in plan §Risks: "Pre/post migration boundary creates a one-event userAgent populated/non-populated transition. The hash chain links each event to the previous event's hash, so this is a hash continuity event, not a chain break."
+
+## Testing Findings
+
+[T1] **Minor**: Replace "console.log + revert" manual verification with Vitest inline snapshots
+- Problem: Plan's Manual Verification section recommends `console.log` then revert — exactly the pattern that gets accidentally committed.
+- Fix: Replace with Vitest `expect(payload).toMatchInlineSnapshot()` for one representative call per pattern. Snapshot lives in PR diff and breaks loudly on shape drift.
+
+[T2] **Major**: `vault/delegation/route.test.ts:350-359` will FAIL after F1 migration unless tenantId preserved on PERSONAL emit
+- Problem: Test asserts `tenantId: TENANT_ID` on PERSONAL emit (line 355). Plan's "after" example would yield `tenantId: undefined` in params.
+- Impact: Test failure on Batch 4.
+- Fix: Apply F1 fix — keep `tenantId` after the helper spread on the PERSONAL emit.
+
+[T3] **Minor**: Document that existing `extractRequestMeta` mocks transparently apply to helpers
+- Problem: Many tests mock `extractRequestMeta`. Helpers internally call it, so mocks transparently apply.
+- Fix: Add one-line note to plan §Testing strategy: "Existing `extractRequestMeta` mocks transparently apply to helper-using sites — no mock updates required."
+
+[T4] **Minor**: Specify priority integration tests
+- Problem: Plan says `npm run test:integration` but doesn't highlight which tests are sensitive to audit-payload changes.
+- Fix: Add to Testing strategy: "Priority integration tests for this refactor: `src/__tests__/integration/audit-and-isolation.test.ts`, `src/__tests__/db-integration/audit-logaudit-non-atomic.integration.test.ts`."
+
+## Adjacent Findings
+
+[F-Adjacent (→ Testing)] Minor: "console.log + revert" manual verification fragility — routed to T1 (already covered).
+
+## Quality Warnings
+None — all findings have evidence and concrete fixes.
+
+## Recurring Issue Check
+
+### Functionality expert
+R1 N/A — no concurrency/transaction race introduced; tx scope unchanged.
+R2 Checked — finding F1 (data-shape change for PERSONAL emit's tenantId).
+R3 Checked — finding F2 (missing tenantId source for audit-emit).
+R4 N/A — no error-handling code path changed.
+R5 N/A — no new validation logic.
+R6 N/A — no schema change.
+R7 N/A — no new API endpoints.
+R8 N/A — no auth/authz change.
+R9 N/A — no encryption code touched.
+R10 Checked — override ordering rule confirmed correct via audit.ts inspection.
+R11 Checked — finding F4 (incidental userAgent population on consent line 152).
+R12 Checked — finding F3 (dead-variable risk from extractRequestMeta orphans).
+R13 N/A — no UI changes.
+R14 N/A — no i18n strings.
+R15 Checked — Bucket C list explicitly frozen with reasons; F2 will add `internal/audit-emit` to the list.
+R16 N/A — no pricing/billing code.
+R17 N/A — no logging level/sink change.
+R18 Checked — JSON log emit shape change (F1) is the only structured-log impact.
+R19 Checked — exact-shape test risk noted in plan §Test red flags; F4 may trigger it.
+R20 N/A — no migration scripts.
+R21 N/A — no env var changes.
+R22 N/A — no new external deps.
+R23 N/A — no caching behavior.
+R24 N/A — no rate-limit change.
+R25 Checked — finding F6 (Batch 6 doc-only depends on prior batches).
+R26 N/A — no feature flags.
+R27 N/A — no scheduled jobs.
+R28 N/A — no Prisma generate/migrate impact.
+R29 N/A — no SSR/CSR boundary change.
+R30 Checked — Pattern 6 in-tx behavior verified: `enqueueAuditInTx` ignores params.tenantId.
+
+### Security expert
+R1 N/A — helpers pre-existing.
+R2 N/A — no constants change.
+R3 Checked — F1/F4/S1 covered specific propagation gaps for ip/userAgent.
+R4 N/A — no event dispatch added or removed.
+R5 N/A — tx scope unchanged.
+R6 N/A — no schema cascade.
+R7 Checked — no E2E references audit module's internal field shape.
+R8 N/A — no UI changes.
+R9 Checked — no fire-and-forget in tx; Pattern 6 is awaited.
+R10 N/A — no new module imports.
+R11 N/A — no display/subscription grouping.
+R12 N/A — no new audit actions.
+R13 N/A — no event delivery loop change.
+R14 N/A — no DB roles changed.
+R15 N/A — no migrations.
+R16 N/A — no DB role tests.
+R17 N/A — no new helper introduced.
+R18 N/A — no privileged-op file movement.
+R19 Checked — verified test assertions use `objectContaining`, helper additions don't break.
+R20 N/A — manual per-file edits, no mechanical insertions.
+R21 Checked — per-batch verification mandated in plan.
+R22 Checked — perspective inversion verified (also `extractClientIp` direct sites — S2).
+R23 N/A — no UI input handlers.
+R24 N/A — no schema migrations.
+R25 N/A — no persisted state changes.
+R26 N/A — no UI disabled-state.
+R27 N/A — no user-facing strings.
+R28 N/A — no toggle/switch labels.
+R29 N/A — no external spec citations in plan.
+R30 N/A — no Markdown citations in plan/PR body yet.
+RS1 N/A — no credential/token comparison.
+RS2 N/A — no new API endpoints.
+RS3 N/A — no new request parameters.
+
+### Testing expert
+R1 N/A — no shared utility introduced.
+R2 N/A — no hardcoded constant changes.
+R3 Checked — Bucket B enumeration validated.
+R4 N/A — no event dispatch.
+R5 N/A — no new tx or read-then-write sequences.
+R6 N/A — no schema cascades.
+R7 N/A — no E2E selectors.
+R8 N/A — no UI changes.
+R9 N/A — no fire-and-forget in tx.
+R10 N/A — no module dependency change.
+R11 N/A — no display/subscription grouping.
+R12 N/A — no new audit actions.
+R13 N/A — no event delivery loop.
+R14 N/A — no DB roles.
+R15 N/A — no migrations.
+R16 N/A — no DB role tests.
+R17 N/A — no new helper.
+R18 N/A — no privileged-op changes.
+R19 Checked — verified Bucket B test files use `objectContaining`. Exception: `vault/delegation/route.test.ts` asserts `tenantId: TENANT_ID` on PERSONAL emit — see T2.
+R20 N/A — no mechanical inserts.
+R21 N/A — no subagent-driven changes yet (planning phase).
+R22 Checked — both perspectives covered: forward AND inverted (`extractClientIp` direct sites — S2).
+R23 N/A — no UI input handlers.
+R24 N/A — no schema migrations.
+R25 N/A — no persisted-state changes.
+R26 N/A — no UI disabled-state.
+R27 N/A — no user-facing strings.
+R28 N/A — no toggle/switch labels.
+R29 N/A — no spec citations.
+R30 N/A — no Markdown autolinks.
+RT1 Checked — mock return shapes match real `extractRequestMeta` shape; migration preserves alignment.
+RT2 N/A — no new tests recommended that aren't testable.
+RT3 N/A — no shared constants in test assertions (audit module is mocked).
+
+---
+
+# Plan Review: enforce-audit-base-helper-usage
+Date: 2026-04-19
+Review round: 2
+
+## Changes from Previous Round
+Round 1 added: Functional 2 forensic-upgrade EXCEPTION (S1/F4); Pattern 5 mandatory tenantId preservation (F1/T2); Pattern 6 explicit pre-tx variable deletion (F3); Pattern 7 for `extractClientIp` direct-use (S2); Bucket C move for `internal/audit-emit/route.ts` (F2); Batch 5 SCIM actor attribution note (S3); Batch 6 reorder (F6); per-call-site override checklist for Batches 2/5 (F5); Risk 5 hash-continuity note (S4); manual-verification snapshot recipe (T1); test-strategy notes for mocks + priority integration tests (T3/T4).
+
+Sub-agent quotas exhausted; Round 2 was performed via local LLM pre-screening (gpt-oss:120b) plus inline orchestrator analysis.
+
+## Functionality Findings
+No new findings.
+
+## Security Findings
+[S5] **Minor**: User-Agent string sensitivity at audit-write boundary
+- Problem: Adding `userAgent` to `MASTER_KEY_ROTATION` and `MCP_CLIENT_DCR_CLAIM` events introduces no new fingerprintable data — the same strings are already captured for HUMAN-actor events.
+- Impact: Threat surface unchanged. `audit_logs.userAgent` is tenant-scoped (RLS) and exposed only via tenant-admin-gated read endpoints.
+- Fix: Documented in plan §Risks/Risk 6 for incident-response clarity.
+
+## Testing Findings
+No new findings.
+
+## Adjacent Findings
+None.
+
+## Quality Warnings
+None.
+
+## Round 2 Rejected Findings (False Alarms — Documented Reason)
+
+[R-rejected-1] [Major] R1 "Missing audit.ts in shared-utility inventory" — REJECTED. The plan explicitly cites `src/lib/audit.ts` and shows the helper signatures throughout. No reimplementation risk.
+
+[R-rejected-2] [Major] R3 "Missing logAuditBulkAsync coverage" — REJECTED. Verified by grep — every `logAuditBulkAsync` call site (`src/app/api/{passwords,teams/[teamId]/passwords}/bulk-*/route.ts` + `empty-trash/route.ts`) is already in Bucket A (uses `personalAuditBase`/`teamAuditBase`). No Bucket B site uses bulk variant.
+
+[R-rejected-3] [Minor] R2 "Leftover AUDIT_SCOPE imports" — REJECTED. Already addressed in plan §"Import updates (mandatory per file)".
+
+[R-rejected-4] [Minor] R4 "Missing per-file actorType override checklist" — REJECTED. Already addressed in plan §"Per-call-site override checklist (Batches 2 and 5)".
+
+## Resolution Status
+- Round 1: All 13 Round-1 findings (4 Major + 9 Minor) are reflected in the plan revisions above.
+- Round 2: 1 new Minor finding (S5) reflected in §Risks/Risk 6. 4 false alarms documented as rejected.
+
+## Recurring Issue Check
+Round 2 used the same R1-R30 / RS / RT framework. No new R items triggered beyond those already covered in Round 1.
+

--- a/src/__tests__/api/share-links/delete.test.ts
+++ b/src/__tests__/api/share-links/delete.test.ts
@@ -24,10 +24,9 @@ vi.mock("@/lib/prisma", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditInTx: mockLogAuditInTx,
-  extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "Test" }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "Test" }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "Test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,

--- a/src/__tests__/api/share-links/delete.test.ts
+++ b/src/__tests__/api/share-links/delete.test.ts
@@ -25,6 +25,9 @@ vi.mock("@/lib/prisma", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditInTx: mockLogAuditInTx,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "Test" }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "Test" }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,

--- a/src/__tests__/api/share-links/route.test.ts
+++ b/src/__tests__/api/share-links/route.test.ts
@@ -48,10 +48,9 @@ vi.mock("@/lib/team-auth", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditInTx: mockLogAuditInTx,
-  extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "Test" }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "Test" }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "Test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,

--- a/src/__tests__/api/share-links/route.test.ts
+++ b/src/__tests__/api/share-links/route.test.ts
@@ -49,6 +49,9 @@ vi.mock("@/lib/team-auth", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditInTx: mockLogAuditInTx,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "Test" }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "Test" }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,

--- a/src/__tests__/lib/audit-helpers.test.ts
+++ b/src/__tests__/lib/audit-helpers.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import {
+  personalAuditBase,
+  teamAuditBase,
+  tenantAuditBase,
+} from "@/lib/audit";
+import { AUDIT_SCOPE } from "@/lib/constants/audit";
+
+function makeReq(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest("http://localhost/api/test", { headers });
+}
+
+describe("personalAuditBase", () => {
+  it("returns PERSONAL scope with userId", () => {
+    const req = makeReq();
+    const result = personalAuditBase(req, "user-1");
+    expect(result.scope).toBe(AUDIT_SCOPE.PERSONAL);
+    expect(result.userId).toBe("user-1");
+  });
+
+  it("includes ip, userAgent, acceptLanguage from request meta", () => {
+    const req = makeReq({
+      "x-forwarded-for": "203.0.113.5",
+      "user-agent": "test-agent/1.0",
+      "accept-language": "en-US,en;q=0.9",
+    });
+    const result = personalAuditBase(req, "user-1");
+    expect(result).toHaveProperty("ip");
+    expect(result.userAgent).toBe("test-agent/1.0");
+    expect(result.acceptLanguage).toBe("en-US,en;q=0.9");
+  });
+
+  it("returns null ip/userAgent when headers absent", () => {
+    const req = makeReq();
+    const result = personalAuditBase(req, "user-1");
+    expect(result.ip).toBeNull();
+    expect(result.userAgent).toBeNull();
+    expect(result.acceptLanguage).toBeNull();
+  });
+
+  it("does NOT set teamId or tenantId", () => {
+    const req = makeReq();
+    const result = personalAuditBase(req, "user-1") as Record<string, unknown>;
+    expect(result.teamId).toBeUndefined();
+    expect(result.tenantId).toBeUndefined();
+  });
+});
+
+describe("teamAuditBase", () => {
+  it("returns TEAM scope with userId and teamId", () => {
+    const req = makeReq();
+    const result = teamAuditBase(req, "user-1", "team-1");
+    expect(result.scope).toBe(AUDIT_SCOPE.TEAM);
+    expect(result.userId).toBe("user-1");
+    expect(result.teamId).toBe("team-1");
+  });
+
+  it("does NOT set tenantId (caller must override if needed)", () => {
+    const req = makeReq();
+    const result = teamAuditBase(req, "user-1", "team-1") as Record<string, unknown>;
+    expect(result.tenantId).toBeUndefined();
+  });
+
+  it("includes request meta (ip, userAgent, acceptLanguage)", () => {
+    const req = makeReq({ "user-agent": "ua" });
+    const result = teamAuditBase(req, "user-1", "team-1");
+    expect(result.userAgent).toBe("ua");
+    expect(result).toHaveProperty("ip");
+    expect(result).toHaveProperty("acceptLanguage");
+  });
+});
+
+describe("tenantAuditBase", () => {
+  it("returns TENANT scope with userId and tenantId", () => {
+    const req = makeReq();
+    const result = tenantAuditBase(req, "user-1", "tenant-1");
+    expect(result.scope).toBe(AUDIT_SCOPE.TENANT);
+    expect(result.userId).toBe("user-1");
+    expect(result.tenantId).toBe("tenant-1");
+  });
+
+  it("does NOT set teamId", () => {
+    const req = makeReq();
+    const result = tenantAuditBase(req, "user-1", "tenant-1") as Record<string, unknown>;
+    expect(result.teamId).toBeUndefined();
+  });
+
+  it("includes request meta (ip, userAgent, acceptLanguage)", () => {
+    const req = makeReq({ "user-agent": "ua" });
+    const result = tenantAuditBase(req, "user-1", "tenant-1");
+    expect(result.userAgent).toBe("ua");
+    expect(result).toHaveProperty("ip");
+    expect(result).toHaveProperty("acceptLanguage");
+  });
+});

--- a/src/app/api/admin/rotate-master-key/route.test.ts
+++ b/src/app/api/admin/rotate-master-key/route.test.ts
@@ -34,6 +34,9 @@ vi.mock("@/lib/rate-limit", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "10.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "10.0.0.1", userAgent: "Test" }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "10.0.0.1", userAgent: "Test" }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "10.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
   withBypassRls: mockWithBypassRls,

--- a/src/app/api/admin/rotate-master-key/route.test.ts
+++ b/src/app/api/admin/rotate-master-key/route.test.ts
@@ -33,10 +33,9 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: () => ({ ip: "10.0.0.1", userAgent: "Test" }),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "10.0.0.1", userAgent: "Test" }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "10.0.0.1", userAgent: "Test" }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "10.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "10.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "10.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "10.0.0.1", userAgent: "Test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
   withBypassRls: mockWithBypassRls,

--- a/src/app/api/admin/rotate-master-key/route.ts
+++ b/src/app/api/admin/rotate-master-key/route.ts
@@ -22,8 +22,8 @@ import {
   getMasterKeyByVersion,
 } from "@/lib/crypto-server";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
-import { AUDIT_SCOPE, AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
+import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -109,19 +109,15 @@ async function handlePOST(req: NextRequest) {
   }
 
   // Audit log (async nonblocking; logAudit handles errors internally)
-  const { ip } = extractRequestMeta(req);
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.MASTER_KEY_ROTATION,
-    userId: SYSTEM_ACTOR_ID,
+    ...tenantAuditBase(req, SYSTEM_ACTOR_ID, operator.tenantId),
     actorType: ACTOR_TYPE.SYSTEM,
-    tenantId: operator.tenantId,
+    action: AUDIT_ACTION.MASTER_KEY_ROTATION,
     metadata: {
       operatorId,
       targetVersion,
       revokedShares,
     },
-    ip,
   });
 
   return NextResponse.json({

--- a/src/app/api/audit-logs/export/route.test.ts
+++ b/src/app/api/audit-logs/export/route.test.ts
@@ -32,10 +32,9 @@ vi.mock("@/lib/team-auth", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: () => ({ ip: null, userAgent: null }),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null, acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null, acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null, acceptLanguage: null }),
 }));
 vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,

--- a/src/app/api/audit-logs/export/route.test.ts
+++ b/src/app/api/audit-logs/export/route.test.ts
@@ -33,7 +33,9 @@ vi.mock("@/lib/team-auth", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
-  personalAuditBase: vi.fn((_, userId) => ({ scope: "PERSONAL", userId })),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,

--- a/src/app/api/audit-logs/export/route.ts
+++ b/src/app/api/audit-logs/export/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, personalAuditBase, teamAuditBase } from "@/lib/audit";
 import { requireTeamPermission } from "@/lib/team-auth";
 import { assertPolicyAllowsExport, PolicyViolationError } from "@/lib/team-policy";
 import { z } from "zod/v4";
 import { errorResponse, handleAuthError, unauthorized } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
-import { TEAM_PERMISSION, AUDIT_ACTION, AUDIT_SCOPE, EXPORT_FORMAT_VALUES } from "@/lib/constants";
+import { TEAM_PERMISSION, AUDIT_ACTION, EXPORT_FORMAT_VALUES } from "@/lib/constants";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { withRequestLog } from "@/lib/with-request-log";
 import { FILENAME_MAX_LENGTH } from "@/lib/validations/common";
@@ -58,10 +58,10 @@ async function handlePOST(req: NextRequest) {
   }
 
   await logAuditAsync({
-    scope: teamId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.PERSONAL,
+    ...(teamId
+      ? teamAuditBase(req, session.user.id, teamId)
+      : personalAuditBase(req, session.user.id)),
     action: AUDIT_ACTION.ENTRY_EXPORT,
-    userId: session.user.id,
-    teamId: teamId ?? undefined,
     metadata: {
       entryCount,
       format,
@@ -69,7 +69,6 @@ async function handlePOST(req: NextRequest) {
       ...(typeof encrypted === "boolean" ? { encrypted } : {}),
       ...(typeof includeTeams === "boolean" ? { includeTeams } : {}),
     },
-    ...extractRequestMeta(req),
   });
 
   return NextResponse.json({ ok: true });

--- a/src/app/api/audit-logs/import/route.ts
+++ b/src/app/api/audit-logs/import/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, personalAuditBase, teamAuditBase } from "@/lib/audit";
 import { z } from "zod/v4";
 import { handleAuthError, unauthorized } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
-import { AUDIT_ACTION, AUDIT_SCOPE, IMPORT_FORMAT_VALUES } from "@/lib/constants";
+import { AUDIT_ACTION, IMPORT_FORMAT_VALUES } from "@/lib/constants";
 import { requireTeamPermission } from "@/lib/team-auth";
 import { TEAM_PERMISSION } from "@/lib/constants";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -41,10 +41,10 @@ async function handlePOST(req: NextRequest) {
   }
 
   await logAuditAsync({
-    scope: teamId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.PERSONAL,
+    ...(teamId
+      ? teamAuditBase(req, session.user.id, teamId)
+      : personalAuditBase(req, session.user.id)),
     action: AUDIT_ACTION.ENTRY_IMPORT,
-    userId: session.user.id,
-    ...(teamId ? { teamId } : {}),
     metadata: {
       requestedCount,
       successCount,
@@ -53,7 +53,6 @@ async function handlePOST(req: NextRequest) {
       ...(format ? { format } : {}),
       ...(typeof encrypted === "boolean" ? { encrypted } : {}),
     },
-    ...extractRequestMeta(req),
   });
 
   return NextResponse.json({ ok: true });

--- a/src/app/api/extension/token/exchange/route.test.ts
+++ b/src/app/api/extension/token/exchange/route.test.ts
@@ -71,6 +71,9 @@ vi.mock("@/lib/tenant-context", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "1.2.3.4", userAgent: "test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "1.2.3.4", userAgent: "test" }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "1.2.3.4", userAgent: "test" }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "1.2.3.4", userAgent: "test" }),
 }));
 vi.mock("@/lib/ip-access", () => ({
   extractClientIp: mockExtractClientIp,

--- a/src/app/api/extension/token/exchange/route.test.ts
+++ b/src/app/api/extension/token/exchange/route.test.ts
@@ -70,10 +70,9 @@ vi.mock("@/lib/tenant-context", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: () => ({ ip: "1.2.3.4", userAgent: "test" }),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "1.2.3.4", userAgent: "test" }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "1.2.3.4", userAgent: "test" }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "1.2.3.4", userAgent: "test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "1.2.3.4", userAgent: "test", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "1.2.3.4", userAgent: "test", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "1.2.3.4", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/ip-access", () => ({
   extractClientIp: mockExtractClientIp,

--- a/src/app/api/extension/token/exchange/route.ts
+++ b/src/app/api/extension/token/exchange/route.ts
@@ -35,10 +35,10 @@ import {
 import { issueExtensionToken } from "@/lib/extension-token";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { extractClientIp, rateLimitKeyFromIp } from "@/lib/ip-access";
-import { logAuditAsync } from "@/lib/audit";
+import { logAuditAsync, personalAuditBase } from "@/lib/audit";
 import { getLogger } from "@/lib/logger";
 import { withRequestLog } from "@/lib/with-request-log";
-import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
+import { AUDIT_ACTION } from "@/lib/constants";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 
 export const runtime = "nodejs";
@@ -152,12 +152,9 @@ async function handlePOST(req: NextRequest) {
     });
   } catch (err) {
     await logAuditAsync({
-      scope: AUDIT_SCOPE.PERSONAL,
-      action: AUDIT_ACTION.EXTENSION_TOKEN_EXCHANGE_FAILURE,
-      userId: consumed.userId,
+      ...personalAuditBase(req, consumed.userId),
       tenantId: consumed.tenantId,
-      ip,
-      userAgent: req.headers.get("user-agent"),
+      action: AUDIT_ACTION.EXTENSION_TOKEN_EXCHANGE_FAILURE,
       metadata: { reason: "issue_failed" },
     });
     getLogger().error(
@@ -174,12 +171,9 @@ async function handlePOST(req: NextRequest) {
 
   // Audit success: userId and tenantId both come from the consumed code record
   await logAuditAsync({
-    scope: AUDIT_SCOPE.PERSONAL,
-    action: AUDIT_ACTION.EXTENSION_TOKEN_EXCHANGE_SUCCESS,
-    userId: consumed.userId,
+    ...personalAuditBase(req, consumed.userId),
     tenantId: consumed.tenantId,
-    ip,
-    userAgent: req.headers.get("user-agent"),
+    action: AUDIT_ACTION.EXTENSION_TOKEN_EXCHANGE_SUCCESS,
   });
 
   return NextResponse.json(

--- a/src/app/api/maintenance/audit-chain-verify/route.ts
+++ b/src/app/api/maintenance/audit-chain-verify/route.ts
@@ -11,8 +11,8 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
-import { AUDIT_SCOPE, AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
+import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
 import { TENANT_ROLE } from "@/lib/constants/tenant-role";
@@ -306,13 +306,10 @@ async function handleGET(req: NextRequest) {
     }
   }
 
-  const { ip, userAgent } = extractRequestMeta(req);
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.AUDIT_CHAIN_VERIFY,
-    userId: SYSTEM_ACTOR_ID,
+    ...tenantAuditBase(req, SYSTEM_ACTOR_ID, membership.tenantId),
     actorType: ACTOR_TYPE.SYSTEM,
-    tenantId: membership.tenantId,
+    action: AUDIT_ACTION.AUDIT_CHAIN_VERIFY,
     metadata: {
       operatorId,
       targetTenantId: tenantId,
@@ -324,8 +321,6 @@ async function handleGET(req: NextRequest) {
       firstGapAfterSeq,
       firstTimestampViolationSeq,
     },
-    ip,
-    userAgent,
   });
 
   return NextResponse.json({

--- a/src/app/api/maintenance/audit-outbox-metrics/route.ts
+++ b/src/app/api/maintenance/audit-outbox-metrics/route.ts
@@ -10,8 +10,8 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
-import { AUDIT_SCOPE, AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
+import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { requireMaintenanceOperator } from "@/lib/maintenance-auth";
 import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
@@ -86,16 +86,11 @@ async function handleGET(req: NextRequest) {
     asOf: new Date().toISOString(),
   };
 
-  const { ip, userAgent } = extractRequestMeta(req);
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.AUDIT_OUTBOX_METRICS_VIEW,
-    userId: SYSTEM_ACTOR_ID,
+    ...tenantAuditBase(req, SYSTEM_ACTOR_ID, membership.tenantId),
     actorType: ACTOR_TYPE.SYSTEM,
-    tenantId: membership.tenantId,
+    action: AUDIT_ACTION.AUDIT_OUTBOX_METRICS_VIEW,
     metadata: { operatorId, pending: metrics.pending, failed: metrics.failed },
-    ip,
-    userAgent,
   });
 
   return NextResponse.json(metrics);

--- a/src/app/api/maintenance/audit-outbox-purge-failed/route.ts
+++ b/src/app/api/maintenance/audit-outbox-purge-failed/route.ts
@@ -13,8 +13,8 @@ import { prisma } from "@/lib/prisma";
 import { parseBody } from "@/lib/parse-body";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
-import { AUDIT_SCOPE, AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
+import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { requireMaintenanceOperator } from "@/lib/maintenance-auth";
 import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
@@ -65,21 +65,16 @@ async function handlePOST(req: NextRequest) {
 
   const purged = Number(rows[0]?.purged ?? 0);
 
-  const { ip, userAgent } = extractRequestMeta(req);
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.AUDIT_OUTBOX_PURGE_EXECUTED,
-    userId: SYSTEM_ACTOR_ID,
+    ...tenantAuditBase(req, SYSTEM_ACTOR_ID, membership.tenantId),
     actorType: ACTOR_TYPE.SYSTEM,
-    tenantId: membership.tenantId,
+    action: AUDIT_ACTION.AUDIT_OUTBOX_PURGE_EXECUTED,
     metadata: {
       operatorId,
       purgedCount: purged,
       filterTenantId: filterTenantId ?? null,
       olderThanDays: olderThanDays ?? null,
     },
-    ip,
-    userAgent,
   });
 
   return NextResponse.json({ purged });

--- a/src/app/api/maintenance/dcr-cleanup/route.ts
+++ b/src/app/api/maintenance/dcr-cleanup/route.ts
@@ -13,8 +13,8 @@ import { prisma } from "@/lib/prisma";
 import { parseBody } from "@/lib/parse-body";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
-import { AUDIT_SCOPE, AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
+import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
 import { AUDIT_METADATA_KEY } from "@/lib/constants";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { requireMaintenanceOperator } from "@/lib/maintenance-auth";
@@ -63,20 +63,15 @@ async function handlePOST(req: NextRequest) {
   BYPASS_PURPOSE.SYSTEM_MAINTENANCE);
 
   // Audit log
-  const { ip, userAgent } = extractRequestMeta(req);
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.MCP_CLIENT_DCR_CLEANUP,
-    userId: SYSTEM_ACTOR_ID,
+    ...tenantAuditBase(req, SYSTEM_ACTOR_ID, membership.tenantId),
     actorType: ACTOR_TYPE.SYSTEM,
-    tenantId: membership.tenantId,
+    action: AUDIT_ACTION.MCP_CLIENT_DCR_CLEANUP,
     metadata: {
       operatorId,
       [AUDIT_METADATA_KEY.PURGED_COUNT]: deleted.count,
       systemWide: true,
     },
-    ip,
-    userAgent,
   });
 
   return NextResponse.json({ deleted: deleted.count });

--- a/src/app/api/maintenance/purge-audit-logs/route.test.ts
+++ b/src/app/api/maintenance/purge-audit-logs/route.test.ts
@@ -34,10 +34,9 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: () => ({ ip: "10.0.0.1", userAgent: "Test" }),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "10.0.0.1", userAgent: "Test" }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "10.0.0.1", userAgent: "Test" }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "10.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "10.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "10.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "10.0.0.1", userAgent: "Test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
   withBypassRls: mockWithBypassRls,

--- a/src/app/api/maintenance/purge-audit-logs/route.test.ts
+++ b/src/app/api/maintenance/purge-audit-logs/route.test.ts
@@ -35,6 +35,9 @@ vi.mock("@/lib/rate-limit", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "10.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "10.0.0.1", userAgent: "Test" }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "10.0.0.1", userAgent: "Test" }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "10.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
   withBypassRls: mockWithBypassRls,

--- a/src/app/api/maintenance/purge-audit-logs/route.ts
+++ b/src/app/api/maintenance/purge-audit-logs/route.ts
@@ -13,8 +13,8 @@ import { prisma } from "@/lib/prisma";
 import { parseBody } from "@/lib/parse-body";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
-import { AUDIT_SCOPE, AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
+import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
 import { AUDIT_METADATA_KEY } from "@/lib/constants";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { requireMaintenanceOperator } from "@/lib/maintenance-auth";
@@ -88,13 +88,10 @@ async function handlePOST(req: NextRequest) {
     return NextResponse.json({ purged: 0, matched: totalPurged, dryRun: true });
   }
 
-  const { ip, userAgent } = extractRequestMeta(req);
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.HISTORY_PURGE,
-    userId: SYSTEM_ACTOR_ID,
+    ...tenantAuditBase(req, SYSTEM_ACTOR_ID, membership.tenantId),
     actorType: ACTOR_TYPE.SYSTEM,
-    tenantId: membership.tenantId,
+    action: AUDIT_ACTION.HISTORY_PURGE,
     metadata: {
       operatorId,
       [AUDIT_METADATA_KEY.PURGED_COUNT]: totalPurged,
@@ -102,8 +99,6 @@ async function handlePOST(req: NextRequest) {
       targetTable: "auditLog",
       systemWide: true,
     },
-    ip,
-    userAgent,
   });
 
   return NextResponse.json({ purged: totalPurged });

--- a/src/app/api/maintenance/purge-history/route.test.ts
+++ b/src/app/api/maintenance/purge-history/route.test.ts
@@ -32,6 +32,9 @@ vi.mock("@/lib/rate-limit", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "10.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "10.0.0.1", userAgent: "Test" }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "10.0.0.1", userAgent: "Test" }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "10.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
   withBypassRls: mockWithBypassRls,

--- a/src/app/api/maintenance/purge-history/route.test.ts
+++ b/src/app/api/maintenance/purge-history/route.test.ts
@@ -31,10 +31,9 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: () => ({ ip: "10.0.0.1", userAgent: "Test" }),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "10.0.0.1", userAgent: "Test" }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "10.0.0.1", userAgent: "Test" }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "10.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "10.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "10.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "10.0.0.1", userAgent: "Test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
   withBypassRls: mockWithBypassRls,

--- a/src/app/api/maintenance/purge-history/route.ts
+++ b/src/app/api/maintenance/purge-history/route.ts
@@ -13,8 +13,8 @@ import { prisma } from "@/lib/prisma";
 import { parseBody } from "@/lib/parse-body";
 import { verifyAdminToken } from "@/lib/admin-token";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
-import { AUDIT_SCOPE, AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
+import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit";
 import { AUDIT_METADATA_KEY } from "@/lib/constants";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { requireMaintenanceOperator } from "@/lib/maintenance-auth";
@@ -72,21 +72,16 @@ async function handlePOST(req: NextRequest) {
   BYPASS_PURPOSE.SYSTEM_MAINTENANCE);
 
   // Audit log
-  const { ip, userAgent } = extractRequestMeta(req);
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.HISTORY_PURGE,
-    userId: SYSTEM_ACTOR_ID,
+    ...tenantAuditBase(req, SYSTEM_ACTOR_ID, membership.tenantId),
     actorType: ACTOR_TYPE.SYSTEM,
-    tenantId: membership.tenantId,
+    action: AUDIT_ACTION.HISTORY_PURGE,
     metadata: {
       operatorId,
       [AUDIT_METADATA_KEY.PURGED_COUNT]: deleted.count,
       retentionDays,
       systemWide: true,
     },
-    ip,
-    userAgent,
   });
 
   return NextResponse.json({ purged: deleted.count });

--- a/src/app/api/mcp/authorize/consent/route.test.ts
+++ b/src/app/api/mcp/authorize/consent/route.test.ts
@@ -7,7 +7,6 @@ const {
   mockFindUnique,
   mockCreateAuthorizationCode,
   mockLogAudit,
-  mockExtractRequestMeta,
   mockMcpClientCount,
   mockMcpClientUpdateMany,
   mockMcpClientFindUnique,
@@ -19,7 +18,6 @@ const {
   mockFindUnique: vi.fn(),
   mockCreateAuthorizationCode: vi.fn(),
   mockLogAudit: vi.fn(),
-  mockExtractRequestMeta: vi.fn().mockReturnValue({ ip: "127.0.0.1", userAgent: "test-agent" }),
   mockMcpClientCount: vi.fn().mockResolvedValue(0),
   mockMcpClientUpdateMany: vi.fn().mockResolvedValue({ count: 1 }),
   mockMcpClientFindUnique: vi.fn(),
@@ -64,10 +62,9 @@ vi.mock("@/lib/mcp/oauth-server", () => ({
 
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: mockExtractRequestMeta,
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test-agent" }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test-agent" }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test-agent" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test-agent", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test-agent", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test-agent", acceptLanguage: null }),
 }));
 
 vi.mock("@/lib/csrf", () => ({

--- a/src/app/api/mcp/authorize/consent/route.test.ts
+++ b/src/app/api/mcp/authorize/consent/route.test.ts
@@ -65,6 +65,9 @@ vi.mock("@/lib/mcp/oauth-server", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: mockExtractRequestMeta,
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test-agent" }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test-agent" }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test-agent" }),
 }));
 
 vi.mock("@/lib/csrf", () => ({

--- a/src/app/api/mcp/authorize/consent/route.ts
+++ b/src/app/api/mcp/authorize/consent/route.ts
@@ -4,8 +4,8 @@ import { prisma } from "@/lib/prisma";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { createAuthorizationCode } from "@/lib/mcp/oauth-server";
 import { MCP_SCOPES, MAX_MCP_CLIENTS_PER_TENANT } from "@/lib/constants/mcp";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
-import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
+import { AUDIT_ACTION } from "@/lib/constants/audit";
 import { assertOrigin } from "@/lib/csrf";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, unauthorized } from "@/lib/api-response";
@@ -63,17 +63,12 @@ export async function POST(req: NextRequest) {
 
   // Handle deny action (before claiming — deny should not bind the client)
   if (action === "deny") {
-    const { ip, userAgent } = extractRequestMeta(req);
     await logAuditAsync({
-      scope: AUDIT_SCOPE.TENANT,
+      ...tenantAuditBase(req, session.user.id, userTenantId),
       action: AUDIT_ACTION.MCP_CONSENT_DENY,
-      userId: session.user.id,
-      tenantId: userTenantId,
       targetType: "McpClient",
       targetId: foundClient.id,
       metadata: { clientId },
-      ip: ip ?? undefined,
-      userAgent: userAgent ?? undefined,
     });
     const denyUrl = new URL(redirectUri);
     denyUrl.searchParams.set("error", "access_denied");
@@ -147,17 +142,13 @@ export async function POST(req: NextRequest) {
       }
       effectiveClient = refetched;
     } else {
-      // Freshly claimed
-      const { ip: claimIp } = extractRequestMeta(req);
+      // Freshly claimed — userAgent is added by helper (forensic upgrade per plan §Functional 2 EXCEPTION)
       await logAuditAsync({
-        scope: AUDIT_SCOPE.TENANT,
+        ...tenantAuditBase(req, session.user.id, userTenantId),
         action: AUDIT_ACTION.MCP_CLIENT_DCR_CLAIM,
-        userId: session.user.id,
-        tenantId: userTenantId,
         targetType: "McpClient",
         targetId: clientIdDb,
         metadata: { clientId: foundClient.clientId },
-        ip: claimIp ?? undefined,
       });
     }
   }
@@ -188,17 +179,12 @@ export async function POST(req: NextRequest) {
   });
 
   // Audit the consent grant
-  const { ip, userAgent } = extractRequestMeta(req);
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
+    ...tenantAuditBase(req, session.user.id, userTenantId),
     action: AUDIT_ACTION.MCP_CONSENT_GRANT,
-    userId: session.user.id,
-    tenantId: userTenantId,
     targetType: "McpClient",
     targetId: effectiveClient.id,
     metadata: { clientId: effectiveClient.clientId, scopes: grantedScopes },
-    ip: ip ?? undefined,
-    userAgent: userAgent ?? undefined,
   });
 
   // Redirect back to the OAuth client with the authorization code

--- a/src/app/api/scim/v2/Groups/[id]/route.test.ts
+++ b/src/app/api/scim/v2/Groups/[id]/route.test.ts
@@ -33,6 +33,9 @@ vi.mock("@/lib/scim/rate-limit", () => ({ checkScimRateLimit: mockCheckScimRateL
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {

--- a/src/app/api/scim/v2/Groups/[id]/route.test.ts
+++ b/src/app/api/scim/v2/Groups/[id]/route.test.ts
@@ -32,10 +32,9 @@ vi.mock("@/lib/scim-token", () => ({ validateScimToken: mockValidateScimToken })
 vi.mock("@/lib/scim/rate-limit", () => ({ checkScimRateLimit: mockCheckScimRateLimit }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: () => ({ ip: null, userAgent: null }),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null, acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null, acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null, acceptLanguage: null }),
 }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {

--- a/src/app/api/scim/v2/Groups/[id]/route.ts
+++ b/src/app/api/scim/v2/Groups/[id]/route.ts
@@ -1,11 +1,11 @@
 import type { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
 import { scimResponse, scimError, getScimBaseUrl } from "@/lib/scim/response";
 import { scimPatchOpSchema, scimGroupSchema } from "@/lib/scim/validations";
 import { parseGroupPatchOps, PatchParseError } from "@/lib/scim/patch-parser";
 import { API_ERROR } from "@/lib/api-error-codes";
-import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
+import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
 import { authorizeScim } from "@/lib/scim/with-scim-auth";
@@ -83,12 +83,10 @@ async function handlePUT(req: NextRequest, { params }: Params): Promise<Response
   }
 
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.SCIM_GROUP_UPDATE,
-    userId: auditUserId,
+    ...tenantAuditBase(req, auditUserId, tenantId),
     actorType: putActorType,
+    action: AUDIT_ACTION.SCIM_GROUP_UPDATE,
     teamId: serviceResult.teamId,
-    tenantId,
     targetType: AUDIT_TARGET_TYPE.TEAM_MEMBER,
     targetId: id,
     metadata: {
@@ -96,7 +94,6 @@ async function handlePUT(req: NextRequest, { params }: Params): Promise<Response
       added: serviceResult.added,
       removed: serviceResult.removed,
     },
-    ...extractRequestMeta(req),
   });
 
   return scimResponse(serviceResult.resource);
@@ -151,19 +148,16 @@ async function handlePATCH(req: NextRequest, { params }: Params): Promise<Respon
   }
 
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.SCIM_GROUP_UPDATE,
-    userId: auditUserId,
+    ...tenantAuditBase(req, auditUserId, tenantId),
     actorType: patchActorType,
+    action: AUDIT_ACTION.SCIM_GROUP_UPDATE,
     teamId: serviceResult.teamId,
-    tenantId,
     targetType: AUDIT_TARGET_TYPE.TEAM_MEMBER,
     targetId: id,
     metadata: {
       role: serviceResult.role,
       operations: actions.map((a) => ({ op: a.op, userId: a.userId })),
     },
-    ...extractRequestMeta(req),
   });
 
   return scimResponse(serviceResult.resource);

--- a/src/app/api/scim/v2/Users/[id]/route.test.ts
+++ b/src/app/api/scim/v2/Users/[id]/route.test.ts
@@ -33,6 +33,9 @@ vi.mock("@/lib/scim/rate-limit", () => ({ checkScimRateLimit: mockCheckScimRateL
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {

--- a/src/app/api/scim/v2/Users/[id]/route.test.ts
+++ b/src/app/api/scim/v2/Users/[id]/route.test.ts
@@ -32,10 +32,9 @@ vi.mock("@/lib/scim-token", () => ({ validateScimToken: mockValidateScimToken })
 vi.mock("@/lib/scim/rate-limit", () => ({ checkScimRateLimit: mockCheckScimRateLimit }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: () => ({ ip: null, userAgent: null }),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null, acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null, acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null, acceptLanguage: null }),
 }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {

--- a/src/app/api/scim/v2/Users/[id]/route.ts
+++ b/src/app/api/scim/v2/Users/[id]/route.ts
@@ -1,10 +1,10 @@
 import type { NextRequest } from "next/server";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
 import { scimResponse, scimError, getScimBaseUrl } from "@/lib/scim/response";
 import { scimUserSchema, scimPatchOpSchema } from "@/lib/scim/validations";
 import { parseUserPatchOps, PatchParseError } from "@/lib/scim/patch-parser";
 import { API_ERROR } from "@/lib/api-error-codes";
-import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
+import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { invalidateUserSessions } from "@/lib/user-session-invalidation";
 import { getLogger } from "@/lib/logger";
@@ -101,11 +101,9 @@ async function handlePUT(req: NextRequest, { params }: Params): Promise<Response
   }
 
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: auditAction,
-    userId: auditUserId,
+    ...tenantAuditBase(req, auditUserId, tenantId),
     actorType: putActorType,
-    tenantId,
+    action: auditAction,
     targetType: AUDIT_TARGET_TYPE.TEAM_MEMBER,
     targetId: userId,
     metadata: {
@@ -115,7 +113,6 @@ async function handlePUT(req: NextRequest, { params }: Params): Promise<Response
       ...(invalidationCounts ?? {}),
       ...(sessionInvalidationFailed ? { sessionInvalidationFailed: true } : {}),
     },
-    ...extractRequestMeta(req),
   });
 
   return scimResponse(resource);
@@ -180,11 +177,9 @@ async function handlePATCH(req: NextRequest, { params }: Params): Promise<Respon
   }
 
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: auditAction,
-    userId: auditUserId,
+    ...tenantAuditBase(req, auditUserId, tenantId),
     actorType: patchActorType,
-    tenantId,
+    action: auditAction,
     targetType: AUDIT_TARGET_TYPE.TEAM_MEMBER,
     targetId: userId,
     metadata: {
@@ -193,7 +188,6 @@ async function handlePATCH(req: NextRequest, { params }: Params): Promise<Respon
       ...(patchInvalidationCounts ?? {}),
       ...(patchSessionInvalidationFailed ? { sessionInvalidationFailed: true } : {}),
     },
-    ...extractRequestMeta(req),
   });
 
   return scimResponse(resource);
@@ -239,11 +233,9 @@ async function handleDELETE(req: NextRequest, { params }: Params): Promise<Respo
   }
 
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.SCIM_USER_DELETE,
-    userId: auditUserId,
+    ...tenantAuditBase(req, auditUserId, tenantId),
     actorType: deleteActorType,
-    tenantId,
+    action: AUDIT_ACTION.SCIM_USER_DELETE,
     targetType: AUDIT_TARGET_TYPE.TEAM_MEMBER,
     targetId: userId,
     metadata: {
@@ -251,7 +243,6 @@ async function handleDELETE(req: NextRequest, { params }: Params): Promise<Respo
       ...(deleteInvalidationCounts ?? {}),
       ...(deleteSessionInvalidationFailed ? { sessionInvalidationFailed: true } : {}),
     },
-    ...extractRequestMeta(req),
   });
 
   return new Response(null, { status: 204 });

--- a/src/app/api/scim/v2/Users/route.test.ts
+++ b/src/app/api/scim/v2/Users/route.test.ts
@@ -27,6 +27,9 @@ vi.mock("@/lib/scim/rate-limit", () => ({ checkScimRateLimit: mockCheckScimRateL
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: null, userAgent: null }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null }),
 }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {

--- a/src/app/api/scim/v2/Users/route.test.ts
+++ b/src/app/api/scim/v2/Users/route.test.ts
@@ -26,10 +26,9 @@ vi.mock("@/lib/scim-token", () => ({ validateScimToken: mockValidateScimToken })
 vi.mock("@/lib/scim/rate-limit", () => ({ checkScimRateLimit: mockCheckScimRateLimit }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: () => ({ ip: null, userAgent: null }),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: null, userAgent: null, acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: null, userAgent: null, acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: null, userAgent: null, acceptLanguage: null }),
 }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {

--- a/src/app/api/scim/v2/Users/route.ts
+++ b/src/app/api/scim/v2/Users/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
 import {
   scimResponse,
   scimError,
@@ -16,7 +16,7 @@ import {
   FilterParseError,
 } from "@/lib/scim/filter-parser";
 import { scimUserSchema } from "@/lib/scim/validations";
-import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
+import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { isScimExternalMappingUniqueViolation } from "@/lib/scim/prisma-error";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -218,15 +218,12 @@ async function handlePOST(req: NextRequest) {
     );
 
     await logAuditAsync({
-      scope: AUDIT_SCOPE.TENANT,
-      action: AUDIT_ACTION.SCIM_USER_CREATE,
-      userId: auditUserId,
+      ...tenantAuditBase(req, auditUserId, tenantId),
       actorType,
-      tenantId,
+      action: AUDIT_ACTION.SCIM_USER_CREATE,
       targetType: AUDIT_TARGET_TYPE.TEAM_MEMBER,
       targetId: created.user.id,
       metadata: { email: userName, externalId },
-      ...extractRequestMeta(req),
     });
 
     const baseUrl = getScimBaseUrl();

--- a/src/app/api/share-links/[id]/route.test.ts
+++ b/src/app/api/share-links/[id]/route.test.ts
@@ -32,10 +32,9 @@ vi.mock("@/lib/tenant-context", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditInTx: mockLogAuditInTx,
-  extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test" }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test" }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
   withBypassRls: mockWithBypassRls,

--- a/src/app/api/share-links/[id]/route.test.ts
+++ b/src/app/api/share-links/[id]/route.test.ts
@@ -33,6 +33,9 @@ vi.mock("@/lib/tenant-context", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditInTx: mockLogAuditInTx,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test" }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test" }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
   withBypassRls: mockWithBypassRls,

--- a/src/app/api/share-links/[id]/route.ts
+++ b/src/app/api/share-links/[id]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAuditInTx, extractRequestMeta } from "@/lib/audit";
+import { logAuditInTx, personalAuditBase, teamAuditBase } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, unauthorized, notFound } from "@/lib/api-response";
-import { AUDIT_TARGET_TYPE, AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
+import { AUDIT_TARGET_TYPE, AUDIT_ACTION } from "@/lib/constants";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -53,19 +53,17 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
   );
 
   // Atomic audit: SHARE_REVOKE / SEND_REVOKE
-  const { ip, userAgent } = extractRequestMeta(req);
   await withBypassRls(prisma, async (tx) => {
+    const teamId = share.teamPasswordEntry?.teamId;
     await logAuditInTx(tx, share.tenantId, {
-      scope: teamPasswordEntryId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.PERSONAL,
+      ...(teamPasswordEntryId && teamId
+        ? teamAuditBase(req, session.user.id, teamId)
+        : personalAuditBase(req, session.user.id)),
       action: share.shareType === "TEXT" || share.shareType === "FILE"
         ? AUDIT_ACTION.SEND_REVOKE
         : AUDIT_ACTION.SHARE_REVOKE,
-      userId: session.user.id,
-      teamId: share.teamPasswordEntry?.teamId,
       targetType: AUDIT_TARGET_TYPE.PASSWORD_SHARE,
       targetId: share.id,
-      ip,
-      userAgent,
     });
   }, BYPASS_PURPOSE.AUDIT_WRITE);
 

--- a/src/app/api/share-links/route.ts
+++ b/src/app/api/share-links/route.ts
@@ -11,7 +11,7 @@ import {
 } from "@/lib/crypto-server";
 import { requireTeamPermission } from "@/lib/team-auth";
 import { assertPolicyAllowsSharing, assertPolicySharePassword, PolicyViolationError } from "@/lib/team-policy";
-import { logAuditInTx, extractRequestMeta } from "@/lib/audit";
+import { logAuditInTx, personalAuditBase, teamAuditBase } from "@/lib/audit";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, handleAuthError, notFound, rateLimited, unauthorized } from "@/lib/api-response";
@@ -20,7 +20,6 @@ import {
   TEAM_PERMISSION,
   AUDIT_TARGET_TYPE,
   AUDIT_ACTION,
-  AUDIT_SCOPE,
   applySharePermissions,
 } from "@/lib/constants";
 import type { EntryTypeValue } from "@/lib/constants";
@@ -183,18 +182,15 @@ async function handlePOST(req: NextRequest) {
   );
 
   // Atomic audit: SHARE_CREATE
-  const { ip, userAgent } = extractRequestMeta(req);
   await withBypassRls(prisma, async (tx) => {
     await logAuditInTx(tx, tenantId, {
-      scope: teamPasswordEntryId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.PERSONAL,
+      ...(teamPasswordEntryId && teamId
+        ? teamAuditBase(req, session.user.id, teamId)
+        : personalAuditBase(req, session.user.id)),
       action: AUDIT_ACTION.SHARE_CREATE,
-      userId: session.user.id,
-      teamId,
       targetType: AUDIT_TARGET_TYPE.PASSWORD_SHARE,
       targetId: share.id,
       metadata: { expiresIn, maxViews: maxViews ?? null },
-      ip,
-      userAgent,
     });
   }, BYPASS_PURPOSE.AUDIT_WRITE);
 

--- a/src/app/api/share-links/verify-access/route.test.ts
+++ b/src/app/api/share-links/verify-access/route.test.ts
@@ -50,10 +50,9 @@ vi.mock("@/lib/ip-access", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "Test" }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "Test" }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "Test", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "Test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/logger", () => {
   const noop = vi.fn();

--- a/src/app/api/share-links/verify-access/route.test.ts
+++ b/src/app/api/share-links/verify-access/route.test.ts
@@ -51,6 +51,9 @@ vi.mock("@/lib/ip-access", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "Test" }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "Test" }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "Test" }),
 }));
 vi.mock("@/lib/logger", () => {
   const noop = vi.fn();

--- a/src/app/api/share-links/verify-access/route.ts
+++ b/src/app/api/share-links/verify-access/route.ts
@@ -6,11 +6,11 @@ import { hashToken, verifyAccessPassword } from "@/lib/crypto-server";
 import { createShareAccessToken } from "@/lib/share-access-token";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { extractClientIp, rateLimitKeyFromIp } from "@/lib/ip-access";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, tenantAuditBase } from "@/lib/audit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, rateLimited, notFound } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
-import { AUDIT_TARGET_TYPE, AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
+import { AUDIT_TARGET_TYPE, AUDIT_ACTION } from "@/lib/constants";
 import { ACTOR_TYPE } from "@/lib/constants/audit";
 import { ANONYMOUS_ACTOR_ID } from "@/lib/constants/app";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -21,7 +21,6 @@ const tokenLimiter = createRateLimiter({ windowMs: 60_000, max: 20 });
 // POST /api/share-links/verify-access — Verify access password for a share
 async function handlePOST(req: NextRequest) {
   const ip = extractClientIp(req) ?? "unknown";
-  const reqMeta = extractRequestMeta(req);
 
   const result = await parseBody(req, verifyShareAccessSchema);
   if (!result.ok) return result.response;
@@ -72,30 +71,24 @@ async function handlePOST(req: NextRequest) {
 
   if (!verifyAccessPassword(password, share.accessPasswordHash)) {
     await logAuditAsync({
-      scope: AUDIT_SCOPE.TENANT,
-      action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_FAILED,
-      userId: ANONYMOUS_ACTOR_ID,
+      ...tenantAuditBase(req, ANONYMOUS_ACTOR_ID, share.tenantId),
       actorType: ACTOR_TYPE.ANONYMOUS,
-      tenantId: share.tenantId,
+      action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_FAILED,
       targetType: AUDIT_TARGET_TYPE.PASSWORD_SHARE,
       targetId: share.id,
       metadata: { ip },
-      ...reqMeta,
     });
 
     return errorResponse(API_ERROR.SHARE_PASSWORD_INCORRECT, 403);
   }
 
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_SUCCESS,
-    userId: ANONYMOUS_ACTOR_ID,
+    ...tenantAuditBase(req, ANONYMOUS_ACTOR_ID, share.tenantId),
     actorType: ACTOR_TYPE.ANONYMOUS,
-    tenantId: share.tenantId,
+    action: AUDIT_ACTION.SHARE_ACCESS_VERIFY_SUCCESS,
     targetType: AUDIT_TARGET_TYPE.PASSWORD_SHARE,
     targetId: share.id,
     metadata: { ip },
-    ...reqMeta,
   });
 
   const accessToken = createShareAccessToken(share.id);

--- a/src/app/api/tenant/access-requests/route.test.ts
+++ b/src/app/api/tenant/access-requests/route.test.ts
@@ -64,7 +64,6 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   resolveActorType: () => "HUMAN",
-  extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
   personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
   teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
   tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),

--- a/src/app/api/tenant/access-requests/route.test.ts
+++ b/src/app/api/tenant/access-requests/route.test.ts
@@ -65,6 +65,9 @@ vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   resolveActorType: () => "HUMAN",
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockRateLimiterCheck }),

--- a/src/app/api/tenant/access-requests/route.ts
+++ b/src/app/api/tenant/access-requests/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { logAuditAsync, extractRequestMeta, resolveActorType } from "@/lib/audit";
+import { logAuditAsync, tenantAuditBase, resolveActorType } from "@/lib/audit";
 import { requireTenantPermission } from "@/lib/tenant-auth";
 import { authOrToken } from "@/lib/auth-or-token";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
-import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
+import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTenantRls, withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
 import { errorResponse, handleAuthError, rateLimited, unauthorized } from "@/lib/api-response";
@@ -198,12 +198,10 @@ async function handlePOST(req: NextRequest) {
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
   await logAuditAsync({
-    scope: AUDIT_SCOPE.TENANT,
-    action: AUDIT_ACTION.ACCESS_REQUEST_CREATE,
-    userId,
+    ...tenantAuditBase(req, userId, tenantId),
     actorType: resolveActorType(authResult),
     serviceAccountId: authResult.type === "service_account" ? serviceAccountId : undefined,
-    tenantId,
+    action: AUDIT_ACTION.ACCESS_REQUEST_CREATE,
     targetType: AUDIT_TARGET_TYPE.ACCESS_REQUEST,
     targetId: accessRequest.id,
     metadata: {
@@ -211,7 +209,6 @@ async function handlePOST(req: NextRequest) {
       requestedScope: requestedScope.join(","),
       expiresInMinutes,
     },
-    ...extractRequestMeta(req),
   });
 
   return NextResponse.json(accessRequest, { status: 201 });

--- a/src/app/api/vault/admin-reset/route.test.ts
+++ b/src/app/api/vault/admin-reset/route.test.ts
@@ -29,10 +29,9 @@ vi.mock("@/lib/csrf", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test" }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test" }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/vault-reset", () => ({
   executeVaultReset: mockExecuteVaultReset,

--- a/src/app/api/vault/admin-reset/route.test.ts
+++ b/src/app/api/vault/admin-reset/route.test.ts
@@ -30,6 +30,9 @@ vi.mock("@/lib/csrf", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test" }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test" }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/vault-reset", () => ({
   executeVaultReset: mockExecuteVaultReset,
@@ -247,9 +250,13 @@ describe("POST /api/vault/admin-reset", () => {
       expect.objectContaining({
         scope: "TENANT",
         tenantId: "tenant-1",
-        teamId: undefined,
       }),
     );
+    // teamId is absent from the params object on TENANT scope (helper omits it,
+    // and the legacy explicit `teamId: undefined` was an implementation detail
+    // that did not affect the persisted audit_logs row).
+    const lastCall = mockLogAudit.mock.calls[mockLogAudit.mock.calls.length - 1]?.[0] as Record<string, unknown> | undefined;
+    expect(lastCall?.teamId).toBeUndefined();
   });
 
   it("confirmation must be English regardless of locale", async () => {

--- a/src/app/api/vault/admin-reset/route.ts
+++ b/src/app/api/vault/admin-reset/route.ts
@@ -7,10 +7,10 @@ import { prisma } from "@/lib/prisma";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { assertOrigin } from "@/lib/csrf";
 import { getAppOrigin } from "@/lib/url-helpers";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, teamAuditBase, tenantAuditBase } from "@/lib/audit";
 import { executeVaultReset } from "@/lib/vault-reset";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
-import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants";
+import { AUDIT_ACTION } from "@/lib/constants";
 import { withRequestLog } from "@/lib/with-request-log";
 import { forbidden, notFound, unauthorized, rateLimited } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
@@ -126,14 +126,15 @@ async function handlePOST(req: NextRequest) {
   const { deletedEntries, deletedAttachments } =
     await executeVaultReset(session.user.id);
 
-  // Audit log — use TENANT scope for tenant-level resets (teamId is null)
-  const auditScope = resetRecord.teamId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.TENANT;
+  // Audit log — use TENANT scope for tenant-level resets (teamId is null).
+  // tenantId is preserved on TEAM emit so the JSON log line + downstream
+  // consumers see it (helper does not set it for team scope).
   await logAuditAsync({
-    scope: auditScope,
-    action: AUDIT_ACTION.ADMIN_VAULT_RESET_EXECUTE,
-    userId: session.user.id,
+    ...(resetRecord.teamId
+      ? teamAuditBase(req, session.user.id, resetRecord.teamId)
+      : tenantAuditBase(req, session.user.id, resetRecord.tenantId)),
     tenantId: resetRecord.tenantId,
-    teamId: resetRecord.teamId ?? undefined,
+    action: AUDIT_ACTION.ADMIN_VAULT_RESET_EXECUTE,
     targetType: "User",
     targetId: session.user.id,
     metadata: {
@@ -141,7 +142,6 @@ async function handlePOST(req: NextRequest) {
       deletedAttachments,
       initiatedById: resetRecord.initiatedById,
     },
-    ...extractRequestMeta(req),
   });
 
   return NextResponse.json({ success: true });

--- a/src/app/api/vault/delegation/check/route.test.ts
+++ b/src/app/api/vault/delegation/check/route.test.ts
@@ -33,9 +33,9 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: null }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: null }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: null }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: null, acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: null, acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: null, acceptLanguage: null }),
 }));
 vi.mock("@/lib/ip-access", () => ({
   extractClientIp: vi.fn(() => "127.0.0.1"),

--- a/src/app/api/vault/delegation/check/route.test.ts
+++ b/src/app/api/vault/delegation/check/route.test.ts
@@ -33,6 +33,9 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: null }),
 }));
 vi.mock("@/lib/ip-access", () => ({
   extractClientIp: vi.fn(() => "127.0.0.1"),

--- a/src/app/api/vault/delegation/check/route.ts
+++ b/src/app/api/vault/delegation/check/route.ts
@@ -12,11 +12,10 @@ import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { authOrToken, hasUserId } from "@/lib/auth-or-token";
-import { logAuditAsync } from "@/lib/audit";
-import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants/audit";
+import { logAuditAsync, personalAuditBase } from "@/lib/audit";
+import { AUDIT_ACTION } from "@/lib/constants/audit";
 import { MCP_CLIENT_ID_PREFIX } from "@/lib/constants/mcp";
 import { createRateLimiter } from "@/lib/rate-limit";
-import { extractClientIp } from "@/lib/ip-access";
 
 const checkRateLimiter = createRateLimiter({ windowMs: 60_000, max: 120 });
 
@@ -90,13 +89,10 @@ export async function GET(request: NextRequest) {
 
   // Lightweight audit (success only)
   await logAuditAsync({
+    ...personalAuditBase(request, userId),
     action: AUDIT_ACTION.DELEGATION_CHECK,
-    scope: AUDIT_SCOPE.PERSONAL,
-    userId,
     targetId: entryId,
     metadata: { clientId, sessionId: session.id },
-    ip: extractClientIp(request),
-    userAgent: request.headers.get("user-agent"),
   });
 
   return NextResponse.json({

--- a/src/app/api/vault/delegation/route.test.ts
+++ b/src/app/api/vault/delegation/route.test.ts
@@ -51,9 +51,9 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: null }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: null }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: null }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: null, acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: null, acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: null, acceptLanguage: null }),
 }));
 vi.mock("@/lib/ip-access", () => ({ extractClientIp: vi.fn(() => "127.0.0.1") }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>, withBypassRls: mockWithBypassRls }));

--- a/src/app/api/vault/delegation/route.test.ts
+++ b/src/app/api/vault/delegation/route.test.ts
@@ -49,7 +49,12 @@ vi.mock("@/lib/csrf", () => ({ assertOrigin: mockAssertOrigin }));
 vi.mock("@/lib/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockRateLimiterCheck }),
 }));
-vi.mock("@/lib/audit", () => ({ logAuditAsync: mockLogAudit }));
+vi.mock("@/lib/audit", () => ({
+  logAuditAsync: mockLogAudit,
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: null }),
+}));
 vi.mock("@/lib/ip-access", () => ({ extractClientIp: vi.fn(() => "127.0.0.1") }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>, withBypassRls: mockWithBypassRls }));
 vi.mock("@/lib/prisma", () => ({

--- a/src/app/api/vault/delegation/route.ts
+++ b/src/app/api/vault/delegation/route.ts
@@ -13,15 +13,14 @@ import { prisma } from "@/lib/prisma";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { resolveUserTenantId } from "@/lib/tenant-context";
 import { withRequestLog } from "@/lib/with-request-log";
-import { logAuditAsync } from "@/lib/audit";
-import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
+import { logAuditAsync, personalAuditBase, tenantAuditBase } from "@/lib/audit";
+import { AUDIT_ACTION } from "@/lib/constants";
 import { MCP_SCOPE } from "@/lib/constants/mcp";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, unauthorized, rateLimited } from "@/lib/api-response";
 import { parseBody } from "@/lib/parse-body";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
-import { extractClientIp } from "@/lib/ip-access";
 import {
   DELEGATION_DEFAULT_TTL_SEC,
   DELEGATION_MAX_TTL_SEC,
@@ -201,18 +200,16 @@ async function handlePOST(request: NextRequest) {
   }
 
   // Audit log — both personal and tenant scope (no plaintext in metadata!)
-  const auditBase = {
+  // tenantId is preserved on the PERSONAL emit (helper does not set it for personal scope,
+  // but downstream JSON log + test assertions require the field — see plan Pattern 5).
+  const auditBody = {
     action: AUDIT_ACTION.DELEGATION_CREATE,
-    userId,
-    tenantId,
     targetId: delegationSession.id,
     metadata: { entryCount: entryIds.length, mcpClientId: mcpToken.clientId },
-    ip: extractClientIp(request),
-    userAgent: request.headers.get("user-agent"),
   };
   await Promise.all([
-    logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.PERSONAL }),
-    logAuditAsync({ ...auditBase, scope: AUDIT_SCOPE.TENANT }),
+    logAuditAsync({ ...personalAuditBase(request, userId), tenantId, ...auditBody }),
+    logAuditAsync({ ...tenantAuditBase(request, userId, tenantId), ...auditBody }),
   ]);
 
   return NextResponse.json({

--- a/src/app/api/watchtower/alert/route.test.ts
+++ b/src/app/api/watchtower/alert/route.test.ts
@@ -34,10 +34,9 @@ vi.mock("@/lib/csrf", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
-  extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
-  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test" }),
-  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test" }),
-  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test" }),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test", acceptLanguage: null }),
 }));
 vi.mock("@/lib/notification", () => ({
   createNotification: mockCreateNotification,

--- a/src/app/api/watchtower/alert/route.test.ts
+++ b/src/app/api/watchtower/alert/route.test.ts
@@ -35,7 +35,9 @@ vi.mock("@/lib/csrf", () => ({
 vi.mock("@/lib/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
-  personalAuditBase: vi.fn((_, userId) => ({ scope: "PERSONAL", userId })),
+  personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test" }),
+  teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test" }),
+  tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test" }),
 }));
 vi.mock("@/lib/notification", () => ({
   createNotification: mockCreateNotification,

--- a/src/app/api/watchtower/alert/route.ts
+++ b/src/app/api/watchtower/alert/route.ts
@@ -6,7 +6,7 @@ import { parseBody } from "@/lib/parse-body";
 import { assertOrigin } from "@/lib/csrf";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { requireTeamMember } from "@/lib/team-auth";
-import { logAuditAsync, extractRequestMeta } from "@/lib/audit";
+import { logAuditAsync, personalAuditBase, teamAuditBase } from "@/lib/audit";
 import { createNotification } from "@/lib/notification";
 import { sendEmail } from "@/lib/email";
 import { watchtowerAlertEmail } from "@/lib/email/templates/watchtower-alert";
@@ -14,7 +14,7 @@ import { serverAppUrl } from "@/lib/url-helpers";
 import { resolveUserLocale } from "@/lib/locale";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { notificationTitle, notificationBody } from "@/lib/notification-messages";
-import { AUDIT_SCOPE, AUDIT_ACTION } from "@/lib/constants";
+import { AUDIT_ACTION } from "@/lib/constants";
 import { NOTIFICATION_TYPE } from "@/lib/constants/notification";
 import { withRequestLog } from "@/lib/with-request-log";
 import { handleAuthError, rateLimited, unauthorized } from "@/lib/api-response";
@@ -87,12 +87,11 @@ async function handlePOST(req: NextRequest) {
 
   // Audit log
   await logAuditAsync({
-    scope: teamId ? AUDIT_SCOPE.TEAM : AUDIT_SCOPE.PERSONAL,
+    ...(teamId
+      ? teamAuditBase(req, session.user.id, teamId)
+      : personalAuditBase(req, session.user.id)),
     action: AUDIT_ACTION.WATCHTOWER_ALERT_SENT,
-    userId: session.user.id,
-    ...(teamId ? { teamId } : {}),
     metadata: { newBreachCount, ...(teamId ? { teamId } : {}) },
-    ...extractRequestMeta(req),
   });
 
   // Send email notification if configured

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -6,6 +6,47 @@
  * the direct-write-to-audit_logs path is removed — all application-emitted events flow through the outbox.
  * Dual-write: PostgreSQL audit_logs + structured JSON to stdout (via pino).
  * extractRequestMeta() extracts IP and User-Agent from NextRequest headers.
+ *
+ * ─── Helper usage policy ──────────────────────────────────────────
+ *
+ * Route handlers that have `req: NextRequest` in scope MUST use one of:
+ *   personalAuditBase(req, userId)
+ *   teamAuditBase(req, userId, teamId)
+ *   tenantAuditBase(req, userId, tenantId)
+ *
+ * Spread the helper FIRST in the call params; place explicit overrides
+ * (action, targetType, targetId, metadata, actorType, serviceAccountId, etc.)
+ * AFTER the spread so override-ordering is correct:
+ *
+ *   await logAuditAsync({
+ *     ...tenantAuditBase(req, userId, tenantId),
+ *     actorType: ACTOR_TYPE.SYSTEM,   // override after spread
+ *     action: AUDIT_ACTION.X,
+ *     targetType, targetId, metadata,
+ *   });
+ *
+ * The helpers ensure forensic ip/userAgent capture and prevent the recurring
+ * class of bug where call sites forget extractRequestMeta(req) or set the
+ * wrong scope.
+ *
+ * ─── Bucket C exceptions (helpers do NOT apply) ───────────────────
+ *
+ * The following contexts cannot use the helpers because no NextRequest is
+ * available at the call site:
+ *   - NextAuth event/jwt callbacks (src/auth.ts, src/lib/auth-adapter.ts)
+ *   - Library functions invoked outside HTTP context
+ *     (src/lib/access-restriction.ts, src/lib/account-lockout.ts when
+ *      request is undefined, src/lib/delegation.ts post-response cleanup,
+ *      src/lib/team-policy.ts, src/lib/extension-token.ts, src/lib/notification.ts)
+ *   - MCP tool execution (src/lib/mcp/tools.ts)
+ *   - Background workers (src/workers/audit-outbox-worker.ts,
+ *     src/lib/directory-sync/engine.ts, src/lib/webhook-dispatcher.ts)
+ *   - Constants validation (src/lib/constants/audit.ts)
+ *   - TENANT-scope routes where tenantId is not available without an extra
+ *     DB lookup (e.g., src/app/api/internal/audit-emit/route.ts,
+ *     src/app/api/mcp/register/route.ts during DCR registration before
+ *     tenant binding) — resolveTenantId() looks up tenant from userId
+ *     internally; using the helper would require redundant lookups.
  */
 
 import { prisma } from "@/lib/prisma";


### PR DESCRIPTION
## Summary
- Migrate 22 route handlers (~52 call sites) from manually-built audit
  payloads to `personalAuditBase` / `teamAuditBase` / `tenantAuditBase`
  helpers. Closes the recurring class of bug where call sites forgot
  `extractRequestMeta(req)` (losing forensic ip/userAgent) or set the
  wrong scope.
- Behavior-preserving except two intentional forensic upgrades
  (`MASTER_KEY_ROTATION`, `MCP_CLIENT_DCR_CLAIM` — both gain `userAgent`
  capture). See plan §Functional 2 EXCEPTION.
- Bucket C exceptions documented in `src/lib/audit.ts` module-doc:
  `internal/audit-emit` and `mcp/register` emit TENANT scope without a
  resolvable tenantId at the call site; both continue to rely on
  `resolveTenantId()`.

## Implementation notes
- Pattern 5 (vault/delegation dual-emit) and Pattern 4 (vault/admin-reset
  conditional team/tenant) explicitly preserve `tenantId` after the
  helper spread so the JSON log line + existing test assertions stay
  intact.
- Pattern 7 (extractClientIp direct-use) covers `vault/delegation*`
  sites that bypassed `extractRequestMeta`.
- 18 test mock files updated with helper mocks (R19 mock-alignment).
  Helper mocks include `acceptLanguage` to match real shape; dead
  `extractRequestMeta` mock entries removed from 16 files.
- New `src/__tests__/lib/audit-helpers.test.ts` (10 tests) covers the
  helpers in isolation — they were previously only tested via mocked
  consumers.

## Review artifacts
- [plan](./docs/archive/review/enforce-audit-base-helper-usage-plan.md)
- [plan review](./docs/archive/review/enforce-audit-base-helper-usage-review.md) (2 rounds)
- [deviation log](./docs/archive/review/enforce-audit-base-helper-usage-deviation.md) (D1-D6)
- [code review](./docs/archive/review/enforce-audit-base-helper-usage-code-review.md) (1 round, T1 Major + T2/T3 Minor fixed; S1 Minor accepted with quantified justification)

## Test plan
- [x] \`npx vitest run\` — 568 files / 7205 tests pass
- [x] \`npx eslint . --max-warnings 0\` — clean
- [x] \`npx next build\` — clean
- [x] \`scripts/pre-pr.sh\` — 9/9 pass
- [ ] Reviewer: confirm one-event hash continuity transition for
      \`userAgent\` field on first post-migration \`MASTER_KEY_ROTATION\`
      / \`MCP_CLIENT_DCR_CLAIM\` event is acceptable (per plan §Risks/Risk 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)