### PR TITLE
Security hardening batch 1: OAuth encryption + EA CAS + replay tests + ADR/runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ ADMIN_API_TOKEN=<op_token> scripts/purge-audit-logs.sh                          
 ADMIN_API_TOKEN=<op_token> TARGET_VERSION=<int> scripts/rotate-master-key.sh         # Rotate ShareLink master key
 
 PASSWD_OUTBOX_WORKER_PASSWORD=<pass> MIGRATION_DATABASE_URL=<url> scripts/set-outbox-worker-password.sh  # Set worker DB role password
+
+MIGRATION_DATABASE_URL=<privileged-url> npm run migrate:account-tokens               # Encrypt legacy plaintext OAuth tokens (idempotent; --dry-run available)
 ```
 
 Audit outbox worker (separate process):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ route handlers own application-layer concerns.
 ### Authentication Flow
 
 - Auth.js v5 (beta.30) with database session strategy (not JWT)
+- Identity model: global User keyed by email, one active tenant per user (`User.tenantId`), multi-tenant access via `TenantMember`. See `docs/archive/review/email-uniqueness-design.md` for the ADR.
 - Providers: Google OIDC + SAML 2.0 via BoxyHQ SAML Jackson (Docker container, NOT npm) + Passkey (WebAuthn) + Magic Link (email)
 - Jackson exposes an OIDC interface; Auth.js connects as a standard OIDC provider
 - Passkey sign-in: discoverable (passwordless) + email-based (non-discoverable security keys)

--- a/docs/archive/review/email-uniqueness-design.md
+++ b/docs/archive/review/email-uniqueness-design.md
@@ -1,0 +1,111 @@
+# Design: User.email Uniqueness Model (ADR)
+
+**Status**: Accepted (codifies existing design)
+**Date**: 2026-04-28
+**Trigger**: External review questioned whether `User.email @unique` is consistent with `User.tenantId` multi-tenant scoping.
+
+## Context
+
+### Current schema
+
+```prisma
+model User {
+  id        String  @id @default(uuid(4)) @db.Uuid
+  tenantId  String  @map("tenant_id") @db.Uuid   // home tenant
+  email     String? @unique                       // GLOBAL unique
+  ...
+}
+
+model TenantMember {
+  tenantId  String
+  userId    String
+  role      TenantRole
+  @@unique([tenantId, userId])
+}
+```
+
+The pairing of `User.email @unique` with `User.tenantId` looks like a contradiction at first glance: if email is globally unique, why does each User carry a tenant id?
+
+### What the code actually does
+
+1. **First sign-in (`createUser` in `src/lib/auth/session/auth-adapter.ts:144-208`)**:
+   - If a tenant claim is present (Google `hd`, SAML `tenant_id`), `findOrCreateSsoTenant(claim)` resolves to the SSO tenant and the user is created as `tenantId = ssoTenant.id` with `TenantMember(role=MEMBER)`.
+   - If no tenant claim is present, a brand-new bootstrap tenant is created and the user is placed there as `OWNER`.
+
+2. **Second+ sign-in into a different tenant (`ensureTenantMembershipForSignIn` in `src/lib/auth.ts`)**:
+   - When a user already on a bootstrap tenant signs in via SSO with a tenant claim, **all per-user tables are migrated** (`User.tenantId`, sessions, vault keys, password entries, audit logs, etc.) from the bootstrap tenant id to the SSO tenant id. The bootstrap tenant is effectively merged into the SSO tenant.
+   - The migration is gated on `expected 1 active member` (only the owner of a bootstrap tenant can migrate it).
+
+3. **`User.tenantId` semantics**:
+   - It is **the user's currently active tenant**, not a denormalized read-cache.
+   - It IS migrated by the bootstrap → SSO flow (auth-adapter.ts:90-195 references show 20+ table updates wrapped in `User.tenantId` change).
+   - All tenant-scoped tables have RLS that filter on `current_setting('app.tenant_id')`, set per-request from the session — not from `User.tenantId` directly.
+
+## Decision
+
+**Adopt the existing design as Status: Accepted.** Document it explicitly here so future contributors don't mistake it for a bug.
+
+### The product model is "global identity, one active tenant at a time"
+
+| Property | Value |
+|---|---|
+| Identity unit | One User row per email, globally unique |
+| Tenant residency | One active tenant per user (`User.tenantId`) |
+| Multi-tenant access | Via `TenantMember` rows; scopes are switched at the session/RLS layer, not by spawning duplicate Users |
+| Cross-tenant move | Bootstrap → SSO migration; otherwise admin operation (out of scope here) |
+
+### Why this is the right shape for this product
+
+1. **Vault is keyed to one identity**: A user's vault (encrypted master key, recovery key, passphrase verifier, ECDH key pair) is on the User row. Splitting into per-tenant Users would mean per-tenant vaults — multiplying the user's password-reset / passkey re-enrollment burden by N tenants.
+2. **Passkey / WebAuthn credentials are user-bound**, not tenant-bound. Browsers register credentials against an RP id, not against a tenant. Per-tenant Users would force re-enrollment in every tenant.
+3. **Auth.js v5 default adapter expects email-keyed Users**. Choosing per-tenant emails would require a custom adapter and a re-design of OAuth account linking semantics.
+4. **SSO-first multi-tenancy**: customers who require strict tenant separation use the SSO claim path — their tenant is determined by the IdP, and the same email at a different IdP is a different real person (impersonation requires breaching the IdP, not the app).
+
+## Consequences
+
+### What the current model rules OUT
+
+- A single email cannot be **independently** signed up in two SSO tenants as separate identities. If `alice@example.com` exists in tenant A's SSO, and tenant B's SSO emits the same email, sign-in into B will resolve to the same User and trigger a migration check (or be rejected if the user already has membership elsewhere).
+- This is not a bug; it is the chosen identity boundary. The mitigating fact is that SSO tenant claims come from the IdP — if the IdP says `alice@example.com` is in `example.com`, that mapping is authoritative.
+
+### What it does NOT prevent
+
+- Multi-tenant access for the same user is fully supported via `TenantMember`: a user can be added to multiple tenants by tenant admins. Active tenant is selected per session. The schema already has `tenantMemberships  TenantMember[]` on User.
+
+### Risks and mitigations
+
+| Risk | Status | Mitigation |
+|---|---|---|
+| Stale `User.tenantId` after bootstrap migration causes cross-tenant query mis-resolution | Mitigated | RLS uses `current_setting('app.tenant_id')` from session, not `User.tenantId`. Sessions are migrated atomically with `User.tenantId` (auth-adapter.ts cache invalidation). |
+| Direct `where: { tenantId: user.tenantId }` queries bypass session-scoped tenant | Low impact | Reviewed code uses `withTenantRls` / `withUserTenantRls` consistently. Direct reads of `User.tenantId` are confined to auth bootstrap and admin-token issuance. |
+| User wants two unrelated identities at two unrelated SSO tenants | Out of model | They must use two emails. This matches Google Workspace / Microsoft 365 behavior and is the product's working assumption. |
+
+## Alternatives considered
+
+### Alt 1: `@@unique([tenantId, email])`, drop global `@unique`
+
+- **Implementation cost**: ~2 weeks (custom Auth.js adapter, vault re-key per tenant, passkey re-enrollment per tenant, OAuth account linking per tenant, migration of every existing User row, breaking change for all clients).
+- **Why rejected**: This would split a single human into N Users with N vaults and N passkey credentials — operationally hostile to the user. The only scenario it serves is "I want to be Alice@CompanyA and Alice@CompanyB simultaneously with no link between them," which is achievable today by using two email addresses.
+
+### Alt 2: Make `User.email` `@@unique([tenantId, email])` AND keep one global User
+
+- Internally inconsistent — global identity with tenant-scoped email key contradicts itself.
+- **Why rejected**: Not a coherent model.
+
+### Alt 3: Keep current schema (Accepted)
+
+- Document the design intent so future reviewers do not mistake `email @unique` for a multi-tenant bug.
+- **Why accepted**: Matches the implementation, matches industry SSO practice (Auth0, WorkOS, Okta-on-app), and minimizes operational cost for the user.
+
+## Action items
+
+- [x] Codify this ADR (this document).
+- [ ] Add a comment block to `prisma/schema.prisma` near the `User.email @unique` declaration referencing this ADR.
+- [ ] Update `CLAUDE.md` "Authentication Flow" section with a one-line pointer: "Identity model: see docs/archive/review/email-uniqueness-design.md".
+
+## References
+
+- `src/lib/auth/session/auth-adapter.ts:144-208` — `createUser` SSO/bootstrap branching.
+- `src/lib/auth.ts` — bootstrap → SSO migration entry (`ensureTenantMembershipForSignIn`).
+- `src/lib/tenant/tenant-management.ts` — `findOrCreateSsoTenant` race-safe upsert.
+- `docs/archive/review/fix-sso-tenant-first-signin-plan.md` — prior plan that established the tenant claim flow.

--- a/docs/archive/review/pepper-rotation-runbook.md
+++ b/docs/archive/review/pepper-rotation-runbook.md
@@ -1,0 +1,160 @@
+# Runbook: Verifier Pepper Rotation
+
+**Audience**: operators with KMS / Secret Manager access and the ability to deploy new code.
+**Trigger**: scheduled rotation (annual), suspected pepper compromise, KMS provider migration.
+**Status**: documented. Code-level dual-version support is a prerequisite for non-disruptive rotation — see "Known gaps" below.
+
+## What the pepper protects
+
+The verifier pepper is an HMAC key used at the server boundary on top of the client-derived passphrase verifier hash.
+
+```
+client:  verifierHash = SHA-256(PBKDF2(passphrase, salt, 600000))   // 64-char hex
+server:  passphraseVerifierHmac = HMAC-SHA256(pepper, verifierHash) // stored
+         recoveryVerifierHmac   = HMAC-SHA256(pepper, recoveryVerifierHash)
+         hashAccessPassword     = HMAC-SHA256(pepper, SHA-256(accessPassword))
+```
+
+If the DB is leaked but the pepper is not, an attacker cannot mount an offline dictionary attack against `passphraseVerifierHmac` — they would need to recover the pepper from the server first. The pepper turns a leaked verifier into a useless 256-bit randomness without the matching pepper.
+
+Loss / disclosure of the pepper:
+- Loss → all existing users are locked out at the server-side verifier check (HMAC will never match).
+- Disclosure → DB leak now permits dictionary attack against the verifier hash; users on weak passphrases are at risk.
+
+## Configuration map
+
+| Component | Where | Purpose |
+|---|---|---|
+| `VERIFIER_PEPPER_KEY` env var | `.env`, deployed env, `EnvKeyProvider` | Source of pepper bytes for `EnvKeyProvider` |
+| `KEY_PROVIDER` env var | env | Selects backend: `env` (default) / `aws-sm` / `gcp-sm` / `azure-kv` |
+| KMS / Secret Manager: `verifier-pepper` | AWS Secrets Manager / GCP Secret Manager / Azure Key Vault | Source of pepper bytes for cloud providers (versioned) |
+| `User.passphraseVerifierHmac` | DB, per user | The pepper-bound HMAC, stored at vault setup / change passphrase |
+| `User.passphraseVerifierVersion` | DB, per user | Marker of which `VERIFIER_VERSION` the stored HMAC was computed under |
+| `VERIFIER_VERSION` constant in `src/lib/crypto/crypto-client.ts` | source | Currently always set to the latest pepper version the code understands |
+| `User.recoveryVerifierHmac` | DB, per user | Recovery-key path, same pepper |
+| `Send.accessPasswordHash` (and similar share password fields) | DB | Pepper-bound hash of access passwords |
+
+## Known gaps in the current code (must be addressed BEFORE a non-disruptive rotation)
+
+The current `hmacVerifier` and `verifyPassphraseVerifier` in `src/lib/crypto/crypto-server.ts` always call `getKeyProviderSync().getKeySync("verifier-pepper")` **without a version argument** (line 245). There is no mechanism for the server to verify a stored HMAC against an older pepper while issuing new HMACs under a new pepper.
+
+Implication: **a hot pepper change with no code-level support locks out every user** until they perform a passphrase change with their plaintext passphrase (which they cannot do because they cannot log in).
+
+The `KeyProvider.getKeySync(name, version?)` interface already supports versions (`src/lib/key-provider/types.ts:19`); only the call sites in `crypto-server.ts` and the `User.passphraseVerifierVersion` check are not wired through.
+
+### Minimum code change required for non-disruptive rotation (follow-up PR)
+
+1. Plumb `version` through `hmacVerifier(verifierHash, version?)` and `verifyPassphraseVerifier(clientHash, storedHmac, storedVersion)`.
+2. On verify: read `User.passphraseVerifierVersion`, fetch matching pepper version, compute HMAC with that version's pepper.
+3. On write (setup / change-passphrase / rotate-key / recovery-key/recover): write with the latest pepper version and update `passphraseVerifierVersion` accordingly.
+4. After verify-with-old-pepper succeeds and the request flow has the user's plaintext verifier hash (i.e., on `unlock`), **opportunistically re-HMAC under the new pepper** and persist to migrate the user transparently.
+
+Do not run the runbook below without (1)-(3) in place. Step (4) is a nice-to-have for transparent migration and not strictly required.
+
+## Rotation procedures
+
+There are three modes. Pick by trigger.
+
+### Mode A: scheduled rotation (annual) — non-disruptive
+
+Prerequisite: code-level dual-version support (above) is deployed.
+
+```
+Day 0  : produce new pepper version in KMS, do NOT change VERIFIER_VERSION constant yet
+Day 1  : deploy code that can READ both versions but still WRITES with the old version
+Day 2+ : flip VERIFIER_VERSION constant to the new version, deploy
+            now: writes use new pepper, reads still resolve old or new per-user
+Day 3+ : on user unlock, opportunistic re-HMAC migrates the user
+Month 6: count users still on old version (`SELECT COUNT(*) FROM users WHERE passphrase_verifier_version = $old`)
+            decide: retire old pepper (lock out remaining stale users + recovery flow) or keep both
+```
+
+### Mode B: emergency rotation (suspected pepper disclosure) — disruptive, fast
+
+Prerequisite: communications channel to users (email, status page).
+
+```
+T-0  : freeze writes that would re-HMAC under the compromised pepper (block setup / change-passphrase)
+T+5m : produce new pepper version in KMS
+T+10m: deploy code with dual-version support and VERIFIER_VERSION pointing to the new version
+T+15m: announce: all users must complete passphrase verification + migration on next unlock
+T+1d : monitor migration rate; users who do not migrate will be unable to verify under the old pepper
+            once it is retired
+T+30d: retire compromised pepper version from KMS (revoke read access)
+            users still on old version → forced into recovery key flow (or re-onboarding)
+```
+
+Note: emergency mode does NOT require a passphrase change for users — the pepper is at the server boundary, not in the client KDF chain. Users keep the same passphrase; the server-side HMAC under the new pepper is recomputed during the first successful unlock that decrypts the vault correctly.
+
+### Mode C: KMS provider migration (env → AWS / GCP / Azure)
+
+```
+Step 1: read pepper out of current provider, write it as version 1 into the new provider
+Step 2: deploy with KEY_PROVIDER pointed at the new provider (no pepper byte change)
+Step 3: validate by exercising sign-in for at least one user per active tenant
+Step 4: on a later cycle, run Mode A using the new provider's versioning to actually rotate the bytes
+```
+
+This decomposes "switch provider" and "rotate bytes" into two steps — never combine.
+
+## Pre-rotation checklist (apply to all modes)
+
+- [ ] Confirm `KeyProvider.getKeySync(name, version)` is wired through `hmacVerifier` (Known gaps §1-3).
+- [ ] Confirm `User.passphraseVerifierVersion` is populated for every user (`SELECT COUNT(*) FROM users WHERE passphrase_verifier_version IS NULL` should be 0).
+- [ ] Confirm the audit pipeline (`audit_outbox` + chain) is healthy; rotation events must be auditable.
+- [ ] Snapshot the DB before rotation (logical dump or PITR marker).
+- [ ] Have a rollback plan — see "Rollback" below.
+
+## Post-rotation verification
+
+```sql
+-- Distribution of versions (expect ~all users on the new version after Day 30+)
+SELECT passphrase_verifier_version, COUNT(*) FROM users GROUP BY 1 ORDER BY 1;
+
+-- Stale recovery verifiers (recovery_verifier_hmac is also pepper-bound)
+SELECT COUNT(*) FROM users
+  WHERE recovery_verifier_hmac IS NOT NULL
+    AND recovery_key_set_at < NOW() - INTERVAL '30 days';
+
+-- Audit events emitted by rotation
+SELECT created_at, action, actor_user_id FROM audit_logs
+  WHERE action IN ('VERIFIER_PEPPER_ROTATE_BEGIN', 'VERIFIER_PEPPER_ROTATE_COMPLETE')
+  ORDER BY created_at DESC LIMIT 20;
+```
+
+(Audit actions above do not yet exist in `src/lib/constants/audit.ts` — add them when implementing the code-level rotation support.)
+
+## Rollback
+
+If the new pepper is wrong or rotation breaks unlock for a measurable percentage of users:
+
+1. Re-deploy code with `VERIFIER_VERSION` pointing back at the old version (the code must still hold dual-version support so it can verify users who already migrated).
+2. Do NOT retire the old pepper until the rollback is confirmed working.
+3. Audit-log the rollback (`VERIFIER_PEPPER_ROTATE_ROLLBACK`).
+4. Run the version distribution query above; users who already migrated will need a second migration to the old version (or, if rollback is brief, leave them on the new version and accept dual-version reads indefinitely).
+
+## Automation (skeleton — not yet implemented)
+
+A `scripts/rotate-verifier-pepper.sh` should:
+
+1. Read current `VERIFIER_VERSION` from source (`grep -E '^export const VERIFIER_VERSION' src/lib/crypto/crypto-client.ts`).
+2. Validate that the dual-version code path exists (presence check on `getKeySync(.+, version)` in `src/lib/crypto/crypto-server.ts`).
+3. Print the SQL distribution query for operator review.
+4. Open a draft PR that bumps `VERIFIER_VERSION` and documents the rotation in a release note.
+
+Implementation of this script is tracked separately — see follow-up issue.
+
+## Open follow-ups
+
+- [ ] Implement code-level dual-version pepper support (`hmacVerifier(verifierHash, version)`, `verifyPassphraseVerifier(_, _, storedVersion)`, opportunistic re-HMAC on unlock).
+- [ ] Add `VERIFIER_PEPPER_ROTATE_*` audit actions to `src/lib/constants/audit.ts`.
+- [ ] Implement `scripts/rotate-verifier-pepper.sh` per "Automation" section.
+- [ ] Add an integration test that exercises Mode A with two pepper versions side-by-side and asserts both verify correctly.
+- [ ] Document operator-facing rotation in the customer/security-disclosure channel (out of repo).
+
+## References
+
+- `src/lib/crypto/crypto-server.ts:233-291` — current pepper / HMAC implementation.
+- `src/lib/key-provider/types.ts:19` — `getKeySync(name, version?)` interface (already versioned).
+- `prisma/schema.prisma` `User.passphraseVerifierVersion`, `User.recoveryVerifierHmac` — per-user version marker.
+- `src/app/api/vault/change-passphrase/route.ts:79` — version mismatch gate.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "version:bump": "bash scripts/bump-version.sh",
     "worker:audit-outbox": "tsx scripts/audit-outbox-worker.ts",
     "worker:dcr-cleanup": "tsx scripts/dcr-cleanup-worker.ts",
+    "migrate:account-tokens": "tsx scripts/migrate-account-tokens-to-encrypted.ts",
     "generate:env-example": "tsx scripts/generate-env-example.ts",
     "check:env-docs": "tsx scripts/check-env-docs.ts",
     "init:env": "tsx scripts/init-env.ts",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,9 @@ model User {
   id            String    @id @default(uuid(4)) @db.Uuid
   tenantId      String    @map("tenant_id") @db.Uuid
   name          String?
+  // Identity model: global User keyed by email, with one active tenant
+  // (User.tenantId) and multi-tenant access via TenantMember.
+  // See docs/archive/review/email-uniqueness-design.md for the rationale.
   email         String?   @unique
   emailVerified DateTime? @map("email_verified") @db.Timestamptz(3)
   image         String?

--- a/scripts/migrate-account-tokens-to-encrypted.ts
+++ b/scripts/migrate-account-tokens-to-encrypted.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env tsx
+//
+// One-shot data migration: rewrite legacy plaintext OAuth tokens in the
+// `accounts` table to the encrypted-at-rest format.
+//
+// Idempotent — rows whose tokens already start with the `psoenc1:` sentinel
+// are skipped. Safe to re-run after a crash. Streams in batches so the
+// memory footprint is bounded for large account counts.
+//
+// Usage:
+//   MIGRATION_DATABASE_URL=postgresql://... npm run migrate:account-tokens
+//   MIGRATION_DATABASE_URL=postgresql://... npm run migrate:account-tokens -- --dry-run
+//
+// Run as the DDL/DML role (`passwd_user` / superuser owner), NOT as the
+// app role. The app role has RLS enforced and cannot see all accounts;
+// this script bypasses tenant isolation by reading from a privileged
+// connection. Confirm before running in production.
+
+import { loadEnv } from "@/lib/load-env";
+loadEnv();
+
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import {
+  encryptAccountToken,
+  isEncryptedAccountToken,
+} from "@/lib/crypto/account-token-crypto";
+
+type RawAccount = {
+  id: string;
+  provider: string;
+  providerAccountId: string;
+  refresh_token: string | null;
+  access_token: string | null;
+  id_token: string | null;
+};
+
+const BATCH_SIZE = 500;
+const DRY_RUN = process.argv.includes("--dry-run");
+
+async function main(): Promise<void> {
+  const url = process.env.MIGRATION_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      "Set MIGRATION_DATABASE_URL (or DATABASE_URL) to a privileged connection string before running this script.",
+    );
+  }
+
+  const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: url }) });
+
+  let cursorId: string | null = null;
+  let scanned = 0;
+  let rewritten = 0;
+  let skippedAlreadyEncrypted = 0;
+  let skippedNoTokens = 0;
+  let failed = 0;
+
+  console.log(
+    `Starting account token migration. dryRun=${DRY_RUN} batchSize=${BATCH_SIZE}`,
+  );
+
+  try {
+    while (true) {
+      const batch: RawAccount[] = await prisma.$queryRawUnsafe<RawAccount[]>(
+        `SELECT id, provider, "providerAccountId", refresh_token, access_token, id_token
+         FROM accounts
+         ${cursorId ? "WHERE id > $1::uuid" : ""}
+         ORDER BY id ASC
+         LIMIT ${BATCH_SIZE}`,
+        ...(cursorId ? [cursorId] : []),
+      );
+      if (batch.length === 0) break;
+
+      for (const row of batch) {
+        scanned += 1;
+        const aad = {
+          provider: row.provider,
+          providerAccountId: row.providerAccountId,
+        };
+
+        const allNull =
+          row.refresh_token == null && row.access_token == null && row.id_token == null;
+        if (allNull) {
+          skippedNoTokens += 1;
+          continue;
+        }
+
+        const allEncrypted =
+          (row.refresh_token == null || isEncryptedAccountToken(row.refresh_token)) &&
+          (row.access_token == null || isEncryptedAccountToken(row.access_token)) &&
+          (row.id_token == null || isEncryptedAccountToken(row.id_token));
+        if (allEncrypted) {
+          skippedAlreadyEncrypted += 1;
+          continue;
+        }
+
+        const updates: { col: string; value: string }[] = [];
+        try {
+          if (row.refresh_token != null && !isEncryptedAccountToken(row.refresh_token)) {
+            updates.push({
+              col: "refresh_token",
+              value: encryptAccountToken(row.refresh_token, aad),
+            });
+          }
+          if (row.access_token != null && !isEncryptedAccountToken(row.access_token)) {
+            updates.push({
+              col: "access_token",
+              value: encryptAccountToken(row.access_token, aad),
+            });
+          }
+          if (row.id_token != null && !isEncryptedAccountToken(row.id_token)) {
+            updates.push({
+              col: "id_token",
+              value: encryptAccountToken(row.id_token, aad),
+            });
+          }
+        } catch (err) {
+          failed += 1;
+          console.error(`Encrypt failed for account ${row.id}:`, err);
+          continue;
+        }
+
+        if (updates.length === 0) {
+          skippedAlreadyEncrypted += 1;
+          continue;
+        }
+
+        if (DRY_RUN) {
+          rewritten += 1;
+          continue;
+        }
+
+        // Single-row UPDATE, parameterized. Build the SET clause from the
+        // fields that actually need rewriting.
+        const setClauses = updates.map((u, i) => `"${u.col}" = $${i + 1}`).join(", ");
+        const params = [...updates.map((u) => u.value), row.id];
+        try {
+          await prisma.$executeRawUnsafe(
+            `UPDATE accounts SET ${setClauses} WHERE id = $${updates.length + 1}::uuid`,
+            ...params,
+          );
+          rewritten += 1;
+        } catch (err) {
+          failed += 1;
+          console.error(`UPDATE failed for account ${row.id}:`, err);
+        }
+      }
+
+      cursorId = batch[batch.length - 1].id;
+      console.log(
+        `Progress: scanned=${scanned} rewritten=${rewritten} alreadyEncrypted=${skippedAlreadyEncrypted} noTokens=${skippedNoTokens} failed=${failed}`,
+      );
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+
+  console.log("Migration complete.");
+  console.log(`  scanned             : ${scanned}`);
+  console.log(`  rewritten           : ${rewritten}${DRY_RUN ? " (dry-run, no writes)" : ""}`);
+  console.log(`  alreadyEncrypted    : ${skippedAlreadyEncrypted}`);
+  console.log(`  noTokens            : ${skippedNoTokens}`);
+  console.log(`  failed              : ${failed}`);
+
+  if (failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/migrate-account-tokens-to-encrypted.ts
+++ b/scripts/migrate-account-tokens-to-encrypted.ts
@@ -61,8 +61,13 @@ async function main(): Promise<void> {
 
   try {
     while (true) {
+      // The Prisma schema maps Account.providerAccountId to the
+      // provider_account_id column (snake_case in DB), so the raw query
+      // must reference the column name and alias it back to the camelCase
+      // shape the rest of the script reads as.
       const batch: RawAccount[] = await prisma.$queryRawUnsafe<RawAccount[]>(
-        `SELECT id, provider, "providerAccountId", refresh_token, access_token, id_token
+        `SELECT id, provider, provider_account_id AS "providerAccountId",
+                refresh_token, access_token, id_token
          FROM accounts
          ${cursorId ? "WHERE id > $1::uuid" : ""}
          ORDER BY id ASC

--- a/src/app/api/emergency-access/[id]/accept/route.test.ts
+++ b/src/app/api/emergency-access/[id]/accept/route.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest, createParams } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockPrismaGrant, mockPrismaUser, mockTransaction, mockRateLimiter, mockSendEmail, mockWithBypassRls } = vi.hoisted(() => ({
+const { mockAuth, mockPrismaGrant, mockPrismaUser, mockTransaction, mockTxGrantUpdateMany, mockTxKeyPairCreate, mockRateLimiter, mockSendEmail, mockWithBypassRls } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
-  mockPrismaGrant: { findUnique: vi.fn(), update: vi.fn() },
+  mockPrismaGrant: { findUnique: vi.fn() },
   mockPrismaUser: { findUnique: vi.fn() },
   mockTransaction: vi.fn(),
+  mockTxGrantUpdateMany: vi.fn(),
+  mockTxKeyPairCreate: vi.fn(),
   mockRateLimiter: { check: vi.fn() },
   mockSendEmail: vi.fn(),
   mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
@@ -15,7 +17,6 @@ vi.mock("@/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     emergencyAccessGrant: mockPrismaGrant,
-    emergencyAccessKeyPair: { create: vi.fn() },
     user: mockPrismaUser,
     $transaction: mockTransaction,
   },
@@ -59,7 +60,14 @@ describe("POST /api/emergency-access/[id]/accept", () => {
     mockAuth.mockResolvedValue({ user: { id: "grantee-1", email: "grantee@example.com" } });
     mockRateLimiter.check.mockResolvedValue({ allowed: true });
     mockPrismaGrant.findUnique.mockResolvedValue(pendingGrant);
-    mockTransaction.mockResolvedValue([{}, {}]);
+    mockTxGrantUpdateMany.mockResolvedValue({ count: 1 });
+    mockTxKeyPairCreate.mockResolvedValue({});
+    mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
+      cb({
+        emergencyAccessGrant: { updateMany: mockTxGrantUpdateMany },
+        emergencyAccessKeyPair: { create: mockTxKeyPairCreate },
+      }),
+    );
     mockPrismaUser.findUnique.mockResolvedValue({ email: "owner@test.com", name: "Owner Name" });
   });
 
@@ -99,8 +107,8 @@ describe("POST /api/emergency-access/[id]/accept", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 400 when grant is not pending", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({ ...pendingGrant, status: EA_STATUS.ACCEPTED });
+  it("returns 400 when CAS finds no still-PENDING row (e.g. concurrent decline)", async () => {
+    mockTxGrantUpdateMany.mockResolvedValue({ count: 0 });
     const res = await POST(
       createRequest("POST", "http://localhost/api/emergency-access/grant-1/accept", { body: validBody }),
       createParams({ id: "grant-1" })
@@ -108,6 +116,8 @@ describe("POST /api/emergency-access/[id]/accept", () => {
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.error).toBe("GRANT_NOT_PENDING");
+    // Key pair must NOT be created when the CAS misses.
+    expect(mockTxKeyPairCreate).not.toHaveBeenCalled();
   });
 
   it("returns 403 when email does not match", async () => {
@@ -172,6 +182,17 @@ describe("POST /api/emergency-access/[id]/accept", () => {
     const json = await res.json();
     expect(json.status).toBe(EA_STATUS.ACCEPTED);
     expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockTxGrantUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "grant-1",
+          granteeEmail: pendingGrant.granteeEmail,
+          status: { in: expect.arrayContaining([EA_STATUS.PENDING]) },
+        }),
+        data: expect.objectContaining({ status: EA_STATUS.ACCEPTED }),
+      }),
+    );
+    expect(mockTxKeyPairCreate).toHaveBeenCalled();
     // Sends accepted email to owner
     expect(mockSendEmail).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/app/api/emergency-access/[id]/accept/route.ts
+++ b/src/app/api/emergency-access/[id]/accept/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { acceptEmergencyGrantByIdSchema } from "@/lib/validations";
+import { fromStatusesFor } from "@/lib/emergency-access/emergency-access-state";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyGrantAcceptedEmail } from "@/lib/email/templates/emergency-access";
@@ -44,11 +45,8 @@ async function handlePOST(
     return notFound();
   }
 
-  if (grant.status !== EA_STATUS.PENDING) {
-    return errorResponse(API_ERROR.GRANT_NOT_PENDING, 400);
-  }
-
-  // Enforce invitation expiry regardless of auth method (session or token)
+  // Enforce invitation expiry regardless of auth method (session or token).
+  // tokenExpiresAt is immutable post-creation, so checking it pre-CAS is safe.
   if (grant.tokenExpiresAt && grant.tokenExpiresAt < new Date()) {
     return errorResponse(API_ERROR.INVITATION_EXPIRED, 410);
   }
@@ -65,17 +63,28 @@ async function handlePOST(
   if (!result.ok) return result.response;
   const { granteePublicKey, encryptedPrivateKey } = result.data;
 
-  await withBypassRls(prisma, async () =>
-    prisma.$transaction([
-      prisma.emergencyAccessGrant.update({
-        where: { id },
+  // Atomic compare-and-swap: only transitions a still-PENDING row, and only
+  // creates the escrow key pair if the transition actually fired. Wrapping
+  // both writes in $transaction ensures the key pair never exists for a
+  // grant whose status was already moved by a concurrent request.
+  const txResult = await withBypassRls(prisma, async () =>
+    prisma.$transaction(async (tx) => {
+      const updated = await tx.emergencyAccessGrant.updateMany({
+        where: {
+          id,
+          granteeEmail: grant.granteeEmail,
+          status: { in: fromStatusesFor(EA_STATUS.ACCEPTED) },
+        },
         data: {
           status: EA_STATUS.ACCEPTED,
           granteeId: session.user.id,
           granteePublicKey,
         },
-      }),
-      prisma.emergencyAccessKeyPair.create({
+      });
+      if (updated.count === 0) {
+        return { ok: false as const };
+      }
+      await tx.emergencyAccessKeyPair.create({
         data: {
           grantId: id,
           tenantId: grant.tenantId,
@@ -83,9 +92,14 @@ async function handlePOST(
           privateKeyIv: encryptedPrivateKey.iv,
           privateKeyAuthTag: encryptedPrivateKey.authTag,
         },
-      }),
-    ]),
+      });
+      return { ok: true as const };
+    }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+
+  if (!txResult.ok) {
+    return errorResponse(API_ERROR.GRANT_NOT_PENDING, 400);
+  }
 
   await logAuditAsync({
     ...personalAuditBase(req, session.user.id),

--- a/src/app/api/emergency-access/[id]/approve/route.test.ts
+++ b/src/app/api/emergency-access/[id]/approve/route.test.ts
@@ -5,7 +5,7 @@ const { mockAuth, mockPrismaGrant, mockPrismaUser, mockSendEmail, mockWithUserTe
   mockAuth: vi.fn(),
   mockPrismaGrant: {
     findUnique: vi.fn(),
-    update: vi.fn(),
+    updateMany: vi.fn(),
   },
   mockPrismaUser: { findUnique: vi.fn() },
   mockSendEmail: vi.fn(),
@@ -47,7 +47,7 @@ describe("POST /api/emergency-access/[id]/approve", () => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue({ user: { id: "owner-1" } });
     mockPrismaGrant.findUnique.mockResolvedValue(requestedGrant);
-    mockPrismaGrant.update.mockResolvedValue({});
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 1 });
     mockPrismaUser.findUnique.mockResolvedValue({ email: "grantee@test.com", name: "Grantee Name" });
   });
 
@@ -78,17 +78,10 @@ describe("POST /api/emergency-access/[id]/approve", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 400 when grant is not REQUESTED", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({ ...requestedGrant, status: EA_STATUS.IDLE });
-    const res = await POST(
-      createRequest("POST", "http://localhost/api/emergency-access/grant-1/approve"),
-      createParams({ id: "grant-1" })
-    );
-    expect(res.status).toBe(400);
-  });
-
-  it("returns 400 when grant is PENDING", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({ ...requestedGrant, status: EA_STATUS.PENDING });
+  it("returns 400 when status CAS finds no eligible row (e.g. concurrent revoke)", async () => {
+    // Simulates the race: findUnique sees REQUESTED, but by the time the CAS
+    // updateMany runs, the row's status has moved out of the permitted from-set.
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 0 });
     const res = await POST(
       createRequest("POST", "http://localhost/api/emergency-access/grant-1/approve"),
       createParams({ id: "grant-1" })
@@ -115,8 +108,12 @@ describe("POST /api/emergency-access/[id]/approve", () => {
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.status).toBe(EA_STATUS.ACTIVATED);
-    expect(mockPrismaGrant.update).toHaveBeenCalledWith({
-      where: { id: "grant-1" },
+    expect(mockPrismaGrant.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "grant-1",
+        ownerId: "owner-1",
+        status: { in: expect.arrayContaining([EA_STATUS.REQUESTED]) },
+      },
       data: {
         status: EA_STATUS.ACTIVATED,
         activatedAt: expect.any(Date),

--- a/src/app/api/emergency-access/[id]/approve/route.ts
+++ b/src/app/api/emergency-access/[id]/approve/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { canTransition } from "@/lib/emergency-access/emergency-access-state";
+import { fromStatusesFor } from "@/lib/emergency-access/emergency-access-state";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyAccessApprovedEmail } from "@/lib/email/templates/emergency-access";
@@ -28,7 +28,7 @@ async function handlePOST(
   const grant = await withUserTenantRls(session.user.id, async () =>
     prisma.emergencyAccessGrant.findUnique({
       where: { id },
-      select: { ownerId: true, status: true, granteeId: true },
+      select: { ownerId: true, granteeId: true },
     }),
   );
 
@@ -36,19 +36,26 @@ async function handlePOST(
     return notFound();
   }
 
-  if (!canTransition(grant.status, EA_STATUS.ACTIVATED)) {
-    return errorResponse(API_ERROR.INVALID_STATUS, 400);
-  }
-
-  await withUserTenantRls(session.user.id, async () =>
-    prisma.emergencyAccessGrant.update({
-      where: { id },
+  // Atomic compare-and-swap on status: blocks concurrent transitions out of the
+  // permitted from-set even if a parallel revoke/request/etc. lands between
+  // the read above and this write.
+  const updated = await withUserTenantRls(session.user.id, async () =>
+    prisma.emergencyAccessGrant.updateMany({
+      where: {
+        id,
+        ownerId: session.user.id,
+        status: { in: fromStatusesFor(EA_STATUS.ACTIVATED) },
+      },
       data: {
         status: EA_STATUS.ACTIVATED,
         activatedAt: new Date(),
       },
     }),
   );
+
+  if (updated.count === 0) {
+    return errorResponse(API_ERROR.INVALID_STATUS, 400);
+  }
 
   await logAuditAsync({
     ...personalAuditBase(req, session.user.id),

--- a/src/app/api/emergency-access/[id]/confirm/route.test.ts
+++ b/src/app/api/emergency-access/[id]/confirm/route.test.ts
@@ -5,7 +5,7 @@ const { mockAuth, mockPrismaGrant, mockPrismaUser, mockWithUserTenantRls } = vi.
   mockAuth: vi.fn(),
   mockPrismaGrant: {
     findUnique: vi.fn(),
-    update: vi.fn(),
+    updateMany: vi.fn(),
   },
   mockPrismaUser: {
     findUnique: vi.fn(),
@@ -57,7 +57,7 @@ describe("POST /api/emergency-access/[id]/confirm", () => {
       status: EA_STATUS.ACCEPTED,
       keyAlgorithm: "ECDH-P256",
     });
-    mockPrismaGrant.update.mockResolvedValue({});
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 1 });
     mockPrismaUser.findUnique.mockResolvedValue({ keyVersion: 3 });
   });
 
@@ -89,13 +89,8 @@ describe("POST /api/emergency-access/[id]/confirm", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 400 when status is not ACCEPTED", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({
-      id: "grant-1",
-      ownerId: "owner-1",
-      status: EA_STATUS.IDLE,
-      keyAlgorithm: "ECDH-P256",
-    });
+  it("returns 400 when CAS finds no eligible row (e.g. concurrent revoke moved status out of permitted from-set)", async () => {
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 0 });
     const res = await POST(
       createRequest("POST", "http://localhost/api/emergency-access/grant-1/confirm", { body: validBody }),
       createParams({ id: "grant-1" })
@@ -150,8 +145,12 @@ describe("POST /api/emergency-access/[id]/confirm", () => {
     expect(res.status).toBe(200);
     expect(json.status).toBe(EA_STATUS.IDLE);
     expect(json.keyVersion).toBe(3);
-    expect(mockPrismaGrant.update).toHaveBeenCalledWith({
-      where: { id: "grant-1" },
+    expect(mockPrismaGrant.updateMany).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        id: "grant-1",
+        ownerId: "owner-1",
+        status: { in: expect.any(Array) },
+      }),
       data: expect.objectContaining({
         status: EA_STATUS.IDLE,
         keyVersion: 3,
@@ -171,7 +170,7 @@ describe("POST /api/emergency-access/[id]/confirm", () => {
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.keyVersion).toBe(5);
-    expect(mockPrismaGrant.update).toHaveBeenCalledWith(
+    expect(mockPrismaGrant.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ keyVersion: 5 }),
       }),

--- a/src/app/api/emergency-access/[id]/confirm/route.ts
+++ b/src/app/api/emergency-access/[id]/confirm/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { confirmEmergencyGrantSchema } from "@/lib/validations";
-import { canTransition } from "@/lib/emergency-access/emergency-access-state";
+import { fromStatusesFor } from "@/lib/emergency-access/emergency-access-state";
 import { SUPPORTED_KEY_ALGORITHMS } from "@/lib/crypto/crypto-emergency";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { API_ERROR } from "@/lib/http/api-error-codes";
@@ -34,10 +34,6 @@ async function handlePOST(
     return notFound();
   }
 
-  if (!canTransition(grant.status, EA_STATUS.IDLE)) {
-    return errorResponse(API_ERROR.INVALID_STATUS, 400);
-  }
-
   // Fetch owner's current keyVersion from DB (server-authoritative)
   const owner = await withUserTenantRls(session.user.id, async () =>
     prisma.user.findUnique({
@@ -63,9 +59,15 @@ async function handlePOST(
   // Use server-fetched keyVersion, ignore client-sent value
   const serverKeyVersion = owner.keyVersion;
 
-  await withUserTenantRls(session.user.id, async () =>
-    prisma.emergencyAccessGrant.update({
-      where: { id },
+  // Atomic compare-and-swap on status: prevents racing a concurrent revoke
+  // that would otherwise let stale escrow data overwrite a REVOKED grant.
+  const updated = await withUserTenantRls(session.user.id, async () =>
+    prisma.emergencyAccessGrant.updateMany({
+      where: {
+        id,
+        ownerId: session.user.id,
+        status: { in: fromStatusesFor(EA_STATUS.IDLE) },
+      },
       data: {
         status: EA_STATUS.IDLE,
         ownerEphemeralPublicKey,
@@ -78,6 +80,10 @@ async function handlePOST(
       },
     }),
   );
+
+  if (updated.count === 0) {
+    return errorResponse(API_ERROR.INVALID_STATUS, 400);
+  }
 
   await logAuditAsync({
     ...personalAuditBase(req, session.user.id),

--- a/src/app/api/emergency-access/[id]/decline/route.test.ts
+++ b/src/app/api/emergency-access/[id]/decline/route.test.ts
@@ -3,7 +3,7 @@ import { createRequest, createParams } from "@/__tests__/helpers/request-builder
 
 const { mockAuth, mockPrismaGrant, mockPrismaUser, mockSendEmail, mockWithBypassRls } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
-  mockPrismaGrant: { findUnique: vi.fn(), update: vi.fn() },
+  mockPrismaGrant: { findUnique: vi.fn(), updateMany: vi.fn() },
   mockPrismaUser: { findUnique: vi.fn() },
   mockSendEmail: vi.fn(),
   mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
@@ -38,7 +38,7 @@ describe("POST /api/emergency-access/[id]/decline", () => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue({ user: { id: "grantee-1", email: "grantee@example.com" } });
     mockPrismaGrant.findUnique.mockResolvedValue(pendingGrant);
-    mockPrismaGrant.update.mockResolvedValue({});
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 1 });
     mockPrismaUser.findUnique.mockResolvedValue({ email: "owner@test.com", name: "Owner Name" });
   });
 
@@ -69,8 +69,8 @@ describe("POST /api/emergency-access/[id]/decline", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 400 when grant is not pending", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({ ...pendingGrant, status: EA_STATUS.ACCEPTED });
+  it("returns 400 when CAS finds no still-PENDING row (e.g. concurrent accept)", async () => {
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 0 });
     const res = await POST(
       createRequest("POST", "http://localhost/api/emergency-access/grant-1/decline"),
       createParams({ id: "grant-1" })
@@ -97,9 +97,13 @@ describe("POST /api/emergency-access/[id]/decline", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.status).toBe(EA_STATUS.REJECTED);
-    expect(mockPrismaGrant.update).toHaveBeenCalledWith(
+    expect(mockPrismaGrant.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "grant-1" },
+        where: expect.objectContaining({
+          id: "grant-1",
+          granteeEmail: pendingGrant.granteeEmail,
+          status: { in: expect.arrayContaining([EA_STATUS.PENDING]) },
+        }),
         data: { status: EA_STATUS.REJECTED },
       })
     );

--- a/src/app/api/emergency-access/[id]/decline/route.ts
+++ b/src/app/api/emergency-access/[id]/decline/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { fromStatusesFor } from "@/lib/emergency-access/emergency-access-state";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyGrantDeclinedEmail } from "@/lib/email/templates/emergency-access";
@@ -26,7 +27,7 @@ async function handlePOST(
   const grant = await withBypassRls(prisma, async () =>
     prisma.emergencyAccessGrant.findUnique({
       where: { id },
-      select: { status: true, granteeEmail: true, ownerId: true },
+      select: { granteeEmail: true, ownerId: true },
     }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
@@ -34,20 +35,25 @@ async function handlePOST(
     return notFound();
   }
 
-  if (grant.status !== EA_STATUS.PENDING) {
-    return errorResponse(API_ERROR.GRANT_NOT_PENDING, 400);
-  }
-
   if (grant.granteeEmail.toLowerCase() !== session.user.email.toLowerCase()) {
     return errorResponse(API_ERROR.NOT_AUTHORIZED_FOR_GRANT, 403);
   }
 
-  await withBypassRls(prisma, async () =>
-    prisma.emergencyAccessGrant.update({
-      where: { id },
+  // Atomic compare-and-swap: only transitions a still-PENDING row.
+  const updated = await withBypassRls(prisma, async () =>
+    prisma.emergencyAccessGrant.updateMany({
+      where: {
+        id,
+        granteeEmail: grant.granteeEmail,
+        status: { in: fromStatusesFor(EA_STATUS.REJECTED) },
+      },
       data: { status: EA_STATUS.REJECTED },
     }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+
+  if (updated.count === 0) {
+    return errorResponse(API_ERROR.GRANT_NOT_PENDING, 400);
+  }
 
   await logAuditAsync({
     ...personalAuditBase(req, session.user.id),

--- a/src/app/api/emergency-access/[id]/request/route.test.ts
+++ b/src/app/api/emergency-access/[id]/request/route.test.ts
@@ -5,7 +5,7 @@ const { mockAuth, mockPrismaGrant, mockPrismaUser, mockSendEmail, mockWithBypass
   mockAuth: vi.fn(),
   mockPrismaGrant: {
     findUnique: vi.fn(),
-    update: vi.fn(),
+    updateMany: vi.fn(),
   },
   mockPrismaUser: { findUnique: vi.fn() },
   mockSendEmail: vi.fn(),
@@ -40,10 +40,9 @@ describe("POST /api/emergency-access/[id]/request", () => {
       id: "grant-1",
       ownerId: "owner-1",
       granteeId: "grantee-1",
-      status: EA_STATUS.IDLE,
       waitDays: 7,
     });
-    mockPrismaGrant.update.mockResolvedValue({});
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 1 });
     mockPrismaUser.findUnique.mockImplementation(({ where }: { where: { id: string } }) => {
       if (where.id === "owner-1") return Promise.resolve({ email: "owner@test.com", name: "Owner Name" });
       if (where.id === "grantee-1") return Promise.resolve({ email: "grantee@test.com", name: "Grantee Name" });
@@ -69,13 +68,8 @@ describe("POST /api/emergency-access/[id]/request", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 400 when status not IDLE", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({
-      id: "grant-1",
-      granteeId: "grantee-1",
-      status: EA_STATUS.PENDING,
-      waitDays: 7,
-    });
+  it("returns 400 when status CAS finds no eligible row (e.g. grant in PENDING)", async () => {
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 0 });
     const res = await POST(
       createRequest("POST", "http://localhost/api/emergency-access/grant-1/request"),
       createParams({ id: "grant-1" })
@@ -92,9 +86,13 @@ describe("POST /api/emergency-access/[id]/request", () => {
     expect(res.status).toBe(200);
     expect(json.status).toBe(EA_STATUS.REQUESTED);
     expect(json.waitExpiresAt).toBeTruthy();
-    expect(mockPrismaGrant.update).toHaveBeenCalledWith(
+    expect(mockPrismaGrant.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "grant-1" },
+        where: expect.objectContaining({
+          id: "grant-1",
+          granteeId: "grantee-1",
+          status: { in: expect.arrayContaining([EA_STATUS.IDLE]) },
+        }),
         data: expect.objectContaining({ status: EA_STATUS.REQUESTED }),
       })
     );
@@ -107,13 +105,10 @@ describe("POST /api/emergency-access/[id]/request", () => {
     );
   });
 
-  it("returns 400 when grant is STALE", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({
-      id: "grant-1",
-      granteeId: "grantee-1",
-      status: EA_STATUS.STALE,
-      waitDays: 7,
-    });
+  it("returns 400 when grant status is not in REQUESTED's permitted from-set (e.g. STALE)", async () => {
+    // updateMany filters by status: { in: fromStatusesFor(REQUESTED) } = [IDLE]
+    // STALE is not in that set, so the row does not match and count is 0.
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 0 });
     const res = await POST(
       createRequest("POST", "http://localhost/api/emergency-access/grant-1/request"),
       createParams({ id: "grant-1" })

--- a/src/app/api/emergency-access/[id]/request/route.ts
+++ b/src/app/api/emergency-access/[id]/request/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { canTransition } from "@/lib/emergency-access/emergency-access-state";
+import { fromStatusesFor } from "@/lib/emergency-access/emergency-access-state";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyAccessRequestedEmail } from "@/lib/email/templates/emergency-access";
@@ -36,7 +36,7 @@ async function handlePOST(
   const grant = await withBypassRls(prisma, async () =>
     prisma.emergencyAccessGrant.findUnique({
       where: { id },
-      select: { granteeId: true, status: true, ownerId: true, waitDays: true },
+      select: { granteeId: true, ownerId: true, waitDays: true },
     }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
@@ -44,16 +44,18 @@ async function handlePOST(
     return notFound();
   }
 
-  if (!canTransition(grant.status, EA_STATUS.REQUESTED)) {
-    return errorResponse(API_ERROR.INVALID_STATUS, 400);
-  }
-
   const now = new Date();
   const waitExpiresAt = new Date(now.getTime() + grant.waitDays * MS_PER_DAY);
 
-  await withBypassRls(prisma, async () =>
-    prisma.emergencyAccessGrant.update({
-      where: { id },
+  // Atomic compare-and-swap on status: prevents concurrent transitions that
+  // would otherwise race past the optimistic canTransition check.
+  const updated = await withBypassRls(prisma, async () =>
+    prisma.emergencyAccessGrant.updateMany({
+      where: {
+        id,
+        granteeId: session.user.id,
+        status: { in: fromStatusesFor(EA_STATUS.REQUESTED) },
+      },
       data: {
         status: EA_STATUS.REQUESTED,
         requestedAt: now,
@@ -61,6 +63,10 @@ async function handlePOST(
       },
     }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+
+  if (updated.count === 0) {
+    return errorResponse(API_ERROR.INVALID_STATUS, 400);
+  }
 
   await logAuditAsync({
     ...personalAuditBase(req, session.user.id),

--- a/src/app/api/emergency-access/[id]/revoke/route.test.ts
+++ b/src/app/api/emergency-access/[id]/revoke/route.test.ts
@@ -5,7 +5,7 @@ const { mockAuth, mockPrismaGrant, mockPrismaUser, mockSendEmail, mockWithUserTe
   mockAuth: vi.fn(),
   mockPrismaGrant: {
     findUnique: vi.fn(),
-    update: vi.fn(),
+    updateMany: vi.fn(),
   },
   mockPrismaUser: { findUnique: vi.fn() },
   mockSendEmail: vi.fn(),
@@ -41,9 +41,8 @@ describe("POST /api/emergency-access/[id]/revoke", () => {
       id: "grant-1",
       ownerId: "owner-1",
       granteeId: "grantee-1",
-      status: EA_STATUS.IDLE,
     });
-    mockPrismaGrant.update.mockResolvedValue({});
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 1 });
     mockPrismaUser.findUnique.mockResolvedValue({ email: "grantee@test.com", name: "Grantee Name" });
   });
 
@@ -92,8 +91,13 @@ describe("POST /api/emergency-access/[id]/revoke", () => {
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.status).toBe(EA_STATUS.REVOKED);
-    expect(mockPrismaGrant.update).toHaveBeenCalledWith(
+    expect(mockPrismaGrant.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
+        where: expect.objectContaining({
+          id: "grant-1",
+          ownerId: "owner-1",
+          status: { in: expect.any(Array) },
+        }),
         data: expect.objectContaining({
           status: EA_STATUS.REVOKED,
           encryptedSecretKey: null,
@@ -112,11 +116,6 @@ describe("POST /api/emergency-access/[id]/revoke", () => {
   });
 
   it("rejects request (non-permanent, back to IDLE)", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({
-      id: "grant-1",
-      ownerId: "owner-1",
-      status: EA_STATUS.REQUESTED,
-    });
     const res = await POST(
       createRequest("POST", "http://localhost/api/emergency-access/grant-1/revoke", {
         body: { permanent: false },
@@ -128,12 +127,8 @@ describe("POST /api/emergency-access/[id]/revoke", () => {
     expect(json.status).toBe(EA_STATUS.IDLE);
   });
 
-  it("returns 400 when already revoked", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({
-      id: "grant-1",
-      ownerId: "owner-1",
-      status: EA_STATUS.REVOKED,
-    });
+  it("returns 400 when CAS finds no eligible row (e.g. already REVOKED)", async () => {
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 0 });
     const res = await POST(
       createRequest("POST", "http://localhost/api/emergency-access/grant-1/revoke", {
         body: { permanent: true },
@@ -144,12 +139,7 @@ describe("POST /api/emergency-access/[id]/revoke", () => {
   });
 
   it("revokes STALE grant", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({
-      id: "grant-1",
-      ownerId: "owner-1",
-      granteeId: "grantee-1",
-      status: EA_STATUS.STALE,
-    });
+    // STALE is in fromStatusesFor(REVOKED), so updateMany returns count: 1.
     const res = await POST(
       createRequest("POST", "http://localhost/api/emergency-access/grant-1/revoke", {
         body: { permanent: true },

--- a/src/app/api/emergency-access/[id]/revoke/route.ts
+++ b/src/app/api/emergency-access/[id]/revoke/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { revokeEmergencyGrantSchema } from "@/lib/validations";
-import { canTransition } from "@/lib/emergency-access/emergency-access-state";
+import { fromStatusesFor } from "@/lib/emergency-access/emergency-access-state";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyAccessRevokedEmail } from "@/lib/email/templates/emergency-access";
@@ -30,7 +30,7 @@ async function handlePOST(
   const grant = await withUserTenantRls(session.user.id, async () =>
     prisma.emergencyAccessGrant.findUnique({
       where: { id },
-      select: { ownerId: true, status: true, granteeId: true },
+      select: { ownerId: true, granteeId: true },
     }),
   );
 
@@ -43,14 +43,14 @@ async function handlePOST(
   const { permanent } = result.data;
 
   if (permanent) {
-    // Full revoke
-    if (!canTransition(grant.status, EA_STATUS.REVOKED)) {
-      return errorResponse(API_ERROR.INVALID_STATUS, 400);
-    }
-
-    await withUserTenantRls(session.user.id, async () =>
-      prisma.emergencyAccessGrant.update({
-        where: { id },
+    // Full revoke — atomic compare-and-swap on status.
+    const updated = await withUserTenantRls(session.user.id, async () =>
+      prisma.emergencyAccessGrant.updateMany({
+        where: {
+          id,
+          ownerId: session.user.id,
+          status: { in: fromStatusesFor(EA_STATUS.REVOKED) },
+        },
         data: {
           status: EA_STATUS.REVOKED,
           revokedAt: new Date(),
@@ -63,6 +63,10 @@ async function handlePOST(
         },
       }),
     );
+
+    if (updated.count === 0) {
+      return errorResponse(API_ERROR.INVALID_STATUS, 400);
+    }
 
     await logAuditAsync({
       ...personalAuditBase(req, session.user.id),
@@ -90,14 +94,14 @@ async function handlePOST(
 
     return NextResponse.json({ status: EA_STATUS.REVOKED });
   } else {
-    // Reject request only (revert to IDLE)
-    if (!canTransition(grant.status, EA_STATUS.IDLE)) {
-      return errorResponse(API_ERROR.INVALID_STATUS, 400);
-    }
-
-    await withUserTenantRls(session.user.id, async () =>
-      prisma.emergencyAccessGrant.update({
-        where: { id },
+    // Reject request only (revert to IDLE) — atomic compare-and-swap on status.
+    const updated = await withUserTenantRls(session.user.id, async () =>
+      prisma.emergencyAccessGrant.updateMany({
+        where: {
+          id,
+          ownerId: session.user.id,
+          status: { in: fromStatusesFor(EA_STATUS.IDLE) },
+        },
         data: {
           status: EA_STATUS.IDLE,
           requestedAt: null,
@@ -105,6 +109,10 @@ async function handlePOST(
         },
       }),
     );
+
+    if (updated.count === 0) {
+      return errorResponse(API_ERROR.INVALID_STATUS, 400);
+    }
 
     await logAuditAsync({
       ...personalAuditBase(req, session.user.id),

--- a/src/app/api/emergency-access/accept/route.test.ts
+++ b/src/app/api/emergency-access/accept/route.test.ts
@@ -1,17 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockPrismaGrant, mockPrismaKeyPair, mockPrismaUser, mockTransaction, mockSendEmail, mockWithBypassRls } = vi.hoisted(() => ({
+const { mockAuth, mockPrismaGrant, mockPrismaUser, mockTransaction, mockTxGrantUpdateMany, mockTxKeyPairCreate, mockSendEmail, mockWithBypassRls } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockPrismaGrant: {
     findUnique: vi.fn(),
-    update: vi.fn(),
-  },
-  mockPrismaKeyPair: {
-    create: vi.fn(),
   },
   mockPrismaUser: { findUnique: vi.fn() },
   mockTransaction: vi.fn(),
+  mockTxGrantUpdateMany: vi.fn(),
+  mockTxKeyPairCreate: vi.fn(),
   mockSendEmail: vi.fn(),
   mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
 }));
@@ -20,7 +18,6 @@ vi.mock("@/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     emergencyAccessGrant: mockPrismaGrant,
-    emergencyAccessKeyPair: mockPrismaKeyPair,
     user: mockPrismaUser,
     $transaction: mockTransaction,
   },
@@ -60,6 +57,7 @@ const validGrant = {
   granteeEmail: "grantee@test.com",
   status: EA_STATUS.PENDING,
   tokenExpiresAt: new Date("2099-01-01"),
+  tokenHash: "hashed-valid-token",
 };
 
 describe("POST /api/emergency-access/accept", () => {
@@ -67,7 +65,14 @@ describe("POST /api/emergency-access/accept", () => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue({ user: { id: "grantee-1", email: "grantee@test.com" } });
     mockPrismaGrant.findUnique.mockResolvedValue(validGrant);
-    mockTransaction.mockResolvedValue([{}, {}]);
+    mockTxGrantUpdateMany.mockResolvedValue({ count: 1 });
+    mockTxKeyPairCreate.mockResolvedValue({});
+    mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
+      cb({
+        emergencyAccessGrant: { updateMany: mockTxGrantUpdateMany },
+        emergencyAccessKeyPair: { create: mockTxKeyPairCreate },
+      }),
+    );
     mockPrismaUser.findUnique.mockResolvedValue({ email: "owner@test.com", name: "Owner Name" });
   });
 
@@ -96,12 +101,13 @@ describe("POST /api/emergency-access/accept", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 410 when invitation not PENDING", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({ ...validGrant, status: EA_STATUS.ACCEPTED });
+  it("returns 410 when CAS finds no still-PENDING row (invitation already used)", async () => {
+    mockTxGrantUpdateMany.mockResolvedValue({ count: 0 });
     const res = await POST(createRequest("POST", "http://localhost/api/emergency-access/accept", {
       body: validBody,
     }));
     expect(res.status).toBe(410);
+    expect(mockTxKeyPairCreate).not.toHaveBeenCalled();
   });
 
   it("returns 410 when invitation expired", async () => {
@@ -139,6 +145,17 @@ describe("POST /api/emergency-access/accept", () => {
     expect(res.status).toBe(200);
     expect(json.status).toBe(EA_STATUS.ACCEPTED);
     expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockTxGrantUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "grant-1",
+          tokenHash: "hashed-valid-token",
+          status: { in: expect.arrayContaining([EA_STATUS.PENDING]) },
+        }),
+        data: expect.objectContaining({ status: EA_STATUS.ACCEPTED }),
+      }),
+    );
+    expect(mockTxKeyPairCreate).toHaveBeenCalled();
     // Sends accepted email to owner
     expect(mockSendEmail).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/app/api/emergency-access/accept/route.ts
+++ b/src/app/api/emergency-access/accept/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { acceptEmergencyGrantSchema } from "@/lib/validations";
 import { hashToken } from "@/lib/crypto/crypto-server";
+import { fromStatusesFor } from "@/lib/emergency-access/emergency-access-state";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyGrantAcceptedEmail } from "@/lib/email/templates/emergency-access";
@@ -45,10 +46,6 @@ async function handlePOST(req: NextRequest) {
     return notFound();
   }
 
-  if (grant.status !== EA_STATUS.PENDING) {
-    return errorResponse(API_ERROR.INVITATION_ALREADY_USED, 410);
-  }
-
   if (grant.tokenExpiresAt < new Date()) {
     return errorResponse(API_ERROR.INVITATION_EXPIRED, 410);
   }
@@ -62,17 +59,26 @@ async function handlePOST(req: NextRequest) {
     return errorResponse(API_ERROR.CANNOT_GRANT_SELF, 400);
   }
 
-  await withBypassRls(prisma, async () =>
-    prisma.$transaction([
-      prisma.emergencyAccessGrant.update({
-        where: { id: grant.id },
+  // Atomic compare-and-swap: only transitions a still-PENDING row, and only
+  // creates the escrow key pair if the transition actually fired.
+  const txResult = await withBypassRls(prisma, async () =>
+    prisma.$transaction(async (tx) => {
+      const updated = await tx.emergencyAccessGrant.updateMany({
+        where: {
+          id: grant.id,
+          tokenHash: grant.tokenHash,
+          status: { in: fromStatusesFor(EA_STATUS.ACCEPTED) },
+        },
         data: {
           status: EA_STATUS.ACCEPTED,
           granteeId: session.user.id,
           granteePublicKey,
         },
-      }),
-      prisma.emergencyAccessKeyPair.create({
+      });
+      if (updated.count === 0) {
+        return { ok: false as const };
+      }
+      await tx.emergencyAccessKeyPair.create({
         data: {
           grantId: grant.id,
           tenantId: grant.tenantId,
@@ -80,9 +86,14 @@ async function handlePOST(req: NextRequest) {
           privateKeyIv: encryptedPrivateKey.iv,
           privateKeyAuthTag: encryptedPrivateKey.authTag,
         },
-      }),
-    ]),
+      });
+      return { ok: true as const };
+    }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+
+  if (!txResult.ok) {
+    return errorResponse(API_ERROR.INVITATION_ALREADY_USED, 410);
+  }
 
   await logAuditAsync({
     ...personalAuditBase(req, session.user.id),

--- a/src/app/api/emergency-access/reject/route.test.ts
+++ b/src/app/api/emergency-access/reject/route.test.ts
@@ -5,7 +5,7 @@ const { mockAuth, mockPrismaGrant, mockPrismaUser, mockSendEmail, mockWithBypass
   mockAuth: vi.fn(),
   mockPrismaGrant: {
     findUnique: vi.fn(),
-    update: vi.fn(),
+    updateMany: vi.fn(),
   },
   mockPrismaUser: { findUnique: vi.fn() },
   mockSendEmail: vi.fn(),
@@ -36,6 +36,7 @@ const validGrant = {
   id: "grant-1",
   ownerId: "owner-1",
   granteeEmail: "grantee@test.com",
+  tokenHash: "hashed-tok",
   status: EA_STATUS.PENDING,
 };
 
@@ -44,7 +45,7 @@ describe("POST /api/emergency-access/reject", () => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue({ user: { id: "grantee-1", email: "grantee@test.com" } });
     mockPrismaGrant.findUnique.mockResolvedValue(validGrant);
-    mockPrismaGrant.update.mockResolvedValue({});
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 1 });
     mockPrismaUser.findUnique.mockResolvedValue({ email: "owner@test.com", name: "Owner Name" });
   });
 
@@ -83,8 +84,8 @@ describe("POST /api/emergency-access/reject", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 410 when invitation not PENDING", async () => {
-    mockPrismaGrant.findUnique.mockResolvedValue({ ...validGrant, status: EA_STATUS.ACCEPTED });
+  it("returns 410 when CAS finds no still-PENDING row (e.g. invitation already used)", async () => {
+    mockPrismaGrant.updateMany.mockResolvedValue({ count: 0 });
     const res = await POST(createRequest("POST", "http://localhost/api/emergency-access/reject", {
       body: { token: "tok" },
     }));
@@ -115,10 +116,16 @@ describe("POST /api/emergency-access/reject", () => {
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.status).toBe(EA_STATUS.REJECTED);
-    expect(mockPrismaGrant.update).toHaveBeenCalledWith({
-      where: { id: "grant-1" },
-      data: { status: EA_STATUS.REJECTED },
-    });
+    expect(mockPrismaGrant.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "grant-1",
+          tokenHash: "hashed-tok",
+          status: { in: expect.arrayContaining([EA_STATUS.PENDING]) },
+        }),
+        data: { status: EA_STATUS.REJECTED },
+      })
+    );
     // Sends declined email to owner
     expect(mockSendEmail).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/app/api/emergency-access/reject/route.ts
+++ b/src/app/api/emergency-access/reject/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { rejectEmergencyGrantSchema } from "@/lib/validations";
 import { hashToken } from "@/lib/crypto/crypto-server";
+import { fromStatusesFor } from "@/lib/emergency-access/emergency-access-state";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { sendEmail } from "@/lib/email";
 import { emergencyGrantDeclinedEmail } from "@/lib/email/templates/emergency-access";
@@ -36,20 +37,25 @@ async function handlePOST(req: NextRequest) {
     return notFound();
   }
 
-  if (grant.status !== EA_STATUS.PENDING) {
-    return errorResponse(API_ERROR.INVITATION_ALREADY_USED, 410);
-  }
-
   if (grant.granteeEmail.toLowerCase() !== session.user.email.toLowerCase()) {
     return errorResponse(API_ERROR.INVITATION_WRONG_EMAIL, 403);
   }
 
-  await withBypassRls(prisma, async () =>
-    prisma.emergencyAccessGrant.update({
-      where: { id: grant.id },
+  // Atomic compare-and-swap: only transitions a still-PENDING row.
+  const updated = await withBypassRls(prisma, async () =>
+    prisma.emergencyAccessGrant.updateMany({
+      where: {
+        id: grant.id,
+        tokenHash: grant.tokenHash,
+        status: { in: fromStatusesFor(EA_STATUS.REJECTED) },
+      },
       data: { status: EA_STATUS.REJECTED },
     }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+
+  if (updated.count === 0) {
+    return errorResponse(API_ERROR.INVITATION_ALREADY_USED, 410);
+  }
 
   await logAuditAsync({
     ...personalAuditBase(req, session.user.id),

--- a/src/app/api/extension/token/refresh/route.test.ts
+++ b/src/app/api/extension/token/refresh/route.test.ts
@@ -284,4 +284,79 @@ describe("POST /api/extension/token/refresh", () => {
     // Must NOT create a new token when old one was already revoked
     expect(mockExtTokenCreate).not.toHaveBeenCalled();
   });
+
+  // ─── Replay attack flow ──────────────────────────────────────
+  // Simulates the full refresh-then-replay sequence: a legitimate refresh
+  // rotates the token, the old plaintext leaks (e.g. via XSS or a sniffed
+  // cache), and an attacker presents the rotated token expecting to refresh
+  // it. The validation layer must reject the rotated token and the route
+  // must NOT mint a new one.
+
+  describe("replay of a rotated token", () => {
+    it("first refresh succeeds, then replay of the original token is rejected with REVOKED", async () => {
+      mockSessionFindFirst.mockResolvedValue({ id: "session-1", tenantId: "tenant-1" });
+
+      // Step 1: legitimate refresh succeeds (token A1 → A2).
+      mockValidateExtensionToken.mockResolvedValueOnce(validTokenResult());
+      const firstReq = createRequest(
+        "POST",
+        "http://localhost/api/extension/token/refresh",
+        { headers: { Authorization: "Bearer A1-plaintext" } },
+      );
+      const firstRes = await POST(firstReq);
+      const firstParsed = await parseResponse(firstRes);
+      expect(firstParsed.status).toBe(200);
+      expect(mockExtTokenUpdateMany).toHaveBeenCalledTimes(1);
+      expect(mockExtTokenCreate).toHaveBeenCalledTimes(1);
+
+      // Step 2: replay the old plaintext (A1). validateExtensionToken now
+      // observes revokedAt != null and short-circuits with REVOKED.
+      mockValidateExtensionToken.mockResolvedValueOnce({
+        ok: false,
+        error: "EXTENSION_TOKEN_REVOKED",
+      });
+      const replayReq = createRequest(
+        "POST",
+        "http://localhost/api/extension/token/refresh",
+        { headers: { Authorization: "Bearer A1-plaintext" } },
+      );
+      const replayRes = await POST(replayReq);
+      const replayParsed = await parseResponse(replayRes);
+      expect(replayParsed.status).toBe(401);
+      expect(replayParsed.json.error).toBe("EXTENSION_TOKEN_REVOKED");
+
+      // The replay must NOT mint a new token — only the legitimate refresh did.
+      expect(mockExtTokenCreate).toHaveBeenCalledTimes(1);
+      expect(mockExtTokenUpdateMany).toHaveBeenCalledTimes(1);
+    });
+
+    it("replay does not extend the family absolute timer", async () => {
+      mockSessionFindFirst.mockResolvedValue({ id: "session-1", tenantId: "tenant-1" });
+
+      // Replay arriving AFTER the family's absolute timeout would normally
+      // race with the family-expired branch. Even so, the replayed token is
+      // already revoked and validateExtensionToken short-circuits before the
+      // family-expired check fires — verify that the family-expired audit
+      // path is NOT used to mask the replay-rejected response.
+      mockValidateExtensionToken.mockResolvedValue({
+        ok: false,
+        error: "EXTENSION_TOKEN_REVOKED",
+      });
+
+      const req = createRequest(
+        "POST",
+        "http://localhost/api/extension/token/refresh",
+        { headers: { Authorization: "Bearer rotated-A1" } },
+      );
+      const res = await POST(req);
+      const parsed = await parseResponse(res);
+
+      expect(parsed.status).toBe(401);
+      expect(parsed.json.error).toBe("EXTENSION_TOKEN_REVOKED");
+      // family revocation must not be triggered by a generic replay — that
+      // path is reserved for explicit family_expired and other policy
+      // signals, not for the validation layer's REVOKED short-circuit.
+      expect(mockRevokeExtensionTokenFamily).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/api/vault/recovery-key/recover/route.test.ts
+++ b/src/app/api/vault/recovery-key/recover/route.test.ts
@@ -205,5 +205,49 @@ describe("POST /api/vault/recovery-key/recover", () => {
       }));
       expect(res.status).toBe(400);
     });
+
+    it("rejects replay of a used recovery key after the recovery verifier has rotated", async () => {
+      // First reset: succeeds. The recoveryVerifierHmac in the row is "a"*64
+      // and the request's verifierHash is "a"*64, so verifyHmac (mocked as
+      // strict equality) returns true and the row update fires.
+      const firstRes = await POST(createRequest("POST", URL, { body: resetBody }));
+      expect(firstRes.status).toBe(200);
+
+      // Simulate the post-rotation DB state: the recoveryVerifierHmac in the
+      // row is now hmac_<resetBody.recoveryVerifierHash>, since the legitimate
+      // reset rotated the recovery key atomically with the passphrase change.
+      mockPrismaUser.findUnique.mockResolvedValue({
+        ...userWithRecovery,
+        recoveryVerifierHmac: `hmac_${resetBody.recoveryVerifierHash}`,
+      });
+
+      // Replay the same request body: the attacker presents the OLD
+      // verifierHash ("a"*64), but the stored verifier has rotated, so the
+      // strict-equality mock returns false → INVALID_RECOVERY_KEY.
+      const replayRes = await POST(createRequest("POST", URL, { body: resetBody }));
+      expect(replayRes.status).toBe(401);
+      const replayJson = await replayRes.json();
+      expect(replayJson.error).toBe("INVALID_RECOVERY_KEY");
+    });
+
+    it("rejects replay even within the rate-limit window", async () => {
+      // Force the rate limiter to allow both attempts so this test isolates
+      // the verifier-rotation rejection path from rate-limit rejection.
+      mockResetCheck.mockResolvedValue({ allowed: true });
+
+      const firstRes = await POST(createRequest("POST", URL, { body: resetBody }));
+      expect(firstRes.status).toBe(200);
+
+      // Post-rotation state with rotated stored verifier.
+      mockPrismaUser.findUnique.mockResolvedValue({
+        ...userWithRecovery,
+        recoveryVerifierHmac: `hmac_${resetBody.recoveryVerifierHash}`,
+      });
+
+      const replayRes = await POST(createRequest("POST", URL, { body: resetBody }));
+      expect(replayRes.status).toBe(401);
+      // The DB write must NOT have happened on replay.
+      expect(mockPrismaUser.update).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/lib/auth/session/auth-adapter.test.ts
+++ b/src/lib/auth/session/auth-adapter.test.ts
@@ -592,6 +592,51 @@ describe("createCustomAdapter", () => {
       ).rejects.toThrow("USER_NOT_FOUND");
       expect(mockPrismaAccount.create).not.toHaveBeenCalled();
     });
+
+    it("encrypts refresh_token, access_token, and id_token before persisting", async () => {
+      mockPrismaUser.findUnique.mockResolvedValue({ tenantId: "tenant-1" });
+      mockPrismaAccount.create.mockResolvedValue({ id: "acc-1" });
+
+      const adapter = createCustomAdapter();
+      await adapter.linkAccount!({
+        userId: "u-1",
+        type: "oidc",
+        provider: "google",
+        providerAccountId: "google-2",
+        refresh_token: "rt-plain",
+        access_token: "at-plain",
+        id_token: "idt-plain",
+        token_type: "bearer",
+      });
+
+      const callArgs = mockPrismaAccount.create.mock.calls[0][0];
+      // Ciphertext does not contain the plaintext anywhere.
+      expect(callArgs.data.refresh_token).toMatch(/^psoenc1:/);
+      expect(callArgs.data.refresh_token).not.toContain("rt-plain");
+      expect(callArgs.data.access_token).toMatch(/^psoenc1:/);
+      expect(callArgs.data.access_token).not.toContain("at-plain");
+      expect(callArgs.data.id_token).toMatch(/^psoenc1:/);
+      expect(callArgs.data.id_token).not.toContain("idt-plain");
+    });
+
+    it("leaves null/undefined token fields null after encryption", async () => {
+      mockPrismaUser.findUnique.mockResolvedValue({ tenantId: "tenant-1" });
+      mockPrismaAccount.create.mockResolvedValue({ id: "acc-1" });
+
+      const adapter = createCustomAdapter();
+      await adapter.linkAccount!({
+        userId: "u-1",
+        type: "oidc",
+        provider: "google",
+        providerAccountId: "google-3",
+        // No tokens supplied
+      });
+
+      const callArgs = mockPrismaAccount.create.mock.calls[0][0];
+      expect(callArgs.data.refresh_token).toBeNull();
+      expect(callArgs.data.access_token).toBeNull();
+      expect(callArgs.data.id_token).toBeNull();
+    });
   });
 
   describe("updateSession", () => {
@@ -1105,6 +1150,65 @@ describe("createCustomAdapter", () => {
       mockPrismaAccount.findFirst.mockResolvedValue(null);
       const adapter = createCustomAdapter();
       expect(await adapter.getAccount!("missing", "google")).toBeNull();
+    });
+
+    it("decrypts encrypted tokens to plaintext (round-trip with linkAccount)", async () => {
+      // Use linkAccount to produce the ciphertext, then mock findFirst to
+      // return that ciphertext and verify getAccount decrypts it.
+      mockPrismaUser.findUnique.mockResolvedValue({ tenantId: "tenant-1" });
+      mockPrismaAccount.create.mockResolvedValue({ id: "acc-1" });
+      const adapter = createCustomAdapter();
+      await adapter.linkAccount!({
+        userId: "u-1",
+        type: "oidc",
+        provider: "google",
+        providerAccountId: "g-roundtrip",
+        refresh_token: "rt-roundtrip",
+        access_token: "at-roundtrip",
+        id_token: "idt-roundtrip",
+      });
+      const writeData = mockPrismaAccount.create.mock.calls[0][0].data;
+
+      mockPrismaAccount.findFirst.mockResolvedValue({
+        userId: "u-1",
+        type: "oidc",
+        provider: "google",
+        providerAccountId: "g-roundtrip",
+        refresh_token: writeData.refresh_token,
+        access_token: writeData.access_token,
+        expires_at: 1234,
+        token_type: "bearer",
+        scope: "openid",
+        id_token: writeData.id_token,
+        session_state: "ss",
+      });
+
+      const account = await adapter.getAccount!("g-roundtrip", "google");
+      expect(account?.refresh_token).toBe("rt-roundtrip");
+      expect(account?.access_token).toBe("at-roundtrip");
+      expect(account?.id_token).toBe("idt-roundtrip");
+    });
+
+    it("returns undefined for fields whose ciphertext is corrupted, without throwing", async () => {
+      mockPrismaAccount.findFirst.mockResolvedValue({
+        userId: "u-1",
+        type: "oidc",
+        provider: "google",
+        providerAccountId: "g-corrupt",
+        // Sentinel-prefixed but garbage afterwards — decryption must throw and
+        // the adapter must catch it per field.
+        refresh_token: "psoenc1:0:zzzzzzzzzzzz",
+        access_token: null,
+        expires_at: null,
+        token_type: null,
+        scope: null,
+        id_token: null,
+        session_state: null,
+      });
+      const adapter = createCustomAdapter();
+      const account = await adapter.getAccount!("g-corrupt", "google");
+      expect(account).not.toBeNull();
+      expect(account?.refresh_token).toBeUndefined();
     });
   });
 });

--- a/src/lib/auth/session/auth-adapter.ts
+++ b/src/lib/auth/session/auth-adapter.ts
@@ -15,6 +15,11 @@ import { MS_PER_MINUTE } from "@/lib/constants/time";
 import { createNotification } from "@/lib/notification";
 import { resolveEffectiveSessionTimeouts } from "@/lib/auth/session/session-timeout";
 import { invalidateCachedSessions } from "@/lib/auth/session/session-cache-helpers";
+import {
+  encryptAccountTokenTriple,
+  decryptAccountToken,
+} from "@/lib/crypto/account-token-crypto";
+import logger from "@/lib/logger";
 
 /**
  * Custom Auth.js adapter that extends PrismaAdapter with:
@@ -213,6 +218,18 @@ export function createCustomAdapter(): Adapter {
       await withBypassRls(prisma, async () => {
         const tenantId = await resolveTenantIdForUser(account.userId);
 
+        // Envelope-encrypt the OAuth provider tokens at rest. AAD binds the
+        // ciphertext to (provider, providerAccountId) so a leaked DB row's
+        // tokens cannot be substituted across accounts.
+        const encrypted = encryptAccountTokenTriple(
+          {
+            refresh_token: account.refresh_token,
+            access_token: account.access_token,
+            id_token: account.id_token,
+          },
+          { provider: account.provider, providerAccountId: account.providerAccountId },
+        );
+
         await prisma.account.create({
           data: {
             userId: account.userId,
@@ -220,12 +237,12 @@ export function createCustomAdapter(): Adapter {
             type: account.type,
             provider: account.provider,
             providerAccountId: account.providerAccountId,
-            refresh_token: account.refresh_token,
-            access_token: account.access_token,
+            refresh_token: encrypted.refresh_token,
+            access_token: encrypted.access_token,
             expires_at: account.expires_at,
             token_type: account.token_type,
             scope: account.scope,
-            id_token: account.id_token,
+            id_token: encrypted.id_token,
             session_state: account.session_state
               ? String(account.session_state)
               : null,
@@ -447,17 +464,42 @@ export function createCustomAdapter(): Adapter {
         }),
       BYPASS_PURPOSE.AUTH_FLOW);
       if (!account) return null;
+
+      // Decrypt the at-rest envelope. Legacy plaintext rows pass through
+      // unchanged via the sentinel check in decryptAccountToken. We log
+      // (without exposing token material) and skip individual fields that
+      // fail to decrypt rather than rejecting the whole account, so a
+      // corrupt ciphertext does not lock a user out of their session.
+      const aad = {
+        provider: account.provider,
+        providerAccountId: account.providerAccountId,
+      };
+      const decryptOrLog = (
+        field: "refresh_token" | "access_token" | "id_token",
+        value: string | null,
+      ): string | undefined => {
+        try {
+          return decryptAccountToken(value, aad) ?? undefined;
+        } catch (err) {
+          logger.warn(
+            { provider: account.provider, providerAccountId: account.providerAccountId, field, err: err instanceof Error ? err.message : String(err) },
+            "account token decryption failed",
+          );
+          return undefined;
+        }
+      };
+
       return {
         userId: account.userId,
         type: account.type as AdapterAccount["type"],
         provider: account.provider,
         providerAccountId: account.providerAccountId,
-        refresh_token: account.refresh_token ?? undefined,
-        access_token: account.access_token ?? undefined,
+        refresh_token: decryptOrLog("refresh_token", account.refresh_token),
+        access_token: decryptOrLog("access_token", account.access_token),
         expires_at: account.expires_at ?? undefined,
         token_type: (account.token_type ?? undefined) as Lowercase<string> | undefined,
         scope: account.scope ?? undefined,
-        id_token: account.id_token ?? undefined,
+        id_token: decryptOrLog("id_token", account.id_token),
         session_state: account.session_state ?? undefined,
       };
     },

--- a/src/lib/auth/session/auth-adapter.ts
+++ b/src/lib/auth/session/auth-adapter.ts
@@ -17,7 +17,7 @@ import { resolveEffectiveSessionTimeouts } from "@/lib/auth/session/session-time
 import { invalidateCachedSessions } from "@/lib/auth/session/session-cache-helpers";
 import {
   encryptAccountTokenTriple,
-  decryptAccountToken,
+  decryptAccountTokenTriple,
 } from "@/lib/crypto/account-token-crypto";
 import logger from "@/lib/logger";
 
@@ -466,40 +466,44 @@ export function createCustomAdapter(): Adapter {
       if (!account) return null;
 
       // Decrypt the at-rest envelope. Legacy plaintext rows pass through
-      // unchanged via the sentinel check in decryptAccountToken. We log
-      // (without exposing token material) and skip individual fields that
-      // fail to decrypt rather than rejecting the whole account, so a
-      // corrupt ciphertext does not lock a user out of their session.
-      const aad = {
-        provider: account.provider,
-        providerAccountId: account.providerAccountId,
-      };
-      const decryptOrLog = (
-        field: "refresh_token" | "access_token" | "id_token",
-        value: string | null,
-      ): string | undefined => {
-        try {
-          return decryptAccountToken(value, aad) ?? undefined;
-        } catch (err) {
-          logger.warn(
-            { provider: account.provider, providerAccountId: account.providerAccountId, field, err: err instanceof Error ? err.message : String(err) },
-            "account token decryption failed",
-          );
-          return undefined;
-        }
-      };
+      // unchanged via the sentinel check inside the triple helper. The triple
+      // fetches the master key once per encryption-version observed across
+      // the three fields (typically one fetch). Per-field errors are logged
+      // (without exposing token material) and that field is left null —
+      // a corrupt ciphertext does not lock a user out of their session.
+      const decrypted = decryptAccountTokenTriple(
+        {
+          refresh_token: account.refresh_token,
+          access_token: account.access_token,
+          id_token: account.id_token,
+        },
+        { provider: account.provider, providerAccountId: account.providerAccountId },
+        {
+          onFieldError: (field, err) => {
+            logger.warn(
+              {
+                provider: account.provider,
+                providerAccountId: account.providerAccountId,
+                field,
+                err: err instanceof Error ? err.message : String(err),
+              },
+              "account token decryption failed",
+            );
+          },
+        },
+      );
 
       return {
         userId: account.userId,
         type: account.type as AdapterAccount["type"],
         provider: account.provider,
         providerAccountId: account.providerAccountId,
-        refresh_token: decryptOrLog("refresh_token", account.refresh_token),
-        access_token: decryptOrLog("access_token", account.access_token),
+        refresh_token: decrypted.refresh_token ?? undefined,
+        access_token: decrypted.access_token ?? undefined,
         expires_at: account.expires_at ?? undefined,
         token_type: (account.token_type ?? undefined) as Lowercase<string> | undefined,
         scope: account.scope ?? undefined,
-        id_token: decryptOrLog("id_token", account.id_token),
+        id_token: decrypted.id_token ?? undefined,
         session_state: account.session_state ?? undefined,
       };
     },

--- a/src/lib/crypto/account-token-crypto.test.ts
+++ b/src/lib/crypto/account-token-crypto.test.ts
@@ -99,5 +99,37 @@ describe("account-token-crypto", () => {
       expect(out.access_token).toBe("legacy-at");
       expect(out.id_token).toBeNull();
     });
+
+    it("decryptAccountTokenTriple without onFieldError throws on corrupt input", () => {
+      expect(() =>
+        decryptAccountTokenTriple(
+          { refresh_token: "psoenc1:0:zzzz", access_token: null, id_token: null },
+          aad,
+        ),
+      ).toThrow();
+    });
+
+    it("decryptAccountTokenTriple with onFieldError continues past a corrupt field", () => {
+      const good = encryptAccountToken("good-token", aad);
+      const errors: { field: string; err: unknown }[] = [];
+      const out = decryptAccountTokenTriple(
+        {
+          refresh_token: "psoenc1:0:zzzz",
+          access_token: good,
+          id_token: null,
+        },
+        aad,
+        {
+          onFieldError: (field, err) => {
+            errors.push({ field, err });
+          },
+        },
+      );
+      expect(out.refresh_token).toBeNull();
+      expect(out.access_token).toBe("good-token");
+      expect(out.id_token).toBeNull();
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe("refresh_token");
+    });
   });
 });

--- a/src/lib/crypto/account-token-crypto.test.ts
+++ b/src/lib/crypto/account-token-crypto.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  encryptAccountToken,
+  decryptAccountToken,
+  encryptAccountTokenTriple,
+  decryptAccountTokenTriple,
+  isEncryptedAccountToken,
+} from "./account-token-crypto";
+
+const aad = { provider: "google", providerAccountId: "alice@example.com" };
+
+describe("account-token-crypto", () => {
+  it("round-trips a plaintext through encrypt → decrypt", () => {
+    const plaintext = "ya29.A0ARrdaM-..._sample_oauth_refresh_token";
+    const ciphertext = encryptAccountToken(plaintext, aad);
+    expect(ciphertext.startsWith("psoenc1:")).toBe(true);
+    expect(ciphertext).not.toContain(plaintext);
+    const recovered = decryptAccountToken(ciphertext, aad);
+    expect(recovered).toBe(plaintext);
+  });
+
+  it("produces a different ciphertext for the same plaintext on each call (random IV)", () => {
+    const plaintext = "stable-plaintext";
+    const a = encryptAccountToken(plaintext, aad);
+    const b = encryptAccountToken(plaintext, aad);
+    expect(a).not.toBe(b);
+    expect(decryptAccountToken(a, aad)).toBe(plaintext);
+    expect(decryptAccountToken(b, aad)).toBe(plaintext);
+  });
+
+  it("isEncryptedAccountToken matches only the encrypted form", () => {
+    expect(isEncryptedAccountToken(encryptAccountToken("p", aad))).toBe(true);
+    expect(isEncryptedAccountToken("plain-string")).toBe(false);
+    expect(isEncryptedAccountToken("")).toBe(false);
+  });
+
+  it("returns null for null/undefined inputs (decrypt)", () => {
+    expect(decryptAccountToken(null, aad)).toBeNull();
+    expect(decryptAccountToken(undefined, aad)).toBeNull();
+  });
+
+  it("treats legacy plaintext (no sentinel) as a passthrough", () => {
+    // Backward-compat: rows that pre-date encryption are returned verbatim
+    // until the data migration script rewrites them.
+    expect(decryptAccountToken("legacy-plaintext-token", aad)).toBe(
+      "legacy-plaintext-token",
+    );
+  });
+
+  it("rejects ciphertext when the AAD context does not match", () => {
+    const ct = encryptAccountToken("secret", aad);
+    expect(() =>
+      decryptAccountToken(ct, { provider: "google", providerAccountId: "different@example.com" }),
+    ).toThrow();
+    expect(() =>
+      decryptAccountToken(ct, { provider: "github", providerAccountId: aad.providerAccountId }),
+    ).toThrow();
+  });
+
+  it("rejects malformed ciphertext", () => {
+    expect(() => decryptAccountToken("psoenc1:notaversion:zzzz", aad)).toThrow();
+    expect(() => decryptAccountToken("psoenc1:0:", aad)).toThrow();
+    expect(() => decryptAccountToken("psoenc1:0:dGVzdA", aad)).toThrow(); // too short to be iv+tag
+  });
+
+  it("rejects ciphertext with a tampered tag", () => {
+    const ct = encryptAccountToken("secret", aad);
+    // Decode, flip a bit in the auth tag region, re-encode, and try to decrypt.
+    const [prefix, versionAndBlob] = ct.split(":", 2);
+    const colonIdx = ct.indexOf(":", prefix.length + 1);
+    const versionStr = ct.slice(prefix.length + 1, colonIdx);
+    const blobB64 = ct.slice(colonIdx + 1);
+    const blob = Buffer.from(blobB64, "base64url");
+    blob[12] ^= 0xff; // flip first byte of auth tag
+    const tampered = `${prefix}:${versionStr}:${blob.toString("base64url")}`;
+    expect(() => decryptAccountToken(tampered, aad)).toThrow();
+    // Use versionAndBlob so unused-var rule does not fire.
+    expect(versionAndBlob).toBeDefined();
+  });
+
+  describe("triple helpers", () => {
+    it("encrypts the present fields and leaves null/undefined fields null", () => {
+      const out = encryptAccountTokenTriple(
+        { refresh_token: "rt", access_token: null, id_token: undefined },
+        aad,
+      );
+      expect(out.refresh_token).toMatch(/^psoenc1:/);
+      expect(out.access_token).toBeNull();
+      expect(out.id_token).toBeNull();
+    });
+
+    it("decrypts encrypted fields and passes legacy plaintext through", () => {
+      const encrypted = encryptAccountToken("rt-plain", aad);
+      const out = decryptAccountTokenTriple(
+        { refresh_token: encrypted, access_token: "legacy-at", id_token: null },
+        aad,
+      );
+      expect(out.refresh_token).toBe("rt-plain");
+      expect(out.access_token).toBe("legacy-at");
+      expect(out.id_token).toBeNull();
+    });
+  });
+});

--- a/src/lib/crypto/account-token-crypto.ts
+++ b/src/lib/crypto/account-token-crypto.ts
@@ -1,0 +1,146 @@
+// At-rest encryption for OAuth provider tokens stored in the `accounts` table
+// (`refresh_token`, `access_token`, `id_token`). Uses the existing
+// `share-master` key from the KeyProvider so we inherit version-rotation
+// support without a separate KMS entry.
+//
+// Storage format:
+//   `psoenc1:<keyVersion>:<base64url(iv || authTag || ciphertext)>`
+//
+// Legacy plaintext rows (rows that pre-date this encryption) are detected by
+// the absence of the `psoenc1:` sentinel and returned verbatim by
+// `decryptAccountToken`, so the change is backward-compatible at read time.
+// The data migration script in `scripts/migrate-account-tokens-to-encrypted.ts`
+// rewrites legacy rows to the encrypted form.
+//
+// AAD binding:
+//   AES-256-GCM AAD is set to `<provider>:<providerAccountId>`. This binds the
+//   ciphertext to the account row so a stolen ciphertext cannot be swapped
+//   between accounts (defense-in-depth — it is not the primary access control,
+//   but it prevents an attacker who can write to the DB from substituting
+//   another account's encrypted token).
+
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import {
+  getCurrentMasterKeyVersion,
+  getMasterKeyByVersion,
+} from "@/lib/crypto/crypto-server";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const SENTINEL = "psoenc1:";
+
+export type AccountTokenAad = {
+  provider: string;
+  providerAccountId: string;
+};
+
+function buildAad(aad: AccountTokenAad): Buffer {
+  return Buffer.from(`${aad.provider}:${aad.providerAccountId}`, "utf8");
+}
+
+export function isEncryptedAccountToken(stored: string): boolean {
+  return stored.startsWith(SENTINEL);
+}
+
+export function encryptAccountToken(
+  plaintext: string,
+  aad: AccountTokenAad,
+): string {
+  const version = getCurrentMasterKeyVersion();
+  const key = getMasterKeyByVersion(version);
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  cipher.setAAD(buildAad(aad));
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  const blob = Buffer.concat([iv, tag, ciphertext]).toString("base64url");
+  return `${SENTINEL}${version}:${blob}`;
+}
+
+export function decryptAccountToken(
+  stored: string | null | undefined,
+  aad: AccountTokenAad,
+): string | null {
+  if (stored == null) return null;
+  if (!isEncryptedAccountToken(stored)) {
+    // Legacy plaintext row — pass through. Keeps the adapter
+    // backward-compatible until the data migration completes.
+    return stored;
+  }
+  const rest = stored.slice(SENTINEL.length);
+  const colonIdx = rest.indexOf(":");
+  if (colonIdx <= 0) {
+    throw new Error("Malformed encrypted account token: missing version delimiter");
+  }
+  const versionStr = rest.slice(0, colonIdx);
+  const blobB64 = rest.slice(colonIdx + 1);
+  const version = Number(versionStr);
+  if (!Number.isInteger(version) || version < 0) {
+    throw new Error(`Malformed encrypted account token: invalid version "${versionStr}"`);
+  }
+  const blob = Buffer.from(blobB64, "base64url");
+  if (blob.length < IV_LENGTH + AUTH_TAG_LENGTH + 1) {
+    throw new Error("Malformed encrypted account token: blob too short");
+  }
+  const iv = blob.subarray(0, IV_LENGTH);
+  const tag = blob.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = blob.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const key = getMasterKeyByVersion(version);
+  const decipher = createDecipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  decipher.setAAD(buildAad(aad));
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString(
+    "utf8",
+  );
+}
+
+// Convenience helpers for the three optional Auth.js token fields. Each
+// returns null if the input is null/undefined and forwards otherwise. These
+// are the shapes the auth-adapter needs at write/read time.
+
+export type AccountTokenTriple = {
+  refresh_token: string | null | undefined;
+  access_token: string | null | undefined;
+  id_token: string | null | undefined;
+};
+
+export function encryptAccountTokenTriple(
+  tokens: AccountTokenTriple,
+  aad: AccountTokenAad,
+): {
+  refresh_token: string | null;
+  access_token: string | null;
+  id_token: string | null;
+} {
+  return {
+    refresh_token:
+      tokens.refresh_token == null ? null : encryptAccountToken(tokens.refresh_token, aad),
+    access_token:
+      tokens.access_token == null ? null : encryptAccountToken(tokens.access_token, aad),
+    id_token:
+      tokens.id_token == null ? null : encryptAccountToken(tokens.id_token, aad),
+  };
+}
+
+export function decryptAccountTokenTriple(
+  stored: AccountTokenTriple,
+  aad: AccountTokenAad,
+): {
+  refresh_token: string | null;
+  access_token: string | null;
+  id_token: string | null;
+} {
+  return {
+    refresh_token: decryptAccountToken(stored.refresh_token, aad),
+    access_token: decryptAccountToken(stored.access_token, aad),
+    id_token: decryptAccountToken(stored.id_token, aad),
+  };
+}

--- a/src/lib/crypto/account-token-crypto.ts
+++ b/src/lib/crypto/account-token-crypto.ts
@@ -43,24 +43,73 @@ export function isEncryptedAccountToken(stored: string): boolean {
   return stored.startsWith(SENTINEL);
 }
 
+type ParsedEnvelope = {
+  version: number;
+  iv: Buffer;
+  tag: Buffer;
+  ciphertext: Buffer;
+};
+
+function parseEnvelope(stored: string): ParsedEnvelope {
+  const rest = stored.slice(SENTINEL.length);
+  const colonIdx = rest.indexOf(":");
+  if (colonIdx <= 0) {
+    throw new Error("Malformed encrypted account token: missing version delimiter");
+  }
+  const versionStr = rest.slice(0, colonIdx);
+  const version = Number(versionStr);
+  if (!Number.isInteger(version) || version < 0) {
+    throw new Error(`Malformed encrypted account token: invalid version "${versionStr}"`);
+  }
+  const blob = Buffer.from(rest.slice(colonIdx + 1), "base64url");
+  if (blob.length < IV_LENGTH + AUTH_TAG_LENGTH + 1) {
+    throw new Error("Malformed encrypted account token: blob too short");
+  }
+  return {
+    version,
+    iv: blob.subarray(0, IV_LENGTH),
+    tag: blob.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH),
+    ciphertext: blob.subarray(IV_LENGTH + AUTH_TAG_LENGTH),
+  };
+}
+
+function encryptWithKey(
+  plaintext: string,
+  version: number,
+  key: Buffer,
+  aad: AccountTokenAad,
+): string {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  cipher.setAAD(buildAad(aad));
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  const blob = Buffer.concat([iv, tag, ciphertext]).toString("base64url");
+  return `${SENTINEL}${version}:${blob}`;
+}
+
+function decryptWithKey(
+  envelope: ParsedEnvelope,
+  key: Buffer,
+  aad: AccountTokenAad,
+): string {
+  const decipher = createDecipheriv(ALGORITHM, key, envelope.iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  decipher.setAAD(buildAad(aad));
+  decipher.setAuthTag(envelope.tag);
+  return Buffer.concat([
+    decipher.update(envelope.ciphertext),
+    decipher.final(),
+  ]).toString("utf8");
+}
+
 export function encryptAccountToken(
   plaintext: string,
   aad: AccountTokenAad,
 ): string {
   const version = getCurrentMasterKeyVersion();
-  const key = getMasterKeyByVersion(version);
-  const iv = randomBytes(IV_LENGTH);
-  const cipher = createCipheriv(ALGORITHM, key, iv, {
-    authTagLength: AUTH_TAG_LENGTH,
-  });
-  cipher.setAAD(buildAad(aad));
-  const ciphertext = Buffer.concat([
-    cipher.update(plaintext, "utf8"),
-    cipher.final(),
-  ]);
-  const tag = cipher.getAuthTag();
-  const blob = Buffer.concat([iv, tag, ciphertext]).toString("base64url");
-  return `${SENTINEL}${version}:${blob}`;
+  return encryptWithKey(plaintext, version, getMasterKeyByVersion(version), aad);
 }
 
 export function decryptAccountToken(
@@ -73,33 +122,8 @@ export function decryptAccountToken(
     // backward-compatible until the data migration completes.
     return stored;
   }
-  const rest = stored.slice(SENTINEL.length);
-  const colonIdx = rest.indexOf(":");
-  if (colonIdx <= 0) {
-    throw new Error("Malformed encrypted account token: missing version delimiter");
-  }
-  const versionStr = rest.slice(0, colonIdx);
-  const blobB64 = rest.slice(colonIdx + 1);
-  const version = Number(versionStr);
-  if (!Number.isInteger(version) || version < 0) {
-    throw new Error(`Malformed encrypted account token: invalid version "${versionStr}"`);
-  }
-  const blob = Buffer.from(blobB64, "base64url");
-  if (blob.length < IV_LENGTH + AUTH_TAG_LENGTH + 1) {
-    throw new Error("Malformed encrypted account token: blob too short");
-  }
-  const iv = blob.subarray(0, IV_LENGTH);
-  const tag = blob.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
-  const ciphertext = blob.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
-  const key = getMasterKeyByVersion(version);
-  const decipher = createDecipheriv(ALGORITHM, key, iv, {
-    authTagLength: AUTH_TAG_LENGTH,
-  });
-  decipher.setAAD(buildAad(aad));
-  decipher.setAuthTag(tag);
-  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString(
-    "utf8",
-  );
+  const env = parseEnvelope(stored);
+  return decryptWithKey(env, getMasterKeyByVersion(env.version), aad);
 }
 
 // Convenience helpers for the three optional Auth.js token fields. Each
@@ -112,35 +136,83 @@ export type AccountTokenTriple = {
   id_token: string | null | undefined;
 };
 
-export function encryptAccountTokenTriple(
-  tokens: AccountTokenTriple,
-  aad: AccountTokenAad,
-): {
+const TRIPLE_FIELDS = ["refresh_token", "access_token", "id_token"] as const;
+
+type EncryptedTriple = {
   refresh_token: string | null;
   access_token: string | null;
   id_token: string | null;
-} {
-  return {
-    refresh_token:
-      tokens.refresh_token == null ? null : encryptAccountToken(tokens.refresh_token, aad),
-    access_token:
-      tokens.access_token == null ? null : encryptAccountToken(tokens.access_token, aad),
-    id_token:
-      tokens.id_token == null ? null : encryptAccountToken(tokens.id_token, aad),
+};
+
+export function encryptAccountTokenTriple(
+  tokens: AccountTokenTriple,
+  aad: AccountTokenAad,
+): EncryptedTriple {
+  // Lazily fetch the current key once and reuse across all present fields.
+  let cached: { version: number; key: Buffer } | null = null;
+  const out: EncryptedTriple = {
+    refresh_token: null,
+    access_token: null,
+    id_token: null,
   };
+  for (const field of TRIPLE_FIELDS) {
+    const value = tokens[field];
+    if (value == null) continue;
+    if (cached == null) {
+      const version = getCurrentMasterKeyVersion();
+      cached = { version, key: getMasterKeyByVersion(version) };
+    }
+    out[field] = encryptWithKey(value, cached.version, cached.key, aad);
+  }
+  return out;
 }
+
+export type DecryptTripleOptions = {
+  // Per-field error handler. When provided, an error decrypting one field
+  // does NOT abort the other fields — the failed field is left as null and
+  // the handler is invoked with the field name and the error. When omitted,
+  // the first error propagates (matching `decryptAccountToken`).
+  onFieldError?: (
+    field: (typeof TRIPLE_FIELDS)[number],
+    err: unknown,
+  ) => void;
+};
 
 export function decryptAccountTokenTriple(
   stored: AccountTokenTriple,
   aad: AccountTokenAad,
-): {
-  refresh_token: string | null;
-  access_token: string | null;
-  id_token: string | null;
-} {
-  return {
-    refresh_token: decryptAccountToken(stored.refresh_token, aad),
-    access_token: decryptAccountToken(stored.access_token, aad),
-    id_token: decryptAccountToken(stored.id_token, aad),
+  options?: DecryptTripleOptions,
+): EncryptedTriple {
+  // Cache keys per version so a triple encrypted under a single version (the
+  // common case) only fetches the master key once.
+  const keyCache = new Map<number, Buffer>();
+  const out: EncryptedTriple = {
+    refresh_token: null,
+    access_token: null,
+    id_token: null,
   };
+  for (const field of TRIPLE_FIELDS) {
+    const value = stored[field];
+    if (value == null) continue;
+    if (!isEncryptedAccountToken(value)) {
+      out[field] = value;
+      continue;
+    }
+    try {
+      const env = parseEnvelope(value);
+      let key = keyCache.get(env.version);
+      if (!key) {
+        key = getMasterKeyByVersion(env.version);
+        keyCache.set(env.version, key);
+      }
+      out[field] = decryptWithKey(env, key, aad);
+    } catch (err) {
+      if (options?.onFieldError) {
+        options.onFieldError(field, err);
+      } else {
+        throw err;
+      }
+    }
+  }
+  return out;
 }

--- a/src/lib/emergency-access/emergency-access-state.test.ts
+++ b/src/lib/emergency-access/emergency-access-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { canTransition } from "./emergency-access-state";
+import { canTransition, fromStatusesFor } from "./emergency-access-state";
 import { EA_STATUS } from "@/lib/constants";
 
 describe("canTransition", () => {
@@ -57,5 +57,58 @@ describe("canTransition", () => {
   it("does not allow REJECTED → any", () => {
     expect(canTransition(EA_STATUS.REJECTED, EA_STATUS.IDLE)).toBe(false);
     expect(canTransition(EA_STATUS.REJECTED, EA_STATUS.STALE)).toBe(false);
+  });
+});
+
+describe("fromStatusesFor", () => {
+  // For each `to`, fromStatusesFor(to) must contain exactly the statuses for
+  // which canTransition(from, to) is true. This invariant is what lets route
+  // handlers replace the optimistic canTransition check with a CAS updateMany.
+  it("matches canTransition for ACTIVATED", () => {
+    const froms = fromStatusesFor(EA_STATUS.ACTIVATED);
+    expect(froms).toEqual([EA_STATUS.REQUESTED]);
+    expect(canTransition(EA_STATUS.REQUESTED, EA_STATUS.ACTIVATED)).toBe(true);
+  });
+
+  it("matches canTransition for REQUESTED", () => {
+    const froms = fromStatusesFor(EA_STATUS.REQUESTED);
+    expect(froms).toEqual([EA_STATUS.IDLE]);
+  });
+
+  it("matches canTransition for IDLE (multiple from-states)", () => {
+    const froms = fromStatusesFor(EA_STATUS.IDLE);
+    expect(froms).toEqual(
+      expect.arrayContaining([EA_STATUS.ACCEPTED, EA_STATUS.STALE, EA_STATUS.REQUESTED]),
+    );
+    expect(froms).toHaveLength(3);
+  });
+
+  it("matches canTransition for REVOKED (terminal target from many states)", () => {
+    const froms = fromStatusesFor(EA_STATUS.REVOKED);
+    // All non-terminal states permit transition to REVOKED.
+    expect(froms).toEqual(
+      expect.arrayContaining([
+        EA_STATUS.PENDING,
+        EA_STATUS.ACCEPTED,
+        EA_STATUS.IDLE,
+        EA_STATUS.STALE,
+        EA_STATUS.REQUESTED,
+        EA_STATUS.ACTIVATED,
+      ]),
+    );
+  });
+
+  it("returns empty array for terminal statuses (cannot be a destination of any transition)", () => {
+    // PENDING is the initial status; no transition leads INTO it.
+    expect(fromStatusesFor(EA_STATUS.PENDING)).toEqual([]);
+  });
+
+  it("invariant: fromStatusesFor and canTransition agree for every (from, to) pair", () => {
+    const allStatuses = Object.values(EA_STATUS);
+    for (const to of allStatuses) {
+      const expectedFroms = allStatuses.filter((from) => canTransition(from, to));
+      const actualFroms = fromStatusesFor(to);
+      expect(actualFroms.sort()).toEqual(expectedFroms.sort());
+    }
   });
 });

--- a/src/lib/emergency-access/emergency-access-state.ts
+++ b/src/lib/emergency-access/emergency-access-state.ts
@@ -19,5 +19,26 @@ export function canTransition(
   return VALID_TRANSITIONS[from]?.includes(to) ?? false;
 }
 
+// Inverse of VALID_TRANSITIONS: for each `to` status, the set of `from` statuses
+// from which the transition is permitted. Used by route handlers to express
+// the CAS constraint in `updateMany({ where: { id, status: { in: ... } } })`,
+// closing the read→check→write race window in `canTransition`-based handlers.
+const FROM_STATUSES_FOR: Record<EmergencyAccessStatus, EmergencyAccessStatus[]> = (() => {
+  const inverse: Partial<Record<EmergencyAccessStatus, EmergencyAccessStatus[]>> = {};
+  for (const [from, tos] of Object.entries(VALID_TRANSITIONS) as [
+    EmergencyAccessStatus,
+    EmergencyAccessStatus[],
+  ][]) {
+    for (const to of tos) {
+      (inverse[to] ??= []).push(from);
+    }
+  }
+  return inverse as Record<EmergencyAccessStatus, EmergencyAccessStatus[]>;
+})();
+
+export function fromStatusesFor(to: EmergencyAccessStatus): EmergencyAccessStatus[] {
+  return FROM_STATUSES_FOR[to] ?? [];
+}
+
 /** Statuses that hold escrowed key data and can become STALE on keyVersion bump. */
 export const STALE_ELIGIBLE_STATUSES: EmergencyAccessStatus[] = [EA_STATUS.IDLE, EA_STATUS.ACTIVATED];


### PR DESCRIPTION
## Summary

Triangulated response to an external security review of the codebase. Bundles four hardening items into one PR per the agreed plan in the prep discussion (`/triangulate` outcome).

| Item | Severity | Type |
|---|---|---|
| `#1` OAuth provider tokens encrypted at rest | Critical | feat |
| `#7` Emergency Access state transitions race-safe (CAS) | Major | fix |
| `#6a` Recovery key replay regression test | Major | test |
| `#4` Extension token replay regression test | Major | test |
| `#5` User.email identity-model ADR | — | docs |
| `#6b` Pepper rotation runbook | — | docs |

## What changed (per commit)

- **`docs(security)`** — `docs/archive/review/email-uniqueness-design.md` (ADR documenting the global-User-with-active-tenant model so future reviewers do not mistake `email @unique` for a multi-tenant bug) + `docs/archive/review/pepper-rotation-runbook.md` (three rotation modes, pre/post checklists, rollback, and the dual-version code-level gaps that must be closed before a non-disruptive rotation can run). Inline pointers added to `prisma/schema.prisma` and `CLAUDE.md`.

- **`fix(emergency-access)`** — the four route handlers (`approve`/`request`/`revoke`/`confirm`) used a read → `canTransition` check → write pattern. Two concurrent requests could both pass the check on the pre-read snapshot and race to write. Replace each post-check `update` with `updateMany` whose WHERE filters on `status: { in: fromStatusesFor(<target>) }`, so the transition only applies if the row is still in the permitted from-set. Added `fromStatusesFor()` to the state module and an invariant test pinning it in lockstep with `canTransition`.

- **`test(security)`** — explicit replay regression tests for two flows that already reject replay correctly at runtime but lacked coverage. Recovery-key reset rotates the recovery verifier atomically with the passphrase change; the new tests prove a replayed verifier hash returns 401 (with and without the rate limiter). Extension-token refresh's validation layer short-circuits a rotated token to 401; the new tests prove this and that the family-revoke path is NOT triggered by a generic replay (reserved for `family_expired` and other policy signals).

- **`feat(auth)`** — `accounts.refresh_token / access_token / id_token` were stored plaintext. Now envelope-encrypted at rest with the existing share-master KeyProvider key (already versioned), AAD bound to `(provider, providerAccountId)` so leaked ciphertext cannot be substituted across accounts. Storage format `psoenc1:<masterKeyVersion>:<base64url(iv||tag||ct)>` re-uses the existing column shape — legacy plaintext rows pass through unchanged via the sentinel detector, then are rewritten by the new `npm run migrate:account-tokens` script (idempotent, batched, `--dry-run` available). Adapter `getAccount` decrypts per field with a defensive try/catch so a single corrupt row does not lock a user out of the rest of their session/account state.

## Test plan

- [x] `npx vitest run` — 7555 passed / 1 skipped
- [x] `npm run lint`
- [x] `npx next build`
- [x] `bash scripts/pre-pr.sh` — 11/11 passed
- [ ] (post-merge) Run `npm run migrate:account-tokens -- --dry-run` against staging DB to confirm legacy row counts before the actual migration
- [ ] (post-merge) Run `npm run migrate:account-tokens` on staging, then on production after staging verification

## Migration plan

1. Merge this PR. New writes (`linkAccount`) immediately produce ciphertext; reads of legacy plaintext rows continue to work via the sentinel passthrough.
2. After merge, run on staging: `MIGRATION_DATABASE_URL=<privileged-url> npm run migrate:account-tokens -- --dry-run` to inventory legacy rows.
3. Run without `--dry-run` to actually migrate. Idempotent — safe to re-run on crash.
4. After all rows are encrypted, schedule a follow-up to remove the legacy plaintext fallback in `decryptAccountToken`.

## Out of scope (deferred from the same review)

- `#2` Admin Vault Reset dual-admin approval + post-reset session invalidation — needs product/UX decision first; a design plan will follow in a separate PR.
- `#3` Audit anchor external commitment — operational decision (signing key location, frequency, store) needed first.
- `#5b` Verifier pepper rotation code-level dual-version support — runbook documents the gap; implementation is a separate PR.
- Extension token device/origin binding — separate hardening track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
