### PR TITLE
feat(ios): AutoFill credential provider MVP — host app + extension

### DIFF
--- a/docs/archive/review/ios-autofill-mvp-hardening-code-review.md
+++ b/docs/archive/review/ios-autofill-mvp-hardening-code-review.md
@@ -1,0 +1,170 @@
+# Code Review: ios-autofill-mvp-hardening
+
+Date: 2026-05-03
+Final round: R3 (verification only — no findings)
+
+## Scope
+
+iOS-only diff against `main`:
+
+- `ios/Shared/Storage/EntryCacheFile.swift` (+ tests)
+- `ios/Shared/Storage/BridgeKeyStore.swift` (+ tests)
+- `ios/PasswdSSOApp/Auth/ServerTrustService.swift` (+ tests)
+- 8 dependent test-mock updates across iOS test files
+
+Web/server changes for the original review's item #4 (Vault Reset cache
+invalidation audit) were initially included but reverted entirely from
+the diff per user direction; that work is recorded in the plan as
+out-of-scope and deferred to a separate web-scoped plan.
+
+## Round 1 Findings
+
+### Functionality (4 findings, all Minor or non-actionable)
+
+- **F-1 Minor** — Dead code `_ = existing.counter` in
+  `BridgeKeyStore.incrementCounter`. **Fixed**: simplified to extract
+  only `uuid` directly, no temp tuple.
+- **F-2** — Verification-only entry confirming `tryMigrateLegacyBlob`
+  on persistBlob failure preserves the legacy item. No fix needed.
+- **F-3 Minor** — `ServerTrust.pin()` update path drops
+  `kSecAttrAccessible` (pre-existing in changed file, in scope).
+  **Fixed**: re-set the attribute on the update path.
+- **F-4 [Adjacent] Minor** — SCIM route narrows
+  `InvalidateUserSessionsResult` type by assignment. Out of scope per
+  plan §"Considerations & constraints". No fix.
+
+### Security (1 in-scope finding, Minor)
+
+- **S-1 Minor** — `VAULT_RESET_CACHE_INVALIDATION_FAILED` missing from
+  team/tenant audit groups. **Out of scope** — applies to Web/server
+  item #4 which was reverted entirely. Recorded for the web-scoped
+  follow-up plan.
+
+### Testing (5 findings, 1 Major + 4 Minor in iOS scope)
+
+- **T-1 Major** — admin-reset failure-path test missing.
+  **Out of scope** — Web/server item.
+- **T-2 Major** — `tryMigrateLegacyBlob` failure path was untested;
+  `MockKeychainAccessor` had no add-failure injection. **Fixed**:
+  extended mock with `addFailureForServices: Set<String>`; added
+  `testLegacyMigrationFailureKeepsLegacyIntact` asserting legacy
+  intact + v2 items absent after a key-v2 add failure.
+- **T-3 Minor** — SCIM mock structural drift. **Out of scope**.
+- **T-4 Minor** — `testHeaderMissingUserIdRejectsAsHeaderInvalid`
+  brittleness. **Fixed**: added a comment explaining the test passes
+  because parseHeaderJSON throws before entries-decrypt; if read-order
+  changes, the test must be rewritten.
+- **T-5 Minor** — `userIdLen` byte-boundary not tested. **Fixed**:
+  added 3 builder-level tests (256, 0xFFFF, oversized rejected).
+
+## Round 2 Findings
+
+### Functionality
+
+No findings. All R1 fixes verified.
+
+### Security
+
+No findings. All R1 fixes verified — including that
+`ServerTrust.pin()` update kSecAttrAccessible re-application is
+identity-rewrite (cannot weaken accessibility) and that the
+BridgeKeyStore migration-failure test correctly exercises the meta-v2
+rollback path on key-v2 add failure.
+
+### Testing (2 new Minor findings)
+
+- **T2-1 Minor** — Boundary tests verify only the AAD BUILD path, not
+  the AAD-USE round-trip. **Fixed**: added
+  `testRoundTripWithUserIdAtByteBoundary` (write+read with 256-byte
+  userId).
+- **T2-2 Minor** — `testLegacyMigrationFailureKeepsLegacyIntact` used
+  `_ = error` (lax). **Fixed**: replaced with
+  `XCTAssertEqual(error as? BridgeKeyStore.Error,
+  .keychainError(errSecParam))` plus a comment tracing the
+  deterministic failure path.
+- Informational — `MockKeychainAccessor.addFailureForServices` is
+  `var Set<String>` on `@unchecked Sendable`; safe under XCTest's
+  main-thread synchronous execution. No action.
+- Informational — failure check before duplicate check in
+  `MockKeychainAccessor.add()` is intentional; failure injection
+  takes precedence over slot occupancy. No action.
+
+## Round 3 Findings
+
+No findings. Both R2 fixes verified syntactically and semantically
+correct, no production code touched, and a sweep confirms no other
+weak `_ = error` stragglers remain in the iOS test corpus.
+
+## Adjacent Findings
+
+- (Functionality → Security) Plan binds `userId` to entries AAD
+  assuming single-userId-per-cache. Confirmed in scope: cache file is
+  per-device per-user; multi-account is not in scope for
+  ios-autofill-mvp.
+- (Testing → Security) Cache-AAD scope decision (drop `headerHash`)
+  was a security-domain decision, confirmed in R1 plan review.
+
+## Resolution Status
+
+### F-1 Minor: dead code `_ = existing.counter`
+
+- **Action**: Removed; `incrementCounter` now uses `let uuid: Data`
+  directly.
+- **Modified file**: `ios/Shared/Storage/BridgeKeyStore.swift` (lines
+  ~200-220)
+
+### F-3 Minor: pin() update drops kSecAttrAccessible
+
+- **Action**: Re-set `kSecAttrAccessible =
+  kSecAttrAccessibleWhenUnlockedThisDeviceOnly` on the update branch.
+- **Modified file**: `ios/PasswdSSOApp/Auth/ServerTrustService.swift`
+  (lines ~114-136)
+
+### T-2 Major: missing migration-failure test
+
+- **Action**: Added `addFailureForServices: Set<String>` to
+  `MockKeychainAccessor`; added
+  `testLegacyMigrationFailureKeepsLegacyIntact` asserting legacy
+  intact + key-v2 absent + meta-v2 rolled back.
+- **Modified file**: `ios/PasswdSSOTests/BridgeKeyStoreTests.swift`
+
+### T-4 Minor: brittleness comment
+
+- **Action**: Added explanatory comment to
+  `testHeaderMissingUserIdRejectsAsHeaderInvalid`.
+- **Modified file**: `ios/PasswdSSOTests/EntryCacheFileTests.swift`
+
+### T-5 Minor: userIdLen boundary tests
+
+- **Action**: Added `testCacheEntriesAADFormatLongUserId`,
+  `testCacheEntriesAADFormatMaxUserId`, and
+  `testCacheEntriesAADFormatOversizeUserIdRejected`.
+- **Modified file**: `ios/PasswdSSOTests/EntryCacheFileTests.swift`
+
+### T2-1 Minor: round-trip at boundary
+
+- **Action**: Added `testRoundTripWithUserIdAtByteBoundary` that
+  writes + reads a cache file with a 256-byte userId, verifying the
+  AAD-on-encrypt and AAD-on-decrypt paths agree at the byte boundary.
+- **Modified file**: `ios/PasswdSSOTests/EntryCacheFileTests.swift`
+
+### T2-2 Minor: tighten error assertion
+
+- **Action**: Replaced `_ = error` with `XCTAssertEqual(error as?
+  BridgeKeyStore.Error, .keychainError(errSecParam))` plus a comment
+  tracing the deterministic failure path.
+- **Modified file**: `ios/PasswdSSOTests/BridgeKeyStoreTests.swift`
+
+### Out of scope (Web/server, not addressed)
+
+- **S-1 Minor — Anti-Deferral check**: out of scope (different
+  feature). The Vault Reset cache-invalidation audit warning belongs
+  to a separate web-scoped plan. Recorded for follow-up.
+- **T-1 Major — Anti-Deferral check**: same as S-1.
+- **T-3 Minor — Anti-Deferral check**: same as S-1.
+
+## Verification
+
+- `xcodebuild test` — TEST SUCCEEDED (final run after R2 fixes).
+- All 13 changed iOS files have corresponding test coverage.
+- `git status --short` confirms no Web/server files in the diff.

--- a/docs/archive/review/ios-autofill-mvp-hardening-plan.md
+++ b/docs/archive/review/ios-autofill-mvp-hardening-plan.md
@@ -1,0 +1,392 @@
+# Plan: ios-autofill-mvp-hardening
+
+## Project context
+
+- Type: iOS native app under `ios/` (parent repo also hosts web app, but this
+  plan is iOS-only)
+- Test infrastructure: iOS XCTest + project CI
+- Active branch: `feature/ios-autofill-mvp` (no new branch — extend the
+  in-flight feature)
+
+## Objective
+
+Resolve three iOS review findings on top of the in-flight iOS AutoFill MVP
+work:
+
+1. (iOS — high) Bind the encrypted-entries blob in `EntryCacheFile` to its
+   header context via AAD so a swap of `(new header + old entries)` is
+   rejected.
+2. (iOS — high) Separate the bridge_key (biometric-gated) from the
+   counter/host_install_uuid (no biometric required) into two distinct
+   Keychain items, eliminating the conflict between `.biometryCurrentSet`
+   ACL and the documented `readDirect()` path.
+3. (iOS — medium) Stop calling the field `tlsSPKISHA256` when the value is
+   actually the SHA-256 of `SecKeyCopyExternalRepresentation` output (raw
+   uncompressed EC point or PKCS#1 RSAPublicKey, not SPKI DER). Make name
+   and implementation match.
+
+A fourth review item (Vault Reset cache-invalidation audit, Web/server
+side) was raised in the same review pass but is **out of scope** for this
+plan — the user explicitly scoped this work to iOS-only.
+
+## Threat model assumptions
+
+The assumed adversary is "an attacker with write access to the App Group
+container or shared Keychain access group, but WITHOUT the user's
+biometric." Concretely: another app installed in the same App Group (rare
+but possible across enterprise MDM scenarios), a compromised Share/Widget
+extension, or local supply-chain tampering on the device. The adversary
+cannot decrypt vault material (vaultKey is wrapped under bridge_key, which
+is `.biometryCurrentSet`-gated).
+
+OUT OF SCOPE: full device compromise (jailbreak, debugger attach with
+breakpoints in the app process, decrypted memory dump). Per Apple's
+platform-security baseline, App-Group-write-access alone is not considered
+"device compromise" — but full-app code-injection is.
+
+## Requirements
+
+### Functional
+
+- F-1: An `EntryCacheFile` written with header H₁ and entries E₁ MUST be
+  rejected when read against any other header (different counter, UUID,
+  or userId) — even when the attacker possesses both halves of valid
+  cache files.
+- F-2: `BridgeKeyStore.create()` produces TWO Keychain items: a
+  biometric-gated item carrying the 32-byte bridge_key, and a
+  non-biometric `WhenUnlockedThisDeviceOnly` item carrying counter (8 BE)
+  + host_install_uuid (16 raw). All existing public API
+  (`readForFill`/`readDirect`/`incrementCounter`/`recoverForwardCounter`/
+  `delete`) MUST continue to work; behavior visible to consumers must not
+  change semantically.
+- F-3: `PinSet` field naming MUST match what the value actually contains
+  (raw leaf-public-key bytes, not SPKI DER). Stored values MUST migrate
+  silently — old keychain entries with the old field name continue to
+  decode AND get re-encoded into the new shape on first write-back.
+
+### Non-functional
+
+- NF-1: No regression in iOS XCTest suite under `ios/PasswdSSOTests/`.
+- NF-2: Wire format / on-disk format changes that affect existing
+  installations MUST include a migration path. For ENTRIES-AAD: feature
+  branch only — no live users; legacy cache files become unreadable
+  (rejected via existing `.authtagInvalid` path), caller re-fetches
+  cleanly. For BRIDGE-KEY split: explicit migrate-on-read step from
+  legacy combined `com.passwd-sso.bridge-key` (56-byte) item.
+
+## Technical approach
+
+### 1. EntryCacheFile entries-blob AAD
+
+Today the entries blob is encrypted with AES-GCM and *no AAD*. Header has
+AAD `"CACHEHDR" || counter(BE 8) || uuid(16)`. So `(new header H₂ + old
+entries E₁)` decrypts cleanly, and the only remaining check is
+`entryCount` matching (defeated by an attacker who controls header JSON
+and re-encrypts under the still-valid vaultKey-derived AEAD key).
+
+**Decision (resolves F-1)**: keep header AAD as-is (no version byte) and
+adopt a parallel-style entries AAD. Both AADs use the same shape: 8-byte
+ASCII tag + counter(BE 8) + uuid(16) + optional fields. The entries AAD
+prepends `userId` length-prefixed.
+
+Entries AAD format:
+
+```text
+"CACHEENT" (8 ASCII)
+counter (BE 8)
+hostInstallUUID (16 raw)
+userIdLen (BE 2)
+userId (UTF-8 bytes)
+```
+
+NO `aadVersion` byte — matches the existing `buildCacheHeaderAAD`
+omission. If we later need versioned AADs, both can be migrated together
+in a deliberate wire-format break.
+
+We do NOT bind `headerHash` per the original review:
+- `counter + uuid + userId` already forces the three identity fields that
+  distinguish one valid header from another.
+- `cacheIssuedAt` and `lastSuccessfulRefreshAt` are time-only fields, not
+  identity; binding them would require re-decrypting the header before
+  the entries AAD can be computed (chicken-and-egg).
+- `entryCount` is verified post-decryption against the JSON array length;
+  an attacker who forges a header (which requires the AEAD key, i.e.,
+  possession of vaultKey) is already past every defense.
+
+Threat-model rationale: the attacker has App Group write access but NO
+vaultKey. Without entries AAD, swapping in old entries is undetectable
+because both ciphertexts decrypt under the legitimate AEAD key with no
+context binding. With entries AAD bound to (counter, uuid, userId), the
+swap is detected. `entryCount` post-decryption check still functions as
+a sanity gate; AAD is the authoritative integrity boundary.
+
+Helper addition: `buildCacheEntriesAAD(counter:hostInstallUUID:userId:)`
+becomes `internal` (not `private`) so the test target can call it under
+`@testable import Shared`.
+
+Migration: cache file is single-device, ephemeral, and auto-rebuilds on
+counter advance. An old (no-AAD-on-entries) cache file written by the
+previous version produces `.authtagInvalid` on read → existing caller
+path forces a fresh fetch. No migration code needed; documented as
+"feature branch unshipped, dev-only impact."
+
+### 2. BridgeKeyStore split
+
+Today: ONE Keychain item with `.biometryCurrentSet` ACL holds
+`[bridge_key:32][counter:8 BE][host_install_uuid:16]` = 56 bytes.
+
+Problem: `readDirect()` / `incrementCounter()` / `recoverForwardCounter()`
+are documented as "no biometric" but the underlying item has
+`.biometryCurrentSet`. On real devices this either prompts (bad UX in
+host-app foreground sync) or returns `errSecAuthFailed`.
+
+**Service names**: use NEW service strings to avoid collision with the
+legacy combined item.
+
+```text
+service = "com.passwd-sso.bridge-key-v2"
+  kSecValueData = bridge_key (32 bytes)
+  kSecAttrAccessControl = .biometryCurrentSet
+  kSecAttrAccessible = WhenUnlockedThisDeviceOnly
+
+service = "com.passwd-sso.bridge-meta-v2"
+  kSecValueData = counter (BE 8) || hostInstallUUID (16) = 24 bytes
+  kSecAttrAccessible = WhenUnlockedThisDeviceOnly
+  (no .biometryCurrentSet ACL)
+```
+
+Legacy combined service `com.passwd-sso.bridge-key` (56-byte payload)
+remains readable for migration purposes only.
+
+**Public API**:
+
+- `create()` writes BOTH new items in this strict order:
+  1. Add `bridge-meta-v2` (no-ACL — least likely to fail).
+  2. Add `bridge-key-v2` (biometric-gated).
+  3. (Migration path only) Delete legacy `bridge-key` if it existed.
+
+  Failure rollback: if step 2 fails, delete `bridge-meta-v2` then bubble
+  up. If step 3 fails, log via OSLog (best-effort) but do not treat as
+  fatal — the new items are valid, legacy item becomes a benign orphan
+  that the migration helper will re-attempt to remove on next read.
+
+- `readForFill(reason:)` MUST return the same `Blob` shape as today.
+  Implementation: read `bridge-key-v2` (with biometric LAContext), then
+  read `bridge-meta-v2` (no-ACL). If either is `errSecItemNotFound`,
+  attempt one-shot legacy migration (see below) and retry; if still
+  missing → `Error.notFound`.
+
+- `readDirect()` reads `bridge-meta-v2` only and returns a Blob with
+  `bridgeKey = Data()` (empty 0-byte). Existing callers
+  (`HostSyncService.fetchAndStore` line 39, `RootView` line 189,
+  `StaleBlobRecoveryService` line 30, `DebugVaultLoader`) all confirmed
+  via grep to read only `cacheVersionCounter` and `hostInstallUUID`
+  after `readDirect()` — none consume `bridgeKey`. Document this in
+  the Blob struct doc-comment.
+
+- `incrementCounter(newCounter:)` operates on `bridge-meta-v2` only (no
+  biometric prompt during background sync). Internally tries to migrate
+  from legacy on `errSecItemNotFound`.
+
+- `recoverForwardCounter(observed:)` unchanged in semantics; calls
+  `readDirect` + `incrementCounter` internally.
+
+- `delete()` deletes `bridge-key-v2`, `bridge-meta-v2`, AND legacy
+  `bridge-key` (best-effort, errSecItemNotFound is OK on each). Returns
+  first non-OK status not equal to `errSecItemNotFound`.
+
+**Self-healing semantics**: `readForFill` and `readDirect` treat any
+single-item missing as `Error.notFound`. The caller path on `notFound`
+is to re-unlock the vault, which calls `create()` again — `create()` is
+idempotent on duplicate (existing fall-back to `update`). Partial-write
+states heal on next vault unlock.
+
+**Legacy migration trigger**: ONE migration helper `tryMigrateLegacyBlob()
+-> Blob?` is invoked from `readForFill`, `readDirect`, and
+`incrementCounter` whenever the v2 items return `errSecItemNotFound`.
+Algorithm:
+
+```swift
+private func tryMigrateLegacyBlob(usingContext: LAContext?) throws -> Blob? {
+  // Read legacy combined item via biometric (if context provided) or
+  // direct (if not). errSecItemNotFound → return nil (no migration
+  // needed).
+  let legacyData = try readLegacy(...)
+  guard let blob = try? deserializeLegacy(legacyData) else { return nil }
+  // Write v2 items. If any step fails, leave legacy intact.
+  try persistBlob(blob)  // writes both v2 items
+  // Best-effort delete of legacy. Failure here is non-fatal; next
+  // call will detect v2 present and skip migration entirely.
+  _ = try? keychain.delete(query: legacyQuery())
+  return blob
+}
+```
+
+**Counter-rollback risk acknowledgment**: removing `.biometryCurrentSet`
+from the meta item allows an attacker with App Group write access to
+overwrite counter to a previous value. Combined with a stolen old cache
+file, this enables a stale-snapshot replay. This trade-off is documented
+as the cost of fixing the `readDirect`-prompts-biometric bug. The threat
+model treats App Group write access as out-of-scope per the threat-model
+assumptions section. A future tightening could add an HMAC over (counter
+|| uuid) keyed by HKDF(bridgeKey, ...), verified on `readForFill`;
+deferred to a follow-up because it would re-introduce a per-fill
+bridgeKey dependency on every counter advance.
+
+### 3. ServerTrustService SPKI hash naming
+
+`extractLeafSPKIHash` hashes `SecKeyCopyExternalRepresentation(publicKey)`
+output. For ECDSA P-256 leaves, this is the 65-byte uncompressed point
+(`0x04 || X || Y`); for RSA leaves, PKCS#1 RSAPublicKey DER. Neither is
+SubjectPublicKeyInfo DER, so `tlsSPKISHA256` is misnamed.
+
+**Decision**: rename + clarify; do NOT change the hashing semantics.
+
+- TOFU pin is computed and compared on-device only; server-side never
+  needs to compute the matching value.
+- Real SPKI DER would require either DER parsing or `encodeP256SPKI`
+  (P-256 only — would silently break RSA leaf certs in private
+  deployments).
+
+Concrete change:
+
+- Rename `PinSet.tlsSPKISHA256` → `PinSet.tlsLeafKeySHA256`. Field
+  doc-comment replaced with: "SHA-256 of the leaf certificate's public
+  key in `SecKeyCopyExternalRepresentation` form (uncompressed EC point
+  or PKCS#1 RSAPublicKey, NOT SPKI DER). Stable per server identity but
+  not interchangeable with `openssl dgst -sha256` over `-pubkey -outform
+  DER`."
+- Custom `Codable` initializer accepts both `tlsSPKISHA256` AND
+  `tlsLeafKeySHA256` JSON keys; `encode(to:)` writes ONLY the new key.
+- **Migration-on-read** in `currentPin()`: when decode succeeds via the
+  legacy alias, the function re-encodes via `pin()` to upgrade the
+  on-disk JSON. Result: next read no longer needs the alias. The legacy
+  alias remains in the decoder permanently with a `// kept for
+  forward-compat with old Keychain blobs` comment — no removal timeline.
+- Rename `SPKIPinningDelegate.capturedSPKIHash` → `capturedLeafKeyHash`.
+- Rename `extractLeafSPKIHash` → `extractLeafKeyHash`; doc-comment
+  matches the field doc.
+
+## Implementation steps
+
+1. **(iOS-1)** `ios/Shared/Storage/EntryCacheFile.swift`:
+   - Add `func buildCacheEntriesAAD(counter:hostInstallUUID:userId:) throws -> Data`
+     as `internal` (file-level, not `private`).
+   - Pass the new AAD to `encryptAESGCM` on entries write.
+   - Pass the same AAD to `decryptAESGCM` on entries read.
+   - Since entries-AAD requires `userId`, and `userId` is parsed from the
+     decrypted header, the read-order remains: decrypt header → read
+     header.userId → build entries-AAD → decrypt entries.
+
+2. **(iOS-1 tests)** `ios/PasswdSSOTests/EntryCacheFileTests.swift`:
+   - `testEntriesBlobBindToCounterRejectsCrossFileSwap`: write file A
+     (counter=10, userId=u1, entries=[A1]); write file B (counter=11,
+     userId=u1, entries=[B1]). Build Frankenstein file C with B's
+     encrypted-header bytes + A's encrypted-entries bytes (parsing the
+     original file format and re-assembling). `readCacheFile(C,
+     expectedCounter=11)` must throw `.rejection(.authtagInvalid)`.
+   - `testEntriesBlobBindToUserIdRejectsCrossUserSwap`: write A
+     (userId=u1) and B (userId=u2) with same counter+uuid; splice
+     B-header + A-entries; reject.
+   - `testEntriesBlobNegativeControl`: write A and B with IDENTICAL
+     (counter, uuid, userId) but different IV (i.e., write twice).
+     Splice B-header + A-entries — expect SUCCESSFUL decryption,
+     because AAD components are identical. (Confirms test detects AAD
+     mismatch specifically, not other corruption.)
+   - Use `@testable import Shared` to access `buildCacheEntriesAAD` when
+     computing expected AAD bytes for direct splice construction.
+
+3. **(iOS-2)** `ios/Shared/Storage/BridgeKeyStore.swift`:
+   - Introduce two service constants:
+     - `bridgeKeyServiceV2 = "com.passwd-sso.bridge-key-v2"`
+     - `bridgeMetaServiceV2 = "com.passwd-sso.bridge-meta-v2"`
+     - `bridgeKeyServiceLegacy = "com.passwd-sso.bridge-key"`
+   - Refactor `create()`, `readForFill()`, `readDirect()`,
+     `incrementCounter()`, `recoverForwardCounter()`, `delete()` per §2.
+   - Add `tryMigrateLegacyBlob()` private helper.
+   - Add new error case: `Error.partiallyCreated` reserved for future use
+     (NOT thrown in MVP — caller treats partial state as `notFound` and
+     re-unlocks).
+   - Keep `bridgeKeyBlobSize = 56` as `legacyBridgeKeyBlobSize = 56`
+     module-private constant, used only inside the migration helper. Add
+     new `bridgeKeyV2Size = 32` and `bridgeMetaV2Size = 24`.
+
+4. **(iOS-2 tests)** `ios/PasswdSSOTests/BridgeKeyStoreTests.swift`:
+   - Extend `MockKeychainAccessor` to record every `copyMatching` call's
+     `kSecAttrService` value into an observable `accessedServices: [String]`
+     array.
+   - `testReadDirectOnlyTouchesMetaService`: assert `accessedServices ==
+     ["com.passwd-sso.bridge-meta-v2"]` after a single `readDirect()`
+     call.
+   - `testReadForFillTouchesBothV2Services`: assert services include
+     both `bridge-key-v2` and `bridge-meta-v2`.
+   - `testLegacyBlobMigrationOnReadDirect`: pre-seed mock with a 56-byte
+     legacy item under `com.passwd-sso.bridge-key`; call `readDirect()`;
+     assert (a) returned blob counter+uuid match legacy bytes 32..56;
+     (b) post-call mock state has `bridge-key-v2` AND `bridge-meta-v2`
+     entries; (c) legacy `bridge-key` entry is deleted.
+   - `testLegacyMigrationFailureKeepsLegacyIntact`: inject Add failure
+     for v2 services; assert legacy item still readable after.
+   - Replace `testBlobSizeIs56Bytes` with `testBridgeKeyV2Is32Bytes` and
+     `testBridgeMetaV2Is24Bytes`.
+
+5. **(iOS-3)** `ios/PasswdSSOApp/Auth/ServerTrustService.swift`:
+   - Rename the field, the function, the delegate property.
+   - Add custom Codable conformance for `PinSet` with legacy-key decoder
+     alias.
+   - Implement `currentPin()` migration-on-read.
+   - Update doc-comments per §3.
+
+6. **(iOS-3 tests)** `ios/PasswdSSOTests/ServerTrustServiceTests.swift`:
+   - `testPinSetDecodesLegacyTLSSPKIKey`: decode hardcoded JSON literal
+     with `tlsSPKISHA256` key → assert decoded.tlsLeafKeySHA256 matches.
+   - `testPinSetEncodesNewTLSLeafKeyKey`: encode → JSON string contains
+     `tlsLeafKeySHA256`, NOT `tlsSPKISHA256`.
+   - `testCurrentPinUpgradesLegacyOnRead`: pre-seed keychain with old
+     JSON; call `currentPin()`; assert subsequent `currentPin()` reads
+     the new shape (verify by checking what the keychain mock now holds).
+   - Update existing tests for renamed fields.
+
+7. **Verification**
+   - iOS: `xcodebuild test` — run on iPhone simulator with iOS 26.x SDK.
+
+## Considerations & constraints
+
+- **Out of scope**: building real SPKI DER for the TOFU pin. Trade-off
+  documented in §3.
+- **Out of scope**: HMAC-protected counter/uuid in the meta item.
+  Documented in §2 with explicit Apple-platform-security-baseline
+  rationale.
+- **Out of scope**: Vault Reset cache-invalidation audit warning (web
+  side). Was originally raised in the same review as the iOS findings
+  but explicitly scoped out of this iOS-only plan per user direction.
+- **Migration risk** for BridgeKeyStore: any failure in the migration
+  helper leaves the legacy item readable, so the worst case is "no
+  migration today, retry on next call." Documented in step 3.
+
+## User operation scenarios
+
+- Scenario A — fresh install on iOS, AutoFill invoked: `readForFill()`
+  reads both v2 items; cache file decrypts including entries AAD;
+  credential surfaces. Verifies F-2 + F-1 happy path.
+- Scenario B — attacker swaps entries portion: replaces `entries` bytes
+  in the cache file with an older counter's entries → reader rejects
+  with `.authtagInvalid` (entries AAD mismatch on counter field) →
+  caller falls back to "vault locked". Verifies F-1.
+- Scenario C — attacker rewrites userId in the header JSON before
+  re-encrypting: requires vaultKey, out of threat model. If the attacker
+  somehow has vaultKey (game over anyway), the entries AAD binding to
+  userId still forces them to also re-encrypt entries with the new
+  userId — adds work but not a defense-in-depth break.
+- Scenario D — host app launch, vault locked, sync needs counter:
+  `readDirect()` reads only `bridge-meta-v2` (no biometric prompt) →
+  succeeds silently. Verifies F-2.
+- Scenario E — upgrade from build with legacy 56-byte combined item:
+  first `readDirect()` triggers `tryMigrateLegacyBlob()` → reads legacy
+  → writes v2 items → deletes legacy → returns Blob. Subsequent calls
+  find v2 items directly. Verifies F-2 migration.
+- Scenario F — TOFU pin first sign-in: hash captured; stored under
+  `tlsLeafKeySHA256`; subsequent sign-ins compare equal. Verifies F-3.
+- Scenario G — upgrade from build with legacy `tlsSPKISHA256`: PinSet
+  decodes via legacy alias; `currentPin()` triggers migration-on-read →
+  re-encodes JSON with new key. Pin not re-prompted. Verifies F-3.

--- a/docs/archive/review/ios-autofill-mvp-hardening-review.md
+++ b/docs/archive/review/ios-autofill-mvp-hardening-review.md
@@ -1,0 +1,132 @@
+# Plan Review: ios-autofill-mvp-hardening
+
+Date: 2026-05-03
+Review round: 1
+
+## Changes from Previous Round
+
+Initial review.
+
+## Summary
+
+Reviewed across 3 expert perspectives (functionality / security / testing).
+The plan covers 3 iOS items only — a fourth Web/server item was raised in
+the original code review but is explicitly out of scope here per user
+direction.
+
+Findings affecting in-scope iOS items: 0 Critical, 6 Major, 8 Minor.
+All Major findings folded into the plan revision before Phase 2.
+
+## Functionality Findings
+
+- **F-1 Major** — Entries-AAD aadVersion byte inconsistent with header
+  AAD. Fix: drop aadVersion from entries-AAD; both AADs share the same
+  shape style. → Plan §1 updated.
+- **F-2 Major** — BridgeKeyStore split write-cleanup atomicity not
+  specified. Fix: explicit ordering (meta first → key second → legacy
+  delete last) + self-healing on partial state via `notFound`. → Plan §2
+  updated.
+- **F-3 Major** — Legacy migration trigger contradiction (`create()` vs
+  first-read). Fix: trigger only from `readForFill`/`readDirect`/
+  `incrementCounter`. → Plan §2 updated.
+- **F-4 Major** — Service-name collision with legacy combined item. Fix:
+  rename new services to `*-v2`; legacy `bridge-key` retained for
+  migration only. → Plan §2 updated.
+- **F-5 Minor** — Threat model documentation. Fix: explicit Threat Model
+  Assumptions section. → Plan top updated.
+- **F-8 Minor** — Pin write-back missing for users who never re-pin. Fix:
+  migration-on-read in `currentPin()`; legacy alias permanent. → Plan §3
+  updated.
+
+## Security Findings
+
+- **S-1 Major** — Counter rollback risk after split (App Group attacker
+  overwrites counter). Resolution: documented as out-of-scope per Apple
+  platform-security baseline. HMAC over counter+uuid noted as future
+  hardening. → Plan §2 acknowledgment added.
+- **S-2 Major** — Migration non-atomicity (partial-state from kill-during-
+  migration). Fix: explicit ordering in `tryMigrateLegacyBlob`; on failure
+  leave legacy intact; legacy delete is best-effort/non-fatal. → Plan §2
+  updated.
+- **S-3 Minor** — `PinSet` field doc-comment misleading. Fix: replace
+  doc-comment text in addition to the function-level rename. → Plan §3
+  updated.
+- **S-5 Minor** — Two AAD construction conventions in same file
+  (cache-header AAD vs cross-platform `buildAADBytes`). Resolution: keep
+  both styles distinct since cross-platform parity is not required for
+  cache files (iOS-only). Documented in Plan §1.
+
+## Testing Findings
+
+- **T-1 Major** — Splice test must call `buildCacheEntriesAAD`. Fix:
+  function `internal` (not `private`); tests use `@testable import
+  Shared`. Add negative-control test (identical context → splice
+  succeeds, confirms test detects AAD specifically). → Plan step 2
+  updated.
+- **T-2 Major** — `MockKeychainAccessor` does not model ACL → false-green
+  risk for "readDirect doesn't touch biometric item." Fix: extend mock
+  with `accessedServices: [String]` recorder; assert exact services
+  touched. → Plan step 4 updated.
+- **T-3 Minor** — JSON-decode test for legacy `tlsSPKISHA256` key.
+  Already in plan; updated step 6 to make test name explicit.
+- **T-7 Minor** — `bridgeKeyBlobSize == 56` constant becomes ambiguous
+  post-split. Fix: rename to `legacyBridgeKeyBlobSize` (module-private,
+  migration-helper only); add `bridgeKeyV2Size = 32` and
+  `bridgeMetaV2Size = 24`. → Plan step 3 updated.
+
+## Out of scope (originally raised, deferred)
+
+The original review pass also raised:
+
+- F-6, F-7 (web-side audit-action consumer enumeration + helper chain)
+- S-4 (vault-reset audit metadata size limits)
+- T-4, T-5, T-6 (web-side mock alignment + audit-action enumeration test
+  files + vault-reset metadata shape)
+
+These all relate to the Vault Reset cache-invalidation audit warning on
+the **Web/server side**, which the user explicitly placed out of scope
+for this iOS-only plan. They are recorded here for traceability and
+should be revisited in a separate, web-scoped plan.
+
+## Adjacent Findings
+
+- (Functionality → Security) Plan adds `userId` to entries AAD assuming
+  single-userId-per-cache. Confirmed in scope: cache file is per-device
+  per-user; multi-account is not in scope for ios-autofill-mvp.
+- (Testing → Security) Cache-AAD scope decision (drop `headerHash`) is a
+  security-domain decision. Security expert (S-5) confirmed `counter +
+  uuid + userId` is adequate.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R3 (sequencing): no in-scope finding
+- R23 (CryptoKit AAD format): F-1
+- R25 (encryption migration version): F-3
+- All other R1-R30: N/A or no issue.
+
+### Security expert
+- R8 (replay/freshness): S-1 (acknowledged out-of-scope by threat model)
+- R15 (migration safety): S-2
+- R16 (TOFU correctness): S-3
+- R23 (algorithmic agility): S-5
+- R25 (cross-extension state): S-1
+- All other R1-R30: N/A or no issue.
+
+### Testing expert
+- RT1 (mock-reality divergence): T-2 (KeychainAccessor doesn't model ACL)
+- RT2 (testability): Confirmed — `encryptAESGCM` public,
+  `MockKeychainAccessor` two-service-keying works, JSONDecoder pattern
+  available
+- RT3 (shared constant in tests): T-7
+- All other R1-R30: N/A or no issue.
+
+## Resolution Status
+
+All in-scope Major findings (F-1, F-2, F-3, F-4, S-2, T-1, T-2) resolved
+by plan revision. Minor findings either folded into the plan or accepted
+with explicit rationale recorded in Plan §"Considerations & constraints".
+
+Web/server findings are NOT addressed here — see "Out of scope" section.
+
+Round complete; proceed to Phase 2 (implementation).

--- a/ios/PasswdSSOApp/Auth/ServerTrustService.swift
+++ b/ios/PasswdSSOApp/Auth/ServerTrustService.swift
@@ -8,12 +8,43 @@ import Shared
 public struct PinSet: Sendable, Equatable, Codable {
   /// SHA-256 of the raw AASA file bytes.
   public let aasaSHA256: Data
-  /// SHA-256 of the server leaf certificate SubjectPublicKeyInfo bytes.
-  public let tlsSPKISHA256: Data
 
-  public init(aasaSHA256: Data, tlsSPKISHA256: Data) {
+  /// SHA-256 of the leaf certificate's public key in
+  /// `SecKeyCopyExternalRepresentation` form (uncompressed EC point or
+  /// PKCS#1 RSAPublicKey, NOT SPKI DER). Stable per server identity but
+  /// not interchangeable with `openssl dgst -sha256` over
+  /// `-pubkey -outform DER`.
+  public let tlsLeafKeySHA256: Data
+
+  public init(aasaSHA256: Data, tlsLeafKeySHA256: Data) {
     self.aasaSHA256 = aasaSHA256
-    self.tlsSPKISHA256 = tlsSPKISHA256
+    self.tlsLeafKeySHA256 = tlsLeafKeySHA256
+  }
+
+  // Custom Codable to accept the legacy `tlsSPKISHA256` JSON key, kept
+  // for forward-compat with older Keychain blobs. New writes encode only
+  // the renamed key. Reads via `currentPin()` re-encode on the way out
+  // so the legacy JSON gets upgraded after the first round-trip.
+  private enum CodingKeys: String, CodingKey {
+    case aasaSHA256
+    case tlsLeafKeySHA256
+    case tlsSPKISHA256  // legacy alias, decoder-only
+  }
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    self.aasaSHA256 = try c.decode(Data.self, forKey: .aasaSHA256)
+    if let v = try c.decodeIfPresent(Data.self, forKey: .tlsLeafKeySHA256) {
+      self.tlsLeafKeySHA256 = v
+    } else {
+      self.tlsLeafKeySHA256 = try c.decode(Data.self, forKey: .tlsSPKISHA256)
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(aasaSHA256, forKey: .aasaSHA256)
+    try c.encode(tlsLeafKeySHA256, forKey: .tlsLeafKeySHA256)
   }
 }
 
@@ -54,7 +85,22 @@ public actor ServerTrustService {
     guard status == errSecSuccess, let data else {
       throw ServerTrustError.keychainError(status)
     }
-    return try JSONDecoder().decode(PinSet.self, from: data)
+    let pinSet = try JSONDecoder().decode(PinSet.self, from: data)
+    // Migration-on-read: if the on-disk JSON used the legacy
+    // `tlsSPKISHA256` key, re-encode and write back so subsequent reads
+    // no longer hit the alias. Best-effort: a write failure is silently
+    // ignored — the alias-decoder still works on the next call.
+    if !looksLikeNewKey(data) {
+      try? await pin(for: serverURL, pinSet)
+    }
+    return pinSet
+  }
+
+  /// Does the JSON already contain `"tlsLeafKeySHA256"`? If false, the
+  /// blob was written by an older build that used the legacy alias key
+  /// `tlsSPKISHA256`, and `currentPin()` re-encodes via `pin()` to upgrade.
+  private func looksLikeNewKey(_ data: Data) -> Bool {
+    data.range(of: Data("tlsLeafKeySHA256".utf8)) != nil
   }
 
   public func pin(for serverURL: URL, _ pinSet: PinSet) async throws {
@@ -66,9 +112,14 @@ public actor ServerTrustService {
 
     let status = keychain.add(query: query)
     if status == errSecDuplicateItem {
+      // Re-set kSecAttrAccessible on update so the attribute cannot drift
+      // from a different writer pre-seeding the same item.
       let updateStatus = keychain.update(
         query: baseQuery(account: account),
-        attributes: [kSecValueData as String: data]
+        attributes: [
+          kSecValueData as String: data,
+          kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        ]
       )
       guard updateStatus == errSecSuccess else { throw ServerTrustError.keychainError(updateStatus) }
     } else if status != errSecSuccess {
@@ -105,18 +156,22 @@ public func hashAASA(_ data: Data) -> Data {
 
 // MARK: - TLS SPKI extraction
 
-/// Delegate that captures the leaf-certificate SPKI SHA-256 during a TLS handshake.
+/// Delegate that captures the leaf-certificate public-key SHA-256 during
+/// a TLS handshake.
 ///
-/// Create the `URLSession` with this delegate and make a request to the server;
-/// the delegate records the SPKI hash for subsequent TOFU pinning.
-public final class SPKIPinningDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
+/// Create the `URLSession` with this delegate and make a request to the
+/// server; the delegate records the leaf-key hash for subsequent TOFU
+/// pinning. NOTE: the captured value is `SHA256(SecKeyCopyExternalRepresentation
+/// output)`, NOT `SHA256(SubjectPublicKeyInfo DER)`. Stable per server
+/// identity, but not interchangeable with values produced by `openssl`.
+public final class LeafKeyPinningDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
   private let lock = NSLock()
-  private var _capturedSPKIHash: Data?
+  private var _capturedLeafKeyHash: Data?
 
-  public var capturedSPKIHash: Data? {
+  public var capturedLeafKeyHash: Data? {
     lock.lock()
     defer { lock.unlock() }
-    return _capturedSPKIHash
+    return _capturedLeafKeyHash
   }
 
   public func urlSession(
@@ -140,18 +195,21 @@ public final class SPKIPinningDelegate: NSObject, URLSessionDelegate, @unchecked
       return
     }
 
-    // Extract leaf certificate SPKI hash.
-    if let spkiHash = extractLeafSPKIHash(serverTrust: serverTrust) {
+    if let hash = extractLeafKeyHash(serverTrust: serverTrust) {
       lock.lock()
-      _capturedSPKIHash = spkiHash
+      _capturedLeafKeyHash = hash
       lock.unlock()
     }
 
     completionHandler(.useCredential, URLCredential(trust: serverTrust))
   }
 
-  private func extractLeafSPKIHash(serverTrust: SecTrust) -> Data? {
+  private func extractLeafKeyHash(serverTrust: SecTrust) -> Data? {
     // SecTrustCopyCertificateChain replaces SecTrustGetCertificateAtIndex (deprecated iOS 15).
+    // Hash is over `SecKeyCopyExternalRepresentation` output:
+    //   - ECDSA P-256: 65-byte uncompressed point (0x04 || X || Y)
+    //   - RSA: PKCS#1 RSAPublicKey DER
+    // NOT SubjectPublicKeyInfo DER.
     guard
       let chain = SecTrustCopyCertificateChain(serverTrust) as? [SecCertificate],
       let leaf = chain.first,

--- a/ios/PasswdSSOTests/AutoLockServiceTests.swift
+++ b/ios/PasswdSSOTests/AutoLockServiceTests.swift
@@ -44,11 +44,13 @@ final class AutoLockServiceTests: XCTestCase {
   }
 
   private func seedKeychain(_ keychain: MockKeychain, counter: UInt64 = 1) {
-    var blob = Data(repeating: 0x01, count: 32)
+    keychain.store["com.passwd-sso.test.bridge-key-v2:blob"] =
+      Data(repeating: 0x01, count: 32)
+    var meta = Data()
     let counterBE = counter.bigEndian
-    withUnsafeBytes(of: counterBE) { blob.append(contentsOf: $0) }
-    blob.append(contentsOf: Data(repeating: 0x02, count: 16))
-    keychain.store["blob"] = blob
+    withUnsafeBytes(of: counterBE) { meta.append(contentsOf: $0) }
+    meta.append(contentsOf: Data(repeating: 0x02, count: 16))
+    keychain.store["com.passwd-sso.test.bridge-meta-v2:blob"] = meta
   }
 
   // MARK: - State after unlock
@@ -91,7 +93,14 @@ final class AutoLockServiceTests: XCTestCase {
     service.startTimer()
     service.lock()
 
-    XCTAssertNil(keychain.store["blob"], "bridge_key_blob should be deleted after lock")
+    XCTAssertNil(
+      keychain.store["com.passwd-sso.test.bridge-key-v2:blob"],
+      "bridge-key-v2 should be deleted after lock"
+    )
+    XCTAssertNil(
+      keychain.store["com.passwd-sso.test.bridge-meta-v2:blob"],
+      "bridge-meta-v2 should be deleted after lock"
+    )
   }
 
   func testLockKeepsWrappedKeyFiles() throws {
@@ -157,8 +166,9 @@ final class AutoLockServiceTests: XCTestCase {
     service.startTimer()
     service.signOut()
 
-    // Bridge key blob should be gone
-    XCTAssertNil(keychain.store["blob"])
+    // V2 bridge-key + bridge-meta items should be gone
+    XCTAssertNil(keychain.store["com.passwd-sso.test.bridge-key-v2:blob"])
+    XCTAssertNil(keychain.store["com.passwd-sso.test.bridge-meta-v2:blob"])
     // Cache file should be gone
     XCTAssertFalse(FileManager.default.fileExists(atPath: cacheURL.path))
     // Wrapped keys should be gone

--- a/ios/PasswdSSOTests/BridgeKeyStoreTests.swift
+++ b/ios/PasswdSSOTests/BridgeKeyStoreTests.swift
@@ -2,11 +2,32 @@ import XCTest
 @testable import Shared
 
 /// Mock Keychain for unit tests (per T42 — no real Keychain, no biometric prompts).
+///
+/// Models the V2 split layout: storage is keyed by `service:account`, so
+/// the mock natively supports the two services (bridge-key-v2 and
+/// bridge-meta-v2) plus the legacy combined service. The mock does NOT
+/// model `.biometryCurrentSet` ACL — assertions about ACL gating must
+/// use the `accessedServices` recorder below to confirm WHICH service
+/// each call touched (a proxy for "did this call require biometrics?").
+///
+/// Failure injection: `addFailureForServices` allows tests to simulate
+/// SecItemAdd failures on specific services, used to verify that
+/// migration / persist paths correctly roll back partial state.
 final class MockKeychainAccessor: KeychainAccessor, @unchecked Sendable {
   private var storage: [String: Data] = [:]
   var copyMatchingCallCount = 0
+  /// Every `service` value passed to `copyMatching` (in call order).
+  /// Used to assert which Keychain items a given operation touched.
+  var accessedServices: [String] = []
+  /// Services for which `add` should return `errSecParam` instead of
+  /// success. Empty by default — failure injection opt-in per test.
+  var addFailureForServices: Set<String> = []
 
   func add(query: [String: Any]) -> OSStatus {
+    if let svc = query[kSecAttrService as String] as? String,
+       addFailureForServices.contains(svc) {
+      return errSecParam
+    }
     let key = storageKey(query)
     if storage[key] != nil { return errSecDuplicateItem }
     if let data = query[kSecValueData as String] as? Data {
@@ -17,6 +38,9 @@ final class MockKeychainAccessor: KeychainAccessor, @unchecked Sendable {
 
   func copyMatching(query: [String: Any]) -> (OSStatus, Data?) {
     copyMatchingCallCount += 1
+    if let svc = query[kSecAttrService as String] as? String {
+      accessedServices.append(svc)
+    }
     let key = storageKey(query)
     if let data = storage[key] {
       return (errSecSuccess, data)
@@ -41,6 +65,16 @@ final class MockKeychainAccessor: KeychainAccessor, @unchecked Sendable {
     return errSecItemNotFound
   }
 
+  func has(service: String, account: String = "blob") -> Bool {
+    storage["\(service):\(account)"] != nil
+  }
+
+  /// Inject a raw payload at a given (service, account) — used to seed
+  /// the legacy 56-byte combined blob for migration tests.
+  func seed(service: String, account: String = "blob", data: Data) {
+    storage["\(service):\(account)"] = data
+  }
+
   private func storageKey(_ query: [String: Any]) -> String {
     let service = query[kSecAttrService as String] as? String ?? ""
     let account = query[kSecAttrAccount as String] as? String ?? ""
@@ -49,6 +83,10 @@ final class MockKeychainAccessor: KeychainAccessor, @unchecked Sendable {
 }
 
 final class BridgeKeyStoreTests: XCTestCase {
+
+  private let legacyService = "com.passwd-sso.bridge-key"
+  private let keyServiceV2 = "com.passwd-sso.bridge-key-v2"
+  private let metaServiceV2 = "com.passwd-sso.bridge-meta-v2"
 
   private func makeStore() -> (BridgeKeyStore, MockKeychainAccessor) {
     let mock = MockKeychainAccessor()
@@ -59,37 +97,74 @@ final class BridgeKeyStoreTests: XCTestCase {
     return (store, mock)
   }
 
-  // MARK: - Blob serialization size
+  // MARK: - Item-size invariants (post-split)
 
-  func testBlobSizeIs56Bytes() throws {
-    let (store, _) = makeStore()
+  func testV2ItemSizesAreSplit() throws {
+    let (store, mock) = makeStore()
 
     let blob = try store.create()
 
     XCTAssertEqual(blob.bridgeKey.count, 32)
     XCTAssertEqual(blob.hostInstallUUID.count, 16)
-    // Total serialized: 32 + 8 + 16 = 56 bytes
-    XCTAssertEqual(bridgeKeyBlobSize, 56)
+    XCTAssertTrue(mock.has(service: keyServiceV2))
+    XCTAssertTrue(mock.has(service: metaServiceV2))
+    XCTAssertFalse(mock.has(service: legacyService))
+    XCTAssertEqual(bridgeKeyV2Size, 32)
+    XCTAssertEqual(bridgeMetaV2Size, 24)
+    XCTAssertEqual(legacyBridgeKeyBlobSize, 56)
   }
 
   // MARK: - Create → read round-trip
 
-  func testCreateThenRead() throws {
+  func testCreateThenReadForFill() throws {
     let (store, _) = makeStore()
 
     let created = try store.create()
     let read = try store.readForFill(reason: "test")
 
-    XCTAssertEqual(created, read)
+    XCTAssertEqual(created.bridgeKey, read.bridgeKey)
+    XCTAssertEqual(created.cacheVersionCounter, read.cacheVersionCounter)
+    XCTAssertEqual(created.hostInstallUUID, read.hostInstallUUID)
   }
 
-  // MARK: - Counter increment
+  // MARK: - readDirect does not touch the biometric-gated bridge_key item
 
-  func testIncrementCounter() throws {
-    let (store, _) = makeStore()
+  func testReadDirectOnlyTouchesMetaService() throws {
+    let (store, mock) = makeStore()
+
+    _ = try store.create()
+    mock.accessedServices.removeAll()
+
+    let blob = try store.readDirect()
+
+    // readDirect must touch ONLY the meta service (no biometric prompt).
+    XCTAssertEqual(mock.accessedServices, [metaServiceV2])
+    // bridgeKey is intentionally empty in the readDirect Blob.
+    XCTAssertEqual(blob.bridgeKey, Data())
+    XCTAssertNotEqual(blob.cacheVersionCounter, 0)
+    XCTAssertEqual(blob.hostInstallUUID.count, 16)
+  }
+
+  func testReadForFillTouchesBothV2Services() throws {
+    let (store, mock) = makeStore()
+
+    _ = try store.create()
+    mock.accessedServices.removeAll()
+
+    _ = try store.readForFill(reason: "test")
+
+    // readForFill reads the biometric-gated key first, then the meta item.
+    XCTAssertEqual(mock.accessedServices, [keyServiceV2, metaServiceV2])
+  }
+
+  // MARK: - Counter increment via meta-only path
+
+  func testIncrementCounterTouchesMetaServiceOnly() throws {
+    let (store, mock) = makeStore()
 
     _ = try store.create()
     let initial = try store.readForFill(reason: "test")
+    mock.accessedServices.removeAll()
 
     try store.incrementCounter(newCounter: initial.cacheVersionCounter + 1)
     let updated = try store.readForFill(reason: "test")
@@ -99,30 +174,219 @@ final class BridgeKeyStoreTests: XCTestCase {
     XCTAssertEqual(updated.hostInstallUUID, initial.hostInstallUUID)
   }
 
-  // MARK: - Delete
+  // MARK: - recoverForwardCounter
 
-  func testDeleteRemovesItem() throws {
+  /// When the cache file is one ahead of the in-Keychain counter (i.e., the
+  /// host crashed between writing the cache and updating the counter),
+  /// recoverForwardCounter advances the meta counter and returns true.
+  func testRecoverForwardCounterAdvancesByOne() throws {
     let (store, _) = makeStore()
+    _ = try store.create()
+    let initial = try store.readDirect()
+
+    let advanced = try store.recoverForwardCounter(observed: initial.cacheVersionCounter + 1)
+
+    XCTAssertTrue(advanced, "observed == current + 1 must advance the counter")
+    XCTAssertEqual(
+      try store.readDirect().cacheVersionCounter,
+      initial.cacheVersionCounter + 1
+    )
+  }
+
+  /// observed == current is a no-op (cache and counter agree).
+  func testRecoverForwardCounterRejectsEqualCounter() throws {
+    let (store, _) = makeStore()
+    _ = try store.create()
+    let initial = try store.readDirect()
+
+    let advanced = try store.recoverForwardCounter(observed: initial.cacheVersionCounter)
+
+    XCTAssertFalse(advanced)
+    XCTAssertEqual(try store.readDirect().cacheVersionCounter,
+                   initial.cacheVersionCounter)
+  }
+
+  /// observed > current + 1 is rejected — recovery is intentionally
+  /// limited to a single forward step to bound the trust window.
+  func testRecoverForwardCounterRejectsForwardByMoreThanOne() throws {
+    let (store, _) = makeStore()
+    _ = try store.create()
+    let initial = try store.readDirect()
+
+    let advanced = try store.recoverForwardCounter(observed: initial.cacheVersionCounter + 2)
+
+    XCTAssertFalse(advanced)
+    XCTAssertEqual(try store.readDirect().cacheVersionCounter,
+                   initial.cacheVersionCounter)
+  }
+
+  /// observed < current (rollback attempt) is rejected.
+  func testRecoverForwardCounterRejectsBackward() throws {
+    let (store, _) = makeStore()
+    _ = try store.create()
+    // Advance to 100 so we can test backward.
+    try store.incrementCounter(newCounter: 100)
+
+    let advanced = try store.recoverForwardCounter(observed: 50)
+
+    XCTAssertFalse(advanced)
+    XCTAssertEqual(try store.readDirect().cacheVersionCounter, 100)
+  }
+
+  /// recoverForwardCounter on an empty store throws notFound (there is no
+  /// counter to recover from).
+  func testRecoverForwardCounterThrowsWhenBlobMissing() {
+    let (store, _) = makeStore()
+
+    XCTAssertThrowsError(try store.recoverForwardCounter(observed: 1)) { error in
+      XCTAssertEqual(error as? BridgeKeyStore.Error, .notFound)
+    }
+  }
+
+  // MARK: - Delete clears both v2 services + legacy
+
+  func testDeleteRemovesBothV2Items() throws {
+    let (store, mock) = makeStore()
 
     _ = try store.create()
     try store.delete()
+
+    XCTAssertFalse(mock.has(service: keyServiceV2))
+    XCTAssertFalse(mock.has(service: metaServiceV2))
 
     XCTAssertThrowsError(try store.readForFill(reason: "test")) { error in
       XCTAssertEqual(error as? BridgeKeyStore.Error, .notFound)
     }
   }
 
-  // MARK: - T42: readForFill uses exactly ONE Keychain read
+  // MARK: - Legacy migration
 
-  func testReadForFillUsesOneKeychainRead() throws {
+  /// Pre-seed mock with a legacy 56-byte combined blob, then trigger
+  /// migration via readDirect. Verify v2 items are written and legacy is
+  /// removed; counter+uuid bytes match the legacy payload.
+  func testLegacyBlobMigrationOnReadDirect() throws {
+    let (store, mock) = makeStore()
+
+    let legacyBridgeKey = Data(repeating: 0xBB, count: 32)
+    let legacyCounter: UInt64 = 0x0102_0304_0506_0708
+    let legacyUUID = Data(repeating: 0xCC, count: 16)
+
+    var legacyBlob = Data()
+    legacyBlob.append(legacyBridgeKey)
+    let counterBE = legacyCounter.bigEndian
+    withUnsafeBytes(of: counterBE) { legacyBlob.append(contentsOf: $0) }
+    legacyBlob.append(legacyUUID)
+    XCTAssertEqual(legacyBlob.count, 56)
+
+    mock.seed(service: legacyService, data: legacyBlob)
+    XCTAssertFalse(mock.has(service: keyServiceV2))
+    XCTAssertFalse(mock.has(service: metaServiceV2))
+
+    let blob = try store.readDirect()
+
+    XCTAssertEqual(blob.cacheVersionCounter, legacyCounter)
+    XCTAssertEqual(blob.hostInstallUUID, legacyUUID)
+    XCTAssertTrue(mock.has(service: keyServiceV2))
+    XCTAssertTrue(mock.has(service: metaServiceV2))
+    XCTAssertFalse(mock.has(service: legacyService),
+                   "legacy item must be deleted after successful migration")
+  }
+
+  /// When the v2-persist step of migration fails, the legacy item MUST
+  /// remain readable so the next call can retry the migration. The worst
+  /// case allowed by the design is "no migration today, retry on next
+  /// call" — never partial state that masks the legacy data.
+  func testLegacyMigrationFailureKeepsLegacyIntact() throws {
+    let (store, mock) = makeStore()
+
+    let legacyBridgeKey = Data(repeating: 0xAA, count: 32)
+    let legacyCounter: UInt64 = 7
+    let legacyUUID = Data(repeating: 0xBB, count: 16)
+    var legacyBlob = Data()
+    legacyBlob.append(legacyBridgeKey)
+    let counterBE = legacyCounter.bigEndian
+    withUnsafeBytes(of: counterBE) { legacyBlob.append(contentsOf: $0) }
+    legacyBlob.append(legacyUUID)
+    mock.seed(service: legacyService, data: legacyBlob)
+
+    // Inject failure on the v2 bridge-key add — meta-v2 will succeed first,
+    // then bridge-key-v2 will fail, persistBlob must roll back meta-v2.
+    mock.addFailureForServices = [keyServiceV2]
+
+    XCTAssertThrowsError(try store.readDirect()) { error in
+      // Failure is deterministic under MockKeychainAccessor:
+      //   readMetaItem (notFound) → tryMigrateLegacyBlob → persistBlob:
+      //   meta-v2 add succeeds → key-v2 add returns errSecParam (injected)
+      //   → meta-v2 rolled back → throws .keychainError(errSecParam).
+      // Pinning the exact type guards against silent regressions where a
+      // future refactor throws the wrong class but happens to leave the
+      // post-state intact.
+      XCTAssertEqual(
+        error as? BridgeKeyStore.Error,
+        .keychainError(errSecParam),
+        "expected .keychainError(errSecParam) from injected key-v2 add failure"
+      )
+    }
+
+    // Legacy item must still exist for retry.
+    XCTAssertTrue(
+      mock.has(service: legacyService),
+      "legacy item must remain intact when v2 persist fails"
+    )
+    // Meta should have been rolled back (or never written if the error
+    // surfaced earlier). bridgeKey-v2 must NOT exist.
+    XCTAssertFalse(
+      mock.has(service: keyServiceV2),
+      "bridge-key-v2 must not exist after persist failure"
+    )
+    XCTAssertFalse(
+      mock.has(service: metaServiceV2),
+      "bridge-meta-v2 must be rolled back when bridge-key-v2 add fails"
+    )
+  }
+
+  /// readForFill on legacy state must also migrate, and the returned Blob
+  /// includes bridgeKey from the legacy bytes.
+  func testLegacyBlobMigrationOnReadForFill() throws {
+    let (store, mock) = makeStore()
+
+    let legacyBridgeKey = Data(repeating: 0xDD, count: 32)
+    let legacyCounter: UInt64 = 42
+    let legacyUUID = Data(repeating: 0xEE, count: 16)
+
+    var legacyBlob = Data()
+    legacyBlob.append(legacyBridgeKey)
+    let counterBE = legacyCounter.bigEndian
+    withUnsafeBytes(of: counterBE) { legacyBlob.append(contentsOf: $0) }
+    legacyBlob.append(legacyUUID)
+    mock.seed(service: legacyService, data: legacyBlob)
+
+    let blob = try store.readForFill(reason: "test")
+
+    XCTAssertEqual(blob.bridgeKey, legacyBridgeKey)
+    XCTAssertEqual(blob.cacheVersionCounter, legacyCounter)
+    XCTAssertEqual(blob.hostInstallUUID, legacyUUID)
+    XCTAssertFalse(mock.has(service: legacyService))
+  }
+
+  // MARK: - readForFill performance: still ONE biometric-gated read
+
+  /// readForFill performs at most TWO copyMatching calls in the steady
+  /// state (no migration): one for bridge-key-v2 (biometric) and one for
+  /// bridge-meta-v2 (no ACL). The biometric prompt is only on the FIRST.
+  func testReadForFillUsesOneBiometricGatedRead() throws {
     let (store, mock) = makeStore()
 
     _ = try store.create()
-    mock.copyMatchingCallCount = 0  // reset after create (which may read)
+    mock.copyMatchingCallCount = 0
+    mock.accessedServices.removeAll()
 
     _ = try store.readForFill(reason: "test")
 
-    XCTAssertEqual(mock.copyMatchingCallCount, 1, "readForFill must use exactly one Keychain read")
+    XCTAssertEqual(mock.copyMatchingCallCount, 2,
+                   "readForFill steady-state: 1 biometric-gated + 1 no-ACL = 2 reads")
+    XCTAssertEqual(mock.accessedServices.first, keyServiceV2,
+                   "the biometric-gated read must be first")
   }
 
   // MARK: - Counter is non-zero after create

--- a/ios/PasswdSSOTests/CredentialResolverTests.swift
+++ b/ios/PasswdSSOTests/CredentialResolverTests.swift
@@ -557,10 +557,14 @@ final class CredentialResolverTests: XCTestCase {
 
     _ = try? await resolver.resolveCandidates(for: [])
 
+    // After the V2 split: readForFill performs 2 SecItemCopyMatching calls —
+    // one for bridge-key-v2 (biometric-gated) and one for bridge-meta-v2
+    // (no ACL, no prompt). Only the FIRST is biometric-gated, so the
+    // single-prompt invariant is preserved: 2 keychain reads = 1 prompt.
     XCTAssertEqual(
       counting.copyMatchingCallCount,
-      1,
-      "resolveCandidates must use exactly ONE Keychain read (one biometric prompt)"
+      2,
+      "resolveCandidates must use exactly TWO Keychain reads (one biometric prompt + one no-ACL meta)"
     )
   }
 

--- a/ios/PasswdSSOTests/EntryCacheFileTests.swift
+++ b/ios/PasswdSSOTests/EntryCacheFileTests.swift
@@ -394,6 +394,13 @@ final class EntryCacheFileTests: XCTestCase {
   }
 
   func testHeaderMissingUserIdRejectsAsHeaderInvalid() throws {
+    // NOTE: this test passes because parseHeaderJSON throws .headerInvalid
+    // BEFORE the entries-decrypt step is reached. The entries blob below
+    // is intentionally encrypted WITHOUT entries-AAD (legacy format). If
+    // the read-order in readCacheFile is ever reordered (entries before
+    // header), this test must be rewritten to encrypt the entries blob
+    // with a real entries-AAD; otherwise the rejection would come from
+    // entries-AAD mismatch, not header-JSON validation.
     // Build a header JSON that omits "userId" and inject it into an encrypted blob,
     // then verify the reader rejects with .headerInvalid.
     let url = tmpURL()
@@ -463,6 +470,285 @@ final class EntryCacheFileTests: XCTestCase {
       } else {
         XCTFail("Expected rejection(.headerInvalid), got \(error)")
       }
+    }
+  }
+
+  // MARK: - Entries-blob AAD binding
+
+  /// Helper: parse a written cache file into (encryptedHeaderBlob, encryptedEntriesBlob).
+  /// Mirrors the reader's framing parse to enable splice-style negative tests.
+  private func parseFile(_ data: Data) -> (header: Data, entries: Data)? {
+    guard data.count >= 12 else { return nil }
+    var off = 8
+    let headerLen = Int(UInt32(bigEndian: data[off..<(off + 4)]
+      .withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }))
+    off += 4
+    let header = data[off..<(off + headerLen)]
+    off += headerLen
+    let entriesLen = Int(UInt32(bigEndian: data[off..<(off + 4)]
+      .withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }))
+    off += 4
+    let entries = data[off..<(off + entriesLen)]
+    return (Data(header), Data(entries))
+  }
+
+  /// Reassemble a file from (encryptedHeaderBlob, encryptedEntriesBlob).
+  private func assembleFile(header: Data, entries: Data) -> Data {
+    var out = Data()
+    out.append(contentsOf: [0x50, 0x53, 0x53, 0x56])  // "PSSV"
+    out.append(0x01)
+    out.append(contentsOf: [0x00, 0x00, 0x00])
+
+    func appendBE32(_ d: inout Data, _ v: UInt32) {
+      let be = v.bigEndian
+      withUnsafeBytes(of: be) { d.append(contentsOf: $0) }
+    }
+    appendBE32(&out, UInt32(header.count))
+    out.append(header)
+    appendBE32(&out, UInt32(entries.count))
+    out.append(entries)
+    return out
+  }
+
+  /// Splicing entries from a different counter must fail entries-AAD verification.
+  func testEntriesBlobBindToCounterRejectsCrossFileSwap() throws {
+    let urlA = tmpURL()
+    let urlB = tmpURL()
+    defer {
+      try? FileManager.default.removeItem(at: urlA)
+      try? FileManager.default.removeItem(at: urlB)
+    }
+
+    let headerA = makeHeader(counter: 10, entryCount: 1)
+    try writeCacheFile(
+      data: CacheData(header: headerA, entries: makeEntriesJSON(count: 1)),
+      vaultKey: vaultKey, hostInstallUUID: hostInstallUUID, path: urlA
+    )
+
+    let headerB = makeHeader(counter: 11, entryCount: 1)
+    try writeCacheFile(
+      data: CacheData(header: headerB, entries: makeEntriesJSON(count: 1)),
+      vaultKey: vaultKey, hostInstallUUID: hostInstallUUID, path: urlB
+    )
+
+    let aBytes = try Data(contentsOf: urlA)
+    let bBytes = try Data(contentsOf: urlB)
+    let aParts = parseFile(aBytes)!
+    let bParts = parseFile(bBytes)!
+
+    // Frankenstein: B's header (counter=11) + A's entries (encrypted with counter=10 AAD)
+    let frankenstein = assembleFile(header: bParts.header, entries: aParts.entries)
+    let urlC = tmpURL()
+    defer { try? FileManager.default.removeItem(at: urlC) }
+    try frankenstein.write(to: urlC)
+
+    XCTAssertThrowsError(
+      try readCacheFile(
+        path: urlC,
+        vaultKey: vaultKey,
+        expectedHostInstallUUID: hostInstallUUID,
+        expectedCounter: 11
+      )
+    ) { error in
+      guard case EntryCacheError.rejection(let kind) = error else {
+        XCTFail("Expected rejection, got \(error)")
+        return
+      }
+      XCTAssertEqual(kind, .authtagInvalid,
+                     "Cross-counter splice should fail entries AAD with .authtagInvalid")
+    }
+  }
+
+  /// Splicing entries from a different userId must fail entries-AAD verification.
+  func testEntriesBlobBindToUserIdRejectsCrossUserSwap() throws {
+    let urlA = tmpURL()
+    let urlB = tmpURL()
+    defer {
+      try? FileManager.default.removeItem(at: urlA)
+      try? FileManager.default.removeItem(at: urlB)
+    }
+
+    let headerA = makeHeader(entryCount: 1, userId: "user-A")
+    try writeCacheFile(
+      data: CacheData(header: headerA, entries: makeEntriesJSON(count: 1)),
+      vaultKey: vaultKey, hostInstallUUID: hostInstallUUID, path: urlA
+    )
+
+    let headerB = makeHeader(entryCount: 1, userId: "user-B")
+    try writeCacheFile(
+      data: CacheData(header: headerB, entries: makeEntriesJSON(count: 1)),
+      vaultKey: vaultKey, hostInstallUUID: hostInstallUUID, path: urlB
+    )
+
+    let aBytes = try Data(contentsOf: urlA)
+    let bBytes = try Data(contentsOf: urlB)
+    let aParts = parseFile(aBytes)!
+    let bParts = parseFile(bBytes)!
+
+    // Frankenstein: B's header (userId=user-B) + A's entries (encrypted with userId=user-A AAD)
+    let frankenstein = assembleFile(header: bParts.header, entries: aParts.entries)
+    let urlC = tmpURL()
+    defer { try? FileManager.default.removeItem(at: urlC) }
+    try frankenstein.write(to: urlC)
+
+    XCTAssertThrowsError(
+      try readCacheFile(
+        path: urlC,
+        vaultKey: vaultKey,
+        expectedHostInstallUUID: hostInstallUUID,
+        expectedCounter: counter
+      )
+    ) { error in
+      guard case EntryCacheError.rejection(let kind) = error else {
+        XCTFail("Expected rejection, got \(error)")
+        return
+      }
+      XCTAssertEqual(kind, .authtagInvalid,
+                     "Cross-userId splice should fail entries AAD with .authtagInvalid")
+    }
+  }
+
+  /// Negative control — confirms the splice tests above detect AAD mismatch
+  /// (not some other corruption). Two writes with IDENTICAL (counter, uuid, userId)
+  /// produce entries blobs that share the same AAD; splicing succeeds.
+  func testEntriesBlobAADNegativeControl() throws {
+    let urlA = tmpURL()
+    let urlB = tmpURL()
+    defer {
+      try? FileManager.default.removeItem(at: urlA)
+      try? FileManager.default.removeItem(at: urlB)
+    }
+
+    // Identical context — only entries content differs.
+    let header = makeHeader(entryCount: 1)
+    try writeCacheFile(
+      data: CacheData(header: header, entries: makeEntriesJSON(count: 1)),
+      vaultKey: vaultKey, hostInstallUUID: hostInstallUUID, path: urlA
+    )
+    try writeCacheFile(
+      data: CacheData(header: header, entries: makeEntriesJSON(count: 1)),
+      vaultKey: vaultKey, hostInstallUUID: hostInstallUUID, path: urlB
+    )
+
+    let aBytes = try Data(contentsOf: urlA)
+    let bBytes = try Data(contentsOf: urlB)
+    let aParts = parseFile(aBytes)!
+    let bParts = parseFile(bBytes)!
+
+    // Splice B-header + A-entries; both share AAD context, so this MUST succeed.
+    let spliced = assembleFile(header: bParts.header, entries: aParts.entries)
+    let urlC = tmpURL()
+    defer { try? FileManager.default.removeItem(at: urlC) }
+    try spliced.write(to: urlC)
+
+    let read = try readCacheFile(
+      path: urlC,
+      vaultKey: vaultKey,
+      expectedHostInstallUUID: hostInstallUUID,
+      expectedCounter: counter
+    )
+    XCTAssertEqual(read.header.entryCount, 1)
+  }
+
+  /// Verify the AAD builder produces deterministic, format-stable bytes.
+  func testCacheEntriesAADFormat() throws {
+    let aad = try buildCacheEntriesAAD(
+      counter: 0x0102_0304_0506_0708,
+      hostInstallUUID: Data(repeating: 0xAA, count: 16),
+      userId: "u"
+    )
+    // Layout: "CACHEENT"(8) || counter(BE 8) || uuid(16) || userIdLen(BE 2) || userId
+    XCTAssertEqual(aad.count, 8 + 8 + 16 + 2 + 1)
+    XCTAssertEqual(Array(aad[0..<8]), Array("CACHEENT".utf8))
+    XCTAssertEqual(Array(aad[8..<16]), [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+    XCTAssertEqual(Array(aad[16..<32]), Array(repeating: UInt8(0xAA), count: 16))
+    XCTAssertEqual(Array(aad[32..<34]), [0x00, 0x01])  // BE 1
+    XCTAssertEqual(aad[34], UInt8(ascii: "u"))
+  }
+
+  /// userIdLen crosses the byte boundary at 256 — verify BE 2-byte encoding
+  /// is `[0x01, 0x00]`, not truncated to `[0x00]` or reversed.
+  func testCacheEntriesAADFormatLongUserId() throws {
+    let userId = String(repeating: "a", count: 256)
+    let aad = try buildCacheEntriesAAD(
+      counter: 0,
+      hostInstallUUID: Data(repeating: 0, count: 16),
+      userId: userId
+    )
+    XCTAssertEqual(aad.count, 8 + 8 + 16 + 2 + 256)
+    XCTAssertEqual(Array(aad[32..<34]), [0x01, 0x00],
+                   "userIdLen=256 must encode as BE [0x01, 0x00]")
+  }
+
+  /// Maximum userId length (UInt16 max) must be accepted.
+  func testCacheEntriesAADFormatMaxUserId() throws {
+    let userId = String(repeating: "a", count: 0xFFFF)
+    let aad = try buildCacheEntriesAAD(
+      counter: 0,
+      hostInstallUUID: Data(repeating: 0, count: 16),
+      userId: userId
+    )
+    XCTAssertEqual(aad.count, 8 + 8 + 16 + 2 + 0xFFFF)
+    XCTAssertEqual(Array(aad[32..<34]), [0xFF, 0xFF])
+  }
+
+  /// Multibyte UTF-8 userId (Japanese, emoji): userIdLen in the AAD is the
+  /// BYTE count, not the character count. A regression that swaps `count`
+  /// for `unicodeScalars.count` would mismatch encode-vs-decode AAD and
+  /// surface as authtagInvalid, but only on non-ASCII userIds.
+  func testRoundTripWithMultibyteUTF8UserId() throws {
+    let url = tmpURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let userId = "ユーザー🔑42"  // 4 chars, 16 bytes (12 for kana + 4 for emoji)
+    let header = makeHeader(entryCount: 0, userId: userId)
+    let data = CacheData(header: header, entries: makeEntriesJSON(count: 0))
+    try writeCacheFile(data: data, vaultKey: vaultKey, hostInstallUUID: hostInstallUUID, path: url)
+
+    let read = try readCacheFile(
+      path: url,
+      vaultKey: vaultKey,
+      expectedHostInstallUUID: hostInstallUUID,
+      expectedCounter: counter
+    )
+    XCTAssertEqual(read.header.userId, userId)
+  }
+
+  /// Encrypt-then-decrypt round-trip with a 256-byte userId — proves the
+  /// AAD-on-encrypt and AAD-on-decrypt paths are byte-identical at the
+  /// 1-byte → 2-byte UInt16 boundary, not just at the build level.
+  func testRoundTripWithUserIdAtByteBoundary() throws {
+    let url = tmpURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let longUserId = String(repeating: "a", count: 256)
+    let header = makeHeader(entryCount: 0, userId: longUserId)
+    let data = CacheData(header: header, entries: makeEntriesJSON(count: 0))
+    try writeCacheFile(data: data, vaultKey: vaultKey, hostInstallUUID: hostInstallUUID, path: url)
+
+    let read = try readCacheFile(
+      path: url,
+      vaultKey: vaultKey,
+      expectedHostInstallUUID: hostInstallUUID,
+      expectedCounter: counter
+    )
+    XCTAssertEqual(read.header.userId.count, 256)
+    XCTAssertEqual(read.header.userId, longUserId)
+  }
+
+  /// userId one byte over UInt16 max must be rejected with .headerInvalid.
+  func testCacheEntriesAADFormatOversizeUserIdRejected() throws {
+    let userId = String(repeating: "a", count: 0x10000)
+    XCTAssertThrowsError(try buildCacheEntriesAAD(
+      counter: 0,
+      hostInstallUUID: Data(repeating: 0, count: 16),
+      userId: userId
+    )) { error in
+      guard case EntryCacheError.rejection(let kind) = error else {
+        XCTFail("Expected rejection, got \(error)")
+        return
+      }
+      XCTAssertEqual(kind, .headerInvalid)
     }
   }
 

--- a/ios/PasswdSSOTests/EntryFetcherTests.swift
+++ b/ios/PasswdSSOTests/EntryFetcherTests.swift
@@ -76,14 +76,15 @@ private func makeMockSession() -> URLSession {
 
 private func makeTokenKeychain(token: String) -> MockKeychain {
   let keychain = MockKeychain()
+  let service = "com.passwd-sso.test.tokens"
   // access_token
   if let data = token.data(using: .utf8) {
-    keychain.store["access_token"] = data
+    keychain.store["\(service):access_token"] = data
   }
   // access_token_expiry (1 hour from now)
   let expiry = ISO8601DateFormatter().string(from: Date().addingTimeInterval(3600))
   if let data = expiry.data(using: .utf8) {
-    keychain.store["access_token_expiry"] = data
+    keychain.store["\(service):access_token_expiry"] = data
   }
   return keychain
 }

--- a/ios/PasswdSSOTests/HostSyncServiceTests.swift
+++ b/ios/PasswdSSOTests/HostSyncServiceTests.swift
@@ -6,51 +6,64 @@ import XCTest
 
 // MARK: - Test helpers for HostSyncService
 
-/// Write a minimal valid 56-byte bridge_key_blob to the mock keychain.
-func seedBlobInKeychain(_ keychain: MockKeychain, counter: UInt64 = 1) {
-  var blob = Data(repeating: 0x01, count: 32)  // bridge_key
+/// Pre-seed the mock keychain with v2-split items (bridge-key-v2 + bridge-meta-v2)
+/// equivalent to a freshly-created BridgeKeyStore at the given counter.
+func seedBlobInKeychain(
+  _ keychain: MockKeychain,
+  counter: UInt64 = 1,
+  service: String = "com.passwd-sso.test.bridge-key"
+) {
+  let bridgeKey = Data(repeating: 0x01, count: 32)
+  var meta = Data()
   let counterBE = counter.bigEndian
-  withUnsafeBytes(of: counterBE) { blob.append(contentsOf: $0) }
-  blob.append(contentsOf: Data(repeating: 0x02, count: 16))  // uuid
-  keychain.store["blob"] = blob
+  withUnsafeBytes(of: counterBE) { meta.append(contentsOf: $0) }
+  meta.append(contentsOf: Data(repeating: 0x02, count: 16))  // uuid
+  keychain.store["\(service)-v2:blob"] = bridgeKey
+  let metaService = service.hasSuffix("bridge-key")
+    ? service.replacingOccurrences(of: "bridge-key", with: "bridge-meta") + "-v2"
+    : service + "-meta-v2"
+  keychain.store["\(metaService):blob"] = meta
 }
 
-/// Mock keychain for BridgeKeyStore tests.
+/// Mock keychain for BridgeKeyStore tests. Keys by `service:account` so the
+/// V2 split layout (two services sharing account="blob") is modeled correctly.
 final class MockKeychain: KeychainAccessor, @unchecked Sendable {
   var store: [String: Data] = [:]
 
+  private func key(_ query: [String: Any]) -> String {
+    let service = query[kSecAttrService as String] as? String ?? ""
+    let account = query[kSecAttrAccount as String] as? String ?? ""
+    return "\(service):\(account)"
+  }
+
   func add(query: [String: Any]) -> OSStatus {
-    guard let account = query[kSecAttrAccount as String] as? String,
-          let data = query[kSecValueData as String] as? Data else {
+    guard let data = query[kSecValueData as String] as? Data else {
       return errSecParam
     }
-    if store[account] != nil { return errSecDuplicateItem }
-    store[account] = data
+    let k = key(query)
+    if store[k] != nil { return errSecDuplicateItem }
+    store[k] = data
     return errSecSuccess
   }
 
   func copyMatching(query: [String: Any]) -> (OSStatus, Data?) {
-    guard let account = query[kSecAttrAccount as String] as? String else {
-      return (errSecParam, nil)
-    }
-    guard let data = store[account] else { return (errSecItemNotFound, nil) }
+    let k = key(query)
+    guard let data = store[k] else { return (errSecItemNotFound, nil) }
     return (errSecSuccess, data)
   }
 
   func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
-    guard let account = query[kSecAttrAccount as String] as? String,
-          let data = attributes[kSecValueData as String] as? Data else {
+    guard let data = attributes[kSecValueData as String] as? Data else {
       return errSecParam
     }
-    store[account] = data
+    let k = key(query)
+    store[k] = data
     return errSecSuccess
   }
 
   func delete(query: [String: Any]) -> OSStatus {
-    guard let account = query[kSecAttrAccount as String] as? String else {
-      return errSecParam
-    }
-    if store.removeValue(forKey: account) != nil { return errSecSuccess }
+    let k = key(query)
+    if store.removeValue(forKey: k) != nil { return errSecSuccess }
     return errSecItemNotFound
   }
 }

--- a/ios/PasswdSSOTests/ServerTrustServiceTests.swift
+++ b/ios/PasswdSSOTests/ServerTrustServiceTests.swift
@@ -25,7 +25,7 @@ final class ServerTrustServiceTests: XCTestCase {
   func testPinAndRetrieve() async throws {
     let pinSet = PinSet(
       aasaSHA256: Data(repeating: 0xAA, count: 32),
-      tlsSPKISHA256: Data(repeating: 0xBB, count: 32)
+      tlsLeafKeySHA256: Data(repeating: 0xBB, count: 32)
     )
     try await service.pin(for: serverURL, pinSet)
 
@@ -37,7 +37,7 @@ final class ServerTrustServiceTests: XCTestCase {
   func testValidateReturnsUnpinnedOnFirstUse() async {
     let observed = PinSet(
       aasaSHA256: Data(repeating: 0x01, count: 32),
-      tlsSPKISHA256: Data(repeating: 0x02, count: 32)
+      tlsLeafKeySHA256: Data(repeating: 0x02, count: 32)
     )
     let result = await service.validate(serverURL: serverURL, observed: observed)
     XCTAssertEqual(result, .unpinned)
@@ -46,7 +46,7 @@ final class ServerTrustServiceTests: XCTestCase {
   func testValidateReturnsMatchWhenEqual() async throws {
     let pinSet = PinSet(
       aasaSHA256: Data(repeating: 0xCC, count: 32),
-      tlsSPKISHA256: Data(repeating: 0xDD, count: 32)
+      tlsLeafKeySHA256: Data(repeating: 0xDD, count: 32)
     )
     try await service.pin(for: serverURL, pinSet)
 
@@ -57,13 +57,13 @@ final class ServerTrustServiceTests: XCTestCase {
   func testValidateReturnsMismatchWhenDifferent() async throws {
     let stored = PinSet(
       aasaSHA256: Data(repeating: 0xEE, count: 32),
-      tlsSPKISHA256: Data(repeating: 0xFF, count: 32)
+      tlsLeafKeySHA256: Data(repeating: 0xFF, count: 32)
     )
     try await service.pin(for: serverURL, stored)
 
     let observed = PinSet(
       aasaSHA256: Data(repeating: 0x11, count: 32),
-      tlsSPKISHA256: Data(repeating: 0x22, count: 32)
+      tlsLeafKeySHA256: Data(repeating: 0x22, count: 32)
     )
     let result = await service.validate(serverURL: serverURL, observed: observed)
     XCTAssertEqual(result, .mismatch(stored: stored, observed: observed))
@@ -72,11 +72,11 @@ final class ServerTrustServiceTests: XCTestCase {
   func testPinOverwrite() async throws {
     let original = PinSet(
       aasaSHA256: Data(repeating: 0x01, count: 32),
-      tlsSPKISHA256: Data(repeating: 0x02, count: 32)
+      tlsLeafKeySHA256: Data(repeating: 0x02, count: 32)
     )
     let updated = PinSet(
       aasaSHA256: Data(repeating: 0x03, count: 32),
-      tlsSPKISHA256: Data(repeating: 0x04, count: 32)
+      tlsLeafKeySHA256: Data(repeating: 0x04, count: 32)
     )
     try await service.pin(for: serverURL, original)
     try await service.pin(for: serverURL, updated)
@@ -85,16 +85,87 @@ final class ServerTrustServiceTests: XCTestCase {
     XCTAssertEqual(result, .match)
   }
 
+  // MARK: - Codable backward compatibility
+
+  /// Legacy Keychain blobs encoded the field as `tlsSPKISHA256`.
+  /// Decoder must accept this alias so an upgrade does not lose the pin.
+  func testPinSetDecodesLegacyTLSSPKIKey() throws {
+    // JSONEncoder serializes Data as base64 strings, so the legacy blob
+    // must use base64 too — not hex.
+    let aasaBase64 = Data(repeating: 0xAA, count: 32).base64EncodedString()
+    let tlsBase64 = Data(repeating: 0xBB, count: 32).base64EncodedString()
+    let legacyJSON = """
+      {"aasaSHA256":"\(aasaBase64)","tlsSPKISHA256":"\(tlsBase64)"}
+      """.data(using: .utf8)!
+
+    let decoded = try JSONDecoder().decode(PinSet.self, from: legacyJSON)
+    XCTAssertEqual(decoded.aasaSHA256, Data(repeating: 0xAA, count: 32))
+    XCTAssertEqual(decoded.tlsLeafKeySHA256, Data(repeating: 0xBB, count: 32))
+  }
+
+  /// Encoder must write only the new key — no legacy alias on output.
+  func testPinSetEncodesOnlyNewKey() throws {
+    let pinSet = PinSet(
+      aasaSHA256: Data(repeating: 0xAA, count: 32),
+      tlsLeafKeySHA256: Data(repeating: 0xBB, count: 32)
+    )
+    let encoded = try JSONEncoder().encode(pinSet)
+    let json = String(data: encoded, encoding: .utf8) ?? ""
+    XCTAssertTrue(json.contains("tlsLeafKeySHA256"))
+    XCTAssertFalse(json.contains("tlsSPKISHA256"))
+  }
+
+  /// First read with a legacy blob in the Keychain triggers
+  /// migration-on-read: the on-disk JSON is rewritten with the new key.
+  func testCurrentPinUpgradesLegacyOnRead() async throws {
+    let aasaBase64 = Data(repeating: 0x11, count: 32).base64EncodedString()
+    let tlsBase64 = Data(repeating: 0x22, count: 32).base64EncodedString()
+    let legacyJSON = """
+      {"aasaSHA256":"\(aasaBase64)","tlsSPKISHA256":"\(tlsBase64)"}
+      """.data(using: .utf8)!
+
+    // Seed the keychain with the legacy JSON for our serverURL.
+    let account = serverURL.absoluteString
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: "com.passwd-sso.server-trust",
+      kSecAttrAccount as String: account,
+      kSecAttrSynchronizable as String: false,
+      kSecValueData as String: legacyJSON,
+      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+    ]
+    XCTAssertEqual(keychain.add(query: query), errSecSuccess)
+
+    let first = try await service.currentPin(for: serverURL)
+    XCTAssertEqual(first?.tlsLeafKeySHA256, Data(repeating: 0x22, count: 32))
+
+    // After read, the on-disk JSON should be re-encoded with the new key.
+    let readQuery: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: "com.passwd-sso.server-trust",
+      kSecAttrAccount as String: account,
+      kSecAttrSynchronizable as String: false,
+      kSecReturnData as String: true,
+    ]
+    let (status, data) = keychain.copyMatching(query: readQuery)
+    XCTAssertEqual(status, errSecSuccess)
+    let stored = String(data: data ?? Data(), encoding: .utf8) ?? ""
+    XCTAssertTrue(stored.contains("tlsLeafKeySHA256"),
+                  "after currentPin(), JSON must be upgraded to the new key")
+    XCTAssertFalse(stored.contains("tlsSPKISHA256"),
+                   "after migration, legacy alias must be gone")
+  }
+
   func testDifferentServerURLsStoredSeparately() async throws {
     let url1 = URL(string: "https://server1.example")!
     let url2 = URL(string: "https://server2.example")!
     let pin1 = PinSet(
       aasaSHA256: Data(repeating: 0xAA, count: 32),
-      tlsSPKISHA256: Data(repeating: 0xAB, count: 32)
+      tlsLeafKeySHA256: Data(repeating: 0xAB, count: 32)
     )
     let pin2 = PinSet(
       aasaSHA256: Data(repeating: 0xCC, count: 32),
-      tlsSPKISHA256: Data(repeating: 0xCD, count: 32)
+      tlsLeafKeySHA256: Data(repeating: 0xCD, count: 32)
     )
 
     try await service.pin(for: url1, pin1)

--- a/ios/PasswdSSOTests/StaleBlobRecoveryServiceTests.swift
+++ b/ios/PasswdSSOTests/StaleBlobRecoveryServiceTests.swift
@@ -26,11 +26,13 @@ final class StaleBlobRecoveryServiceTests: XCTestCase {
 
   private func makeKeychain(counter: UInt64, uuid: Data = Data(repeating: 0xAB, count: 16)) -> MockKeychain {
     let keychain = MockKeychain()
-    var blob = Data(repeating: 0x01, count: 32)  // bridge_key
+    // V2 split: bridge-key-v2 (32 bytes) + bridge-meta-v2 (8-byte BE counter || 16-byte uuid).
+    keychain.store["com.passwd-sso.test.bridge-key-v2:blob"] = Data(repeating: 0x01, count: 32)
+    var meta = Data()
     let counterBE = counter.bigEndian
-    withUnsafeBytes(of: counterBE) { blob.append(contentsOf: $0) }
-    blob.append(uuid)
-    keychain.store["blob"] = blob
+    withUnsafeBytes(of: counterBE) { meta.append(contentsOf: $0) }
+    meta.append(uuid)
+    keychain.store["com.passwd-sso.test.bridge-meta-v2:blob"] = meta
     return keychain
   }
 

--- a/ios/PasswdSSOTests/VaultUnlockerTests.swift
+++ b/ios/PasswdSSOTests/VaultUnlockerTests.swift
@@ -223,9 +223,21 @@ final class VaultUnlockerTests: XCTestCase {
 
     _ = try await unlocker.unlock(passphrase: passphrase)
 
-    // Bridge key blob should exist in keychain
-    XCTAssertNotNil(keychain.store["blob"], "Bridge key blob must be written to keychain")
-    XCTAssertEqual(keychain.store["blob"]?.count, 56)
+    // V2 split: two items written — bridge-key-v2 (32 bytes) + bridge-meta-v2 (24 bytes).
+    XCTAssertNotNil(
+      keychain.store["com.passwd-sso.test.bridge-key-v2:blob"],
+      "Bridge-key v2 item must be written to keychain"
+    )
+    XCTAssertEqual(
+      keychain.store["com.passwd-sso.test.bridge-key-v2:blob"]?.count, 32
+    )
+    XCTAssertNotNil(
+      keychain.store["com.passwd-sso.test.bridge-meta-v2:blob"],
+      "Bridge-meta v2 item must be written to keychain"
+    )
+    XCTAssertEqual(
+      keychain.store["com.passwd-sso.test.bridge-meta-v2:blob"]?.count, 24
+    )
   }
 
   // MARK: - Wrong passphrase

--- a/ios/PasswdSSOTests/VaultViewModelTests.swift
+++ b/ios/PasswdSSOTests/VaultViewModelTests.swift
@@ -217,7 +217,7 @@ final class VaultViewModelTests: XCTestCase {
 
   private func makeBridgeKeyStore() -> BridgeKeyStore {
     let kc = MockKeychain()
-    seedBlobInKeychain(kc, counter: 1)
+    seedBlobInKeychain(kc, counter: 1, service: "com.test.vm.bridge-key")
     return BridgeKeyStore(
       accessGroup: "test",
       service: "com.test.vm.bridge-key",

--- a/ios/Shared/Storage/BridgeKeyStore.swift
+++ b/ios/Shared/Storage/BridgeKeyStore.swift
@@ -2,11 +2,24 @@ import Foundation
 import LocalAuthentication
 import Security
 
-// Per plan §"Encrypted-entries cache integrity":
-// bridge_key_blob layout: [bridge_key:32][counter:8 BE][host_install_uuid:16] = 56 bytes total.
-// All multi-byte integers are big-endian.
+// Storage layout: TWO Keychain items in the same App Group.
+//   bridge-key-v2: 32-byte bridge_key, .biometryCurrentSet ACL
+//   bridge-meta-v2: 24-byte (counter:8 BE || hostInstallUUID:16), no ACL
+//
+// Splitting the items lets host-app code read counter/uuid (via meta)
+// without forcing a biometric prompt while AutoFill still gates bridge_key
+// reads on biometrics.
+//
+// Legacy V1 storage (for migration only): ONE 56-byte combined item under
+// `com.passwd-sso.bridge-key`. Read via the migration helper on first
+// access after upgrade and replaced with the v2 layout.
 
-let bridgeKeyBlobSize = 56
+// Internal (not public) so the test target can assert on sizes via
+// `@testable import Shared` without leaking the values into the public
+// Shared module surface.
+internal let legacyBridgeKeyBlobSize = 56
+internal let bridgeKeyV2Size = 32
+internal let bridgeMetaV2Size = 24
 
 /// Keychain abstraction for dependency injection in tests (per T42).
 public protocol KeychainAccessor: Sendable {
@@ -41,8 +54,15 @@ public struct SystemKeychainAccessor: KeychainAccessor, Sendable {
 
 public final class BridgeKeyStore: Sendable {
 
+  /// Logical bundle of bridge-key + counter/uuid. After the V2 split, the
+  /// two Keychain items back this struct: `bridgeKey` comes from
+  /// `bridge-key-v2` (biometric-gated), and `cacheVersionCounter` +
+  /// `hostInstallUUID` come from `bridge-meta-v2` (no ACL).
+  ///
+  /// `readDirect()` returns a Blob with `bridgeKey` set to an empty
+  /// `Data()` because that callers' code path never consumes the key.
   public struct Blob: Sendable, Equatable {
-    public let bridgeKey: Data         // 32 bytes
+    public let bridgeKey: Data         // 32 bytes (or empty after readDirect)
     public let cacheVersionCounter: UInt64
     public let hostInstallUUID: Data   // 16 bytes
 
@@ -61,20 +81,37 @@ public final class BridgeKeyStore: Sendable {
   }
 
   private let accessGroup: String
-  private let service: String
+  private let serviceKeyV2: String
+  private let serviceMetaV2: String
+  private let serviceLegacy: String
   private let keychain: KeychainAccessor
 
+  /// `service` is treated as the LEGACY service name (used for migration
+  /// reads only). The two V2 service names are derived from it.
+  ///
+  /// Convention: `service` MUST end in "bridge-key". The v2 services are
+  /// derived as `<service>-v2` (key) and the same string with "bridge-key"
+  /// → "bridge-meta" plus "-v2" (meta). Tests follow the same convention.
   public init(
     accessGroup: String,
     service: String = "com.passwd-sso.bridge-key",
     keychain: KeychainAccessor = SystemKeychainAccessor()
   ) {
+    precondition(service.hasSuffix("bridge-key"),
+                 "BridgeKeyStore service name must end in 'bridge-key'")
     self.accessGroup = accessGroup
-    self.service = service
+    self.serviceLegacy = service
+    self.serviceKeyV2 = service + "-v2"
+    self.serviceMetaV2 = service
+      .replacingOccurrences(of: "bridge-key", with: "bridge-meta") + "-v2"
     self.keychain = keychain
   }
 
+  // MARK: - Public API
+
   /// Create on first unlock: random bridge_key, random non-zero counter, random UUID.
+  /// Writes BOTH v2 items in this order: meta first, then key. On failure
+  /// of the second write, deletes the first to avoid orphaned state.
   public func create() throws -> Blob {
     var bridgeKeyBytes = Data(repeating: 0, count: 32)
     var counterBytes = Data(repeating: 0, count: 8)
@@ -93,8 +130,6 @@ public final class BridgeKeyStore: Sendable {
       throw Error.keychainError(errSecParam)
     }
 
-    // Treat random bytes as a big-endian u64; ensure non-zero.
-    // Per plan §"Encrypted-entries cache integrity": counter is big-endian in serialized form.
     var counter = counterBytes.withUnsafeBytes { UInt64(bigEndian: $0.loadUnaligned(as: UInt64.self)) }
     if counter == 0 { counter = 1 }
 
@@ -103,71 +138,105 @@ public final class BridgeKeyStore: Sendable {
       cacheVersionCounter: counter,
       hostInstallUUID: uuidBytes
     )
+
     try persistBlob(blob)
+    // Best-effort cleanup: a legacy combined item is no longer needed.
+    _ = keychain.delete(query: legacyBaseQuery())
     return blob
   }
 
-  /// Read with biometric prompt (LAContext, reuseDuration = 0). Per plan S16.
+  /// Read with biometric prompt. Sets `reuseDuration = 0` so each fill
+  /// triggers a fresh biometric authentication instead of reusing iOS's
+  /// auth cache. On legacy state, transparently migrate to v2 layout
+  /// before returning.
   public func readForFill(reason: String) throws -> Blob {
-    // Per plan T42: ONE Keychain read covers bridge_key + counter + uuid.
     let context = LAContext()
-    // Per plan §"Per-fill biometric reuse": must be 0 to prevent iOS auth-cache reuse.
     context.touchIDAuthenticationAllowableReuseDuration = 0
-
-    // Per plan S16: set localizedReason on LAContext before use.
     context.localizedReason = reason
-    var query: [String: Any] = baseQuery()
-    query[kSecReturnData as String] = true
-    query[kSecUseAuthenticationContext as String] = context
 
-    let (status, data) = keychain.copyMatching(query: query)
-    if status == errSecItemNotFound { throw Error.notFound }
-    if status == errSecUserCanceled || status == errSecAuthFailed { throw Error.biometryFailed }
-    guard status == errSecSuccess, let data else {
-      throw Error.keychainError(status)
+    // 1. Read bridge_key (biometric-gated).
+    var keyQuery: [String: Any] = baseQuery(service: serviceKeyV2)
+    keyQuery[kSecReturnData as String] = true
+    keyQuery[kSecUseAuthenticationContext as String] = context
+    let (keyStatus, keyData) = keychain.copyMatching(query: keyQuery)
+
+    if keyStatus == errSecItemNotFound {
+      // No v2 yet — try legacy migration with biometric.
+      if let migrated = try tryMigrateLegacyBlob(context: context) {
+        return migrated
+      }
+      throw Error.notFound
     }
-    return try deserialize(data)
+    if keyStatus == errSecUserCanceled || keyStatus == errSecAuthFailed {
+      throw Error.biometryFailed
+    }
+    guard keyStatus == errSecSuccess, let keyBytes = keyData else {
+      throw Error.keychainError(keyStatus)
+    }
+    guard keyBytes.count == bridgeKeyV2Size else { throw Error.invalidBlob }
+
+    // 2. Read meta (no ACL — same context is harmless).
+    let meta = try readMetaItem()
+    return Blob(
+      bridgeKey: keyBytes,
+      cacheVersionCounter: meta.counter,
+      hostInstallUUID: meta.uuid
+    )
   }
 
-  /// Increment counter and persist (called during cache write per plan §"Write ordering").
-  public func incrementCounter(newCounter: UInt64) throws {
-    var query: [String: Any] = baseQuery()
-    query[kSecReturnData as String] = true
-
-    let (status, existingData) = keychain.copyMatching(query: query)
-    guard status == errSecSuccess, let existingData else {
-      throw status == errSecItemNotFound ? Error.notFound : Error.keychainError(status)
+  /// Read counter + uuid only — no biometric prompt. The returned Blob has
+  /// `bridgeKey == Data()` (empty); callers that need the key must use
+  /// `readForFill`.
+  public func readDirect() throws -> Blob {
+    do {
+      let meta = try readMetaItem()
+      return Blob(
+        bridgeKey: Data(),
+        cacheVersionCounter: meta.counter,
+        hostInstallUUID: meta.uuid
+      )
+    } catch Error.notFound {
+      // Try legacy migration without biometric.
+      if let migrated = try tryMigrateLegacyBlob(context: nil) {
+        return Blob(
+          bridgeKey: Data(),
+          cacheVersionCounter: migrated.cacheVersionCounter,
+          hostInstallUUID: migrated.hostInstallUUID
+        )
+      }
+      throw Error.notFound
     }
-    var blob = try deserialize(existingData)
-    blob = Blob(
-      bridgeKey: blob.bridgeKey,
-      cacheVersionCounter: newCounter,
-      hostInstallUUID: blob.hostInstallUUID
+  }
+
+  /// Increment counter and persist. Called by HostSyncService after the
+  /// atomic cache-file rename so the on-disk file at counter N+1 is
+  /// matched by the in-Keychain counter only after the file commit.
+  public func incrementCounter(newCounter: UInt64) throws {
+    // Read existing meta (or migrate from legacy if needed). The previous
+    // counter is intentionally discarded — caller is the source of truth
+    // for `newCounter`. We only need uuid to preserve the meta payload.
+    let uuid: Data
+    do {
+      uuid = try readMetaItem().uuid
+    } catch Error.notFound {
+      if let migrated = try tryMigrateLegacyBlob(context: nil) {
+        uuid = migrated.hostInstallUUID
+      } else {
+        throw Error.notFound
+      }
+    }
+
+    let newMeta = serializeMeta(counter: newCounter, uuid: uuid)
+    let updateStatus = keychain.update(
+      query: baseQuery(service: serviceMetaV2),
+      attributes: [kSecValueData as String: newMeta]
     )
-    let updateStatus = keychain.update(query: baseQuery(), attributes: [
-      kSecValueData as String: serialize(blob),
-    ])
     guard updateStatus == errSecSuccess else {
       throw Error.keychainError(updateStatus)
     }
   }
 
-  /// Read without biometric — used by host app for recovery and counter updates.
-  /// Does NOT trigger a biometric prompt.
-  public func readDirect() throws -> Blob {
-    var query: [String: Any] = baseQuery()
-    query[kSecReturnData as String] = true
-
-    let (status, data) = keychain.copyMatching(query: query)
-    if status == errSecItemNotFound { throw Error.notFound }
-    guard status == errSecSuccess, let data else {
-      throw Error.keychainError(status)
-    }
-    return try deserialize(data)
-  }
-
-  /// Advance the blob counter to `observed` only if `observed == current + 1`.
-  /// Returns true if the counter was advanced; false if no action was needed.
+  /// Advance the meta counter to `observed` only if `observed == current + 1`.
   public func recoverForwardCounter(observed: UInt64) throws -> Bool {
     let current = try readDirect()
     guard observed == current.cacheVersionCounter + 1 else {
@@ -177,17 +246,30 @@ public final class BridgeKeyStore: Sendable {
     return true
   }
 
-  /// Delete — no biometric required for delete (per plan §"App-side auto-lock or logout").
+  /// Delete — no biometric required. Removes both v2 items and any
+  /// remaining legacy item. Returns the first non-OK status (other than
+  /// `errSecItemNotFound`) encountered, or success if everything was
+  /// missing or deleted.
   public func delete() throws {
-    let status = keychain.delete(query: baseQuery())
-    guard status == errSecSuccess || status == errSecItemNotFound else {
-      throw Error.keychainError(status)
+    var firstError: OSStatus = errSecSuccess
+    for query in [
+      baseQuery(service: serviceKeyV2),
+      baseQuery(service: serviceMetaV2),
+      legacyBaseQuery(),
+    ] {
+      let status = keychain.delete(query: query)
+      if status != errSecSuccess && status != errSecItemNotFound && firstError == errSecSuccess {
+        firstError = status
+      }
+    }
+    guard firstError == errSecSuccess else {
+      throw Error.keychainError(firstError)
     }
   }
 
-  // MARK: - Private helpers
+  // MARK: - Private helpers — V2
 
-  private func baseQuery() -> [String: Any] {
+  private func baseQuery(service: String) -> [String: Any] {
     [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: service,
@@ -197,54 +279,135 @@ public final class BridgeKeyStore: Sendable {
     ]
   }
 
+  private func legacyBaseQuery() -> [String: Any] {
+    baseQuery(service: serviceLegacy)
+  }
+
+  private func readMetaItem() throws -> (counter: UInt64, uuid: Data) {
+    var query: [String: Any] = baseQuery(service: serviceMetaV2)
+    query[kSecReturnData as String] = true
+    let (status, data) = keychain.copyMatching(query: query)
+    if status == errSecItemNotFound { throw Error.notFound }
+    guard status == errSecSuccess, let data else {
+      throw Error.keychainError(status)
+    }
+    guard data.count == bridgeMetaV2Size else { throw Error.invalidBlob }
+    let counter = data[0..<8].withUnsafeBytes { UInt64(bigEndian: $0.loadUnaligned(as: UInt64.self)) }
+    let uuid = Data(data[8..<24])
+    return (counter, uuid)
+  }
+
+  private func serializeMeta(counter: UInt64, uuid: Data) -> Data {
+    var data = Data(capacity: bridgeMetaV2Size)
+    let counterBE = counter.bigEndian
+    withUnsafeBytes(of: counterBE) { data.append(contentsOf: $0) }
+    data.append(uuid)
+    return data
+  }
+
+  /// Persist BOTH v2 items. Order: meta first → key second. On failure
+  /// of the key write, attempt to delete the meta to keep state self-
+  /// consistent (next call will see notFound on both).
   private func persistBlob(_ blob: Blob) throws {
+    let metaData = serializeMeta(counter: blob.cacheVersionCounter, uuid: blob.hostInstallUUID)
+
+    // 1. Meta — no ACL.
+    var metaQuery = baseQuery(service: serviceMetaV2)
+    metaQuery[kSecValueData as String] = metaData
+    metaQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+
+    var metaStatus = keychain.add(query: metaQuery)
+    if metaStatus == errSecDuplicateItem {
+      metaStatus = keychain.update(
+        query: baseQuery(service: serviceMetaV2),
+        attributes: [
+          kSecValueData as String: metaData,
+          kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        ]
+      )
+    }
+    guard metaStatus == errSecSuccess else {
+      throw Error.keychainError(metaStatus)
+    }
+
+    // 2. Bridge key — .biometryCurrentSet ACL.
     var error: Unmanaged<CFError>?
     guard let accessControl = SecAccessControlCreateWithFlags(
       kCFAllocatorDefault,
       kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-      .biometryCurrentSet,  // Per plan S14: NO .devicePasscode fallback
+      .biometryCurrentSet,
       &error
     ) else {
+      // Roll back meta to keep partial-state out of the store.
+      _ = keychain.delete(query: baseQuery(service: serviceMetaV2))
       throw Error.keychainError(errSecParam)
     }
 
-    var query = baseQuery()
-    query[kSecValueData as String] = serialize(blob)
-    query[kSecAttrAccessControl as String] = accessControl
+    var keyQuery = baseQuery(service: serviceKeyV2)
+    keyQuery[kSecValueData as String] = blob.bridgeKey
+    keyQuery[kSecAttrAccessControl as String] = accessControl
 
-    let status = keychain.add(query: query)
-    if status == errSecDuplicateItem {
-      let updateStatus = keychain.update(query: baseQuery(), attributes: [
-        kSecValueData as String: serialize(blob),
-        kSecAttrAccessControl as String: accessControl,
-      ])
-      guard updateStatus == errSecSuccess else { throw Error.keychainError(updateStatus) }
-    } else if status != errSecSuccess {
-      throw Error.keychainError(status)
+    var keyStatus = keychain.add(query: keyQuery)
+    if keyStatus == errSecDuplicateItem {
+      keyStatus = keychain.update(
+        query: baseQuery(service: serviceKeyV2),
+        attributes: [
+          kSecValueData as String: blob.bridgeKey,
+          kSecAttrAccessControl as String: accessControl,
+        ]
+      )
+    }
+    if keyStatus != errSecSuccess {
+      // Roll back meta on key-write failure.
+      _ = keychain.delete(query: baseQuery(service: serviceMetaV2))
+      throw Error.keychainError(keyStatus)
     }
   }
 
-  /// Serialize blob: [bridge_key:32][counter:8 BE][host_install_uuid:16] = 56 bytes.
-  private func serialize(_ blob: Blob) -> Data {
-    var data = Data(capacity: bridgeKeyBlobSize)
-    data.append(blob.bridgeKey)
-    let counterBE = blob.cacheVersionCounter.bigEndian
-    withUnsafeBytes(of: counterBE) { data.append(contentsOf: $0) }
-    data.append(blob.hostInstallUUID)
-    return data
-  }
+  // MARK: - Private helpers — legacy migration
 
-  /// Deserialize from 56-byte blob.
-  private func deserialize(_ data: Data) throws -> Blob {
-    guard data.count == bridgeKeyBlobSize else { throw Error.invalidBlob }
-    let bridgeKey = data[0..<32]
-    // Per plan: big-endian u64 counter; use loadUnaligned to avoid SIGBUS on Data slices.
-    let counter = data[32..<40].withUnsafeBytes { UInt64(bigEndian: $0.loadUnaligned(as: UInt64.self)) }
-    let uuid = data[40..<56]
-    return Blob(
-      bridgeKey: Data(bridgeKey),
+  /// Read legacy 56-byte combined item; if present, persist as v2 and
+  /// delete the legacy item. Returns the migrated Blob, or nil when
+  /// no legacy item exists.
+  ///
+  /// `context` is used to authenticate the legacy item read when the
+  /// caller is `readForFill`; pass nil from `readDirect`/`incrementCounter`
+  /// (the legacy item had a `.biometryCurrentSet` ACL, so a no-context
+  /// read either prompts via the system or fails — both cases are handled
+  /// by treating the "miss" as `notFound`, in which case the caller
+  /// surfaces the error and the user re-unlocks the vault).
+  private func tryMigrateLegacyBlob(context: LAContext?) throws -> Blob? {
+    var query: [String: Any] = legacyBaseQuery()
+    query[kSecReturnData as String] = true
+    if let context {
+      query[kSecUseAuthenticationContext as String] = context
+    }
+
+    let (status, data) = keychain.copyMatching(query: query)
+    if status == errSecItemNotFound { return nil }
+    guard status == errSecSuccess, let data else {
+      // Treat any other failure as "no migration possible" — caller
+      // surfaces notFound so the user re-creates fresh state.
+      return nil
+    }
+    guard data.count == legacyBridgeKeyBlobSize else { return nil }
+
+    let bridgeKey = Data(data[0..<32])
+    let counter = data[32..<40]
+      .withUnsafeBytes { UInt64(bigEndian: $0.loadUnaligned(as: UInt64.self)) }
+    let uuid = Data(data[40..<56])
+    let blob = Blob(
+      bridgeKey: bridgeKey,
       cacheVersionCounter: counter,
-      hostInstallUUID: Data(uuid)
+      hostInstallUUID: uuid
     )
+
+    // Write v2 items. On failure, leave legacy intact so the next call
+    // re-attempts the migration.
+    try persistBlob(blob)
+
+    // Best-effort delete of legacy item; non-fatal if it fails.
+    _ = keychain.delete(query: legacyBaseQuery())
+    return blob
   }
 }

--- a/ios/Shared/Storage/EntryCacheFile.swift
+++ b/ios/Shared/Storage/EntryCacheFile.swift
@@ -91,10 +91,20 @@ public func writeCacheFile(
   encryptedHeader.append(hdrCipher)
   encryptedHeader.append(hdrTag)
 
-  // Encrypt entries
+  // Encrypt entries with AAD bound to (counter, uuid, userId).
+  // Without this binding, an attacker with App Group write access could
+  // splice old `entries` bytes onto a fresh header — both ciphertexts
+  // would decrypt cleanly under the same vault key and `entryCount` is
+  // attacker-controlled. AAD over identity fields blocks the splice.
+  let entriesAAD = try buildCacheEntriesAAD(
+    counter: data.header.cacheVersionCounter,
+    hostInstallUUID: hostInstallUUID,
+    userId: data.header.userId
+  )
   let (entCipher, entIV, entTag) = try encryptAESGCM(
     plaintext: data.entries,
-    key: vaultKey
+    key: vaultKey,
+    aad: entriesAAD
   )
   var encryptedEntries = Data(capacity: 12 + entCipher.count + 16)
   encryptedEntries.append(entIV)
@@ -211,8 +221,17 @@ public func readCacheFile(
     throw EntryCacheError.rejection(.headerStale)
   }
 
-  // Decrypt entries (no AAD on entries blob)
-  let entriesData = try decryptEntriesBlob(Data(encryptedEntriesBlob), vaultKey: vaultKey)
+  // Decrypt entries with AAD reconstructed from the (now-trusted) header.
+  let entriesAAD = try buildCacheEntriesAAD(
+    counter: header.cacheVersionCounter,
+    hostInstallUUID: header.hostInstallUUID,
+    userId: header.userId
+  )
+  let entriesData = try decryptEntriesBlob(
+    Data(encryptedEntriesBlob),
+    vaultKey: vaultKey,
+    aad: entriesAAD
+  )
 
   // Validate entry count
   let entryCount = try countJSONArrayElements(entriesData)
@@ -226,13 +245,38 @@ public func readCacheFile(
 // MARK: - Private helpers
 
 private func buildCacheHeaderAAD(counter: UInt64, hostInstallUUID: Data) throws -> Data {
-  // Per plan §"Encrypted-entries cache integrity":
-  // AAD = "CACHEHDR" (8 ASCII bytes) || counter (BE 8 bytes) || hostInstallUUID (16 raw bytes)
+  // Header AAD layout (byte-identical to host-app and AutoFill ext):
+  //   "CACHEHDR" (8 ASCII) || counter (BE 8) || hostInstallUUID (16 raw)
   var aad = Data(capacity: 32)
   aad.append(contentsOf: Array("CACHEHDR".utf8))
   let counterBE = counter.bigEndian
   withUnsafeBytes(of: counterBE) { aad.append(contentsOf: $0) }
   aad.append(hostInstallUUID)
+  return aad
+}
+
+/// Entries-blob AAD = "CACHEENT" || counter(BE 8) || uuid(16)
+///                  || userIdLen(BE 2) || userId(UTF-8)
+///
+/// Internal (not private) so test targets can call it via
+/// `@testable import Shared` to construct splice-test fixtures.
+internal func buildCacheEntriesAAD(
+  counter: UInt64,
+  hostInstallUUID: Data,
+  userId: String
+) throws -> Data {
+  let userIdBytes = Array(userId.utf8)
+  guard userIdBytes.count <= 0xFFFF else {
+    throw EntryCacheError.rejection(.headerInvalid)
+  }
+  var aad = Data(capacity: 8 + 8 + 16 + 2 + userIdBytes.count)
+  aad.append(contentsOf: Array("CACHEENT".utf8))
+  let counterBE = counter.bigEndian
+  withUnsafeBytes(of: counterBE) { aad.append(contentsOf: $0) }
+  aad.append(hostInstallUUID)
+  let userIdLen = UInt16(userIdBytes.count).bigEndian
+  withUnsafeBytes(of: userIdLen) { aad.append(contentsOf: $0) }
+  aad.append(contentsOf: userIdBytes)
   return aad
 }
 
@@ -326,7 +370,7 @@ private func parseHeaderJSON(_ data: Data) throws -> CacheHeader {
   )
 }
 
-private func decryptEntriesBlob(_ blob: Data, vaultKey: SymmetricKey) throws -> Data {
+private func decryptEntriesBlob(_ blob: Data, vaultKey: SymmetricKey, aad: Data) throws -> Data {
   // Blob = IV(12) || ciphertext || tag(16)
   guard blob.count >= 12 + 16 else {
     throw EntryCacheError.rejection(.headerInvalid)
@@ -336,7 +380,7 @@ private func decryptEntriesBlob(_ blob: Data, vaultKey: SymmetricKey) throws -> 
   let ciphertext = Data(blob[12..<(blob.count - 16)])
 
   do {
-    return try decryptAESGCM(ciphertext: ciphertext, iv: iv, tag: tag, key: vaultKey)
+    return try decryptAESGCM(ciphertext: ciphertext, iv: iv, tag: tag, key: vaultKey, aad: aad)
   } catch {
     throw EntryCacheError.rejection(.authtagInvalid)
   }


### PR DESCRIPTION
## Summary

Adds the iOS AutoFill MVP: a host app that signs in to passwd-sso, fetches the personal vault, and writes a per-device encrypted cache; and a Credential Provider extension that surfaces matching credentials at fill time. Ships as 5 Xcode targets generated via XcodeGen.

### Host app

- Sign-in via PKCE + DPoP + ASWebAuthenticationSession; basePath-aware AASA route on the server
- Vault unlock with passphrase verification + Secure Enclave bridge-key derivation
- Browse / view / manual edit personal entries
- Auto-lock + foreground sync + rollback-flag drain
- Real DPoP signer (Secure Enclave P-256)
- TOFU server pinning (AASA SHA-256 + leaf-key SHA-256)

### AutoFill extension

- Credential provider extension (.appex) embedded in the host app
- AAD-bound decrypt path keyed by App-Group bridge-key
- Single biometric prompt per fill; non-discoverable security-key fallback

### Server

- basePath preservation in AASA + DPoP htu canonicalization
- iOS CI job (`ios-ci`) gating builds on `ios/` + `extension-fixtures/` path filter

### Hardening (final commit on this branch)

- Cache `entries` blob now AAD-bound to (counter, uuid, userId) — blocks splice attacks from App Group write access
- BridgeKeyStore split into two Keychain items: `bridge_key` (`.biometryCurrentSet`) + `counter/uuid` (no ACL); host-app foreground sync no longer prompts biometric on counter reads. Legacy 56-byte combined item migrates on first read.
- `tlsSPKISHA256` → `tlsLeafKeySHA256` rename so the field name matches what is actually hashed (`SecKeyCopyExternalRepresentation` output, not SPKI DER). Decoder accepts both keys for forward-compat; `currentPin()` upgrades legacy JSON in place.

## Architecture artifacts

- `docs/archive/review/ios-autofill-mvp-plan.md` — original 7-round triangulate plan
- `docs/archive/review/ios-autofill-mvp-hardening-{plan,review,code-review}.md` — hardening pass plan + 1 plan-review round + 3 code-review rounds (R3 returned no findings)
- `docs/archive/review/ios-autofill-mvp-verification-status.md` — what was tested vs deferred
- `docs/archive/review/ios-autofill-mvp-manual-test-plan.md` — 10 standard + 15 adversarial scenarios

## Out of scope

- HMAC-protected counter/uuid in the meta item — counter rollback by an attacker with App Group write access is documented as out-of-scope per Apple platform-security baseline (App Group write access ≠ device compromise per Apple's threat model)
- Real SPKI DER for the TOFU pin — leaf-key hash is sufficient for on-device TOFU; OpenSSL-style SPKI hash would require either a DER parser or P-256-only assumption
- Vault Reset cache-invalidation audit warning (web/server) — separate finding from the same review pass; deferred to a web-scoped follow-up plan

## Test plan

- [x] `xcodebuild test` (iPhone 17 simulator, iOS 26.4.1) — all green
- [x] Manual scenarios documented in `docs/archive/review/ios-autofill-mvp-manual-test-plan.md`
- [ ] Real-device end-to-end on physical iPhone (deferred per verification-status doc — TestFlight pass still pending)
- [ ] Browser fill + share-sheet credential workflows on real device

## Notes for reviewer

- Branch contains merges from `main` (#422, #423, #424, #425, #426) so the diff against main is large; the iOS-specific work is concentrated under `ios/` and the iOS CI job under `.github/workflows/`
- The hardening commit (top of branch) addresses three independent review findings each in a separate Swift file; recommend reviewing that commit first since it ships the security-relevant decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)