### PR TITLE
fix(security): enforce tenant IP on bearer routes and close share-content TOCTOU

### DIFF
--- a/docs/archive/review/api-key-ip-bypass-and-share-toctou-code-review.md
+++ b/docs/archive/review/api-key-ip-bypass-and-share-toctou-code-review.md
@@ -1,0 +1,325 @@
+# Code Review: api-key-ip-bypass-and-share-toctou
+
+Date: 2026-04-20T12:45Z
+Review round: 1
+Branch: fix/api-key-ip-bypass-and-share-toctou
+Base commit: 408803e7
+
+## Changes from Previous Round
+Initial review.
+
+## Diff summary
+- src/app/api/api-keys/[id]/route.ts — drop `skipAccessRestriction: true`
+- src/app/api/api-keys/route.ts — drop `skipAccessRestriction: true` on GET + POST
+- src/app/api/api-keys/[id]/route.test.ts — assertion drops `skipAccessRestriction: true`
+- src/app/api/api-keys/route.test.ts — two assertions updated
+- src/app/api/share-links/[id]/content/route.ts — add `revoked_at IS NULL AND expires_at > NOW()` to UPDATE WHERE; FILE path adds no-op conditional UPDATE
+- src/app/api/share-links/[id]/content/route.test.ts — rewrite FILE non-increment assertion, mock 0 for max-views test, +2 TOCTOU tests
+
+## Functionality Findings
+
+### F1 [Major]: TOCTOU pattern unfixed in /s/[token]/download/route.ts
+- File: src/app/s/[token]/download/route.ts:91-106
+- Evidence: both the password-protected and non-protected UPDATE branches only re-assert `id` and `max_views` (same pre-fix pattern).
+- Problem: The JS-level revoked/expired check at line 58 is not re-asserted in the UPDATE. A share revoked/expired between findUnique and the UPDATE still has `view_count` incremented and the decrypted file streamed.
+- Impact: Revoked/expired FILE Send content can be exfiltrated during the race window — higher-impact sibling of the content fix since binary payloads are larger.
+- Fix: Add `AND "revoked_at" IS NULL AND "expires_at" > NOW()` to both UPDATE WHERE clauses.
+
+### F2 [Major]: TOCTOU pattern unfixed in /s/[token]/page.tsx
+- File: src/app/s/[token]/page.tsx:93-97
+- Evidence: public server component for non-protected (no access password) shares has the same UPDATE pattern.
+- Problem: Same TOCTOU for non-protected public shares (broader audience since no password gate).
+- Impact: Non-protected shares can leak decrypted entry data after revocation/expiry.
+- Fix: Same additive predicates in the UPDATE WHERE.
+
+### F3 [Minor]: Inconsistent expiry strictness between JS and SQL checks
+- File: src/app/api/share-links/[id]/content/route.ts:75 vs 93,110
+- Evidence: JS uses `<` (valid if `expiresAt == now`); SQL uses `>` (invalid if `expires_at == NOW()`).
+- Problem: SQL stricter than JS — at the microsecond boundary a share accepted by JS may be rejected by SQL. Fail-safe direction, no correctness/security regression.
+- Fix: Document the asymmetry (optional) or align boundaries.
+
+### F4 [Minor]: No-op UPDATE on FILE path creates WAL / autovacuum overhead
+- File: src/app/api/share-links/[id]/content/route.ts:105-111
+- Evidence: PostgreSQL writes a new heap tuple for every UPDATE regardless of value equality; BEFORE UPDATE trigger `trg_enforce_tenant_id_password_shares` fires (short-circuits via `app.bypass_rls` fast-path).
+- Problem: Per-request tuple churn on active shares.
+- Fix: Consider `SELECT 1 FROM password_shares WHERE ... FOR UPDATE` to take a row lock without heap write. Trade-off: current approach is uniform with the non-FILE branch.
+
+### F5 [Minor, Adjacent → Testing]: FILE no-op regression coverage is loose
+- See T2 below. Flagged by Functionality expert; dedup target is Testing T2.
+
+## Security Findings
+
+### S1 [Major]: Tenant IP restriction NOT enforced on POST /api/extension/token/refresh
+- File: src/app/api/extension/token/refresh/route.ts:28-141
+- Evidence: route listed as Bearer-bypass in proxy.ts:190, but handler calls `validateExtensionToken(req)` directly — no `enforceAccessRestriction` invocation.
+- Problem: Same root cause class as Finding 1 (now fixed for /api/api-keys) — bearer-bypass route that does not enforce tenant CIDR/Tailscale at the handler.
+- Attack vector: Attacker exfiltrates an extension bearer inside the tenant network, relocates off-network, rotates via refresh once per idleTimeout window to keep the token live indefinitely until family absolute cap (default 30 days).
+- Impact: Tenant network-boundary bypassed for extension token lifecycle. Same severity as Finding 1.
+- Fix: Call `enforceAccessRestriction(req, result.data.userId, activeSession.tenantId)` after `validateExtensionToken` success, before rotation. `tenantId` already resolved from activeSession.
+
+### S2 [Major]: TOCTOU in FILE Send /s/[token]/download/route.ts (duplicate of F1)
+- See F1. Security angle: FILE payloads are typically higher-sensitivity binary content.
+
+### S3 [Minor]: Tenant IP not enforced on /api/tenant/access-requests (SA JIT)
+- File: src/app/api/tenant/access-requests/route.ts:97-214
+- Evidence: `handlePOST` calls `authOrToken(req)` directly (line 98); no `enforceAccessRestriction`.
+- Problem: `sa_` token with `access-request:create` can queue JIT requests from any IP. No token is issued without admin approval, so no privilege escalation — but DoS / audit noise vector from off-network.
+- Fix: Add `enforceAccessRestriction(req, userId, tenantId)` after tenant resolution in each branch, or migrate to `checkAuth`.
+
+### S4 [Minor]: Tenant IP not enforced on GET /api/vault/delegation/check
+- File: src/app/api/vault/delegation/check/route.ts:27-103
+- Evidence: handler calls `authOrToken(request)` directly, no IP check. Reachable via Bearer per proxy.ts:193.
+- Problem: CLI agent using an extension bearer from outside the tenant network can probe delegation authorization for arbitrary entryIds. Reconnaissance risk; no plaintext returned.
+- Fix: Add `enforceAccessRestriction` after `hasUserId(authResult)`.
+
+### S5 [Minor]: Tenant IP not enforced on DELETE /api/extension/token
+- File: src/app/api/extension/token/route.ts:80-108
+- Evidence: handleDELETE calls `validateExtensionToken(req)` only.
+- Problem: Consistency-only; revoking one's own token from off-network is not a privilege escalation.
+- Fix: Optional — add enforceAccessRestriction for policy consistency across the extension-token lifecycle.
+
+## Testing Findings
+
+### T1 [Major]: TOCTOU tests do not verify SQL predicates — only the 410 branch
+- File: src/app/api/share-links/[id]/content/route.test.ts:223-238 (and the FILE variant)
+- Evidence: `mockPrismaExecuteRaw.mockResolvedValue(0)` → handler returns 410. The tagged-template SQL body is opaque to the mock — a predicate-dropping regression would still return 0 rows in the mocked world and still pass.
+- Problem: Tests named "TOCTOU" do not exercise TOCTOU-specific SQL state; they only prove "when $executeRaw returns 0, handler returns 410."
+- Impact: The exact regression class the fix targets (missing `revoked_at IS NULL` / `expires_at > NOW()`) is not guarded by these tests.
+- Fix: Capture the tagged-template `strings` array from the mock and assert each predicate appears in the SQL body.
+
+### T2 [Minor]: "does not increment viewCount for FILE shares" lost its no-write proof
+- File: src/app/api/share-links/[id]/content/route.test.ts:192-204
+- Evidence: previous assertion `expect(mockPrismaExecuteRaw).not.toHaveBeenCalled()` replaced with `expect(json.viewCount).toBe(MOCK_SHARE.viewCount)`.
+- Problem: New assertion checks only the response field, which is computed as `share.viewCount + viewCountDelta` from the pre-UPDATE snapshot. An accidental `+ 1` in the FILE SET clause would still pass because the response reads the cached value.
+- Fix: Add structural assertion: the SQL body contains `SET "view_count" = "view_count"` (not `+ 1`) and `$executeRaw` was called exactly once.
+
+### T3 [Minor]: Two FILE 410 tests are indistinguishable at the handler level
+- File: src/app/api/share-links/[id]/content/route.test.ts:206-238 (max_views vs TOCTOU)
+- Evidence: both mock `$executeRaw → 0`; handler reads neither `maxViews` nor `revokedAt` after the JS pre-check, so the two scenarios are functionally identical to the handler.
+- Fix: Merge or combine with T1's predicate assertions so each test verifies a distinct predicate matched 0 rows.
+
+## Adjacent Findings
+- F5 (Functionality) routes to Testing — dedup to T2.
+
+## Quality Warnings
+None — all findings include file:line evidence and concrete fix recommendations.
+
+## Seed Finding Dispositions
+
+### Functionality seed
+- F-seed-1 (`expires_at > NOW()` fails for NULL at line 86) — **Rejected**: `PasswordShare.expiresAt` is `DateTime` (NOT NULL) in prisma/schema.prisma:733. Never-expiring shares are not modeled. Pre-existing JS comparison `share.expiresAt < new Date()` confirms non-null runtime invariant.
+- F-seed-2 (same claim at line 96 FILE branch) — **Rejected**: same reason.
+
+### Security seed
+- Empty (returned "No findings") — performed full R1-R30 check independently per seed-trust advisory. Discovered S1-S5.
+
+### Testing seed
+- T-seed-1 (api-keys IP enforcement not tested) — **Rejected**: split-responsibility coverage is intentional. `check-auth.test.ts:247-366` covers `skipAccessRestriction` branch under `describe("skipAccessRestriction option")` and `describe("allowTokens + skipAccessRestriction")`. Route tests assert `checkAuth` receives strict `{ allowTokens: true }` (exact-shape match) so a regression reintroducing `skipAccessRestriction: true` would fail.
+- T-seed-2 (assertion title too vague) — **Rejected**: behavior-based titles beat argument-shape titles. Regression would be stylistic.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1: Checked — no issue
+- R2: Checked — no issue
+- R3: Finding F1, F2 (TOCTOU propagation gap)
+- R4: Checked — no issue
+- R5: Checked — no issue (single-statement UPDATE is atomic; tx wrapping intact)
+- R6: Checked — no issue
+- R7: Addressed for target files; F1/F2 for siblings
+- R8: Checked — no issue (non-null column)
+- R9: Checked — no issue
+- R10: N/A
+- R11: Checked — no issue
+- R12: Checked — no issue
+- R13: N/A
+- R14: Finding F3 (boundary strictness asymmetry)
+- R15: Checked — no issue
+- R16: Checked — no issue
+- R17: Checked — helper extraction deferred until F1/F2 fix
+- R18: Checked — no issue
+- R19: Finding F5 → Adjacent → T2
+- R20: Checked — no issue
+- R21: N/A
+- R22: N/A
+- R23: N/A
+- R24: N/A
+- R25: N/A
+- R26: N/A
+- R27: Finding F4 (trigger overhead on no-op UPDATE, short-circuits)
+- R28: Checked — no issue
+- R29: N/A
+- R30: Checked — no issue
+
+### Security expert
+- R1: Finding 1 fixed; S1/S3/S4/S5 remain
+- R2: Checked — no issue
+- R3: Finding S2 (TOCTOU propagation)
+- R4: Checked — no issue (fail-closed behavior preserved)
+- R5: Checked — no issue
+- R6: N/A
+- R7: N/A
+- R8: Checked — no issue
+- R9: N/A
+- R10: N/A
+- R11: Checked — HMAC-verified payload
+- R12: N/A
+- R13: N/A
+- R14: Checked — `passwd_app` has SELECT on tenants (verified infra/postgres/initdb/02-create-app-role.sql:31)
+- R15: Checked — rate limiters preserved
+- R16: Checked — ACCESS_DENIED audit emitted on denial
+- R17: Checked — covered by RS1
+- R18: Addressed in fix target files; S2 remaining
+- R19: Checked — api_key/mcp_token rejected post-checkAuth
+- R20: Checked — no change
+- R21: Checked — no change
+- R22: Checked — no change
+- R23: N/A
+- R24: Checked — NOT NULL column
+- R25: Checked — server time
+- R26: Checked — all methods updated
+- R27: Checked — explicit 403 on denial
+- R28: N/A
+- R29: Checked — citations verified
+- R30: Checked — no drift
+- RS1: Checked — `verifyShareAccessToken` uses `crypto.timingSafeEqual`
+- RS2: Checked — rate limiters preserved
+- RS3: Checked — no new inputs
+
+### Testing expert
+- R1-R30: All checked; no additional hits beyond T1-T3
+- R7: N/A
+- R19: Finding T1, T2 (exact-shape for SQL body)
+- R21: Vacuous-equivalent pair → Finding T3
+- RT1: Mock alignment OK (Postgres returns matched row count for no-op UPDATE)
+- RT2: Proposed SQL-text assertions feasible in vitest
+- RT3: Checked — no issue
+
+## Proposed Resolution Map
+
+| Finding | Severity | Disposition |
+|---|---|---|
+| F1 / S2 (/s/[token]/download TOCTOU) | Major | **FIX in this PR** — same class as Finding 2 scope |
+| F2 (/s/[token]/page.tsx TOCTOU) | Major | **FIX in this PR** — same class |
+| S1 (/api/extension/token/refresh IP bypass) | Major | **FIX in this PR** — same class as Finding 1 scope |
+| T1 (TOCTOU SQL predicate test) | Major | **FIX in this PR** — required to guard the fix |
+| T2 (FILE no-op proof) | Minor | **FIX in this PR** — minor cost |
+| T3 (vacuous-equivalent pair) | Minor | **FIX in this PR** — fold into T1 |
+| F5 | Minor (Adjacent) | Dedup to T2 — same fix |
+| F3 (expiry strictness asymmetry) | Minor | **Accept** — fail-safe direction, add one-line comment |
+| F4 (no-op UPDATE WAL) | Minor | **Accept** — trade-off against consistency with non-FILE branch; document |
+| S3 (/api/tenant/access-requests IP bypass) | Minor | **DEFER to separate PR** (pending user decision) |
+| S4 (/api/vault/delegation/check IP bypass) | Minor | **DEFER to separate PR** (pending user decision) |
+| S5 (DELETE /api/extension/token IP bypass) | Minor | **DEFER to separate PR** (pending user decision) |
+
+## Resolution Status
+
+### Round 1 → Round 2 (commit 4bf64257)
+
+#### F1/S2 Major /s/[token]/download TOCTOU — Fixed
+- Action: Added `AND "revoked_at" IS NULL AND "expires_at" > NOW()` to both password-protected and non-protected UPDATE branches.
+- Modified files: [src/app/s/[token]/download/route.ts:91-106](src/app/s/[token]/download/route.ts#L91-L106), [src/__tests__/api/s/download.test.ts](src/__tests__/api/s/download.test.ts) (added 3 tests incl. SQL predicate assertion).
+
+#### F2 Major /s/[token]/page.tsx TOCTOU — Fixed
+- Action: Non-FILE branch gains the same atomic predicates; FILE branch gets a no-op conditional UPDATE (`SET view_count = view_count`) to atomically recheck revocation/expiry/max-views.
+- Modified files: [src/app/s/[token]/page.tsx:92-124](src/app/s/[token]/page.tsx#L92-L124).
+
+#### S1 Major /api/extension/token/refresh IP bypass — Fixed
+- Action: Added `enforceAccessRestriction` after session check. Round 3 promoted it to before rate limit (see R2-F2 below).
+- Modified files: [src/app/api/extension/token/refresh/route.ts](src/app/api/extension/token/refresh/route.ts).
+
+#### S3 Minor /api/tenant/access-requests IP bypass — Fixed
+- Action: Added `enforceAccessRestriction` on SA and non-session admin branches; session path left to middleware. Round 3 moved SA IP check before rate limit (see N1 below).
+- Modified files: [src/app/api/tenant/access-requests/route.ts](src/app/api/tenant/access-requests/route.ts).
+
+#### S4 Minor /api/vault/delegation/check IP bypass — Fixed
+- Action: Added `enforceAccessRestriction` for non-session auth types with tenantIdOverride for api_key/mcp_token.
+- Modified files: [src/app/api/vault/delegation/check/route.ts](src/app/api/vault/delegation/check/route.ts).
+
+#### S5 Minor /api/extension/token DELETE IP bypass — Fixed
+- Action: Added `enforceAccessRestriction` after validateExtensionToken. Round 3 made it pass tenantId explicitly (see N4 below).
+- Modified files: [src/app/api/extension/token/route.ts](src/app/api/extension/token/route.ts).
+
+#### T1 Major TOCTOU tests don't verify SQL predicates — Fixed
+- Action: Added `sqlBodyOf` helper to collapse tagged-template args; new tests regex-assert `revoked_at IS NULL`, `expires_at > NOW()`, `max_views`, and `view_count` SET shape.
+- Modified files: [src/app/api/share-links/[id]/content/route.test.ts](src/app/api/share-links/[id]/content/route.test.ts), [src/__tests__/api/s/download.test.ts](src/__tests__/api/s/download.test.ts).
+
+#### T2 Minor FILE no-op regression coverage — Fixed
+- Action: Test now asserts the SQL body contains `"view_count" = "view_count"` (no-op) and NOT `+ 1`.
+
+#### T3 Minor Duplicate 410 tests — Fixed
+- Action: Merged the old "max views exceeded" test with the TOCTOU test ("returns 410 when atomic UPDATE matches 0 rows"). No coverage lost — both drove the same code path.
+
+### Round 2 → Round 3 (commit b16a27f1)
+
+#### N2 Critical session+Bearer IP bypass — Fixed
+- Action: `proxy.ts` now requires `!hasSessionCookie` for the bearer-bypass branch. Requests carrying both a session cookie and a Bearer header fall through to the session-authenticated path where middleware enforces tenant IP. Legitimate Bearer-only clients (chrome-extension origin, API key, SA/MCP tokens) do not ship the Auth.js session cookie so the bypass still applies to them.
+- Verification: 3 new tests in [src/__tests__/proxy.test.ts](src/__tests__/proxy.test.ts) cover `/api/passwords`, `/api/api-keys`, and `/api/vault/delegation/check` with the session+Bearer combo — each asserts middleware-level 401 (proves fall-through to session path) and that session lookup ran.
+- Modified files: [src/proxy.ts:227-245](src/proxy.ts#L227-L245).
+
+#### N1 Medium SA path IP check after rate limit — Fixed
+- Action: Moved `enforceAccessRestriction` ahead of the per-SA rate limiter so an off-network stolen-bearer attacker cannot burn the legitimate SA's hourly request budget. userId is `SYSTEM_ACTOR_ID` since `sa.createdById` is not resolved yet; `actorType: SERVICE_ACCOUNT` and `tenantId` are passed for correct audit.
+- Modified files: [src/app/api/tenant/access-requests/route.ts:122-134](src/app/api/tenant/access-requests/route.ts#L122-L134).
+
+#### N4 Low extension/token DELETE fail-open on orphaned user — Fixed
+- Action: Extended `ValidatedExtensionToken` with `tenantId`; DELETE handler now passes it explicitly instead of relying on `resolveUserTenantId(userId)` which returns null for users without tenant mapping.
+- Modified files: [src/lib/extension-token.ts:18-25,88,120](src/lib/extension-token.ts), [src/app/api/extension/token/route.ts](src/app/api/extension/token/route.ts).
+
+#### R2-F1 Minor delegation/check test literal — Fixed
+- Action: Changed `type: "extension"` to `type: "token", scopes: []` to match the real `AuthResult` discriminated union defined in [src/lib/auth-or-token.ts:23](src/lib/auth-or-token.ts#L23).
+- Modified files: [src/app/api/vault/delegation/check/route.test.ts](src/app/api/vault/delegation/check/route.test.ts).
+
+#### R2-F2 Minor IP-enforcement placement inconsistent — Fixed
+- Action: Moved IP check ahead of rate limiter in refresh (mirrors N1 for the extension-token-refresh budget).
+- Modified files: [src/app/api/extension/token/refresh/route.ts:35-42](src/app/api/extension/token/refresh/route.ts#L35-L42).
+
+#### R2-F4 Info stale refresh session mocks — Fixed
+- Action: Added `tenantId: "tenant-1"` to 4 pre-existing session-findFirst mocks so the mock data matches the production row shape.
+- Modified files: [src/app/api/extension/token/refresh/route.test.ts](src/app/api/extension/token/refresh/route.test.ts).
+
+### Accepted (not fixed in this PR)
+
+#### F3 Minor Expiry strictness asymmetry JS `<` vs SQL `>` — Accepted
+- **Anti-Deferral check**: Acceptable risk.
+  - Worst case: a share whose `expiresAt == now` within microseconds of the request is accepted by the JS check but rejected by the SQL atomic UPDATE → user sees 410.
+  - Likelihood: vanishingly low — requires microsecond-accurate coincidence. Fail-safe direction (rejects when ambiguous).
+  - Cost to fix: trivial (align operators) but tests need updating across multiple files. No security impact.
+- **Orchestrator sign-off**: Accepted — fail-safe direction means no security or data-integrity regression.
+
+#### F4 Minor No-op UPDATE WAL overhead on FILE path — Accepted
+- **Anti-Deferral check**: Acceptable risk.
+  - Worst case: every share content API call on a FILE share writes a heap tuple + WAL record; autovacuum load scales with share traffic.
+  - Likelihood: WAL bloat only when FILE shares are viewed heavily via the content API (download route handles actual download). Low-traffic in practice.
+  - Cost to fix: moderate — would require `SELECT ... FOR UPDATE` + transaction wrapping for equivalent atomicity without heap write. Trade-off against consistency with non-FILE branch.
+- **Orchestrator sign-off**: Accepted — consistency benefit outweighs marginal WAL cost; revisit if hot share shows up in production telemetry.
+
+#### N3 Low extension/token DELETE validity timing oracle — Accepted
+- **Anti-Deferral check**: Acceptable risk.
+  - Worst case: attacker holding a stolen token can distinguish live (403 after IP check) vs. revoked/expired (400 before IP check) without being on-network.
+  - Likelihood: attacker must already have the raw 256-bit token. Oracle is equivalent to what they could learn by attempting a normal password read.
+  - Cost to fix: moderate — would require swapping auth+IP order or unifying error codes. Readability cost.
+- **Orchestrator sign-off**: Accepted — oracle does not add to an attacker who already holds the token.
+
+#### R2-F3 Minor enforceAccessRestriction duplication — Accepted
+- **Anti-Deferral check**: Out of scope (different feature).
+- **Justification**: Refactor tracked in [docs/archive/review/refactoring-plan-plan.md](docs/archive/review/refactoring-plan-plan.md) which proposes migrating route handlers to `checkAuth({ allowTokens: true })`. Expanding this PR into that refactor would break the focused security-fix scope.
+- **Orchestrator sign-off**: Accepted — cross-referenced existing plan.
+
+#### T4 Low extension-token DELETE test — Accepted
+- **Anti-Deferral check**: Acceptable risk.
+- **Justification**: Current assertion (`for...of` loop checking no `revokedAt` in update data) is correct. Alternative `expect.objectContaining` form is subjective style preference.
+- **Orchestrator sign-off**: Accepted.
+
+#### T5 Info `expect.anything()` for req arg — Accepted
+- **Anti-Deferral check**: Acceptable risk.
+- **Justification**: The load-bearing assertion is on tenantId forwarding; req shape is not part of the contract being tested.
+- **Orchestrator sign-off**: Accepted.
+
+#### T6 Low Mock `Response` vs `NextResponse` type — Accepted
+- **Anti-Deferral check**: Acceptable risk.
+- **Justification**: `NextResponse extends Response`; the `if (denied) return denied;` pattern accepts either at runtime. No observable behavior difference.
+- **Orchestrator sign-off**: Accepted.
+
+#### N5 Info access-requests GET same class as N2 — Resolved by N2 fix
+- **Anti-Deferral check**: Covered by the same middleware change.
+- **Orchestrator sign-off**: Resolved (no code change needed in the handler — middleware now blocks session+Bearer before the handler runs).

--- a/src/__tests__/api/s/download.test.ts
+++ b/src/__tests__/api/s/download.test.ts
@@ -257,4 +257,56 @@ describe("GET /s/[token]/download", () => {
     expect(res.status).toBe(200);
     expect(mockVerifyAccessToken).toHaveBeenCalledWith("valid-access-token", "share-1");
   });
+
+  // TOCTOU atomicity: findUnique returns a share that still looks valid,
+  // but it is revoked/expired between the JS check and the UPDATE. The
+  // UPDATE's re-asserted revoked_at/expires_at predicates must match 0
+  // rows and the handler must return 410 without streaming the file.
+  it("returns 410 when non-protected share is revoked between findUnique and UPDATE (TOCTOU)", async () => {
+    mockFindUnique.mockResolvedValue(makeFileShare());
+    mockExecuteRaw.mockResolvedValueOnce(0);
+
+    const req = createDownloadRequest(VALID_TOKEN);
+    const res = await GET(req as never, createParams({ token: VALID_TOKEN }));
+
+    expect(res.status).toBe(410);
+    expect(mockDecryptShareBinary).not.toHaveBeenCalled();
+  });
+
+  it("returns 410 when password-protected share is revoked between findUnique and UPDATE (TOCTOU)", async () => {
+    mockFindUnique.mockResolvedValue(
+      makeFileShare({ accessPasswordHash: "some-hash" })
+    );
+    mockVerifyAccessToken.mockReturnValueOnce(true);
+    mockExecuteRaw.mockResolvedValueOnce(0);
+
+    const req = new NextRequest(`http://localhost/s/${VALID_TOKEN}/download`, {
+      headers: {
+        "x-forwarded-for": "1.2.3.4",
+        authorization: "Bearer valid-access-token",
+      },
+    } as ConstructorParameters<typeof NextRequest>[1]);
+    const res = await GET(req as never, createParams({ token: VALID_TOKEN }));
+
+    expect(res.status).toBe(410);
+    expect(mockDecryptShareBinary).not.toHaveBeenCalled();
+  });
+
+  // T1: the UPDATE's SQL body must contain every TOCTOU predicate so a
+  // regression that drops one of them fails the test instead of silently
+  // returning "0 rows updated" under the mock.
+  it("UPDATE SQL re-asserts revoked_at, expires_at, and max_views predicates", async () => {
+    mockFindUnique.mockResolvedValue(makeFileShare());
+
+    const req = createDownloadRequest(VALID_TOKEN);
+    await GET(req as never, createParams({ token: VALID_TOKEN }));
+
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    const callArg = mockExecuteRaw.mock.calls[0][0] as unknown;
+    const sqlBody = Array.isArray(callArg) ? callArg.join("?") : String(callArg);
+    expect(sqlBody).toMatch(/"revoked_at"\s+IS\s+NULL/i);
+    expect(sqlBody).toMatch(/"expires_at"\s*>\s*NOW\(\)/i);
+    expect(sqlBody).toMatch(/"max_views"\s+IS\s+NULL\s+OR\s+"view_count"\s*<\s*"max_views"/i);
+    expect(sqlBody).toMatch(/"view_count"\s*=\s*"view_count"\s*\+\s*1/i);
+  });
 });

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -212,6 +212,50 @@ describe("proxy — handleApiAuth Bearer bypass", () => {
     expect(res.status).toBe(401);
   });
 
+  // N2: session cookie + arbitrary Bearer must not skip the middleware
+  // session+IP check. If it did, an attacker off-network could combine a
+  // valid session cookie with any Bearer string to defeat the tenant IP
+  // restriction — authOrToken prefers session, so the handler would grant
+  // access without any IP gate.
+  it("does NOT bypass when session cookie is present alongside Bearer + /api/passwords", async () => {
+    const res = await proxy(
+      createApiRequest("/api/passwords", {
+        Authorization: "Bearer tok123",
+        Cookie: "authjs.session-token=sess-cookie-plus-bearer",
+      }),
+      dummyOptions,
+    );
+    // Falls through to the session-authenticated path; session fetch mock
+    // returns { user: null } so the middleware rejects with 401.
+    expect(res.status).toBe(401);
+    // The session lookup MUST have run (proves we did not bypass).
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("does NOT bypass when session cookie is present alongside Bearer + /api/api-keys", async () => {
+    const res = await proxy(
+      createApiRequest("/api/api-keys", {
+        Authorization: "Bearer tok123",
+        Cookie: "authjs.session-token=sess-cookie-plus-bearer-apikey",
+      }),
+      dummyOptions,
+    );
+    expect(res.status).toBe(401);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("does NOT bypass when session cookie is present alongside Bearer + /api/vault/delegation", async () => {
+    const res = await proxy(
+      createApiRequest("/api/vault/delegation/check", {
+        Authorization: "Bearer tok123",
+        Cookie: "authjs.session-token=sess-cookie-plus-bearer-deleg",
+      }),
+      dummyOptions,
+    );
+    expect(res.status).toBe(401);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
   it("returns 401 for /api/sends without session", async () => {
     const res = await proxy(
       createApiRequest("/api/sends", {

--- a/src/app/api/api-keys/[id]/route.test.ts
+++ b/src/app/api/api-keys/[id]/route.test.ts
@@ -143,7 +143,7 @@ describe("DELETE /api/api-keys/[id]", () => {
     expect(res.status).toBe(404);
   });
 
-  it("calls checkAuth with allowTokens and skipAccessRestriction", async () => {
+  it("calls checkAuth with allowTokens and enforces access restriction", async () => {
     mockCheckAuth.mockResolvedValue(authFail());
 
     await DELETE(
@@ -152,7 +152,7 @@ describe("DELETE /api/api-keys/[id]", () => {
     );
     expect(mockCheckAuth).toHaveBeenCalledWith(
       expect.any(NextRequest),
-      { allowTokens: true, skipAccessRestriction: true },
+      { allowTokens: true },
     );
   });
 

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -13,9 +13,7 @@ async function handleDELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  // skipAccessRestriction: deliberate — API key management is session/extension-token only;
-  // IP restriction is not enforced here (matches pre-checkAuth behavior).
-  const authed = await checkAuth(req, { allowTokens: true, skipAccessRestriction: true });
+  const authed = await checkAuth(req, { allowTokens: true });
   if (!authed.ok) return authed.response;
   // Only session and extension token can manage API keys
   if (authed.auth.type === "api_key" || authed.auth.type === "mcp_token") {

--- a/src/app/api/api-keys/route.test.ts
+++ b/src/app/api/api-keys/route.test.ts
@@ -148,7 +148,7 @@ describe("GET /api/api-keys", () => {
     expect(json).toEqual([]);
   });
 
-  it("calls checkAuth with allowTokens and skipAccessRestriction", async () => {
+  it("calls checkAuth with allowTokens and enforces access restriction", async () => {
     mockCheckAuth.mockResolvedValue({
       ok: true,
       auth: { type: "session", userId: "u1" },
@@ -158,7 +158,7 @@ describe("GET /api/api-keys", () => {
     await GET(createRequest("GET", "http://localhost:3000/api/api-keys"));
     expect(mockCheckAuth).toHaveBeenCalledWith(
       expect.any(NextRequest),
-      { allowTokens: true, skipAccessRestriction: true },
+      { allowTokens: true },
     );
   });
 });
@@ -203,7 +203,7 @@ describe("POST /api/api-keys", () => {
     expect(res.status).toBe(401);
   });
 
-  it("calls checkAuth with allowTokens and skipAccessRestriction", async () => {
+  it("calls checkAuth with allowTokens and enforces access restriction", async () => {
     mockCheckAuth.mockResolvedValue(authFail());
 
     await POST(
@@ -213,7 +213,7 @@ describe("POST /api/api-keys", () => {
     );
     expect(mockCheckAuth).toHaveBeenCalledWith(
       expect.any(NextRequest),
-      { allowTokens: true, skipAccessRestriction: true },
+      { allowTokens: true },
     );
   });
 

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -23,9 +23,9 @@ const apiKeyCreateLimiter = createRateLimiter({ windowMs: MS_PER_HOUR, max: 5 })
 
 // GET /api/api-keys — List API keys for the current user
 async function handleGET(req: NextRequest) {
-  // skipAccessRestriction: deliberate — API key management is session/extension-token only;
-  // IP restriction is not enforced here (matches pre-checkAuth behavior).
-  const authed = await checkAuth(req, { allowTokens: true, skipAccessRestriction: true });
+  // Tenant IP restriction applies to all auth types (session + extension token)
+  // to prevent long-lived API-key issuance from outside the tenant network boundary.
+  const authed = await checkAuth(req, { allowTokens: true });
   if (!authed.ok) return authed.response;
   // Only session and extension token can manage API keys
   if (authed.auth.type === "api_key" || authed.auth.type === "mcp_token") {
@@ -66,9 +66,7 @@ async function handleGET(req: NextRequest) {
 
 // POST /api/api-keys — Create a new API key (session or extension token, NOT API key)
 async function handlePOST(req: NextRequest) {
-  // skipAccessRestriction: deliberate — API key management is session/extension-token only;
-  // IP restriction is not enforced here (matches pre-checkAuth behavior).
-  const authed = await checkAuth(req, { allowTokens: true, skipAccessRestriction: true });
+  const authed = await checkAuth(req, { allowTokens: true });
   if (!authed.ok) return authed.response;
   // Only session and extension token can create API keys
   if (authed.auth.type === "api_key" || authed.auth.type === "mcp_token") {

--- a/src/app/api/extension/token/refresh/route.test.ts
+++ b/src/app/api/extension/token/refresh/route.test.ts
@@ -84,6 +84,7 @@ function validTokenResult(overrides?: Record<string, unknown>) {
     data: {
       tokenId: "old-tok-id",
       userId: "user-1",
+      tenantId: "tenant-1",
       scopes: ["passwords:read", "vault:unlock-data"],
       expiresAt: new Date("2030-01-01"),
       familyId: "fam-1",
@@ -215,7 +216,7 @@ describe("POST /api/extension/token/refresh", () => {
 
   it("refreshes token successfully", async () => {
     mockValidateExtensionToken.mockResolvedValue(validTokenResult());
-    mockSessionFindFirst.mockResolvedValue({ id: "session-1" });
+    mockSessionFindFirst.mockResolvedValue({ id: "session-1", tenantId: "tenant-1" });
 
     const req = createRequest("POST", "http://localhost/api/extension/token/refresh", {
       headers: { Authorization: "Bearer valid-token" },
@@ -231,7 +232,7 @@ describe("POST /api/extension/token/refresh", () => {
 
   it("revokes old token and creates new in transaction", async () => {
     mockValidateExtensionToken.mockResolvedValue(validTokenResult());
-    mockSessionFindFirst.mockResolvedValue({ id: "session-1" });
+    mockSessionFindFirst.mockResolvedValue({ id: "session-1", tenantId: "tenant-1" });
 
     const req = createRequest("POST", "http://localhost/api/extension/token/refresh", {
       headers: { Authorization: "Bearer valid-token" },
@@ -251,7 +252,7 @@ describe("POST /api/extension/token/refresh", () => {
     mockValidateExtensionToken.mockResolvedValue(
       validTokenResult({ scopes: ["passwords:read"] }),
     );
-    mockSessionFindFirst.mockResolvedValue({ id: "session-1" });
+    mockSessionFindFirst.mockResolvedValue({ id: "session-1", tenantId: "tenant-1" });
     mockExtTokenCreate.mockResolvedValue({
       expiresAt: new Date("2030-01-01"),
       scope: "passwords:read",
@@ -268,7 +269,7 @@ describe("POST /api/extension/token/refresh", () => {
 
   it("returns 401 on concurrent refresh (optimistic lock)", async () => {
     mockValidateExtensionToken.mockResolvedValue(validTokenResult());
-    mockSessionFindFirst.mockResolvedValue({ id: "session-1" });
+    mockSessionFindFirst.mockResolvedValue({ id: "session-1", tenantId: "tenant-1" });
     // updateMany returns count: 0 — already revoked by concurrent request
     mockExtTokenUpdateMany.mockResolvedValue({ count: 0 });
 

--- a/src/app/api/extension/token/refresh/route.test.ts
+++ b/src/app/api/extension/token/refresh/route.test.ts
@@ -14,6 +14,7 @@ const {
   mockTransaction,
   mockWithUserTenantRls,
   mockWithBypassRls,
+  mockEnforceAccessRestriction,
 } = vi.hoisted(() => ({
   mockValidateExtensionToken: vi.fn(),
   mockRevokeExtensionTokenFamily: vi.fn().mockResolvedValue({ rowsRevoked: 0 }),
@@ -28,11 +29,16 @@ const {
   mockTransaction: vi.fn(),
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
   mockWithBypassRls: vi.fn(async (_p: unknown, fn: () => unknown) => fn()),
+  mockEnforceAccessRestriction: vi.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue(null),
 }));
 
 vi.mock("@/lib/extension-token", () => ({
   validateExtensionToken: mockValidateExtensionToken,
   revokeExtensionTokenFamily: mockRevokeExtensionTokenFamily,
+}));
+
+vi.mock("@/lib/access-restriction", () => ({
+  enforceAccessRestriction: mockEnforceAccessRestriction,
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -181,6 +187,30 @@ describe("POST /api/extension/token/refresh", () => {
 
     expect(status).toBe(401);
     expect(json.error).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 when client IP is outside the tenant access restriction", async () => {
+    mockValidateExtensionToken.mockResolvedValue(validTokenResult());
+    mockSessionFindFirst.mockResolvedValue({ id: "session-1", tenantId: "tenant-1" });
+    const denied = new Response(
+      JSON.stringify({ error: "ACCESS_DENIED" }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
+    mockEnforceAccessRestriction.mockResolvedValueOnce(denied);
+
+    const req = createRequest("POST", "http://localhost/api/extension/token/refresh", {
+      headers: { Authorization: "Bearer valid-token" },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(403);
+    // Must not rotate token when IP is denied
+    expect(mockExtTokenCreate).not.toHaveBeenCalled();
+    expect(mockEnforceAccessRestriction).toHaveBeenCalledWith(
+      expect.anything(),
+      "user-1",
+      "tenant-1",
+    );
   });
 
   it("refreshes token successfully", async () => {

--- a/src/app/api/extension/token/refresh/route.ts
+++ b/src/app/api/extension/token/refresh/route.ts
@@ -33,7 +33,14 @@ async function handlePOST(req: NextRequest) {
     return errorResponse(API_ERROR[result.error], 401);
   }
 
-  const { tokenId, userId, scopes, familyId, familyCreatedAt } = result.data;
+  const { tokenId, userId, tenantId, scopes, familyId, familyCreatedAt } = result.data;
+
+  // Tenant network-boundary enforcement comes BEFORE rate limit so an
+  // off-network holder of a stolen bearer cannot burn the legitimate
+  // user's per-user refresh budget (DoS the live extension). tenantId
+  // comes directly from the validated token row.
+  const denied = await enforceAccessRestriction(req, userId, tenantId);
+  if (denied) return denied;
 
   const rl = await refreshLimiter.check(`rl:ext_refresh:${userId}`);
   if (!rl.allowed) {
@@ -54,13 +61,6 @@ async function handlePOST(req: NextRequest) {
   if (!activeSession) {
     return unauthorized();
   }
-
-  // Tenant network-boundary enforcement: Bearer reached this handler via
-  // proxy.ts bearer-bypass, so IP must be re-checked here or an extension
-  // token could be rotated indefinitely from outside the tenant CIDR /
-  // Tailscale range up to the family absolute cap.
-  const denied = await enforceAccessRestriction(req, userId, activeSession.tenantId);
-  if (denied) return denied;
 
   // Read tenant extension-token TTL policy
   const tenant = await withBypassRls(prisma, async () =>

--- a/src/app/api/extension/token/refresh/route.ts
+++ b/src/app/api/extension/token/refresh/route.ts
@@ -5,6 +5,7 @@ import { createRateLimiter } from "@/lib/rate-limit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, rateLimited, unauthorized } from "@/lib/api-response";
 import { validateExtensionToken, revokeExtensionTokenFamily } from "@/lib/extension-token";
+import { enforceAccessRestriction } from "@/lib/access-restriction";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -53,6 +54,13 @@ async function handlePOST(req: NextRequest) {
   if (!activeSession) {
     return unauthorized();
   }
+
+  // Tenant network-boundary enforcement: Bearer reached this handler via
+  // proxy.ts bearer-bypass, so IP must be re-checked here or an extension
+  // token could be rotated indefinitely from outside the tenant CIDR /
+  // Tailscale range up to the family absolute cap.
+  const denied = await enforceAccessRestriction(req, userId, activeSession.tenantId);
+  if (denied) return denied;
 
   // Read tenant extension-token TTL policy
   const tenant = await withBypassRls(prisma, async () =>

--- a/src/app/api/extension/token/route.test.ts
+++ b/src/app/api/extension/token/route.test.ts
@@ -16,6 +16,7 @@ const {
   mockCheck,
   mockWithUserTenantRls,
   mockWithBypassRls,
+  mockEnforceAccessRestriction,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockCreate: vi.fn(),
@@ -28,6 +29,7 @@ const {
   mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
   mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
+  mockEnforceAccessRestriction: vi.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue(null),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -65,6 +67,9 @@ vi.mock("@/lib/tenant-context", () => ({
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
   withBypassRls: mockWithBypassRls,
+}));
+vi.mock("@/lib/access-restriction", () => ({
+  enforceAccessRestriction: mockEnforceAccessRestriction,
 }));
 
 import { POST, DELETE } from "./route";
@@ -235,5 +240,33 @@ describe("DELETE /api/extension/token", () => {
 
     expect(status).toBe(404);
     expect(json.error).toBe("EXTENSION_TOKEN_INVALID");
+  });
+
+  it("returns 403 when client IP is outside the tenant access restriction", async () => {
+    mockFindUnique.mockResolvedValue({
+      id: "t1",
+      userId: DEFAULT_SESSION.user.id,
+      scope: "passwords:read,vault:unlock-data",
+      expiresAt: new Date("2030-01-01"),
+      revokedAt: null,
+    });
+    const denied = new Response(
+      JSON.stringify({ error: "ACCESS_DENIED" }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
+    mockEnforceAccessRestriction.mockResolvedValueOnce(denied);
+
+    const req = createRequest("DELETE", "http://localhost/api/extension/token", {
+      headers: { Authorization: `Bearer ${"a".repeat(64)}` },
+    });
+    const res = await DELETE(req);
+
+    expect(res.status).toBe(403);
+    // validateExtensionToken internally updates lastUsedAt on every successful
+    // validation; that call is expected. What must NOT happen under IP denial
+    // is the revoke write (`revokedAt: <date>`).
+    for (const call of mockUpdate.mock.calls) {
+      expect(call[0].data).not.toHaveProperty("revokedAt");
+    }
   });
 });

--- a/src/app/api/extension/token/route.ts
+++ b/src/app/api/extension/token/route.ts
@@ -92,8 +92,14 @@ async function handleDELETE(req: NextRequest) {
 
   // Tenant network-boundary enforcement: Bearer bypasses middleware access
   // restriction, so the full extension-token lifecycle (issue/refresh/revoke)
-  // must be gated at the tenant CIDR / Tailscale boundary.
-  const denied = await enforceAccessRestriction(req, result.data.userId);
+  // must be gated at the tenant CIDR / Tailscale boundary. tenantId is
+  // taken directly from the validated token row (not resolved from userId)
+  // to avoid a silent fail-open if user→tenant resolution returns null.
+  const denied = await enforceAccessRestriction(
+    req,
+    result.data.userId,
+    result.data.tenantId,
+  );
   if (denied) return denied;
 
   await withUserTenantRls(result.data.userId, async () =>

--- a/src/app/api/extension/token/route.ts
+++ b/src/app/api/extension/token/route.ts
@@ -5,6 +5,7 @@ import { createRateLimiter } from "@/lib/rate-limit";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { errorResponse, rateLimited, unauthorized } from "@/lib/api-response";
 import { issueExtensionToken, validateExtensionToken } from "@/lib/extension-token";
+import { enforceAccessRestriction } from "@/lib/access-restriction";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { EXTENSION_TOKEN_DEFAULT_SCOPES } from "@/lib/constants";
 import { withRequestLog } from "@/lib/with-request-log";
@@ -88,6 +89,12 @@ async function handleDELETE(req: NextRequest) {
     };
     return errorResponse(API_ERROR[result.error], statusMap[result.error] ?? 400);
   }
+
+  // Tenant network-boundary enforcement: Bearer bypasses middleware access
+  // restriction, so the full extension-token lifecycle (issue/refresh/revoke)
+  // must be gated at the tenant CIDR / Tailscale boundary.
+  const denied = await enforceAccessRestriction(req, result.data.userId);
+  if (denied) return denied;
 
   await withUserTenantRls(result.data.userId, async () =>
     prisma.extensionToken.update({

--- a/src/app/api/share-links/[id]/content/route.test.ts
+++ b/src/app/api/share-links/[id]/content/route.test.ts
@@ -194,8 +194,13 @@ describe("GET /api/share-links/[id]/content", () => {
       ...MOCK_SHARE,
       shareType: "FILE",
     });
-    await GET(createContentRequest(), createParams({ id: SHARE_ID }));
-    expect(mockPrismaExecuteRaw).not.toHaveBeenCalled();
+    const res = await GET(createContentRequest(), createParams({ id: SHARE_ID }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // FILE path runs a no-op conditional UPDATE to atomically recheck
+    // revocation/expiry/maxViews, but view_count is incremented by the
+    // download route instead — response viewCount reflects the DB row.
+    expect(json.viewCount).toBe(MOCK_SHARE.viewCount);
   });
 
   it("returns 410 when FILE share max views exceeded", async () => {
@@ -205,6 +210,29 @@ describe("GET /api/share-links/[id]/content", () => {
       maxViews: 3,
       viewCount: 3,
     });
+    // Conditional UPDATE matches 0 rows when maxViews is reached.
+    mockPrismaExecuteRaw.mockResolvedValue(0);
+    const res = await GET(createContentRequest(), createParams({ id: SHARE_ID }));
+    expect(res.status).toBe(410);
+  });
+
+  // TOCTOU atomicity: findUnique returns a share that still looks valid,
+  // but the share is revoked/expired between the JS check and the UPDATE.
+  // The UPDATE's re-asserted predicates must match 0 rows and the handler
+  // must return 410 without leaking data.
+  it("returns 410 when revoked between findUnique and UPDATE (TOCTOU)", async () => {
+    mockPrismaPasswordShare.findUnique.mockResolvedValue(MOCK_SHARE);
+    mockPrismaExecuteRaw.mockResolvedValue(0);
+    const res = await GET(createContentRequest(), createParams({ id: SHARE_ID }));
+    expect(res.status).toBe(410);
+  });
+
+  it("returns 410 for FILE share revoked between findUnique and recheck (TOCTOU)", async () => {
+    mockPrismaPasswordShare.findUnique.mockResolvedValue({
+      ...MOCK_SHARE,
+      shareType: "FILE",
+    });
+    mockPrismaExecuteRaw.mockResolvedValue(0);
     const res = await GET(createContentRequest(), createParams({ id: SHARE_ID }));
     expect(res.status).toBe(410);
   });

--- a/src/app/api/share-links/[id]/content/route.test.ts
+++ b/src/app/api/share-links/[id]/content/route.test.ts
@@ -88,6 +88,15 @@ function createContentRequest(overrides: Record<string, string> = {}) {
   });
 }
 
+// Collapse a tagged-template `$executeRaw` call (captured by vi.fn()) into a
+// single SQL string for predicate assertions. The first call argument is a
+// readonly string[] (the template parts); remaining args are interpolated
+// values we don't need for shape verification.
+function sqlBodyOf(callArgs: readonly unknown[]): string {
+  const strings = callArgs[0];
+  return Array.isArray(strings) ? strings.join("?") : String(strings);
+}
+
 describe("GET /api/share-links/[id]/content", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -149,12 +158,6 @@ describe("GET /api/share-links/[id]/content", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 410 when max views exceeded", async () => {
-    mockPrismaExecuteRaw.mockResolvedValue(0); // 0 rows updated = view limit reached
-    const res = await GET(createContentRequest(), createParams({ id: SHARE_ID }));
-    expect(res.status).toBe(410);
-  });
-
   it("returns encrypted data for E2E share (masterKeyVersion=0)", async () => {
     const res = await GET(createContentRequest(), createParams({ id: SHARE_ID }));
     expect(res.status).toBe(200);
@@ -189,7 +192,7 @@ describe("GET /api/share-links/[id]/content", () => {
     expect(res.status).toBe(404);
   });
 
-  it("does not increment viewCount for FILE shares", async () => {
+  it("does not increment viewCount for FILE shares (no-op UPDATE only)", async () => {
     mockPrismaPasswordShare.findUnique.mockResolvedValue({
       ...MOCK_SHARE,
       shareType: "FILE",
@@ -197,37 +200,31 @@ describe("GET /api/share-links/[id]/content", () => {
     const res = await GET(createContentRequest(), createParams({ id: SHARE_ID }));
     expect(res.status).toBe(200);
     const json = await res.json();
-    // FILE path runs a no-op conditional UPDATE to atomically recheck
-    // revocation/expiry/maxViews, but view_count is incremented by the
-    // download route instead — response viewCount reflects the DB row.
     expect(json.viewCount).toBe(MOCK_SHARE.viewCount);
+
+    // T2: prove the UPDATE is a no-op write, not an accidental `+ 1`.
+    expect(mockPrismaExecuteRaw).toHaveBeenCalledTimes(1);
+    const sql = sqlBodyOf(mockPrismaExecuteRaw.mock.calls[0]);
+    expect(sql).toMatch(/"view_count"\s*=\s*"view_count"(?!\s*\+)/i);
+    expect(sql).not.toMatch(/"view_count"\s*=\s*"view_count"\s*\+\s*1/i);
   });
 
-  it("returns 410 when FILE share max views exceeded", async () => {
-    mockPrismaPasswordShare.findUnique.mockResolvedValue({
-      ...MOCK_SHARE,
-      shareType: "FILE",
-      maxViews: 3,
-      viewCount: 3,
-    });
-    // Conditional UPDATE matches 0 rows when maxViews is reached.
-    mockPrismaExecuteRaw.mockResolvedValue(0);
-    const res = await GET(createContentRequest(), createParams({ id: SHARE_ID }));
-    expect(res.status).toBe(410);
-  });
-
-  // TOCTOU atomicity: findUnique returns a share that still looks valid,
-  // but the share is revoked/expired between the JS check and the UPDATE.
-  // The UPDATE's re-asserted predicates must match 0 rows and the handler
-  // must return 410 without leaking data.
-  it("returns 410 when revoked between findUnique and UPDATE (TOCTOU)", async () => {
+  // Non-FILE TOCTOU: the JS pre-check reads revokedAt=null / expiresAt=future
+  // from findUnique, but the UPDATE must re-assert those predicates. Running
+  // the test with findUnique returning a still-valid share and $executeRaw
+  // returning 0 simulates the row being revoked/expired/max-views-hit in the
+  // interleaving window.
+  it("returns 410 when atomic UPDATE matches 0 rows (TOCTOU or maxViews)", async () => {
     mockPrismaPasswordShare.findUnique.mockResolvedValue(MOCK_SHARE);
     mockPrismaExecuteRaw.mockResolvedValue(0);
     const res = await GET(createContentRequest(), createParams({ id: SHARE_ID }));
     expect(res.status).toBe(410);
   });
 
-  it("returns 410 for FILE share revoked between findUnique and recheck (TOCTOU)", async () => {
+  // FILE path mirrors the TOCTOU recheck but with a no-op SET (view_count
+  // increment is owned by the download route). $executeRaw returning 0
+  // simulates revocation/expiry/max-views in the interleaving window.
+  it("returns 410 for FILE share when atomic recheck matches 0 rows (TOCTOU or maxViews)", async () => {
     mockPrismaPasswordShare.findUnique.mockResolvedValue({
       ...MOCK_SHARE,
       shareType: "FILE",
@@ -235,5 +232,39 @@ describe("GET /api/share-links/[id]/content", () => {
     mockPrismaExecuteRaw.mockResolvedValue(0);
     const res = await GET(createContentRequest(), createParams({ id: SHARE_ID }));
     expect(res.status).toBe(410);
+  });
+
+  // T1: verify the UPDATE SQL actually contains every TOCTOU predicate so a
+  // predicate-dropping regression fails the test instead of silently returning
+  // "0 rows" under the mock. Non-FILE path increments view_count.
+  it("non-FILE UPDATE SQL re-asserts revoked_at, expires_at, max_views predicates and increments view_count", async () => {
+    mockPrismaPasswordShare.findUnique.mockResolvedValue(MOCK_SHARE);
+    await GET(createContentRequest(), createParams({ id: SHARE_ID }));
+
+    expect(mockPrismaExecuteRaw).toHaveBeenCalledTimes(1);
+    const sql = sqlBodyOf(mockPrismaExecuteRaw.mock.calls[0]);
+    expect(sql).toMatch(/"revoked_at"\s+IS\s+NULL/i);
+    expect(sql).toMatch(/"expires_at"\s*>\s*NOW\(\)/i);
+    expect(sql).toMatch(/"max_views"\s+IS\s+NULL\s+OR\s+"view_count"\s*<\s*"max_views"/i);
+    expect(sql).toMatch(/"view_count"\s*=\s*"view_count"\s*\+\s*1/i);
+  });
+
+  // T1: FILE path must carry the same predicates; view_count must NOT be
+  // incremented here (download route owns that).
+  it("FILE recheck SQL re-asserts revoked_at, expires_at, max_views predicates without incrementing view_count", async () => {
+    mockPrismaPasswordShare.findUnique.mockResolvedValue({
+      ...MOCK_SHARE,
+      shareType: "FILE",
+    });
+    await GET(createContentRequest(), createParams({ id: SHARE_ID }));
+
+    expect(mockPrismaExecuteRaw).toHaveBeenCalledTimes(1);
+    const sql = sqlBodyOf(mockPrismaExecuteRaw.mock.calls[0]);
+    expect(sql).toMatch(/"revoked_at"\s+IS\s+NULL/i);
+    expect(sql).toMatch(/"expires_at"\s*>\s*NOW\(\)/i);
+    expect(sql).toMatch(/"max_views"\s+IS\s+NULL\s+OR\s+"view_count"\s*<\s*"max_views"/i);
+    // No-op SET, not `+ 1` — download route handles the increment.
+    expect(sql).toMatch(/"view_count"\s*=\s*"view_count"(?!\s*\+)/i);
+    expect(sql).not.toMatch(/"view_count"\s*=\s*"view_count"\s*\+\s*1/i);
   });
 });

--- a/src/app/api/share-links/[id]/content/route.ts
+++ b/src/app/api/share-links/[id]/content/route.ts
@@ -76,7 +76,11 @@ async function handleGET(req: NextRequest, { params }: Params) {
       return notFound();
     }
 
-    // Atomically check maxViews and increment viewCount.
+    // Atomically check revocation/expiry/maxViews and increment viewCount.
+    // The revoked_at/expires_at predicates are re-asserted here (in addition
+    // to the JS check above) to close a TOCTOU window: between findUnique
+    // and the UPDATE, the share may be revoked or expire, and we must not
+    // leak data in that window.
     // For FILE shares, viewCount is incremented by the download route instead,
     // to prevent bypass via direct download (skipping content API).
     let viewCountDelta = 0;
@@ -85,6 +89,8 @@ async function handleGET(req: NextRequest, { params }: Params) {
         UPDATE "password_shares"
         SET "view_count" = "view_count" + 1
         WHERE "id" = ${share.id}
+          AND "revoked_at" IS NULL
+          AND "expires_at" > NOW()
           AND ("max_views" IS NULL OR "view_count" < "max_views")`;
 
       if (updated === 0) {
@@ -92,8 +98,19 @@ async function handleGET(req: NextRequest, { params }: Params) {
       }
       viewCountDelta = 1;
     } else {
-      // FILE: just check maxViews without incrementing
-      if (share.maxViews !== null && share.viewCount >= share.maxViews) {
+      // FILE: check revocation/expiry/maxViews atomically without incrementing.
+      // viewCount is incremented by the download route. We use a no-op
+      // conditional UPDATE (SET view_count = view_count) to re-assert the
+      // state under the same row-lock semantics as the non-FILE path.
+      const stillValid: number = await prisma.$executeRaw`
+        UPDATE "password_shares"
+        SET "view_count" = "view_count"
+        WHERE "id" = ${share.id}
+          AND "revoked_at" IS NULL
+          AND "expires_at" > NOW()
+          AND ("max_views" IS NULL OR "view_count" < "max_views")`;
+
+      if (stillValid === 0) {
         return errorResponse(API_ERROR.NOT_FOUND, 410);
       }
     }

--- a/src/app/api/tenant/access-requests/route.test.ts
+++ b/src/app/api/tenant/access-requests/route.test.ts
@@ -14,6 +14,7 @@ const {
   mockAccessRequestCreate,
   mockServiceAccountFindUnique,
   mockDispatchTenantWebhook,
+  mockEnforceAccessRestriction,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockAuthOrToken: vi.fn(),
@@ -26,6 +27,7 @@ const {
   mockAccessRequestCreate: vi.fn(),
   mockServiceAccountFindUnique: vi.fn(),
   mockDispatchTenantWebhook: vi.fn(),
+  mockEnforceAccessRestriction: vi.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue(null),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -76,6 +78,9 @@ vi.mock("@/lib/with-request-log", () => ({
 }));
 vi.mock("@/lib/webhook-dispatcher", () => ({
   dispatchTenantWebhook: mockDispatchTenantWebhook,
+}));
+vi.mock("@/lib/access-restriction", () => ({
+  enforceAccessRestriction: mockEnforceAccessRestriction,
 }));
 
 import { GET, POST } from "@/app/api/tenant/access-requests/route";
@@ -343,6 +348,34 @@ describe("POST /api/tenant/access-requests", () => {
 
     expect(status).toBe(201);
     expect(json.id).toBe("req-sa-1");
+  });
+
+  it("returns 403 when SA token request is from outside tenant IP range", async () => {
+    mockAuthOrToken.mockResolvedValue({
+      type: "service_account",
+      serviceAccountId: SA_ID,
+      tenantId: "tenant-1",
+      tokenId: "tok-denied",
+      scopes: ["access-request:create"],
+    });
+    mockServiceAccountFindUnique.mockResolvedValue({
+      isActive: true,
+      createdById: DEFAULT_SESSION.user.id,
+    });
+    const denied = new Response(
+      JSON.stringify({ error: "ACCESS_DENIED" }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
+    mockEnforceAccessRestriction.mockResolvedValueOnce(denied);
+
+    const req = createRequest("POST", "http://localhost/api/tenant/access-requests", {
+      body: { requestedScope: ["passwords:read"] },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(403);
+    // Must not create the request when IP is denied
+    expect(mockAccessRequestCreate).not.toHaveBeenCalled();
   });
 
   it("returns 403 when SA token lacks access-request:create scope", async () => {

--- a/src/app/api/tenant/access-requests/route.ts
+++ b/src/app/api/tenant/access-requests/route.ts
@@ -5,6 +5,7 @@ import { logAuditAsync, tenantAuditBase, resolveActorType } from "@/lib/audit";
 import { requireTenantPermission } from "@/lib/tenant-auth";
 import { authOrToken } from "@/lib/auth-or-token";
 import { enforceAccessRestriction } from "@/lib/access-restriction";
+import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
@@ -119,6 +120,20 @@ async function handlePOST(req: NextRequest) {
     tenantId = authResult.tenantId;
     serviceAccountId = authResult.serviceAccountId;
 
+    // Enforce tenant network-boundary policy BEFORE rate limit so an
+    // off-network holder of a stolen SA bearer cannot burn the per-SA
+    // request budget against the legitimate SA. userId is the SA sentinel
+    // (SYSTEM_ACTOR_ID) here because sa.createdById is not resolved until
+    // the active-SA lookup below; the denial audit records tenantId and
+    // serviceAccountId via actorType/metadata regardless.
+    const denied = await enforceAccessRestriction(
+      req,
+      SYSTEM_ACTOR_ID,
+      tenantId,
+      ACTOR_TYPE.SERVICE_ACCOUNT,
+    );
+    if (denied) return denied;
+
     const rl = await accessRequestCreateLimiter.check(`rl:access_request_create:sa:${serviceAccountId}`);
     if (!rl.allowed) return rateLimited(rl.retryAfterMs);
 
@@ -140,16 +155,6 @@ async function handlePOST(req: NextRequest) {
       return errorResponse(API_ERROR.SA_NOT_FOUND, 404);
     }
     userId = sa.createdById;
-
-    // Enforce tenant network-boundary policy for SA self-service — the
-    // Bearer path in proxy.ts bypasses middleware access restriction.
-    const denied = await enforceAccessRestriction(
-      req,
-      userId,
-      tenantId,
-      ACTOR_TYPE.SERVICE_ACCOUNT,
-    );
-    if (denied) return denied;
   } else {
     // Admin path: session or API key auth
     if (!("userId" in authResult)) return unauthorized();

--- a/src/app/api/tenant/access-requests/route.ts
+++ b/src/app/api/tenant/access-requests/route.ts
@@ -4,10 +4,12 @@ import { prisma } from "@/lib/prisma";
 import { logAuditAsync, tenantAuditBase, resolveActorType } from "@/lib/audit";
 import { requireTenantPermission } from "@/lib/tenant-auth";
 import { authOrToken } from "@/lib/auth-or-token";
+import { enforceAccessRestriction } from "@/lib/access-restriction";
 import { API_ERROR } from "@/lib/api-error-codes";
 import { parseBody } from "@/lib/parse-body";
 import { TENANT_PERMISSION } from "@/lib/constants/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
+import { ACTOR_TYPE } from "@/lib/constants/audit";
 import { withTenantRls, withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/with-request-log";
 import { errorResponse, handleAuthError, rateLimited, unauthorized } from "@/lib/api-response";
@@ -138,6 +140,16 @@ async function handlePOST(req: NextRequest) {
       return errorResponse(API_ERROR.SA_NOT_FOUND, 404);
     }
     userId = sa.createdById;
+
+    // Enforce tenant network-boundary policy for SA self-service — the
+    // Bearer path in proxy.ts bypasses middleware access restriction.
+    const denied = await enforceAccessRestriction(
+      req,
+      userId,
+      tenantId,
+      ACTOR_TYPE.SERVICE_ACCOUNT,
+    );
+    if (denied) return denied;
   } else {
     // Admin path: session or API key auth
     if (!("userId" in authResult)) return unauthorized();
@@ -150,6 +162,19 @@ async function handlePOST(req: NextRequest) {
       return handleAuthError(err);
     }
     tenantId = actor.tenantId;
+
+    // Session reaches this handler via middleware which already enforces
+    // tenant IP restriction. API key / other token types bypass middleware
+    // access restriction and must be checked here.
+    if (authResult.type !== "session") {
+      const denied = await enforceAccessRestriction(
+        req,
+        userId,
+        tenantId,
+        resolveActorType(authResult),
+      );
+      if (denied) return denied;
+    }
 
     const rl = await accessRequestCreateLimiter.check(`rl:access_request_create:${tenantId}`);
     if (!rl.allowed) return rateLimited(rl.retryAfterMs);

--- a/src/app/api/vault/delegation/check/route.test.ts
+++ b/src/app/api/vault/delegation/check/route.test.ts
@@ -6,6 +6,7 @@ const {
   mockWithBypassRls,
   mockRateLimiterCheck,
   mockLogAudit,
+  mockEnforceAccessRestriction,
 } = vi.hoisted(() => ({
   mockAuthOrToken: vi.fn(),
   mockPrismaDelegationSession: {
@@ -14,6 +15,7 @@ const {
   mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
   mockRateLimiterCheck: vi.fn(),
   mockLogAudit: vi.fn(),
+  mockEnforceAccessRestriction: vi.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue(null),
 }));
 
 vi.mock("@/lib/auth-or-token", () => ({
@@ -39,6 +41,9 @@ vi.mock("@/lib/audit", () => ({
 }));
 vi.mock("@/lib/ip-access", () => ({
   extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+vi.mock("@/lib/access-restriction", () => ({
+  enforceAccessRestriction: mockEnforceAccessRestriction,
 }));
 vi.mock("@/lib/logger", () => ({
   default: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) },
@@ -99,6 +104,22 @@ describe("GET /api/vault/delegation/check", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.authorized).toBe(true);
+  });
+
+  it("returns 403 when Bearer token is from outside tenant IP range", async () => {
+    mockAuthOrToken.mockResolvedValue({ type: "extension", userId: "user-1" });
+    const denied = new Response(
+      JSON.stringify({ error: "ACCESS_DENIED" }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
+    mockEnforceAccessRestriction.mockResolvedValueOnce(denied);
+
+    const res = await GET(makeRequest({ clientId: VALID_CLIENT_ID, entryId: VALID_ENTRY_ID }));
+
+    expect(res.status).toBe(403);
+    // Must not look up delegation or log audit when IP is denied
+    expect(mockPrismaDelegationSession.findFirst).not.toHaveBeenCalled();
+    expect(mockLogAudit).not.toHaveBeenCalled();
   });
 
   it("returns 429 when rate limited", async () => {

--- a/src/app/api/vault/delegation/check/route.test.ts
+++ b/src/app/api/vault/delegation/check/route.test.ts
@@ -93,7 +93,7 @@ describe("GET /api/vault/delegation/check", () => {
   });
 
   it("accepts Bearer token auth (extension token)", async () => {
-    mockAuthOrToken.mockResolvedValue({ type: "extension", userId: "user-1" });
+    mockAuthOrToken.mockResolvedValue({ type: "token", userId: "user-1", scopes: [] });
     mockPrismaDelegationSession.findFirst.mockResolvedValue({
       id: SESSION_ID,
       expiresAt: EXPIRES_AT,
@@ -107,7 +107,7 @@ describe("GET /api/vault/delegation/check", () => {
   });
 
   it("returns 403 when Bearer token is from outside tenant IP range", async () => {
-    mockAuthOrToken.mockResolvedValue({ type: "extension", userId: "user-1" });
+    mockAuthOrToken.mockResolvedValue({ type: "token", userId: "user-1", scopes: [] });
     const denied = new Response(
       JSON.stringify({ error: "ACCESS_DENIED" }),
       { status: 403, headers: { "Content-Type": "application/json" } },

--- a/src/app/api/vault/delegation/check/route.ts
+++ b/src/app/api/vault/delegation/check/route.ts
@@ -12,6 +12,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { authOrToken, hasUserId } from "@/lib/auth-or-token";
+import { enforceAccessRestriction } from "@/lib/access-restriction";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit";
 import { AUDIT_ACTION } from "@/lib/constants/audit";
 import { MCP_CLIENT_ID_PREFIX } from "@/lib/constants/mcp";
@@ -38,6 +39,18 @@ export async function GET(request: NextRequest) {
   }
 
   const userId = authResult.userId;
+
+  // Tenant network-boundary enforcement for non-session auth. Session
+  // already passed the middleware check; Bearer (extension / api_key /
+  // mcp_token) bypassed middleware and must be re-checked here.
+  if (authResult.type !== "session") {
+    const tenantIdOverride =
+      authResult.type === "api_key" || authResult.type === "mcp_token"
+        ? authResult.tenantId
+        : undefined;
+    const denied = await enforceAccessRestriction(request, userId, tenantIdOverride);
+    if (denied) return denied;
+  }
 
   // Rate limit per user
   const rl = await checkRateLimiter.check(`delegation:check:${userId}`);

--- a/src/app/s/[token]/download/route.ts
+++ b/src/app/s/[token]/download/route.ts
@@ -87,22 +87,31 @@ export async function GET(req: NextRequest, { params }: Params) {
         );
       }
 
-      // Atomically increment viewCount for password-protected downloads
+      // Atomically increment viewCount for password-protected downloads.
+      // The revoked_at/expires_at predicates are re-asserted here (in addition
+      // to the JS check above) to close a TOCTOU window: between findUnique
+      // and the UPDATE the share may be revoked or expire, and we must not
+      // leak the decrypted file in that window.
       const updated: number = await prisma.$executeRaw`
         UPDATE "password_shares"
         SET "view_count" = "view_count" + 1
         WHERE "id" = ${share.id}
+          AND "revoked_at" IS NULL
+          AND "expires_at" > NOW()
           AND ("max_views" IS NULL OR "view_count" < "max_views")`;
 
       if (updated === 0) {
         return new NextResponse(null, { status: 410 });
       }
     } else {
-      // Non-protected: atomically check and increment viewCount at download time
+      // Non-protected: atomically check and increment viewCount at download time.
+      // Same TOCTOU-closing predicates as the password-protected branch.
       const updated: number = await prisma.$executeRaw`
         UPDATE "password_shares"
         SET "view_count" = "view_count" + 1
         WHERE "id" = ${share.id}
+          AND "revoked_at" IS NULL
+          AND "expires_at" > NOW()
           AND ("max_views" IS NULL OR "view_count" < "max_views")`;
 
       if (updated === 0) {

--- a/src/app/s/[token]/page.tsx
+++ b/src/app/s/[token]/page.tsx
@@ -89,18 +89,36 @@ export default async function SharePage({ params }: Props) {
     // Non-protected share: increment viewCount for non-FILE shares.
     // FILE shares defer viewCount increment to the download route to prevent
     // race conditions where concurrent page loads allow extra downloads.
+    // The revoked_at/expires_at predicates are re-asserted here to close a
+    // TOCTOU window between findUnique and the UPDATE — without them, a
+    // share revoked/expired in that window would still render.
     if (share.shareType !== "FILE") {
       const updated: number = await prisma.$executeRaw`
         UPDATE "password_shares"
         SET "view_count" = "view_count" + 1
         WHERE "id" = ${share.id}
+          AND "revoked_at" IS NULL
+          AND "expires_at" > NOW()
           AND ("max_views" IS NULL OR "view_count" < "max_views")`;
 
       if (updated === 0) {
         return <ShareError reason="maxViews" />;
       }
-    } else if (share.maxViews !== null && share.viewCount >= share.maxViews) {
-      return <ShareError reason="maxViews" />;
+    } else {
+      // FILE: no-op conditional UPDATE to atomically recheck revocation/
+      // expiry/maxViews without touching view_count (incremented by the
+      // download route).
+      const stillValid: number = await prisma.$executeRaw`
+        UPDATE "password_shares"
+        SET "view_count" = "view_count"
+        WHERE "id" = ${share.id}
+          AND "revoked_at" IS NULL
+          AND "expires_at" > NOW()
+          AND ("max_views" IS NULL OR "view_count" < "max_views")`;
+
+      if (stillValid === 0) {
+        return <ShareError reason="maxViews" />;
+      }
     }
 
     // Record access log (must await inside withBypassRls transaction)

--- a/src/lib/extension-token.ts
+++ b/src/lib/extension-token.ts
@@ -18,6 +18,7 @@ import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 export interface ValidatedExtensionToken {
   tokenId: string;
   userId: string;
+  tenantId: string;
   scopes: ExtensionTokenScope[];
   expiresAt: Date;
   familyId: string;
@@ -88,6 +89,7 @@ export async function validateExtensionToken(
       select: {
         id: true,
         userId: true,
+        tenantId: true,
         scope: true,
         expiresAt: true,
         revokedAt: true,
@@ -120,6 +122,7 @@ export async function validateExtensionToken(
     data: {
       tokenId: token.id,
       userId: token.userId,
+      tenantId: token.tenantId,
       scopes: parseScopes(token.scope),
       expiresAt: token.expiresAt,
       familyId: token.familyId,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -228,7 +228,17 @@ async function handleApiAuth(request: NextRequest) {
     .get("authorization")
     ?.startsWith("Bearer ");
 
-  if (hasBearer && isBearerRoute) {
+  // Bearer-bypass only applies when no session cookie is present. If both
+  // are sent, authOrToken prefers session (auth-or-token.ts:64-68) and the
+  // tenant IP restriction must still gate the request — falling through to
+  // the session-authenticated path below enforces it. Legitimate Bearer-
+  // only clients (extension from chrome-extension:// origin, API key
+  // clients, SA / MCP tokens) do not ship the Auth.js session cookie, so
+  // the bypass still applies to them.
+  const hasSessionCookie =
+    extractSessionToken(request.headers.get("cookie") ?? "") !== "";
+
+  if (hasBearer && isBearerRoute && !hasSessionCookie) {
     const res = NextResponse.next();
     res.headers.set("Cache-Control", "private, no-store");
     return applyCorsHeaders(request, res, { allowExtension: true });


### PR DESCRIPTION
## Summary
Closes two reported findings and the R3-propagation siblings uncovered during multi-agent review:
- Tenant IP restriction is now enforced on all bearer-bypass routes (api-keys, extension token lifecycle, SA self-service JIT, vault delegation check), closing both direct bypass and the session+Bearer combination.
- Share-link content retrieval and FILE send download now atomically re-assert `revoked_at IS NULL AND expires_at > NOW()` inside the view-count UPDATE, eliminating the TOCTOU window between `findUnique` and the increment.

## Motivation
The initial review surfaced two issues:
1. **IP restriction bypass**: `/api/api-keys` was listed as a bearer-bypass route AND passed `skipAccessRestriction: true`, so long-lived `api_` tokens could be issued from outside the tenant CIDR/Tailscale range.
2. **Share content TOCTOU**: the UPDATE that decided 410 vs. 200 only re-asserted `id` and `max_views`, so a share revoked/expired between `findUnique` and the UPDATE would still leak its decrypted payload.

Multi-agent review uncovered the same classes in sibling routes and a **Critical** architectural finding: `authOrToken` prefers session over Bearer, so `session cookie + arbitrary Bearer header` on any bearer-bypass route defeated tenant IP enforcement entirely.

## Implementation notes

### IP enforcement (bearer-bypass routes)
- **proxy.ts**: bearer-bypass now requires `!hasSessionCookie`. Session + Bearer combos fall through to the session path where middleware enforces IP. Bearer-only clients (chrome-extension origin, API key, SA/MCP tokens) continue to bypass because they don't ship the Auth.js session cookie.
- **api-keys**: removed `skipAccessRestriction: true` from GET/POST/DELETE; `checkAuth` now enforces IP for non-session auth.
- **extension token lifecycle**: `POST /refresh` and `DELETE /api/extension/token` now call `enforceAccessRestriction` before rate limit, using `tenantId` from the validated token row to avoid fail-open on orphaned users.
- **access-requests**: SA path enforces IP before rate limit (prevents off-network DoS of legitimate SA's hourly budget); admin path enforces only for non-session (session is middleware-gated).
- **vault/delegation/check**: enforces for non-session auth with tenantIdOverride for api_key/mcp_token types.

### TOCTOU closure (share-links)
- **share-links content, download (FILE Send), public share page**: UPDATE WHERE adds `AND "revoked_at" IS NULL AND "expires_at" > NOW()`. FILE paths use a no-op conditional UPDATE (`SET view_count = view_count`) to atomically re-check without touching the download-route-owned increment.

### Test additions
- SQL-body predicate assertions (new `sqlBodyOf` helper) prove the TOCTOU predicates are in the emitted SQL, not just that the handler returns 410 when the mock returns 0.
- IP-denial tests for every newly-gated bearer route, asserting both 403 status AND short-circuit of side-effecting work (no token create/revoke, no DB lookup).
- 3 new proxy tests cover session+Bearer combos on `/api/passwords`, `/api/api-keys`, `/api/vault/delegation/check`.

## Review artifacts
- [docs/archive/review/api-key-ip-bypass-and-share-toctou-code-review.md](./docs/archive/review/api-key-ip-bypass-and-share-toctou-code-review.md) — full 3-round multi-agent review log with Anti-Deferral justifications for the accepted findings (F3, F4, N3, R2-F3, T4, T5, T6).

## Test plan
- [x] \`npx vitest run\` — all tests pass (15 new: TOCTOU SQL predicate + IP denial + session+Bearer bypass)
- [x] \`npx next build\` — production build succeeds
- [x] \`bash scripts/pre-pr.sh\` — 9/9 checks pass
- [x] **IP denial on bearer routes** — covered by:
  - [src/app/api/api-keys/route.test.ts](./src/app/api/api-keys/route.test.ts) "calls checkAuth with allowTokens and enforces access restriction" (GET/POST)
  - [src/app/api/api-keys/[id]/route.test.ts](./src/app/api/api-keys/[id]/route.test.ts) (DELETE)
  - [src/app/api/extension/token/refresh/route.test.ts](./src/app/api/extension/token/refresh/route.test.ts) "returns 403 when client IP is outside the tenant access restriction"
  - [src/app/api/extension/token/route.test.ts](./src/app/api/extension/token/route.test.ts) (DELETE, asserts no \`revokedAt\` update on deny)
  - [src/app/api/tenant/access-requests/route.test.ts](./src/app/api/tenant/access-requests/route.test.ts) (SA path)
  - [src/app/api/vault/delegation/check/route.test.ts](./src/app/api/vault/delegation/check/route.test.ts) (asserts no delegation lookup or audit log on deny)
  - [src/lib/check-auth.test.ts](./src/lib/check-auth.test.ts) covers the core \`enforceAccessRestriction\` branch
- [x] **session+Bearer bypass closed** — 3 new tests in [src/__tests__/proxy.test.ts](./src/__tests__/proxy.test.ts) verify \`/api/passwords\`, \`/api/api-keys\`, \`/api/vault/delegation/check\` fall through to session path (session lookup fired → 401 from mock) when cookie+Bearer are combined
- [x] **TOCTOU closure (SQL predicates actually emitted)** — [src/app/api/share-links/[id]/content/route.test.ts](./src/app/api/share-links/[id]/content/route.test.ts) and [src/__tests__/api/s/download.test.ts](./src/__tests__/api/s/download.test.ts) regex-assert \`revoked_at IS NULL\`, \`expires_at > NOW()\`, \`max_views\` in the \`\$executeRaw\` body, and \`view_count = view_count\` (no \`+ 1\`) for FILE branch
- [x] **TOCTOU closure (handler returns 410 when UPDATE matches 0)** — covered by "returns 410 when atomic UPDATE matches 0 rows (TOCTOU or maxViews)" in both content and download test files
- [ ] Integration verification against real Postgres (optional follow-up) — the existing integration test suite does not exercise these TOCTOU paths with concurrent writers; consider adding in a future PR if the refactoring-plan consolidation introduces a \`checkAuth\` migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)