### PR TITLE
fix(audit): honor actorType filter in personal/tenant download

### DIFF
--- a/docs/archive/review/audit-log-download-actor-type-filter-code-review.md
+++ b/docs/archive/review/audit-log-download-actor-type-filter-code-review.md
@@ -1,0 +1,80 @@
+# Code Review: audit-log-download-actor-type-filter
+Date: 2026-05-03
+Review round: 1
+
+## Changes from Previous Round
+Initial review.
+
+## Functionality Findings
+
+### F1 [Minor]: R34 deferred bug has no grep-able TODO marker in source code
+- File: `src/app/api/audit-logs/download/route.ts` (around line 63-67, the `where` literal)
+- Evidence: `grep -rn "audit-log-download-emergency"` returned no source matches. Project convention is `TODO(slug):` in source (confirmed at `src/lib/constants/app.ts:41` and `src/lib/audit/audit.ts:85`). The plan says the deferred bug is "Filed as `TODO(audit-log-download-emergency-access-or-clause)` for a future task" — but the marker exists only in the plan document.
+- Problem: Without an in-source `TODO(audit-log-download-emergency-access-or-clause)` comment adjacent to the `where` literal, the deferred fix is invisible to future developers reading the file.
+- Impact: Low operational risk; UX-only gap. But violates the R34 deferral contract requiring a grep-able marker.
+- Fix: Add a one-line TODO comment immediately before the `where` literal in `src/app/api/audit-logs/download/route.ts`.
+
+## Security Findings
+
+No findings.
+
+## Testing Findings
+
+No findings. All 4 Ollama seed findings were rejected:
+- 2 Major seeds (mock.calls[0][0] index fragility): rejected — does not reproduce. `vi.clearAllMocks()` resets calls before each test; only `auditLog.findMany` is the Prisma call (other ops are mocked at module boundary, no Prisma).
+- 2 Minor seeds ("should …" naming convention): rejected — contradicts established convention in the same files. Existing tests use third-person declarative form; not a single existing test starts with "should". New tests follow the file convention exactly.
+
+## Adjacent Findings
+
+None.
+
+## Quality Warnings
+
+None (Ollama merge produced no VAGUE / NO-EVIDENCE / UNTESTED-CLAIM flags).
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1: Checked — no issue
+- R2: N/A
+- R3: Checked — all 6 audit-log routes use parseActorType
+- R4: N/A
+- R5-R6: N/A
+- R7: Checked — indentation-only; no E2E selector breakage
+- R8: Checked — pattern-consistency fix; matches reference (tenant/members/page.tsx)
+- R9-R16: N/A
+- R17: Checked — parseActorType reused; no inline equivalents
+- R18: N/A
+- R19: Checked — assertion form correct (objectContaining/not.toHaveProperty)
+- R20-R33: N/A
+- R34: Finding F1 (Minor — TODO marker missing from source); deferral itself is sound
+- R35: N/A
+
+### Security expert
+- R1-R35: all Checked / N/A as appropriate; no findings
+- R3: pattern propagation complete
+- R7: no E2E selector breakage
+- R22: no syntactically-different equivalent of parseActorType (verified via grep)
+- R34: deferral cost-justified; under-disclosure only; no security regression
+- R35: N/A
+- RS1: N/A (no credential comparison)
+- RS2: existing rate limiters unchanged
+- RS3: parseActorType allowlist strict; no bypass via case mismatch / encoding / type coercion
+
+### Testing expert
+- R1-R35: all Checked / N/A; no findings
+- R3: complete propagation across 6 routes
+- R7: no E2E selector breakage
+- R17: no helper reimplementation
+- R19: real parseActorType used (not mocked) — tests integration of route + parser
+- R34: deferral-related testing concerns out of scope
+- RT1: mock-reality alignment confirmed
+- RT2: lazy-stream consume-first applied throughout
+- RT3: from searchParam present in all tenant tests; string literal usage acceptable per existing pattern
+
+## Resolution Status
+
+### F1 [Minor] R34 TODO marker missing from source — RESOLVED (round 1)
+- **Anti-Deferral check**: not applicable (finding is being fixed, not deferred)
+- Action: Added a 2-line `TODO(audit-log-download-emergency-access-or-clause)` comment immediately before the `where` literal in `src/app/api/audit-logs/download/route.ts`.
+- Modified file: `src/app/api/audit-logs/download/route.ts:62`

--- a/docs/archive/review/audit-log-download-actor-type-filter-manual-test.md
+++ b/docs/archive/review/audit-log-download-actor-type-filter-manual-test.md
@@ -1,0 +1,54 @@
+# Manual Test Plan: audit-log-download-actor-type-filter
+
+Tier: Tier-1 (UI surface — admin audit-logs page changed; not auth/authz/crypto/session, so no Tier-2 adversarial scenarios).
+
+The R3-F2 page change is a pure JSX whitespace re-flow (no logic, no selector, no aria-* changes), so the user-facing behavior under test is the R3-F1 server-side filter parity for the personal and tenant audit log downloads.
+
+## Pre-conditions
+
+- Local dev stack up: `npm run docker:up` (Postgres + Redis + Jackson + Mailpit + audit-outbox-worker)
+- App running: `npm run dev`
+- Browser session signed in as a tenant admin user (so all three download surfaces are reachable)
+- The user's personal audit log has events from at least two distinct actor types (e.g., HUMAN events from logins, plus SERVICE_ACCOUNT events if any service-account activity has occurred). For the tenant view, generate at least one SA token activity to ensure SERVICE_ACCOUNT rows exist:
+  - Mint a service account at `/admin/tenant/machine-identity/service-accounts`, generate a token, perform any read via `/api/v1/passwords` with the SA token.
+
+## Steps
+
+### S1. Personal audit log download — actorType=HUMAN
+1. Navigate to `/dashboard/account/audit-logs`.
+2. Set the actor type dropdown to **HUMAN**.
+3. Click **Download → JSONL**.
+4. Open the downloaded file.
+
+### S2. Personal audit log download — actorType=SERVICE_ACCOUNT
+1. On the same page, set the dropdown to **SERVICE_ACCOUNT**.
+2. Click **Download → JSONL**.
+3. Open the downloaded file.
+
+### S3. Personal audit log download — actorType=ALL (regression check)
+1. Set the dropdown to **ALL**.
+2. Click **Download → JSONL**.
+3. Open the downloaded file.
+
+### S4. Tenant audit log download — actorType=SERVICE_ACCOUNT
+1. Navigate to `/admin/tenant/audit-logs` (admin role required).
+2. Set the actor type dropdown to **SERVICE_ACCOUNT**.
+3. Pick a date range covering at least the last 7 days.
+4. Click **Download → CSV**.
+5. Open the CSV.
+
+### S5. Team admin audit-logs page — visual rendering (R3-F2)
+1. Navigate to `/admin/teams/<team-id>/audit-logs` (team admin/owner required).
+2. Visually compare the layout against `/admin/tenant/members` (the canonical SectionLayout pattern).
+
+## Expected result
+
+- **S1**: Every line in the JSONL has `"actorType": "HUMAN"`. No SERVICE_ACCOUNT or MCP_AGENT rows present.
+- **S2**: Every line has `"actorType": "SERVICE_ACCOUNT"`. No HUMAN rows present.
+- **S3**: Mixed actorType values present (matches today's full-export behavior — regression check).
+- **S4**: CSV body rows are exclusively SERVICE_ACCOUNT actors (the `actorType` column is currently omitted from CSV per the parent review's R2-F2 deferral, so verify by cross-referencing the same date range in the on-screen list with the SA filter applied — row count should match).
+- **S5**: The Card sits flush within the `SectionLayout` frame with consistent padding/margin (matches the layout of `/admin/tenant/members` and `/admin/teams/<id>/general/profile`). No visual regression — header, filter row, download button, and log list all aligned.
+
+## Rollback
+
+- Single revert: `git revert <PR-merge-sha>` reverses all 4 commits cleanly. No DB migration to undo, no config change, no data state mutation.

--- a/docs/archive/review/audit-log-download-actor-type-filter-plan.md
+++ b/docs/archive/review/audit-log-download-actor-type-filter-plan.md
@@ -192,6 +192,33 @@ These items were considered and explicitly excluded — they would expand blast 
 
 - Single commit; revert is `git revert <sha>`. No data migration to undo.
 
+## Implementation Checklist (Phase 2 step 2-1)
+
+### Files to modify
+- [ ] `src/app/api/audit-logs/download/route.ts` — import + parseActorType call (after `to` line 41, before date validation line 44) + spread in `where` literal (lines 62-65)
+- [ ] `src/app/api/tenant/audit-logs/download/route.ts` — import + parseActorType call (after `to` line 46, before `if (!from && !to)` early return line 49) + `if (validActorType) where.actorType = validActorType` after `where` construction
+- [ ] `src/app/[locale]/admin/teams/[teamId]/audit-logs/page.tsx` — re-indent `<Card>` block (line 207) +2 spaces through `</Card>`
+- [ ] `src/app/api/audit-logs/download/route.test.ts` — 3 new tests (present/absent/invalid actorType) with mandatory `await parseStreamResponse(res)` consume + `not.toHaveProperty` for absent/invalid
+- [ ] `src/app/api/tenant/audit-logs/download/route.test.ts` — 3 new tests with mandatory `await streamToString(res)` consume + mandatory `from`/`to` searchParams + `not.toHaveProperty`
+
+### Shared utilities to reuse (must NOT reimplement)
+- `parseActorType(searchParams: URLSearchParams)` from `@/lib/audit/audit-query` — only valid entry point for actorType validation
+- `parseActionsCsvParam(actionsParam: string | null)` from same module — already imported in both target files
+- `VALID_ACTOR_TYPES` constant — already exported from `@/lib/audit/audit-query`; do not redefine
+- `buildAuditLogStream` + `buildAuditLogDownloadResponse` from `@/lib/audit/audit-log-stream` — unchanged; lazy stream behavior is the source of T1/T2 testing requirements
+- `withUserTenantRls(userId, fn)` from `@/lib/tenant-context` — personal route RLS wrapper; unchanged
+- `withTenantRls(prisma, tenantId, fn)` from `@/lib/tenant-rls` — tenant route RLS wrapper; unchanged
+- `createRequest` (test helper) from `@/__tests__/helpers/request-builder` — already imported in both test files
+- `parseStreamResponse` (defined inline in `src/app/api/audit-logs/download/route.test.ts:53-66`) — reuse for personal tests
+- `streamToString` (defined inline in `src/app/api/tenant/audit-logs/download/route.test.ts`) — reuse for tenant tests
+
+### Patterns to follow consistently
+- parseActorType import grouping: add `parseActorType` to the existing destructured import from `@/lib/audit/audit-query` (do NOT create a new import line)
+- parseActorType call position: AFTER `to` extraction, BEFORE the date validation block (matches `teams/[teamId]/audit-logs/download/route.ts:66`)
+- `where` clause shape: spread for `Prisma.AuditLogWhereInput` typing (personal); imperative `if (validActorType) where.actorType = validActorType;` for `Record<string, unknown>` typing (tenant)
+- Test assertion form: `expect.objectContaining({ where: expect.objectContaining({ actorType: "..." }) })` for present case; `expect(calledWith.where).not.toHaveProperty("actorType")` for absent/invalid cases
+- Lazy-stream consume-first: `await parseStreamResponse(res)` (personal) / `await streamToString(res)` (tenant) BEFORE asserting on `mockPrismaAuditLog.findMany.mock.calls`
+
 ## Recurring Issue Check (plan-time)
 
 (Filled in detail by review experts in Step 1-4. Listed here so the plan declares which checks apply.)

--- a/docs/archive/review/audit-log-download-actor-type-filter-plan.md
+++ b/docs/archive/review/audit-log-download-actor-type-filter-plan.md
@@ -1,0 +1,210 @@
+# Plan: Audit Log Download — actorType Filter Parity + SectionLayout Indent
+
+## Project context
+
+- **Type**: web app (Next.js 16 App Router)
+- **Test infrastructure**: unit + integration + E2E + CI/CD
+  - Vitest for unit tests; Playwright for E2E; CI runs `npx vitest run` + `npx next build` + lint
+- **Origin**: revives stash@{0} from a now-deleted `fix/release-please-patch-bump` branch (review round 3 of `unify-audit-log-consistency`). The same fix must be re-implemented against the current source structure (`@/lib/audit/audit-query` path, `parseActionsCsvParam`-based where-clause builder).
+
+## Objective
+
+Restore filter parity across the three audit log download endpoints (personal / tenant / team) and remove a UI indentation regression in the team audit-log admin page.
+
+Two independent but topically related fixes ship in one PR because they are the round-3 carry-over from the same `unify-audit-log-consistency` review:
+
+1. **R3-F1 [Major]** — `/api/audit-logs/download` and `/api/tenant/audit-logs/download` ignore the `actorType` query parameter that the UI sends. The team download endpoint (`/api/teams/[teamId]/audit-logs/download`) already honors it. As a result, the personal and tenant download buttons silently return data inconsistent with the UI's `actorType` filter selection.
+2. **R3-F2 [Minor]** — `src/app/[locale]/admin/teams/[teamId]/audit-logs/page.tsx` has stale 4-space indentation under `<SectionLayout>` (Card and children sit at column 5 instead of column 7). Other admin pages that wrap their return body in `<SectionLayout>` indent inner content one extra level (e.g. `tenant/members/page.tsx:17` — `<TenantMembersCard />` at col 7).
+
+## Requirements
+
+### Functional
+
+1. `GET /api/audit-logs/download?actorType=<HUMAN|SERVICE_ACCOUNT|MCP_AGENT|SYSTEM|ANONYMOUS>` MUST narrow the result set to that actorType. Other valid combinations (no `actorType` param, unknown `actorType` value) MUST behave as today (return all rows).
+2. `GET /api/tenant/audit-logs/download?actorType=…` MUST narrow the result set in the same way.
+3. The `actorType` param contract is exactly `parseActorType` (`src/lib/audit/audit-query.ts:14`): valid set is `["HUMAN", "SERVICE_ACCOUNT", "MCP_AGENT", "SYSTEM", "ANONYMOUS"]`. Unknown / case-mismatched / empty values are silently ignored (no 400) — this matches the existing list endpoints and the team download endpoint, so behavior is consistent across all six routes.
+4. The team audit-log admin page MUST render with consistent JSX indentation matching the SectionLayout-wrapped pattern used elsewhere in `src/app/[locale]/admin/`.
+
+### Non-functional
+
+- No new dependencies; reuse `parseActorType` from `@/lib/audit/audit-query`.
+- No DB schema, migration, env-var, or DB-role changes.
+- No public API contract change beyond honoring an already-documented and already-sent query parameter.
+- Build (`npx next build`), test (`npx vitest run`), and lint MUST pass before commit.
+
+## Technical approach
+
+### Pattern reference: existing team download endpoint
+
+`src/app/api/teams/[teamId]/audit-logs/download/route.ts` is the canonical pattern:
+
+```ts
+import { parseActionsCsvParam, parseActorType } from "@/lib/audit/audit-query";
+// ...
+const validActorType = parseActorType(searchParams);
+// ...
+const where: Prisma.AuditLogWhereInput = {
+  teamId,
+  scope: AUDIT_SCOPE.TEAM,
+  ...(validActorType ? { actorType: validActorType } : {}),
+};
+```
+
+The personal and tenant download endpoints adopt the same shape. No new helper, no schema changes.
+
+### File-by-file change set
+
+| File | Change |
+|---|---|
+| `src/app/api/audit-logs/download/route.ts` | Add `parseActorType` to the existing `@/lib/audit/audit-query` import. Call `parseActorType(searchParams)` after the other `searchParams.get(...)` calls. Spread `...(validActorType ? { actorType: validActorType } : {})` into the `where` literal. |
+| `src/app/api/tenant/audit-logs/download/route.ts` | Same as above. The where clause is typed as `Record<string, unknown>` (not `Prisma.AuditLogWhereInput`) here — keep the existing typing rather than tightening it; spread works the same way. |
+| `src/app/[locale]/admin/teams/[teamId]/audit-logs/page.tsx` | Re-indent the JSX block from `<Card>` at line 207 down through its closing `</Card>` so each line gains 2 extra leading spaces. No semantic change; no new imports. |
+| `src/app/api/audit-logs/download/route.test.ts` | Add unit tests verifying actorType is reflected in the Prisma `where` clause: (a) valid value → `actorType: "<value>"` present in `where`; (b) absent param → no `actorType` key; (c) invalid value → no `actorType` key (silent ignore). |
+| `src/app/api/tenant/audit-logs/download/route.test.ts` | Same three-case test set; mirror the existing patterns for the team download test. |
+
+### Out of scope (deliberately deferred)
+
+These items were considered and explicitly excluded — they would expand blast radius without addressing the round-3 finding:
+
+- **Personal download `OR` clause for `EMERGENCY_VAULT_ACCESS`** — the personal *list* endpoint (`audit-logs/route.ts:44-57`) includes an `OR` branch that surfaces emergency-vault-access events targeting `session.user.id` even when `userId` is not the session user. The personal *download* endpoint (`audit-logs/download/route.ts:62-65`) lacks this branch and only filters by `userId`. This is a pre-existing list-vs-download inconsistency, NOT introduced by R3-F1, and is broader than the actorType question. Tracked as a separate follow-up. **Anti-Deferral check**: pre-existing in unchanged file → routed to a separate plan. Cost-to-fix > 30 min (requires understanding emergency-access semantics, audit log schema for emergency events, and updating download tests). Filed as `TODO(audit-log-download-emergency-access-or-clause)` for a future task.
+- **CSV column for `actorType`** — already deferred in R2 of the parent review (out of scope; all three download endpoints consistently omit it from CSV output). Re-deferring.
+- **Strict 400 on unknown `actorType`** — would diverge from the list endpoints' lenient behavior. Deferred to a separate "tighten audit log param validation" plan if/when the team chooses to harden lenient parsing globally.
+- **`buildAuditLogDateFilter` strict-validation gap** in list routes — pre-existing R3-S2 finding; download routes already validate. Out of scope.
+- **Zod migration of `parseActorType`** — pre-existing R3-S1 finding; consistent with existing `parseActionsCsvParam` pattern. Out of scope.
+
+## Implementation steps
+
+1. Create branch from latest `origin/main`: `git fetch origin main && git checkout -b fix/audit-log-download-actor-type-filter origin/main`.
+2. Edit `src/app/api/audit-logs/download/route.ts`:
+   - Update the import on line 14 to `import { parseActionsCsvParam, parseActorType } from "@/lib/audit/audit-query";`.
+   - **After the `to` extraction (line 41), and BEFORE the date validation block (line 44)** — matching the team route's canonical position at `teams/[teamId]/audit-logs/download/route.ts:66` (parseActorType is grouped with the other `searchParams.get(...)` calls and placed BEFORE date validation). Add `const validActorType = parseActorType(searchParams);` at this position.
+   - In the `where` literal (lines 62-65), add the spread `...(validActorType ? { actorType: validActorType } : {})`.
+3. Edit `src/app/api/tenant/audit-logs/download/route.ts`:
+   - Update the import on line 12 the same way.
+   - **After the `to` extraction (line 46), and BEFORE the `if (!from && !to)` early return (line 49)** — matching the team route's canonical position. Add `const validActorType = parseActorType(searchParams);` at this position.
+   - In the `where` literal (lines 70-73), add the same spread (or `if (validActorType) where.actorType = validActorType;` to match the looser typing).
+4. Edit `src/app/[locale]/admin/teams/[teamId]/audit-logs/page.tsx`:
+   - Re-indent the block from `<Card>` (currently line 207) through its matching `</Card>` so each affected line gains 2 leading spaces. The block is purely JSX inside a single return — no logic change. Verify the closing tag at the SectionLayout boundary still aligns.
+5. Add tests to `src/app/api/audit-logs/download/route.test.ts`:
+   - **MANDATORY pre-assertion step**: each new test MUST consume the response stream via `await parseStreamResponse(res)` BEFORE asserting on `mockPrismaAuditLog.findMany.mock.calls`. The download route returns a lazy `ReadableStream` from `buildAuditLogStream`; `findMany` is only invoked from inside the stream's pull callback. The existing pagination test at `route.test.ts:228-238` is the reference pattern. Without this consume-first step, `findMany.mock.calls[0]` is `undefined` at assertion time and the test silently throws (or vacuously passes if the throw is swallowed).
+   - `it("filters by actorType when provided", …)`:
+     ```ts
+     const req = createRequest("GET", "http://localhost:3000/api/audit-logs/download", {
+       searchParams: { actorType: "SERVICE_ACCOUNT" },
+     });
+     const res = await GET(req);
+     await parseStreamResponse(res); // REQUIRED: triggers lazy fetchBatch
+     expect(mockPrismaAuditLog.findMany.mock.calls[0][0]).toEqual(
+       expect.objectContaining({
+         where: expect.objectContaining({ actorType: "SERVICE_ACCOUNT" }),
+       }),
+     );
+     ```
+   - `it("omits actorType filter when param absent", …)`:
+     ```ts
+     const req = createRequest("GET", "http://localhost:3000/api/audit-logs/download");
+     const res = await GET(req);
+     await parseStreamResponse(res);
+     const calledWith = mockPrismaAuditLog.findMany.mock.calls[0][0];
+     expect(calledWith.where).not.toHaveProperty("actorType");
+     ```
+     Note: `not.toHaveProperty("actorType")` is preferred over `not.objectContaining({ actorType: "value" })` because the latter only refutes a specific value and would pass even if `where` contained a different valid actorType (e.g., a regression where `parseActorType` always returns `"HUMAN"`).
+   - `it("ignores unknown actorType silently", …)`:
+     ```ts
+     const req = createRequest("GET", "http://localhost:3000/api/audit-logs/download", {
+       searchParams: { actorType: "NOT_REAL" },
+     });
+     const res = await GET(req);
+     await parseStreamResponse(res);
+     const calledWith = mockPrismaAuditLog.findMany.mock.calls[0][0];
+     expect(calledWith.where).not.toHaveProperty("actorType");
+     ```
+6. Add equivalent tests to `src/app/api/tenant/audit-logs/download/route.test.ts`. **Same MANDATORY pre-assertion step** — use the existing `await streamToString(res)` helper (already used in the file) before asserting on `findMany.mock.calls`. The route also returns a lazy `ReadableStream`. **EQUALLY MANDATORY**: every tenant test request MUST include `from` and `to` searchParams or the route returns 400 at the `if (!from && !to)` early-return guard before `findMany` is ever called — making `findMany.mock.calls` empty. Pattern (apply to all three cases — present / absent / invalid actorType):
+   ```ts
+   const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
+     searchParams: { from: "2026-01-01", to: "2026-01-31", actorType: "SERVICE_ACCOUNT" /* or omit / "NOT_REAL" */ },
+   });
+   const res = await GET(req);
+   await streamToString(res);  // REQUIRED: triggers lazy fetchBatch
+   const calledWith = mockPrismaAuditLog.findMany.mock.calls[0][0];
+   // Then either:
+   expect(calledWith.where).toEqual(expect.objectContaining({ actorType: "SERVICE_ACCOUNT" }));
+   // OR for absent/invalid cases:
+   expect(calledWith.where).not.toHaveProperty("actorType");
+   ```
+7. Run `npx vitest run` — all suites green.
+8. Run `npx next build` — production build succeeds.
+9. Run `npm run lint` — no new warnings.
+10. Commit with message `fix(audit): honor actorType filter in personal/tenant download + indent team audit page`.
+11. Open one PR (no per-step PRs — see memory: PR cadence aggregate).
+
+## Testing strategy
+
+### Unit tests (vitest)
+
+- **R3-F1 functional verification**: per the table above, three new tests per endpoint — six new tests total.
+- **Pattern reference for assertion shape**: existing tests in `src/app/api/audit-logs/download/route.test.ts:202-279` already mock `mockPrismaAuditLog.findMany` and inspect `mock.calls[N][0]`. The new tests reuse this pattern — assert on `where` shape via `expect.objectContaining({ actorType: ... })` for the present case, and `not.toHaveProperty("actorType")` for absent/invalid cases (see step 5 snippets and the assertion-form preference note below).
+- **Existing coverage preserved**: all 13 existing tests in the personal download test file and all corresponding tests in the tenant download test file MUST continue to pass unchanged. The R3-F1 change is additive — no existing assertion is loosened.
+- **`parseActorType` itself is already covered** by `src/lib/audit/audit-query.test.ts:48-69` (5 cases). No new tests needed for the parser.
+- **Lazy-stream consumption (mandatory)**: both download routes return a `ReadableStream` from `buildAuditLogStream`. `prisma.auditLog.findMany` is invoked from inside the stream's pull callback, NOT synchronously at `GET(req)` time. Every new test that asserts on `mockPrismaAuditLog.findMany.mock.calls` MUST first consume the stream (`await parseStreamResponse(res)` for personal, `await streamToString(res)` for tenant). The existing pagination test in the personal route file (`route.test.ts:228-238`) is the reference pattern. Tests that skip the consume-first step will see `findMany.mock.calls[0] === undefined` and either silently throw or vacuously pass.
+- **Assertion-form preference**: for "absent param" and "invalid param" cases, prefer `expect(calledWith.where).not.toHaveProperty("actorType")` over `not.toEqual(expect.objectContaining({ actorType: "value" }))`. The latter only refutes a specific value and would pass if `where` contained a different valid actorType (e.g., a regression where `parseActorType` always returns `"HUMAN"`). The `not.toHaveProperty` form refutes the key's presence entirely, which is the actual invariant.
+
+### Integration / E2E
+
+- No new integration test required for this PR. The route-level integration test gap for actorType filter reflection (R3-T1 in the parent review) is the same gap that exists for `action`/`from`/`to` params. Closing it is a separate, larger task that affects all six audit log routes (3 list + 3 download) and is filed as `TODO(audit-log-route-integration-tests)`.
+- E2E coverage exists for the audit log download UI flow — no new E2E test required since the only change is honoring an already-documented param. The hook (`src/hooks/vault/use-audit-logs.ts:127`) already adds `actorType` to the download URL when the filter selection is non-`ALL`; that path was already exercised by the team download flow. The personal/tenant flows now match.
+
+### Build / lint
+
+- `npx next build` is mandatory after the change. The personal download test file mocks `@/lib/audit/audit` and `@/lib/security/rate-limit` — no mock-shape drift expected since we are only adding a where-clause spread, but verify the build does not error on type narrowing for the new `actorType` field.
+- `npm run lint` — no new ESLint suppressions, no underscore-prefixed unused vars (per repo memory: `feedback_no_suppress_warnings`).
+
+## User operation scenarios
+
+1. **Personal audit log download with HUMAN filter**: User opens `/dashboard/account/audit-logs`, sets the actor type dropdown to "HUMAN", clicks Download → JSONL. Expected: only logs with `actorType: "HUMAN"` are downloaded. Today: ALL logs are downloaded regardless of dropdown selection.
+2. **Tenant audit log download with SERVICE_ACCOUNT filter**: Tenant admin opens `/admin/tenant/audit-logs`, sets the dropdown to "SERVICE_ACCOUNT", picks a date range, clicks Download → CSV. Expected: only SA-actor rows. Today: all rows.
+3. **Default (ALL) flow unchanged**: User leaves the dropdown at "ALL". The hook does not append the `actorType` query param (`use-audit-logs.ts:127`). The download endpoint sees no `actorType` param, `parseActorType` returns `undefined`, the spread injects nothing, and `where` is identical to today's behavior.
+4. **Crafted invalid actorType (manual API call)**: A power user calls `GET /api/audit-logs/download?actorType=ADMIN&from=…&to=…`. `parseActorType` returns `undefined`, the spread injects nothing, and the user receives all logs (silent ignore). This matches the team download endpoint and the list endpoints — no special-case 400.
+5. **Team audit log admin page render**: A team admin opens `/admin/teams/<id>/audit-logs`. Expected: page renders with consistent indentation. The visual output is unchanged — this is a JSX whitespace-only change.
+
+## Considerations & constraints
+
+### Risks
+
+- **TypeScript narrowing on `Prisma.AuditLogWhereInput`** (personal download): the spread `...(validActorType ? { actorType: validActorType } : {})` produces a discriminated union that TypeScript collapses. The team download endpoint uses the exact same shape and compiles, so the same shape is expected to compile here. If the build flags it, fall back to `if (validActorType) where.actorType = validActorType;` (used by the tenant list endpoint at `tenant/audit-logs/route.ts:97`).
+- **Loose-typed where in tenant download** (`Record<string, unknown>`): less type-safe; the imperative `if (validActorType) where.actorType = validActorType;` form is preferred to keep the additive change visible.
+- **R34 (adjacent pre-existing bug)**: the personal download endpoint's missing `OR` branch for `EMERGENCY_VAULT_ACCESS` (vs the personal list endpoint) is an adjacent bug in the same file. It is in-scope for R34 per the rule that adjacent bugs in the same diff must be fixed OR cost-justified for deferral. Justification per Anti-Deferral Rules:
+  - **Worst case**: a user who has been granted emergency access to another user's vault sees those events in the personal *list* view but cannot include them in a personal *download*. The events still exist in `audit_logs`, just not in the downloaded file. No data loss, no security regression — only UX gap.
+  - **Likelihood**: low (emergency access is a rare flow; users who use it rarely download audit logs from the personal view because tenant admins typically use the tenant download view for cross-user audit needs).
+  - **Cost to fix**: > 30 minutes — requires (a) updating the personal download where clause to mirror the list endpoint's OR pattern, (b) adding tests for the emergency-access branch in the download path, (c) cross-checking that the streaming pagination cursor still works correctly with the `OR` clause (cursor on `id` ordered by `createdAt: asc` may interact with OR differently than with a single `userId` filter), (d) verifying no RLS policy boundary is crossed. The 30-minute exemption does NOT apply to security-list bugs; this is on the edge — it touches audit-log filtering for emergency-access (an authorization-adjacent surface), so impact analysis is required before deferring. Impact analysis: the missing OR is symmetric to the list endpoint, which has been live for several releases without security incident. The download endpoint is read-only with the same RLS scope (`withUserTenantRls`) as the list. No new authorization boundary is crossed by the deferral. Routed as `TODO(audit-log-download-emergency-access-or-clause)`.
+  - **Cursor-OR concern is scoped to the deferred fix only**: the cost-to-fix item (c) above describes a concern specific to the deferred OR-clause fix. **It does NOT apply to the actorType filter being added in this plan.** The actorType filter is a top-level equality predicate spread into the existing `where` literal; the cursor (`id` unique, `createdAt: asc` ordering) remains stable regardless of additional equality filters in `where`. Adding the actorType filter does not interact with cursor pagination in any new way.
+- **Stash-origin caveat**: the original stash was based on a different repo state where the audit-query helpers lived at `@/lib/audit-query` (not `@/lib/audit/audit-query`) and the where clause used `VALID_ACTIONS` directly. We are NOT applying the stash mechanically — the changes are re-derived from the current source.
+
+### Dependencies
+
+- None. No new packages, no schema migrations, no env vars.
+
+### Backward compatibility
+
+- Fully backward compatible. The `actorType` query param was already documented (UI sends it). Existing clients that did not send it see no change. Clients that did send it now get the filtered result they expected.
+
+### Rollback
+
+- Single commit; revert is `git revert <sha>`. No data migration to undo.
+
+## Recurring Issue Check (plan-time)
+
+(Filled in detail by review experts in Step 1-4. Listed here so the plan declares which checks apply.)
+
+- **R1 / R17 / R22 (helper reuse)**: `parseActorType` is the existing helper. Forward perspective — both routes adopt it. Inverted perspective — no syntactically-different equivalent (e.g. inline `searchParams.get("actorType")` with manual validation) exists in the changed files.
+- **R3 (pattern propagation)**: enumerated all six audit-log routes (`audit-logs/route.ts`, `tenant/audit-logs/route.ts`, `teams/[teamId]/audit-logs/route.ts`, plus the three download counterparts). Five already use `parseActorType`; the two download routes are the gap this plan closes.
+- **R7 (E2E selector breakage)**: no JSX role/aria/data-testid/data-slot change. Indentation-only edit on the team page; selectors unchanged.
+- **R8 (UI pattern inconsistency)**: R3-F2 is itself a pattern-inconsistency fix.
+- **R12 (enum/action group coverage gap)**: no new audit action; no group definition change.
+- **R19 (test mock alignment + exact-shape assertion obligation)**: new tests use `expect.objectContaining` for the positive case (asserting `actorType` IS in `where`) and `not.toHaveProperty("actorType")` for the negative cases (asserting `actorType` is NOT in `where`). The negative form (`not.toHaveProperty`) is intentionally stronger than `not.objectContaining({ actorType: "value" })` so that a regression where `parseActorType` always returns a fixed valid value would still be caught. No exact-shape `toEqual` assertions on `where` exist currently; nothing to update.
+- **R21 (subagent verification)**: tests + lint + build re-run by orchestrator after sub-agent edits. Security-relevant test path — audit log filtering is access-control-adjacent — completed.
+- **R23 (mid-stroke input mutation)**: N/A — no input handler changes.
+- **R29 / R30 (citations / autolink)**: no external standard cited; no PR body autolink risk in plan text.
+- **R31 (destructive ops)**: none in this plan or in the verification scripts.
+- **R34 (adjacent pre-existing bug deferred)**: addressed above — emergency-access OR branch deferred with full Worst case / Likelihood / Cost-to-fix justification and TODO marker.
+- **R35 (manual test plan for production-deployed components)**: diff matches NO deployment-artifact list pattern (no Dockerfile, no compose, no manifests, no Helm, no Terraform, no IAM/TLS/IdP material). Tier-1/Tier-2 do not fire. No `*-manual-test.md` artifact required.

--- a/docs/archive/review/audit-log-download-actor-type-filter-review.md
+++ b/docs/archive/review/audit-log-download-actor-type-filter-review.md
@@ -1,0 +1,99 @@
+# Plan Review: audit-log-download-actor-type-filter
+Date: 2026-05-03
+Review rounds: 3 (1 full + 2 incremental)
+
+## Round-by-round summary
+
+- **Round 1**: Functionality flagged F1 (insertion-point divergence) + F3 (R34 cursor-OR concern misplaced). Security: no findings. Testing flagged T1 (Major — lazy stream consumption gap) + T2 (tenant equivalent) + T3 (assertion-form weakness). Plan amended.
+- **Round 2**: Functionality observed F1 fix overshot (canonical position is BEFORE date validation, not after) + raised F4 (plan internal inconsistency). Security: no new findings. Testing confirmed T1/T2/T3 resolved + raised T4 (stale `not.objectContaining` text on line 134) + T5 (tenant snippet absent). Plan amended.
+- **Round 3**: Targeted verification — F1, F4, T4, T5 all confirmed resolved. No new findings. Loop terminates clean.
+
+## Round 1 Findings
+
+### F1 [Minor]: Plan steps 2/3 prescribed parseActorType insertion point — RESOLVED IN ROUND 2 (after a Round 1 over-correction)
+- File: docs/archive/review/audit-log-download-actor-type-filter-plan.md (steps 2 & 3)
+- Round 1 fix attempt: moved prescription from "after `to` extraction" to "after date validation block" — this overshot.
+- Round 2 correction: reverted to "after `to` extraction, and BEFORE date validation block" — matching canonical `teams/[teamId]/audit-logs/download/route.ts:66`.
+
+### F3 [Minor]: R34 deferral note unnecessarily raised cursor-OR concern — RESOLVED IN ROUND 1
+- Amended note explicitly scopes the cursor-OR concern to the deferred OR-clause fix only; does not apply to the actorType filter being added in this plan.
+
+### S1-Sn: No findings (Round 1 and Round 2)
+
+The plan adds actorType query-parameter support to two download endpoints via the existing `parseActorType` helper. No new trust boundaries, no schema changes, no new dependencies. RLS isolation, authorization gating, input validation (strict allowlist with identity comparison; Prisma parameterizes), and information disclosure surfaces all checked across both rounds — no security regression. Deferred OR-clause is under-disclosure (not over-disclosure); RLS continues to enforce tenant isolation; actorType filter cannot bypass the missing OR or reach unauthorized records.
+
+### T1 [Major]: Personal download tests must consume the response stream before asserting on `findMany.mock.calls` — RESOLVED IN ROUND 1
+- The personal route returns a lazy `ReadableStream`; `findMany` is invoked from inside the stream's pull callback. Plan now requires `await parseStreamResponse(res)` before assertions in step 5 with three sample snippets demonstrating the pattern, plus the Testing strategy section reinforcing the requirement.
+
+### T2 [Minor]: Tenant download — same lazy-stream consumption requirement — RESOLVED IN ROUND 1
+- Step 6 now mandates `await streamToString(res)` before assertions.
+
+### T3 [Minor]: Use `not.toHaveProperty("actorType")` instead of `not.objectContaining` for absent/invalid cases — RESOLVED IN ROUND 1
+- Step 5 snippets and Testing strategy section now use the stronger form. The weaker form remains in explanatory contrast notes (intentional — explains why the stronger form is preferred).
+
+## Round 2 Findings
+
+### F4 [Minor] (new in Round 2): Plan internal inconsistency between pattern-reference snippet and step instructions — RESOLVED IN ROUND 2
+- The pattern-reference snippet (Technical approach section) showed parseActorType in its canonical position; the Round 1 step-2/3 over-correction created a contradiction. The Round 2 F1 revert resolved both.
+
+### T4 [Minor] (new in Round 2): Testing strategy bullet still contained stale `expect.not.objectContaining({ actorType: ... })` — RESOLVED IN ROUND 2
+- Replaced with `not.toHaveProperty("actorType") for absent/invalid cases`. Explanatory contrast mention preserved as the "why" note.
+
+### T5 [Minor] (new in Round 2): Step 6 lacked tenant test snippet; from/to requirement in prose only — RESOLVED IN ROUND 2
+- Added explicit tenant snippet showing `from`/`to` searchParams + `await streamToString(res)` consume + both `expect.objectContaining` and `not.toHaveProperty` assertion forms with a bolded "EQUALLY MANDATORY" note.
+
+## Adjacent Findings
+
+None.
+
+## Quality Warnings
+
+None across all three rounds (Ollama merge produced no VAGUE / NO-EVIDENCE / UNTESTED-CLAIM flags in Round 1; Round 2 and Round 3 were focused incremental reviews).
+
+## Recurring Issue Check (final state after Round 3)
+
+### Functionality expert
+- R1: Checked — no issue
+- R2: N/A
+- R3: Checked — no issue (all 6 audit-log routes enumerated; 4 already use parseActorType, 2 are this plan's targets)
+- R4: N/A
+- R5: N/A (read-only)
+- R6: N/A
+- R7: Checked — no issue (indentation-only; no ARIA/role/data-testid changes)
+- R8: N/A (this is the R3-F2 fix itself; reference pattern in `tenant/members/page.tsx` confirmed)
+- R9: N/A
+- R10: N/A
+- R11: N/A
+- R12: N/A
+- R13: N/A
+- R14: N/A
+- R15: N/A
+- R16: N/A
+- R17: Checked — no issue
+- R18: N/A
+- R19: Checked — no issue
+- R20: N/A
+- R21: Checked
+- R22: Checked
+- R23: N/A
+- R24: N/A
+- R25: N/A
+- R26: N/A
+- R27: N/A
+- R28: N/A
+- R29: N/A
+- R30: N/A
+- R31: N/A
+- R32: N/A
+- R33: N/A
+- R34: Checked — deferral cost-justified per Anti-Deferral Rules; cursor-OR concern correctly scoped to deferred fix
+- R35: N/A (no deployment-artifact files in diff)
+
+### Security expert
+- All R1-R35 + RS1-RS3: same as Round 1 (no changes)
+- R34: Deferral remains acceptable (under-disclosure not over-disclosure; RLS preserved)
+
+### Testing expert
+- R1-R35 + RT1-RT3: all checked; T1/T2/T3/T4/T5 resolved.
+- RT2 in particular: lazy-stream consume-first requirement now explicit at step + strategy levels
+- RT3: tenant-route early-return guard now explicit in step 6 with concrete snippet

--- a/src/app/[locale]/admin/teams/[teamId]/audit-logs/page.tsx
+++ b/src/app/[locale]/admin/teams/[teamId]/audit-logs/page.tsx
@@ -204,69 +204,69 @@ export default function TeamAdminAuditLogsPage({
       title={tAdmin("teamSectionAuditLogs")}
       description={tAdmin("teamSectionAuditLogsDesc")}
     >
-    <Card>
-      <SectionCardHeader icon={ScrollText} title={tAdmin("navAuditLogs")} description={tAdmin("teamSectionAuditLogsDesc")} />
-      <CardContent className="space-y-4">
-        <div className="rounded-xl border bg-card/80 p-4">
-          <div className="space-y-3">
-            <div className="flex flex-wrap items-end gap-3">
-              <div className="space-y-1">
-                <Label className="text-xs">{t("actorTypeLabel")}</Label>
-                <Select value={audit.actorTypeFilter} onValueChange={audit.setActorTypeFilter}>
-                  <SelectTrigger className="w-[180px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="ALL">{t("actorTypeAll")}</SelectItem>
-                    <SelectItem value="HUMAN">{t("actorTypeHuman")}</SelectItem>
-                    <SelectItem value="SERVICE_ACCOUNT">{t("actorTypeSa")}</SelectItem>
-                    <SelectItem value="MCP_AGENT">{t("actorTypeMcp")}</SelectItem>
-                  </SelectContent>
-                </Select>
+      <Card>
+        <SectionCardHeader icon={ScrollText} title={tAdmin("navAuditLogs")} description={tAdmin("teamSectionAuditLogsDesc")} />
+        <CardContent className="space-y-4">
+          <div className="rounded-xl border bg-card/80 p-4">
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-end gap-3">
+                <div className="space-y-1">
+                  <Label className="text-xs">{t("actorTypeLabel")}</Label>
+                  <Select value={audit.actorTypeFilter} onValueChange={audit.setActorTypeFilter}>
+                    <SelectTrigger className="w-[180px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ALL">{t("actorTypeAll")}</SelectItem>
+                      <SelectItem value="HUMAN">{t("actorTypeHuman")}</SelectItem>
+                      <SelectItem value="SERVICE_ACCOUNT">{t("actorTypeSa")}</SelectItem>
+                      <SelectItem value="MCP_AGENT">{t("actorTypeMcp")}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <AuditDateFilter
+                  dateFrom={audit.dateFrom}
+                  dateTo={audit.dateTo}
+                  setDateFrom={audit.setDateFrom}
+                  setDateTo={audit.setDateTo}
+                />
               </div>
-              <AuditDateFilter
-                dateFrom={audit.dateFrom}
-                dateTo={audit.dateTo}
-                setDateFrom={audit.setDateFrom}
-                setDateTo={audit.setDateTo}
+              <AuditActionFilter
+                actionGroups={ACTION_GROUPS}
+                selectedActions={audit.selectedActions}
+                actionSearch={audit.actionSearch}
+                filterOpen={audit.filterOpen}
+                actionSummary={audit.actionSummary}
+                actionLabel={audit.actionLabel}
+                filteredActions={audit.filteredActions}
+                isActionSelected={audit.isActionSelected}
+                toggleAction={audit.toggleAction}
+                setGroupSelection={audit.setGroupSelection}
+                clearActions={audit.clearActions}
+                setActionSearch={audit.setActionSearch}
+                setFilterOpen={audit.setFilterOpen}
               />
             </div>
-            <AuditActionFilter
-              actionGroups={ACTION_GROUPS}
-              selectedActions={audit.selectedActions}
-              actionSearch={audit.actionSearch}
-              filterOpen={audit.filterOpen}
-              actionSummary={audit.actionSummary}
-              actionLabel={audit.actionLabel}
-              filteredActions={audit.filteredActions}
-              isActionSelected={audit.isActionSelected}
-              toggleAction={audit.toggleAction}
-              setGroupSelection={audit.setGroupSelection}
-              clearActions={audit.clearActions}
-              setActionSearch={audit.setActionSearch}
-              setFilterOpen={audit.setFilterOpen}
+          </div>
+
+          <div className="flex justify-end">
+            <AuditDownloadButton
+              downloading={audit.downloading}
+              onDownload={audit.handleDownload}
+              exportAllowed={exportAllowed}
             />
           </div>
-        </div>
 
-        <div className="flex justify-end">
-          <AuditDownloadButton
-            downloading={audit.downloading}
-            onDownload={audit.handleDownload}
-            exportAllowed={exportAllowed}
+          <AuditLogList
+            logs={audit.logs}
+            loading={audit.loading}
+            loadingMore={audit.loadingMore}
+            nextCursor={audit.nextCursor}
+            onLoadMore={audit.handleLoadMore}
+            renderItem={renderItem}
           />
-        </div>
-
-        <AuditLogList
-          logs={audit.logs}
-          loading={audit.loading}
-          loadingMore={audit.loadingMore}
-          nextCursor={audit.nextCursor}
-          onLoadMore={audit.handleLoadMore}
-          renderItem={renderItem}
-        />
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
     </SectionLayout>
   );
 }

--- a/src/app/api/audit-logs/download/route.test.ts
+++ b/src/app/api/audit-logs/download/route.test.ts
@@ -276,4 +276,37 @@ describe("GET /api/audit-logs/download", () => {
       }),
     );
   });
+
+  it("filters by actorType when provided", async () => {
+    const req = createRequest("GET", "http://localhost:3000/api/audit-logs/download", {
+      searchParams: { actorType: "SERVICE_ACCOUNT" },
+    });
+    const res = await GET(req);
+    await parseStreamResponse(res);
+
+    const calledWith = mockPrismaAuditLog.findMany.mock.calls[0][0];
+    expect(calledWith.where).toEqual(
+      expect.objectContaining({ actorType: "SERVICE_ACCOUNT" }),
+    );
+  });
+
+  it("omits actorType filter when param absent", async () => {
+    const req = createRequest("GET", "http://localhost:3000/api/audit-logs/download");
+    const res = await GET(req);
+    await parseStreamResponse(res);
+
+    const calledWith = mockPrismaAuditLog.findMany.mock.calls[0][0];
+    expect(calledWith.where).not.toHaveProperty("actorType");
+  });
+
+  it("ignores unknown actorType silently", async () => {
+    const req = createRequest("GET", "http://localhost:3000/api/audit-logs/download", {
+      searchParams: { actorType: "NOT_REAL" },
+    });
+    const res = await GET(req);
+    await parseStreamResponse(res);
+
+    const calledWith = mockPrismaAuditLog.findMany.mock.calls[0][0];
+    expect(calledWith.where).not.toHaveProperty("actorType");
+  });
 });

--- a/src/app/api/audit-logs/download/route.ts
+++ b/src/app/api/audit-logs/download/route.ts
@@ -60,6 +60,10 @@ async function handleGET(req: NextRequest) {
     }
   }
 
+  // TODO(audit-log-download-emergency-access-or-clause): personal LIST endpoint
+  // (audit-logs/route.ts:44-57) surfaces EMERGENCY_VAULT_ACCESS events targeting
+  // session.user.id via an OR branch; this download endpoint does not. Symmetry
+  // gap is pre-existing UX (under-disclosure), not security; deferred per plan.
   const where: Prisma.AuditLogWhereInput = {
     scope: AUDIT_SCOPE.PERSONAL,
     userId: session.user.id,

--- a/src/app/api/audit-logs/download/route.ts
+++ b/src/app/api/audit-logs/download/route.ts
@@ -60,15 +60,13 @@ async function handleGET(req: NextRequest) {
     }
   }
 
-  // TODO(audit-log-download-emergency-access-or-clause): personal LIST endpoint
-  // (audit-logs/route.ts:44-57) surfaces EMERGENCY_VAULT_ACCESS events targeting
-  // session.user.id via an OR branch; this download endpoint does not. Symmetry
-  // gap is pre-existing UX (under-disclosure), not security; deferred per plan.
+  // TODO(audit-log-download-emergency-access-or-clause): download omits the OR-branch for EMERGENCY_VAULT_ACCESS events present in the list endpoint; pre-existing UX gap, not security.
   const where: Prisma.AuditLogWhereInput = {
     scope: AUDIT_SCOPE.PERSONAL,
     userId: session.user.id,
-    ...(validActorType ? { actorType: validActorType } : {}),
   };
+
+  if (validActorType) where.actorType = validActorType;
 
   const parsedActions = parseActionsCsvParam(actionsParam);
   if ("invalid" in parsedActions) {

--- a/src/app/api/audit-logs/download/route.ts
+++ b/src/app/api/audit-logs/download/route.ts
@@ -11,7 +11,7 @@ import {
 import type { Prisma } from "@prisma/client";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { withRequestLog } from "@/lib/http/with-request-log";
-import { parseActionsCsvParam } from "@/lib/audit/audit-query";
+import { parseActionsCsvParam, parseActorType } from "@/lib/audit/audit-query";
 import { AUDIT_LOG_MAX_RANGE_DAYS } from "@/lib/validations/common.server";
 import { MS_PER_DAY } from "@/lib/constants/time";
 import { buildAuditLogStream, buildAuditLogDownloadResponse } from "@/lib/audit/audit-log-stream";
@@ -39,6 +39,7 @@ async function handleGET(req: NextRequest) {
   const actionsParam = searchParams.get("actions");
   const from = searchParams.get("from");
   const to = searchParams.get("to");
+  const validActorType = parseActorType(searchParams);
 
   // Validate date range
   if (from || to) {
@@ -62,6 +63,7 @@ async function handleGET(req: NextRequest) {
   const where: Prisma.AuditLogWhereInput = {
     scope: AUDIT_SCOPE.PERSONAL,
     userId: session.user.id,
+    ...(validActorType ? { actorType: validActorType } : {}),
   };
 
   const parsedActions = parseActionsCsvParam(actionsParam);

--- a/src/app/api/tenant/audit-logs/download/route.test.ts
+++ b/src/app/api/tenant/audit-logs/download/route.test.ts
@@ -84,6 +84,10 @@ async function streamToString(response: Response): Promise<string> {
   return result;
 }
 
+// 7-day-ago ISO string — used to satisfy the route's "from or to required" guard
+// without coupling tests to a specific calendar date.
+const VALID_FROM = new Date(Date.now() - 7 * 86400000).toISOString();
+
 const MOCK_LOGS = [
   {
     id: "log-1",
@@ -110,7 +114,7 @@ describe("GET /api/tenant/audit-logs/download", () => {
   it("returns 401 when not authenticated", async () => {
     mockAuth.mockResolvedValue(null);
     const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
-      searchParams: { from: new Date(Date.now() - 7 * 86400000).toISOString() },
+      searchParams: { from: VALID_FROM },
     });
     const res = await GET(req);
     expect(res.status).toBe(401);
@@ -119,7 +123,7 @@ describe("GET /api/tenant/audit-logs/download", () => {
   it("returns 403 when permission denied", async () => {
     mockRequireTenantPermission.mockRejectedValue(new TenantAuthError("INSUFFICIENT_PERMISSION", 403));
     const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
-      searchParams: { from: new Date(Date.now() - 7 * 86400000).toISOString() },
+      searchParams: { from: VALID_FROM },
     });
     const res = await GET(req);
     expect(res.status).toBe(403);
@@ -128,7 +132,7 @@ describe("GET /api/tenant/audit-logs/download", () => {
   it("rethrows unexpected permission errors", async () => {
     mockRequireTenantPermission.mockRejectedValue(new Error("boom"));
     const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
-      searchParams: { from: new Date(Date.now() - 7 * 86400000).toISOString() },
+      searchParams: { from: VALID_FROM },
     });
     await expect(GET(req)).rejects.toThrow("boom");
   });
@@ -136,7 +140,7 @@ describe("GET /api/tenant/audit-logs/download", () => {
   it("returns 429 when rate limited", async () => {
     mockDownloadLimiterCheck.mockResolvedValue({ allowed: false });
     const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
-      searchParams: { from: new Date(Date.now() - 7 * 86400000).toISOString() },
+      searchParams: { from: VALID_FROM },
     });
     const res = await GET(req);
     expect(res.status).toBe(429);
@@ -176,7 +180,7 @@ describe("GET /api/tenant/audit-logs/download", () => {
 
   it("returns 400 for invalid action filters", async () => {
     const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
-      searchParams: { from: new Date(Date.now() - 7 * 86400000).toISOString(), actions: "ENTRY_CREATE,NOT_REAL" },
+      searchParams: { from: VALID_FROM, actions: "ENTRY_CREATE,NOT_REAL" },
     });
     const res = await GET(req);
     expect(res.status).toBe(400);
@@ -184,7 +188,7 @@ describe("GET /api/tenant/audit-logs/download", () => {
 
   it("streams JSONL format by default", async () => {
     const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
-      searchParams: { from: new Date(Date.now() - 7 * 86400000).toISOString() },
+      searchParams: { from: VALID_FROM },
     });
     const res = await GET(req);
     expect(res.status).toBe(200);
@@ -200,7 +204,7 @@ describe("GET /api/tenant/audit-logs/download", () => {
 
   it("streams CSV format when requested", async () => {
     const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
-      searchParams: { from: new Date(Date.now() - 7 * 86400000).toISOString(), format: "csv" },
+      searchParams: { from: VALID_FROM, format: "csv" },
     });
     const res = await GET(req);
     expect(res.status).toBe(200);
@@ -215,7 +219,7 @@ describe("GET /api/tenant/audit-logs/download", () => {
 
   it("records audit log download event", async () => {
     const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
-      searchParams: { from: new Date(Date.now() - 7 * 86400000).toISOString() },
+      searchParams: { from: VALID_FROM },
     });
     const res = await GET(req);
     await streamToString(res);
@@ -228,7 +232,7 @@ describe("GET /api/tenant/audit-logs/download", () => {
   it("filters by actorType when provided", async () => {
     const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
       searchParams: {
-        from: new Date(Date.now() - 7 * 86400000).toISOString(),
+        from: VALID_FROM,
         actorType: "SERVICE_ACCOUNT",
       },
     });
@@ -243,7 +247,7 @@ describe("GET /api/tenant/audit-logs/download", () => {
 
   it("omits actorType filter when param absent", async () => {
     const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
-      searchParams: { from: new Date(Date.now() - 7 * 86400000).toISOString() },
+      searchParams: { from: VALID_FROM },
     });
     const res = await GET(req);
     await streamToString(res);
@@ -255,7 +259,7 @@ describe("GET /api/tenant/audit-logs/download", () => {
   it("ignores unknown actorType silently", async () => {
     const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
       searchParams: {
-        from: new Date(Date.now() - 7 * 86400000).toISOString(),
+        from: VALID_FROM,
         actorType: "NOT_REAL",
       },
     });

--- a/src/app/api/tenant/audit-logs/download/route.test.ts
+++ b/src/app/api/tenant/audit-logs/download/route.test.ts
@@ -224,4 +224,45 @@ describe("GET /api/tenant/audit-logs/download", () => {
       expect.objectContaining({ action: "AUDIT_LOG_DOWNLOAD" }),
     );
   });
+
+  it("filters by actorType when provided", async () => {
+    const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
+      searchParams: {
+        from: new Date(Date.now() - 7 * 86400000).toISOString(),
+        actorType: "SERVICE_ACCOUNT",
+      },
+    });
+    const res = await GET(req);
+    await streamToString(res);
+
+    const calledWith = mockPrismaAuditLog.findMany.mock.calls[0][0];
+    expect(calledWith.where).toEqual(
+      expect.objectContaining({ actorType: "SERVICE_ACCOUNT" }),
+    );
+  });
+
+  it("omits actorType filter when param absent", async () => {
+    const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
+      searchParams: { from: new Date(Date.now() - 7 * 86400000).toISOString() },
+    });
+    const res = await GET(req);
+    await streamToString(res);
+
+    const calledWith = mockPrismaAuditLog.findMany.mock.calls[0][0];
+    expect(calledWith.where).not.toHaveProperty("actorType");
+  });
+
+  it("ignores unknown actorType silently", async () => {
+    const req = createRequest("GET", "http://localhost:3000/api/tenant/audit-logs/download", {
+      searchParams: {
+        from: new Date(Date.now() - 7 * 86400000).toISOString(),
+        actorType: "NOT_REAL",
+      },
+    });
+    const res = await GET(req);
+    await streamToString(res);
+
+    const calledWith = mockPrismaAuditLog.findMany.mock.calls[0][0];
+    expect(calledWith.where).not.toHaveProperty("actorType");
+  });
 });

--- a/src/app/api/tenant/audit-logs/download/route.ts
+++ b/src/app/api/tenant/audit-logs/download/route.ts
@@ -9,7 +9,7 @@ import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { handleAuthError, rateLimited, unauthorized, validationError } from "@/lib/http/api-response";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
-import { parseActionsCsvParam } from "@/lib/audit/audit-query";
+import { parseActionsCsvParam, parseActorType } from "@/lib/audit/audit-query";
 import { AUDIT_LOG_MAX_RANGE_DAYS } from "@/lib/validations/common.server";
 import { MS_PER_DAY } from "@/lib/constants/time";
 import { buildAuditLogStream, buildAuditLogDownloadResponse } from "@/lib/audit/audit-log-stream";
@@ -44,6 +44,7 @@ async function handleGET(req: NextRequest) {
   const actionsParam = searchParams.get("actions");
   const from = searchParams.get("from");
   const to = searchParams.get("to");
+  const validActorType = parseActorType(searchParams);
 
   // Require at least one date boundary
   if (!from && !to) {
@@ -71,6 +72,8 @@ async function handleGET(req: NextRequest) {
     scope: { in: [AUDIT_SCOPE.TENANT, AUDIT_SCOPE.TEAM] },
     tenantId: actor.tenantId,
   };
+
+  if (validActorType) where.actorType = validActorType;
 
   const parsedActions = parseActionsCsvParam(actionsParam);
   if ("invalid" in parsedActions) {


### PR DESCRIPTION
## Summary

- Fix R3-F1 [Major]: personal (`/api/audit-logs/download`) and tenant (`/api/tenant/audit-logs/download`) download endpoints silently ignored the `actorType` query param that the UI sends — downloaded JSONL/CSV did not match on-screen filter selection. Adopts the canonical `parseActorType` pattern already in use by the team route.
- Fix R3-F2 [Minor]: re-indent the team admin audit-logs page Card block (+2 spaces) to match the SectionLayout-wrapped pattern used elsewhere in `admin/`. Pure JSX whitespace; no logic / selector / aria-* change.
- Add `TODO(audit-log-download-emergency-access-or-clause)` in-source marker (R34 deferral) and a 6-test vitest suite addition (3 per route).

Origin: revives stash from a now-deleted `fix/release-please-patch-bump` branch (round 3 of `unify-audit-log-consistency` review). Re-implemented against the current source structure.

## Approach

For both download routes, call the existing `parseActorType` helper from `@/lib/audit/audit-query` and add `if (validActorType) where.actorType = validActorType;` after `where` construction (matches the file-local mutation pattern already used for `action` / `createdAt`). Strict allowlist validation is preserved — invalid values are silently ignored to match the list endpoints.

## Test plan

- [x] `npx vitest run` — 9195 tests pass (incl. 6 new actorType cases)
- [x] `npm run lint` — zero warnings
- [x] `npx next build` — compiled successfully
- [x] `bash scripts/pre-pr.sh` — 13/13 checks pass
- [ ] Manual test plan executed (see `docs/archive/review/audit-log-download-actor-type-filter-manual-test.md`)
  - [ ] Personal download with actorType=HUMAN — only HUMAN rows
  - [ ] Personal download with actorType=SERVICE_ACCOUNT — only SA rows
  - [ ] Personal download with actorType=ALL — mixed rows (regression check)
  - [ ] Tenant download with actorType=SERVICE_ACCOUNT — only SA rows
  - [ ] Team admin audit-logs page renders flush within SectionLayout

## Process

Built via `/triangulate` (3 phases: plan → impl → code review) + `/simplify` cleanup. All artifacts under [`docs/archive/review/`](docs/archive/review/):
- `audit-log-download-actor-type-filter-plan.md` — finalized plan
- `audit-log-download-actor-type-filter-review.md` — plan review log (3 rounds)
- `audit-log-download-actor-type-filter-code-review.md` — code review log (1 round)
- `audit-log-download-actor-type-filter-manual-test.md` — R35 Tier-1 manual test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)