### PR TITLE
fix(admin): align operator validation across maintenance routes

### DIFF
--- a/docs/archive/review/admin-operator-validation-and-audit-test-code-review.md
+++ b/docs/archive/review/admin-operator-validation-and-audit-test-code-review.md
@@ -1,0 +1,172 @@
+# Code Review: admin-operator-validation-and-audit-test
+Date: 2026-04-27
+Review rounds: 2
+Branch: fix/admin-operator-validation-and-audit-test
+
+## Changes from Previous Round
+- Round 1: Initial review on the F2/T3/R18 baseline diff (4 files).
+- Round 2: After applying all fixes including the out-of-scope ones (option D — full fix). Verified S1/S2/S3 in `maintenance-auth.ts` + `audit-chain-verify/route.ts`, T2 split, F1 message tightening, T3 cleanup of two extra test files. New finding T1 (Round 2) added.
+
+## Scope summary
+
+This PR addresses two minor cleanups carried over from the PR #398 (proxy-csrf-enforcement) review:
+
+- **F2** (`src/app/api/admin/rotate-master-key/route.ts`): Replace ad-hoc `prisma.user.findUnique` operatorId validation with the shared `requireMaintenanceOperator` helper (active OWNER/ADMIN + deactivatedAt: null check), aligning with all other maintenance routes.
+- **T3** (`src/app/api/internal/audit-emit/route.test.ts`): Remove redundant `vi.mock("@/lib/constants")` block and import the real `AUDIT_ACTION` / `AUDIT_SCOPE` constants.
+- **R18 sync** (`scripts/checks/check-bypass-rls.mjs`): Narrow the `rotate-master-key/route.ts` allowlist after `prisma.user` access moved out of the file.
+
+Files changed: 4. No new plan was required (Phase 2 direct).
+
+## Functionality Findings
+
+### F1 — Minor: Error message contract test assertion is weak
+- **File**: `src/app/api/admin/rotate-master-key/route.test.ts:158`
+- **Evidence**: Old error: `"operatorId does not match an existing user"`. New error (from `requireMaintenanceOperator`): `"operatorId is not an active tenant admin"`. Test asserts `expect(body.error).toContain("operatorId")` — passes with both strings.
+- **Problem**: The assertion does not pin the new semantic ("active admin" rejection vs "user not found"); a future helper-message change that drops the word "operatorId" would silently regress.
+- **Impact**: Low. The new where-clause assertion (`expect(where.role)... expect(where.deactivatedAt)`) covers the behavioral contract at the query level. Only the message check is weak.
+- **Fix**: Tighten to `expect(body.error).toContain("active tenant admin")`.
+
+## Security Findings
+
+### S1 — Minor [Out of scope — different file]: `audit-chain-verify` inlines its own active-admin check instead of using `requireMaintenanceOperator`
+- **File**: `src/app/api/maintenance/audit-chain-verify/route.ts:106-125`
+- **Evidence**: All other maintenance routes consuming `operatorId` (`purge-history`, `purge-audit-logs`, `dcr-cleanup`, `audit-outbox-metrics`, `audit-outbox-purge-failed`) call `requireMaintenanceOperator`. `audit-chain-verify` has its own `tenantMember.findFirst` with the same role/deactivated filters but additionally cross-checks `userId + tenantId` (scoped variant).
+- **Problem**: Divergent maintenance point — if "active admin" semantics evolve in `requireMaintenanceOperator`, this route will not pick it up.
+- **Anti-Deferral check**: out of scope (different feature). File is NOT in this PR's diff.
+- **Routing**: TODO(post-csrf-cleanup) — extend `requireMaintenanceOperator` with optional `tenantId` filter, then migrate this route. Track alongside group B work.
+
+### S2 — Minor [Out of scope — different file]: `requireMaintenanceOperator` `findFirst` without orderBy yields non-deterministic tenantId
+- **File**: `src/lib/auth/access/maintenance-auth.ts:29`
+- **Evidence**: `prisma.tenantMember.findFirst({ where: { userId, role: { in: [OWNER, ADMIN] }, deactivatedAt: null } })` — no `orderBy`. A user who is OWNER of tenant A and ADMIN of tenant B returns an arbitrary row.
+- **Problem**: For system-wide admin actions like `rotate-master-key` (which affects all tenants' shares), the audit-log tenantId attribution becomes indeterminate in multi-tenant deployments where one user holds admin in multiple tenants.
+- **Anti-Deferral check**: out of scope (different file, predates this PR). File is NOT in diff.
+- **Routing**: TODO(post-csrf-cleanup) — either add `orderBy: { createdAt: "asc" }` to the helper, or require explicit `tenantId` body param for system-wide admin endpoints. Track alongside group B/C work.
+
+### S3 — Minor [Out of scope — different file]: `as MaintenanceOperator` cast bypasses type narrowing
+- **File**: `src/lib/auth/access/maintenance-auth.ts:48`
+- **Evidence**: `return { ok: true, operator: membership as MaintenanceOperator };` — Prisma returns `role: TenantRole` (broad enum), but the helper's return type narrows to `OWNER | ADMIN` only.
+- **Anti-Deferral check**: out of scope (pre-existing in unchanged file).
+- **Routing**: TODO(post-csrf-cleanup) — replace cast with explicit runtime check. Track alongside group B work.
+
+### Recurring Issue checks (security-relevant)
+
+- **RS1 timing-safe**: `verifyAdminToken` uses `timingSafeEqual` on SHA-256 hash. No regression.
+- **RS2 rate limit**: `createRateLimiter({ windowMs: 60_000, max: 1 })` applied after auth. Correct.
+- **RS3 input validation**: `operatorId: z.string().uuid()` at schema boundary. Correct.
+- **R3 propagation (operatorId)**: All `operatorId`-consuming routes except `audit-chain-verify` (S1) now use `requireMaintenanceOperator`.
+- **R18 narrowing**: `prisma.user` confirmed absent from `rotate-master-key/route.ts` post-fix; narrowing safe.
+- **F2 regression check**: Old check accepted any UUID mapping to a user (deactivated, MEMBER, any tenant). New check strictly requires `role in [OWNER, ADMIN] AND deactivatedAt IS NULL`. Strictly stronger; no legitimate cases lost.
+
+## Testing Findings
+
+### T2 — Major: rotate-master-key rejection test bundles two filter assertions into one case
+- **File**: `src/app/api/admin/rotate-master-key/route.test.ts:149-167`
+- **Evidence**: Reference file `src/app/api/maintenance/purge-history/route.test.ts:140-171` has three separate rejection tests (generic null, MEMBER role, deactivated admin). The new test in this PR has one test combining `where.role` + `where.deactivatedAt` assertions.
+- **Problem**: If `where.role` assertion fails first, `where.deactivatedAt` is never reached — less diagnostic and inconsistent with the established pattern.
+- **Impact**: Both filters ARE asserted, so coverage is preserved; this is a test quality / debuggability issue, not a false-green.
+- **Fix**: Split into two tests mirroring the reference pattern (MEMBER role rejection asserting `where.role`; deactivated admin rejection asserting `where.deactivatedAt`).
+
+### T3 — Minor [Out of scope — different files]: Two other test files have the same redundant `vi.mock("@/lib/constants", importOriginal)` pattern
+- **Files**: `src/app/api/auth/passkey/verify/route.test.ts:55`, `src/components/share/send-dialog.test.tsx:78`
+- **Anti-Deferral check**: out of scope (different files). NOT in this PR's diff.
+- **Routing**: TODO(post-csrf-cleanup) — apply the same T3 cleanup to those two files in a follow-up PR after individual inspection (some keys may be genuinely missing from real constants and need to remain stubs).
+
+### Recurring Issue checks (testing-relevant)
+
+- **RT1 mock-reality**: `mockTenantMemberFindFirst` returns `{ tenantId, role }` matching the real `select: { tenantId: true, role: true }` exactly.
+- **RT3 shared constants**: T3 cleanup correctly imports real constants; no test rendered vacuous (`AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED` resolves to the same `"PASSKEY_ENFORCEMENT_BLOCKED"` string previously asserted as a literal).
+- **R19 mock alignment**: All mocks aligned with the new helper's surface.
+- **Test count baseline**: Net zero — one `it(` was renamed (no add/remove).
+
+## Adjacent Findings
+
+(See S1, S2, S3, T3 — all flagged with `[Out of scope — different file]` and routed to TODO(post-csrf-cleanup).)
+
+## Quality Warnings
+
+None. All findings include evidence, file:line, and concrete fixes.
+
+## Recurring Issue Check (consolidated)
+
+### Functionality expert
+- R1-R30: Checked. R3 / R12 / R17 / R18 / R22 directly verified. No issue except F1 Minor (above).
+
+### Security expert
+- R1-R30: Checked. R3 (operatorId propagation), R18 (allowlist narrowing) verified.
+- RS1 (timing-safe): Pass.
+- RS2 (rate limit): Pass.
+- RS3 (input validation): Pass.
+- Findings: S1, S2, S3 (all Out of scope — diff-external).
+
+### Testing expert
+- R1-R30: Checked. R3 (mock pattern propagation) → T3.
+- RT1 (mock-reality divergence): Pass.
+- RT2 (testability): N/A — all touched code is unit-testable.
+- RT3 (shared constants): Pass.
+- Findings: T2 Major (in scope), T3 Minor (out of scope).
+
+## Resolution Status
+
+### F1 Minor — Error message contract assertion was weak
+- **Action**: Tightened both new split tests in T2 to `expect(body.error).toContain("active tenant admin")` (was `.toContain("operatorId")`).
+- **Modified file**: `src/app/api/admin/rotate-master-key/route.test.ts:158, 174`
+- **Round 2 status**: Resolved (verified by Functionality expert).
+
+### T2 Major — Rejection test bundled two filter assertions
+- **Action**: Split the single rejection test into two — one asserting `where.role` (MEMBER role rejection), one asserting `where.deactivatedAt` (deactivated admin rejection). Mirrors `purge-history/route.test.ts:140-171` reference pattern.
+- **Modified file**: `src/app/api/admin/rotate-master-key/route.test.ts:149-179`
+- **Round 2 status**: Resolved (verified by Testing expert).
+
+### S1 Minor — `audit-chain-verify` inlined operator validation
+- **Action**: Migrated to `requireMaintenanceOperator(operatorId, { tenantId })` after extending the helper signature with optional `tenantId`. Removed inline `tenantMember.findFirst` block and now-unused `TENANT_ROLE` import. Added entry to `check-bypass-rls.mjs` (narrowed from `["tenantMember"]` to `[]` since only `$queryRawUnsafe` access remains).
+- **Modified files**:
+  - `src/app/api/maintenance/audit-chain-verify/route.ts:106-108` (replaced 18 lines of inline check)
+  - `src/lib/auth/access/maintenance-auth.ts` (added `MaintenanceOperatorOptions` + `tenantId` filter)
+  - `scripts/checks/check-bypass-rls.mjs:68` (narrowed allowlist)
+- **Round 2 status**: Resolved (verified by Functionality + Security experts).
+
+### S2 Minor — `findFirst` non-deterministic for multi-tenant admins
+- **Action**: Added `orderBy: { createdAt: "asc" }` to the `requireMaintenanceOperator` query. Pins audit attribution to the operator's oldest admin membership when they hold admin in multiple tenants.
+- **Modified file**: `src/lib/auth/access/maintenance-auth.ts:42-44`
+- **Round 2 status**: Resolved. Security expert verified no new attack vector — caller cannot influence ordering, and the `tenantId`-filtered call site (audit-chain-verify) is unique-bound by `@@unique([tenantId, userId])`.
+
+### S3 Minor — `as MaintenanceOperator` cast bypassed type narrowing
+- **Action**: Replaced cast with explicit runtime narrowing. Throws `Error("requireMaintenanceOperator invariant violated: unexpected role X")` if the DB returns a row whose role is not OWNER/ADMIN despite the where filter. Defensive against schema/enum drift.
+- **Modified file**: `src/lib/auth/access/maintenance-auth.ts:55-65`
+- **Round 2 status**: Resolved. Security expert noted Minor observation N3 (named Error subclass possible per TS rules); accepted as-is — `src/lib/auth/` consistently uses `throw new Error(...)` with descriptive messages, no Error subclass convention exists.
+
+### T3 Minor — Redundant `vi.mock("@/lib/constants")` cleanup
+- **Action**:
+  - In-scope (Round 1 file): removed redundant block from `src/app/api/internal/audit-emit/route.test.ts`, replaced literals with `AUDIT_ACTION` / `AUDIT_SCOPE` imports.
+  - Out-of-scope files (Round 1 → fixed under option D in Round 2):
+    - `src/app/api/auth/passkey/verify/route.test.ts:55-63` — removed (override values matched real constants AUTH_LOGIN/SESSION_REVOKE_ALL/EXTENSION_TOKEN_FAMILY_REVOKED, AUDIT_SCOPE.PERSONAL).
+    - `src/components/share/send-dialog.test.tsx:78-87` — removed (override values matched real constants API_PATH.SENDS/SENDS_FILE).
+- **Modified files**:
+  - `src/app/api/internal/audit-emit/route.test.ts`
+  - `src/app/api/auth/passkey/verify/route.test.ts`
+  - `src/components/share/send-dialog.test.tsx`
+- **Round 2 status**: Resolved. Testing expert verified no test became vacuous; all 24 affected tests pass.
+
+### T1 Major (Round 2 — new) — `requireMaintenanceOperator` new options/orderBy/throw had no direct test
+- **Action**: Created `src/lib/auth/access/maintenance-auth.test.ts` with 11 unit tests covering:
+  - Default success (OWNER + ADMIN roles)
+  - 400 NextResponse path
+  - role / deactivatedAt where filters
+  - `orderBy: { createdAt: "asc" }` presence
+  - `tenantId` option forwarding (omitted, undefined, provided)
+  - Runtime invariant throw on unexpected role
+  - `BYPASS_PURPOSE.SYSTEM_MAINTENANCE` argument to `withBypassRls`
+- **Modified file**: `src/lib/auth/access/maintenance-auth.test.ts` (new file, 12 tests including 1 setup test)
+- **Status**: Resolved. 11/11 tests pass.
+
+### N3 Minor (Round 2 — new) — Use named Error subclass
+- **Anti-Deferral check**: acceptable risk
+- **Justification**:
+  - Worst case: future Error subclass convention adopted; this throw not migrated.
+  - Likelihood: low — `src/lib/auth/` uses plain `throw new Error(...)` consistently, no codebase-wide subclass convention.
+  - Cost to fix: ~10 LOC for new InvariantError subclass + integration; net negative if no other call sites adopt it.
+- **Decision**: Skipped. Codebase convention takes precedence; revisit if a project-wide Error subclass policy is adopted.
+- **Orchestrator sign-off**: Acceptable risk justified — codebase has no Error subclass convention; introducing one for a single defensive throw is over-engineering.
+
+### S1/S2/S3/T3 — Pre-existing-in-unchanged-file resolution
+All four findings were initially flagged as `[Out of scope — different file]` in Round 1. The user invoked option D (full fix in this PR) per the 30-minute Anti-Deferral rule. All have been resolved in scope.

--- a/scripts/checks/check-bypass-rls.mjs
+++ b/scripts/checks/check-bypass-rls.mjs
@@ -32,7 +32,7 @@ const ALLOWED_USAGE = new Map([
   ["src/lib/auth/access/maintenance-auth.ts", ["tenantMember"]],
   ["src/app/api/extension/bridge-code/route.ts", ["extensionBridgeCode"]],
   ["src/app/api/extension/token/exchange/route.ts", ["extensionBridgeCode"]],
-  ["src/app/api/admin/rotate-master-key/route.ts", ["user", "passwordShare"]],
+  ["src/app/api/admin/rotate-master-key/route.ts", ["passwordShare"]],
   ["src/app/api/maintenance/purge-history/route.ts", ["passwordEntryHistory"]],
   ["src/app/api/teams/route.ts", ["teamMember"]],
   ["src/app/api/teams/pending-key-distributions/route.ts", ["teamMember"]],
@@ -65,7 +65,7 @@ const ALLOWED_USAGE = new Map([
   ["src/app/api/maintenance/purge-audit-logs/route.ts", ["tenant", "auditLog"]],
   ["src/app/api/maintenance/audit-outbox-metrics/route.ts", []],
   ["src/app/api/maintenance/audit-outbox-purge-failed/route.ts", []],
-  ["src/app/api/maintenance/audit-chain-verify/route.ts", ["tenantMember"]],
+  ["src/app/api/maintenance/audit-chain-verify/route.ts", []],
   ["src/app/api/user/passkey-status/route.ts", ["webAuthnCredential", "user"]],
   ["src/app/api/share-links/route.ts", ["auditOutbox"]], // logAuditInTx for SHARE_CREATE
   ["src/app/api/share-links/[id]/route.ts", ["auditOutbox"]], // logAuditInTx for SHARE_REVOKE

--- a/src/app/api/admin/rotate-master-key/route.test.ts
+++ b/src/app/api/admin/rotate-master-key/route.test.ts
@@ -8,14 +8,14 @@ const ADMIN_TOKEN = randomBytes(32).toString("hex");
 
 const {
   mockShareUpdateMany,
-  mockUserFindUnique,
+  mockTenantMemberFindFirst,
   mockCheck,
   mockLogAudit,
   mockWithBypassRls,
   mockWithTenantRls,
 } = vi.hoisted(() => ({
   mockShareUpdateMany: vi.fn(),
-  mockUserFindUnique: vi.fn(),
+  mockTenantMemberFindFirst: vi.fn(),
   mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
   mockLogAudit: vi.fn(),
   mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
@@ -25,7 +25,7 @@ const {
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     passwordShare: { updateMany: mockShareUpdateMany },
-    user: { findUnique: mockUserFindUnique },
+    tenantMember: { findFirst: mockTenantMemberFindFirst },
   },
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
@@ -146,8 +146,8 @@ describe("POST /api/admin/rotate-master-key", () => {
     expect(body.error).toContain("does not match");
   });
 
-  it("returns 400 when operatorId does not exist", async () => {
-    mockUserFindUnique.mockResolvedValue(null);
+  it("returns 400 when operatorId has MEMBER role", async () => {
+    mockTenantMemberFindFirst.mockResolvedValue(null);
     const req = createRequest(
       { targetVersion: 2, operatorId: "660e8400-e29b-41d4-a716-446655440099" },
       ADMIN_TOKEN
@@ -155,11 +155,31 @@ describe("POST /api/admin/rotate-master-key", () => {
     const res = await POST(req);
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("operatorId");
+    expect(body.error).toContain("active tenant admin");
+
+    // Verify the query filters by admin roles
+    const where = mockTenantMemberFindFirst.mock.calls[0][0].where;
+    expect(where.role).toEqual({ in: ["OWNER", "ADMIN"] });
+  });
+
+  it("returns 400 when operatorId is a deactivated admin", async () => {
+    mockTenantMemberFindFirst.mockResolvedValue(null);
+    const req = createRequest(
+      { targetVersion: 2, operatorId: "660e8400-e29b-41d4-a716-446655440099" },
+      ADMIN_TOKEN
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("active tenant admin");
+
+    // Verify the query filters out deactivated members
+    const where = mockTenantMemberFindFirst.mock.calls[0][0].where;
+    expect(where.deactivatedAt).toBeNull();
   });
 
   it("returns 200 with targetVersion and revokedShares=0 when no shares to revoke", async () => {
-    mockUserFindUnique.mockResolvedValue({ id: "660e8400-e29b-41d4-a716-446655440001", tenantId: "tenant-1" });
+    mockTenantMemberFindFirst.mockResolvedValue({ tenantId: "tenant-1", role: "ADMIN" });
 
     const req = createRequest(
       { targetVersion: 2, operatorId: "660e8400-e29b-41d4-a716-446655440001" },
@@ -190,7 +210,7 @@ describe("POST /api/admin/rotate-master-key", () => {
   });
 
   it("revokes old shares when revokeShares is true", async () => {
-    mockUserFindUnique.mockResolvedValue({ id: "660e8400-e29b-41d4-a716-446655440001", tenantId: "tenant-1" });
+    mockTenantMemberFindFirst.mockResolvedValue({ tenantId: "tenant-1", role: "ADMIN" });
     mockShareUpdateMany.mockResolvedValue({ count: 3 });
 
     const req = createRequest(
@@ -214,7 +234,7 @@ describe("POST /api/admin/rotate-master-key", () => {
   });
 
   it("does not call shareUpdateMany when revokeShares is false", async () => {
-    mockUserFindUnique.mockResolvedValue({ id: "660e8400-e29b-41d4-a716-446655440001", tenantId: "tenant-1" });
+    mockTenantMemberFindFirst.mockResolvedValue({ tenantId: "tenant-1", role: "ADMIN" });
 
     const req = createRequest(
       { targetVersion: 2, operatorId: "660e8400-e29b-41d4-a716-446655440001", revokeShares: false },

--- a/src/app/api/admin/rotate-master-key/route.ts
+++ b/src/app/api/admin/rotate-master-key/route.ts
@@ -25,6 +25,7 @@ import { createRateLimiter } from "@/lib/security/rate-limit";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+import { requireMaintenanceOperator } from "@/lib/auth/access/maintenance-auth";
 import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { rateLimited, unauthorized } from "@/lib/http/api-response";
@@ -77,19 +78,10 @@ async function handlePOST(req: NextRequest) {
     );
   }
 
-  // Verify operatorId is a valid user
-  const operator = await withBypassRls(prisma, async () =>
-    prisma.user.findUnique({
-      where: { id: operatorId },
-      select: { id: true, tenantId: true },
-    }),
-  BYPASS_PURPOSE.SYSTEM_MAINTENANCE);
-  if (!operator) {
-    return NextResponse.json(
-      { error: "operatorId does not match an existing user" },
-      { status: 400 }
-    );
-  }
+  // Verify operatorId is an active tenant admin
+  const op = await requireMaintenanceOperator(operatorId);
+  if (!op.ok) return op.response;
+  const operator = op.operator;
 
   // Revoke old-version shares if requested
   // Revoke shares across ALL tenants (master key is system-wide)

--- a/src/app/api/auth/passkey/verify/route.test.ts
+++ b/src/app/api/auth/passkey/verify/route.test.ts
@@ -52,16 +52,6 @@ vi.mock("@/lib/audit/audit", () => ({
   }),
 }));
 
-vi.mock("@/lib/constants", async (importOriginal) => ({
-  ...(await importOriginal()) as Record<string, unknown>,
-  AUDIT_ACTION: {
-    AUTH_LOGIN: "AUTH_LOGIN",
-    SESSION_REVOKE_ALL: "SESSION_REVOKE_ALL",
-    EXTENSION_TOKEN_FAMILY_REVOKED: "EXTENSION_TOKEN_FAMILY_REVOKED",
-  },
-  AUDIT_SCOPE: { PERSONAL: "PERSONAL" },
-}));
-
 vi.mock("@/lib/auth/tokens/extension-token", () => ({
   revokeAllExtensionTokensForUser: vi.fn().mockResolvedValue({ rowsRevoked: 0, familiesRevoked: 0 }),
 }));

--- a/src/app/api/internal/audit-emit/route.test.ts
+++ b/src/app/api/internal/audit-emit/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextResponse } from "next/server";
 import { createRequest } from "@/__tests__/helpers/request-builder";
+import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 
 const {
   mockCheckAuth,
@@ -22,20 +23,6 @@ vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: mockExtractRequestMeta,
 }));
-vi.mock("@/lib/constants", async (importOriginal) => {
-  const actual = await importOriginal() as Record<string, unknown>;
-  return {
-    ...actual,
-    AUDIT_ACTION: {
-      ...(actual.AUDIT_ACTION as Record<string, string>),
-      PASSKEY_ENFORCEMENT_BLOCKED: "PASSKEY_ENFORCEMENT_BLOCKED",
-    },
-    AUDIT_SCOPE: {
-      ...(actual.AUDIT_SCOPE as Record<string, string>),
-      TENANT: "TENANT",
-    },
-  };
-});
 
 import { POST } from "./route";
 
@@ -61,7 +48,7 @@ describe("POST /api/internal/audit-emit", () => {
     mockCheckAuth.mockResolvedValue(authFail());
     const res = await POST(
       createRequest("POST", "http://localhost/api/internal/audit-emit", {
-        body: { action: "PASSKEY_ENFORCEMENT_BLOCKED" },
+        body: { action: AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED },
       }),
     );
     expect(res.status).toBe(401);
@@ -88,7 +75,7 @@ describe("POST /api/internal/audit-emit", () => {
   it("returns 200 and calls logAuditAsync with correct params for PASSKEY_ENFORCEMENT_BLOCKED", async () => {
     const res = await POST(
       createRequest("POST", "http://localhost/api/internal/audit-emit", {
-        body: { action: "PASSKEY_ENFORCEMENT_BLOCKED" },
+        body: { action: AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED },
       }),
     );
     expect(res.status).toBe(200);
@@ -96,8 +83,8 @@ describe("POST /api/internal/audit-emit", () => {
     expect(json).toEqual({ ok: true });
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: "TENANT",
-        action: "PASSKEY_ENFORCEMENT_BLOCKED",
+        scope: AUDIT_SCOPE.TENANT,
+        action: AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED,
         userId: "user-1",
       }),
     );
@@ -107,7 +94,7 @@ describe("POST /api/internal/audit-emit", () => {
     mockRateLimiterCheck.mockResolvedValue({ allowed: false });
     const res = await POST(
       createRequest("POST", "http://localhost/api/internal/audit-emit", {
-        body: { action: "PASSKEY_ENFORCEMENT_BLOCKED" },
+        body: { action: AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED },
       }),
     );
     expect(res.status).toBe(429);
@@ -117,7 +104,7 @@ describe("POST /api/internal/audit-emit", () => {
     const meta = { redirectedPath: "/dashboard", reason: "no_passkey" };
     const res = await POST(
       createRequest("POST", "http://localhost/api/internal/audit-emit", {
-        body: { action: "PASSKEY_ENFORCEMENT_BLOCKED", metadata: meta },
+        body: { action: AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED, metadata: meta },
       }),
     );
     expect(res.status).toBe(200);
@@ -133,7 +120,7 @@ describe("POST /api/internal/audit-emit", () => {
   it("uses empty object as metadata when metadata is not provided", async () => {
     const res = await POST(
       createRequest("POST", "http://localhost/api/internal/audit-emit", {
-        body: { action: "PASSKEY_ENFORCEMENT_BLOCKED" },
+        body: { action: AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED },
       }),
     );
     expect(res.status).toBe(200);

--- a/src/app/api/maintenance/audit-chain-verify/route.ts
+++ b/src/app/api/maintenance/audit-chain-verify/route.ts
@@ -14,8 +14,8 @@ import { createRateLimiter } from "@/lib/security/rate-limit";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+import { requireMaintenanceOperator } from "@/lib/auth/access/maintenance-auth";
 import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
-import { TENANT_ROLE } from "@/lib/constants/auth/tenant-role";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { rateLimited, unauthorized } from "@/lib/http/api-response";
 import { parseQuery } from "@/lib/http/parse-body";
@@ -103,26 +103,9 @@ async function handleGET(req: NextRequest) {
   if (!result.ok) return result.response;
   const { tenantId, operatorId, from, to } = result.data;
 
-  const membership = await withBypassRls(
-    prisma,
-    async () =>
-      prisma.tenantMember.findFirst({
-        where: {
-          userId: operatorId,
-          tenantId,
-          role: { in: [TENANT_ROLE.OWNER, TENANT_ROLE.ADMIN] },
-          deactivatedAt: null,
-        },
-        select: { tenantId: true },
-      }),
-    BYPASS_PURPOSE.SYSTEM_MAINTENANCE,
-  );
-  if (!membership) {
-    return NextResponse.json(
-      { error: "operatorId is not an active tenant admin" },
-      { status: 400 },
-    );
-  }
+  const op = await requireMaintenanceOperator(operatorId, { tenantId });
+  if (!op.ok) return op.response;
+  const membership = op.operator;
 
   // Read the anchor row to get the snapshot upper bound
   const anchors = await withBypassRls(

--- a/src/components/share/send-dialog.test.tsx
+++ b/src/components/share/send-dialog.test.tsx
@@ -75,17 +75,6 @@ vi.mock("@/lib/http/api-error-codes", () => ({
   apiErrorToI18nKey: (e: string) => e,
 }));
 
-vi.mock("@/lib/constants", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/constants")>();
-  return {
-    ...actual,
-    API_PATH: {
-      SENDS: "/api/sends",
-      SENDS_FILE: "/api/sends/file",
-    },
-  };
-});
-
 vi.mock("@/lib/validations", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/validations")>();
   return { ...actual };

--- a/src/lib/auth/access/maintenance-auth.test.ts
+++ b/src/lib/auth/access/maintenance-auth.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockFindFirst, mockWithBypassRls } = vi.hoisted(() => ({
+  mockFindFirst: vi.fn(),
+  mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    tenantMember: { findFirst: mockFindFirst },
+  },
+}));
+
+vi.mock("@/lib/tenant-rls", async (importOriginal) => ({
+  ...(await importOriginal()) as Record<string, unknown>,
+  withBypassRls: mockWithBypassRls,
+}));
+
+import { requireMaintenanceOperator } from "./maintenance-auth";
+import { TENANT_ROLE } from "@/lib/constants/auth/tenant-role";
+import { BYPASS_PURPOSE } from "@/lib/tenant-rls";
+
+describe("requireMaintenanceOperator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns operator on active OWNER membership", async () => {
+    mockFindFirst.mockResolvedValue({ tenantId: "tenant-1", role: TENANT_ROLE.OWNER });
+
+    const result = await requireMaintenanceOperator("user-1");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.operator).toEqual({ tenantId: "tenant-1", role: "OWNER" });
+    }
+  });
+
+  it("returns operator on active ADMIN membership", async () => {
+    mockFindFirst.mockResolvedValue({ tenantId: "tenant-1", role: TENANT_ROLE.ADMIN });
+
+    const result = await requireMaintenanceOperator("user-1");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.operator.role).toBe("ADMIN");
+    }
+  });
+
+  it("returns 400 NextResponse when no active admin membership found", async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    const result = await requireMaintenanceOperator("user-1");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(400);
+      const body = await result.response.json();
+      expect(body.error).toContain("active tenant admin");
+    }
+  });
+
+  it("filters by OWNER and ADMIN roles only", async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    await requireMaintenanceOperator("user-1");
+
+    const where = mockFindFirst.mock.calls[0][0].where;
+    expect(where.role).toEqual({ in: [TENANT_ROLE.OWNER, TENANT_ROLE.ADMIN] });
+  });
+
+  it("filters out deactivated members", async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    await requireMaintenanceOperator("user-1");
+
+    const where = mockFindFirst.mock.calls[0][0].where;
+    expect(where.deactivatedAt).toBeNull();
+  });
+
+  it("orders by createdAt ascending for deterministic multi-tenant resolution", async () => {
+    mockFindFirst.mockResolvedValue({ tenantId: "tenant-1", role: TENANT_ROLE.ADMIN });
+
+    await requireMaintenanceOperator("user-1");
+
+    const args = mockFindFirst.mock.calls[0][0];
+    expect(args.orderBy).toEqual({ createdAt: "asc" });
+  });
+
+  it("does NOT add tenantId to where clause when option is omitted", async () => {
+    mockFindFirst.mockResolvedValue({ tenantId: "tenant-1", role: TENANT_ROLE.ADMIN });
+
+    await requireMaintenanceOperator("user-1");
+
+    const where = mockFindFirst.mock.calls[0][0].where;
+    expect(where).not.toHaveProperty("tenantId");
+  });
+
+  it("adds tenantId to where clause when option is provided", async () => {
+    mockFindFirst.mockResolvedValue({ tenantId: "tenant-1", role: TENANT_ROLE.ADMIN });
+
+    await requireMaintenanceOperator("user-1", { tenantId: "tenant-1" });
+
+    const where = mockFindFirst.mock.calls[0][0].where;
+    expect(where.tenantId).toBe("tenant-1");
+  });
+
+  it("treats explicit tenantId: undefined the same as omitted option", async () => {
+    mockFindFirst.mockResolvedValue({ tenantId: "tenant-1", role: TENANT_ROLE.ADMIN });
+
+    await requireMaintenanceOperator("user-1", { tenantId: undefined });
+
+    const where = mockFindFirst.mock.calls[0][0].where;
+    expect(where).not.toHaveProperty("tenantId");
+  });
+
+  it("throws when DB returns a row whose role is unexpectedly outside OWNER/ADMIN", async () => {
+    // Simulates schema/enum drift where the where filter is bypassed.
+    mockFindFirst.mockResolvedValue({ tenantId: "tenant-1", role: "MEMBER" });
+
+    await expect(requireMaintenanceOperator("user-1")).rejects.toThrow(
+      /invariant violated/,
+    );
+  });
+
+  it("uses BYPASS_PURPOSE.SYSTEM_MAINTENANCE for the RLS bypass", async () => {
+    mockFindFirst.mockResolvedValue({ tenantId: "tenant-1", role: TENANT_ROLE.ADMIN });
+
+    await requireMaintenanceOperator("user-1");
+
+    // Second arg to withBypassRls is the function, third is the purpose.
+    const purpose = mockWithBypassRls.mock.calls[0][2];
+    expect(purpose).toBe(BYPASS_PURPOSE.SYSTEM_MAINTENANCE);
+  });
+});

--- a/src/lib/auth/access/maintenance-auth.ts
+++ b/src/lib/auth/access/maintenance-auth.ts
@@ -15,6 +15,13 @@ export interface MaintenanceOperator {
   role: typeof TENANT_ROLE.OWNER | typeof TENANT_ROLE.ADMIN;
 }
 
+export interface MaintenanceOperatorOptions {
+  // Restrict the membership lookup to a specific tenant. When omitted, any
+  // active OWNER/ADMIN membership of the operator is accepted; multi-tenant
+  // admins resolve deterministically via createdAt-asc ordering.
+  tenantId?: string;
+}
+
 /**
  * Resolve `operatorId` to an active tenant OWNER/ADMIN membership.
  * Returns the membership on success, or a 400 NextResponse if the operator
@@ -22,6 +29,7 @@ export interface MaintenanceOperator {
  */
 export async function requireMaintenanceOperator(
   operatorId: string,
+  options: MaintenanceOperatorOptions = {},
 ): Promise<{ ok: true; operator: MaintenanceOperator } | { ok: false; response: NextResponse }> {
   const membership = await withBypassRls(
     prisma,
@@ -29,9 +37,13 @@ export async function requireMaintenanceOperator(
       prisma.tenantMember.findFirst({
         where: {
           userId: operatorId,
+          ...(options.tenantId !== undefined ? { tenantId: options.tenantId } : {}),
           role: { in: [TENANT_ROLE.OWNER, TENANT_ROLE.ADMIN] },
           deactivatedAt: null,
         },
+        // Deterministic selection when the operator holds admin in multiple
+        // tenants — pin to the oldest membership so audit attribution is stable.
+        orderBy: { createdAt: "asc" },
         select: { tenantId: true, role: true },
       }),
     BYPASS_PURPOSE.SYSTEM_MAINTENANCE,
@@ -45,5 +57,13 @@ export async function requireMaintenanceOperator(
       ),
     };
   }
-  return { ok: true, operator: membership as MaintenanceOperator };
+  // The role filter above guarantees membership.role is OWNER or ADMIN, but
+  // the Prisma client types it as the broader TenantRole enum. Narrow at
+  // runtime so the cast cannot mask a future schema/enum drift.
+  if (membership.role !== TENANT_ROLE.OWNER && membership.role !== TENANT_ROLE.ADMIN) {
+    throw new Error(
+      `requireMaintenanceOperator invariant violated: unexpected role ${membership.role}`,
+    );
+  }
+  return { ok: true, operator: { tenantId: membership.tenantId, role: membership.role } };
 }


### PR DESCRIPTION
## Summary

- **Migration to shared helper**: `rotate-master-key` and `audit-chain-verify` now use `requireMaintenanceOperator` for operator validation, replacing ad-hoc `prisma.user.findUnique` (which accepted deactivated/MEMBER users) and inline `tenantMember.findFirst`.
- **Helper hardening**: `maintenance-auth.ts` gains `orderBy: createdAt-asc` (deterministic for multi-tenant admins), an explicit runtime role narrowing check (replaces `as MaintenanceOperator` cast), and an optional `tenantId` filter for scoped routes.
- **Test cleanup**: Removed 3 redundant `vi.mock(\"@/lib/constants\", importOriginal)` blocks where override values matched real constants. Added 11 direct unit tests for `requireMaintenanceOperator`.

## Background

This bundle resolves residual findings from the [PR #398](https://github.com/ngc-shj/passwd-sso/pull/398) (proxy-csrf-enforcement) review log. F2 / T3 / R18 / S1 / S2 / S3 references are documented in [docs/archive/review/admin-operator-validation-and-audit-test-code-review.md](docs/archive/review/admin-operator-validation-and-audit-test-code-review.md).

Phase 3 multi-agent review (functionality / security / testing) ran 2 rounds — all findings resolved or accepted with documented justification (N3 Minor: codebase has no Error subclass convention).

## Test plan

- [x] \`npx vitest run\` (full suite passes — 86+ targeted tests verified)
- [x] \`npx next build\` (production build succeeds)
- [x] \`bash scripts/pre-pr.sh\` (11/11 checks pass, including \`check-bypass-rls\`)
- [x] Direct helper unit tests added: 11 cases covering tenantId option, orderBy, runtime invariant throw

## Notes for reviewer

- Pre-existing routes (\`purge-history\`, \`purge-audit-logs\`, \`dcr-cleanup\`, \`audit-outbox-metrics\`, \`audit-outbox-purge-failed\`) are unaffected — backward-compatible signature (\`options\` defaults to \`{}\`).
- \`check-bypass-rls.mjs\` allowlist was narrowed in two places: \`rotate-master-key/route.ts\` (\`[\"user\", \"passwordShare\"]\` → \`[\"passwordShare\"]\`) and \`audit-chain-verify/route.ts\` (\`[\"tenantMember\"]\` → \`[]\`, since only \`\$queryRawUnsafe\` access remains).
- No DB schema or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)