### PR TITLE
fix(maintenance): scope op_* token routes to issuer tenant

### DIFF
--- a/docs/operations/admin-tokens.md
+++ b/docs/operations/admin-tokens.md
@@ -26,6 +26,20 @@ Pre-condition: a session-authenticated tenant OWNER or ADMIN. The session must h
 
 After closing the modal, the dashboard shows the token's prefix, expiry, and last-used time — but never the plaintext again. If you lose the plaintext, mint a new token and revoke the old one.
 
+## Scope: tenant-bound, not system-wide
+
+Every `op_*` token is bound to the issuer's `tenantId`. The maintenance routes
+(`purge-history`, `purge-audit-logs`, `audit-outbox-purge-failed`,
+`audit-chain-verify`) operate **only** on rows whose `tenant_id` matches the
+token. Cross-tenant attempts (e.g. supplying another tenant's UUID in
+`audit-outbox-purge-failed`'s body) are rejected with 403, not silently scoped.
+
+If you operate a deployment that hosts multiple tenants and need to run
+maintenance against more than one, mint a token in each target tenant and run
+the script per-token. There is no single token that can purge across tenants —
+this is intentional, to ensure a leaked token cannot be used as a cross-tenant
+anti-forensics or data-destruction vector.
+
 ## Usage
 
 ```bash
@@ -65,10 +79,11 @@ curl -X POST -H "Authorization: Bearer $ADMIN_API_TOKEN" \
 curl -H "Authorization: Bearer $ADMIN_API_TOKEN" \
   "$APP_URL/api/maintenance/audit-outbox-metrics"
 
-# Outbox purge of FAILED rows (optionally filter by tenant or age)
+# Outbox purge of FAILED rows for the operator-token's tenant (optional age filter)
+# tenantId, when provided, must equal the token's bound tenantId — cross-tenant attempts return 403.
 curl -X POST -H "Authorization: Bearer $ADMIN_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"tenantId":"<uuid>","olderThanDays":7}' \
+  -d '{"olderThanDays":7}' \
   "$APP_URL/api/maintenance/audit-outbox-purge-failed"
 
 # Audit chain verify

--- a/docs/operations/admin-tokens.md
+++ b/docs/operations/admin-tokens.md
@@ -30,9 +30,12 @@ After closing the modal, the dashboard shows the token's prefix, expiry, and las
 
 Every `op_*` token is bound to the issuer's `tenantId`. The maintenance routes
 (`purge-history`, `purge-audit-logs`, `audit-outbox-purge-failed`,
-`audit-chain-verify`) operate **only** on rows whose `tenant_id` matches the
-token. Cross-tenant attempts (e.g. supplying another tenant's UUID in
-`audit-outbox-purge-failed`'s body) are rejected with 403, not silently scoped.
+`audit-outbox-metrics`, `audit-chain-verify`) operate **only** on rows whose
+`tenant_id` matches the token. Cross-tenant attempts (e.g. supplying another
+tenant's UUID in `audit-outbox-purge-failed`'s body) are rejected with 403,
+not silently scoped. `audit-outbox-metrics` returns aggregates only for the
+token's own tenant — queue depth and failure counts of other tenants are not
+exposed.
 
 If you operate a deployment that hosts multiple tenants and need to run
 maintenance against more than one, mint a token in each target tenant and run
@@ -75,7 +78,7 @@ For routes without a dedicated script (`dcr-cleanup`, `audit-outbox-metrics`, `a
 curl -X POST -H "Authorization: Bearer $ADMIN_API_TOKEN" \
   "$APP_URL/api/maintenance/dcr-cleanup"
 
-# Outbox metrics (cross-tenant aggregates)
+# Outbox metrics for the operator-token's tenant
 curl -H "Authorization: Bearer $ADMIN_API_TOKEN" \
   "$APP_URL/api/maintenance/audit-outbox-metrics"
 

--- a/docs/operations/audit-log-forwarding.md
+++ b/docs/operations/audit-log-forwarding.md
@@ -16,7 +16,7 @@ Route handler
 2. **audit-outbox-worker** (`npm run worker:audit-outbox`) drains `PENDING` rows from `audit_outbox` into `audit_logs`. The worker must be running for audit events to appear in `audit_logs`. Without it, events accumulate in `audit_outbox` indefinitely.
 
 **Monitoring outbox health:**
-- `GET /api/maintenance/audit-outbox-metrics` (requires `op_*` Bearer token) — returns cross-tenant aggregates (pending count, failed count, oldest pending row age).
+- `GET /api/maintenance/audit-outbox-metrics` (requires `op_*` Bearer token) — returns aggregates (pending count, failed count, oldest pending row age) scoped to the operator-token's bound tenant. Multi-tenant operators query each tenant separately via its own token.
 - `POST /api/maintenance/audit-outbox-purge-failed` (requires `op_*` Bearer token) — purges FAILED rows for the operator-token's bound tenant. The optional `tenantId` body field, when provided, must match the token's tenantId; cross-tenant attempts return 403. `olderThanDays` is an optional age filter.
 
 ## Overview

--- a/docs/operations/audit-log-forwarding.md
+++ b/docs/operations/audit-log-forwarding.md
@@ -17,7 +17,7 @@ Route handler
 
 **Monitoring outbox health:**
 - `GET /api/maintenance/audit-outbox-metrics` (requires `op_*` Bearer token) — returns cross-tenant aggregates (pending count, failed count, oldest pending row age).
-- `POST /api/maintenance/audit-outbox-purge-failed` (requires `op_*` Bearer token) — purges FAILED rows, optionally filtered by `tenantId` and `olderThanDays`.
+- `POST /api/maintenance/audit-outbox-purge-failed` (requires `op_*` Bearer token) — purges FAILED rows for the operator-token's bound tenant. The optional `tenantId` body field, when provided, must match the token's tenantId; cross-tenant attempts return 403. `olderThanDays` is an optional age filter.
 
 ## Overview
 

--- a/src/app/api/maintenance/audit-outbox-metrics/route.test.ts
+++ b/src/app/api/maintenance/audit-outbox-metrics/route.test.ts
@@ -54,7 +54,7 @@ import { OPERATOR_TOKEN_PREFIX } from "@/lib/constants/auth/operator-token";
 
 const SUBJECT_USER_ID = "660e8400-e29b-41d4-a716-446655440001";
 const TOKEN_ID = "op-token-id-1";
-const TENANT_ID = "tenant-1";
+const TENANT_ID = "550e8400-e29b-41d4-a716-446655440001";
 
 const VALID_OP_TOKEN = `${OPERATOR_TOKEN_PREFIX}${"a".repeat(43)}`;
 
@@ -160,6 +160,22 @@ describe("GET /api/maintenance/audit-outbox-metrics", () => {
     expect(typeof body.asOf).toBe("string");
   });
 
+  it("scopes the SQL aggregate to the operator-token's tenantId", async () => {
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+
+    const req = createRequest(VALID_OP_TOKEN);
+    await GET(req);
+
+    // Tagged template: [strings, ...values]. The only interpolated value is
+    // auth.tenantId, used in the SQL WHERE clause. Without it, every tenant's
+    // queue depth and failure counts leak through this endpoint.
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+    const queryArgs = mockQueryRaw.mock.calls[0];
+    expect(queryArgs.slice(1)).toContain(TENANT_ID);
+    const sqlStrings = queryArgs[0] as string[];
+    expect(sqlStrings.join("")).toMatch(/WHERE\s+tenant_id\s*=/);
+  });
+
   it("returns zeros when query result row is empty", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
     mockQueryRaw.mockResolvedValue([{}]);
@@ -192,6 +208,7 @@ describe("GET /api/maintenance/audit-outbox-metrics", () => {
         metadata: expect.objectContaining({
           tokenSubjectUserId: SUBJECT_USER_ID,
           tokenId: TOKEN_ID,
+          scopedTenantId: TENANT_ID,
           pending: 5,
           failed: 2,
         }),

--- a/src/app/api/maintenance/audit-outbox-metrics/route.ts
+++ b/src/app/api/maintenance/audit-outbox-metrics/route.ts
@@ -1,7 +1,10 @@
 /**
  * GET /api/maintenance/audit-outbox-metrics
  *
- * Returns global (cross-tenant) outbox aggregates for infrastructure operators.
+ * Returns outbox aggregates scoped to the operator-token's bound tenantId.
+ * Cross-tenant aggregates are intentionally not exposed: a tenant admin's
+ * token must not reveal queue depth, failure counts, or oldest-pending age
+ * for another tenant. Multi-tenant operators mint a token per tenant.
  * Authenticated via per-operator op_* token (mint via /dashboard/tenant/operator-tokens).
  */
 
@@ -44,6 +47,9 @@ async function handleGET(req: NextRequest) {
   });
   if (!op.ok) return op.response;
 
+  // Scope aggregates to the operator-token's bound tenant. Without the
+  // WHERE filter, queue depth and failure counts of every other tenant
+  // leak through this endpoint.
   const rows = await withBypassRls(prisma, async () =>
     prisma.$queryRaw<MetricsRow[]>`
       SELECT
@@ -57,6 +63,7 @@ async function handleGET(req: NextRequest) {
         COUNT(*) FILTER (WHERE status = 'FAILED' AND attempt_count >= max_attempts)
           AS dead_letter_count
       FROM audit_outbox
+      WHERE tenant_id = ${auth.tenantId}::uuid
     `,
   BYPASS_PURPOSE.SYSTEM_MAINTENANCE);
 
@@ -78,6 +85,7 @@ async function handleGET(req: NextRequest) {
     metadata: {
       tokenSubjectUserId: auth.subjectUserId,
       tokenId: auth.tokenId,
+      scopedTenantId: auth.tenantId,
       pending: metrics.pending,
       failed: metrics.failed,
     },

--- a/src/app/api/maintenance/audit-outbox-purge-failed/route.test.ts
+++ b/src/app/api/maintenance/audit-outbox-purge-failed/route.test.ts
@@ -54,7 +54,7 @@ import { OPERATOR_TOKEN_PREFIX } from "@/lib/constants/auth/operator-token";
 
 const SUBJECT_USER_ID = "660e8400-e29b-41d4-a716-446655440001";
 const TOKEN_ID = "op-token-id-1";
-const TENANT_ID = "tenant-1";
+const TENANT_ID = "550e8400-e29b-41d4-a716-446655440001";
 const FILTER_TENANT_ID = "550e8400-e29b-41d4-a716-446655440002";
 
 const VALID_OP_TOKEN = `${OPERATOR_TOKEN_PREFIX}${"a".repeat(43)}`;
@@ -161,16 +161,28 @@ describe("POST /api/maintenance/audit-outbox-purge-failed", () => {
     expect(body.purged).toBe(0);
   });
 
-  it("accepts body with tenantId filter and returns 200", async () => {
+  it("accepts body.tenantId only when it matches the auth token's tenantId", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
     mockQueryRaw.mockResolvedValue([{ purged: BigInt(4) }]);
 
-    const req = createRequest({ tenantId: FILTER_TENANT_ID }, VALID_OP_TOKEN);
+    const req = createRequest({ tenantId: TENANT_ID }, VALID_OP_TOKEN);
     const res = await POST(req);
     expect(res.status).toBe(200);
 
     const body = await res.json();
     expect(body.purged).toBe(4);
+  });
+
+  it("rejects body.tenantId that does not match the auth token's tenantId with 403", async () => {
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+
+    const req = createRequest({ tenantId: FILTER_TENANT_ID }, VALID_OP_TOKEN);
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+
+    // Cross-tenant attempts must NOT reach the delete query or audit log.
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+    expect(mockLogAudit).not.toHaveBeenCalled();
   });
 
   it("accepts body with olderThanDays filter and returns 200", async () => {
@@ -185,11 +197,11 @@ describe("POST /api/maintenance/audit-outbox-purge-failed", () => {
     expect(body.purged).toBe(2);
   });
 
-  it("accepts body with both tenantId and olderThanDays filters and returns 200", async () => {
+  it("accepts body with matching tenantId and olderThanDays filters and returns 200", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
     mockQueryRaw.mockResolvedValue([{ purged: BigInt(1) }]);
 
-    const req = createRequest({ tenantId: FILTER_TENANT_ID, olderThanDays: 7 }, VALID_OP_TOKEN);
+    const req = createRequest({ tenantId: TENANT_ID, olderThanDays: 7 }, VALID_OP_TOKEN);
     const res = await POST(req);
     expect(res.status).toBe(200);
 
@@ -203,7 +215,7 @@ describe("POST /api/maintenance/audit-outbox-purge-failed", () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
     mockQueryRaw.mockResolvedValue([{ purged: BigInt(6) }]);
 
-    const req = createRequest({ tenantId: FILTER_TENANT_ID, olderThanDays: 14 }, VALID_OP_TOKEN);
+    const req = createRequest({ tenantId: TENANT_ID, olderThanDays: 14 }, VALID_OP_TOKEN);
     await POST(req);
 
     expect(mockLogAudit).toHaveBeenCalledWith(
@@ -217,19 +229,20 @@ describe("POST /api/maintenance/audit-outbox-purge-failed", () => {
           tokenSubjectUserId: SUBJECT_USER_ID,
           tokenId: TOKEN_ID,
           purgedCount: 6,
-          filterTenantId: FILTER_TENANT_ID,
+          scopedTenantId: TENANT_ID,
           olderThanDays: 14,
         }),
       }),
     );
 
-    // Strict shape: legacy fields must not appear
+    // Strict shape: legacy / mis-implying fields must not appear
     const metadata = mockLogAudit.mock.calls[0][0].metadata;
     expect(metadata.operatorId).toBeUndefined();
     expect(metadata.authPath).toBeUndefined();
+    expect(metadata.filterTenantId).toBeUndefined();
   });
 
-  it("logs audit with null filters when no body filters provided", async () => {
+  it("logs audit with scopedTenantId when no body filters provided", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
     mockQueryRaw.mockResolvedValue([{ purged: BigInt(0) }]);
 
@@ -239,10 +252,36 @@ describe("POST /api/maintenance/audit-outbox-purge-failed", () => {
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: expect.objectContaining({
-          filterTenantId: null,
+          scopedTenantId: TENANT_ID,
           olderThanDays: null,
         }),
       }),
     );
+  });
+
+  // ─── Tenant Isolation ─────────────────────────────────────
+
+  it("a tenant-A operator token cannot purge another tenant's FAILED rows even via empty body", async () => {
+    const TENANT_A = "550e8400-e29b-41d4-a716-44665544000a";
+    mockVerifyAdminToken.mockResolvedValue({
+      ok: true,
+      auth: { ...VALID_AUTH, tenantId: TENANT_A },
+    });
+    mockRequireMaintenanceOperator.mockResolvedValue({
+      ok: true,
+      operator: { tenantId: TENANT_A, role: "ADMIN" },
+    });
+    mockQueryRaw.mockResolvedValue([{ purged: BigInt(0) }]);
+
+    const req = createRequest({}, VALID_OP_TOKEN);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // The raw SQL DELETE must be parameterized with TENANT_A as the tenant
+    // filter — never null/all-tenant. Inspect the tagged template values.
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+    const queryArgs = mockQueryRaw.mock.calls[0];
+    // Tagged template: [strings, ...values]
+    expect(queryArgs.slice(1)).toContain(TENANT_A);
   });
 });

--- a/src/app/api/maintenance/audit-outbox-purge-failed/route.ts
+++ b/src/app/api/maintenance/audit-outbox-purge-failed/route.ts
@@ -1,11 +1,13 @@
 /**
  * POST /api/maintenance/audit-outbox-purge-failed
  *
- * Operator-driven explicit purge of FAILED outbox rows.
+ * Operator-driven explicit purge of FAILED outbox rows for the operator-token's
+ * bound tenant. Cross-tenant purge is rejected (403); the optional `tenantId`
+ * body field exists only for explicitness and MUST equal the token's tenantId.
  * Authenticated via per-operator op_* token (mint via /dashboard/tenant/operator-tokens).
  *
  * Body: { tenantId?: string, olderThanDays?: number }
- *   tenantId — optional filter (which tenant's failed rows to purge)
+ *   tenantId — optional, must match the operator-token's tenantId when provided
  *   olderThanDays — optional age filter
  */
 
@@ -20,7 +22,8 @@ import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { requireMaintenanceOperator } from "@/lib/auth/access/maintenance-auth";
 import { withRequestLog } from "@/lib/http/with-request-log";
-import { rateLimited, unauthorized } from "@/lib/http/api-response";
+import { errorResponse, rateLimited, unauthorized } from "@/lib/http/api-response";
+import { API_ERROR } from "@/lib/http/api-error-codes";
 
 const rateLimiter = createRateLimiter({ windowMs: 60_000, max: 1 });
 
@@ -46,12 +49,20 @@ async function handlePOST(req: NextRequest) {
 
   const { tenantId: filterTenantId, olderThanDays } = result.data;
 
+  // Operator-token boundary: a token is bound to a single tenant. Reject
+  // cross-tenant purge requests; multi-tenant operators must mint a separate
+  // token per tenant. Body-supplied tenantId is accepted only as an explicit
+  // restatement of auth.tenantId — never as a way to target another tenant.
+  if (filterTenantId !== undefined && filterTenantId !== auth.tenantId) {
+    return errorResponse(API_ERROR.FORBIDDEN, 403);
+  }
+
   const op = await requireMaintenanceOperator(auth.subjectUserId, {
     tenantId: auth.tenantId,
   });
   if (!op.ok) return op.response;
 
-  const tenantFilter = filterTenantId ?? null;
+  const tenantFilter = auth.tenantId;
   const daysFilter = olderThanDays ?? null;
 
   const rows = await withBypassRls(
@@ -61,7 +72,7 @@ async function handlePOST(req: NextRequest) {
         WITH deleted AS (
           DELETE FROM audit_outbox
           WHERE status = 'FAILED'
-            AND (${tenantFilter}::uuid IS NULL OR tenant_id = ${tenantFilter}::uuid)
+            AND tenant_id = ${tenantFilter}::uuid
             AND (${daysFilter}::int IS NULL OR created_at < now() - make_interval(days => ${daysFilter}::int))
           RETURNING id
         ) SELECT COUNT(*) AS purged FROM deleted
@@ -79,7 +90,7 @@ async function handlePOST(req: NextRequest) {
       tokenSubjectUserId: auth.subjectUserId,
       tokenId: auth.tokenId,
       purgedCount: purged,
-      filterTenantId: filterTenantId ?? null,
+      scopedTenantId: auth.tenantId,
       olderThanDays: olderThanDays ?? null,
     },
   });

--- a/src/app/api/maintenance/purge-audit-logs/route.test.ts
+++ b/src/app/api/maintenance/purge-audit-logs/route.test.ts
@@ -6,7 +6,7 @@ const {
   mockDeleteMany,
   mockCount,
   mockRequireMaintenanceOperator,
-  mockTenantFindMany,
+  mockTenantFindUnique,
   mockCheck,
   mockLogAudit,
   mockWithBypassRls,
@@ -15,7 +15,7 @@ const {
   mockDeleteMany: vi.fn(),
   mockCount: vi.fn(),
   mockRequireMaintenanceOperator: vi.fn(),
-  mockTenantFindMany: vi.fn(),
+  mockTenantFindUnique: vi.fn(),
   mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
   mockLogAudit: vi.fn(),
   mockWithBypassRls: vi.fn(
@@ -29,7 +29,7 @@ vi.mock("@/lib/auth/tokens/admin-token", () => ({
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     auditLog: { deleteMany: mockDeleteMany, count: mockCount },
-    tenant: { findMany: mockTenantFindMany },
+    tenant: { findUnique: mockTenantFindUnique },
   },
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
@@ -95,7 +95,7 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
       ok: true,
       operator: { tenantId: TENANT_ID, role: "ADMIN" },
     });
-    mockTenantFindMany.mockResolvedValue([{ id: TENANT_ID, auditLogRetentionDays: null }]);
+    mockTenantFindUnique.mockResolvedValue({ auditLogRetentionDays: null });
     mockDeleteMany.mockResolvedValue({ count: 0 });
     mockCount.mockResolvedValue(0);
   });
@@ -157,27 +157,43 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
 
   // ─── Purge Success ────────────────────────────────────────
 
-  it("purges audit log entries per-tenant and returns total count", async () => {
+  it("purges audit log entries for the operator's tenant only and returns count", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockTenantFindMany.mockResolvedValue([
-      { id: "tenant-1", auditLogRetentionDays: null },
-      { id: "tenant-2", auditLogRetentionDays: null },
-    ]);
-    mockDeleteMany
-      .mockResolvedValueOnce({ count: 20 })
-      .mockResolvedValueOnce({ count: 10 });
+    mockTenantFindUnique.mockResolvedValue({ auditLogRetentionDays: null });
+    mockDeleteMany.mockResolvedValueOnce({ count: 20 });
 
     const req = createRequest({}, VALID_OP_TOKEN);
     const res = await POST(req);
     expect(res.status).toBe(200);
 
     const body = await res.json();
-    expect(body.purged).toBe(30);
+    expect(body.purged).toBe(20);
+
+    // Tenant lookup must use the auth token's tenantId (not findMany).
+    expect(mockTenantFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: TENANT_ID } }),
+    );
+    // The single deleteMany must include tenantId = auth.tenantId.
+    expect(mockDeleteMany).toHaveBeenCalledTimes(1);
+    expect(mockDeleteMany.mock.calls[0][0].where.tenantId).toBe(TENANT_ID);
+  });
+
+  it("returns 0 when the bound tenant no longer exists", async () => {
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+    mockTenantFindUnique.mockResolvedValue(null);
+
+    const req = createRequest({}, VALID_OP_TOKEN);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.purged).toBe(0);
+    expect(mockDeleteMany).not.toHaveBeenCalled();
   });
 
   it("uses default retentionDays of 365", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockTenantFindMany.mockResolvedValue([{ id: TENANT_ID, auditLogRetentionDays: null }]);
+    mockTenantFindUnique.mockResolvedValue({ auditLogRetentionDays: null });
     mockDeleteMany.mockResolvedValue({ count: 0 });
 
     const req = createRequest({}, VALID_OP_TOKEN);
@@ -190,7 +206,7 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
 
   it("respects tenant-level retention floor: uses max(requested, tenantRetention)", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockTenantFindMany.mockResolvedValue([{ id: TENANT_ID, auditLogRetentionDays: 730 }]);
+    mockTenantFindUnique.mockResolvedValue({ auditLogRetentionDays: 730 });
     mockDeleteMany.mockResolvedValue({ count: 0 });
 
     const req = createRequest({ retentionDays: 365 }, VALID_OP_TOKEN);
@@ -203,7 +219,7 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
 
   it("uses requested retentionDays when it exceeds tenant retention", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockTenantFindMany.mockResolvedValue([{ id: TENANT_ID, auditLogRetentionDays: 90 }]);
+    mockTenantFindUnique.mockResolvedValue({ auditLogRetentionDays: 90 });
     mockDeleteMany.mockResolvedValue({ count: 0 });
 
     const req = createRequest({ retentionDays: 730 }, VALID_OP_TOKEN);
@@ -218,7 +234,7 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
 
   it("returns matched count without deleting when dryRun is true", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockTenantFindMany.mockResolvedValue([{ id: TENANT_ID, auditLogRetentionDays: null }]);
+    mockTenantFindUnique.mockResolvedValue({ auditLogRetentionDays: null });
     mockCount.mockResolvedValueOnce(8);
 
     const req = createRequest({ dryRun: true }, VALID_OP_TOKEN);
@@ -232,11 +248,12 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
 
     expect(mockDeleteMany).not.toHaveBeenCalled();
     expect(mockCount).toHaveBeenCalledTimes(1);
+    expect(mockCount.mock.calls[0][0].where.tenantId).toBe(TENANT_ID);
   });
 
   it("dry run respects tenant retention floor for count", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockTenantFindMany.mockResolvedValue([{ id: TENANT_ID, auditLogRetentionDays: 730 }]);
+    mockTenantFindUnique.mockResolvedValue({ auditLogRetentionDays: 730 });
     mockCount.mockResolvedValueOnce(5);
 
     const req = createRequest({ retentionDays: 365, dryRun: true }, VALID_OP_TOKEN);
@@ -251,7 +268,7 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
 
   it("logs audit with HUMAN actorType and token fields on successful purge", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockTenantFindMany.mockResolvedValue([{ id: TENANT_ID, auditLogRetentionDays: null }]);
+    mockTenantFindUnique.mockResolvedValue({ auditLogRetentionDays: null });
     mockDeleteMany.mockResolvedValueOnce({ count: 5 });
 
     const req = createRequest({}, VALID_OP_TOKEN);
@@ -270,20 +287,21 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
           purgedCount: 5,
           retentionDays: 365,
           targetTable: "auditLog",
-          systemWide: true,
+          scopedTenantId: TENANT_ID,
         }),
       }),
     );
 
-    // Strict shape: legacy fields must not appear
+    // Strict shape: legacy / mis-implying fields must not appear
     const metadata = mockLogAudit.mock.calls[0][0].metadata;
     expect(metadata.operatorId).toBeUndefined();
     expect(metadata.authPath).toBeUndefined();
+    expect(metadata.systemWide).toBeUndefined();
   });
 
   it("emits audit with dryRun metadata on dryRun", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockTenantFindMany.mockResolvedValue([{ id: TENANT_ID, auditLogRetentionDays: null }]);
+    mockTenantFindUnique.mockResolvedValue({ auditLogRetentionDays: null });
     mockCount.mockResolvedValue(3);
 
     const req = createRequest({ dryRun: true }, VALID_OP_TOKEN);
@@ -300,7 +318,7 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
           purgedCount: 0,
           matched: 3,
           retentionDays: 365,
-          systemWide: true,
+          scopedTenantId: TENANT_ID,
           dryRun: true,
           targetTable: "auditLog",
         }),
@@ -310,5 +328,33 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
     const metadata = mockLogAudit.mock.calls[0][0].metadata;
     expect(metadata.operatorId).toBeUndefined();
     expect(metadata.authPath).toBeUndefined();
+    expect(metadata.systemWide).toBeUndefined();
+  });
+
+  // ─── Tenant Isolation ─────────────────────────────────────
+
+  it("a tenant-A operator token cannot delete tenant-B audit logs", async () => {
+    const TENANT_A = "550e8400-e29b-41d4-a716-44665544000a";
+    mockVerifyAdminToken.mockResolvedValue({
+      ok: true,
+      auth: { ...VALID_AUTH, tenantId: TENANT_A },
+    });
+    mockRequireMaintenanceOperator.mockResolvedValue({
+      ok: true,
+      operator: { tenantId: TENANT_A, role: "ADMIN" },
+    });
+    mockTenantFindUnique.mockResolvedValue({ auditLogRetentionDays: null });
+    mockDeleteMany.mockResolvedValueOnce({ count: 0 });
+
+    const req = createRequest({}, VALID_OP_TOKEN);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // Tenant lookup must use auth.tenantId; deleteMany must be filtered to it.
+    expect(mockTenantFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: TENANT_A } }),
+    );
+    expect(mockDeleteMany).toHaveBeenCalledTimes(1);
+    expect(mockDeleteMany.mock.calls[0][0].where.tenantId).toBe(TENANT_A);
   });
 });

--- a/src/app/api/maintenance/purge-audit-logs/route.ts
+++ b/src/app/api/maintenance/purge-audit-logs/route.ts
@@ -1,7 +1,10 @@
 /**
  * POST /api/maintenance/purge-audit-logs
  *
- * System-wide purge of audit log entries older than retentionDays.
+ * Tenant-scoped purge of audit log entries older than retentionDays.
+ * Operates only on rows belonging to the operator-token's bound tenantId;
+ * a token issued in tenant A cannot erase audit evidence in tenant B.
+ * The tenant's own auditLogRetentionDays floor is still respected.
  * Authenticated via per-operator op_* token (mint via /dashboard/tenant/operator-tokens).
  *
  * Body: { retentionDays?: number, dryRun?: boolean }
@@ -32,44 +35,43 @@ const bodySchema = z.object({
   dryRun: z.boolean().default(false),
 });
 
-async function purgeAcrossTenants(
+async function purgeForTenant(
+  tenantId: string,
   retentionDays: number,
   dryRun: boolean,
 ): Promise<number> {
-  const tenants = await withBypassRls(prisma, async () =>
-    prisma.tenant.findMany({
-      select: { id: true, auditLogRetentionDays: true },
+  const tenant = await withBypassRls(prisma, async () =>
+    prisma.tenant.findUnique({
+      where: { id: tenantId },
+      select: { auditLogRetentionDays: true },
     }),
   BYPASS_PURPOSE.SYSTEM_MAINTENANCE);
+  if (!tenant) {
+    return 0;
+  }
 
-  // Per-tenant purge (parallel): each tenant's floor retention is respected
-  const perTenantCounts = await Promise.all(
-    tenants.map(async (tenant) => {
-      const tenantRetention = tenant.auditLogRetentionDays;
-      // Use the stricter (longer) of the requested vs tenant-configured retention
-      const effectiveRetentionDays = tenantRetention
-        ? Math.max(retentionDays, tenantRetention)
-        : retentionDays;
-      const tenantCutoff = new Date(
-        Date.now() - effectiveRetentionDays * MS_PER_DAY,
-      );
-
-      if (dryRun) {
-        return withBypassRls(prisma, async () =>
-          prisma.auditLog.count({
-            where: { tenantId: tenant.id, createdAt: { lt: tenantCutoff } },
-          }),
-        BYPASS_PURPOSE.SYSTEM_MAINTENANCE);
-      }
-      const result = await withBypassRls(prisma, async () =>
-        prisma.auditLog.deleteMany({
-          where: { tenantId: tenant.id, createdAt: { lt: tenantCutoff } },
-        }),
-      BYPASS_PURPOSE.SYSTEM_MAINTENANCE);
-      return result.count;
-    }),
+  // Use the stricter (longer) of the requested vs tenant-configured retention
+  const tenantRetention = tenant.auditLogRetentionDays;
+  const effectiveRetentionDays = tenantRetention
+    ? Math.max(retentionDays, tenantRetention)
+    : retentionDays;
+  const tenantCutoff = new Date(
+    Date.now() - effectiveRetentionDays * MS_PER_DAY,
   );
-  return perTenantCounts.reduce((a, b) => a + b, 0);
+
+  if (dryRun) {
+    return withBypassRls(prisma, async () =>
+      prisma.auditLog.count({
+        where: { tenantId, createdAt: { lt: tenantCutoff } },
+      }),
+    BYPASS_PURPOSE.SYSTEM_MAINTENANCE);
+  }
+  const result = await withBypassRls(prisma, async () =>
+    prisma.auditLog.deleteMany({
+      where: { tenantId, createdAt: { lt: tenantCutoff } },
+    }),
+  BYPASS_PURPOSE.SYSTEM_MAINTENANCE);
+  return result.count;
 }
 
 async function handlePOST(req: NextRequest) {
@@ -94,7 +96,10 @@ async function handlePOST(req: NextRequest) {
   });
   if (!op.ok) return op.response;
 
-  const totalPurged = await purgeAcrossTenants(retentionDays, dryRun);
+  // Scope purge to the operator-token's bound tenant. Without this,
+  // a tenant-A admin who mints an op_* token can erase audit evidence
+  // in every other tenant — a cross-tenant anti-forensics vector.
+  const totalPurged = await purgeForTenant(auth.tenantId, retentionDays, dryRun);
 
   if (dryRun) {
     await logAuditAsync({
@@ -108,7 +113,7 @@ async function handlePOST(req: NextRequest) {
         matched: totalPurged,
         retentionDays,
         targetTable: "auditLog",
-        systemWide: true,
+        scopedTenantId: auth.tenantId,
         dryRun: true,
       },
     });
@@ -125,7 +130,7 @@ async function handlePOST(req: NextRequest) {
       [AUDIT_METADATA_KEY.PURGED_COUNT]: totalPurged,
       retentionDays,
       targetTable: "auditLog",
-      systemWide: true,
+      scopedTenantId: auth.tenantId,
     },
   });
 

--- a/src/app/api/maintenance/purge-history/route.test.ts
+++ b/src/app/api/maintenance/purge-history/route.test.ts
@@ -163,7 +163,7 @@ describe("POST /api/maintenance/purge-history", () => {
     expect(body.purged).toBe(42);
   });
 
-  it("does not filter by userId (system-wide purge)", async () => {
+  it("scopes deletion to the operator-token's tenantId only", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
     mockDeleteMany.mockResolvedValue({ count: 0 });
 
@@ -173,6 +173,18 @@ describe("POST /api/maintenance/purge-history", () => {
     const where = mockDeleteMany.mock.calls[0][0].where;
     expect(where).not.toHaveProperty("entry");
     expect(where).toHaveProperty("changedAt");
+    expect(where).toHaveProperty("tenantId", TENANT_ID);
+  });
+
+  it("scopes dryRun count to the operator-token's tenantId only", async () => {
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+    mockCount.mockResolvedValue(7);
+
+    const req = createRequest({ dryRun: true }, VALID_OP_TOKEN);
+    await POST(req);
+
+    const where = mockCount.mock.calls[0][0].where;
+    expect(where).toHaveProperty("tenantId", TENANT_ID);
   });
 
   it("uses default retentionDays of 90", async () => {
@@ -243,15 +255,16 @@ describe("POST /api/maintenance/purge-history", () => {
           tokenId: TOKEN_ID,
           purgedCount: 5,
           retentionDays: 90,
-          systemWide: true,
+          scopedTenantId: TENANT_ID,
         }),
       }),
     );
 
-    // Strict shape: legacy fields must not appear
+    // Strict shape: legacy / mis-implying fields must not appear
     const metadata = mockLogAudit.mock.calls[0][0].metadata;
     expect(metadata.operatorId).toBeUndefined();
     expect(metadata.authPath).toBeUndefined();
+    expect(metadata.systemWide).toBeUndefined();
   });
 
   it("emits audit with dryRun metadata on dryRun", async () => {
@@ -272,7 +285,7 @@ describe("POST /api/maintenance/purge-history", () => {
           purgedCount: 0,
           matched: 3,
           retentionDays: 90,
-          systemWide: true,
+          scopedTenantId: TENANT_ID,
           dryRun: true,
         }),
       }),
@@ -281,5 +294,30 @@ describe("POST /api/maintenance/purge-history", () => {
     const metadata = mockLogAudit.mock.calls[0][0].metadata;
     expect(metadata.operatorId).toBeUndefined();
     expect(metadata.authPath).toBeUndefined();
+    expect(metadata.systemWide).toBeUndefined();
+  });
+
+  // ─── Tenant Isolation ─────────────────────────────────────
+
+  it("a tenant-A operator token cannot delete tenant-B history rows", async () => {
+    const TENANT_A = "550e8400-e29b-41d4-a716-44665544000a";
+    mockVerifyAdminToken.mockResolvedValue({
+      ok: true,
+      auth: { ...VALID_AUTH, tenantId: TENANT_A },
+    });
+    mockRequireMaintenanceOperator.mockResolvedValue({
+      ok: true,
+      operator: { tenantId: TENANT_A, role: "ADMIN" },
+    });
+    mockDeleteMany.mockResolvedValue({ count: 0 });
+
+    const req = createRequest({}, VALID_OP_TOKEN);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // The deleteMany must include tenantId = TENANT_A. Without that, a
+    // tenant-A admin's token would erase history rows in every tenant.
+    const where = mockDeleteMany.mock.calls[0][0].where;
+    expect(where.tenantId).toBe(TENANT_A);
   });
 });

--- a/src/app/api/maintenance/purge-history/route.ts
+++ b/src/app/api/maintenance/purge-history/route.ts
@@ -1,7 +1,9 @@
 /**
  * POST /api/maintenance/purge-history
  *
- * System-wide purge of password entry history older than retentionDays.
+ * Tenant-scoped purge of password entry history older than retentionDays.
+ * Operates only on rows belonging to the operator-token's bound tenantId;
+ * a token issued in tenant A cannot affect tenant B's history.
  * Authenticated via per-operator op_* token (mint via /dashboard/tenant/operator-tokens).
  *
  * Body: { retentionDays?: number, dryRun?: boolean }
@@ -55,7 +57,13 @@ async function handlePOST(req: NextRequest) {
   if (!op.ok) return op.response;
 
   const cutoffDate = new Date(Date.now() - retentionDays * MS_PER_DAY);
-  const whereClause = { changedAt: { lt: cutoffDate } };
+  // Scope deletion to the operator-token's bound tenant. Without this,
+  // a tenant-A admin who mints an op_* token can delete history rows in
+  // every other tenant via the system-wide where clause.
+  const whereClause = {
+    tenantId: auth.tenantId,
+    changedAt: { lt: cutoffDate },
+  };
 
   if (dryRun) {
     const matched = await withBypassRls(prisma, async () =>
@@ -71,7 +79,7 @@ async function handlePOST(req: NextRequest) {
         [AUDIT_METADATA_KEY.PURGED_COUNT]: 0,
         matched,
         retentionDays,
-        systemWide: true,
+        scopedTenantId: auth.tenantId,
         dryRun: true,
       },
     });
@@ -91,7 +99,7 @@ async function handlePOST(req: NextRequest) {
       tokenId: auth.tokenId,
       [AUDIT_METADATA_KEY.PURGED_COUNT]: deleted.count,
       retentionDays,
-      systemWide: true,
+      scopedTenantId: auth.tenantId,
     },
   });
 


### PR DESCRIPTION
## Summary

The four maintenance routes that authenticate via per-operator `op_*`
tokens were operating system-wide despite tokens being tenant-scoped.
A tenant admin could mint a token and act on every other tenant's data.
This PR aligns these routes with `audit-chain-verify`, which already
gates on `auth.tenantId`.

| Route | Pre-fix behavior | Post-fix behavior |
|---|---|---|
| `purge-history` | `deleteMany({where:{changedAt:...}})` — system-wide | `where: { tenantId: auth.tenantId, changedAt: ... }` |
| `purge-audit-logs` | `tenant.findMany()` → loop over **all** tenants | `tenant.findUnique({ id: auth.tenantId })` only |
| `audit-outbox-purge-failed` | `body.tenantId ?? null` ⇒ all-tenant SQL allowed | `body.tenantId !== auth.tenantId → 403`; SQL forced to `auth.tenantId` |
| `audit-outbox-metrics` | `SELECT ... FROM audit_outbox` — cross-tenant aggregates leaked queue depth / failed count of other tenants | `WHERE tenant_id = auth.tenantId` |

The regression was introduced when commit c510abc2 replaced the shared
`ADMIN_API_TOKEN` (conceptually system-level) with per-tenant `op_*`
tokens but did not retighten the routes' query scopes.

Audit metadata: `systemWide: true` is replaced by `scopedTenantId: <uuid>`
across all four routes — SIEM rules keying on `systemWide` need to be
updated. Existing `actorType=HUMAN` + action-name correlation is unchanged.

## Test plan

- [x] Unit: every affected route has a tenant-isolation test asserting the
      `where.tenantId` / SQL-bound parameter equals `auth.tenantId`
- [x] Strict-shape negative assertions: `metadata.systemWide` and
      `metadata.filterTenantId` are no longer present
- [x] `npx vitest run` — 590 files / 7515 tests pass
- [x] `npx next build` — exit 0
- [x] `npm run lint` — exit 0
- [x] `bash scripts/pre-pr.sh` — 11/11 checks
- [x] Live verification against local dev instance:
  - dry-run `purge-history` → 200, scoped
  - dry-run `purge-audit-logs` → 200, scoped
  - cross-tenant `audit-outbox-purge-failed` → **403 / FORBIDDEN**
  - own-tenant `audit-outbox-purge-failed` → 200; `purged=0` while
    system-wide `failed=1` persisted, proving the operator's token
    cannot reach another tenant's FAILED row (the strongest evidence
    that the gate is doing its job)
  - `audit-outbox-metrics` → `failed: 1 → 0` after redeploy, proving
    the cross-tenant aggregate leak is closed

## Notes for reviewers

- `purge-history` does not touch `team_password_entry_histories`. That is
  pre-existing scope (the route was always limited to personal-vault
  history) and is unchanged here. Consider as a separate follow-up if
  team history retention is desired.

## Out of scope (intentional, follow-up tracked)

`audit-outbox-metrics` was previously documented as "cross-tenant aggregates
for infrastructure operators" — that intent is now intentionally rescinded.
Multi-tenant deployments wanting a single global health view should add a
separate ops-only path with a different token type.

`dcr-cleanup` retains its system-wide behavior. It deletes `mcpClient` rows
where `tenantId IS NULL` (unclaimed DCR registrations) and `dcrExpiresAt < now`
— rows with no tenant owner that have already expired. Today this is not a
cross-tenant data-access vector, but the underlying pattern (a tenant admin's
op_* token operating on system-level rows) is a latent privilege footgun: a
future loosening of the WHERE filter would silently grant every tenant admin
broader power. Severity assessment:

- Today: Minor (aggregate DCR registration rate observable via `deleted` count;
  TOCTOU race on mid-claim expired clients with negligible impact).
- Latent: Major (privilege escalation footgun if WHERE filter drifts).

Recommended follow-up: replace the API with a background sweeper running under
the existing privileged DB role (mirrors the audit-outbox-worker pattern), so
tenant-admin tokens can never reach this code path. Tracked as a separate PR.