### PR TITLE
test(extension): extract TOTP and URL-matching test vectors to shared JSON fixtures

### DIFF
--- a/extension/src/__tests__/lib/totp.test.ts
+++ b/extension/src/__tests__/lib/totp.test.ts
@@ -1,52 +1,29 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { generateTOTPCode } from "../../lib/totp";
+import rfc6238Vectors from "../../../test/fixtures/totp-rfc6238-vectors.json";
 
-// RFC 6238 test secret: "12345678901234567890" as Base32
-const RFC_SECRET_SHA1 = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
-// RFC 6238 test secret for SHA256: "12345678901234567890123456789012" as Base32
-const RFC_SECRET_SHA256 =
-  "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA";
-// RFC 6238 test secret for SHA512: 64 bytes as Base32
-const RFC_SECRET_SHA512 =
-  "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNA";
+// SHA1 secret used by behaviour tests below; pulled from the shared fixture
+// so iOS XCTest can consume the same vectors via Bundle resource loading.
+const RFC_SECRET_SHA1 = rfc6238Vectors.find((v) => v.algorithm === "SHA1")!
+  .secret;
 
 describe("generateTOTPCode", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("generates correct SHA1 code at RFC 6238 test time T=59", () => {
-    vi.spyOn(Date, "now").mockReturnValue(59_000);
-    const code = generateTOTPCode({
-      secret: RFC_SECRET_SHA1,
-      algorithm: "SHA1",
-      digits: 8,
-      period: 30,
+  for (const v of rfc6238Vectors) {
+    it(`generates correct ${v.algorithm} code at RFC 6238 test time T=${v.T_seconds}`, () => {
+      vi.spyOn(Date, "now").mockReturnValue(v.T_seconds * 1000);
+      const code = generateTOTPCode({
+        secret: v.secret,
+        algorithm: v.algorithm,
+        digits: v.digits,
+        period: v.period,
+      });
+      expect(code).toBe(v.expected);
     });
-    expect(code).toBe("94287082");
-  });
-
-  it("generates correct SHA256 code at RFC 6238 test time T=59", () => {
-    vi.spyOn(Date, "now").mockReturnValue(59_000);
-    const code = generateTOTPCode({
-      secret: RFC_SECRET_SHA256,
-      algorithm: "SHA256",
-      digits: 8,
-      period: 30,
-    });
-    expect(code).toBe("46119246");
-  });
-
-  it("generates correct SHA512 code at RFC 6238 test time T=59", () => {
-    vi.spyOn(Date, "now").mockReturnValue(59_000);
-    const code = generateTOTPCode({
-      secret: RFC_SECRET_SHA512,
-      algorithm: "SHA512",
-      digits: 8,
-      period: 30,
-    });
-    expect(code).toBe("90693936");
-  });
+  }
 
   it("defaults to SHA1, 6 digits, 30s period", () => {
     vi.spyOn(Date, "now").mockReturnValue(59_000);

--- a/extension/src/__tests__/lib/url-matching.test.ts
+++ b/extension/src/__tests__/lib/url-matching.test.ts
@@ -4,45 +4,22 @@ import {
   isHostMatch,
   sortByUrlMatch,
 } from "../../lib/url-matching";
+import urlMatchCases from "../../../test/fixtures/url-match-cases.json";
 
 describe("extractHost", () => {
-  it("extracts hostname from full URL", () => {
-    expect(extractHost("https://mail.google.com/inbox")).toBe("mail.google.com");
-  });
-
-  it("returns null for invalid URL", () => {
-    expect(extractHost("not-a-url")).toBeNull();
-  });
-
-  it("returns null for non-http(s) scheme", () => {
-    expect(extractHost("edge://extensions")).toBeNull();
-  });
-
-  it("handles localhost with port", () => {
-    expect(extractHost("http://localhost:3000/")).toBe("localhost");
-  });
+  for (const c of urlMatchCases.extractHost) {
+    it(c.name, () => {
+      expect(extractHost(c.url)).toBe(c.expected);
+    });
+  }
 });
 
 describe("isHostMatch", () => {
-  it("matches exact hostname", () => {
-    expect(isHostMatch("example.com", "example.com")).toBe(true);
-  });
-
-  it("matches with www prefix normalization", () => {
-    expect(isHostMatch("example.com", "www.example.com")).toBe(true);
-  });
-
-  it("matches subdomain", () => {
-    expect(isHostMatch("google.com", "mail.google.com")).toBe(true);
-  });
-
-  it("does not match unrelated domains", () => {
-    expect(isHostMatch("example.com", "google.com")).toBe(false);
-  });
-
-  it("does not match partial suffix", () => {
-    expect(isHostMatch("example.com", "notexample.com")).toBe(false);
-  });
+  for (const c of urlMatchCases.isHostMatch) {
+    it(c.name, () => {
+      expect(isHostMatch(c.stored, c.current)).toBe(c.expected);
+    });
+  }
 });
 
 describe("sortByUrlMatch", () => {

--- a/extension/test/fixtures/totp-rfc6238-vectors.json
+++ b/extension/test/fixtures/totp-rfc6238-vectors.json
@@ -1,0 +1,29 @@
+[
+  {
+    "algorithm": "SHA1",
+    "secret": "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ",
+    "secretComment": "RFC 6238 test secret '12345678901234567890' as Base32",
+    "T_seconds": 59,
+    "digits": 8,
+    "period": 30,
+    "expected": "94287082"
+  },
+  {
+    "algorithm": "SHA256",
+    "secret": "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA",
+    "secretComment": "RFC 6238 test secret '12345678901234567890123456789012' as Base32",
+    "T_seconds": 59,
+    "digits": 8,
+    "period": 30,
+    "expected": "46119246"
+  },
+  {
+    "algorithm": "SHA512",
+    "secret": "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNA",
+    "secretComment": "RFC 6238 64-byte test secret as Base32",
+    "T_seconds": 59,
+    "digits": 8,
+    "period": 30,
+    "expected": "90693936"
+  }
+]

--- a/extension/test/fixtures/url-match-cases.json
+++ b/extension/test/fixtures/url-match-cases.json
@@ -1,0 +1,56 @@
+{
+  "extractHost": [
+    {
+      "name": "extracts hostname from full URL",
+      "url": "https://mail.google.com/inbox",
+      "expected": "mail.google.com"
+    },
+    {
+      "name": "returns null for invalid URL",
+      "url": "not-a-url",
+      "expected": null
+    },
+    {
+      "name": "returns null for non-http(s) scheme",
+      "url": "edge://extensions",
+      "expected": null
+    },
+    {
+      "name": "handles localhost with port",
+      "url": "http://localhost:3000/",
+      "expected": "localhost"
+    }
+  ],
+  "isHostMatch": [
+    {
+      "name": "matches exact hostname",
+      "stored": "example.com",
+      "current": "example.com",
+      "expected": true
+    },
+    {
+      "name": "matches with www prefix normalization",
+      "stored": "example.com",
+      "current": "www.example.com",
+      "expected": true
+    },
+    {
+      "name": "matches subdomain",
+      "stored": "google.com",
+      "current": "mail.google.com",
+      "expected": true
+    },
+    {
+      "name": "does not match unrelated domains",
+      "stored": "example.com",
+      "current": "google.com",
+      "expected": false
+    },
+    {
+      "name": "does not match partial suffix",
+      "stored": "example.com",
+      "current": "notexample.com",
+      "expected": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Extracts the inlined RFC 6238 TOTP vectors and URL host-match cases from
  the extension's Vitest tests into JSON files under `extension/test/fixtures/`.
- Refactors `totp.test.ts` and `url-matching.test.ts` to load from JSON;
  test-case names and assertion logic are unchanged.
- The vectors will be reused by the planned iOS XCTest suite via Bundle
  resource loading, so the source of truth lives once.

## Why

This is Step 2 of the ios-autofill-mvp plan
(`docs/archive/review/ios-autofill-mvp-plan.md` on the
`feature/ios-autofill-mvp` branch). Land before any iOS Swift code so the
host-matching and TOTP parity tests on iOS read the same vectors the
browser-extension Vitest suite reads.

`background-login-save.test.ts` is intentionally NOT extracted: its
existing tests depend on per-test AES-GCM round-trips against a freshly
generated `CryptoKey`, which JSON cannot encode. Save/update via AutoFill
is also out of scope for the iOS MVP.

## Verification (T26 contract from the iOS plan)

- `vitest --reporter=json` BEFORE vs AFTER on the two modified files:
  24 / 24 tests pass; the test-case `fullName` set is byte-identical
  (`diff /tmp/vitest-before-names.txt /tmp/vitest-after-names.txt` →
  empty).
- Full extension suite: 659 / 659 pass; `tsc --noEmit` clean;
  `vite build` succeeds.
- `scripts/pre-pr.sh`: 11 / 11 pre-PR checks pass.

## Test plan

- [x] `cd extension && npm test` — 659 / 659 pass.
- [x] `cd extension && npx tsc --noEmit` — clean.
- [x] `cd extension && npm run build` — success.
- [x] `bash scripts/pre-pr.sh` — all checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)