### PR TITLE
fix(cache): TTL sweep before FIFO fallback in policy and session timeout caches

### DIFF
--- a/src/lib/auth/policy/access-restriction.test.ts
+++ b/src/lib/auth/policy/access-restriction.test.ts
@@ -40,7 +40,12 @@ vi.mock("@/lib/tenant-context", () => ({
   resolveUserTenantId: vi.fn(),
 }));
 
-import { checkAccessRestrictionWithAudit, _clearPolicyCache } from "@/lib/auth/policy/access-restriction";
+import {
+  checkAccessRestrictionWithAudit,
+  _clearPolicyCache,
+  _policyCache,
+  _POLICY_CACHE_MAX_SIZE,
+} from "@/lib/auth/policy/access-restriction";
 import { NextRequest } from "next/server";
 
 describe("checkAccessRestrictionWithAudit — sentinel fallback", () => {
@@ -74,5 +79,74 @@ describe("checkAccessRestrictionWithAudit — sentinel fallback", () => {
         tenantId: "tenant-1",
       }),
     );
+  });
+});
+
+describe("policyCache eviction — TTL sweep before FIFO", () => {
+  beforeEach(() => {
+    _clearPolicyCache();
+  });
+
+  it("evicts expired entries first when the cache fills, preserving fresh entries", async () => {
+    // Pre-fill the cache to capacity. Mark every odd-indexed entry as
+    // already expired; even-indexed entries remain fresh. With pure FIFO
+    // eviction the head ("expired-0") would still be evicted as oldest by
+    // insertion order even when other expired entries are deeper in the
+    // map — so this test passes trivially under either FIFO or sweep.
+    // The interesting assertion is the second one: after the sweep fires
+    // it should remove ALL expired entries, leaving the fresh ones intact.
+    const now = Date.now();
+    for (let i = 0; i < _POLICY_CACHE_MAX_SIZE; i++) {
+      _policyCache.set(`tenant-${i}`, {
+        policy: {
+          allowedCidrs: [],
+          tailscaleEnabled: false,
+          tailscaleTailnet: null,
+        },
+        // Half expired, half fresh — interleaved so the FIFO head is fresh.
+        expiresAt: i % 2 === 0 ? now + 60_000 : now - 1,
+      });
+    }
+    expect(_policyCache.size).toBe(_POLICY_CACHE_MAX_SIZE);
+
+    // Trigger the eviction path by calling the route through one fresh
+    // tenant fetch. The eviction is inline in getTenantAccessPolicy, so we
+    // call its public consumer.
+    const req = new NextRequest("http://localhost/api/test");
+    await checkAccessRestrictionWithAudit("tenant-new", "1.2.3.4", "user-x", req);
+
+    // After the TTL sweep, every expired entry (odd indices) is gone; the
+    // fresh entries (even indices) survive. Plus the newly-inserted entry.
+    expect(_policyCache.has("tenant-new")).toBe(true);
+    for (let i = 0; i < _POLICY_CACHE_MAX_SIZE; i++) {
+      if (i % 2 === 0) {
+        expect(_policyCache.has(`tenant-${i}`)).toBe(true);
+      } else {
+        expect(_policyCache.has(`tenant-${i}`)).toBe(false);
+      }
+    }
+  });
+
+  it("falls back to FIFO when every entry is fresh", async () => {
+    const now = Date.now();
+    for (let i = 0; i < _POLICY_CACHE_MAX_SIZE; i++) {
+      _policyCache.set(`tenant-${i}`, {
+        policy: {
+          allowedCidrs: [],
+          tailscaleEnabled: false,
+          tailscaleTailnet: null,
+        },
+        expiresAt: now + 60_000,
+      });
+    }
+    expect(_policyCache.size).toBe(_POLICY_CACHE_MAX_SIZE);
+
+    const req = new NextRequest("http://localhost/api/test");
+    await checkAccessRestrictionWithAudit("tenant-new", "1.2.3.4", "user-x", req);
+
+    // All fresh → TTL sweep deletes nothing → FIFO fallback evicts head ("tenant-0").
+    expect(_policyCache.has("tenant-0")).toBe(false);
+    expect(_policyCache.has("tenant-new")).toBe(true);
+    expect(_policyCache.size).toBe(_POLICY_CACHE_MAX_SIZE);
   });
 });

--- a/src/lib/auth/policy/access-restriction.ts
+++ b/src/lib/auth/policy/access-restriction.ts
@@ -46,10 +46,20 @@ async function getTenantAccessPolicy(
   }
   if (cached) policyCache.delete(tenantId);
 
-  // Evict oldest entry when cache is full (Map iterates in insertion order)
+  // Cache full: evict expired entries first (TTL sweep), then fall back to
+  // FIFO oldest only if every entry is still fresh. This avoids the bug
+  // where a hot but TTL-fresh entry sits at the head of insertion order
+  // and gets evicted before less-active entries that happened to be
+  // inserted later. Mirrors the pattern in `src/lib/proxy/auth-gate.ts`.
   if (policyCache.size >= POLICY_CACHE_MAX_SIZE) {
-    const oldest = policyCache.keys().next().value;
-    if (oldest !== undefined) policyCache.delete(oldest);
+    const now = Date.now();
+    for (const [k, v] of policyCache) {
+      if (v.expiresAt <= now) policyCache.delete(k);
+    }
+    if (policyCache.size >= POLICY_CACHE_MAX_SIZE) {
+      const oldest = policyCache.keys().next().value;
+      if (oldest !== undefined) policyCache.delete(oldest);
+    }
   }
 
   const tenant = await withBypassRls(prisma, async () =>
@@ -282,3 +292,8 @@ export async function enforceAccessRestriction(
 export function _clearPolicyCache(): void {
   policyCache.clear();
 }
+
+/** @internal Direct access to the policy cache for eviction-behavior tests. */
+export const _policyCache = policyCache;
+/** @internal Cache size cap for eviction-behavior tests. */
+export const _POLICY_CACHE_MAX_SIZE = POLICY_CACHE_MAX_SIZE;

--- a/src/lib/auth/session/session-timeout.test.ts
+++ b/src/lib/auth/session/session-timeout.test.ts
@@ -215,3 +215,58 @@ describe("invalidateSessionTimeoutCacheForTenant", () => {
     expect(_internal.cache.get("user-tenant-b")).toBeDefined();
   });
 });
+
+describe("session timeout cache eviction — TTL sweep before FIFO", () => {
+  beforeEach(() => {
+    _internal.clear();
+    mockFindUnique.mockReset();
+  });
+
+  it("evicts expired entries first when the cache fills, preserving fresh entries", async () => {
+    const now = Date.now();
+    // Pre-fill the cache to capacity. Half expired, half fresh, interleaved.
+    for (let i = 0; i < _internal.MAX_SIZE; i++) {
+      _internal.cache.set(`user-${i}`, {
+        idleMinutes: 30,
+        absoluteMinutes: 480,
+        tenantId: `tenant-${i % 5}`,
+        expiresAt: i % 2 === 0 ? now + 60_000 : now - 1,
+      });
+    }
+    expect(_internal.cache.size).toBe(_internal.MAX_SIZE);
+
+    // New user fetch triggers eviction path
+    seedUser({ tenantIdle: 60, tenantAbsolute: 600 });
+    await resolveEffectiveSessionTimeouts("user-new", null);
+
+    expect(_internal.cache.has("user-new")).toBe(true);
+    // After TTL sweep, all expired (odd-indexed) entries are gone; fresh
+    // (even-indexed) entries survive. The fresh head ("user-0") was NOT
+    // evicted as a FIFO casualty.
+    expect(_internal.cache.has("user-0")).toBe(true);
+    expect(_internal.cache.has("user-1")).toBe(false);
+    expect(_internal.cache.has("user-2")).toBe(true);
+    expect(_internal.cache.has("user-3")).toBe(false);
+  });
+
+  it("falls back to FIFO when every entry is fresh", async () => {
+    const now = Date.now();
+    for (let i = 0; i < _internal.MAX_SIZE; i++) {
+      _internal.cache.set(`user-${i}`, {
+        idleMinutes: 30,
+        absoluteMinutes: 480,
+        tenantId: `tenant-${i % 5}`,
+        expiresAt: now + 60_000,
+      });
+    }
+    expect(_internal.cache.size).toBe(_internal.MAX_SIZE);
+
+    seedUser({ tenantIdle: 60, tenantAbsolute: 600 });
+    await resolveEffectiveSessionTimeouts("user-new", null);
+
+    // All fresh → sweep no-op → FIFO evicts head (user-0).
+    expect(_internal.cache.has("user-0")).toBe(false);
+    expect(_internal.cache.has("user-new")).toBe(true);
+    expect(_internal.cache.size).toBe(_internal.MAX_SIZE);
+  });
+});

--- a/src/lib/auth/session/session-timeout.ts
+++ b/src/lib/auth/session/session-timeout.ts
@@ -22,6 +22,7 @@ const cache = new Map<string, CacheEntry>();
 export const _internal = {
   cache,
   clear: () => cache.clear(),
+  MAX_SIZE: SESSION_TIMEOUT_CACHE_MAX_SIZE,
 };
 
 export interface ResolvedSessionTimeouts {
@@ -122,9 +123,20 @@ export async function resolveEffectiveSessionTimeouts(
     expiresAt: Date.now() + SESSION_TIMEOUT_CACHE_TTL_MS,
   };
 
+  // Cache full: evict expired entries first (TTL sweep), then fall back to
+  // FIFO oldest only if every entry is still fresh. This avoids the bug
+  // where a hot but TTL-fresh entry sits at the head of insertion order
+  // and gets evicted before less-active entries that happened to be
+  // inserted later. Mirrors the pattern in `src/lib/proxy/auth-gate.ts`.
   if (cache.size >= SESSION_TIMEOUT_CACHE_MAX_SIZE) {
-    const oldest = cache.keys().next().value;
-    if (oldest !== undefined) cache.delete(oldest);
+    const now = Date.now();
+    for (const [k, v] of cache) {
+      if (v.expiresAt <= now) cache.delete(k);
+    }
+    if (cache.size >= SESSION_TIMEOUT_CACHE_MAX_SIZE) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) cache.delete(oldest);
+    }
   }
   cache.set(userId, resolved);
 


### PR DESCRIPTION
## Summary

R3 propagation finding from the [PR #404 code review](docs/archive/review/passkey-audit-staleness-eviction-code-review.md). Two TTL-bounded caches used pure FIFO eviction: a hot but still-fresh entry inserted early sat at the head and could be evicted before less-active recently-inserted entries.

The pattern that was already correct in [\`src/lib/proxy/auth-gate.ts:128-145\`](src/lib/proxy/auth-gate.ts#L128) — TTL sweep first, FIFO fallback only when every entry is still fresh — is now applied to the two missing sites:

- \`src/lib/auth/policy/access-restriction.ts\` (POLICY_CACHE_MAX_SIZE=1000, TTL=60s)
- \`src/lib/auth/session/session-timeout.ts\` (SESSION_TIMEOUT_CACHE_MAX_SIZE=10000, TTL=60s)

## Why this is the right fix (vs LRU-on-hit)

- The cache hit path runs on every protected request — adding a delete-then-set per hit (LRU-on-hit) is overhead on a hot path.
- The eviction event runs only when the cache fills — O(N) sweep amortized across many fast hits.
- TTL sweep is semantically correct for time-bounded caches: expired entries are evicted preferentially because they were going to expire anyway; fresh entries with future demand survive.
- Consistent with the established \`auth-gate.ts\` pattern.

## Test plan

- [x] 4 new tests covering both caches: (a) interleaved fresh+expired pre-fill — sweep removes all expired, fresh entries survive (this is the FIFO bug fix); (b) all fresh — sweep is a no-op, FIFO evicts the head (regression guard for the fallback path).
- [x] All 20 targeted tests pass (4 new + 16 existing in session-timeout, 4 in access-restriction).
- [x] \`bash scripts/pre-pr.sh\` (11/11 checks pass).
- [x] \`npx next build\` succeeds.

## Notes for reviewer

- **Future opportunity**: the two-pass eviction is now duplicated across three sites (\`auth-gate.ts\`, \`access-restriction.ts\`, \`session-timeout.ts\`). A shared \`evictExpiredOrOldest(map, maxSize)\` helper would DRY this. Deferred to keep this PR focused on the bug fix; tracked as a separate refactor.
- Behavior is unchanged for any cache that fills with all-fresh entries. The change is observable only when the cache contains a mix of fresh and expired entries at the moment a new insert hits the size cap — which is the exact scenario this PR is fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)