### PR TITLE
refactor(csp): unify loopback redirect URI accept set across DCR, manual MCP routes, frontend, and CSP

### DIFF
--- a/docs/archive/review/csp-form-action-loopback-scoping-code-review.md
+++ b/docs/archive/review/csp-form-action-loopback-scoping-code-review.md
@@ -1,0 +1,95 @@
+# Code Review: csp-form-action-loopback-scoping
+Date: 2026-04-27
+Review round: 1 (terminated — only finding was a non-code git-staging issue, fixed before commit)
+Branch: refactor/csp-form-action-loopback-scoping
+
+## Changes from Previous Round
+Initial code review.
+
+## Summary
+
+3 expert agents reviewed in parallel against the plan and `git diff origin/main`.
+
+| Expert | Outcome |
+|--------|---------|
+| Functionality | **No findings.** Plan adherence verified. The `buildCspHeader` extraction (deviation from plan's "export from proxy.ts") was assessed as a clean architectural improvement — security headers belong under `src/lib/security/`. R3 propagation re-verified; remaining loopback-host references are in distinct contexts (SSRF blocklist, CIDR config, CLI server validation). R10 / R20 / R21 all pass. |
+| Security | **No findings.** CSP widening sound (loopback IPs not externally routable). RFC 8252 §7.3 / §8.3 citations verified against the live RFC during Phase 2 Step 2-1. CSRF Origin gate at consent route preserved. Open redirect still gated by server-side `redirectUris.includes(redirectUri)`. The four surfaces (DCR / Manual POST / Manual PUT / Frontend) plus the CSP directive accept the same loopback host set with no drift. |
+| Testing | **F1 (Critical, non-code)**: `src/__tests__/csp-header.test.ts` and `src/lib/security/csp-builder.ts` were untracked at review time — they would not have shipped via the PR. **Fixed**: `git add` of both files before the implementation commit. All 61 targeted tests pass; CSP regression test pins all three loopback host literals. RT1 mock-reality alignment verified for the new PUT loopback test. |
+
+After F1 fix the implementation is complete and clean. No subsequent rounds needed.
+
+## Functionality Findings
+No findings.
+
+Verified:
+- Plan steps 1–6 all executed.
+- `LOOPBACK_REDIRECT_RE` defined exactly once in `src/lib/constants/auth/mcp.ts`; consumed by DCR, manual POST, manual PUT, and frontend validator.
+- CSP `form-action` includes all three loopback hosts in the same order as the regex accepts them.
+- `buildCspHeader` extraction preserves all module-level constants (`_isProd`, `_cspMode`, `_rawCspMode`, `_reportUri`, `_stylePrefix`, `_styleSuffix`, `_staticDirectives`) verbatim.
+- R3 propagation (no missed sites): SSRF webhook validator (`url-validation.ts:14`), trusted proxy CIDRs, external-HTTP blocklist, Tailscale daemon comment, CLI server-URL validation are all intentionally separate concerns and not in scope for this regex.
+- R10: `mcp.ts` imports only `MS_PER_MINUTE` from a leaf time module; safe for client component import.
+- R21: `npx next build` exits 0; TypeScript types resolve cleanly across all new imports.
+
+## Security Findings
+No findings.
+
+Verified:
+- `proxy.ts` (root) delegates to `src/lib/security/csp-builder.ts`. CSP content matches the plan: `'self' http://localhost:* http://127.0.0.1:* http://[::1]:*` in `form-action`.
+- RFC 8252 §7.3 ("Loopback Interface Redirection", "MUST allow any port") and §8.3 ("Loopback Redirect Considerations", "use of localhost is NOT RECOMMENDED") cited accurately in both `csp-builder.ts` and `mcp.ts`. Phase 2 verified against `https://www.rfc-editor.org/rfc/rfc8252.html`.
+- The four surfaces (DCR, Manual POST, Manual PUT, Frontend) plus CSP form-action have identical loopback host accept sets. No drift.
+- Frontend `validateRedirectUris` call sites (mcp-client-card.tsx lines 158, 233) gate submission on the validation result; no stale-state issue.
+- CSRF Origin gate at consent route (line 14-17) untouched.
+- Open redirect remains gated by `foundClient.redirectUris.includes(redirectUri)` (consent route line 45).
+- `_cspMode` safety guard in production preserved.
+- No client-bundle exposure of server-only env vars (`csp-builder.ts` is server-only).
+
+## Testing Findings
+
+### F1 — Critical (non-code, fixed): untracked files
+
+- **Files**: `src/__tests__/csp-header.test.ts`, `src/lib/security/csp-builder.ts`
+- **Problem**: After Phase 2, both files were untracked (`?? ` in `git status`). Without `git add`, neither would ship via the PR — the test would not run in CI and the new module would be missing entirely.
+- **Resolution**: `git add` both files alongside the modified files in the same commit. Verified post-commit: `git log --stat HEAD -1` shows `create mode 100644` for both.
+
+Beyond F1, no testing findings:
+- T1 (CSP false-negative pattern): resolved by `csp-builder.ts` extraction + direct unit test in `csp-header.test.ts`. The test pins all three loopback host literals plus a sanity check that broad `http:*` is NOT in form-action.
+- T2 (manual route no-port reject): added via `it.each` for both POST and PUT.
+- T3 (DCR `[::1]` no-port reject): added (paired with `[::1]` accept).
+- RT1 (mock-reality divergence): mock shapes for new PUT loopback test align with production select.
+- R19 (mock alignment): no test mocks `@/lib/security/csp-builder`; new module does not affect existing mocks.
+
+## Adjacent Findings
+None.
+
+## Quality Warnings
+None.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R3 (propagation): Verified — no missed sites.
+- R10 (circular import): Pass — `mcp.ts` is a leaf module from the client perspective.
+- R20 (mechanical edit safety): Pass — both manual route refines edited per-file.
+- R21 (build verification): Pass — `npx next build` exits 0.
+- Others: N/A.
+
+### Security expert
+- R3, R29, RS1, RS3: Pass.
+- R12 / R13 / R9 / R24 / R25: N/A.
+
+### Testing expert
+- R19 (mock alignment): Pass.
+- R20 (mechanical edit): Pass.
+- R21 (verification): Pass after F1 fix.
+- RT1 (mock-reality): Pass.
+- RT2 (testability): Pass — extraction enabled direct unit testing of `buildCspHeader`.
+- RT3 (shared constants): Pass — tests use `LOOPBACK_REDIRECT_RE` indirectly via shape assertions.
+
+## Resolution Status
+
+### F1 Critical (Testing) — Untracked files
+- Action: `git add src/__tests__/csp-header.test.ts src/lib/security/csp-builder.ts` before the implementation commit.
+- Modified file: implementation commit (commit message references both new files).
+- Status: Resolved (verified by `git log --stat HEAD -1`).
+
+All other findings: No action needed.

--- a/docs/archive/review/csp-form-action-loopback-scoping-plan.md
+++ b/docs/archive/review/csp-form-action-loopback-scoping-plan.md
@@ -1,0 +1,231 @@
+# Plan: csp-form-action-loopback-scoping
+
+Branch: `refactor/csp-form-action-loopback-scoping`
+Plan file: `docs/archive/review/csp-form-action-loopback-scoping-plan.md`
+
+## Project context
+
+- **Type**: web app (Next.js 16 + Prisma 7 + PostgreSQL 16)
+- **Test infrastructure**: unit + integration (vitest)
+- The product hosts an OAuth 2.1 Authorization Code (PKCE) endpoint for MCP clients. The consent flow involves a browser form-POST that triggers a server-side 302 redirect to a loopback `redirect_uri` registered by the client (Claude Code, Claude Desktop, the project's own CLI).
+
+## Objective
+
+Resolve **S2** from the [PR #398 review log](csrf-admin-token-cache-review.md). The CSP `form-action` directive in production allows `'self' http://localhost:* http://127.0.0.1:*` so the consent form's 302 redirect to a loopback callback succeeds. Investigation surfaced three follow-on issues:
+
+- **B1 (Major)** — DCR (`/api/mcp/register`) accepts `http://[::1]:<port>/` redirect URIs, but the CSP `form-action` directive omits `http://[::1]:*`. An IPv6-loopback OAuth client would silently fail at the consent-form-redirect step (CSP-blocked). DCR-accepted redirect URIs MUST all be CSP-allowed.
+- **B2 (Minor)** — Manual MCP client management (`POST/PUT /api/tenant/mcp-clients[/...]`) only accepts `http://localhost:<port>/` redirect URIs. DCR accepts `localhost` AND `127.0.0.1` AND `[::1]`. The same model rows can have different validation surfaces depending on the registration path. Unify by extracting and reusing the DCR regex.
+- **B3 (Info)** — Strengthen the CSP `form-action` rationale comment to explain the RFC 8252 §8.3 trade-off (RFC marks `localhost` as NOT RECOMMENDED, but Claude Code uses it; we keep `localhost` for compatibility). The expanded comment becomes the canonical record so future security review does not have to re-derive the trade-off.
+
+## Requirements
+
+### Functional
+
+1. **CSP** in `proxy.ts` MUST list `http://[::1]:*` alongside `http://localhost:*` and `http://127.0.0.1:*` so the OAuth consent form-POST can 302-redirect to any DCR-accepted loopback redirect URI without CSP-blocking.
+2. **Manual MCP client schemas** (`POST /api/tenant/mcp-clients`, `PUT /api/tenant/mcp-clients/[id]`) MUST accept the same loopback redirect URI patterns as DCR: `http://(127.0.0.1|localhost|[::1]):<port>/...`.
+3. The validation regex MUST live in a single shared location so DCR and the manual routes import it. The shared module is the source of truth — drift cannot accumulate across handlers.
+4. **Comment** on the CSP `form-action` line in `proxy.ts` MUST cite RFC 8252 §7.3 (loopback IP literal MUST be allowed) and §8.3 (`localhost` NOT RECOMMENDED but kept for Claude Code compatibility), and reference DCR's regex as the security-invariant pair.
+
+### Non-functional
+
+- Backward compat: any redirect URI currently accepted by DCR or the manual routes MUST continue to be accepted.
+- No schema migration (no DB changes).
+- The CSP change applies in all environments (dev + strict), matching the existing line.
+- Test count baseline: tests added (boundary cases), no tests removed.
+
+### Out of scope
+
+- Extending the CSP `form-action` to include arbitrary HTTPS redirect targets — `'self'` already covers them via the implicit "redirect to same origin" rule, and the server's own 302 handlers redirect to URIs that are validated upstream against the registered `redirectUris`. The new directive only widens the loopback case.
+- Tightening the CSP further (dropping `localhost`, RFC §8.3 alignment) — explicitly deferred per the existing comment; Claude Code/Desktop compatibility takes precedence.
+- Migrating any registered DCR clients with `localhost:*` URIs to `127.0.0.1:*`.
+- Changing the CLI's loopback choice (`127.0.0.1` only) — separate concern.
+
+## Technical approach
+
+### 1. Shared regex module
+
+Create or extend a constants module to host the loopback redirect regex. The natural home is `src/lib/constants/auth/mcp.ts` (already houses `MCP_SCOPES`).
+
+Add a single named export:
+
+```ts
+// RFC 8252 §7.3 mandates loopback IP literal support; §8.3 marks "localhost"
+// as NOT RECOMMENDED but real OAuth clients (Claude Code, Claude Desktop)
+// use it. Pair with the CSP form-action directive in proxy.ts — any host
+// pattern accepted here MUST appear there or the consent-form 302 redirect
+// is CSP-blocked.
+export const LOOPBACK_REDIRECT_RE = /^http:\/\/(127\.0\.0\.1|localhost|\[::1\]):\d+\//;
+```
+
+### 2. DCR consumer
+
+Replace the inline regex in `src/app/api/mcp/register/route.ts:31` with the imported constant. Behavior unchanged.
+
+### 3. Manual MCP client schemas
+
+In both `src/app/api/tenant/mcp-clients/route.ts` and `src/app/api/tenant/mcp-clients/[id]/route.ts`, replace:
+
+```ts
+.refine(
+  (u) => {
+    try {
+      const url = new URL(u);
+      return url.protocol === "https:" || (url.protocol === "http:" && url.hostname === "localhost");
+    } catch { return false; }
+  },
+  { message: "redirect_uri must use https:// or http://localhost" },
+)
+```
+
+with the DCR-equivalent shape:
+
+```ts
+.refine(
+  (u) => {
+    try {
+      const url = new URL(u);
+      return url.protocol === "https:" || LOOPBACK_REDIRECT_RE.test(u);
+    } catch { return false; }
+  },
+  { message: "redirect_uri must use https:// or http://(127.0.0.1|localhost|[::1]):<port>/" },
+)
+```
+
+**Editor note (F5)**: apply `Edit` per-file rather than `replace_all` across the whole repo. The two files contain the textually-identical refine block exactly once each; per-file edits avoid wider unintended substitution.
+
+### 3b. DCR error message unification (F2/S1)
+
+`src/app/api/mcp/register/route.ts:51` currently reads:
+
+```ts
+"redirect_uris must use https:// or http://localhost:<port>/ or http://127.0.0.1:<port>/"
+```
+
+This message omits `[::1]` even though the regex accepts it. Update to the same canonical message used by the manual routes:
+
+```ts
+"redirect_uris must use https:// or http://(127.0.0.1|localhost|[::1]):<port>/"
+```
+
+### 3c. Frontend validator parity (F1)
+
+`src/components/settings/developer/mcp-client-card.tsx:68-76` contains a client-side `validateRedirectUris` that mirrors the OLD server predicate (only `localhost` accepted). After the server schema broadens, this client guard would still reject `127.0.0.1` and `[::1]` URIs — admin cannot enter the URI they want.
+
+Update the client validator to use the same regex predicate as the server. Since `src/lib/constants/auth/mcp.ts` is a leaf constants module (string + regex only, no server runtime), it is safe to import from a `"use client"` component. Verify by reading the module's imports during Phase 2 Step 2-1; if the module gains a server-only dependency later, fall back to inlining the regex literal with a `// see: LOOPBACK_REDIRECT_RE in @/lib/constants/auth/mcp` reference comment.
+
+### 4. CSP
+
+In `proxy.ts:37`, update the directive:
+
+```ts
+"form-action 'self' http://localhost:* http://127.0.0.1:* http://[::1]:*",
+```
+
+And replace the existing `localhost/127.0.0.1 required in all environments...` comment block with the strengthened B3 version that cross-references DCR and cites RFC 8252 §7.3 / §8.3.
+
+### 5. Tests
+
+Add the following test cases:
+
+- **DCR** (`src/app/api/mcp/register/route.test.ts`):
+  - Positive: `http://[::1]:<port>/callback` accepted.
+  - Negative: `http://[::1]/` (no port) rejected — symmetric with the existing `http://127.0.0.1/` and `http://localhost/` no-port reject tests (T3 — non-optional).
+- **Manual MCP client POST** (`src/app/api/tenant/mcp-clients/route.test.ts`):
+  - Positive: `http://127.0.0.1:<port>/` and `http://[::1]:<port>/` accepted (currently rejected).
+  - Negative (T2): `http://127.0.0.1/`, `http://localhost/`, `http://[::1]/` (no port) rejected. The current test file has no redirect-URI rejection tests at all — adding them establishes a regression guard against future schema regressions.
+- **Manual MCP client PUT** (`src/app/api/tenant/mcp-clients/[id]/route.test.ts`): same positive + negative matrix as POST.
+- **CSP regression** (T1 — critical to get right):
+  - DO NOT extend the existing `_applySecurityHeaders` test pattern that uses a hardcoded `dummyOptions.cspHeader` string — that pattern bypasses `buildCspHeader()` and gives a false-negative if the production CSP forgets `[::1]`.
+  - Instead: either (a) export `buildCspHeader` from `proxy.ts` as a named export and unit-test its output directly, or (b) write a test that calls the exported `proxy(request)` function with a mock `NextRequest` and asserts the response header includes `http://[::1]:*` in `form-action`.
+  - Pin all three loopback host literals (`localhost:*`, `127.0.0.1:*`, `[::1]:*`) so accidental removal of any one is caught.
+
+## Implementation steps
+
+1. **Add shared regex constant** to `src/lib/constants/auth/mcp.ts` with the explanatory comment cited in §1 above. Verify the file has no server-only imports so it remains client-safe (consumed by `mcp-client-card.tsx`).
+2. **Switch DCR** to import from the shared module (drop the inline `LOOPBACK_REDIRECT_RE`). Also update the DCR error message at `register/route.ts:51` to the unified form (per §3b).
+3. **Update manual MCP client schemas** (POST `/route.ts` + PUT `/[id]/route.ts`) to import the regex and broaden the `refine` predicate; unify the error message.
+4. **Update frontend validator** `src/components/settings/developer/mcp-client-card.tsx:68-76` (`validateRedirectUris`) to use the same predicate. Import `LOOPBACK_REDIRECT_RE` from the shared module (verified client-safe in step 1).
+5. **Update CSP** in `proxy.ts`: add `http://[::1]:*` to the `form-action` directive (place after `127.0.0.1:*`) and rewrite the adjacent comment block per §4 above. The comment MUST name `LOOPBACK_REDIRECT_RE` so a future grep finds the CSP-side mirror from the regex side.
+6. **Refactor for testability** (T1): export `buildCspHeader` from `proxy.ts` as a named export so the CSP regression test can unit-test it without relying on the hardcoded `dummyOptions.cspHeader` pattern.
+7. **Add positive + negative tests** per §5 above (DCR `[::1]` accept + no-port reject; manual MCP POST/PUT three accept + three reject; CSP regression pinning all three loopback hosts).
+8. **Verify**:
+   - `npx vitest run src/app/api/mcp/register src/app/api/tenant/mcp-clients src/__tests__/proxy.test.ts src/components/settings/developer` (targeted)
+   - `npx next build` (catches TypeScript errors, especially the new import in four files)
+   - `bash scripts/pre-pr.sh` (11/11)
+
+## Testing strategy
+
+| Layer | Test |
+|-------|------|
+| DCR redirect URI accept | Positive: `http://[::1]:<port>/`. Existing tests for `127.0.0.1` and `localhost` remain. |
+| DCR redirect URI reject | Existing reject tests unchanged. Add: `http://[::1]/` rejected (no port) — symmetric with the existing `127.0.0.1` and `localhost` no-port reject cases. |
+| Manual MCP client POST | Positive cases for `127.0.0.1` and `[::1]` (newly accepted post-fix). Existing `localhost` case unchanged. |
+| Manual MCP client PUT | Same as POST. |
+| CSP shape | Assert response `Content-Security-Policy` header contains `http://[::1]:*` in `form-action`. Pin existing `localhost:*` and `127.0.0.1:*` to prevent accidental removal. |
+| Regex unit (optional) | If `mcp.test.ts` accumulates regex tests, add `LOOPBACK_REDIRECT_RE` cases there directly to avoid spreading the matrix across route tests. |
+
+## Considerations & constraints
+
+### CSP `form-action` and 302 redirects
+
+CSP `form-action` controls form-submit targets AND any 302 redirect chain that follows. The OAuth consent flow uses:
+
+1. JS-built `<form method="POST" action="/api/mcp/authorize/consent">`.
+2. The route returns `NextResponse.redirect(redirect_uri, 302)` where `redirect_uri` is a registered loopback URI.
+
+If the redirect target is not in `form-action`, the browser blocks the navigation **after** the form POST has reached the server (audit log writes succeed, but the user is stranded with a CSP violation). This is the failure mode being fixed.
+
+### Why `[::1]` only, not all-IPv6?
+
+`[::1]` is the IPv6 loopback literal. There is no IPv6 wildcard host syntax in CSP source expressions, and routable IPv6 redirect URIs are not part of the loopback flow per RFC 8252 §7.3. Adding only the literal matches DCR's accept list.
+
+### R3 propagation (other consumers of the loopback pattern)
+
+After this change, `LOOPBACK_REDIRECT_RE` is referenced from:
+
+- `src/lib/constants/auth/mcp.ts` (definition)
+- `src/app/api/mcp/register/route.ts` (DCR)
+- `src/app/api/tenant/mcp-clients/route.ts` (manual create)
+- `src/app/api/tenant/mcp-clients/[id]/route.ts` (manual update)
+
+The CSP directive in `proxy.ts` is the **header-side mirror**. The strengthened comment in `proxy.ts` MUST name the regex constant so a future contributor adding a host (e.g., `127.0.0.2`) updates both sides.
+
+### R29 spec citations
+
+- **RFC 8252 §7.3** ("Loopback Interface Redirection"): paraphrase — "the authorization server MUST allow any port to be specified at the time of the request for loopback IP redirect URIs". The `:*` port wildcard in CSP and the `:\d+/` requirement in the regex satisfy this.
+- **RFC 8252 §8.3** ("Loopback Redirect Considerations"): paraphrase — "The use of 'localhost' is NOT RECOMMENDED. ... avoids inadvertently listening on network interfaces other than the loopback interface."
+- These citations exist in DCR (route.ts:29-30). The plan author has not re-verified them against the live RFC in this environment — flagged `citation unverified — please confirm` per Common Rules R29 / "Verify citations, do not fabricate them". During Phase 2 Step 2-1, fetch RFC 8252 from `https://www.rfc-editor.org/rfc/rfc8252.html` and confirm both section numbers and the paraphrased claims still appear there.
+
+### Edge cases (regex)
+
+- **Port :0**: the regex `:\d+/` matches `:0`. No real client registers before binding to an OS-assigned port, so `:0` would never appear in a registered URI. Accepted as-is; no additional validation needed.
+- **Port > 65535**: the regex matches arbitrary digit sequences. Pre-filter: Zod `z.string().url()` calls `new URL(...)` which throws on invalid ports (>65535), so the upstream guard catches `http://127.0.0.1:99999/` before the regex fires. The two-stage check (URL constructor + regex) is the correct chain.
+- **Trailing path/query/hash**: the regex anchors at the first `/` after the port, so `http://127.0.0.1:8080/callback?state=foo` and similar are correctly accepted.
+- **Alias forms**: `127.000.000.001`, `127.1`, `0177.0.0.1`, `0x7f.0.0.1` are NOT matched by the literal-text regex (correct security posture — these forms can evade naive host comparisons but are blocked here).
+
+### R12 / R13 / R9 / R24 / R25 — N/A
+
+No new audit actions, no new event dispatch surface, no new DB transactions, no migration, no persisted-state field.
+
+## User operation scenarios
+
+1. **Claude Desktop registers via DCR with `http://localhost:8765/callback`** (existing behavior).
+   Pre-fix: works. Post-fix: works (no behavior change for the dominant case).
+
+2. **A new IPv6-only OAuth client registers via DCR with `http://[::1]:8765/callback`**.
+   Pre-fix: DCR accepts; CSP blocks the consent-form 302 → user stranded.
+   Post-fix: DCR accepts; CSP allows; redirect succeeds.
+
+3. **Tenant admin manually creates an MCP client with `http://127.0.0.1:9000/callback`** via the dashboard.
+   Pre-fix: rejected by manual schema (only `localhost` allowed); admin must use `localhost` instead.
+   Post-fix: accepted (matches DCR).
+
+4. **Tenant admin updates an existing MCP client to add `http://[::1]:9001/callback`** to its redirect URI list.
+   Pre-fix: rejected.
+   Post-fix: accepted.
+
+5. **The project CLI** (`cli/src/lib/oauth.ts`) registers via DCR with `http://127.0.0.1:<port>/callback`.
+   Pre-fix and post-fix: works. The CLI binds to `127.0.0.1` only, never `localhost` or `[::1]`. No CLI change needed.
+
+## Implementation Checklist
+(Populated in Phase 2 Step 2-1.)

--- a/docs/archive/review/csp-form-action-loopback-scoping-review.md
+++ b/docs/archive/review/csp-form-action-loopback-scoping-review.md
@@ -1,0 +1,64 @@
+# Plan Review: csp-form-action-loopback-scoping
+Date: 2026-04-27
+Review rounds: 2
+
+## Round 2 Summary
+
+All Round 1 findings (Critical T1, Major F1/T2, Minor F2/F3/F4/F5/S1/T3, Info S2) verified RESOLVED. One new minor finding caught in Round 2:
+
+- **T4 (Minor)** — Testing strategy table still labeled `[::1]` no-port reject as "Optional" while §5 made it non-optional. Internal plan inconsistency. **Fixed in plan immediately** — table updated to match §5.
+
+Plan is stable. Proceeding to Phase 2.
+
+## Round 1 Summary
+
+3 expert agents reviewed in parallel against the initial plan.
+
+| ID | Severity | Source | Status |
+|----|----------|--------|--------|
+| F1 | Major | Functionality | Frontend validator (`mcp-client-card.tsx:71`) not in scope → client/server divergence. **Reflected — plan §3c + step 4.** |
+| F2 | Minor | Functionality | DCR error message at `register/route.ts:51` omits `[::1]`. **Reflected — plan §3b + step 2.** |
+| F3 | Minor | Functionality | Document port :0 acceptance. **Reflected — plan "Edge cases (regex)" section.** |
+| F4 | Minor | Functionality | Confirm port > 65535 chain (URL ctor → regex). **Reflected — same.** |
+| F5 | Minor | Functionality | R20 mechanical edit safety note. **Reflected — plan §3 editor note.** |
+| S1 | Minor | Security | Same root as F2 (DCR error message). **Reflected via F2.** |
+| S2 | Info | Security | RFC 8252 §7.3 / §8.3 citation unverified. **Flagged in plan R29 section as `citation unverified — please confirm` per Common Rules R29.** |
+| S3-S6 | — | Security | Confirm-only (CSRF gate / open redirect / port squatting / URL alias bypass) — all bounded or pre-existing-and-mitigated. No action required. |
+| T1 | **Critical** | Testing | CSP regression test using hardcoded `dummyOptions.cspHeader` would false-negative. **Reflected — plan §5 mandates `buildCspHeader` export OR `proxy()` real-response check; step 6 added for export.** |
+| T2 | Major | Testing | Manual route no-port reject tests missing. **Reflected — plan §5 negative cases for both POST + PUT.** |
+| T3 | Minor | Testing | DCR `[::1]` no-port reject was Optional. **Reflected — plan §5 makes it non-optional, symmetric with `127.0.0.1` / `localhost`.** |
+
+All Critical and Major findings reflected in the plan. Round 2 verification follows.
+
+## Round 1 — Functionality (full)
+
+(See Round 1 sub-agent output saved separately — synthesized above. Key takeaway: F1 is the load-bearing fix; without the frontend update, scenarios 3 & 4 in the plan break in the UI.)
+
+## Round 1 — Security (full)
+
+(See Round 1 sub-agent output saved separately — synthesized above. Key takeaway: the threat model is unchanged. The CSP widening is bounded by loopback semantics + server-side `redirectUris` allowlist + PKCE. RFC citations need manual verification before commit.)
+
+## Round 1 — Testing (full)
+
+(See Round 1 sub-agent output saved separately — synthesized above. Key takeaway: the existing `_applySecurityHeaders` test pattern in `proxy.test.ts:31` uses a hardcoded `dummyOptions.cspHeader = "default-src 'self'"` — using that pattern for the new test would NOT exercise the `[::1]:*` addition. Either export `buildCspHeader` or test through the real `proxy()` export.)
+
+## Recurring Issue Check (Round 1 — consolidated)
+
+### Functionality expert
+- R3: F1 — frontend consumer was a propagation gap (now fixed).
+- R10: Verified — `src/lib/constants/auth/mcp.ts` is a leaf module.
+- R20: F5 — edit-per-file note added.
+- R22: Other route-level redirect URI validators reviewed — only authorize/consent/token routes, which validate by DB allowlist (not regex). Out of scope.
+- R29: paraphrase-only citations, marked unverified.
+
+### Security expert
+- R3 / R29 / RS1 / RS3: covered above.
+- R12 / R13 / R9 / R24 / R25: N/A.
+
+### Testing expert
+- RT1: T1 — mock-reality divergence in existing test pattern.
+- R19 / R20: covered above.
+- R24 / R25 / R21: N/A.
+
+## Round 2 Status
+Pending — plan updated; verification re-launched against the updated plan to confirm all Round 1 findings are correctly addressed.

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,45 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { proxy as handleProxy } from "./src/proxy";
-
-// Pre-compute static CSP parts at module init time to avoid per-request work.
-// Only the nonce value is injected per-request.
-const _isProd = process.env.NODE_ENV === "production";
-// Safety guard: in production, never allow CSP_MODE=dev to downgrade the CSP.
-// Ops mistakes (wrong .env.production, Docker env, etc.) must not silently
-// disable strict-dynamic + nonce in prod. Only "strict" is accepted in prod.
-const _rawCspMode = process.env.CSP_MODE ?? (_isProd ? "strict" : "dev");
-const _cspMode = _isProd && _rawCspMode !== "strict" ? "strict" : _rawCspMode;
-if (_isProd && _rawCspMode !== _cspMode) {
-  console.warn(
-    `[CSP] CSP_MODE="${_rawCspMode}" is ignored in production builds; using "strict"`,
-  );
-}
-const _reportUri = `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/api/csp-report`;
-// In dev mode style-src and script-src use 'unsafe-inline'; in strict mode
-// nonce + 'strict-dynamic' is injected. Dev uses 'unsafe-inline' because the
-// per-request nonce flow via cookie is not reliable for Next.js HMR/dev-overlay
-// inline scripts (Next.js 16.2+ tightened cookie propagation to server components).
-// Note: the per-request nonce is still generated and set as the `csp-nonce`
-// cookie in dev (read by `src/app/layout.tsx` for a <meta name="csp-nonce">),
-// but plays no CSP role in dev because the header uses 'unsafe-inline'.
-// Production never hits this branch.
-const _stylePrefix = _cspMode === "dev" ? "style-src 'self' 'unsafe-inline'" : "style-src 'self' 'nonce-";
-const _styleSuffix = _cspMode === "dev" ? "" : "'";
-const _staticDirectives = [
-  "img-src 'self' data: https:",
-  "font-src 'self'",
-  `connect-src 'self'${process.env.NEXT_PUBLIC_SENTRY_DSN ? " https://*.ingest.us.sentry.io https://*.ingest.sentry.io" : ""}`,
-  "object-src 'none'",
-  "base-uri 'self'",
-  // localhost/127.0.0.1 required in all environments: OAuth consent form redirects
-  // to native app callback (RFC 8252 — Claude Code, Claude Desktop use localhost)
-  "form-action 'self' http://localhost:* http://127.0.0.1:*",
-  "frame-ancestors 'none'",
-  "upgrade-insecure-requests",
-  "report-to csp-endpoint",
-  `report-uri ${_reportUri}`,
-].join("; ");
+import { buildCspHeader } from "./src/lib/security/csp-builder";
 
 export function proxy(request: NextRequest) {
   // Guard: skip Next.js internals that the matcher regex may not exclude
@@ -71,24 +33,4 @@ function generateNonce(): string {
   let binary = "";
   for (const b of bytes) binary += String.fromCharCode(b);
   return btoa(binary);
-}
-
-function buildCspHeader(nonce: string): string {
-  // Dev mode: 'unsafe-inline' + 'unsafe-eval' (no nonce, no strict-dynamic).
-  //   Necessary because Next.js HMR, Turbopack dev overlay, and React Fast Refresh
-  //   inject inline scripts that cannot receive the per-request CSP nonce.
-  //   This is the standard Next.js dev CSP configuration.
-  // Strict mode: per-request nonce + 'strict-dynamic'.
-  //   Inline scripts without the nonce are blocked. 'unsafe-eval' is intentionally
-  //   NOT included even when strict mode is selected via CSP_MODE=strict in a
-  //   non-prod NODE_ENV — strict mode approximates prod CSP and prod has no
-  //   need for 'unsafe-eval' (Turbopack dev overlay uses eval() and will be
-  //   blocked, but in that case the caller should use dev mode instead).
-  const scriptSrc = _cspMode === "dev"
-    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'"
-    : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'wasm-unsafe-eval'`;
-  const styleSrc = _cspMode === "dev"
-    ? _stylePrefix
-    : `${_stylePrefix}${nonce}${_styleSuffix}`;
-  return `default-src 'self'; ${scriptSrc}; ${styleSrc}; ${_staticDirectives}`;
 }

--- a/src/__tests__/csp-header.test.ts
+++ b/src/__tests__/csp-header.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { buildCspHeader } from "../lib/security/csp-builder";
+
+// These tests pin the loopback host literals in the CSP `form-action`
+// directive against accidental removal. The directive MUST mirror DCR's
+// LOOPBACK_REDIRECT_RE accept set (see src/lib/constants/auth/mcp.ts) —
+// any host accepted by the regex but missing here causes the OAuth
+// consent-form 302 redirect to be CSP-blocked after the audit log has
+// already been written.
+
+describe("buildCspHeader — form-action loopback hosts", () => {
+  const NONCE = "test-nonce-12345";
+  const csp = buildCspHeader(NONCE);
+
+  it("allows form submissions to same origin", () => {
+    expect(csp).toContain("form-action 'self'");
+  });
+
+  it("allows http://localhost:* for OAuth loopback redirects", () => {
+    expect(csp).toMatch(/form-action[^;]*\bhttp:\/\/localhost:\*/);
+  });
+
+  it("allows http://127.0.0.1:* for OAuth loopback redirects (RFC 8252 §7.3)", () => {
+    expect(csp).toMatch(/form-action[^;]*\bhttp:\/\/127\.0\.0\.1:\*/);
+  });
+
+  it("allows http://[::1]:* for IPv6 OAuth loopback redirects (RFC 8252 §7.3)", () => {
+    expect(csp).toMatch(/form-action[^;]*http:\/\/\[::1\]:\*/);
+  });
+
+  it("does NOT allow non-loopback HTTP form targets in form-action", () => {
+    // Sanity check: no broad http:* or arbitrary http hosts in form-action.
+    const formActionMatch = csp.match(/form-action[^;]*/);
+    expect(formActionMatch).not.toBeNull();
+    const formAction = formActionMatch![0];
+    expect(formAction).not.toMatch(/\bhttp:\*/);
+    expect(formAction).not.toContain("http://example.com");
+  });
+});

--- a/src/app/api/mcp/register/route.test.ts
+++ b/src/app/api/mcp/register/route.test.ts
@@ -198,6 +198,33 @@ describe("POST /api/mcp/register", () => {
     expect(json.error).toBe("invalid_client_metadata");
   });
 
+  it("accepts http://[::1]:<port>/ IPv6 loopback redirect URIs (RFC 8252 §7.3)", async () => {
+    const req = createRequest("POST", "http://localhost/api/mcp/register", {
+      body: {
+        client_name: "Test",
+        redirect_uris: ["http://[::1]:3000/callback"],
+      },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(201);
+  });
+
+  it("rejects http://[::1]/ IPv6 loopback without port", async () => {
+    const req = createRequest("POST", "http://localhost/api/mcp/register", {
+      body: {
+        client_name: "Test",
+        redirect_uris: ["http://[::1]/callback"],
+      },
+    });
+    const res = await POST(req);
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(400);
+    expect(json.error).toBe("invalid_client_metadata");
+  });
+
   it("rejects plain http:// (non-loopback) redirect URIs", async () => {
     const req = createRequest("POST", "http://localhost/api/mcp/register", {
       body: {

--- a/src/app/api/mcp/register/route.ts
+++ b/src/app/api/mcp/register/route.ts
@@ -16,6 +16,7 @@ import {
   MAX_UNCLAIMED_DCR_CLIENTS,
   DCR_RATE_LIMIT_WINDOW_MS,
   DCR_RATE_LIMIT_MAX,
+  LOOPBACK_REDIRECT_RE,
 } from "@/lib/constants/auth/mcp";
 import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
 import { withRequestLog } from "@/lib/http/with-request-log";
@@ -24,11 +25,6 @@ const dcrRateLimiter = createRateLimiter({
   windowMs: DCR_RATE_LIMIT_WINDOW_MS,
   max: DCR_RATE_LIMIT_MAX,
 });
-
-// Loopback redirect URIs: allow both the loopback IP literals and localhost with a port.
-// RFC 8252 §7.3 specifies loopback IP literals (127.0.0.1 / [::1]); §8.3 marks
-// localhost as NOT RECOMMENDED, but real clients (Claude Code) use it.
-const LOOPBACK_REDIRECT_RE = /^http:\/\/(127\.0\.0\.1|localhost|\[::1\]):\d+\//;
 
 const dcrSchema = z.object({
   client_name: z.string().min(1).max(100),
@@ -48,7 +44,7 @@ const dcrSchema = z.object({
         }),
       {
         message:
-          "redirect_uris must use https:// or http://localhost:<port>/ or http://127.0.0.1:<port>/",
+          "redirect_uris must use https:// or http://(127.0.0.1|localhost|[::1]):<port>/",
       },
     ),
   grant_types: z.array(z.string()).optional(),

--- a/src/app/api/tenant/mcp-clients/[id]/route.test.ts
+++ b/src/app/api/tenant/mcp-clients/[id]/route.test.ts
@@ -171,6 +171,43 @@ describe("PUT /api/tenant/mcp-clients/[id]", () => {
     expect(status).toBe(404);
   });
 
+  it.each([
+    ["http://127.0.0.1:8765/callback"],
+    ["http://localhost:8765/callback"],
+    ["http://[::1]:8765/callback"],
+  ])("accepts loopback redirect URI update: %s", async (uri) => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockMcpClientFindFirst.mockResolvedValue(makeClient());
+    mockMcpClientUpdate.mockResolvedValue(makeClient({ redirectUris: [uri] }));
+
+    const req = createRequest("PUT", "http://localhost/api/tenant/mcp-clients/client-1", {
+      body: { redirectUris: [uri] },
+    });
+    const res = await PUT(req, createParams({ id: "client-1" }));
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(200);
+  });
+
+  it.each([
+    ["http://127.0.0.1/callback"],
+    ["http://localhost/callback"],
+    ["http://[::1]/callback"],
+  ])("rejects loopback redirect URI without port: %s", async (uri) => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockMcpClientFindFirst.mockResolvedValue(makeClient());
+
+    const req = createRequest("PUT", "http://localhost/api/tenant/mcp-clients/client-1", {
+      body: { redirectUris: [uri] },
+    });
+    const res = await PUT(req, createParams({ id: "client-1" }));
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(400);
+  });
+
   it("returns 409 on name conflict (P2002)", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockRequireTenantPermission.mockResolvedValue(ACTOR);

--- a/src/app/api/tenant/mcp-clients/[id]/route.ts
+++ b/src/app/api/tenant/mcp-clients/[id]/route.ts
@@ -8,7 +8,7 @@ import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION } from "@/lib/constants/audit/audit";
 import { AUDIT_TARGET_TYPE } from "@/lib/constants/audit/audit-target";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
-import { MCP_SCOPES } from "@/lib/constants/auth/mcp";
+import { MCP_SCOPES, LOOPBACK_REDIRECT_RE } from "@/lib/constants/auth/mcp";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { errorResponse, handleAuthError, notFound, unauthorized } from "@/lib/http/api-response";
 import { parseBody } from "@/lib/http/parse-body";
@@ -22,10 +22,10 @@ const updateSchema = z.object({
       (u) => {
         try {
           const url = new URL(u);
-          return url.protocol === "https:" || (url.protocol === "http:" && url.hostname === "localhost");
+          return url.protocol === "https:" || LOOPBACK_REDIRECT_RE.test(u);
         } catch { return false; }
       },
-      { message: "redirect_uri must use https:// or http://localhost" },
+      { message: "redirect_uri must use https:// or http://(127.0.0.1|localhost|[::1]):<port>/" },
     ),
   ).min(1).max(10).optional(),
   allowedScopes: z.array(z.enum(MCP_SCOPES as [string, ...string[]])).min(1).optional(),

--- a/src/app/api/tenant/mcp-clients/route.test.ts
+++ b/src/app/api/tenant/mcp-clients/route.test.ts
@@ -199,6 +199,52 @@ describe("POST /api/tenant/mcp-clients", () => {
     );
   });
 
+  it.each([
+    ["http://127.0.0.1:8765/callback"],
+    ["http://localhost:8765/callback"],
+    ["http://[::1]:8765/callback"],
+  ])("accepts loopback redirect URI %s", async (uri) => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockMcpClientCount.mockResolvedValue(0);
+    mockMcpClientFindFirst.mockResolvedValue(null);
+    mockMcpClientCreate.mockResolvedValue(makeClient({ id: "client-loopback" }));
+
+    const req = createRequest("POST", "http://localhost/api/tenant/mcp-clients", {
+      body: {
+        name: "loopback-client",
+        redirectUris: [uri],
+        allowedScopes: ["credentials:list"],
+      },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(201);
+  });
+
+  it.each([
+    ["http://127.0.0.1/callback"],
+    ["http://localhost/callback"],
+    ["http://[::1]/callback"],
+  ])("rejects loopback redirect URI without port: %s", async (uri) => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockMcpClientCount.mockResolvedValue(0);
+
+    const req = createRequest("POST", "http://localhost/api/tenant/mcp-clients", {
+      body: {
+        name: "loopback-client",
+        redirectUris: [uri],
+        allowedScopes: ["credentials:list"],
+      },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(400);
+  });
+
   it("returns 409 for name conflict", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockRequireTenantPermission.mockResolvedValue(ACTOR);

--- a/src/app/api/tenant/mcp-clients/route.ts
+++ b/src/app/api/tenant/mcp-clients/route.ts
@@ -9,7 +9,7 @@ import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION } from "@/lib/constants/audit/audit";
 import { AUDIT_TARGET_TYPE } from "@/lib/constants/audit/audit-target";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
-import { MAX_MCP_CLIENTS_PER_TENANT, MCP_SCOPES } from "@/lib/constants/auth/mcp";
+import { MAX_MCP_CLIENTS_PER_TENANT, MCP_SCOPES, LOOPBACK_REDIRECT_RE } from "@/lib/constants/auth/mcp";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { errorResponse, handleAuthError, unauthorized } from "@/lib/http/api-response";
 import { parseBody } from "@/lib/http/parse-body";
@@ -23,10 +23,10 @@ const createSchema = z.object({
       (u) => {
         try {
           const url = new URL(u);
-          return url.protocol === "https:" || (url.protocol === "http:" && url.hostname === "localhost");
+          return url.protocol === "https:" || LOOPBACK_REDIRECT_RE.test(u);
         } catch { return false; }
       },
-      { message: "redirect_uri must use https:// or http://localhost" },
+      { message: "redirect_uri must use https:// or http://(127.0.0.1|localhost|[::1]):<port>/" },
     ),
   ).min(1).max(10),
   allowedScopes: z.array(z.enum(MCP_SCOPES as [string, ...string[]])).min(1),

--- a/src/components/settings/developer/mcp-client-card.tsx
+++ b/src/components/settings/developer/mcp-client-card.tsx
@@ -39,7 +39,7 @@ import { Blocks, ChevronDown, Loader2, Plus, Search, Trash2, Pencil, Users } fro
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { apiPath } from "@/lib/constants";
-import { MCP_SCOPES } from "@/lib/constants/auth/mcp";
+import { MCP_SCOPES, LOOPBACK_REDIRECT_RE } from "@/lib/constants/auth/mcp";
 import { fetchApi } from "@/lib/url-helpers";
 import { formatDateTime } from "@/lib/format/format-datetime";
 import { ScopeBadges } from "@/components/settings/developer/scope-badges";
@@ -65,10 +65,13 @@ interface NewClientCredentials {
 }
 
 function validateRedirectUris(uris: string[]): boolean {
+  // Mirrors the server-side schema in `src/app/api/tenant/mcp-clients/route.ts`
+  // and DCR (`src/app/api/mcp/register/route.ts`). Keep in sync via the shared
+  // LOOPBACK_REDIRECT_RE constant.
   return uris.every((u) => {
     try {
       const url = new URL(u);
-      return url.protocol === "https:" || (url.protocol === "http:" && url.hostname === "localhost");
+      return url.protocol === "https:" || LOOPBACK_REDIRECT_RE.test(u);
     } catch {
       return false;
     }

--- a/src/lib/constants/auth/mcp.ts
+++ b/src/lib/constants/auth/mcp.ts
@@ -44,6 +44,23 @@ export const MCP_PROTOCOL_VERSION = "2025-03-26";
 export const MCP_SERVER_NAME = "passwd-sso";
 export const MCP_SERVER_VERSION = "1.0.0";
 
+// Loopback redirect URI regex shared by:
+//   - DCR (`/api/mcp/register`)
+//   - Manual MCP client management (`/api/tenant/mcp-clients`, `/api/tenant/mcp-clients/[id]`)
+//   - Frontend validator (`mcp-client-card.tsx`)
+// The CSP `form-action` directive in `proxy.ts` MUST mirror the host set
+// accepted here (`localhost`, `127.0.0.1`, `[::1]`) — any host accepted by
+// this regex but missing from the CSP causes the consent-form 302 redirect
+// to be CSP-blocked.
+//
+// RFC 8252 §7.3 mandates loopback IP literal support and "MUST allow any
+// port"; §8.3 marks `localhost` as NOT RECOMMENDED but real OAuth clients
+// (Claude Code, Claude Desktop) use it, so we keep it for compatibility.
+//
+// Pre-filter: callers should run `z.string().url()` first so `new URL()`
+// rejects invalid ports (>65535) before this regex sees them.
+export const LOOPBACK_REDIRECT_RE = /^http:\/\/(127\.0\.0\.1|localhost|\[::1\]):\d+\//;
+
 // DCR (Dynamic Client Registration) constants
 export const MCP_REFRESH_TOKEN_PREFIX = "mcpr_";
 export const MCP_REFRESH_TOKEN_EXPIRY_SEC = 604800; // 7 days

--- a/src/lib/security/csp-builder.ts
+++ b/src/lib/security/csp-builder.ts
@@ -1,0 +1,73 @@
+// CSP header construction for the Next.js proxy. Extracted from `proxy.ts`
+// (root) so it can be unit-tested without pulling in the full Next.js
+// middleware import chain (next-intl, etc.).
+
+// Pre-compute static CSP parts at module init time to avoid per-request work.
+// Only the nonce value is injected per-request.
+const _isProd = process.env.NODE_ENV === "production";
+// Safety guard: in production, never allow CSP_MODE=dev to downgrade the CSP.
+// Ops mistakes (wrong .env.production, Docker env, etc.) must not silently
+// disable strict-dynamic + nonce in prod. Only "strict" is accepted in prod.
+const _rawCspMode = process.env.CSP_MODE ?? (_isProd ? "strict" : "dev");
+const _cspMode = _isProd && _rawCspMode !== "strict" ? "strict" : _rawCspMode;
+if (_isProd && _rawCspMode !== _cspMode) {
+  console.warn(
+    `[CSP] CSP_MODE="${_rawCspMode}" is ignored in production builds; using "strict"`,
+  );
+}
+const _reportUri = `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/api/csp-report`;
+// In dev mode style-src and script-src use 'unsafe-inline'; in strict mode
+// nonce + 'strict-dynamic' is injected. Dev uses 'unsafe-inline' because the
+// per-request nonce flow via cookie is not reliable for Next.js HMR/dev-overlay
+// inline scripts (Next.js 16.2+ tightened cookie propagation to server components).
+// Note: the per-request nonce is still generated and set as the `csp-nonce`
+// cookie in dev (read by `src/app/layout.tsx` for a <meta name="csp-nonce">),
+// but plays no CSP role in dev because the header uses 'unsafe-inline'.
+// Production never hits this branch.
+const _stylePrefix = _cspMode === "dev" ? "style-src 'self' 'unsafe-inline'" : "style-src 'self' 'nonce-";
+const _styleSuffix = _cspMode === "dev" ? "" : "'";
+const _staticDirectives = [
+  "img-src 'self' data: https:",
+  "font-src 'self'",
+  `connect-src 'self'${process.env.NEXT_PUBLIC_SENTRY_DSN ? " https://*.ingest.us.sentry.io https://*.ingest.sentry.io" : ""}`,
+  "object-src 'none'",
+  "base-uri 'self'",
+  // OAuth consent form-POSTs back to /api/mcp/authorize/consent which then
+  // returns a 302 redirect to the registered native-app callback URI. CSP
+  // form-action constrains BOTH the form target AND any subsequent 302 in
+  // the redirect chain, so every loopback host accepted by DCR's
+  // LOOPBACK_REDIRECT_RE (see src/lib/constants/auth/mcp.ts) MUST be listed
+  // here — otherwise the consent flow appears to succeed but the browser
+  // blocks the final redirect after the audit log has already been written.
+  //
+  // RFC 8252 §7.3 mandates the loopback IP literal forms (127.0.0.1, [::1])
+  // and "MUST allow any port"; §8.3 marks `localhost` as NOT RECOMMENDED but
+  // real OAuth clients (Claude Code, Claude Desktop) use it, so we keep it.
+  // Loopback is local-only — these wildcards do not widen the network attack
+  // surface.
+  "form-action 'self' http://localhost:* http://127.0.0.1:* http://[::1]:*",
+  "frame-ancestors 'none'",
+  "upgrade-insecure-requests",
+  "report-to csp-endpoint",
+  `report-uri ${_reportUri}`,
+].join("; ");
+
+export function buildCspHeader(nonce: string): string {
+  // Dev mode: 'unsafe-inline' + 'unsafe-eval' (no nonce, no strict-dynamic).
+  //   Necessary because Next.js HMR, Turbopack dev overlay, and React Fast Refresh
+  //   inject inline scripts that cannot receive the per-request CSP nonce.
+  //   This is the standard Next.js dev CSP configuration.
+  // Strict mode: per-request nonce + 'strict-dynamic'.
+  //   Inline scripts without the nonce are blocked. 'unsafe-eval' is intentionally
+  //   NOT included even when strict mode is selected via CSP_MODE=strict in a
+  //   non-prod NODE_ENV — strict mode approximates prod CSP and prod has no
+  //   need for 'unsafe-eval' (Turbopack dev overlay uses eval() and will be
+  //   blocked, but in that case the caller should use dev mode instead).
+  const scriptSrc = _cspMode === "dev"
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'"
+    : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'wasm-unsafe-eval'`;
+  const styleSrc = _cspMode === "dev"
+    ? _stylePrefix
+    : `${_stylePrefix}${nonce}${_styleSuffix}`;
+  return `default-src 'self'; ${scriptSrc}; ${styleSrc}; ${_staticDirectives}`;
+}


### PR DESCRIPTION
## Summary

Resolve **S2** from the [PR #398 review log](docs/archive/review/csrf-admin-token-cache-review.md) — closing two surface inconsistencies that surfaced during the design investigation.

- **CSP \`form-action\`** now lists \`http://[::1]:*\` alongside \`http://localhost:*\` and \`http://127.0.0.1:*\`. DCR's \`LOOPBACK_REDIRECT_RE\` already accepted \`[::1]\` redirect URIs, but CSP didn't — IPv6-loopback OAuth clients silently failed at the consent-form 302 redirect (after the audit log was already written).
- **Manual MCP client management** (\`POST/PUT /api/tenant/mcp-clients[/...]\`) now accepts the same loopback host set as DCR (\`localhost\`, \`127.0.0.1\`, \`[::1]\`). Previously only \`localhost\` was accepted via the manual path, so admins couldn't register what DCR could.
- **Single source of truth**: \`LOOPBACK_REDIRECT_RE\` extracted to \`src/lib/constants/auth/mcp.ts\` and consumed by DCR, manual POST, manual PUT, and the frontend validator (\`mcp-client-card.tsx\`). The CSP \`form-action\` directive in \`csp-builder.ts\` mirrors the same host set with cross-referencing comments on both sides.
- **\`buildCspHeader\` extracted** to \`src/lib/security/csp-builder.ts\` so the CSP regression test can pin all three loopback host literals without pulling in the full Next.js / next-intl middleware import chain. Behavior-preserving extraction.

## Background

This is **S2** + the related **B1/B2/B3** issues from the residual PR #398 review. Phase 1 plan + 2-round expert review and Phase 3 code review:

- [csp-form-action-loopback-scoping-plan.md](docs/archive/review/csp-form-action-loopback-scoping-plan.md)
- [csp-form-action-loopback-scoping-review.md](docs/archive/review/csp-form-action-loopback-scoping-review.md)
- [csp-form-action-loopback-scoping-code-review.md](docs/archive/review/csp-form-action-loopback-scoping-code-review.md)

RFC 8252 §7.3 and §8.3 citations were verified against \`https://www.rfc-editor.org/rfc/rfc8252.html\` during Phase 2 Step 2-1.

## Test plan

- [x] 74 targeted tests pass (DCR / Manual POST+PUT / CSP regression / frontend / audit-emit)
- [x] CSP regression test pins all three loopback host literals: \`localhost:*\`, \`127.0.0.1:*\`, \`[::1]:*\` (false-negative resistant)
- [x] \`bash scripts/pre-pr.sh\` (12/12 checks pass)
- [x] \`npx next build\` succeeds
- [x] Phase 3 review (3 experts, no code findings — only a pre-commit \`git add\` issue caught and fixed)

## Notes for reviewer

- Loopback IPs are not routable from outside the user's machine; the CSP wildcard widening does NOT broaden the network attack surface.
- Open redirect remains gated server-side by \`foundClient.redirectUris.includes(redirectUri)\` at \`/api/mcp/authorize/consent\` — the schema-acceptance widening only changes which URIs an admin can register, not which redirects are followed at consent time.
- \`cli/src/lib/oauth.ts\` (project CLI) uses \`http://127.0.0.1:\${port}/callback\`. No CLI change needed; the existing positive test for \`127.0.0.1\` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)