### PR TITLE
feat(audit-emit): bound metadata payload size to prevent outbox bloat

### DIFF
--- a/src/app/api/internal/audit-emit/route.test.ts
+++ b/src/app/api/internal/audit-emit/route.test.ts
@@ -130,4 +130,83 @@ describe("POST /api/internal/audit-emit", () => {
       }),
     );
   });
+
+  it("returns 400 when metadata exceeds 20 top-level keys", async () => {
+    const tooManyKeys: Record<string, number> = {};
+    for (let i = 0; i < 21; i++) tooManyKeys[`k${i}`] = i;
+
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/internal/audit-emit", {
+        body: {
+          action: AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED,
+          metadata: tooManyKeys,
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockLogAudit).not.toHaveBeenCalled();
+  });
+
+  it("accepts metadata with exactly 20 top-level keys (boundary)", async () => {
+    const exactKeys: Record<string, number> = {};
+    for (let i = 0; i < 20; i++) exactKeys[`k${i}`] = i;
+
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/internal/audit-emit", {
+        body: {
+          action: AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED,
+          metadata: exactKeys,
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when metadata serialized size exceeds 4KB", async () => {
+    // 5KB string in a single value to exceed the 4096-byte cap regardless of
+    // top-level key count.
+    const largePayload = { blob: "a".repeat(5 * 1024) };
+
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/internal/audit-emit", {
+        body: {
+          action: AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED,
+          metadata: largePayload,
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockLogAudit).not.toHaveBeenCalled();
+  });
+
+  it("rejects deeply nested payloads via the byte cap", async () => {
+    // Build a deep object whose serialized size easily blows past 4KB.
+    let deep: Record<string, unknown> = { leaf: "x".repeat(100) };
+    for (let i = 0; i < 50; i++) {
+      deep = { nested: deep, padding: "y".repeat(100) };
+    }
+
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/internal/audit-emit", {
+        body: {
+          action: AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED,
+          metadata: deep,
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockLogAudit).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when metadata is not an object", async () => {
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/internal/audit-emit", {
+        body: {
+          action: AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED,
+          metadata: "not-an-object",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
 });

--- a/src/app/api/internal/audit-emit/route.ts
+++ b/src/app/api/internal/audit-emit/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { z } from "zod";
 import { checkAuth } from "@/lib/auth/session/check-auth";
 import { logAuditAsync, extractRequestMeta } from "@/lib/audit/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
@@ -16,6 +17,35 @@ const ALLOWED_ACTIONS = new Set<string>([
   AUDIT_ACTION.PASSKEY_ENFORCEMENT_BLOCKED,
 ]);
 
+// Bound the metadata payload an authenticated caller may write to the audit
+// outbox. Without these limits, a misbehaving (or compromised) caller can
+// push large payloads into audit_outbox and bloat the table or its drained
+// audit_logs storage. These limits cover top-level keys and serialized size;
+// the byte cap also bounds nesting depth implicitly.
+const MAX_METADATA_KEYS = 20;
+const MAX_METADATA_BYTES = 4096;
+
+const metadataSchema = z
+  .record(z.string(), z.unknown())
+  .refine((m) => Object.keys(m).length <= MAX_METADATA_KEYS, {
+    message: `metadata must have at most ${MAX_METADATA_KEYS} keys`,
+  })
+  .refine(
+    (m) => {
+      try {
+        return new TextEncoder().encode(JSON.stringify(m)).byteLength <= MAX_METADATA_BYTES;
+      } catch {
+        return false;
+      }
+    },
+    { message: `metadata must be at most ${MAX_METADATA_BYTES} bytes when serialized` },
+  );
+
+const bodySchema = z.object({
+  action: z.string(),
+  metadata: metadataSchema.optional(),
+});
+
 export async function POST(request: NextRequest) {
   const authResult = await checkAuth(request);
   if (!authResult.ok) return NextResponse.json({}, { status: 401 });
@@ -27,16 +57,21 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({}, { status: 429 });
   }
 
-  let body: { action: string; metadata?: Record<string, unknown> };
+  let rawBody: unknown;
   try {
-    body = await request.json();
+    rawBody = await request.json();
   } catch {
     return NextResponse.json({}, { status: 400 });
   }
 
-  const { action, metadata } = body;
+  const parsed = bodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json({}, { status: 400 });
+  }
 
-  if (!action || !ALLOWED_ACTIONS.has(action)) {
+  const { action, metadata } = parsed.data;
+
+  if (!ALLOWED_ACTIONS.has(action)) {
     return NextResponse.json({}, { status: 400 });
   }
 

--- a/src/app/api/tenant/mcp-clients/[id]/route.test.ts
+++ b/src/app/api/tenant/mcp-clients/[id]/route.test.ts
@@ -129,6 +129,30 @@ describe("PUT /api/tenant/mcp-clients/[id]", () => {
       expect.objectContaining({
         action: "MCP_CLIENT_UPDATE",
         tenantId: "tenant-1",
+        // Audit metadata must list the explicit schema fields only (no
+        // wholesale spread of the input body).
+        metadata: { name: "updated-client" },
+      }),
+    );
+  });
+
+  it("audit metadata only includes fields actually changed", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockMcpClientFindFirst.mockResolvedValue(makeClient());
+    mockMcpClientUpdate.mockResolvedValue(makeClient({ isActive: false }));
+
+    const req = createRequest("PUT", "http://localhost/api/tenant/mcp-clients/client-1", {
+      body: { isActive: false },
+    });
+    const res = await PUT(req, createParams({ id: "client-1" }));
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(200);
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "MCP_CLIENT_UPDATE",
+        metadata: { isActive: false },
       }),
     );
   });

--- a/src/app/api/tenant/mcp-clients/[id]/route.ts
+++ b/src/app/api/tenant/mcp-clients/[id]/route.ts
@@ -121,7 +121,14 @@ async function handlePUT(
     action: AUDIT_ACTION.MCP_CLIENT_UPDATE,
     targetType: AUDIT_TARGET_TYPE.MCP_CLIENT,
     targetId: id,
-    metadata: data as Record<string, unknown>,
+    // Spread known schema fields explicitly so future updateSchema
+    // additions do not silently expand the audit payload.
+    metadata: {
+      ...(data.name !== undefined && { name: data.name }),
+      ...(data.redirectUris !== undefined && { redirectUris: data.redirectUris }),
+      ...(data.allowedScopes !== undefined && { allowedScopes: data.allowedScopes }),
+      ...(data.isActive !== undefined && { isActive: data.isActive }),
+    },
   });
 
   return NextResponse.json({ client: updated });


### PR DESCRIPTION
## Summary

Tighten the audit metadata write surface to prevent outbox bloat and silent payload expansion.

### `audit-emit` route — payload size bounds

- **Zod \`safeParse\`** replaces inline \`request.json()\` parsing.
- **\`MAX_METADATA_KEYS = 20\`** — top-level key count cap.
- **\`MAX_METADATA_BYTES = 4096\`** — UTF-8 serialized byte cap; also bounds nesting depth implicitly (a deep object cannot fit in 4 KB).
- Non-object metadata (arrays, primitives) rejected at the schema level.
- Existing per-user rate limit (max 20 / 60 s) preserved; effective per-user throughput cap is **80 KB/min**.

### `mcp-clients` PUT — explicit field spread

The \`MCP_CLIENT_UPDATE\` audit emission cast the entire Zod-parsed body to \`Record<string, unknown>\`. Future \`updateSchema\` additions would silently expand the audit payload — a sensitive field added later (e.g., a secret) would auto-leak. Replaced with explicit field spread of the four known fields (\`name\`, \`redirectUris\`, \`allowedScopes\`, \`isActive\`). Future schema additions now require an intentional audit-side change.

## Background

- **\`audit-emit\` cap** is **S1** from the [PR #398 review log](docs/archive/review/csrf-admin-token-cache-review.md). Without these caps, a misbehaving (or compromised) authenticated session can flood \`audit_outbox\` and degrade the chain worker.
- **\`mcp-clients\` cast** was a low-severity finding surfaced by Phase 3 review of S1 — fixed in the same PR per the 30-minute Anti-Deferral rule (small, related, no impact-analysis cost).

## Test plan

- [x] Unit tests pass (20 tests across both files; 5 new boundary/rejection cases for \`audit-emit\`, 1 new test for \`mcp-clients\` partial-update metadata)
- [x] \`bash scripts/pre-pr.sh\` (11/11 checks pass)
- [x] \`npx next build\` succeeds
- [x] Phase 3 security review (no blocking findings)

## Notes for reviewer

- The single existing caller (\`src/proxy.ts:155\` → audit-emit) sends \`{ blockedPath: pathWithoutLocale }\` — one key, well below caps. No regression risk.
- TextEncoder UTF-8 byte length is used (NOT character count) to defeat wide-character inflation tricks.
- The mcp-clients fix is behavior-preserving (same payload shape for the current schema); the change makes the audit metadata an explicit allowlist rather than an implicit one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)