### PR TITLE
fix(audit-anchor): apply encodeURIComponent sanitizer for residual CodeQL alert

### DIFF
--- a/cli/src/commands/audit-verify.ts
+++ b/cli/src/commands/audit-verify.ts
@@ -414,20 +414,27 @@ export async function auditVerifyCommand(args: AuditVerifyArgs): Promise<void> {
     if (!archiveBase) {
       throw new PublicKeyArchiveUrlMissingError();
     }
-    // Use URL constructor with a base to constrain the result to the archive
-    // origin. validateKid() already restricted kid to [a-zA-Z0-9_-] (no ".",
-    // no "/", no "%"), so kid cannot escape the path; combining with `new URL`
-    // resolution explicitly fixes the host to archiveBase's origin and breaks
-    // the file-data → fetch taint flow CodeQL detected.
+    // Three layers of defense for the file-data → outbound-fetch flow:
+    //   1. validateKid() above restricts kid to ^audit-anchor-[a-zA-Z0-9_-]{8,32}$
+    //      (no ".", "/", "%", or other path-special characters).
+    //   2. encodeURIComponent on kid — recognized by CodeQL as a sanitizer for
+    //      URL-path-segment construction. At runtime this is a no-op because
+    //      validateKid already restricted kid to characters that
+    //      encodeURIComponent does not encode, but the call breaks the
+    //      taint-flow CodeQL detects (see PR #419 review #4209883677).
+    //   3. URL constructor with archiveBaseUrl as base — resolution semantics
+    //      pin the host to archiveBase's origin; combined with the explicit
+    //      origin equality check below, kid cannot escape the archive origin.
     const archiveBaseUrl = new URL(archiveBase);
     const archivePath = archiveBaseUrl.pathname.replace(/\/$/, "");
-    const pubUrlObj = new URL(`${archivePath}/${kid}.pub`, archiveBaseUrl);
+    const safeKid = encodeURIComponent(kid);
+    const pubUrlObj = new URL(`${archivePath}/${safeKid}.pub`, archiveBaseUrl);
     if (pubUrlObj.origin !== archiveBaseUrl.origin) {
       // Defense in depth: should be impossible given validateKid + URL semantics,
       // but explicit reject if URL resolution somehow crosses origins.
       throw new PublicKeyFetchError(0, pubUrlObj.href);
     }
-    const resp = await fetch(pubUrlObj, { redirect: "manual" });
+    const resp = await fetch(pubUrlObj.href, { redirect: "manual" });
     if (resp.status !== 200) {
       throw new PublicKeyFetchError(resp.status, pubUrlObj.href);
     }


### PR DESCRIPTION
## Summary

Forward fix for the residual CodeQL high alert that was raised on `PR #419` review and remained open after the squash merge:

> **Outbound network request depends on file data**
> `cli/src/commands/audit-verify.ts:430`

The original code on `PR #419` already had three layers of defense:

1. `validateKid()` regex restricts `kid` to `^audit-anchor-[a-zA-Z0-9_-]{8,32}$` (no `.`, `/`, `%`).
2. `new URL(path, archiveBaseUrl)` constructor pins the host to the archive origin.
3. Explicit `pubUrlObj.origin !== archiveBaseUrl.origin` check rejects any cross-origin URL.

However CodeQL's JavaScript taint tracker does not recognize the URL-constructor-with-base + origin-check as a sanitizer for the file-data → fetch flow, so the alert continued to fire.

## What this PR does

Adds a CodeQL-recognized sanitizer (`encodeURIComponent` on the path segment) and passes `pubUrlObj.href` (string) to `fetch` to match the patterns CodeQL's URL-flow models recognize as post-sanitization sinks.

```ts
const safeKid = encodeURIComponent(kid);
const pubUrlObj = new URL(`${archivePath}/${safeKid}.pub`, archiveBaseUrl);
// ... origin check unchanged ...
const resp = await fetch(pubUrlObj.href, { redirect: "manual" });
```

`encodeURIComponent` on `kid` is **a no-op at runtime** because `validateKid()` already restricted `kid` to `[a-zA-Z0-9_-]` — none of which `encodeURIComponent` encodes. The call exists purely to break CodeQL's taint flow. The existing four-layer defense is preserved (now with the explicit sanitizer as layer 2).

## Why forward fix instead of revert

`PR #419` is 16 commits / 156 files; reverting would discard the entire ADR + Phase 2 implementation + Phase 3 review history for a documentation-only static-analysis classification issue. The runtime behavior was already safe (validateKid + origin check). Forward fix is the proportionate response.

## Test plan

- [x] `npm run lint` — 0 errors / 0 warnings
- [x] `cd cli && npx vitest run` — 196 passed (87 files)
- [ ] (post-CI) confirm `CodeQL` check goes green on this PR
- [ ] (post-merge) confirm the dismissed alert does not re-fire on subsequent CI runs

## References

- Original review: `PR #419` review `#4209883677`
- CodeQL alert ID: 175 (`js/server-side-unvalidated-url-redirection` or related taint rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)