### PR TITLE
fix(security): close XFF spoofing and Origin fail-open

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,6 +167,18 @@ BLOB_BACKEND=db
 # Generate with: openssl rand -hex 32
 # ADMIN_API_TOKEN=
 
+# --- Reverse proxy / client IP extraction ---
+# Comma-separated CIDRs whose X-Forwarded-For header is trusted.
+# Defaults to loopback (127.0.0.1/32, ::1/128) when unset.
+# TRUSTED_PROXIES=10.0.0.0/8
+
+# Opt-in: trust X-Forwarded-For / X-Real-IP even when the runtime cannot expose
+# the socket peer IP (Next.js 16, some serverless runtimes). Without this flag,
+# forwarded headers are ignored to prevent IP spoofing by arbitrary clients.
+# Set to true ONLY when the app is guaranteed to sit behind a trusted reverse
+# proxy that overwrites these headers (e.g. nginx, K8s ingress, Cloudflare).
+# TRUST_PROXY_HEADERS=false
+
 # --- Next.js Dev Server (optional) ---
 # Allowed origins for Next.js dev server (comma-separated hostnames).
 # Required when accessing dev server from a non-localhost origin (e.g., Tailscale).

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,16 @@ RUN npm ci --ignore-scripts
 # Stage 2: Build the application
 FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS builder
 WORKDIR /app
-ARG DATABASE_URL
-ENV DATABASE_URL=$DATABASE_URL
+# DATABASE_URL is needed only for `prisma generate` to satisfy env("DATABASE_URL")
+# in prisma.config.ts — no actual DB connection is opened at build time. A dummy
+# default keeps standalone `docker build` working, and callers can override via
+# `--build-arg`. We intentionally do NOT persist it as ENV to avoid leaking any
+# overridden value into `docker history` / image metadata, and to keep it out
+# of later RUN layers.
+ARG DATABASE_URL=postgresql://build:build@localhost:5432/passwd_sso
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN npx prisma generate
+RUN DATABASE_URL="$DATABASE_URL" npx prisma generate
 RUN npx next build
 RUN npx esbuild scripts/audit-outbox-worker.ts \
       --bundle --platform=node --target=node20 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,9 @@ services:
       args:
         DATABASE_URL: postgresql://build:build@localhost:5432/passwd_sso
     environment:
-      - DATABASE_URL=postgresql://passwd_user:passwd_pass@db:5432/passwd_sso
+      # MIGRATION_DATABASE_URL is the canonical name for the SUPERUSER URL
+      # used by Prisma CLI (see prisma.config.ts); matches .env.example.
+      - MIGRATION_DATABASE_URL=postgresql://passwd_user:passwd_pass@db:5432/passwd_sso
     depends_on:
       db:
         condition: service_healthy

--- a/src/__tests__/lib/ip-access.test.ts
+++ b/src/__tests__/lib/ip-access.test.ts
@@ -153,18 +153,28 @@ describe("isValidIpAddress", () => {
 });
 
 describe("extractClientIp", () => {
-  const originalEnv = process.env.TRUSTED_PROXIES;
+  const originalProxies = process.env.TRUSTED_PROXIES;
+  const originalTrustHeaders = process.env.TRUST_PROXY_HEADERS;
 
   beforeEach(() => {
     _resetTrustedProxyCache();
     delete process.env.TRUSTED_PROXIES;
+    // NextRequest in the test env does not expose a socket peer IP, so XFF /
+    // x-real-ip extraction requires the explicit opt-in. Tests that verify
+    // the fail-closed path unset this flag locally.
+    process.env.TRUST_PROXY_HEADERS = "true";
   });
 
   afterEach(() => {
-    if (originalEnv !== undefined) {
-      process.env.TRUSTED_PROXIES = originalEnv;
+    if (originalProxies !== undefined) {
+      process.env.TRUSTED_PROXIES = originalProxies;
     } else {
       delete process.env.TRUSTED_PROXIES;
+    }
+    if (originalTrustHeaders !== undefined) {
+      process.env.TRUST_PROXY_HEADERS = originalTrustHeaders;
+    } else {
+      delete process.env.TRUST_PROXY_HEADERS;
     }
     _resetTrustedProxyCache();
   });
@@ -229,6 +239,42 @@ describe("extractClientIp", () => {
       "x-forwarded-for": "172.16.0.5",
     });
     expect(extractClientIp(req)).toBe("172.16.0.5");
+  });
+
+  describe("fail-closed when socket IP and opt-in are both absent", () => {
+    // Simulates the default Next.js 16 runtime state: request.ip is undefined
+    // and the operator has not set TRUST_PROXY_HEADERS=true. In this case
+    // forwarded headers MUST be ignored — otherwise any client can spoof
+    // their IP via X-Forwarded-For or X-Real-IP.
+    beforeEach(() => {
+      delete process.env.TRUST_PROXY_HEADERS;
+      _resetTrustedProxyCache();
+    });
+
+    it("ignores x-forwarded-for without TRUST_PROXY_HEADERS opt-in", () => {
+      const req = makeReq("/api/test", {
+        "x-forwarded-for": "203.0.113.99",
+      });
+      expect(extractClientIp(req)).toBeNull();
+    });
+
+    it("ignores x-real-ip without TRUST_PROXY_HEADERS opt-in", () => {
+      const req = makeReq("/api/test", {
+        "x-real-ip": "203.0.113.99",
+      });
+      expect(extractClientIp(req)).toBeNull();
+    });
+
+    it("rejects XFF spoofing even with explicit trusted proxy CIDR", () => {
+      // Without socket IP verification, TRUSTED_PROXIES alone cannot
+      // distinguish a real proxy from a spoofed header.
+      process.env.TRUSTED_PROXIES = "10.0.0.0/8";
+      _resetTrustedProxyCache();
+      const req = makeReq("/api/test", {
+        "x-forwarded-for": "203.0.113.99, 10.0.0.1",
+      });
+      expect(extractClientIp(req)).toBeNull();
+    });
   });
 });
 

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -22,6 +22,10 @@ process.env.WEBAUTHN_RP_ID = "localhost";
 process.env.WEBAUTHN_RP_NAME = "Test App";
 process.env.WEBAUTHN_PRF_SECRET = "c".repeat(64);
 process.env.DIRECTORY_SYNC_MASTER_KEY = "d".repeat(64);
+// NextRequest in the Node test env does not expose request.ip, so tests that
+// exercise XFF / X-Real-IP extraction need the reverse-proxy opt-in. Tests
+// verifying the fail-closed path unset this locally.
+process.env.TRUST_PROXY_HEADERS = "true";
 
 // Initialize the EnvKeyProvider singleton so getKeyProviderSync() works in tests.
 // Tests that exercise provider selection (key-provider/index.test.ts) reset and

--- a/src/lib/csrf.test.ts
+++ b/src/lib/csrf.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { assertOrigin } from "./csrf";
 
-function makeRequest(origin?: string): Request {
-  const headers: Record<string, string> = {};
+function makeRequest(
+  origin?: string,
+  extraHeaders: Record<string, string> = {},
+): Request {
+  const headers: Record<string, string> = { ...extraHeaders };
   if (origin) headers["origin"] = origin;
   return new Request("http://localhost:3000/api/vault/reset", {
     method: "POST",
@@ -34,11 +37,39 @@ describe("assertOrigin", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null when APP_URL is not configured (dev convenience)", () => {
+  it("returns null when origin matches Host header (APP_URL/AUTH_URL unset)", () => {
     delete process.env.APP_URL;
     delete process.env.AUTH_URL;
-    const result = assertOrigin(makeRequest("http://evil.com"));
+    const result = assertOrigin(
+      makeRequest("http://localhost:3000", { host: "localhost:3000" }),
+    );
     expect(result).toBeNull();
+  });
+
+  it("returns 403 when origin differs from Host (APP_URL/AUTH_URL unset)", async () => {
+    delete process.env.APP_URL;
+    delete process.env.AUTH_URL;
+    const result = assertOrigin(
+      makeRequest("http://evil.com", { host: "localhost:3000" }),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  it("returns 403 when origin is missing even if APP_URL/AUTH_URL are unset", async () => {
+    delete process.env.APP_URL;
+    delete process.env.AUTH_URL;
+    const result = assertOrigin(makeRequest(undefined, { host: "localhost:3000" }));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  it("returns 403 when origin and Host are both missing and APP_URL is unset", async () => {
+    delete process.env.APP_URL;
+    delete process.env.AUTH_URL;
+    const result = assertOrigin(makeRequest());
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
   });
 
   it("returns 403 when origin is missing and APP_URL is set", async () => {

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -14,9 +14,18 @@ import { NextResponse } from "next/server";
 import { API_ERROR } from "./api-error-codes";
 import { getAppOrigin } from "@/lib/url-helpers";
 
+const forbidden = (): NextResponse =>
+  NextResponse.json({ error: API_ERROR.INVALID_ORIGIN }, { status: 403 });
+
 /**
  * Assert that the request's Origin header matches the application URL.
  * Returns null if valid, or a 403 NextResponse if invalid.
+ *
+ * Destructive endpoints always require an Origin header. When APP_URL /
+ * AUTH_URL is not configured, the expected origin is derived from the Host
+ * header. Note: `x-forwarded-proto` is only honored as a scheme hint — the
+ * origin comparison still requires Host to match, so a spoofed proto alone
+ * cannot forge a same-origin request.
  *
  * Usage in route handlers:
  *   const originError = assertOrigin(request);
@@ -24,52 +33,25 @@ import { getAppOrigin } from "@/lib/url-helpers";
  */
 export function assertOrigin(request: Request): NextResponse | null {
   const origin = request.headers.get("origin");
+  if (!origin) return forbidden();
+
+  let expectedOrigin: string;
   const appUrl = getAppOrigin();
-
-  if (!appUrl) {
-    // Derive expected origin from Host header when APP_URL is not configured
+  if (appUrl) {
+    expectedOrigin = appUrl;
+  } else {
     const host = request.headers.get("host");
-    if (!host || !origin) return null;
+    if (!host) return forbidden();
     const proto = request.headers.get("x-forwarded-proto") || "http";
-    const expectedOrigin = `${proto}://${host}`;
-    try {
-      if (new URL(origin).origin !== new URL(expectedOrigin).origin) {
-        return NextResponse.json(
-          { error: API_ERROR.INVALID_ORIGIN },
-          { status: 403 },
-        );
-      }
-    } catch {
-      return NextResponse.json(
-        { error: API_ERROR.INVALID_ORIGIN },
-        { status: 403 },
-      );
-    }
-    return null;
-  }
-
-  if (!origin) {
-    // Missing Origin header — reject for destructive endpoints
-    return NextResponse.json(
-      { error: API_ERROR.INVALID_ORIGIN },
-      { status: 403 },
-    );
+    expectedOrigin = `${proto}://${host}`;
   }
 
   try {
-    const originUrl = new URL(origin);
-    const expectedUrl = new URL(appUrl);
-    if (originUrl.origin !== expectedUrl.origin) {
-      return NextResponse.json(
-        { error: API_ERROR.INVALID_ORIGIN },
-        { status: 403 },
-      );
+    if (new URL(origin).origin !== new URL(expectedOrigin).origin) {
+      return forbidden();
     }
   } catch {
-    return NextResponse.json(
-      { error: API_ERROR.INVALID_ORIGIN },
-      { status: 403 },
-    );
+    return forbidden();
   }
 
   return null;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -98,6 +98,19 @@ const envSchema = z
       )
       .optional(),
 
+    // --- Reverse proxy / client IP extraction ---
+    // CIDRs of trusted proxies whose X-Forwarded-For is honored.
+    // Comma-separated. Defaults to loopback when unset.
+    TRUSTED_PROXIES: z.string().optional(),
+    // Opt-in to trusting forwarded headers when the runtime does not expose
+    // the socket peer IP (Next.js 16 and some serverless runtimes). Without
+    // this flag, forwarded headers are ignored to prevent IP spoofing.
+    // Set only when behind a trusted reverse proxy that overwrites XFF.
+    TRUST_PROXY_HEADERS: z
+      .enum(["true", "false"])
+      .default("false")
+      .transform((v) => v === "true"),
+
     // --- Auth.js core ---
     AUTH_SECRET: z.string().optional(),
     AUTH_URL: z

--- a/src/lib/ip-access.ts
+++ b/src/lib/ip-access.ts
@@ -268,11 +268,28 @@ export function isValidCidr(cidr: string): boolean {
 // ─── Client IP extraction ────────────────────────────────────
 
 /**
+ * Whether to trust forwarded headers (XFF / X-Real-IP) when the socket IP is
+ * unavailable. Without the socket IP we cannot verify the direct connection
+ * came from a trusted proxy, so defaulting to trust would let any client
+ * spoof its IP via a header. Set `TRUST_PROXY_HEADERS=true` only when the
+ * deployment is guaranteed to sit behind a trusted reverse proxy that
+ * overwrites these headers (e.g. nginx, K8s ingress, Cloudflare).
+ */
+function trustProxyHeadersWithoutSocket(): boolean {
+  return process.env.TRUST_PROXY_HEADERS === "true";
+}
+
+/**
  * Extract the real client IP from a request using the rightmost-untrusted pattern.
  *
  * Walks X-Forwarded-For from right to left, stripping trusted proxy IPs.
  * Returns the first untrusted IP. If the direct connection is not from a
  * trusted proxy, X-Forwarded-For is ignored and the socket address is used.
+ *
+ * When the socket IP is unavailable (common in Next.js 16 and some serverless
+ * runtimes), forwarded headers are ignored unless `TRUST_PROXY_HEADERS=true`
+ * is explicitly set. This prevents IP spoofing via client-controlled headers
+ * when the framework does not expose the underlying connection address.
  */
 export function extractClientIp(request: NextRequest): string | null {
   // Next.js provides the socket IP via request.ip (may be undefined in some environments)
@@ -294,15 +311,12 @@ export function extractClientIpFromHeaders(
   const xff = headers.get("x-forwarded-for");
   const xRealIp = headers.get("x-real-ip");
 
-  // If no forwarded headers, use socket IP or x-real-ip
-  if (!xff) {
-    const raw = socketIp ?? xRealIp ?? null;
-    return raw ? normalizeIp(raw) : null;
-  }
-
-  // Check if the direct connection comes from a trusted proxy.
-  // In many environments (Docker, reverse proxy), socketIp may be unavailable.
-  // If socketIp is available and NOT trusted, ignore X-Forwarded-For.
+  // Determine whether we can trust forwarded headers from the direct peer.
+  // - socketIp available + in TRUSTED_PROXIES  -> trust headers
+  // - socketIp available + NOT in TRUSTED_PROXIES -> ignore headers, use socketIp
+  // - socketIp unavailable -> trust only if TRUST_PROXY_HEADERS=true is set
+  //   (explicit opt-in for environments where the runtime hides the peer IP)
+  let headersTrusted: boolean;
   if (socketIp) {
     const normalizedSocket = normalizeIp(socketIp);
     const trusted = getTrustedProxies();
@@ -312,6 +326,19 @@ export function extractClientIpFromHeaders(
     if (!socketTrusted) {
       return normalizedSocket;
     }
+    headersTrusted = true;
+  } else {
+    headersTrusted = trustProxyHeadersWithoutSocket();
+  }
+
+  if (!headersTrusted) {
+    // Fail-closed: forwarded headers could be attacker-controlled.
+    // Callers treat null as "unknown IP" and deny when restrictions are active.
+    return null;
+  }
+
+  if (!xff) {
+    return xRealIp ? normalizeIp(xRealIp) : null;
   }
 
   // Rightmost-untrusted: walk from right to left


### PR DESCRIPTION
## Summary

- **S1 (High)** `ip-access.ts` — Next.js 16 does not expose the socket peer IP, so the old code walked `X-Forwarded-For` blindly and let clients spoof their address. Default to fail-closed; deployments behind a trusted reverse proxy opt in with `TRUST_PROXY_HEADERS=true`.
- **S2 (Medium)** `csrf.ts` — `assertOrigin` returned null (allow) when `APP_URL`/`AUTH_URL` was unset AND the `Origin` header was missing. Destructive endpoints (`vault/reset`, `vault/recovery-key/recover`) relied on this check. Always require Origin; Host-based fallback still works when env is unset but now requires Host too.
- **S3 (Medium)** `Dockerfile` — stopped persisting `DATABASE_URL` as ENV in the builder stage. Passed only to `prisma generate` to keep overridden values out of image history.
- **S4 (Low)** `docker-compose.yml` — renamed the `migrate` service's `DATABASE_URL` to `MIGRATION_DATABASE_URL` to match `.env.example` and `prisma.config.ts`.

## Deployment impact (⚠ action required)

Deployments behind a trusted reverse proxy — including Tailscale Serve, nginx, K8s ingress, Cloudflare — must add `TRUST_PROXY_HEADERS=true` to their environment. Otherwise:

- `extractClientIp` returns `null`
- Tenant IP restrictions reject all traffic when active
- Share-link rate limiting collapses to a single ``unknown`` bucket
- Audit log `ip` field becomes `null`

`.env.example` documents the flag; `src/lib/env.ts` schema validates it.

## Test plan

- [x] `npx vitest run src/__tests__/lib/ip-access.test.ts src/lib/csrf.test.ts src/lib/env.test.ts` (71 passed)
- [x] `npx vitest run` full suite (7223 passed, 568 files)
- [x] `bash scripts/pre-pr.sh` (all 9 steps green — lint, static checks, tests, build)
- [ ] Manual: confirm real deployment behind Tailscale Serve works after setting `TRUST_PROXY_HEADERS=true`

## Notes

New tests cover the fail-closed path for both `ip-access` (3 cases: XFF ignored, X-Real-IP ignored, spoofed XFF with configured TRUSTED_PROXIES still rejected) and `csrf` (4 cases: Host match, Host mismatch, Origin missing with env unset, both missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)