### PR TITLE
feat(ci): runtime cross-tenant RLS predicate verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,9 +458,6 @@ jobs:
           psql -v ON_ERROR_STOP=1 postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso -f scripts/rls-smoke-verify.sql
           echo "✓ RLS enforcement verified: passwd_app cannot see seeded rows"
 
-      # Cross-tenant predicate verification (issue #434).
-      # Layered checks: seed two tenants → coverage check → predicate verify
-      # as passwd_app → gate self-check (negative test). All must pass.
       - name: Cross-tenant seed (SUPERUSER)
         run: psql -v ON_ERROR_STOP=1 postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso -f scripts/rls-cross-tenant-seed.sql
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,6 +457,28 @@ jobs:
         run: |
           psql -v ON_ERROR_STOP=1 postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso -f scripts/rls-smoke-verify.sql
           echo "✓ RLS enforcement verified: passwd_app cannot see seeded rows"
+
+      # Cross-tenant predicate verification (issue #434).
+      # Layered checks: seed two tenants → coverage check → predicate verify
+      # as passwd_app → gate self-check (negative test). All must pass.
+      - name: Cross-tenant seed (SUPERUSER)
+        run: psql -v ON_ERROR_STOP=1 postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso -f scripts/rls-cross-tenant-seed.sql
+
+      - name: Cross-tenant coverage check (SUPERUSER)
+        run: psql -v ON_ERROR_STOP=1 postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso -f scripts/rls-cross-tenant-coverage.sql
+
+      - name: Cross-tenant RLS predicate verify (NOSUPERUSER)
+        run: |
+          EXPECTED_TABLES=$(awk 'NF && $1 !~ /^#/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print}' scripts/rls-cross-tenant-tables.manifest | paste -sd,)
+          psql -v ON_ERROR_STOP=1 -v expected_tables="$EXPECTED_TABLES" \
+            postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso \
+            -f scripts/rls-cross-tenant-verify.sql
+
+      - name: Cross-tenant verify negative test (gate self-check)
+        run: bash scripts/rls-cross-tenant-negative-test.sh
+        env:
+          MIGRATION_DATABASE_URL: "postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso"
+          APP_DATABASE_URL: "postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso"
   # ─── Container Scan (Trivy) ─────────────────────────────────
   container-scan:
     name: "Trivy: Container image scan"

--- a/docs/archive/review/verify-rls-predicate-code-review.md
+++ b/docs/archive/review/verify-rls-predicate-code-review.md
@@ -1,0 +1,158 @@
+# Code Review: verify-rls-predicate
+Date: 2026-05-04
+Review rounds: 2 (converged after fixing pre-pr.sh shell-quoting bug)
+
+## Changes from Previous Round
+
+Round 2 verified the Round 1 fixes and surfaced one Major issue (pre-pr.sh awk quoting) which was then fixed and re-verified.
+
+## Functionality Findings (Round 1)
+
+### F1 [Minor]: Negative-test header doesn't document seed prerequisite
+- File: `scripts/rls-cross-tenant-negative-test.sh:1-30`
+- Problem: Cases 0/4 invoke the full verify SQL which expects all 53 manifest tables seeded — running the script directly without seed produces confusing "FAIL case 0/4" output pointing at unrelated tables.
+- Fix: Added explicit prerequisite paragraph to the script header (lines 32-36).
+
+### F2 [Minor — DEFERRED]: Seed file not idempotent on re-run
+- File: `scripts/rls-cross-tenant-seed.sql:57-59`
+- Status: Not addressed — CI fresh DB per job; local re-runs use `prisma migrate reset` (already documented in plan §Manual test plan).
+- Anti-Deferral check: acceptable risk
+  - Worst case: confused developer error message on local re-run
+  - Likelihood: low (documented workflow)
+  - Cost to fix: ~5 lines + risk of `ON CONFLICT` masking real seed errors elsewhere
+
+### F3 [Minor]: Coverage `%s` vs verify `%L` inconsistency
+- File: `scripts/rls-cross-tenant-coverage.sql:50`
+- Problem: ASSERT message uses `%s` while verify.sql:244,303,376 use `%L` for the same purpose
+- Fix: Changed `%s` → `%L` for consistency
+
+## Security Findings (Round 1)
+
+**No findings.** The Security expert confirmed:
+- `format('%I', t)` correctly identifier-quotes; `t` is sourced from `pg_class.relname` (trusted) + defensive regex assertion
+- Block 4's `filter_clause` mixes `%I`/`%L` only with hardcoded UUID literals; documented as constants-only
+- Privilege boundaries explicitly asserted in Block 1
+- Negative test uses `set -euo pipefail` + trap-based cleanup
+- `app.bypass_rls` soft-GUC limitation pre-existing; documented in SQL comment + tracked as follow-up
+- No PII / secrets in committed artifacts
+
+## Testing Findings
+
+### T1 [Major]: Negative test coverage gap (Round 1)
+- File: `scripts/rls-cross-tenant-negative-test.sh:139-177`
+- Problem: Negative test covered only 5 of 8 stable error codes — `[E-RLS-COLPARITY]`, `[E-RLS-DISCOVER]`, `[E-RLS-MANIFEST-EXTRA]`, `[E-RLS-COUNT-B]` not exercised
+- Fix: Added Case 6 (`[E-RLS-MANIFEST-EXTRA]`) and Case 7 (`[E-RLS-COLPARITY]`). Coverage gaps for `COUNT-B` (mirrors `COUNT-A`), `DISCOVER` (requires fragile catalog REVOKE), and `ROLE` (runner-role cannot self-test) explicitly documented in script header.
+
+### T2 [Major]: pre-pr.sh stub validation scope (Round 1) + awk-quoting bug (Round 2)
+- File: `scripts/pre-pr.sh:42-58`
+- Problem (R1): Original `expected_tables=users` stub caused early-exit at Block 1 manifest assertion, leaving Blocks 2-5 unvalidated
+- Fix (R1 → R2 attempt): Use full manifest from `scripts/rls-cross-tenant-tables.manifest`; accept `[E-RLS-*]` codes as parse-OK
+- Problem (R2): The awk pipeline had broken `\\$1` quoting under `bash -c '...'` — bash interpreted `\$1` as the empty positional arg, awk crashed silently, `EXPECTED_TABLES` was empty, the broad regex masked the failure
+- Fix (R2): Replaced awk with `sed -E "/^#/d; /^[[:space:]]*$/d; s/^[[:space:]]+//; s/[[:space:]]+$//"` — no `$`-ambiguity inside `bash -c`. Tightened the regex to a whitelist of canonical `[E-RLS-*]` codes (prevents typo-codes from being silently accepted).
+
+### T3-T5 [Minor — DEFERRED]
+- T3: Indirect-detection signal quality for vacuous mutations — acceptable; mutations ARE caught indirectly via Case 0 calibration mismatch
+- T4: Block 2 + Block 3 coupled coverage — Block 3 mirrors Block 2 by design
+- T5: Local-dev cleanup ergonomics — already idempotent via `DROP TABLE IF EXISTS` in setup heredoc
+
+## Adjacent Findings
+
+- Functionality expert noted no [Adjacent] findings for security or testing.
+- Security expert had no findings, no [Adjacent].
+- Testing expert had no [Adjacent] findings.
+
+## Quality Warnings
+
+None — no findings flagged for VAGUE / NO-EVIDENCE / UNTESTED-CLAIM. All findings include file:line references and concrete evidence from empirical verification.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1 (DRY): OK — discovery query duplicated 5× across blocks; extracting would force temp view as passwd_app (deferred per plan)
+- R2 (KISS): OK
+- R3 (YAGNI): OK
+- R5/R9 (transaction boundaries): OK — file header forbids BEGIN/COMMIT and `--single-transaction`; SET LOCAL scoping verified empirically
+- R10 N/A
+- R14 (DB role grants): OK — re-grants DML to passwd_app (matches existing pattern)
+- R15 (hardcoded env values): OK — CI-only credentials
+- R16 (dev/CI parity): OK — local docker exec sequence matches CI step order
+- R20 (mechanical edits in structured constructs): OK — ci.yml insertion at correct rls-smoke job position
+- R21 (sub-agent verification): OK — re-ran full pipeline empirically against passwd-sso-db-1
+- R30 (schema drift): OK — manifest equality vs discovery enforced
+- R31 (destructive ops): OK — seed runs as passwd_user (intended); negative-test trap-based DROP works
+- R32 (runtime-shape boot test): OK — the new SQL/shell IS the runtime boot
+- R33 (CI cross-config propagation): OK — `app` filter already covers `scripts/**`
+- R34 (existing test reuse): OK — existing `rls-smoke-{seed,verify}.sql` are unmodified
+- R35 (manual-test for deployed components): OK — manual test plan inlined in the plan
+- R36: N/A
+
+### Security expert
+- R1-R30: OK or N/A (CI/SQL-only, no app code)
+- R31: OK — DROP TABLE IF EXISTS targeted, ephemeral CI Postgres
+- R32-R36: N/A
+- RS1-RS3: OK (input validation at boundaries; no injection vectors)
+- RS4: OK — UUIDs are deterministic test sentinels (`...A0`/`...B0`); emails use reserved `.test.local` TLD per RFC 6761
+
+### Testing expert
+- R1-R31: OK or N/A
+- R32 (runtime-shape boot test): SATISFIED — verify IS a real-DB runtime test
+- R33 (CI cross-config propagation): SATISFIED — single rls-smoke job
+- R34: N/A
+- R35 (manual test plan): SATISFIED — inlined in plan
+- R36: N/A
+- RT1 (mock-reality divergence): SATISFIED — no mocks; real Postgres
+- RT2 (testability): SATISFIED — every assertion reachable in psql + DO blocks. After R2 fixes, all 8 negative-test cases (0-7) exercise distinct stable error codes
+- RT3 (shared constants in tests): DEFERRED per plan T23 — UUIDs `...A0`/`...B0` duplicated across 4 files; tracked as follow-up
+
+## Resolution Status
+
+### F1 [Minor] Negative-test header doesn't document seed prerequisite — RESOLVED
+- Action: Added "Prerequisite" paragraph to script header
+- Modified file: `scripts/rls-cross-tenant-negative-test.sh:32-36`
+
+### F2 [Minor] Seed not idempotent — DEFERRED (acceptable risk)
+- Anti-Deferral check: acceptable risk
+- Justification:
+  - Worst case: confusing local re-run error
+  - Likelihood: low (documented workflow uses `prisma migrate reset`)
+  - Cost to fix: ~5 lines + risk of `ON CONFLICT` masking real seed errors
+- Orchestrator sign-off: Anti-Deferral §3 satisfied (acceptable risk with quantified tradeoff)
+
+### F3 [Minor] Coverage `%s` vs verify `%L` — RESOLVED
+- Action: Changed `%s` → `%L` for consistency with verify.sql
+- Modified file: `scripts/rls-cross-tenant-coverage.sql:50`
+
+### T1 [Major] Negative test coverage gap — RESOLVED
+- Action: Added Case 6 (MANIFEST-EXTRA) and Case 7 (COLPARITY) with custom helpers; updated cleanup trap to drop `rls_colparity_probe`; documented uncovered codes (COUNT-B / DISCOVER / ROLE) in script header
+- Modified file: `scripts/rls-cross-tenant-negative-test.sh` (header lines 33-44, cleanup function line 50, new functions lines 178-229)
+- Verification: all 8 cases (0-7) PASS empirically against local docker DB
+
+### T2 [Major] pre-pr.sh validation scope + awk-quoting bug — RESOLVED
+- Action (R1→R2): Switched stub `expected_tables=users` to full manifest derived from the manifest file
+- Action (R2 Major-1 fix): Replaced awk pipeline (which had broken `$1`-quoting under `bash -c '...'`) with sed; tightened broad regex to specific `[E-RLS-*]` whitelist
+- Modified file: `scripts/pre-pr.sh:40-58`
+- Verification: pre-pr.sh now correctly fires `[E-RLS-COUNT-A]` (Block 2 fail when no seed); whitelist regex matches; pre-pr.sh exits 0 with all 13 checks pass
+
+### T3 [Minor] Indirect-detection signal quality — DEFERRED
+- Anti-Deferral check: acceptable risk
+- Justification:
+  - Worst case: confusing failure attribution during regression
+  - Likelihood: low (Case 0 calibration mismatches are unambiguous)
+  - Cost to fix: 1 case + helper; not worth the additional complexity
+- Orchestrator sign-off: acceptable
+
+### T4 [Minor] Block 2/3 coupled coverage — DEFERRED
+- Anti-Deferral check: acceptable risk
+- Justification: Block 3 is a structural mirror of Block 2; a "Block 3 only" defect is mechanically unlikely. Adding a tenant-A-only negative case would double the test complexity for marginal coverage gain
+- Orchestrator sign-off: acceptable
+
+### T5 [Minor] Local-dev cleanup ergonomics — RESOLVED (already idempotent)
+- Action: Setup heredoc already starts with `DROP TABLE IF EXISTS rls_negative_test CASCADE` so re-runs are idempotent. Verified by inspection
+- No code change needed
+
+## Convergence verdict
+
+**READY TO MERGE.** All Critical/Major findings resolved. Three Minors deferred with explicit Anti-Deferral justification. Empirical verification:
+- Seed → coverage → verify (full pipeline): all exit 0 against local docker DB
+- Negative test: all 8 cases (0-7) PASS
+- pre-pr.sh: 13/13 checks pass including the new `Static: rls-cross-tenant SQL parse`

--- a/docs/archive/review/verify-rls-predicate-deviation.md
+++ b/docs/archive/review/verify-rls-predicate-deviation.md
@@ -1,0 +1,58 @@
+# Coding Deviation Log: verify-rls-predicate
+
+## Block 4: `RESET app.tenant_id` → `SET LOCAL app.tenant_id = nil-UUID`
+
+**Plan said**: Block 4 of `scripts/rls-cross-tenant-verify.sql` would `RESET app.tenant_id` to neutralize the tenant-filter clause, then `SET LOCAL app.bypass_rls = 'on'` to admit all rows via the bypass branch.
+
+**Implementation does**: `SET LOCAL app.tenant_id = '00000000-0000-0000-0000-000000000000'` (the nil UUID) instead of RESET.
+
+**Why**: Postgres quirk discovered during empirical verification — once a custom GUC (`app.tenant_id`) has been SET (or `SET LOCAL`'d) in a session, subsequent calls to `current_setting('app.tenant_id', true)` return the empty string `''` rather than NULL — even after `RESET` or `DISCARD ALL`. The tenant_isolation policy evaluates `tenant_id = current_setting('app.tenant_id', true)::uuid`, which raises `invalid input syntax for type uuid: ""` BEFORE the OR-bypass clause can short-circuit. The error halts the verify file before any per-table count is computed.
+
+**Net effect**: same semantic intent ("tenant filter neutralized; bypass clause exclusively drives visibility"). The nil UUID parses cleanly, matches no real tenant_id (real tenants use `…000A0` / `…000B0`), and lets the OR-bypass branch admit all rows. Block 4's `count = 2` (or 3 for `mcp_clients`) assertion semantics are preserved.
+
+**Files affected**:
+- `scripts/rls-cross-tenant-verify.sql` — Block 4 implementation uses nil-UUID
+- `docs/archive/review/verify-rls-predicate-plan.md` — Block 4 description updated to match
+
+**Verification**: empirical re-test against the local docker DB (`postgres:16-alpine`) shows the verify file now exits 0 against a correctly-seeded DB; the negative-test gate self-check passes all 6 cases including Case 4 (`[E-RLS-BYPASS]` fires correctly when the bypass clause is dropped from the throwaway policy).
+
+---
+
+## Seed: `SET app.bypass_rls = 'on'` for trigger bypass
+
+**Plan said**: seed runs as `passwd_user` (SUPERUSER) which bypasses RLS.
+
+**Implementation does**: also sets `SET app.bypass_rls = 'on'` at the top of the seed file.
+
+**Why**: SUPERUSER bypasses RLS but does NOT bypass `BEFORE INSERT` triggers. 27 of the 53 tenant-scoped tables have an `enforce_tenant_id_from_context()` trigger that raises `tenant_id missing and app.tenant_id is not set` regardless of role unless `app.bypass_rls = 'on'` is set. The trigger explicitly short-circuits when this GUC is on. The seed file needs to bypass this trigger to insert rows directly with deterministic tenant_ids (without `SET LOCAL app.tenant_id` per insert).
+
+**Files affected**: `scripts/rls-cross-tenant-seed.sql` (top of file).
+
+---
+
+## Verify SQL: `:'expected_tables'` → bridged via `SET app.expected_tables`
+
+**Plan said**: Block 1 of the verify SQL reads `:'expected_tables'` directly inside DO blocks (per the literal SQL in plan §"Block 1 manifest parity").
+
+**Implementation does**: bridges the psql variable to a session GUC at the top of the file (`SET app.expected_tables TO :'expected_tables';`), then DO blocks read it via `current_setting('app.expected_tables', true)`.
+
+**Why**: PostgreSQL psql does NOT re-scan dollar-quoted string contents (the bodies of `DO $$ … $$` blocks) for `:'var'` substitution. Using `:'expected_tables'` directly inside a DO block raises `syntax error at or near ":"`. The GUC bridge preserves the plan's intent — the comma-separated list reaches the DO block via `current_setting()` instead of psql variable substitution. Behaviorally identical for the manifest-parity assertions.
+
+**Files affected**: `scripts/rls-cross-tenant-verify.sql` (top of file + Block 1 ASSERT bodies).
+
+---
+
+## Seed: enum value corrections
+
+**Plan said**: nothing specific about enum values.
+
+**Implementation does**: uses correct enum values per the live schema:
+- `DirectorySyncProvider`: `GOOGLE_WORKSPACE` (NOT `GOOGLE`)
+- `NotificationType`: `SECURITY_ALERT` (no `INFO` value exists)
+- `AuditAction`: `AUTH_LOGIN` (no `PASSWORD_VIEWED`)
+- `audit_outbox.status`: `'SENT'` with `sent_at = NOW()` so the cleanup trigger guard (`status IN ('SENT','FAILED')`) permits cleanup DELETEs
+- `audit_logs.actor_type`: `'SYSTEM'` to satisfy the `audit_logs_outbox_id_actor_type_check` constraint without needing a separate outbox→audit_log linkage
+
+**Why**: discovered during seed-file authoring against the live schema; these are not deviations from the plan's intent (the plan didn't specify enum values), but they're recorded here for traceability.
+
+**Files affected**: `scripts/rls-cross-tenant-seed.sql`.

--- a/docs/archive/review/verify-rls-predicate-plan.md
+++ b/docs/archive/review/verify-rls-predicate-plan.md
@@ -1,0 +1,739 @@
+# Plan: Verify RLS Policy Predicate Correctness at Runtime
+
+Issue: [#434](https://github.com/ngc-shj/passwd-sso/issues/434) — `ci(rls): verify RLS policy predicate correctness at runtime, not just grants`
+
+## Project context
+
+- **Type**: web app (Next.js 16 + Prisma + PostgreSQL 16) with multi-tenant RLS-based isolation. Change is CI / SQL-only (no application code).
+- **Test infrastructure**: unit (Vitest) + integration (Vitest with real Postgres) + E2E (Playwright) + CI/CD (GitHub Actions). The RLS smoke test runs in `.github/workflows/ci.yml` job `rls-smoke`.
+- **Runtime constraint**: target Postgres image is `postgres:16-alpine` in CI. No `pgTAP` extension is installed; we rely on `psql -v ON_ERROR_STOP=1` plus `DO $$ ... ASSERT ... $$` PL/pgSQL blocks.
+
+## Objective
+
+Add a CI-enforced **runtime** check that the `tenant_isolation` RLS policy on every tenant-scoped table actually filters by `tenant_id`. A migration that defined `CREATE POLICY ... USING (true)` (or omitted the predicate) would pass the existing `check-migration-drift.mjs` (presence) and `rls-smoke` (grants/visibility-without-GUC) checks while silently allowing cross-tenant reads.
+
+## Requirements
+
+### Functional (from issue acceptance criteria)
+
+1. Seed two tenants `A` and `B` with **one row each** in every tenant-scoped table.
+2. As `passwd_app` (NOSUPERUSER, NOBYPASSRLS), set `app.tenant_id = '<A>'` and `app.bypass_rls = ''` (off):
+   - For every tenant-scoped table `T`: `SELECT count(*) FROM T` MUST return **exactly 1** (A's row).
+3. Repeat with `app.tenant_id = '<B>'`: counts MUST remain exactly 1 each (B's row).
+4. **Auto-discovery**: enumerate tenant-scoped tables from `pg_policy` (system catalog) cross-referenced with `information_schema.columns`. Do not hand-maintain a Node/SQL list of table names in the verify-step loop.
+5. **Optional bypass-channel sanity**: with `app.bypass_rls = 'on'` AND `app.tenant_id` reset, counts MUST be exactly 2 (or 3 for `mcp_clients` — see §Special cases) — confirms the bypass GUC alone admits all seeded rows.
+6. **Loud failure**: any deviation MUST exit non-zero with the offending table name in the error message. CI MUST fail red.
+
+### Non-functional
+
+- Run on CI with the existing `rls-smoke` Postgres service (no new container).
+- Total added wall-clock under 2 min on the existing CI runner (~53 tables × 4 query passes + automated negative test).
+- Locally runnable with `npm run docker:up` Postgres + the same psql commands.
+- No new npm dependency.
+
+### Out of scope
+
+- WORM / external audit offload (issue says so).
+- RLS policy refactor — verification only.
+- Pure lexical inspection of policy expressions (runtime cross-tenant assertion is strictly stronger).
+- Hardening `app.bypass_rls` against in-session `SET` by `passwd_app` (this is a soft GUC by design; documented in §Considerations; **follow-up issue tracked alongside this PR's merge**).
+
+## Technical approach
+
+### Discovery query — use `pg_policy` (not `pg_policies` view)
+
+The view `pg_policies` includes a `pg_has_role(c.relowner, 'USAGE')` filter that hides policies on tables owned by roles the current user lacks USAGE on. In this project, all tables are owned by `passwd_user` (SUPERUSER) and `passwd_app` is intentionally NOT a member of `passwd_user`. The verify step runs as `passwd_app`. To avoid the role-filter pitfall, the discovery query reads the underlying catalog `pg_policy` directly (PUBLIC has SELECT on `pg_catalog` by default — verified during implementation pre-flight; see §Pre-merge verification):
+
+```sql
+-- Concrete discovery query (works as passwd_app)
+SELECT c.relname AS table_name
+FROM pg_catalog.pg_policy p
+JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+JOIN information_schema.columns col
+  ON col.table_schema = n.nspname
+ AND col.table_name = c.relname
+ AND col.column_name = 'tenant_id'
+WHERE n.nspname = 'public'
+  AND c.relname <> 'tenants'
+  AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+ORDER BY c.relname;
+```
+
+The OR-clause matches both the canonical `<table>_tenant_isolation` form AND the bare `tenant_isolation` form. **Empirical state**: as of plan-execution time, the `team_policies` policy was renamed from bare `tenant_isolation` to `team_policies_tenant_isolation` in migration `20260321110000_convert_id_columns_to_uuid_type` (line 531). All current `tenant_isolation` policies follow the suffix convention. The bare-name OR-branch is retained as defensive forward-compat — if a future migration introduces a bare-name policy, the discovery query covers it without code change. Confirm at implementation time via `SELECT polname FROM pg_catalog.pg_policy WHERE polname = 'tenant_isolation'` (expect 0 rows in the current schema; non-zero would mean a migration introduced one — manifest must include the corresponding table).
+
+**Pre-merge verification**: before submitting the PR, the implementer must run, against a migrated test DB:
+```sql
+-- as passwd_app
+SELECT count(*) FROM pg_catalog.pg_policy WHERE polname = 'tenant_isolation' OR polname LIKE '%\_tenant_isolation' ESCAPE '\';
+```
+Expected: ~53 (the count of tenant-scoped tables; `tenants` itself has no policy in the current schema). If this returns 0, `passwd_app` lacks SELECT on `pg_policy` and the plan needs a structural revision (likely a `GRANT SELECT ON pg_catalog.pg_policy TO passwd_app` step in the role-creation script). Empirical pre-flight (using `npm run docker:up`) confirms `passwd_app` does have SELECT on `pg_policy` by default. See §Pre-merge verification checklist. **Note**: the explicit pg_catalog GRANT, if needed, is information-disclosure-bounded — `passwd_app` already executes against these policies via RLS; seeing the *expression text* adds modest disclosure with no rights escalation.
+
+### Tenant-scoped tables manifest (replaces a numeric floor)
+
+Instead of a numeric `EXPECTED_MIN_TENANT_SCOPED_TABLES`, the plan commits a manifest file `scripts/rls-cross-tenant-tables.manifest` listing each tenant-scoped table on its own line. The verify step asserts the discovered table set EQUALS the manifest set (no `>=` — strict equality). Adding/removing a tenant-scoped table requires editing the manifest in the same PR; a one-line numeric decrement is replaced by an explicit table-name diff that's much harder for a reviewer to overlook.
+
+```text
+# scripts/rls-cross-tenant-tables.manifest
+# One tenant-scoped table per line. Lines starting with # are comments.
+# Adding a table: insert a line in alphabetical order. Removing a table requires
+# REMOVING the policy AND the column AND the line here — three explicit deltas.
+# All current tenant_isolation policies follow the <table>_tenant_isolation suffix convention.
+# (Bare-name 'tenant_isolation' on team_policies was renamed in migration 20260321110000.)
+# The discovery OR-branch for bare-name remains as defensive forward-compat.
+access_requests
+accounts
+admin_vault_resets
+api_keys
+attachments
+audit_chain_anchors
+... (53 lines total — current count; reviewer-readable diffs replace the soft numeric floor)
+webauthn_credentials
+```
+
+Block 1 of the verify SQL reads the manifest via `psql --variable` substitution. The shell pre-step builds `EXPECTED_TABLES` with whitespace-trimmed, sorted entries:
+
+```bash
+# In ci.yml step (and the negative-test wrapper appends `,rls_negative_test` to this value)
+EXPECTED_TABLES=$(awk 'NF && $1 !~ /^#/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print}' \
+  scripts/rls-cross-tenant-tables.manifest | paste -sd,)
+psql -v ON_ERROR_STOP=1 -v expected_tables="$EXPECTED_TABLES" \
+  "$APP_DATABASE_URL" -f scripts/rls-cross-tenant-verify.sql
+```
+
+The `awk` form trims leading/trailing whitespace per line (addresses F30/S20 — preserves loud-fail but improves DX) and skips blank/comment lines.
+
+The verify SQL receives `:expected_tables` as a comma-separated string. **Use set-equality (not array equality)** — array `=` in PostgreSQL is order-sensitive, and we don't want to depend on alphabetical-ordering enforcement in the manifest. Block 1 asserts both directions of the symmetric difference:
+
+```sql
+-- manifest \\ discovery (extra in manifest, missing from DB)
+ASSERT NOT EXISTS (
+  SELECT m.t FROM unnest(string_to_array(:'expected_tables', ',')) AS m(t)
+  EXCEPT
+  SELECT c.relname FROM <discovery>
+), format('Manifest has tables not in discovery: %s', (
+  SELECT string_agg(m.t, ',')
+  FROM unnest(string_to_array(:'expected_tables', ',')) AS m(t)
+  WHERE m.t NOT IN (SELECT c.relname FROM <discovery>)
+));
+
+-- discovery \\ manifest (extra in DB, missing from manifest)
+ASSERT NOT EXISTS (
+  SELECT c.relname FROM <discovery>
+  EXCEPT
+  SELECT m.t FROM unnest(string_to_array(:'expected_tables', ',')) AS m(t)
+), format('Discovery has tables not in manifest: %s', (
+  SELECT string_agg(c.relname, ',')
+  FROM <discovery>
+  WHERE c.relname NOT IN (SELECT m.t FROM unnest(string_to_array(:'expected_tables', ',')) AS m(t))
+));
+```
+
+The two-sided EXCEPT plus name-listing failure messages give precise attribution: the operator sees exactly which tables are extra/missing on which side.
+
+This change addresses S3 / S5 / S12 / F18 from prior review rounds — eliminates the soft numeric floor; makes additions/removals explicit table-name diffs. F27/T22 from R3 — order-insensitive set comparison.
+
+### Verification structure
+
+Three new SQL artifacts plus one shell wrapper:
+
+1. **`scripts/rls-cross-tenant-seed.sql`** — runs as `passwd_user` (SUPERUSER, bypasses RLS). Seeds tenants A (`00000000-0000-0000-0000-0000000000A0`) and B (`…000B0`) plus one row per tenant in every tenant-scoped table. **Special case**: `mcp_clients` also seeds a third row with `tenant_id = NULL`. Hand-maintained; child rows use `gen_random_uuid()`; only tenant + user IDs are deterministic.
+
+2. **`scripts/rls-cross-tenant-coverage.sql`** — runs as `passwd_user`. Uses the same discovery query (working as SUPERUSER, hits no role-filter issues). For each discovered table, asserts **exactly 1** row exists for tenant A AND exactly 1 for tenant B. Failure message points at the seed file.
+
+3. **`scripts/rls-cross-tenant-verify.sql`** — runs as `passwd_app`. Five `DO $$` blocks:
+
+   **File-header comment** (mandatory): `-- DO NOT WRAP THIS FILE IN BEGIN/COMMIT OR INVOKE psql WITH --single-transaction. Each DO block must run as its own top-level statement so SET LOCAL is scoped to that block's implicit transaction.`
+
+   **Block 1 (role flags + structural invariants)** — ASSERT halts on first failure, so order matters. Each ASSERT message starts with a **stable error code** (`[E-RLS-<TAG>]`) so the negative-test wrapper can reliably regex-match the specific guard that fired regardless of future message-prose changes (addresses T31/F34 from R4 review).
+
+   ASSERT order (load-bearing):
+   1. **Role flags** — `[E-RLS-ROLE]`: `current_user = 'passwd_app'`, `session_user = current_user`, `current_setting('is_superuser') = 'off'`, `NOT rolsuper`, `NOT rolbypassrls`.
+   2. **Discovery accessibility self-test** — `[E-RLS-DISCOVER]`: `ASSERT (SELECT count(*) FROM pg_catalog.pg_policy WHERE polname='tenant_isolation' OR polname LIKE '%\_tenant_isolation' ESCAPE '\') > 0, '[E-RLS-DISCOVER] passwd_app cannot read pg_policy — discovery is broken'`.
+   3. **NULL-clause guard** — `[E-RLS-NULL]` (MUST run BEFORE symmetry guard — see ordering rationale below):
+      ```sql
+      ASSERT NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_policy p
+        JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname='public'
+          AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+          AND (p.polqual IS NULL OR p.polwithcheck IS NULL)
+      ), '[E-RLS-NULL] A tenant_isolation policy has a NULL USING or WITH CHECK clause (USING NULL = policy applies to all rows). Treat as a defect. Convention: tenant_isolation policies must be FOR ALL with non-NULL USING and WITH CHECK; FOR INSERT-only would also fire this guard as a false positive — use a different policyname for INSERT-only patterns.';
+      ```
+   4. **USING ↔ WITH CHECK symmetry** — `[E-RLS-SYM]`:
+      ```sql
+      ASSERT NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_policy p
+        JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname='public'
+          AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+          AND pg_get_expr(p.polqual, p.polrelid) IS DISTINCT FROM pg_get_expr(p.polwithcheck, p.polrelid)
+      ), '[E-RLS-SYM] A tenant_isolation policy has asymmetric USING vs WITH CHECK — add INSERT/UPDATE/DELETE assertions OR normalise the policy.';
+      ```
+   5. **Column parity** — `[E-RLS-COLPARITY]`: count of `information_schema.columns` rows where `column_name='tenant_id' AND table_schema='public' AND table_name <> 'tenants'` equals discovered count. Catches "tenant_id column added without policy" (or vice versa).
+   6. **Manifest parity (manifest \\ discovery)** — `[E-RLS-MANIFEST-EXTRA]`: tables in manifest that are not in DB.
+   7. **Manifest parity (discovery \\ manifest)** — `[E-RLS-MANIFEST-MISSING]`: tables in DB that are not in manifest.
+
+   **Ordering rationale (T29 from R4)**: NULL-clause MUST run before symmetry. A NULL `polqual` and a non-NULL `polwithcheck` (e.g., from `CREATE POLICY ... FOR INSERT WITH CHECK (true)`) produce `NULL IS DISTINCT FROM 'true' = TRUE`, which fires the symmetry guard FIRST if it runs first — masking the underlying NULL-clause defect with a generic-asymmetry message. The negative test's Case 3 (NULL-clause) would then never exercise `[E-RLS-NULL]`. Putting `[E-RLS-NULL]` first means: any NULL-clause defect surfaces with the precise tag; any other asymmetry surfaces with `[E-RLS-SYM]`.
+
+   **Notes on `IS DISTINCT FROM`**: NULL-aware; `NULL IS DISTINCT FROM NULL` is FALSE, `NULL IS DISTINCT FROM 'x'` is TRUE — required so two-NULL-clause symmetry doesn't false-positive (the NULL-clause guard already fires for any single-side NULL).
+
+   **Comment in the SQL near `[E-RLS-SYM]`**: `-- Compares pg_get_expr() output (canonicalized expression text). Catches the common asymmetric-write-clause bug. Theoretical false positives (cosmetic deparser differences) are loud failures and recoverable by reviewing pg_get_expr output directly.`
+
+   **Comment in the SQL near `[E-RLS-NULL]`**: `-- Convention: tenant_isolation policies are FOR ALL with non-NULL clauses. A FOR INSERT-only policy with the tenant_isolation name would false-positive here; use a different policyname for INSERT-only patterns.`
+
+   **Block 2 (tenant A → exactly 1 per discovered table)** — uses RAISE NOTICE accumulator for multi-table failure visibility (rather than ASSERT-halt-on-first):
+   ```sql
+   DO $$
+   DECLARE
+     t text;
+     n bigint;
+     expected bigint;
+     failures int := 0;
+   BEGIN
+     -- Defensive prelude
+     ASSERT current_setting('app.bypass_rls', true) IS NULL OR current_setting('app.bypass_rls', true) = '',
+       'pre-Block-2: app.bypass_rls must be unset';
+     SET LOCAL app.tenant_id = '00000000-0000-0000-0000-0000000000A0';
+     ASSERT current_setting('app.tenant_id', true) = '00000000-0000-0000-0000-0000000000A0',
+       'pre-Block-2: SET LOCAL app.tenant_id failed';
+     -- Per-table loop
+     FOR t IN (<discovery query>) LOOP
+       ASSERT t ~ '^[a-z_][a-z0-9_]*$', format('table name failed regex: %s', t);  -- defensive (S6/F14)
+       expected := CASE t WHEN 'mcp_clients' THEN 1 ELSE 1 END;  -- placeholder; only mcp_clients is special-cased today
+       EXECUTE format('SELECT count(*) FROM %I', t) INTO n;
+       IF n <> expected THEN
+         RAISE NOTICE 'FAIL table=% block=verify-A tenant=A expected=% got=% — likely cause: policy bug (cross-tenant leak). Coverage already confirmed exactly 1 row in DB.',
+           t, expected, n;
+         failures := failures + 1;
+       END IF;
+     END LOOP;
+     IF failures > 0 THEN
+       RAISE EXCEPTION '[E-RLS-COUNT-A] Block 2 (tenant A): % tables failed — see NOTICE lines above', failures;
+     END IF;
+   END $$;
+   ```
+   The accumulator pattern reports ALL failing tables in one CI run instead of one per push (T14).
+
+   **Block 3 (tenant B → exactly 1)**: mirror of Block 2 with `…000B0` and error code `[E-RLS-COUNT-B]` in the EXCEPTION message (`[E-RLS-COUNT-B] Block 3 (tenant B): % tables failed — see NOTICE lines above`).
+
+   **Block 4 (bypass-channel sanity, with tenant filter explicitly disabled)**:
+   ```sql
+   DO $$
+   DECLARE
+     t text;
+     n bigint;
+     expected bigint;
+     filter_clause text;
+     failures int := 0;
+   BEGIN
+     RESET app.tenant_id;  -- no-op-safe: SET LOCAL from Block 3 already discarded at txn boundary
+     SET LOCAL app.bypass_rls = 'on';
+     ASSERT current_setting('app.tenant_id', true) IS NULL OR current_setting('app.tenant_id', true) = '',
+       'pre-Block-4: app.tenant_id must be unset (the RESET above should have ensured this)';
+     FOR t IN (<discovery query>) LOOP
+       expected := CASE t WHEN 'mcp_clients' THEN 3 ELSE 2 END;
+       -- filter_clause built from constants only (UUID literals from the seed). NEVER pass user input here.
+       filter_clause := CASE t
+         WHEN 'mcp_clients' THEN format(
+           'tenant_id IN (%L::uuid, %L::uuid) OR tenant_id IS NULL',
+           '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000B0')
+         ELSE format(
+           'tenant_id IN (%L::uuid, %L::uuid)',
+           '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000B0')
+       END;
+       EXECUTE format('SELECT count(*) FILTER (WHERE %s) FROM %I', filter_clause, t) INTO n;
+       IF n <> expected THEN
+         RAISE NOTICE 'FAIL table=% block=bypass expected=% got=% — likely cause: policy bypass clause regression (the OR app.bypass_rls=on branch was removed or weakened)',
+           t, expected, n;
+         failures := failures + 1;
+       END IF;
+     END LOOP;
+     -- mcp_clients: assert NULL row appears under bypass (defense-in-depth, F21)
+     SELECT count(*) INTO n FROM mcp_clients WHERE tenant_id IS NULL;
+     IF n <> 1 THEN
+       RAISE NOTICE 'FAIL mcp_clients NULL-tenant row not visible under bypass — count=%', n;
+       failures := failures + 1;
+     END IF;
+     IF failures > 0 THEN
+       RAISE EXCEPTION '[E-RLS-BYPASS] Block 4 (bypass): % failures — see NOTICE lines above', failures;
+     END IF;
+   END $$;
+   ```
+   Comment in SQL: `-- NOTE: app.bypass_rls is a soft GUC. SQL-level access to passwd_app session can SET it to 'on' and defeat RLS. RLS is one layer; do not rely on it as the sole tenant boundary. Hardening tracked as a follow-up issue.`
+
+   **Block 5 (cleanup)**: `RESET app.bypass_rls; RESET app.tenant_id`. No-op safety net — `SET LOCAL` from prior blocks is already discarded at txn boundary; this block makes the intent explicit and harmless if a future maintainer changes prior blocks to `SET` (no LOCAL).
+
+   **`client_min_messages` guard**: at the top of Blocks 2/3/4, add `SET LOCAL client_min_messages = 'NOTICE';` so a future CI invocation that sets `PGOPTIONS=-c client_min_messages=WARNING` (used elsewhere to silence noisy migrations) does NOT suppress per-table `RAISE NOTICE` lines — addresses T21 from R3.
+
+4. **`scripts/rls-cross-tenant-negative-test.sh`** — gate self-check that exercises the verify step's failure path. Uses an **ephemeral throwaway table** so no real production policy is ever mutated. Runs **multiple shapes** to cover all five failure surfaces in the verify SQL (T24/F26 from R3 review), choosing the **`--variable` override mechanism** (NOT manifest file mutation) so the manifest file is never written during testing.
+
+   **Setup (once per script run, as `passwd_user`)**:
+   ```sql
+   CREATE TABLE rls_negative_test (
+     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+     tenant_id uuid NOT NULL
+   );
+   ALTER TABLE rls_negative_test ENABLE ROW LEVEL SECURITY;
+   ALTER TABLE rls_negative_test FORCE ROW LEVEL SECURITY;
+   GRANT SELECT, INSERT ON rls_negative_test TO passwd_app;
+   -- Insert as passwd_user (SUPERUSER, bypasses RLS regardless of policy).
+   -- INSERTing as passwd_user (not passwd_app) avoids depending on the
+   -- throwaway policy's WITH CHECK admitting NULL or the ALTER DEFAULT
+   -- PRIVILEGES grant chain — the test data is ground truth, set up by SUPERUSER.
+   INSERT INTO rls_negative_test (tenant_id) VALUES
+     ('00000000-0000-0000-0000-0000000000A0'),
+     ('00000000-0000-0000-0000-0000000000B0');
+   ```
+
+   **Per-shape iteration** (the script runs ALL of these in sequence, asserting each fires the correct guard via stable error-code matching). All cases use a deterministic policy state — Case 5 explicitly sets a SAFE policy first so its assertion exercises only manifest-parity (NOT cross-fired by stale Case 4 state):
+
+   | Case | Policy shape on `rls_negative_test` | EXPECTED_TABLES setting | Expected stable-code |
+   |---|---|---|---|
+   | (0) Pre-flight calibration | `USING ((current_setting('app.bypass_rls', true) = 'on') OR tenant_id = current_setting('app.tenant_id', true)::uuid) WITH CHECK (same)` (canonical, correct) | manifest + throwaway | exit 0 (sanity: harness is calibrated) |
+   | (1) Permissive USING / symmetric | `USING (true) WITH CHECK (true)` | manifest + throwaway | `[E-RLS-COUNT-A]` (Block 2, count=2) |
+   | (2) Asymmetric USING/WITH CHECK | `USING (tenant_id = current_setting('app.tenant_id', true)::uuid OR current_setting('app.bypass_rls', true) = 'on') WITH CHECK (true)` | manifest + throwaway | `[E-RLS-SYM]` |
+   | (3) NULL USING clause | `DROP POLICY` then `CREATE POLICY rls_negative_test_tenant_isolation ON rls_negative_test FOR INSERT WITH CHECK (true)` (legacy INSERT-only → polqual NULL) | manifest + throwaway | `[E-RLS-NULL]` (NULL-clause guard fires before symmetry guard per Block 1 ordering) |
+   | (4) Bypass clause dropped | `USING (tenant_id = current_setting('app.tenant_id', true)::uuid) WITH CHECK (tenant_id = current_setting('app.tenant_id', true)::uuid)` | manifest + throwaway | `[E-RLS-BYPASS]` (Block 4 count=0) |
+   | (5) Manifest drift (with deterministic policy state) | Same canonical policy as Case 0 (so only manifest mismatch fires, not Block 2/4) | **manifest WITHOUT throwaway** | `[E-RLS-MANIFEST-MISSING]` (discovery has rls_negative_test, manifest doesn't) |
+
+   **Why Case 0 (pre-flight) is required (T32 from R4)**: without it, a verify-file syntax error or harness misconfiguration would make every subsequent case exit non-zero — and the regex matchers might accidentally match (e.g., a parser error message containing the substring "Block"). Case 0 proves `verify` can return GREEN under a correct policy + correct EXPECTED_TABLES, so subsequent RED outcomes are attributable to the deliberate mutation.
+
+   **Per-shape script body** (bash — actual implementation):
+   ```bash
+   # Case 5 uses the same canonical policy as Case 0 — NOT the broken policy from Case 4.
+   # This ensures Block 1 manifest-parity is the only failing check.
+   CANONICAL_POLICY="USING ((current_setting('app.bypass_rls', true) = 'on') OR tenant_id = current_setting('app.tenant_id', true)::uuid) WITH CHECK ((current_setting('app.bypass_rls', true) = 'on') OR tenant_id = current_setting('app.tenant_id', true)::uuid)"
+
+   run_negative_case() {
+     local case_id="$1"
+     local create_policy_sql="$2"          # SQL fragment, e.g. "USING (true) WITH CHECK (true)"
+     local expected_code="$3"               # stable error code, e.g. "[E-RLS-COUNT-A]" — or empty for Case 0 (expect exit 0)
+     local omit_throwaway_from_manifest="${4:-no}"
+     # Apply the policy state (Case 3 uses a different DDL form — handled by caller passing full DDL).
+     psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test;"
+     psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -c "$create_policy_sql"
+     # Build EXPECTED_TABLES (manifest entries are whitespace-trimmed)
+     local manifest_entries
+     manifest_entries=$(awk 'NF && $1 !~ /^#/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print}' \
+       scripts/rls-cross-tenant-tables.manifest | paste -sd,)
+     local expected_tables
+     if [[ "$omit_throwaway_from_manifest" == "yes" ]]; then
+       expected_tables="$manifest_entries"
+     else
+       expected_tables="${manifest_entries},rls_negative_test"
+     fi
+     # Run verify; capture exit and combined output.
+     local verify_output ec
+     verify_output=$(psql "$APP_DATABASE_URL" -v ON_ERROR_STOP=1 -v expected_tables="$expected_tables" \
+       -f scripts/rls-cross-tenant-verify.sql 2>&1) && ec=0 || ec=$?
+     if [[ -z "$expected_code" ]]; then
+       # Case 0: expect exit 0
+       if (( ec != 0 )); then
+         printf 'FAIL case %s: pre-flight calibration verify did NOT pass under canonical policy. Output:\n%s\n' "$case_id" "$verify_output"
+         return 1
+       fi
+       printf 'PASS case %s (pre-flight calibration)\n' "$case_id"
+       return 0
+     fi
+     if (( ec == 0 )); then
+       printf 'FAIL case %s: verify exited 0 against deliberately-broken policy — gate is broken (vacuous pass)\n' "$case_id"
+       return 1
+     fi
+     # Match against stable error code, not freeform prose.
+     if ! grep -qF -- "$expected_code" <<<"$verify_output"; then
+       printf 'FAIL case %s: verify failed but expected code %s not found in output:\n%s\n' \
+         "$case_id" "$expected_code" "$verify_output"
+       return 1
+     fi
+     printf 'PASS case %s (matched %s)\n' "$case_id" "$expected_code"
+   }
+
+   # Driver: accumulate failures, run all cases, exit with count.
+   total_failures=0
+   run_negative_case 0 "$CANONICAL_POLICY" "" "no" || (( total_failures++ ))
+   run_negative_case 1 "USING (true) WITH CHECK (true)" "[E-RLS-COUNT-A]" "no" || (( total_failures++ ))
+   run_negative_case 2 "USING (tenant_id = current_setting('app.tenant_id', true)::uuid OR current_setting('app.bypass_rls', true) = 'on') WITH CHECK (true)" "[E-RLS-SYM]" "no" || (( total_failures++ ))
+   # Case 3 uses a different DDL — INSERT-only legacy form. Caller passes a synthesized SQL string that DROPs and re-CREATEs:
+   run_negative_case 3 "/*intentionally rebuilt to FOR INSERT-only*/ CREATE POLICY rls_negative_test_tenant_isolation ON rls_negative_test FOR INSERT WITH CHECK (true)" "[E-RLS-NULL]" "no" || (( total_failures++ ))
+   run_negative_case 4 "USING (tenant_id = current_setting('app.tenant_id', true)::uuid) WITH CHECK (tenant_id = current_setting('app.tenant_id', true)::uuid)" "[E-RLS-BYPASS]" "no" || (( total_failures++ ))
+   run_negative_case 5 "$CANONICAL_POLICY" "[E-RLS-MANIFEST-MISSING]" "yes" || (( total_failures++ ))
+
+   if (( total_failures > 0 )); then
+     printf '\n%d negative-test cases failed.\n' "$total_failures"
+     exit 1
+   fi
+   printf '\nAll negative-test cases PASS.\n'
+   ```
+
+   The driver accumulates failures across all 6 cases (T33 from R4 — operator sees full failure surface in one run, not abort-on-first). The Case 3 SQL fragment uses a comment marker so the dispatcher's `psql -c` form treats the SQL as a single statement with a leading no-op comment; alternative implementations may pass the policy SQL via stdin. Implementer chooses the cleanest form.
+
+   **Cleanup (always, via `trap` on EXIT/INT/TERM)**: `DROP TABLE IF EXISTS rls_negative_test CASCADE`. The trap-based DROP is idempotent.
+
+   **Header comment**:
+   ```
+   # rls-cross-tenant-negative-test.sh — gate self-check
+   #
+   # Runs a Case 0 pre-flight calibration (canonical policy → exit 0) plus
+   # 5 distinct failure shapes against an ephemeral throwaway table to verify
+   # the cross-tenant verify SQL correctly detects each:
+   #   0. canonical policy + correct manifest (sanity: harness calibrated)
+   #   1. permissive symmetric → [E-RLS-COUNT-A]
+   #   2. asymmetric USING/WITH CHECK → [E-RLS-SYM]
+   #   3. NULL USING clause (FOR INSERT-only) → [E-RLS-NULL]
+   #   4. dropped bypass clause → [E-RLS-BYPASS]
+   #   5. manifest drift (canonical policy + manifest missing throwaway) → [E-RLS-MANIFEST-MISSING]
+   #
+   # Each case matches a stable error code (e.g., [E-RLS-NULL]), not freeform
+   # prose, so future EXCEPTION message wording changes do not silently break
+   # gate self-check coverage.
+   #
+   # Mechanism: --variable override (no manifest file mutation). The script
+   # builds EXPECTED_TABLES in-process, appending the throwaway table name
+   # to the manifest contents (or omitting it for case 5) and passes via
+   # `psql -v expected_tables=...`. The manifest file on disk is never modified.
+   #
+   # CI safety:
+   # - This script MUST run sequentially in rls-smoke. Do NOT parallelize
+   #   with other DB-touching steps — the throwaway policy is committed
+   #   global state for the duration of each case.
+   # - Trap fires on EXIT/ERR/INT/TERM but NOT SIGKILL. CI Postgres is
+   #   ephemeral so a leaked throwaway table is discarded with the runner.
+   #   Do NOT run against a shared/persistent DB without modification.
+   ```
+
+### CI integration
+
+Extend the existing `rls-smoke` job in `.github/workflows/ci.yml` with **four** new steps after `Verify RLS enforcement`:
+
+```yaml
+- name: Cross-tenant seed (SUPERUSER)
+  run: psql -v ON_ERROR_STOP=1 "$MIGRATION_DATABASE_URL" -f scripts/rls-cross-tenant-seed.sql
+  env:
+    MIGRATION_DATABASE_URL: "postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso"
+
+- name: Cross-tenant coverage check (SUPERUSER)
+  run: psql -v ON_ERROR_STOP=1 "$MIGRATION_DATABASE_URL" -f scripts/rls-cross-tenant-coverage.sql
+  env:
+    MIGRATION_DATABASE_URL: "postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso"
+
+- name: Cross-tenant RLS predicate verify (NOSUPERUSER)
+  run: |
+    EXPECTED_TABLES=$(awk 'NF && $1 !~ /^#/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print}' \
+      scripts/rls-cross-tenant-tables.manifest | paste -sd,)
+    psql -v ON_ERROR_STOP=1 -v expected_tables="$EXPECTED_TABLES" \
+      "postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso" \
+      -f scripts/rls-cross-tenant-verify.sql
+
+- name: Cross-tenant verify negative test (gate self-check)
+  run: bash scripts/rls-cross-tenant-negative-test.sh
+  env:
+    MIGRATION_DATABASE_URL: "postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso"
+    APP_DATABASE_URL: "postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso"
+```
+
+**Path filter / branch protection**: the existing `if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'` already triggers on changes to `prisma/migrations/**` (the existing rls-smoke job's primary trigger). At implementation time, **verify** that the `changes` job's `app` filter includes the new files: `scripts/rls-cross-tenant-*.{sql,sh}` and `scripts/rls-cross-tenant-tables.manifest`. If not present, add them. Required-status checks (branch protection) must already include `rls-smoke` (existing requirement); confirm at implementation time.
+
+The existing `rls-smoke-seed.sql` and `rls-smoke-verify.sql` are NOT modified by this PR — they verify a different invariant (without-GUC visibility on a smaller table set). See §Considerations for the decision rationale and the follow-up issue.
+
+### Special cases
+
+#### Nullable-tenant tables: `mcp_clients`
+
+`prisma/schema.prisma` declares `model McpClient { tenantId String? }`. DCR pre-claimed clients have `tenant_id IS NULL` until claimed.
+
+**Code-inspected fact** (per pre-merge verification): the live policy `mcp_clients_tenant_isolation` in `prisma/migrations/20260328075528_add_rls_machine_identity_tables/migration.sql:49-57` uses **identical USING and WITH CHECK clauses** with the standard `bypass OR tenant_id = current_setting(...)::uuid` template — same as every other tenant_isolation policy. The symmetry guard does not need a special exception for this table.
+
+**Behavior under the standard template**:
+- `passwd_app` with `app.tenant_id = '<A>'`: `NULL = '<A>'::uuid` → NULL → falsy → NULL row invisible. count = 1 (A's row only).
+- `passwd_app` with bypass=on, tenant_id reset: NULL row admitted via the OR-bypass clause. count = 3 (A's + B's + NULL).
+- `passwd_app` cannot INSERT a NULL-tenant row: WITH CHECK requires bypass=on or `tenant_id = current_setting()::uuid` (the latter rejects NULL on the LHS via NULL = uuid → NULL → fail). NULL rows are created only by `passwd_user` or by sessions that explicitly set `app.bypass_rls = 'on'` (the DCR pre-claim admin path).
+
+**Plan handling**:
+- Seed file inserts 3 rows in `mcp_clients`: A's (tenant_id = `<A>`), B's (tenant_id = `<B>`), NULL.
+- Block 2/3 expected count = 1 per tenant.
+- Block 4 expected count = 3, plus a separate NULL-row-visibility assertion.
+- Coverage check: assert exactly 1 row per tenant in `mcp_clients` filtered by tenant_id; the NULL row is asserted separately.
+
+#### Future nullable-tenant tables
+
+Adding another nullable-tenant table requires updating: (1) the seed file (3 rows), (2) the per-table override CASE in Block 4, (3) a NULL-row visibility assertion in Block 4. Documented in the seed and verify file headers.
+
+### How auto-discovery + manifest handles drift
+
+Adding a new tenant-scoped table requires:
+1. (existing) Migration adds the column, ENABLE/FORCE RLS, `<table>_tenant_isolation` policy → `check-migration-drift.mjs` validates.
+2. **New**: dependency-ordered INSERTs in `scripts/rls-cross-tenant-seed.sql`.
+3. **New**: append the table name to `scripts/rls-cross-tenant-tables.manifest` (alphabetical order).
+4. **New**: if the new table's `tenant_id` is nullable, also update the per-table override CASE in `scripts/rls-cross-tenant-verify.sql` Block 4.
+
+Removing a tenant-scoped table requires DELETING the manifest line — the diff is explicit and scrutable.
+
+**Renames** are auto-handled — the discovery query reflects post-rename state. Renaming a table requires updating the manifest entry to the new name.
+
+## Implementation steps
+
+1. **Pre-merge verification (before writing code)** — see §Pre-merge verification checklist below. Confirm `passwd_app` can SELECT `pg_catalog.pg_policy`. Confirm the `mcp_clients_tenant_isolation` live policy is symmetric (already done by code inspection of `migrations/.../20260328075528_*/migration.sql:45-57`).
+
+2. **Create `scripts/rls-cross-tenant-tables.manifest`**:
+   - One tenant-scoped table per line, alphabetical order.
+   - Header comment block explaining the maintenance contract: removing a table requires removing the line + the policy + the column (three explicit deltas).
+   - Generate the initial list from the discovery query against a migrated DB; the output (currently 53 tables) is the canonical seed for the manifest. Re-run if the schema was migrated since the last regeneration.
+
+3. **Create `scripts/rls-cross-tenant-seed.sql`**:
+   - Seeds tenants A and B with deterministic UUIDs.
+   - For every manifest table, insert dependency-ordered rows. Document FK chains as inline comments.
+   - `mcp_clients`: 3 rows (A, B, NULL).
+   - Idempotency: CI uses fresh Postgres; local re-runs may need TRUNCATE first (documented).
+   - File header comment: `-- Use %I (identifier quoting), never %s. Identifiers come from system catalog data (trusted). Never widen this rule by interpolating user input.`
+
+4. **Create `scripts/rls-cross-tenant-coverage.sql`**:
+   - Single `DO $$` running as `passwd_user`.
+   - Same discovery query as the verify step (consistent cross-step). Use accumulator pattern for multi-table failure visibility.
+   - Failure messages point at the seed file.
+
+5. **Create `scripts/rls-cross-tenant-verify.sql`**:
+   - File header forbidding BEGIN/COMMIT and `--single-transaction`.
+   - Five DO blocks per §Verification structure; comments per the listed positions.
+   - Defensive `ASSERT t ~ '^[a-z_][a-z0-9_]*$'` in each loop.
+
+6. **Create `scripts/rls-cross-tenant-negative-test.sh`**:
+   - `set -euo pipefail`.
+   - Capture the manifest, append the throwaway table name temporarily.
+   - Trap-based cleanup.
+   - Header comment per §Verification structure.
+
+7. **Update `.github/workflows/ci.yml`**:
+   - Four new steps after `Verify RLS enforcement`.
+   - Path-filter additions to the `changes` job's `app` filter.
+
+8. **Add a syntax-check entry to `scripts/pre-pr.sh`** (T13 mitigation; pre-pr.sh exists in the repo). The entry uses `pg_isready` to skip gracefully when no local Postgres is running. **Important caveats** addressed (F34/T28 from R4):
+   - `psql -c "BEGIN;" -f file -c "ROLLBACK;"` does NOT give atomic rollback across the three commands (each `-c` is its own top-level statement). Use `psql --single-transaction -f file` (`-1` short form) for true atomic rollback.
+   - The verify file references `:'expected_tables'`. Without `-v expected_tables=...`, psql 14+ raises an error before any ASSERT runs — the check would surface a misleading parse error. Solution: pass a stub variable AND check both the seed and coverage files atomically; the verify file is parse-checked separately by passing a stub manifest derived from the committed file.
+   - The check is **parse-time only**: a stub manifest is built so Block 1 manifest-parity will fail (LOUD), but the script invocation captures this expected failure and still passes the pre-pr.sh step IF the failure is `[E-RLS-MANIFEST-MISSING]` or `[E-RLS-MANIFEST-EXTRA]` (i.e., the SQL parsed successfully and reached the assertion). Any other failure means a syntax error.
+
+   Sketch:
+   ```bash
+   if pg_isready -h localhost -p 5432 -q -t 1; then
+     run_step "Static: rls-cross-tenant SQL parse" \
+       bash -c '
+         set -euo pipefail
+         DB_URL="postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso"
+         APP_URL="postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso"
+         # Seed and coverage: atomic transaction, rollback at end (truly parse-only).
+         for f in scripts/rls-cross-tenant-seed.sql scripts/rls-cross-tenant-coverage.sql; do
+           psql --single-transaction -v ON_ERROR_STOP=1 "$DB_URL" -f "$f" >/dev/null \
+             || true  # ROLLBACK happens automatically when --single-transaction errors out
+         done
+         # Verify: pass stub manifest (intentionally wrong) — parse must succeed,
+         # then accept either zero exit or an [E-RLS-MANIFEST-*] failure as PASS.
+         STUB="users"
+         out=$(psql -v ON_ERROR_STOP=1 -v expected_tables="$STUB" "$APP_URL" \
+           -f scripts/rls-cross-tenant-verify.sql 2>&1) && ec=0 || ec=$?
+         if (( ec == 0 )) || grep -qE "\[E-RLS-MANIFEST-(EXTRA|MISSING)\]" <<<"$out"; then
+           exit 0  # parse OK — failed assertion is expected with stub manifest
+         fi
+         echo "$out"
+         exit 1  # syntax/parse error or unexpected ASSERT failure
+       '
+   else
+     echo "  [skip: rls-cross-tenant SQL parse — local Postgres not running (npm run docker:up to enable)]"
+   fi
+   ```
+   This catches typos and structural SQL bugs locally without behavioral testing. Behavioral correctness comes from CI.
+
+9. **File two follow-up issues alongside this PR's merge**:
+   - **`app.bypass_rls` GUC hardening** — soft-GUC limitation documented in this plan; remediation (replace GUC with a `passwd_user`-only marker, e.g., `current_user = 'passwd_user'`) is a separate plan.
+   - **Expand existing `rls-smoke-seed.sql` / `rls-smoke-verify.sql` to all 53 tenant-scoped tables** OR formally retire it as superseded by the new cross-tenant verify. Decision documented in §Considerations.
+
+## Testing strategy
+
+The four new artifacts ARE the test. Three layers of correctness:
+
+| Layer | Asserts | Catches |
+|---|---|---|
+| Coverage check (SUPERUSER) | Each manifest table has exactly 1 row per tenant in seed | Seed bugs |
+| Verify (NOSUPERUSER) | Discovery == manifest; column count == discovery count; symmetry; per-tenant exactly-1; bypass exactly-2 (or 3 for mcp_clients) | Predicate bugs (cross-tenant leak, dropped bypass, asymmetric mutation policies, drifted manifest, removed/added column without policy) |
+| Negative test (gate self-check) | Verify exits non-zero against a deliberately-broken throwaway-table policy | Regression in the verify step itself (e.g., refactor that turns the gate vacuous) |
+
+### Manual sanity check (negative cases beyond the automated gate self-check)
+
+The automated negative test exercises the throwaway-table case. For broader confidence, the following are run manually before merge (NOT committed):
+
+| Negative case | Mutation | Expected outcome |
+|---|---|---|
+| Predicate too permissive | Edit a real table's policy to `USING (true)` | Block 2/3 fails on that table |
+| Predicate omits tenant filter | Edit policy to `USING (current_setting('app.tenant_id', true) IS NOT NULL)` | Block 2 fails (count = 2) |
+| Bypass clause dropped | Edit policy to `USING (tenant_id = current_setting('app.tenant_id', true)::uuid)` | Block 4 fails (count = 0) |
+| Asymmetric USING/WITH CHECK | Edit policy with `USING (...)` ≠ `WITH CHECK (...)` | Block 1 symmetry guard fails |
+| NULL USING clause | Edit policy with `USING NULL` | Block 1 non-NULL guard fails |
+| Manifest drift | Add a new table with policy + column but forget the manifest entry | Block 1 manifest-parity fails — message names the missing manifest entry |
+| Column added without policy | Add `tenant_id` column without policy | Block 1 column-parity fails |
+
+## Manual test plan (inlined)
+
+### Pre-conditions
+
+```bash
+# Local docker stack
+npm run docker:up
+npm run db:migrate
+
+# Confirm passwd_app role exists locally; if not, run the role-creation SQL from
+# .github/workflows/ci.yml lines 432-446 against the dev DB once (see "Initial setup" below).
+
+# Confirm passwd_app can read pg_policy (S13 pre-merge verification)
+psql "postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso" \
+  -c "SELECT count(*) FROM pg_catalog.pg_policy WHERE polname = 'tenant_isolation' OR polname LIKE '%\_tenant_isolation' ESCAPE '\';"
+# Expected: ~53 (current count of tenant-scoped tables — re-derive from live DB if schema changed). If 0: STOP — passwd_app lacks SELECT on pg_policy. Plan needs structural revision.
+
+# Confirm role flags
+psql "postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso" \
+  -c "SELECT rolname, rolsuper, rolbypassrls FROM pg_roles WHERE rolname = 'passwd_app';"
+# Expected: rolname=passwd_app, rolsuper=f, rolbypassrls=f
+
+# Set env vars for the local docker stack
+export MIGRATION_DATABASE_URL="postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso"
+export APP_DATABASE_URL="postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso"
+```
+
+### Initial setup (only if `passwd_app` does not exist locally)
+
+Extract from `.github/workflows/ci.yml:432-446` and run as `passwd_user`. The existing CI doc references this; not duplicated here.
+
+### Steps
+
+1. **Cross-tenant seed**:
+   ```bash
+   psql -v ON_ERROR_STOP=1 "$MIGRATION_DATABASE_URL" -f scripts/rls-cross-tenant-seed.sql
+   ```
+   Expected: exit 0.
+
+2. **Coverage check**:
+   ```bash
+   psql -v ON_ERROR_STOP=1 "$MIGRATION_DATABASE_URL" -f scripts/rls-cross-tenant-coverage.sql
+   ```
+   Expected: exit 0. NOTICE lines for failures (multi-table accumulator).
+
+3. **Verify (as passwd_app)**:
+   ```bash
+   EXPECTED_TABLES=$(awk 'NF && $1 !~ /^#/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print}' \
+      scripts/rls-cross-tenant-tables.manifest | paste -sd,)
+   psql -v ON_ERROR_STOP=1 -v expected_tables="$EXPECTED_TABLES" \
+     "$APP_DATABASE_URL" -f scripts/rls-cross-tenant-verify.sql
+   ```
+   Expected: exit 0.
+
+4. **Gate self-check (negative test)**:
+   ```bash
+   bash scripts/rls-cross-tenant-negative-test.sh
+   ```
+   Expected: exit 0 (the script asserts the verify caught the deliberately-broken throwaway-table policy and DROP succeeded).
+
+5. **Adversarial sanity** (operator-driven): apply a manual mutation from the table above, re-run step 3, confirm exit non-zero with the offending table name. Restore via `prisma migrate reset` or by re-running migrations.
+
+### Rollback
+
+Nothing to roll back — the new files are additive. If the new CI steps fail on main, revert the workflow YAML changes; the SQL/shell files are inert without the workflow steps invoking them.
+
+## Pre-merge verification checklist
+
+Before submitting the PR, the implementer runs each item; all must pass.
+
+- [ ] **Discovery accessibility**: `psql -U passwd_app … -c "SELECT count(*) FROM pg_catalog.pg_policy WHERE polname='tenant_isolation' OR polname LIKE '%\_tenant_isolation' ESCAPE '\';"` returns ~53 (NOT 0). If 0, add `GRANT SELECT ON pg_catalog.pg_policy TO passwd_app` to the role-creation script — and update the plan accordingly.
+- [ ] **Manifest equality**: discovery output (as passwd_app) matches the committed manifest exactly.
+- [ ] **mcp_clients symmetry confirmed**: code-inspected and verified symmetric in `migrations/20260328075528_*/migration.sql:45-57`.
+- [ ] **Manual test plan steps 1-5 all pass** locally.
+- [ ] **One adversarial mutation** from the manual table runs and produces a non-zero exit with the offending table name.
+
+## Considerations & constraints
+
+### Risks (revised)
+
+1. **Seed file drift** — adding a new tenant-scoped table without updating the seed file. Mitigation: coverage check fails loudly; failure points at the seed file.
+
+2. **Manifest drift** (replaces "floor too low"): the manifest must equal the discovery output. Adding/removing a tenant-scoped table requires editing the manifest in the same PR; a removal is an explicit table-name diff — much harder to overlook in code review than a numeric decrement.
+
+3. **NOT NULL / FK chain complexity** — chains can be 3-5 levels deep. The seed file enumerates these in dependency order with comments.
+
+4. **Convention drift** — discovery filter matches `tenant_isolation` and `<table>_tenant_isolation`. Other policy names are silently excluded — but the manifest equality check catches this if any future policy doesn't match (the table would appear in the manifest but not in the discovery → assertion fails).
+
+5. **CI runtime** — estimated <2 min for ~53 tables × 4 query passes + the negative-test wrapper (~30 s). Within the 10-min job timeout.
+
+6. **`current_setting('app.tenant_id', true)` semantics** — when unset, returns NULL → `tenant_id = NULL` → falsy. Setting to `''` raises `invalid input syntax for type uuid`; do NOT use `SET app.tenant_id = ''`. Either leave unset, RESET, or set to a valid UUID.
+
+7. **Transaction model and `SET LOCAL` scoping** — psql autocommits each top-level statement; each `DO $$ … END $$` is one top-level statement, so `SET LOCAL` inside it is scoped to that block's implicit transaction. **DO NOT** wrap the file in `BEGIN…COMMIT` and **DO NOT** invoke psql with `--single-transaction` — both would merge all five DO blocks into one transaction, causing Block 4's `app.bypass_rls = 'on'` to leak into subsequent assertions in the same psql session and false-green predicate regressions. The verify file's header comment enforces this.
+
+8. **Defensive `SET LOCAL` verification** — every block uses `ASSERT current_setting(...) = '<expected>'` after each `SET LOCAL` to confirm the GUC took effect. Catches a hypothetical future runtime regression in `SET LOCAL` semantics before per-table assertions run.
+
+9. **`app.bypass_rls` is a soft GUC** — `passwd_app` can `SET app.bypass_rls = 'on'`. NOBYPASSRLS (Postgres-engine attribute) and `app.bypass_rls` (policy-evaluated GUC) are independent. SQL injection on a `passwd_app` session can defeat RLS by setting this GUC. **Documented in the verify SQL comment AND tracked as a follow-up issue alongside this PR's merge** (item 9 of Implementation steps).
+
+10. **Defense-in-depth on dynamic SQL** — `format('%I', t)` is the safe identifier-quoting specifier; `t` comes from `pg_class` (system catalog, trusted). The defensive `ASSERT t ~ '^[a-z_][a-z0-9_]*$'` in the loop is belt-and-suspenders. The Block 4 `filter_clause` mixes `%I` and `%L` and is interpolated into a larger `format(... %s ...)` — this is safe because `filter_clause` is built from constants only (UUIDs from the seed file). A SQL comment near each `EXECUTE` documents this and forbids extending `filter_clause` to user input.
+
+11. **Symmetry guard textual edge cases** — `pg_get_expr(qual, ...) IS DISTINCT FROM pg_get_expr(with_check, ...)` compares canonicalized expression text from the deparser. False-positive (cosmetic deparser difference flagging as asymmetric) is theoretically possible but produces a loud failure that's recoverable by inspecting `pg_get_expr` output directly. False-negative (semantically asymmetric but textually equal) is excluded by the deparser's canonicalization. Documented in the SQL comment.
+
+12. **Negative-test SIGKILL** — bash trap fires on EXIT/ERR/INT/TERM, not SIGKILL. CI Postgres is per-job and ephemeral; a leaked throwaway table is discarded with the runner. Documented; do NOT run the script against shared/persistent DB without modification.
+
+### Constraints honored
+
+- No new container, no new package.
+- Same `passwd_app` / `passwd_user` role pattern.
+- Same psql + DO-block ASSERT idiom.
+- Manifest file is a flat text file — no new tooling.
+
+### What this does NOT solve (decided in plan review)
+
+1. **Existing `rls-smoke-seed.sql` / `rls-smoke-verify.sql` narrow scope (S7)**: the existing smoke check covers only 7 of ~53 tenant-scoped tables. The new cross-tenant verify supersedes it in COVERAGE breadth, but they verify different invariants (without-GUC default invisibility vs cross-tenant predicate correctness). KEEP existing files unchanged in this PR. Filing a follow-up issue alongside merge to either auto-discover the without-GUC seed/verify too, or formally retire it.
+
+2. **Mutation tests for INSERT/UPDATE/DELETE predicates**: not added. Block 1 USING ↔ WITH CHECK symmetry assertion is the trigger for adding mutation tests in a follow-up plan if symmetry breaks.
+
+3. **`app.bypass_rls` GUC hardening**: out of scope; **follow-up issue filed alongside this PR's merge** (item 9 of Implementation steps).
+
+4. **CODEOWNERS introduction**: out of scope unless `.github/CODEOWNERS` already exists. Not required for safety because the manifest replaces the soft floor — additions/removals are explicit table-name diffs visible in code review without specialized tooling.
+
+## User operation scenarios
+
+### Scenario 1: Developer adds a new tenant-scoped table (NOT NULL tenant_id)
+
+1. Adds the model + migration (column, ENABLE/FORCE RLS, `<table>_tenant_isolation` policy) → `check-migration-drift.mjs` passes.
+2. CI:
+   - Existing `rls-smoke` (7-table list) → passes (new table not in list).
+   - **NEW** Cross-tenant seed → succeeds (new table has 0 rows).
+   - **NEW** Cross-tenant coverage check → **FAILS**: `Table foo_bars expected exactly 1 row for tenant A, found 0 — fix rls-cross-tenant-seed.sql`.
+3. Developer adds INSERTs for tenant A and B in the seed (dependency-ordered) AND appends the table name to `scripts/rls-cross-tenant-tables.manifest`. Re-pushes.
+4. CI green. Block 1 manifest-parity passes (manifest matches discovery). Block 2/3 pass (count = 1 per tenant). Block 4 passes (count = 2 with bypass).
+
+### Scenario 2: Defective predicate caught by Blocks 2/3
+
+A migration writes `USING (tenant_id = '00000000-...AAAA-...')` (developer pasted a literal UUID). CI:
+- `check-migration-drift.mjs` passes; existing `rls-smoke` passes; coverage passes.
+- **NEW** Verify Block 2 fails — the policy ignores the GUC. NOTICE: `FAIL table=foo block=verify-A tenant=A expected=1 got=2 — likely cause: policy bug`. Block 2 ends with `RAISE EXCEPTION` — exit non-zero.
+
+### Scenario 3: Asymmetric USING/WITH CHECK introduced
+
+A migration writes `USING (tenant_id = current_setting(...))` + `WITH CHECK (true)`. CI:
+- Block 1 symmetry guard fails: `A tenant_isolation policy has asymmetric USING vs WITH CHECK`.
+
+### Scenario 4: Bypass channel regression
+
+Migration removes the `OR app.bypass_rls = 'on'` clause. CI:
+- Existing rls-smoke passes; coverage passes; Block 2/3 pass (tenant filter still works).
+- Block 4 fails: count = 0 (no GUC, no bypass admission) instead of 2.
+
+### Scenario 5: Verify step itself regresses (gate self-check)
+
+Refactor changes `expected := 1` to `expected := count` (vacuous). CI:
+- Cross-tenant verify passes (vacuously).
+- **NEW** Cross-tenant verify negative test fails: throwaway table with `USING (true)` admits 2 rows; the (now-broken) verify reports 2 = 2, exits 0; the negative-test wrapper expected non-zero → fails with `Negative test: verify exited 0 against a deliberately-broken policy — gate is broken (vacuous pass)`.
+
+### Scenario 6: Discovery accessibility silently broken (S13 hypothetical)
+
+If a future change causes `passwd_app` to lose SELECT on `pg_policy`:
+- Block 1 discovery accessibility self-test fails immediately: `passwd_app cannot read pg_policy — discovery is broken`.
+- Operator restores the grant or revises the role-creation script.
+
+### Scenario 7: Local re-run
+
+See §Manual test plan above.

--- a/docs/archive/review/verify-rls-predicate-plan.md
+++ b/docs/archive/review/verify-rls-predicate-plan.md
@@ -229,10 +229,17 @@ Three new SQL artifacts plus one shell wrapper:
      filter_clause text;
      failures int := 0;
    BEGIN
-     RESET app.tenant_id;  -- no-op-safe: SET LOCAL from Block 3 already discarded at txn boundary
+     -- IMPORTANT: cannot use `RESET app.tenant_id`. Postgres quirk: once a
+     -- custom GUC has been SET in a session, current_setting(name, true)
+     -- returns '' rather than NULL even after RESET / DISCARD ALL. The
+     -- policy's `current_setting('app.tenant_id', true)::uuid` cast then
+     -- raises `invalid input syntax for type uuid: ""` BEFORE the OR-bypass
+     -- clause can short-circuit. Use the nil-UUID instead — it parses
+     -- cleanly, matches no real tenant, and lets bypass drive visibility.
+     SET LOCAL app.tenant_id = '00000000-0000-0000-0000-000000000000';
      SET LOCAL app.bypass_rls = 'on';
-     ASSERT current_setting('app.tenant_id', true) IS NULL OR current_setting('app.tenant_id', true) = '',
-       'pre-Block-4: app.tenant_id must be unset (the RESET above should have ensured this)';
+     ASSERT current_setting('app.tenant_id', true) = '00000000-0000-0000-0000-000000000000',
+       'pre-Block-4: SET LOCAL app.tenant_id (nil sentinel) failed';
      FOR t IN (<discovery query>) LOOP
        expected := CASE t WHEN 'mcp_clients' THEN 3 ELSE 2 END;
        -- filter_clause built from constants only (UUID literals from the seed). NEVER pass user input here.
@@ -737,3 +744,34 @@ If a future change causes `passwd_app` to lose SELECT on `pg_policy`:
 ### Scenario 7: Local re-run
 
 See §Manual test plan above.
+
+## Implementation Checklist
+
+### Files to create
+- `scripts/rls-cross-tenant-tables.manifest` — 53 tenant-scoped tables (alphabetical, current count from live DB)
+- `scripts/rls-cross-tenant-seed.sql` — seed two tenants (`…000A0`, `…000B0`) + 1 row per tenant per table; mcp_clients NULL row
+- `scripts/rls-cross-tenant-coverage.sql` — single DO block, asserts exactly 1 row per tenant per discovered table (as `passwd_user`)
+- `scripts/rls-cross-tenant-verify.sql` — 5 DO blocks with stable `[E-RLS-*]` codes (as `passwd_app`)
+- `scripts/rls-cross-tenant-negative-test.sh` — Case 0 (pre-flight) + 5 cases + accumulator
+
+### Files to modify
+- `.github/workflows/ci.yml` — add 4 steps to the `rls-smoke` job + path filter additions to the `changes` job's `app` filter
+- `scripts/pre-pr.sh` — add a `pg_isready`-gated SQL parse-check entry
+
+### Shared utilities to reuse (none — all rls-smoke files are bespoke SQL)
+- pre-pr.sh `run_step "label" command...` pattern (referenced in implementation step 8)
+- existing role-creation SQL from `.github/workflows/ci.yml:432-446` (re-used unchanged)
+- `psql -v ON_ERROR_STOP=1` invocation pattern (existing rls-smoke style)
+- DO `$$` … `ASSERT` … `$$` PL/pgSQL idiom (existing `rls-smoke-verify.sql` style)
+
+### Empirically-verified preconditions (from local docker stack pre-flight)
+- 53 tenant-scoped tables exist in the live schema (matches plan's expected count)
+- `passwd_app` (NOSUPERUSER, NOBYPASSRLS) **CAN** read `pg_catalog.pg_policy` directly — discovery query returns 53 rows. No `GRANT SELECT ON pg_catalog.pg_policy TO passwd_app` needed in role-creation script (S13 fully resolved).
+- `passwd_user` is SUPERUSER, BYPASSRLS — fits the seed/coverage role
+- `mcp_clients_tenant_isolation` policy USING ≡ WITH CHECK (matches plan claim — F20 resolved)
+- All 53 policies follow `<table>_tenant_isolation` suffix convention; bare-name `tenant_isolation` returns 0 (defensive OR-branch retained)
+
+### Pattern consistency
+- New SQL files mirror `scripts/rls-smoke-seed.sql` / `scripts/rls-smoke-verify.sql` style (header comment, ASSERT idiom, GRANT semantics)
+- Stable error codes `[E-RLS-*]` are a NEW convention introduced by this PR; documented in the verify file header
+- Manifest file is a new artifact; flat text, alphabetical, comment-prefixed maintenance contract

--- a/docs/archive/review/verify-rls-predicate-review.md
+++ b/docs/archive/review/verify-rls-predicate-review.md
@@ -1,0 +1,368 @@
+# Plan Review: verify-rls-predicate
+Date: 2026-05-04
+Review rounds: 5 (converged at "READY TO MERGE")
+
+## Round 5 — Convergence
+
+Combined functionality + security + testing single-pass review verified all R4 Major findings (F34/T28, T29, T30, T31) are RESOLVED:
+
+- **F34/T28 (pre-pr.sh)**: sketch passes stub `expected_tables=users`, accepts `[E-RLS-MANIFEST-(EXTRA|MISSING)]` as parse-OK, uses `--single-transaction` for atomic rollback.
+- **T29 (Block 1 ordering)**: NULL-clause guard now runs BEFORE symmetry guard (item 3 vs item 4); rationale documented.
+- **T30 (Case 5 deterministic)**: Case 5 uses `$CANONICAL_POLICY`, only `[E-RLS-MANIFEST-MISSING]` can fire.
+- **T31 (stable error codes)**: 10 codes embedded in ASSERTs (`[E-RLS-ROLE]`, `[E-RLS-DISCOVER]`, `[E-RLS-NULL]`, `[E-RLS-SYM]`, `[E-RLS-COLPARITY]`, `[E-RLS-MANIFEST-EXTRA]`, `[E-RLS-MANIFEST-MISSING]`, `[E-RLS-COUNT-A]`, `[E-RLS-COUNT-B]`, `[E-RLS-BYPASS]`); driver uses `grep -qF` (literal match).
+
+R4 Minors (T32 Case 0 pre-flight, T33 accumulator) also addressed.
+
+### R5 new findings (3 Minors, none blocking)
+- M1: pre-pr.sh sketch retains `grep -qE` for the `(EXTRA|MISSING)` alternation — intentional, acceptable.
+- M2: Block 2/3/4 prelude ASSERTs (`pre-Block-2:`) lack `[E-RLS-...]` prefix — not negative-test-targeted, acceptable.
+- M3: Defensive `ASSERT t ~ regex` lacks code prefix — same rationale.
+
+**Convergence verdict: READY TO MERGE.** Recommended proceeding to Phase 2 (Coding).
+
+## Round 4 — major fixes & new findings
+
+R3→R4 transitions resolved 7 Major + many Minor findings. New R4 Majors:
+- F34/T28 — pre-pr.sh sketch missing `-v expected_tables`
+- T29 — Block 1 NULL-clause / symmetry order cross-fire
+- T30 — Case 5 manifest drift policy state unspecified
+- T31 — Regex-based expected_failure_pattern fragile
+
+All resolved in plan v5 (see Round 5 above).
+
+## Round 3 — major fixes & new findings
+
+R2→R3 transitions: floor → manifest, pg_policies → pg_policy, capture/restore → throwaway-table negative test. New R3 Majors (F25, F26, S12, S13, T11, T12, T22, T24) all resolved in plan v4.
+
+## Round 2 — Changes from Round 1
+
+## Round 2 — Changes from Previous Round
+
+Plan v2 was rewritten to address all 3 Critical and 9 Major findings from Round 1:
+- Floor 23 → manifest file `scripts/rls-cross-tenant-tables.manifest` (replaces numeric floor entirely; addresses S3 / S5 / S12 / F18 silent-shrink concerns)
+- Discovery LIKE pattern fixed (matches bare and suffixed names)
+- mcp_clients NULL-row added to seed; per-table override map for verify and bypass blocks
+- Bypass count uses `count(*) FILTER (...)` form to avoid collision with existing rls-smoke-seed rows
+- Risk #6 transaction-model justification rewritten; file header forbids BEGIN/COMMIT and `--single-transaction`; defensive `ASSERT current_setting()` guards added in each block
+- Coverage strengthened to `=1`; ASSERT messages enriched with cause hints
+- Block 1 parity assertion (column count vs discovery count) added
+- Block 1 role-flag checks include session_user, is_superuser
+- USING ↔ WITH CHECK runtime symmetry guard added (Block 1) — using `IS DISTINCT FROM` form (NULL-aware) plus a non-NULL guard
+- Negative test added as 4th CI step using an **ephemeral throwaway table** (eliminates capture/restore corruption risk on real `users` policy)
+- Block 4 explicitly `RESET app.tenant_id` to test bypass channel in isolation
+- Manual test plan inlined with concrete env-var values for the local docker stack
+- ASSERT-halt-on-first-failure replaced with `RAISE NOTICE` + accumulator + final `RAISE EXCEPTION` pattern in Blocks 2/3/4 (multi-table failures surface in one CI run)
+- Discovery query switched from `pg_policies` view to `pg_catalog.pg_policy` table to avoid the role-USAGE filter that may hide policies from `passwd_app` (S13)
+- Discovery-accessibility self-test added in Block 1 (loud failure if `passwd_app` can't read `pg_policy`)
+- Pre-merge verification checklist added
+- Two follow-up issues committed in Implementation step 9: app.bypass_rls hardening; rls-smoke-seed expansion or retirement
+- F20 confirmed by code inspection (live mcp_clients policy is symmetric — no exception needed)
+
+## Round 2 Findings
+
+### Functionality (Round 2)
+
+#### F18 [Major]: Floor==parity-target framing has weak defense-in-depth
+- File: plan v2 line 215-216
+- Resolution: **RESOLVED in plan v3**. Numeric floor replaced with manifest file; manifest equality check makes silent-shrink scenarios impossible without an explicit table-name diff.
+
+#### F19 [Major]: COALESCE form of symmetry guard masks NULL=NULL case
+- File: plan v2 line 94 (was `COALESCE(qual::text, '') <> COALESCE(with_check::text, '')`)
+- Resolution: **RESOLVED in plan v3**. Switched to `pg_get_expr(p.polqual, p.polrelid) IS DISTINCT FROM pg_get_expr(p.polwithcheck, p.polrelid)`. Added a separate non-NULL guard for `polqual IS NULL OR polwithcheck IS NULL`.
+
+#### F20 [Major]: mcp_clients live policy may be asymmetric
+- Resolution: **RESOLVED by code inspection**. `prisma/migrations/20260328075528_add_rls_machine_identity_tables/migration.sql:45-57` confirms USING ≡ WITH CHECK using the standard symmetric template. No exception list needed in symmetry guard. Added explicit note in §Special cases.
+
+#### F21 [Minor]: mcp_clients bypass FILTER doesn't separately assert NULL row
+- Resolution: **RESOLVED in plan v3**. Block 4 explicitly asserts `count(*) FROM mcp_clients WHERE tenant_id IS NULL = 1` after the FILTER form check.
+
+#### F22 [Minor]: Negative-test broken-policy window race
+- Resolution: **RESOLVED in plan v3** structurally — the negative test now uses an **ephemeral throwaway table** instead of mutating a real production-table policy. There is no broken state of any real policy at any point. Sequencing constraint comment retained in script header.
+
+#### F23 [Minor]: pg_get_expr round-trip may not be byte-identical
+- Resolution: **RESOLVED in plan v3** structurally — same as F22. The throwaway-table approach eliminates the capture/restore problem because there is no real policy to round-trip. The test simply DROPs the throwaway table at end.
+
+#### F24 [Minor]: Block 4 RESET commentary slightly misleading
+- Resolution: **RESOLVED in plan v3**. Block 4 commentary now says: "no-op-safe: SET LOCAL from Block 3 already discarded at txn boundary". RESET retained as defensive intent marker.
+
+### Security (Round 2)
+
+#### S11 [Minor]: Text-equality symmetry guard has theoretical edge cases
+- Resolution: **RESOLVED in plan v3**. SQL comment near the symmetry guard explicitly documents the false-positive vs false-negative tradeoff.
+
+#### S12 [Major]: No in-PR friction for floor decrements
+- Resolution: **RESOLVED in plan v3**. Replaced floor with a manifest file. Adding/removing a table requires editing a named-line entry; the diff is scrutable in code review without specialized tooling.
+
+#### S13 [Major]: passwd_app may not see policies via pg_policies (role-USAGE filter)
+- Resolution: **STRUCTURALLY ADDRESSED in plan v3**. Discovery switched from `pg_policies` view to `pg_catalog.pg_policy` table. Block 1 includes a discovery-accessibility self-test (`SELECT count(*) FROM pg_policy ... > 0`) that fails loudly if `passwd_app` lacks SELECT — catches the silent-zero-discovery failure mode before any per-table assertion. Pre-merge verification checklist requires running this query manually before submitting the PR.
+
+#### S14 [Minor]: app.bypass_rls follow-up not committed
+- Resolution: **RESOLVED in plan v3**. Implementation step 9 explicitly commits to filing two follow-up issues alongside merge.
+
+#### S15 [Minor]: SIGKILL would skip trap
+- Resolution: **DOCUMENTED in plan v3**. CI Postgres is ephemeral; leaked throwaway table is discarded with the runner. Header comment makes the constraint explicit.
+
+#### S16 [Minor]: Manual test pre-condition insufficient
+- Resolution: **RESOLVED in plan v3**. Manual test plan pre-conditions now include explicit psql precheck commands for `passwd_app` role + role flag verification + discovery accessibility.
+
+### Testing (Round 2)
+
+#### T11 [Major]: Negative test pre-condition not asserted (canonical-shape invariant)
+- Resolution: **RESOLVED in plan v3** structurally — same fix as F22. Throwaway-table approach eliminates the canonical-shape capture concern because there's no real policy state to capture.
+
+#### T12 [Major]: Manual test plan env-var defaults missing
+- Resolution: **RESOLVED in plan v3**. Pre-conditions section includes concrete `MIGRATION_DATABASE_URL` and `APP_DATABASE_URL` strings for the local docker stack.
+
+#### T13 [Minor → upgraded]: T7 deferred status warrants explicit cost statement
+- Resolution: **RESOLVED in plan v3**. Implementation step 8 adds a `scripts/pre-pr.sh` syntax-check entry as short-term mitigation; if `pre-pr.sh` doesn't exist, the step files a follow-up issue.
+
+#### T14 [Minor]: ASSERT halts on first failure — multi-table CI failures
+- Resolution: **RESOLVED in plan v3**. Blocks 2/3/4 now use `RAISE NOTICE` accumulator + final `RAISE EXCEPTION` pattern. Multi-table breakage surfaces all failing tables in one CI run.
+
+#### T15 [Minor]: Defensive note on textual symmetry check edge cases
+- Resolution: **RESOLVED in plan v3**. SQL comment near symmetry guard documents the false-positive recoverability path.
+
+#### T16 [Minor]: %s interpolation in Block 4 needs comment
+- Resolution: **RESOLVED in plan v3**. Comment near `EXECUTE format(... %s ...)` documents that `filter_clause` is built from constants only and forbids extending to user input.
+
+#### T17 [Minor]: Negative-test single-table target brittleness
+- Resolution: **RESOLVED in plan v3** structurally — same fix as F22. Throwaway table eliminates dependency on a specific real-table.
+
+#### T18 [Adjacent]: app.bypass_rls follow-up
+- Resolution: **RESOLVED in plan v3** via S14 fix.
+
+## Round 1 Findings (preserved for traceability)
+
+### Original summary (Round 1)
+
+## Summary
+
+Three experts (Functionality / Security / Testing) reviewed the plan at `docs/archive/review/verify-rls-predicate-plan.md`.
+
+- **3 Critical findings** — all on coverage / discovery completeness:
+  - The cited table count (23) is wrong by ~30 tables; actual is ~52
+  - Discovery `LIKE '%_tenant_isolation'` excludes the existing bare-named `tenant_isolation` policy on `team_policies`
+  - `mcp_clients.tenant_id` is nullable; "exactly 1 row per tenant" assertion is fragile and the NULL-tenant invisibility case is unverified
+- **9 Major findings** — fail-mode attribution, transaction reasoning, missing guards (USING == WITH CHECK symmetry, policies-must-not-decrease floor), Block 4 redundancy, manual-test.md not delivered, negative-cases manual-only
+- **~10 Minor / Adjacent**
+
+## Functionality Findings
+
+### F1 [Critical]: EXPECTED_MIN_TENANT_SCOPED_TABLES = 23 is wrong by ~30 tables
+- **File**: `docs/archive/review/verify-rls-predicate-plan.md:79, :139, :184`
+- **Evidence**: Counting unique tables with `*_tenant_isolation` policy across ALL migrations yields ~52, not 23. The phase7 migration is only the initial batch; `access_requests`, `audit_chain_anchors`, `audit_outbox`, `directory_sync_*`, `notifications`, `service_accounts`, `tenant_members`, `webauthn_credentials`, etc. were added later.
+- **Problem**: `ASSERT discovered_count >= 23` will silently pass with only 23 tables seeded — defeats the "loud failure" requirement.
+- **Fix**: Run the actual discovery query during implementation; set the floor to the real number. Update plan text to "currently ~52 (verify with `SELECT count(*) FROM pg_policies WHERE policyname ~ 'tenant_isolation'`)". Document that the bump is required on EVERY new tenant-scoped table.
+
+### F2 [Critical]: Discovery filter `policyname LIKE '%_tenant_isolation'` excludes `team_policies`
+- **File**: plan:60-65
+- **Evidence**: `prisma/migrations/20260301210000_add_team_policy/migration.sql:39` and `…20260302130000_fix_team_policy_rls/migration.sql` both create the policy as `CREATE POLICY "tenant_isolation" ON "team_policies"` with bare name (no table prefix). SQL `_` is single-char wildcard, so `'tenant_isolation'` does NOT match `'%_tenant_isolation'` (no leading char available).
+- **Problem**: `team_policies` (a tenant-scoped table holding cross-tenant policy data) is silently excluded from auto-discovery. The plan's own guard ("`check-migration-drift.mjs` is the upstream guard") is incorrect — the drift check requires `\\S*tenant_isolation` which DOES match the bare name.
+- **Fix**: Change LIKE to `(policyname = 'tenant_isolation' OR policyname LIKE '%_tenant_isolation')` OR `policyname ~ 'tenant_isolation$'`. Add a defense-in-depth assertion: every table with a `tenant_id` column must appear in the discovered set.
+
+### F3 [Critical]: `mcp_clients.tenant_id` is nullable; NULL-row invisibility unverified
+- **File**: plan:21-22, :76-77
+- **Evidence**: `prisma/schema.prisma` declares `model McpClient { tenantId String? }` — the only nullable `tenantId` in the schema. DCR pre-claimed clients have `tenant_id IS NULL`.
+- **Problem**: The `count = 1` assertion under `app.tenant_id = '<A>'` is correct only because no NULL row exists in the test DB. A future predicate bug like `USING (tenant_id IS NULL OR tenant_id = current_setting(…))` (a plausible attempt to "include unclaimed clients in tenant view") would make NULL rows visible to every tenant — but the assertion still sees count = 1 if no NULL rows are seeded.
+- **Fix**: Seed a third row in `mcp_clients` with `tenant_id = NULL`. Per-tenant assertion remains `count = 1`. Bypass-block expected count for `mcp_clients` becomes 3, not 2 — implement via per-table override map keyed by table name.
+
+### F4 [Major]: Bypass-block `count = 2` will collide with existing `rls-smoke-seed.sql` rows
+- **File**: plan:78, :138, :102 ("existing rls-smoke files NOT modified")
+- **Evidence**: Existing `rls-smoke-seed.sql:30-57` seeds 1 row of 7 tables under tenant `…0001`. After both seeds run in the same `rls-smoke` job, those tables have 3 rows total (existing + A + B) — bypass-block ASSERT count=2 fails on every overlapping table.
+- **Problem**: CI step will fail in its current form with no policy bug — pure seed-data interference. Implementer may "fix" by weakening to `count >= 1`, gutting the test.
+- **Fix**: Replace the absolute `count = 2` with `count(*) FILTER (WHERE tenant_id IN ('<A>', '<B>')) = 2`. (For mcp_clients per F3, the FILTER is `tenant_id IN ('<A>', '<B>') OR tenant_id IS NULL` — but counting NULLs requires `count(*) FILTER (WHERE tenant_id IN ('<A>', '<B>') OR tenant_id IS NULL) = 3`.)
+
+### F5 [Major]: Transaction-model justification text is inaccurate (conclusion correct)
+- **File**: plan:194 (Risk #6)
+- **Evidence**: Plan says "Each `DO $$` block is itself a transaction (PL/pgSQL function call)". Technically false — `DO` runs in the calling transaction; it does not create a subtransaction. The correct mechanism: psql autocommits each top-level statement; `DO $$ … END $$` is one top-level statement, so it gets its own implicit txn, so `SET LOCAL` is reset between top-level statements.
+- **Problem**: A future maintainer wrapping the file in `BEGIN…COMMIT` (or invoking psql with `--single-transaction`) silently turns Block 2/3/4's `SET LOCAL` from per-block to file-wide — Block 4's `app.bypass_rls = 'on'` would leak into a subsequent assertion in the same session, false-greening predicate regressions.
+- **Fix**: (1) Restate Risk #6 with correct mechanism. (2) Forbid `BEGIN…COMMIT` and `--single-transaction` wrapping at the top of the file with a `-- DO NOT WRAP IN TRANSACTION` comment. (3) Add defensive guards at the start of each block: `ASSERT current_setting('app.bypass_rls', true) IN ('', NULL)` before Block 2/3, and `ASSERT current_setting('app.tenant_id', true) = '<A>'` after each `SET LOCAL` to verify the GUC is actually what we think it is. (See also S1 — same finding routed via Security.)
+
+### F6 / T4 [Major]: Failure-mode attribution conflated; coverage `≥1 exists` weaker than verify `=1`
+- **File**: plan:130-132, :241-246, :76-77
+- **Evidence**: Coverage check uses `WHERE tenant_id = '<A>'` and asserts existence (≥1); verify asserts `count = 1`. If seed accidentally inserts 2 rows for tenant A, coverage passes, verify fails with policy-bug-shaped message ("expected 1 got 2").
+- **Problem**: Asymmetric assertions create an ambiguity zone where seed bugs present as policy bugs, eroding trust in the gate.
+- **Fix**: (1) Strengthen coverage to `ASSERT n = 1` (exactly one). (2) ASSERT messages embed expected/actual + cause hint: `format('table=%I block=verify tenant=%s expected=1 got=%s — likely cause: policy bug (cross-tenant leak) — coverage already confirmed exactly 1 row in DB', t, '<A>', n)`.
+
+### F7 [Major]: Per-table seed cost understated; Scenario 1 overstates simplicity
+- **File**: plan:116-117, :128, :211-220
+- **Evidence**: FK chains 3-5 deep. `team_password_favorites` requires `users → tenants → teams → team_members → team_password_entries → team_password_favorites`. `mcp_refresh_tokens` requires `mcp_clients → mcp_access_tokens`. Scenario 1 says "developer adds two INSERT lines"; actual is dependency-ordered inserts across multiple file sections.
+- **Fix**: Update Scenario 1 to enumerate (1) dependency-ordered INSERTs, possibly across sections; (2) bump floor; (3) verify locally. Re-estimate runtime as <2 min for ~55 tables × 4 query passes (still well within the 10-min job timeout).
+
+### F8 [Major]: Tables with `tenant_id` column but missing policy are silently excluded
+- **File**: plan:50-66 (discovery intersection)
+- **Evidence**: Plan punts the "column exists but policy missing" invariant to `check-migration-drift.mjs` (separate job). If that check is skipped or its job fails, this runtime check still reports green.
+- **Problem**: Defense-in-depth gap; violates "loud failure mode" within this CI step.
+- **Fix**: Add a Block 1 assertion: `(SELECT count(*) FROM information_schema.columns WHERE table_schema='public' AND column_name='tenant_id' AND table_name <> 'tenants') = (count of discovered tables)`. Failure message names which side is short and which table is missing.
+
+### F9 [Major]: Block 1 role-flag checks miss `session_user` vs `current_user`
+- **File**: plan:75, :135
+- **Evidence**: Plan asserts `current_user = 'passwd_app'`, `NOT rolsuper`, `NOT rolbypassrls`. Does not check `session_user` or `current_setting('is_superuser')`.
+- **Problem**: A misconfigured invocation that runs `psql … as superuser …` then `SET ROLE passwd_app` would pass the existing checks but the privilege evaluation may differ in subtle ways.
+- **Fix**: Add `ASSERT session_user = current_user, 'session_user must equal current_user (no SET ROLE expected)'` and `ASSERT current_setting('is_superuser') = 'off'`.
+
+### F10 [Minor]: ID assignment scheme for child rows unspecified (PK collision risk)
+- **Fix**: State explicitly: child rows use `gen_random_uuid()`; only tenant rows themselves use deterministic UUIDs (`…000A0` / `…000B0`).
+
+### F11 [Minor]: USING == WITH CHECK symmetry has no automated guard (see also S2 Major)
+- **Fix**: Add runtime check: `ASSERT NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND policyname ~ 'tenant_isolation' AND COALESCE(qual::text, '') != COALESCE(with_check::text, ''))`. Failure message names the asymmetric policy.
+
+### F12 [Minor]: Risk #5 reasoning about `current_setting('app.tenant_id')` comparison incorrect
+- **Evidence**: `tenant_id::uuid = ''::text` raises `invalid input syntax for type uuid` (an error), not silently false. NULL → `uuid = NULL` → NULL → falsy in USING.
+- **Fix**: Restate Risk #5: when unset, returns NULL → falsy. Setting to `''` raises an error — do NOT use `SET app.tenant_id = ''`; either leave unset or use a valid UUID.
+
+### F13 [Minor]: Discovery brittleness on schema/column-name conventions
+- **Fix**: Add comment in SQL file: convention is `public` schema + `tenant_id` column; drift = silent exclusion. The discovery query is in lockstep with `check-migration-drift.mjs`.
+
+### F14 [Minor]: SQL-injection safety of `format('%I', t)` not documented in SQL
+- **Fix**: Add comment near `EXECUTE format()` explaining `%I` is the safe identifier-quoting specifier; table names from `information_schema` / `pg_policies` are trusted system catalog data; never widen to `%s` or to user input.
+
+### F15 [Minor]: Plan does not state rename-handling
+- **Fix**: One-line note in "How auto-discovery handles drift": "Renames are auto-handled — `information_schema` and `pg_policies` reflect post-rename state. The alias map in `check-migration-drift.mjs` is needed only for static migration-text analysis, not at runtime."
+
+## Security Findings
+
+### S1 [Major]: `SET LOCAL` semantics — risk if file is wrapped in transaction
+- **File**: plan:78, :138, :194 (Risk #6)
+- **Evidence**: Same as F5. Plan's reason ("DO is a transaction") is wrong; the correct guarantee is "psql autocommits each top-level statement → each DO is its own implicit transaction". Wrapping in BEGIN/COMMIT would let `SET LOCAL` from one block leak into others.
+- **Attack vector**: future maintainer (not malicious) wraps in transaction → SET LOCAL `app.bypass_rls=on` from Block 4 leaks into next Block 2/3 invocation in the same session → predicate regression false-greens → reaches production.
+- **Fix**: See F5. Use `SET app.tenant_id = ...` + explicit `RESET app.tenant_id` / `RESET app.bypass_rls` at end of every block. Add defensive guards.
+
+### S2 [Major]: USING != WITH CHECK divergence is unguarded
+- **File**: plan:39, :177 (Out of scope §3)
+- **Evidence**: Plan exempts mutation tests on the assumption that the project's `tenant_isolation` template uses identical USING and WITH CHECK clauses. No automated check enforces this.
+- **Attack vector**: developer typo (asymmetric clauses, e.g., `USING (tenant_id = ...)` + `WITH CHECK (true)`) → tenant A's app can INSERT rows with `tenant_id = '<B>'` (cross-tenant write). SELECT-only test passes.
+- **Fix**: Promote F11 from Minor to Major. Add the `qual::text != with_check::text` runtime guard. Failure message: "Policy <name>: USING and WITH CHECK clauses differ — add INSERT/UPDATE/DELETE assertions to rls-cross-tenant-verify.sql or normalise the policy".
+
+### S3 [Major]: Floor `>= 23` does not catch silent policy removal
+- **File**: plan:79, :139, :184
+- **Evidence**: A future migration that drops `foo_tenant_isolation` and adds a new tenant-scoped table would keep count constant; floor passes.
+- **Attack vector**: developer | `DROP POLICY foo_tenant_isolation` (intentional refactor that misses replacement, OR ALTER TABLE recreate that forgets the policy) | `passwd_app` queries `foo` — if FORCE RLS still on, default-deny (functional break, caught by app tests); if FORCE was also dropped, all rows visible (silent confidentiality breach).
+- **Fix**: Augment with a "policies must not silently shrink" check. Either: (a) commit `scripts/rls-policy-manifest.txt` (one line per `<table>:<policy>` pair) and diff-check in CI, OR (b) require the floor to **equal** (not `>=`) the manifest count, OR (c) extend `check-migration-drift.mjs` to verify both `tenant_id` column AND `*_tenant_isolation` policy exist for every model. Recommend (c) — minimal new infrastructure.
+
+### S4 [Minor]: Bypass-channel test codifies `count = 2 when bypass = on` — locks in soft GUC
+- **File**: plan:78, :138, :246
+- **Evidence**: `app.bypass_rls` is a custom GUC; Postgres allows any role to SET it. NOBYPASSRLS attribute is independent. SQL injection on a `passwd_app` session can `SET app.bypass_rls = 'on'` and defeat RLS entirely.
+- **Fix**: Add a comment to the verify SQL: `-- NOTE: app.bypass_rls is a soft GUC — any SQL-level access to passwd_app session can defeat it. RLS is one layer; do not rely on it as the sole tenant boundary.` Out of scope for this plan to harden the GUC; in scope to document.
+
+### S5 [Minor]: Floor-bump in same PR has no two-step approval
+- **File**: plan:79, :184, :220 (Scenario 1)
+- **Evidence**: Decrementing the floor in the same PR that removes a policy is one integer change; CI green.
+- **Fix**: Either (a) derive floor dynamically (cannot be wrongly bumped), OR (b) add `scripts/rls-cross-tenant-*.sql` to `.github/CODEOWNERS` requiring a security-team reviewer. Plan recommends (a).
+
+### S6 [Minor]: SQL injection — `format('%I', t)` is safe; document for completeness
+- **Evidence**: `passwd_app` lacks `CREATE` on schema public (`ci.yml:437`); `t` comes from system catalog. No injection.
+- **Fix**: Add defensive `ASSERT t ~ '^[a-z_][a-z0-9_]*$'` belt-and-suspenders.
+
+### S7 [Minor — R34]: Existing `rls-smoke-seed.sql` covers only 7 of ~52 tables (adjacent gap)
+- **Evidence**: `scripts/rls-smoke-seed.sql:30-57` seeds 7 tables; `rls-smoke-verify.sql:18-33` asserts on those 7. Pre-existing narrow scope.
+- **Fix**: As part of this plan, decide between: (a) replacing `rls-smoke-verify.sql`'s static list with an auto-discovered loop asserting `count = 0` for all `_tenant_isolation` tables when no GUC is set; OR (b) explicitly state in the plan that the new cross-tenant verify supersedes the existing without-GUC verify and decide whether to extend or retire the existing files. Plan currently says "existing files NOT modified" — re-examine.
+
+### S8 [Minor — RS4]: PII in committed artifacts — clean.
+
+## Testing Findings
+
+### T1 [Critical]: EXPECTED_MIN_TENANT_SCOPED_TABLES = 23 vs ~52 actual — duplicate of F1
+- Merged with F1 above; preserved here for severity tracking.
+
+### T2 [Critical]: `LIKE '%_tenant_isolation'` excludes `team_policies` bare-named policy — duplicate of F2
+- Merged with F2 above; preserved here for severity tracking.
+
+### T3 [Major]: Negative-case validation manual-only; no automated regression test for the gate's own correctness
+- **File**: plan:154-163
+- **Evidence**: 4 negative cases (USING true / wrong column / dropped bypass / seed gap) listed as a manual ritual. No CI step exercises the failure path of the new test. A future refactor of `rls-cross-tenant-verify.sql` (e.g., changing `ASSERT count = 1` to `>= 1` to accommodate a "shared" tenant) would silently turn the gate into a vacuous pass.
+- **Fix**: Add a fourth step to the rls-smoke job: `Cross-tenant verify negative test`. The step (1) creates a temporary `CREATE OR REPLACE POLICY foo_tenant_isolation ON <one_table> USING (true) WITH CHECK (true)`; (2) runs `rls-cross-tenant-verify.sql`; (3) `expect exit != 0`; (4) restores the original policy. Sequencing note (T10 from Functionality): cross-session SAVEPOINTs do not work; the bad policy must be created in a real transaction and explicitly dropped/restored after, with a `trap` to ensure restoration even if verify-step fails for another reason.
+
+### T4 [Major]: count = 1 conflates seed bugs with policy bugs — duplicate of F6
+- Merged with F6 above; preserved here for severity tracking.
+
+### T5 [Major]: Block 4 with `app.tenant_id` still set is redundant with Blocks 2/3
+- **File**: plan:78, :138
+- **Evidence**: With current OR-template `(bypass=on OR tenant_id=GUC)`, both clauses can be simultaneously satisfied. Block 4 cannot distinguish "bypass clause works" from "tenant filter happens to pass too". A future migration changing OR to AND would already be detected by Blocks 2/3.
+- **Fix**: Block 4 must `RESET app.tenant_id` first (or `SET LOCAL app.tenant_id = ''` — but per F12, that errors on UUID cast → use `RESET`). Then `SET LOCAL app.bypass_rls = 'on'`. With tenant filter explicitly disabled, count = 2 proves the bypass clause alone admits both rows.
+
+### T6 [Major]: Manual-test.md file promised but not delivered with plan
+- **File**: plan:167
+- **Evidence**: Plan references `docs/archive/review/verify-rls-predicate-manual-test.md` but file does not exist. The manual-test list in the plan body lacks expected outputs, exact connection strings for both roles, and how to confirm an adversarial run failed correctly.
+- **Fix**: Inline the full manual-test content in the plan with explicit expected outputs and exit codes. (Or commit `verify-rls-predicate-manual-test.md` alongside the plan; recommend inlining since it's small.)
+
+### T7 [Minor]: No SQL syntax check at PR-review time
+- **Fix**: Optional. Defer.
+
+### T8 [Minor]: Path-filter / branch-protection coverage not audited
+- **File**: plan:104-110
+- **Evidence**: `rls-smoke` job has `if: needs.changes.outputs.app == 'true' || ci == 'true'`. Plan doesn't audit whether `changes` filter covers `prisma/migrations/**` and the new SQL paths.
+- **Fix**: Add to "CI integration" section: "Path filter `needs.changes.outputs.app` must include `prisma/migrations/**` and `scripts/rls-cross-tenant-*.sql`. Required-status checks (branch protection) must include `rls-smoke`. Verified at implementation time."
+
+### T9 [Minor]: Coverage check failure-attribution adequate IF T4/F6 is adopted
+- No separate fix.
+
+### T10 [Adjacent — Functionality]: Negative-test SAVEPOINT crosses session boundaries
+- **Note**: T3's fix proposal needs adjustment. `passwd_user` (creates bad policy) and `passwd_app` (runs verify) are separate connections — SAVEPOINTs do not span them. The negative test must DROP/CREATE the policy in committed transactions, then explicitly restore the original definition after, using a `trap` or `EXIT` handler.
+- **Routing**: Functionality refinement to T3.
+
+### RT2 caveat: ASSERT halts on first failure
+- **Evidence**: PL/pgSQL `ASSERT` aborts the block on first failure. If 5 tables are broken, only the first is reported.
+- **Fix**: Acceptable (consistent with existing rls-smoke-verify). Document in plan: "ASSERT halts on first failure; debug locally to find all broken tables".
+
+## Adjacent Findings (routed)
+
+- F16 → Testing (covered by T3)
+- F17 → Security (covered by S2)
+- S9 → Functionality (covered by F1)
+- S10 → Testing (covered by T3)
+- T10 → Functionality (refinement to T3, see above)
+
+## Quality Warnings
+
+None — Ollama merge unavailable; manual dedup performed. No findings flagged for VAGUE / NO-EVIDENCE / UNTESTED-CLAIM by orchestrator review.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1 N/A
+- R2 HIT — `EXPECTED_MIN_TENANT_SCOPED_TABLES` hardcoded and wrong (F1)
+- R3 HIT — undercoverage of ~30 tables (F1); bare policy excluded (F2)
+- R4 N/A
+- R5 HIT (minor) — transaction reasoning inaccurate (F5)
+- R6 N/A
+- R7 HIT — silent exclusion via LIKE pattern (F2); silent exclusion of column-without-policy (F8)
+- R8 HIT — nullable mcp_clients tenantId (F3); negative tests not committed (F16/T3)
+- R9-R13 N/A
+- R14 OK
+- R15 OK
+- R16 HIT (minor) — local-runbook missing `passwd_app` role creation
+- R17-R28 N/A
+- R29 N/A
+- R30 HIT — schema-drift gaps (F2)
+- R31 N/A
+- R32 OK
+- R33 N/A
+- R34 OK
+- R35 HIT (minor) — manual-test.md not delivered (T6)
+- R36 N/A
+
+### Security expert
+- R1-R28 N/A
+- R29 N/A
+- R31 N/A
+- R32 OK
+- R33 N/A
+- R34 HIT — existing rls-smoke-verify.sql narrow scope (S7)
+- R36 N/A
+- RS1 N/A
+- RS2 N/A
+- RS3 OK — `format('%I', …)` is safe given current grants (S6)
+- RS4 OK — no PII (S8)
+
+### Testing expert
+- R1 HIT — "23" floor SSoT violation (T1)
+- R2-R31 N/A or related to other findings
+- R32 PARTIAL — strong RLS layer test, but does NOT exercise application's runtime path that sets `app.tenant_id` via Prisma client wrapper. Plan should state this.
+- R33 see T8
+- R34 N/A
+- R35 HIT — manual-test.md not delivered (T6)
+- R36 N/A
+- RT1 N/A — no mocks
+- RT2 OK — all assertions achievable in psql + DO; ASSERT halts on first failure (caveat noted)
+- RT3 see T1 — derive dynamically to avoid 3-place SSoT

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -43,11 +43,24 @@ run_step "Static: migration-drift" node scripts/checks/check-migration-drift.mjs
 if command -v docker >/dev/null 2>&1 && docker exec passwd-sso-db-1 pg_isready -U passwd_user -q 2>/dev/null; then
   run_step "Static: rls-cross-tenant SQL parse" bash -c '
     set -uo pipefail
-    # Parse-only: feed a stub manifest and accept exit 0 OR a known
-    # [E-RLS-MANIFEST-*] failure as proof the SQL parsed successfully.
+    # Parse-only: feed the FULL manifest. Verify will exit either:
+    #   - 0 (DB has cross-tenant seed applied; full validation, all 5 blocks parsed)
+    #   - non-zero with a known [E-RLS-*] code (parse OK, ASSERT fired)
+    # Without the cross-tenant seed applied, Block 1 manifest parity passes
+    # (manifest matches discovery), and Block 2 then fires [E-RLS-COUNT-A]
+    # because no rows match the tenant — proves Block 1+2 parsed successfully.
+    # Blocks 3-5 are only parsed when the seed is present; CI catches errors
+    # there during the full pipeline run.
+    # Manifest pipeline uses sed (not awk) to avoid bash/awk $-quoting hazards
+    # inside `bash -c "..."`.
+    EXPECTED_TABLES=$(sed -E "/^#/d; /^[[:space:]]*$/d; s/^[[:space:]]+//; s/[[:space:]]+$//" \
+      scripts/rls-cross-tenant-tables.manifest | paste -sd,)
     out=$(cat scripts/rls-cross-tenant-verify.sql | docker exec -i passwd-sso-db-1 \
-      psql -U passwd_app -d passwd_sso -v ON_ERROR_STOP=1 -v expected_tables="users" 2>&1) && ec=0 || ec=$?
-    if (( ec == 0 )) || grep -qE "\[E-RLS-MANIFEST-(EXTRA|MISSING)\]" <<<"$out"; then
+      psql -U passwd_app -d passwd_sso -v ON_ERROR_STOP=1 -v expected_tables="$EXPECTED_TABLES" 2>&1) && ec=0 || ec=$?
+    # Whitelist the specific codes that can legitimately fire on the parse
+    # path. Anchored matching prevents typo-codes (e.g. [E-RLS-NUL] missing
+    # the L) from being silently accepted as "parsed OK".
+    if (( ec == 0 )) || grep -qE "\[E-RLS-(MANIFEST-(EXTRA|MISSING)|COLPARITY|COUNT-A|COUNT-B|NULL|SYM|BYPASS|DISCOVER|ROLE|COVERAGE)\]" <<<"$out"; then
       exit 0
     fi
     printf "%s\n" "$out"

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -43,23 +43,12 @@ run_step "Static: migration-drift" node scripts/checks/check-migration-drift.mjs
 if command -v docker >/dev/null 2>&1 && docker exec passwd-sso-db-1 pg_isready -U passwd_user -q 2>/dev/null; then
   run_step "Static: rls-cross-tenant SQL parse" bash -c '
     set -uo pipefail
-    # Parse-only: feed the FULL manifest. Verify will exit either:
-    #   - 0 (DB has cross-tenant seed applied; full validation, all 5 blocks parsed)
-    #   - non-zero with a known [E-RLS-*] code (parse OK, ASSERT fired)
-    # Without the cross-tenant seed applied, Block 1 manifest parity passes
-    # (manifest matches discovery), and Block 2 then fires [E-RLS-COUNT-A]
-    # because no rows match the tenant — proves Block 1+2 parsed successfully.
-    # Blocks 3-5 are only parsed when the seed is present; CI catches errors
-    # there during the full pipeline run.
-    # Manifest pipeline uses sed (not awk) to avoid bash/awk $-quoting hazards
-    # inside `bash -c "..."`.
+    # sed (not awk) — bash -c "..." double-escapes positional vars and breaks awk $1 references.
     EXPECTED_TABLES=$(sed -E "/^#/d; /^[[:space:]]*$/d; s/^[[:space:]]+//; s/[[:space:]]+$//" \
       scripts/rls-cross-tenant-tables.manifest | paste -sd,)
     out=$(cat scripts/rls-cross-tenant-verify.sql | docker exec -i passwd-sso-db-1 \
       psql -U passwd_app -d passwd_sso -v ON_ERROR_STOP=1 -v expected_tables="$EXPECTED_TABLES" 2>&1) && ec=0 || ec=$?
-    # Whitelist the specific codes that can legitimately fire on the parse
-    # path. Anchored matching prevents typo-codes (e.g. [E-RLS-NUL] missing
-    # the L) from being silently accepted as "parsed OK".
+    # Whitelist exact codes — typos like [E-RLS-NUL] would otherwise pass.
     if (( ec == 0 )) || grep -qE "\[E-RLS-(MANIFEST-(EXTRA|MISSING)|COLPARITY|COUNT-A|COUNT-B|NULL|SYM|BYPASS|DISCOVER|ROLE|COVERAGE)\]" <<<"$out"; then
       exit 0
     fi

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -37,6 +37,25 @@ run_step "Static: team-auth-rls"  node scripts/checks/check-team-auth-rls.mjs
 run_step "Static: bypass-rls"     node scripts/checks/check-bypass-rls.mjs
 run_step "Static: crypto-domains" node scripts/checks/check-crypto-domains.mjs
 run_step "Static: migration-drift" node scripts/checks/check-migration-drift.mjs
+# Cross-tenant SQL parse check (issue #434). Runs against the local docker DB
+# if reachable; skips gracefully otherwise (preserves pre-pr.sh's "no Postgres
+# required" contract for the static checks above).
+if command -v docker >/dev/null 2>&1 && docker exec passwd-sso-db-1 pg_isready -U passwd_user -q 2>/dev/null; then
+  run_step "Static: rls-cross-tenant SQL parse" bash -c '
+    set -uo pipefail
+    # Parse-only: feed a stub manifest and accept exit 0 OR a known
+    # [E-RLS-MANIFEST-*] failure as proof the SQL parsed successfully.
+    out=$(cat scripts/rls-cross-tenant-verify.sql | docker exec -i passwd-sso-db-1 \
+      psql -U passwd_app -d passwd_sso -v ON_ERROR_STOP=1 -v expected_tables="users" 2>&1) && ec=0 || ec=$?
+    if (( ec == 0 )) || grep -qE "\[E-RLS-MANIFEST-(EXTRA|MISSING)\]" <<<"$out"; then
+      exit 0
+    fi
+    printf "%s\n" "$out"
+    exit 1
+  '
+else
+  printf "  [skip: rls-cross-tenant SQL parse — local docker DB not running (npm run docker:up to enable)]\n\n"
+fi
 run_step "Static: no-deprecated-logAudit" bash -c 'if grep -rn "logAudit(" src/ --include="*.ts" --include="*.tsx" | grep -v "logAuditAsync\|logAuditInTx" | grep -v "\.test\." | grep -v "^\s*//" | grep -v "^\s*\*" | grep -q .; then echo "Residual logAudit() calls found:"; grep -rn "logAudit(" src/ --include="*.ts" --include="*.tsx" | grep -v "logAuditAsync\|logAuditInTx" | grep -v "\.test\." | grep -v "^\s*//" | grep -v "^\s*\*"; exit 1; fi'
 
 if command -v gitleaks >/dev/null 2>&1; then

--- a/scripts/rls-cross-tenant-coverage.sql
+++ b/scripts/rls-cross-tenant-coverage.sql
@@ -47,7 +47,7 @@ BEGIN
   ) LOOP
     -- Defensive identifier-shape guard (system catalog is trusted, but
     -- belt-and-suspenders for the dynamic SQL).
-    ASSERT t ~ '^[a-z_][a-z0-9_]*$', format('table name failed regex: %s', t);
+    ASSERT t ~ '^[a-z_][a-z0-9_]*$', format('table name failed regex: %L', t);
 
     EXECUTE format('SELECT count(*) FROM %I WHERE tenant_id = $1', t)
       INTO n USING tenant_a;

--- a/scripts/rls-cross-tenant-coverage.sql
+++ b/scripts/rls-cross-tenant-coverage.sql
@@ -1,0 +1,77 @@
+-- RLS Cross-Tenant Verify: Coverage check
+--
+-- Runs as passwd_user (SUPERUSER, BYPASSRLS).
+--
+-- Asserts that for every tenant-scoped table discovered via pg_policy,
+-- the seed file (rls-cross-tenant-seed.sql) inserted exactly 1 row for
+-- tenant A AND exactly 1 row for tenant B. For mcp_clients, also asserts
+-- exactly 1 row with tenant_id IS NULL (DCR pre-claimed clients).
+--
+-- This catches seed-file drift: a new tenant-scoped table added to the
+-- manifest + migration but NOT seeded would surface here as "expected=1
+-- got=0 — fix rls-cross-tenant-seed.sql" before the (passwd_app) verify
+-- step runs.
+--
+-- Uses the SAME discovery query as scripts/rls-cross-tenant-verify.sql
+-- (consistent across files; no role-filter pitfall here because we run
+-- as SUPERUSER but the query doesn't depend on it).
+--
+-- Use %I (identifier quoting) for table names in dynamic SQL — never %s.
+-- Identifiers come from system catalog data (trusted).
+--
+-- Local usage:
+--   cat scripts/rls-cross-tenant-coverage.sql | docker exec -i passwd-sso-db-1 \
+--     psql -U passwd_user -d passwd_sso -v ON_ERROR_STOP=1
+
+DO $$
+DECLARE
+  t text;
+  n bigint;
+  failures int := 0;
+  tenant_a constant uuid := '00000000-0000-0000-0000-0000000000A0';
+  tenant_b constant uuid := '00000000-0000-0000-0000-0000000000B0';
+BEGIN
+  FOR t IN (
+    SELECT c.relname AS table_name
+    FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    JOIN information_schema.columns col
+      ON col.table_schema = n.nspname
+     AND col.table_name = c.relname
+     AND col.column_name = 'tenant_id'
+    WHERE n.nspname = 'public'
+      AND c.relname <> 'tenants'
+      AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+    ORDER BY c.relname
+  ) LOOP
+    -- Defensive identifier-shape guard (system catalog is trusted, but
+    -- belt-and-suspenders for the dynamic SQL).
+    ASSERT t ~ '^[a-z_][a-z0-9_]*$', format('table name failed regex: %s', t);
+
+    EXECUTE format('SELECT count(*) FROM %I WHERE tenant_id = $1', t)
+      INTO n USING tenant_a;
+    IF n <> 1 THEN
+      RAISE NOTICE 'FAIL coverage table=% tenant=A expected=1 got=% — fix rls-cross-tenant-seed.sql', t, n;
+      failures := failures + 1;
+    END IF;
+
+    EXECUTE format('SELECT count(*) FROM %I WHERE tenant_id = $1', t)
+      INTO n USING tenant_b;
+    IF n <> 1 THEN
+      RAISE NOTICE 'FAIL coverage table=% tenant=B expected=1 got=% — fix rls-cross-tenant-seed.sql', t, n;
+      failures := failures + 1;
+    END IF;
+  END LOOP;
+
+  -- Special case: mcp_clients also has a NULL-tenant row (DCR pre-claimed).
+  SELECT count(*) INTO n FROM mcp_clients WHERE tenant_id IS NULL;
+  IF n <> 1 THEN
+    RAISE NOTICE 'FAIL coverage mcp_clients NULL-tenant expected=1 got=% — fix rls-cross-tenant-seed.sql', n;
+    failures := failures + 1;
+  END IF;
+
+  IF failures > 0 THEN
+    RAISE EXCEPTION '[E-RLS-COVERAGE] Coverage check: % failures — see NOTICE lines above. Fix scripts/rls-cross-tenant-seed.sql.', failures;
+  END IF;
+END $$;

--- a/scripts/rls-cross-tenant-negative-test.sh
+++ b/scripts/rls-cross-tenant-negative-test.sh
@@ -104,11 +104,10 @@ run_negative_case() {
   local expected_code="$3"
   local omit_throwaway_from_manifest="${4:-no}"
 
-  # Reset to a clean policy slate, then apply the case's policy.
+  # Reset to a clean policy slate, then apply the case's policy (single -c
+  # call so both run in one connection / transaction).
   psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
-    -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test;"
-  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
-    -c "$create_policy_sql"
+    -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test; $create_policy_sql;"
 
   local expected_tables
   if [[ "$omit_throwaway_from_manifest" == "yes" ]]; then
@@ -200,9 +199,7 @@ run_negative_case 5 \
 # the throwaway in/out.
 run_case_6_manifest_extra() {
   psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
-    -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test;"
-  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
-    -c "$CANONICAL_POLICY_SQL"
+    -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test; $CANONICAL_POLICY_SQL;"
   local expected_tables="${manifest_entries},rls_negative_test,rls_phantom_not_in_db"
   local out ec
   out=$(psql "$APP_DATABASE_URL" -v ON_ERROR_STOP=1 \
@@ -228,9 +225,7 @@ run_case_6_manifest_extra || total_failures=$((total_failures + 1))
 run_case_7_colparity() {
   # Reset to canonical policy so SYM/NULL pass.
   psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
-    -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test;"
-  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
-    -c "$CANONICAL_POLICY_SQL"
+    -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test; $CANONICAL_POLICY_SQL;"
   # Create the column-only probe.
   psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q -c "
     DROP TABLE IF EXISTS rls_colparity_probe CASCADE;

--- a/scripts/rls-cross-tenant-negative-test.sh
+++ b/scripts/rls-cross-tenant-negative-test.sh
@@ -2,7 +2,7 @@
 # rls-cross-tenant-negative-test.sh — gate self-check
 #
 # Runs a Case 0 pre-flight calibration (canonical policy → exit 0) plus
-# 5 distinct failure shapes against an ephemeral throwaway table to verify
+# 7 distinct failure shapes against an ephemeral throwaway table to verify
 # the cross-tenant verify SQL correctly detects each:
 #   0. canonical policy + correct manifest (sanity: harness calibrated)
 #   1. permissive symmetric → [E-RLS-COUNT-A]
@@ -10,10 +10,24 @@
 #   3. NULL USING clause (FOR INSERT-only) → [E-RLS-NULL]
 #   4. dropped bypass clause → [E-RLS-BYPASS]
 #   5. manifest drift (canonical policy + manifest missing throwaway) → [E-RLS-MANIFEST-MISSING]
+#   6. manifest contains a name not in DB → [E-RLS-MANIFEST-EXTRA]
+#   7. column-parity probe (tenant_id column without policy) → [E-RLS-COLPARITY]
+#
+# Codes NOT exercised here (acceptable coverage gaps):
+#   - [E-RLS-COUNT-B]: structurally identical to [E-RLS-COUNT-A] (Block 3 mirrors Block 2).
+#   - [E-RLS-DISCOVER]: requires REVOKE on system catalog which is fragile and rarely portable.
+#   - [E-RLS-ROLE]: requires running the verify as a different role; covered by R21 verification not by this self-check.
 #
 # Each case matches a stable error code (e.g., [E-RLS-NULL]), not freeform
 # prose, so future EXCEPTION message wording changes do not silently break
 # gate self-check coverage.
+#
+# Prerequisite: scripts/rls-cross-tenant-seed.sql must be applied (as
+# passwd_user) before this script runs. Cases 0 and 4 invoke the full verify
+# SQL which expects exactly 1 row per tenant in all 53 manifest tables — if
+# the seed has not been applied, Block 2 fires [E-RLS-COUNT-A] before Cases
+# 0/4 reach their target assertions. CI runs them in order (seed → coverage
+# → verify → negative-test); local debugging must do the same.
 #
 # Mechanism: --variable override (no manifest file mutation). The script
 # builds EXPECTED_TABLES in-process, appending the throwaway table name
@@ -42,9 +56,12 @@ MANIFEST_FILE="$SCRIPT_DIR/rls-cross-tenant-tables.manifest"
 VERIFY_SQL="$SCRIPT_DIR/rls-cross-tenant-verify.sql"
 
 # Trap-based cleanup: idempotent DROP. Fires on EXIT/ERR/INT/TERM (not SIGKILL).
+# Drops BOTH the negative-test policy target AND the colparity probe table
+# created by Case 7. Both DROPs are IF EXISTS so the trap is safe to fire
+# before/after either table has been created.
 cleanup() {
   psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=0 -q \
-    -c "DROP TABLE IF EXISTS rls_negative_test CASCADE;" >/dev/null 2>&1 || true
+    -c "DROP TABLE IF EXISTS rls_negative_test CASCADE; DROP TABLE IF EXISTS rls_colparity_probe CASCADE;" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
 
@@ -175,6 +192,72 @@ run_negative_case 5 \
   "$CANONICAL_POLICY_SQL" \
   "[E-RLS-MANIFEST-MISSING]" \
   "yes" || total_failures=$((total_failures + 1))
+
+# Case 6: manifest contains a name not in DB → Block 1 [E-RLS-MANIFEST-EXTRA].
+# Reuses canonical policy (so Block 2/3/4 don't pre-empt) and passes a manifest
+# that includes a phantom table name. Custom helper rather than run_negative_case
+# because we need to inject the phantom into expected_tables, not just toggle
+# the throwaway in/out.
+run_case_6_manifest_extra() {
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
+    -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test;"
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
+    -c "$CANONICAL_POLICY_SQL"
+  local expected_tables="${manifest_entries},rls_negative_test,rls_phantom_not_in_db"
+  local out ec
+  out=$(psql "$APP_DATABASE_URL" -v ON_ERROR_STOP=1 \
+    -v expected_tables="$expected_tables" \
+    -f "$VERIFY_SQL" 2>&1) && ec=0 || ec=$?
+  if (( ec == 0 )); then
+    printf 'FAIL case 6: verify exited 0 against manifest with phantom table — gate is broken\n'
+    return 1
+  fi
+  if ! grep -qF -- "[E-RLS-MANIFEST-EXTRA]" <<<"$out"; then
+    printf 'FAIL case 6: verify failed but expected code [E-RLS-MANIFEST-EXTRA] not found in output:\n%s\n' "$out"
+    return 1
+  fi
+  printf 'PASS case 6 (matched [E-RLS-MANIFEST-EXTRA])\n'
+}
+run_case_6_manifest_extra || total_failures=$((total_failures + 1))
+
+# Case 7: column-parity mismatch — a separate probe table has tenant_id column
+# but NO tenant_isolation policy → Block 1 [E-RLS-COLPARITY] fires before the
+# manifest assertions because COLPARITY runs earlier in Block 1's load-bearing
+# order. Probe is created in this case body and dropped after; the trap also
+# drops it as a safety net.
+run_case_7_colparity() {
+  # Reset to canonical policy so SYM/NULL pass.
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
+    -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test;"
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
+    -c "$CANONICAL_POLICY_SQL"
+  # Create the column-only probe.
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q -c "
+    DROP TABLE IF EXISTS rls_colparity_probe CASCADE;
+    CREATE TABLE rls_colparity_probe (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), tenant_id uuid NOT NULL);
+  "
+  # Manifest includes rls_negative_test but NOT the probe — discovery returns
+  # 53 + 1 = 54 (matches manifest), columns return 53 + 1 (negative_test) +
+  # 1 (probe) = 55. So COLPARITY: column count 55 != discovery count 54.
+  local expected_tables="${manifest_entries},rls_negative_test"
+  local out ec
+  out=$(psql "$APP_DATABASE_URL" -v ON_ERROR_STOP=1 \
+    -v expected_tables="$expected_tables" \
+    -f "$VERIFY_SQL" 2>&1) && ec=0 || ec=$?
+  # Drop probe regardless (trap also covers).
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=0 -q \
+    -c "DROP TABLE IF EXISTS rls_colparity_probe CASCADE;" >/dev/null 2>&1 || true
+  if (( ec == 0 )); then
+    printf 'FAIL case 7: verify exited 0 with extra column-without-policy — gate is broken\n'
+    return 1
+  fi
+  if ! grep -qF -- "[E-RLS-COLPARITY]" <<<"$out"; then
+    printf 'FAIL case 7: verify failed but expected code [E-RLS-COLPARITY] not found in output:\n%s\n' "$out"
+    return 1
+  fi
+  printf 'PASS case 7 (matched [E-RLS-COLPARITY])\n'
+}
+run_case_7_colparity || total_failures=$((total_failures + 1))
 
 if (( total_failures > 0 )); then
   printf '\n%d negative-test cases failed.\n' "$total_failures"

--- a/scripts/rls-cross-tenant-negative-test.sh
+++ b/scripts/rls-cross-tenant-negative-test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# rls-cross-tenant-negative-test.sh — gate self-check
+#
+# Runs a Case 0 pre-flight calibration (canonical policy → exit 0) plus
+# 5 distinct failure shapes against an ephemeral throwaway table to verify
+# the cross-tenant verify SQL correctly detects each:
+#   0. canonical policy + correct manifest (sanity: harness calibrated)
+#   1. permissive symmetric → [E-RLS-COUNT-A]
+#   2. asymmetric USING/WITH CHECK → [E-RLS-SYM]
+#   3. NULL USING clause (FOR INSERT-only) → [E-RLS-NULL]
+#   4. dropped bypass clause → [E-RLS-BYPASS]
+#   5. manifest drift (canonical policy + manifest missing throwaway) → [E-RLS-MANIFEST-MISSING]
+#
+# Each case matches a stable error code (e.g., [E-RLS-NULL]), not freeform
+# prose, so future EXCEPTION message wording changes do not silently break
+# gate self-check coverage.
+#
+# Mechanism: --variable override (no manifest file mutation). The script
+# builds EXPECTED_TABLES in-process, appending the throwaway table name
+# to the manifest contents (or omitting it for case 5) and passes via
+# `psql -v expected_tables=...`. The manifest file on disk is never modified.
+#
+# CI safety:
+# - This script MUST run sequentially in rls-smoke. Do NOT parallelize
+#   with other DB-touching steps — the throwaway policy is committed
+#   global state for the duration of each case.
+# - Trap fires on EXIT/ERR/INT/TERM but NOT SIGKILL. CI Postgres is
+#   ephemeral so a leaked throwaway table is discarded with the runner.
+#   Do NOT run against a shared/persistent DB without modification.
+#
+# Required env vars:
+#   MIGRATION_DATABASE_URL — passwd_user (SUPERUSER) connection string
+#   APP_DATABASE_URL       — passwd_app  (NOSUPERUSER) connection string
+
+set -euo pipefail
+
+: "${MIGRATION_DATABASE_URL:?MIGRATION_DATABASE_URL must be set (passwd_user URL)}"
+: "${APP_DATABASE_URL:?APP_DATABASE_URL must be set (passwd_app URL)}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST_FILE="$SCRIPT_DIR/rls-cross-tenant-tables.manifest"
+VERIFY_SQL="$SCRIPT_DIR/rls-cross-tenant-verify.sql"
+
+# Trap-based cleanup: idempotent DROP. Fires on EXIT/ERR/INT/TERM (not SIGKILL).
+cleanup() {
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=0 -q \
+    -c "DROP TABLE IF EXISTS rls_negative_test CASCADE;" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+# Setup: create the ephemeral throwaway table and seed two tenant rows
+# as passwd_user (SUPERUSER, bypasses RLS regardless of policy state).
+# Inserting as SUPERUSER is ground truth — the test data exists no matter
+# what the throwaway policy's WITH CHECK clause is.
+psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q <<'SQL'
+DROP TABLE IF EXISTS rls_negative_test CASCADE;
+CREATE TABLE rls_negative_test (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL
+);
+ALTER TABLE rls_negative_test ENABLE ROW LEVEL SECURITY;
+ALTER TABLE rls_negative_test FORCE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT ON rls_negative_test TO passwd_app;
+INSERT INTO rls_negative_test (tenant_id) VALUES
+  ('00000000-0000-0000-0000-0000000000A0'),
+  ('00000000-0000-0000-0000-0000000000B0');
+SQL
+
+# Canonical policy: exactly the shape every real tenant_isolation policy uses.
+# Case 0 (pre-flight) asserts a verify run under this policy + the
+# manifest-with-throwaway exits 0. Case 5 reuses this so only manifest-parity
+# fires (NOT cross-fired by stale Case 4 state).
+CANONICAL_POLICY_SQL="CREATE POLICY rls_negative_test_tenant_isolation ON rls_negative_test FOR ALL USING ((current_setting('app.bypass_rls', true) = 'on') OR tenant_id = current_setting('app.tenant_id', true)::uuid) WITH CHECK ((current_setting('app.bypass_rls', true) = 'on') OR tenant_id = current_setting('app.tenant_id', true)::uuid)"
+
+# Build the manifest entries (whitespace-trimmed, comments stripped).
+manifest_entries=$(awk 'NF && $1 !~ /^#/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print}' \
+  "$MANIFEST_FILE" | paste -sd,)
+
+# run_negative_case <case_id> <create_policy_sql> <expected_code> <omit_throwaway_from_manifest>
+#   case_id                 : human label for log lines
+#   create_policy_sql       : full CREATE POLICY DDL fragment (already includes the policy name + table)
+#   expected_code           : stable [E-RLS-*] code; empty string means "expect exit 0" (Case 0)
+#   omit_throwaway_from_manifest: "yes" to omit, anything else (default "no") to include
+run_negative_case() {
+  local case_id="$1"
+  local create_policy_sql="$2"
+  local expected_code="$3"
+  local omit_throwaway_from_manifest="${4:-no}"
+
+  # Reset to a clean policy slate, then apply the case's policy.
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
+    -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test;"
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
+    -c "$create_policy_sql"
+
+  local expected_tables
+  if [[ "$omit_throwaway_from_manifest" == "yes" ]]; then
+    expected_tables="$manifest_entries"
+  else
+    expected_tables="${manifest_entries},rls_negative_test"
+  fi
+
+  # Run verify; capture exit and combined output.
+  local verify_output ec
+  verify_output=$(psql "$APP_DATABASE_URL" -v ON_ERROR_STOP=1 \
+    -v expected_tables="$expected_tables" \
+    -f "$VERIFY_SQL" 2>&1) && ec=0 || ec=$?
+
+  if [[ -z "$expected_code" ]]; then
+    # Case 0: expect exit 0 (calibration).
+    if (( ec != 0 )); then
+      printf 'FAIL case %s: pre-flight calibration verify did NOT pass under canonical policy. Output:\n%s\n' \
+        "$case_id" "$verify_output"
+      return 1
+    fi
+    printf 'PASS case %s (pre-flight calibration)\n' "$case_id"
+    return 0
+  fi
+
+  if (( ec == 0 )); then
+    printf 'FAIL case %s: verify exited 0 against deliberately-broken policy — gate is broken (vacuous pass)\n' \
+      "$case_id"
+    return 1
+  fi
+
+  # Match against stable error code, not freeform prose.
+  if ! grep -qF -- "$expected_code" <<<"$verify_output"; then
+    printf 'FAIL case %s: verify failed but expected code %s not found in output:\n%s\n' \
+      "$case_id" "$expected_code" "$verify_output"
+    return 1
+  fi
+
+  printf 'PASS case %s (matched %s)\n' "$case_id" "$expected_code"
+}
+
+# Driver: accumulate failures, run all cases, exit with count.
+total_failures=0
+
+# Case 0: canonical policy + correct manifest → exit 0 (sanity).
+run_negative_case 0 \
+  "$CANONICAL_POLICY_SQL" \
+  "" \
+  "no" || total_failures=$((total_failures + 1))
+
+# Case 1: permissive symmetric → Block 2 count fails for tenant A
+# (USING (true) admits both A and B rows under SET LOCAL app.tenant_id=A).
+run_negative_case 1 \
+  "CREATE POLICY rls_negative_test_tenant_isolation ON rls_negative_test FOR ALL USING (true) WITH CHECK (true)" \
+  "[E-RLS-COUNT-A]" \
+  "no" || total_failures=$((total_failures + 1))
+
+# Case 2: asymmetric USING vs WITH CHECK → Block 1 [E-RLS-SYM].
+run_negative_case 2 \
+  "CREATE POLICY rls_negative_test_tenant_isolation ON rls_negative_test FOR ALL USING (tenant_id = current_setting('app.tenant_id', true)::uuid OR current_setting('app.bypass_rls', true) = 'on') WITH CHECK (true)" \
+  "[E-RLS-SYM]" \
+  "no" || total_failures=$((total_failures + 1))
+
+# Case 3: NULL USING clause via FOR INSERT-only legacy form (polqual NULL,
+# polwithcheck non-NULL) → Block 1 [E-RLS-NULL] (fires BEFORE [E-RLS-SYM]
+# per the documented ordering).
+run_negative_case 3 \
+  "CREATE POLICY rls_negative_test_tenant_isolation ON rls_negative_test FOR INSERT WITH CHECK (true)" \
+  "[E-RLS-NULL]" \
+  "no" || total_failures=$((total_failures + 1))
+
+# Case 4: bypass clause dropped → Block 4 count fails (count=0 with bypass=on).
+run_negative_case 4 \
+  "CREATE POLICY rls_negative_test_tenant_isolation ON rls_negative_test FOR ALL USING (tenant_id = current_setting('app.tenant_id', true)::uuid) WITH CHECK (tenant_id = current_setting('app.tenant_id', true)::uuid)" \
+  "[E-RLS-BYPASS]" \
+  "no" || total_failures=$((total_failures + 1))
+
+# Case 5: manifest drift — canonical policy (so Block 2/3/4 all pass), but
+# manifest is missing the throwaway → Block 1 [E-RLS-MANIFEST-MISSING].
+run_negative_case 5 \
+  "$CANONICAL_POLICY_SQL" \
+  "[E-RLS-MANIFEST-MISSING]" \
+  "yes" || total_failures=$((total_failures + 1))
+
+if (( total_failures > 0 )); then
+  printf '\n%d negative-test cases failed.\n' "$total_failures"
+  exit 1
+fi
+
+printf '\nAll negative-test cases PASS.\n'

--- a/scripts/rls-cross-tenant-seed.sql
+++ b/scripts/rls-cross-tenant-seed.sql
@@ -1,0 +1,301 @@
+-- RLS Cross-Tenant Verify: Seed data
+--
+-- Seeds two tenants A (00000000-0000-0000-0000-0000000000A0) and
+-- B (00000000-0000-0000-0000-0000000000B0) with exactly one row per
+-- tenant in each of the 53 tenant-scoped tables. mcp_clients also
+-- gets a third row with tenant_id = NULL (DCR pre-claimed clients).
+--
+-- Runs as passwd_user (SUPERUSER, BYPASSRLS). Sets app.bypass_rls = 'on'
+-- to also bypass the BEFORE INSERT triggers (enforce_tenant_id_from_context)
+-- that otherwise would reject inserts when app.tenant_id is unset.
+--
+-- Local usage:
+--   cat scripts/rls-cross-tenant-seed.sql | docker exec -i passwd-sso-db-1 \
+--     psql -U passwd_user -d passwd_sso -v ON_ERROR_STOP=1
+--
+-- Maintenance contract — adding a new tenant-scoped table requires:
+--   1. Migration: add tenant_id column + ENABLE/FORCE RLS + tenant_isolation policy.
+--   2. This file: insert one row per tenant (A and B), in dependency order
+--      (parent FKs first). For nullable-tenant tables, also insert a NULL row.
+--   3. scripts/rls-cross-tenant-tables.manifest: append the table name.
+-- The coverage step (rls-cross-tenant-coverage.sql) will fail loudly with
+-- "expected=1 got=0 — fix rls-cross-tenant-seed.sql" if step 2 is forgotten.
+--
+-- Identifier convention:
+--   - Tenant A id: 00000000-0000-0000-0000-0000000000A0
+--   - Tenant B id: 00000000-0000-0000-0000-0000000000B0
+--   - User A id:   00000000-0000-0000-0000-0000000000A1
+--   - User B id:   00000000-0000-0000-0000-0000000000B1
+--   - Other deterministic-needed parents use ...A2/B2, ...A3/B3, etc.
+--   - All non-FK-referenced child rows use gen_random_uuid().
+--
+-- This seed must NOT collide with rls-smoke-seed.sql which uses
+--   tenant 00000000-0000-0000-0000-000000000001 + 00000000-...0010 / ...0011.
+--
+-- Use %I (identifier quoting) — never %s — when extending dynamic SQL here.
+-- Identifiers come from system catalog data (trusted). Never widen this rule
+-- by interpolating user input.
+
+-- Re-grant DML to passwd_app (the verify step runs as passwd_app).
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO passwd_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO passwd_app;
+
+-- Bypass enforce_tenant_id_from_context triggers AND RLS for the entire seed.
+-- passwd_user is SUPERUSER so RLS is bypassed already, but the BEFORE INSERT
+-- triggers still fire and would raise 'tenant_id missing and app.tenant_id is
+-- not set' for tables that have the trigger. The trigger checks app.bypass_rls
+-- explicitly and short-circuits.
+SET app.bypass_rls = 'on';
+
+-- ---------------------------------------------------------------------------
+-- Parents: tenants → users (NOTE: inserting a user with tenant_id matching
+--   md5(user.id) auto-creates a tenant_members row via
+--   ensure_tenant_owner_membership_after_user_insert. Our deterministic UUIDs
+--   do NOT match md5(...), so the trigger no-ops — we insert tenant_members
+--   explicitly below.)
+-- ---------------------------------------------------------------------------
+INSERT INTO tenants (id, name, slug, created_at, updated_at) VALUES
+  ('00000000-0000-0000-0000-0000000000A0', 'rls-x-tenant-a', 'rls-x-tenant-a', NOW(), NOW()),
+  ('00000000-0000-0000-0000-0000000000B0', 'rls-x-tenant-b', 'rls-x-tenant-b', NOW(), NOW());
+
+INSERT INTO users (id, tenant_id, email, created_at, updated_at) VALUES
+  ('00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A0', 'rls-x-a@test.local', NOW(), NOW()),
+  ('00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B0', 'rls-x-b@test.local', NOW(), NOW());
+
+-- ---------------------------------------------------------------------------
+-- Level 1: depends only on tenant + user
+-- ---------------------------------------------------------------------------
+INSERT INTO accounts (id, user_id, tenant_id, type, provider, provider_account_id) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A0', 'oauth', 'rls-x-a', 'rls-x-a-acct'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B0', 'oauth', 'rls-x-b', 'rls-x-b-acct');
+
+INSERT INTO api_keys (id, user_id, tenant_id, token_hash, prefix, name, scope, expires_at, created_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A0', md5('rls-x-a-api')::text, 'apxa', 'rls-x-a-api', 'passwords:read', NOW() + interval '1 hour', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B0', md5('rls-x-b-api')::text, 'apxb', 'rls-x-b-api', 'passwords:read', NOW() + interval '1 hour', NOW());
+
+INSERT INTO audit_chain_anchors (tenant_id, chain_seq, prev_hash, updated_at) VALUES
+  ('00000000-0000-0000-0000-0000000000A0', 0, '\x00'::bytea, NOW()),
+  ('00000000-0000-0000-0000-0000000000B0', 0, '\x00'::bytea, NOW());
+
+-- audit_outbox: cleanup trigger requires status IN ('SENT','FAILED') for DELETE.
+-- We pre-set status='SENT' so the cleanup section can DELETE without firing the guard.
+INSERT INTO audit_outbox (id, tenant_id, payload, status, sent_at) VALUES
+  ('00000000-0000-0000-0000-0000000000AA', '00000000-0000-0000-0000-0000000000A0', '{"rls":"x-a"}'::jsonb, 'SENT', NOW()),
+  ('00000000-0000-0000-0000-0000000000BA', '00000000-0000-0000-0000-0000000000B0', '{"rls":"x-b"}'::jsonb, 'SENT', NOW());
+
+INSERT INTO audit_delivery_targets (id, tenant_id, kind, config_encrypted, config_iv, config_auth_tag, master_key_version) VALUES
+  ('00000000-0000-0000-0000-0000000000A9', '00000000-0000-0000-0000-0000000000A0', 'WEBHOOK', 'enc', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 1),
+  ('00000000-0000-0000-0000-0000000000B9', '00000000-0000-0000-0000-0000000000B0', 'WEBHOOK', 'enc', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 1);
+
+INSERT INTO directory_sync_configs (id, tenant_id, provider, display_name, encrypted_credentials, credentials_iv, credentials_auth_tag, updated_at) VALUES
+  ('00000000-0000-0000-0000-0000000000AD', '00000000-0000-0000-0000-0000000000A0', 'GOOGLE_WORKSPACE', 'rls-x-a-ds', 'enc', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', NOW()),
+  ('00000000-0000-0000-0000-0000000000BD', '00000000-0000-0000-0000-0000000000B0', 'GOOGLE_WORKSPACE', 'rls-x-b-ds', 'enc', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', NOW());
+
+INSERT INTO emergency_access_grants (id, tenant_id, owner_id, grantee_email, wait_days, token_hash, token_expires_at, updated_at) VALUES
+  ('00000000-0000-0000-0000-0000000000AC', '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', 'grantee-a@test.local', 1, md5('rls-x-a-ea')::text, NOW() + interval '1 day', NOW()),
+  ('00000000-0000-0000-0000-0000000000BC', '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', 'grantee-b@test.local', 1, md5('rls-x-b-ea')::text, NOW() + interval '1 day', NOW());
+
+INSERT INTO extension_bridge_codes (id, tenant_id, user_id, code_hash, scope, expires_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', md5('rls-x-a-eb')::text, 'passwords:read', NOW() + interval '1 hour'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', md5('rls-x-b-eb')::text, 'passwords:read', NOW() + interval '1 hour');
+
+INSERT INTO extension_tokens (id, user_id, tenant_id, token_hash, scope, expires_at, family_id) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A0', md5('rls-x-a-et')::text, 'passwords:read', NOW() + interval '1 hour', gen_random_uuid()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B0', md5('rls-x-b-et')::text, 'passwords:read', NOW() + interval '1 hour', gen_random_uuid());
+
+INSERT INTO folders (id, tenant_id, user_id, name, updated_at) VALUES
+  ('00000000-0000-0000-0000-0000000000A8', '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', 'rls-x-a-folder', NOW()),
+  ('00000000-0000-0000-0000-0000000000B8', '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', 'rls-x-b-folder', NOW());
+
+INSERT INTO mobile_bridge_codes (id, tenant_id, user_id, code_hash, state, code_challenge, device_pubkey, expires_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', md5('rls-x-a-mb')::text, 'state-a', md5('rls-x-a-mbc')::text, 'pubkey-a', NOW() + interval '1 hour'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', md5('rls-x-b-mb')::text, 'state-b', md5('rls-x-b-mbc')::text, 'pubkey-b', NOW() + interval '1 hour');
+
+INSERT INTO notifications (id, tenant_id, user_id, type, title, body) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', 'SECURITY_ALERT', 'rls-x-a', 'rls-x-a body'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', 'SECURITY_ALERT', 'rls-x-b', 'rls-x-b body');
+
+INSERT INTO operator_tokens (id, tenant_id, subject_user_id, created_by_user_id, token_hash, prefix, name, scope, expires_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A1', md5('rls-x-a-op')::text, 'opxa', 'rls-x-a-op', 'admin', NOW() + interval '1 hour'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B1', md5('rls-x-b-op')::text, 'opxb', 'rls-x-b-op', 'admin', NOW() + interval '1 hour');
+
+INSERT INTO personal_log_access_grants (id, tenant_id, requester_id, target_user_id, reason, expires_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A1', 'rls-x-a reason', NOW() + interval '1 hour'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B1', 'rls-x-b reason', NOW() + interval '1 hour');
+
+INSERT INTO scim_external_mappings (id, tenant_id, external_id, resource_type, internal_id, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', 'ext-a', 'User', 'int-a', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', 'ext-b', 'User', 'int-b', NOW());
+
+INSERT INTO scim_tokens (id, tenant_id, token_hash, created_by_id) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', md5('rls-x-a-scim')::text, '00000000-0000-0000-0000-0000000000A1'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', md5('rls-x-b-scim')::text, '00000000-0000-0000-0000-0000000000B1');
+
+INSERT INTO sessions (id, user_id, tenant_id, session_token, expires) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A0', md5('rls-x-a-sess')::text, NOW() + interval '1 hour'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B0', md5('rls-x-b-sess')::text, NOW() + interval '1 hour');
+
+INSERT INTO tags (id, tenant_id, user_id, name, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', 'rls-x-a-tag', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', 'rls-x-b-tag', NOW());
+
+INSERT INTO tenant_members (id, tenant_id, user_id, role, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', 'OWNER', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', 'OWNER', NOW());
+
+INSERT INTO tenant_webhooks (id, tenant_id, url, secret_encrypted, secret_iv, secret_auth_tag, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', 'https://rls-x-a.test/hook', 'enc', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', 'https://rls-x-b.test/hook', 'enc', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', NOW());
+
+INSERT INTO vault_keys (id, tenant_id, user_id, version, verification_ciphertext, verification_iv, verification_auth_tag) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', 1, 'ct-a', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', 1, 'ct-b', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff');
+
+INSERT INTO webauthn_credentials (id, user_id, tenant_id, credential_id, public_key, device_type) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A0', 'cred-rls-x-a', 'pk-a', 'singleDevice'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B0', 'cred-rls-x-b', 'pk-b', 'singleDevice');
+
+-- ---------------------------------------------------------------------------
+-- Level 2: teams + service_accounts (depend on user)
+-- ---------------------------------------------------------------------------
+INSERT INTO teams (id, tenant_id, name, slug, updated_at) VALUES
+  ('00000000-0000-0000-0000-0000000000A2', '00000000-0000-0000-0000-0000000000A0', 'rls-x-a-team', 'rls-x-a-team', NOW()),
+  ('00000000-0000-0000-0000-0000000000B2', '00000000-0000-0000-0000-0000000000B0', 'rls-x-b-team', 'rls-x-b-team', NOW());
+
+INSERT INTO service_accounts (id, tenant_id, name, identity_type, is_active, created_by_id, updated_at) VALUES
+  ('00000000-0000-0000-0000-0000000000A3', '00000000-0000-0000-0000-0000000000A0', 'rls-x-a-sa', 'SERVICE_ACCOUNT', true, '00000000-0000-0000-0000-0000000000A1', NOW()),
+  ('00000000-0000-0000-0000-0000000000B3', '00000000-0000-0000-0000-0000000000B0', 'rls-x-b-sa', 'SERVICE_ACCOUNT', true, '00000000-0000-0000-0000-0000000000B1', NOW());
+
+-- ---------------------------------------------------------------------------
+-- Level 3: depend on team or service_account
+-- ---------------------------------------------------------------------------
+INSERT INTO admin_vault_resets (id, tenant_id, target_user_id, initiated_by_id, token_hash, expires_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A1', md5('rls-x-a-avr')::text, NOW() + interval '1 hour'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B1', md5('rls-x-b-avr')::text, NOW() + interval '1 hour');
+
+INSERT INTO access_requests (id, tenant_id, service_account_id, requested_scope, expires_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A3', 'passwords:read', NOW() + interval '1 hour'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B3', 'passwords:read', NOW() + interval '1 hour');
+
+INSERT INTO directory_sync_logs (id, tenant_id, config_id, status, started_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000AD', 'SUCCESS', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000BD', 'SUCCESS', NOW());
+
+INSERT INTO emergency_access_key_pairs (id, grant_id, encrypted_private_key, private_key_iv, private_key_auth_tag, tenant_id) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000AC', 'epk-a', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', '00000000-0000-0000-0000-0000000000A0'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000BC', 'epk-b', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', '00000000-0000-0000-0000-0000000000B0');
+
+INSERT INTO scim_group_mappings (id, tenant_id, team_id, external_group_id, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A2', 'ext-grp-a', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B2', 'ext-grp-b', NOW());
+
+INSERT INTO service_account_tokens (id, service_account_id, tenant_id, token_hash, prefix, name, scope, expires_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A3', '00000000-0000-0000-0000-0000000000A0', md5('rls-x-a-sat')::text, 'satxa', 'rls-x-a-sat', 'passwords:read', NOW() + interval '1 hour'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B3', '00000000-0000-0000-0000-0000000000B0', md5('rls-x-b-sat')::text, 'satxb', 'rls-x-b-sat', 'passwords:read', NOW() + interval '1 hour');
+
+INSERT INTO team_folders (id, tenant_id, team_id, name, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A2', 'rls-x-a-tf', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B2', 'rls-x-b-tf', NOW());
+
+INSERT INTO team_invitations (id, tenant_id, team_id, email, token, expires_at, invited_by_id, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A2', 'invitee-a@test.local', md5('rls-x-a-inv')::text, NOW() + interval '1 day', '00000000-0000-0000-0000-0000000000A1', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B2', 'invitee-b@test.local', md5('rls-x-b-inv')::text, NOW() + interval '1 day', '00000000-0000-0000-0000-0000000000B1', NOW());
+
+INSERT INTO team_member_keys (id, tenant_id, team_id, user_id, encrypted_team_key, team_key_iv, team_key_auth_tag, ephemeral_public_key, hkdf_salt, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A2', '00000000-0000-0000-0000-0000000000A1', 'etk-a', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 'eph-a', 'aabbccddeeff00112233aabbccddeeff00112233aabbccddeeff00112233aabb', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B2', '00000000-0000-0000-0000-0000000000B1', 'etk-b', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 'eph-b', 'aabbccddeeff00112233aabbccddeeff00112233aabbccddeeff00112233aabb', NOW());
+
+INSERT INTO team_members (id, tenant_id, team_id, user_id, role, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A2', '00000000-0000-0000-0000-0000000000A1', 'OWNER', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B2', '00000000-0000-0000-0000-0000000000B1', 'OWNER', NOW());
+
+INSERT INTO team_policies (id, tenant_id, team_id, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A2', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B2', NOW());
+
+INSERT INTO team_tags (id, tenant_id, team_id, name, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A2', 'rls-x-a-tt', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B2', 'rls-x-b-tt', NOW());
+
+INSERT INTO team_webhooks (id, tenant_id, team_id, url, secret_encrypted, secret_iv, secret_auth_tag, updated_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A2', 'https://rls-x-a-team.test/hook', 'enc', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', NOW()),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B2', 'https://rls-x-b-team.test/hook', 'enc', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', NOW());
+
+-- ---------------------------------------------------------------------------
+-- Level 4: password_entries (depend on user, optional folder)
+-- ---------------------------------------------------------------------------
+INSERT INTO password_entries (id, tenant_id, user_id, encrypted_blob, blob_iv, blob_auth_tag, encrypted_overview, overview_iv, overview_auth_tag, key_version, updated_at) VALUES
+  ('00000000-0000-0000-0000-0000000000A6', '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', 'eb-a', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 'ov-a', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 1, NOW()),
+  ('00000000-0000-0000-0000-0000000000B6', '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', 'eb-b', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 'ov-b', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 1, NOW());
+
+INSERT INTO team_password_entries (id, tenant_id, team_id, created_by_id, updated_by_id, encrypted_blob, blob_iv, blob_auth_tag, encrypted_overview, overview_iv, overview_auth_tag, updated_at) VALUES
+  ('00000000-0000-0000-0000-0000000000A7', '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A2', '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A1', 'tb-a', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 'tov-a', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', NOW()),
+  ('00000000-0000-0000-0000-0000000000B7', '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B2', '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B1', 'tb-b', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 'tov-b', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', NOW());
+
+-- ---------------------------------------------------------------------------
+-- Level 5: depend on password_entries / team_password_entries
+-- ---------------------------------------------------------------------------
+INSERT INTO attachments (id, tenant_id, password_entry_id, created_by_id, filename, content_type, size_bytes, encrypted_data, iv, auth_tag) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A6', '00000000-0000-0000-0000-0000000000A1', 'rls-x-a.txt', 'text/plain', 1, '\x00'::bytea, 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B6', '00000000-0000-0000-0000-0000000000B1', 'rls-x-b.txt', 'text/plain', 1, '\x00'::bytea, 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff');
+
+INSERT INTO password_entry_histories (id, tenant_id, entry_id, encrypted_blob, blob_iv, blob_auth_tag, key_version) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A6', 'h-a', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 1),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B6', 'h-b', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', 1);
+
+INSERT INTO team_password_entry_histories (id, tenant_id, entry_id, encrypted_blob, blob_iv, blob_auth_tag, changed_by_id) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A7', 'th-a', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', '00000000-0000-0000-0000-0000000000A1'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B7', 'th-b', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', '00000000-0000-0000-0000-0000000000B1');
+
+INSERT INTO team_password_favorites (id, tenant_id, user_id, team_password_entry_id) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A7'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B7');
+
+INSERT INTO password_shares (id, tenant_id, token_hash, encrypted_data, data_iv, data_auth_tag, expires_at, created_by_id, password_entry_id) VALUES
+  ('00000000-0000-0000-0000-0000000000AB', '00000000-0000-0000-0000-0000000000A0', md5('rls-x-a-share')::text, 'sh-a', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', NOW() + interval '1 day', '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A6'),
+  ('00000000-0000-0000-0000-0000000000BB', '00000000-0000-0000-0000-0000000000B0', md5('rls-x-b-share')::text, 'sh-b', 'aabbccddeeff00112233aabb', 'aabbccddeeff00112233aabbccddeeff', NOW() + interval '1 day', '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B6');
+
+INSERT INTO share_access_logs (id, tenant_id, share_id) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000AB'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000BB');
+
+-- ---------------------------------------------------------------------------
+-- audit_logs: depends on outbox (CHECK constraint requires non-null outbox_id
+-- unless actor_type='SYSTEM'). Simplest: use SYSTEM actor.
+-- ---------------------------------------------------------------------------
+INSERT INTO audit_logs (id, tenant_id, scope, action, user_id, actor_type) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', 'PERSONAL', 'AUTH_LOGIN', '00000000-0000-0000-0000-0000000000A1', 'SYSTEM'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', 'PERSONAL', 'AUTH_LOGIN', '00000000-0000-0000-0000-0000000000B1', 'SYSTEM');
+
+INSERT INTO audit_deliveries (id, outbox_id, target_id, tenant_id) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000AA', '00000000-0000-0000-0000-0000000000A9', '00000000-0000-0000-0000-0000000000A0'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000BA', '00000000-0000-0000-0000-0000000000B9', '00000000-0000-0000-0000-0000000000B0');
+
+-- ---------------------------------------------------------------------------
+-- MCP chain: clients (NULL row + A + B) → access_tokens → refresh_tokens,
+--            authorization_codes, delegation_sessions
+-- ---------------------------------------------------------------------------
+-- Special case: mcp_clients allows tenant_id IS NULL (DCR pre-claimed clients).
+-- Seed three rows: A's, B's, and one with NULL tenant.
+INSERT INTO mcp_clients (id, tenant_id, client_id, client_secret_hash, name, allowed_scopes, updated_at, is_dcr) VALUES
+  ('00000000-0000-0000-0000-0000000000A4', '00000000-0000-0000-0000-0000000000A0', 'mcpc_rlsxa', md5('rls-x-a-mcp')::text, 'rls-x-a-mcp', 'credentials:list', NOW(), false),
+  ('00000000-0000-0000-0000-0000000000B4', '00000000-0000-0000-0000-0000000000B0', 'mcpc_rlsxb', md5('rls-x-b-mcp')::text, 'rls-x-b-mcp', 'credentials:list', NOW(), false),
+  ('00000000-0000-0000-0000-0000000000C4', NULL,                                   'mcpc_rlsxn', md5('rls-x-n-mcp')::text, 'rls-x-n-mcp-dcr-preclaimed', 'credentials:list', NOW(), true);
+
+INSERT INTO mcp_access_tokens (id, tenant_id, client_id, user_id, token_hash, scope, expires_at) VALUES
+  ('00000000-0000-0000-0000-0000000000A5', '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A4', '00000000-0000-0000-0000-0000000000A1', md5('rls-x-a-mcat')::text, 'credentials:list', NOW() + interval '1 hour'),
+  ('00000000-0000-0000-0000-0000000000B5', '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B4', '00000000-0000-0000-0000-0000000000B1', md5('rls-x-b-mcat')::text, 'credentials:list', NOW() + interval '1 hour');
+
+INSERT INTO mcp_authorization_codes (id, tenant_id, client_id, user_id, redirect_uri, scope, code_hash, code_challenge, expires_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A4', '00000000-0000-0000-0000-0000000000A1', 'http://localhost/cb', 'credentials:list', md5('rls-x-a-mac')::text, md5('rls-x-a-mac-cc')::text, NOW() + interval '1 hour'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B4', '00000000-0000-0000-0000-0000000000B1', 'http://localhost/cb', 'credentials:list', md5('rls-x-b-mac')::text, md5('rls-x-b-mac-cc')::text, NOW() + interval '1 hour');
+
+INSERT INTO mcp_refresh_tokens (id, tenant_id, family_id, access_token_id, client_id, user_id, token_hash, scope, expires_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', gen_random_uuid(), '00000000-0000-0000-0000-0000000000A5', '00000000-0000-0000-0000-0000000000A4', '00000000-0000-0000-0000-0000000000A1', md5('rls-x-a-mrt')::text, 'credentials:list', NOW() + interval '1 hour'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', gen_random_uuid(), '00000000-0000-0000-0000-0000000000B5', '00000000-0000-0000-0000-0000000000B4', '00000000-0000-0000-0000-0000000000B1', md5('rls-x-b-mrt')::text, 'credentials:list', NOW() + interval '1 hour');
+
+INSERT INTO delegation_sessions (id, tenant_id, user_id, mcp_token_id, expires_at) VALUES
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000A0', '00000000-0000-0000-0000-0000000000A1', '00000000-0000-0000-0000-0000000000A5', NOW() + interval '1 hour'),
+  (gen_random_uuid(), '00000000-0000-0000-0000-0000000000B0', '00000000-0000-0000-0000-0000000000B1', '00000000-0000-0000-0000-0000000000B5', NOW() + interval '1 hour');
+
+RESET app.bypass_rls;

--- a/scripts/rls-cross-tenant-tables.manifest
+++ b/scripts/rls-cross-tenant-tables.manifest
@@ -1,0 +1,78 @@
+# scripts/rls-cross-tenant-tables.manifest
+#
+# Canonical list of tenant-scoped tables (one per line, alphabetical).
+# Used by the cross-tenant RLS predicate verify step in CI to assert
+# discovery == manifest (set equality). See docs/archive/review/
+# verify-rls-predicate-plan.md.
+#
+# Maintenance contract — adding a tenant-scoped table requires THREE deltas
+# in the same PR:
+#   1. Migration: add the `tenant_id` column + ENABLE/FORCE RLS + the
+#      `<table>_tenant_isolation` policy.
+#   2. scripts/rls-cross-tenant-seed.sql: insert dependency-ordered rows
+#      (one for tenant A, one for tenant B; plus one NULL-tenant row if the
+#      table allows nullable tenant_id, e.g. mcp_clients).
+#   3. scripts/rls-cross-tenant-tables.manifest: insert a line in
+#      alphabetical order.
+# Removing a tenant-scoped table requires REMOVING all three.
+#
+# All current tenant_isolation policies follow the <table>_tenant_isolation
+# suffix convention. The bare-name 'tenant_isolation' policy on team_policies
+# was renamed in migration 20260321110000_convert_id_columns_to_uuid_type.
+# The discovery OR-branch for the bare name remains as defensive forward-compat.
+#
+# Total: 53 tenant-scoped tables (excludes `tenants` itself, which is
+# structurally exempt — it has no `tenant_id` column).
+access_requests
+accounts
+admin_vault_resets
+api_keys
+attachments
+audit_chain_anchors
+audit_deliveries
+audit_delivery_targets
+audit_logs
+audit_outbox
+delegation_sessions
+directory_sync_configs
+directory_sync_logs
+emergency_access_grants
+emergency_access_key_pairs
+extension_bridge_codes
+extension_tokens
+folders
+mcp_access_tokens
+mcp_authorization_codes
+mcp_clients
+mcp_refresh_tokens
+mobile_bridge_codes
+notifications
+operator_tokens
+password_entries
+password_entry_histories
+password_shares
+personal_log_access_grants
+scim_external_mappings
+scim_group_mappings
+scim_tokens
+service_account_tokens
+service_accounts
+sessions
+share_access_logs
+tags
+team_folders
+team_invitations
+team_member_keys
+team_members
+team_password_entries
+team_password_entry_histories
+team_password_favorites
+team_policies
+team_tags
+team_webhooks
+teams
+tenant_members
+tenant_webhooks
+users
+vault_keys
+webauthn_credentials

--- a/scripts/rls-cross-tenant-verify.sql
+++ b/scripts/rls-cross-tenant-verify.sql
@@ -1,0 +1,430 @@
+-- RLS Cross-Tenant Predicate Verify
+--
+-- Runs as passwd_app (NOSUPERUSER, NOBYPASSRLS).
+-- Asserts that every `tenant_isolation` policy actually filters by tenant_id at
+-- runtime — catches "USING (true)", dropped bypass clauses, asymmetric
+-- USING/WITH CHECK, NULL clauses, and manifest drift.
+--
+-- DO NOT WRAP THIS FILE IN BEGIN/COMMIT OR INVOKE psql WITH --single-transaction.
+-- Each DO block must run as its own top-level statement so SET LOCAL is scoped
+-- to that block's implicit transaction. Wrapping in a single transaction would
+-- merge all DO blocks into one transaction, causing Block 4's app.bypass_rls=on
+-- to leak into subsequent assertions in the same psql session and false-green
+-- predicate regressions.
+--
+-- Stable error codes (`[E-RLS-*]`) are part of the public contract — the
+-- gate self-check (rls-cross-tenant-negative-test.sh) regex-matches these
+-- codes, so message prose can change but the bracketed code must not.
+--
+-- Required psql variable:
+--   -v expected_tables=<comma-separated manifest> (no spaces)
+--
+-- See docs/archive/review/verify-rls-predicate-plan.md for the design.
+
+-- Bridge the psql variable into a session GUC so the DO blocks (whose
+-- dollar-quoted bodies are not re-scanned for psql variable substitution)
+-- can read it via `current_setting('app.expected_tables', true)`.
+SET app.expected_tables TO :'expected_tables';
+
+-- =====================================================================
+-- Block 1: Role flags + structural invariants.
+-- ASSERT halts on first failure, so order is LOAD-BEARING:
+--   1. [E-RLS-ROLE]               role flags
+--   2. [E-RLS-DISCOVER]           discovery accessibility self-test
+--   3. [E-RLS-NULL]               NULL USING/WITH CHECK clause guard
+--                                 (MUST run BEFORE symmetry — a NULL polqual
+--                                 vs non-NULL polwithcheck would otherwise
+--                                 fire [E-RLS-SYM] first and mask the defect)
+--   4. [E-RLS-SYM]                USING ↔ WITH CHECK symmetry
+--   5. [E-RLS-COLPARITY]          column count vs discovery count parity
+--   6. [E-RLS-MANIFEST-EXTRA]     manifest \ discovery
+--   7. [E-RLS-MANIFEST-MISSING]   discovery \ manifest
+-- =====================================================================
+DO $$
+DECLARE
+  discovered_count int;
+  column_count int;
+BEGIN
+  -- 1. Role flags. Belt-and-suspenders: defends against the verify step
+  --    being accidentally invoked as passwd_user (SUPERUSER bypasses RLS,
+  --    yielding a false-green run).
+  ASSERT current_user = 'passwd_app',
+    format('[E-RLS-ROLE] verify must run as passwd_app, got %L', current_user);
+  ASSERT session_user = current_user,
+    '[E-RLS-ROLE] session_user must equal current_user (no SET ROLE in this script)';
+  ASSERT current_setting('is_superuser') = 'off',
+    '[E-RLS-ROLE] is_superuser must be off';
+  ASSERT (SELECT NOT rolsuper FROM pg_roles WHERE rolname = current_user),
+    '[E-RLS-ROLE] passwd_app must not be SUPERUSER';
+  ASSERT (SELECT NOT rolbypassrls FROM pg_roles WHERE rolname = current_user),
+    '[E-RLS-ROLE] passwd_app must not have BYPASSRLS';
+
+  -- 2. Discovery accessibility self-test. If passwd_app cannot SELECT from
+  --    pg_catalog.pg_policy, the entire verify step is silently vacuous.
+  ASSERT (
+    SELECT count(*) FROM pg_catalog.pg_policy
+    WHERE polname = 'tenant_isolation'
+       OR polname LIKE '%\_tenant_isolation' ESCAPE '\'
+  ) > 0,
+    '[E-RLS-DISCOVER] passwd_app cannot read pg_policy — discovery is broken';
+
+  -- 3. NULL USING / WITH CHECK clause guard.
+  --    Convention: tenant_isolation policies are FOR ALL with non-NULL clauses.
+  --    A FOR INSERT-only policy (polqual NULL, polwithcheck non-NULL) named
+  --    `<table>_tenant_isolation` would false-positive here — use a different
+  --    policyname for INSERT-only patterns.
+  ASSERT NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+      AND (p.polqual IS NULL OR p.polwithcheck IS NULL)
+  ),
+    '[E-RLS-NULL] A tenant_isolation policy has a NULL USING or WITH CHECK clause (USING NULL = policy applies to all rows). Treat as a defect. Convention: tenant_isolation policies must be FOR ALL with non-NULL USING and WITH CHECK; FOR INSERT-only would also fire this guard as a false positive — use a different policyname for INSERT-only patterns.';
+
+  -- 4. USING ↔ WITH CHECK symmetry guard.
+  --    Compares pg_get_expr() output (canonicalized expression text). Catches
+  --    the common asymmetric-write-clause bug (e.g., USING (tenant filter)
+  --    + WITH CHECK (true) admits cross-tenant INSERTs). Theoretical false
+  --    positives (cosmetic deparser differences) are loud failures and
+  --    recoverable by reviewing pg_get_expr output directly.
+  --    `IS DISTINCT FROM` is NULL-aware: NULL IS DISTINCT FROM NULL = FALSE,
+  --    so the prior NULL-clause guard is the right place for that case.
+  ASSERT NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+      AND pg_get_expr(p.polqual, p.polrelid)
+          IS DISTINCT FROM pg_get_expr(p.polwithcheck, p.polrelid)
+  ),
+    '[E-RLS-SYM] A tenant_isolation policy has asymmetric USING vs WITH CHECK — add INSERT/UPDATE/DELETE assertions OR normalise the policy.';
+
+  -- 5. Column parity: every discovered policy table has a tenant_id column,
+  --    and every public.tenant_id column (other than `tenants`) has a policy.
+  SELECT count(*) INTO discovered_count
+  FROM pg_catalog.pg_policy p
+  JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  JOIN information_schema.columns col
+    ON col.table_schema = n.nspname
+   AND col.table_name = c.relname
+   AND col.column_name = 'tenant_id'
+  WHERE n.nspname = 'public'
+    AND c.relname <> 'tenants'
+    AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\');
+
+  SELECT count(*) INTO column_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND column_name = 'tenant_id'
+    AND table_name <> 'tenants';
+
+  ASSERT discovered_count = column_count,
+    format('[E-RLS-COLPARITY] tenant_id column count (%s) does not equal discovered tenant_isolation policy count (%s) — a column was added without a policy, or a policy without its column.',
+      column_count, discovered_count);
+
+  -- 6. Manifest \ discovery (extra in manifest, missing from DB).
+  ASSERT NOT EXISTS (
+    SELECT m.t FROM unnest(string_to_array(current_setting('app.expected_tables', true), ',')) AS m(t)
+    EXCEPT
+    SELECT c.relname
+    FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    JOIN information_schema.columns col
+      ON col.table_schema = n.nspname
+     AND col.table_name = c.relname
+     AND col.column_name = 'tenant_id'
+    WHERE n.nspname = 'public'
+      AND c.relname <> 'tenants'
+      AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+  ),
+    format('[E-RLS-MANIFEST-EXTRA] Manifest has tables not in discovery: %s', (
+      SELECT string_agg(m.t, ',')
+      FROM unnest(string_to_array(current_setting('app.expected_tables', true), ',')) AS m(t)
+      WHERE m.t NOT IN (
+        SELECT c.relname
+        FROM pg_catalog.pg_policy p
+        JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        JOIN information_schema.columns col
+          ON col.table_schema = n.nspname
+         AND col.table_name = c.relname
+         AND col.column_name = 'tenant_id'
+        WHERE n.nspname = 'public'
+          AND c.relname <> 'tenants'
+          AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+      )
+    ));
+
+  -- 7. Discovery \ manifest (extra in DB, missing from manifest).
+  ASSERT NOT EXISTS (
+    SELECT c.relname
+    FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    JOIN information_schema.columns col
+      ON col.table_schema = n.nspname
+     AND col.table_name = c.relname
+     AND col.column_name = 'tenant_id'
+    WHERE n.nspname = 'public'
+      AND c.relname <> 'tenants'
+      AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+    EXCEPT
+    SELECT m.t FROM unnest(string_to_array(current_setting('app.expected_tables', true), ',')) AS m(t)
+  ),
+    format('[E-RLS-MANIFEST-MISSING] Discovery has tables not in manifest: %s', (
+      SELECT string_agg(c.relname, ',')
+      FROM pg_catalog.pg_policy p
+      JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+      JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+      JOIN information_schema.columns col
+        ON col.table_schema = n.nspname
+       AND col.table_name = c.relname
+       AND col.column_name = 'tenant_id'
+      WHERE n.nspname = 'public'
+        AND c.relname <> 'tenants'
+        AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+        AND c.relname NOT IN (
+          SELECT m.t FROM unnest(string_to_array(current_setting('app.expected_tables', true), ',')) AS m(t)
+        )
+    ));
+END $$;
+
+-- =====================================================================
+-- Block 2: Tenant A → exactly 1 row visible per discovered table.
+-- Accumulator pattern (RAISE NOTICE per failing table, RAISE EXCEPTION at end)
+-- so a multi-table predicate regression surfaces ALL offending tables in one
+-- CI run instead of one per push.
+-- =====================================================================
+DO $$
+DECLARE
+  t text;
+  n bigint;
+  expected bigint;
+  failures int := 0;
+BEGIN
+  -- Ensure NOTICE lines are not suppressed by a future PGOPTIONS=-c
+  -- client_min_messages=WARNING invocation.
+  SET LOCAL client_min_messages = 'NOTICE';
+
+  -- Defensive prelude: bypass must NOT be on entering Block 2.
+  ASSERT current_setting('app.bypass_rls', true) IS NULL
+      OR current_setting('app.bypass_rls', true) = '',
+    'pre-Block-2: app.bypass_rls must be unset';
+
+  SET LOCAL app.tenant_id = '00000000-0000-0000-0000-0000000000A0';
+
+  -- Defensive ASSERT confirming the GUC took effect — catches a hypothetical
+  -- runtime regression in SET LOCAL semantics before per-table assertions run.
+  ASSERT current_setting('app.tenant_id', true) = '00000000-0000-0000-0000-0000000000A0',
+    'pre-Block-2: SET LOCAL app.tenant_id failed';
+
+  FOR t IN
+    SELECT c.relname
+    FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    JOIN information_schema.columns col
+      ON col.table_schema = n.nspname
+     AND col.table_name = c.relname
+     AND col.column_name = 'tenant_id'
+    WHERE n.nspname = 'public'
+      AND c.relname <> 'tenants'
+      AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+    ORDER BY c.relname
+  LOOP
+    -- Defensive identifier regex (belt-and-suspenders for SQL injection — `t`
+    -- comes from pg_class which is trusted, but %I + this regex make the
+    -- safety property local and obvious).
+    ASSERT t ~ '^[a-z_][a-z0-9_]*$',
+      format('table name failed regex: %L', t);
+
+    -- Per-table expected count for tenant A. Currently every tenant-scoped
+    -- table has exactly 1 A-row in the seed; the CASE keeps the shape
+    -- identical to Block 4 so future special-cases plug in mechanically.
+    expected := CASE t WHEN 'mcp_clients' THEN 1 ELSE 1 END;
+
+    -- %I quotes the identifier safely; never widen to %s for table names.
+    EXECUTE format('SELECT count(*) FROM %I', t) INTO n;
+
+    IF n <> expected THEN
+      RAISE NOTICE 'FAIL table=% block=verify-A tenant=A expected=% got=% — likely cause: policy bug (cross-tenant leak). Coverage already confirmed exactly 1 row in DB.',
+        t, expected, n;
+      failures := failures + 1;
+    END IF;
+  END LOOP;
+
+  IF failures > 0 THEN
+    RAISE EXCEPTION '[E-RLS-COUNT-A] Block 2 (tenant A): % tables failed — see NOTICE lines above', failures;
+  END IF;
+END $$;
+
+-- =====================================================================
+-- Block 3: Tenant B → exactly 1 row visible per discovered table.
+-- Mirror of Block 2 with tenant B's UUID and error code [E-RLS-COUNT-B].
+-- =====================================================================
+DO $$
+DECLARE
+  t text;
+  n bigint;
+  expected bigint;
+  failures int := 0;
+BEGIN
+  SET LOCAL client_min_messages = 'NOTICE';
+
+  ASSERT current_setting('app.bypass_rls', true) IS NULL
+      OR current_setting('app.bypass_rls', true) = '',
+    'pre-Block-3: app.bypass_rls must be unset';
+
+  SET LOCAL app.tenant_id = '00000000-0000-0000-0000-0000000000B0';
+
+  ASSERT current_setting('app.tenant_id', true) = '00000000-0000-0000-0000-0000000000B0',
+    'pre-Block-3: SET LOCAL app.tenant_id failed';
+
+  FOR t IN
+    SELECT c.relname
+    FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    JOIN information_schema.columns col
+      ON col.table_schema = n.nspname
+     AND col.table_name = c.relname
+     AND col.column_name = 'tenant_id'
+    WHERE n.nspname = 'public'
+      AND c.relname <> 'tenants'
+      AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+    ORDER BY c.relname
+  LOOP
+    ASSERT t ~ '^[a-z_][a-z0-9_]*$',
+      format('table name failed regex: %L', t);
+
+    expected := CASE t WHEN 'mcp_clients' THEN 1 ELSE 1 END;
+
+    EXECUTE format('SELECT count(*) FROM %I', t) INTO n;
+
+    IF n <> expected THEN
+      RAISE NOTICE 'FAIL table=% block=verify-B tenant=B expected=% got=% — likely cause: policy bug (cross-tenant leak). Coverage already confirmed exactly 1 row in DB.',
+        t, expected, n;
+      failures := failures + 1;
+    END IF;
+  END LOOP;
+
+  IF failures > 0 THEN
+    RAISE EXCEPTION '[E-RLS-COUNT-B] Block 3 (tenant B): % tables failed — see NOTICE lines above', failures;
+  END IF;
+END $$;
+
+-- =====================================================================
+-- Block 4: Bypass-channel sanity. With app.bypass_rls=on AND app.tenant_id
+-- reset, the OR-bypass clause in each policy must admit BOTH seeded rows
+-- (3 for mcp_clients: A + B + NULL).
+--
+-- NOTE: app.bypass_rls is a soft GUC. SQL-level access to a passwd_app session
+-- can SET it to 'on' and defeat RLS. RLS is one layer; do not rely on it as
+-- the sole tenant boundary. Hardening tracked as a follow-up issue.
+-- =====================================================================
+DO $$
+DECLARE
+  t text;
+  n bigint;
+  expected bigint;
+  filter_clause text;
+  failures int := 0;
+BEGIN
+  SET LOCAL client_min_messages = 'NOTICE';
+
+  -- IMPORTANT: cannot use `RESET app.tenant_id` here. Postgres quirk: once a
+  -- custom GUC has been SET (or SET LOCAL'd) in a session, subsequent calls
+  -- to `current_setting('app.tenant_id', true)` return the empty string ''
+  -- — NOT NULL — even after RESET / DISCARD ALL. The policy's USING clause
+  -- then evaluates `tenant_id = ''::uuid`, which raises
+  -- `invalid input syntax for type uuid: ""` BEFORE the OR-bypass branch
+  -- can short-circuit. (Confirmed empirically against postgres:16-alpine.)
+  --
+  -- The fix: set app.tenant_id to a valid sentinel UUID that cannot match
+  -- any real tenant_id. The all-zeros nil-UUID is the canonical choice —
+  -- it parses cleanly, matches no seeded row (tenants A/B use ...000A0/B0),
+  -- and lets the OR-bypass clause exclusively drive the visibility result.
+  -- Net effect: same semantic intent as "tenant filter disabled, bypass-only".
+  SET LOCAL app.tenant_id = '00000000-0000-0000-0000-000000000000';
+  SET LOCAL app.bypass_rls = 'on';
+
+  ASSERT current_setting('app.tenant_id', true) = '00000000-0000-0000-0000-000000000000',
+    'pre-Block-4: SET LOCAL app.tenant_id (nil sentinel) failed';
+  ASSERT current_setting('app.bypass_rls', true) = 'on',
+    'pre-Block-4: SET LOCAL app.bypass_rls failed';
+
+  FOR t IN
+    SELECT c.relname
+    FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    JOIN information_schema.columns col
+      ON col.table_schema = n.nspname
+     AND col.table_name = c.relname
+     AND col.column_name = 'tenant_id'
+    WHERE n.nspname = 'public'
+      AND c.relname <> 'tenants'
+      AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+    ORDER BY c.relname
+  LOOP
+    ASSERT t ~ '^[a-z_][a-z0-9_]*$',
+      format('table name failed regex: %L', t);
+
+    expected := CASE t WHEN 'mcp_clients' THEN 3 ELSE 2 END;
+
+    -- filter_clause is built from CONSTANTS only (UUID literals from the
+    -- seed). %L quotes them as SQL literals; the cast to ::uuid is added
+    -- explicitly. NEVER widen this to interpolate user input — it is
+    -- inlined into a larger format() via %s and that is only safe because
+    -- the only input shape here is a constant UUID literal.
+    filter_clause := CASE t
+      WHEN 'mcp_clients' THEN format(
+        'tenant_id IN (%L::uuid, %L::uuid) OR tenant_id IS NULL',
+        '00000000-0000-0000-0000-0000000000A0',
+        '00000000-0000-0000-0000-0000000000B0')
+      ELSE format(
+        'tenant_id IN (%L::uuid, %L::uuid)',
+        '00000000-0000-0000-0000-0000000000A0',
+        '00000000-0000-0000-0000-0000000000B0')
+    END;
+
+    EXECUTE format('SELECT count(*) FILTER (WHERE %s) FROM %I', filter_clause, t) INTO n;
+
+    IF n <> expected THEN
+      RAISE NOTICE 'FAIL table=% block=bypass expected=% got=% — likely cause: policy bypass clause regression (the OR app.bypass_rls=on branch was removed or weakened)',
+        t, expected, n;
+      failures := failures + 1;
+    END IF;
+  END LOOP;
+
+  -- Defense-in-depth: assert the mcp_clients NULL-tenant row is visible
+  -- under bypass. The filtered count above already requires it (3 = 2 named +
+  -- 1 NULL), but an explicit NULL-only assertion catches a regression where
+  -- the policy admits exactly 2 named rows + 1 spurious row from elsewhere.
+  SELECT count(*) INTO n FROM mcp_clients WHERE tenant_id IS NULL;
+  IF n <> 1 THEN
+    RAISE NOTICE 'FAIL mcp_clients NULL-tenant row not visible under bypass — count=%', n;
+    failures := failures + 1;
+  END IF;
+
+  IF failures > 0 THEN
+    RAISE EXCEPTION '[E-RLS-BYPASS] Block 4 (bypass): % failures — see NOTICE lines above', failures;
+  END IF;
+END $$;
+
+-- =====================================================================
+-- Block 5: Cleanup. Defensive no-op safety net — SET LOCAL from prior blocks
+-- is already discarded at the transaction boundary; this block makes the
+-- intent explicit and harmless if a future maintainer changes prior blocks
+-- to non-LOCAL SET.
+-- =====================================================================
+DO $$
+BEGIN
+  RESET app.bypass_rls;
+  RESET app.tenant_id;
+END $$;

--- a/scripts/rls-cross-tenant-verify.sql
+++ b/scripts/rls-cross-tenant-verify.sql
@@ -204,8 +204,8 @@ DO $$
 DECLARE
   t text;
   n bigint;
-  expected bigint;
   failures int := 0;
+  tenant_a constant uuid := '00000000-0000-0000-0000-0000000000A0';
 BEGIN
   -- Ensure NOTICE lines are not suppressed by a future PGOPTIONS=-c
   -- client_min_messages=WARNING invocation.
@@ -243,17 +243,12 @@ BEGIN
     ASSERT t ~ '^[a-z_][a-z0-9_]*$',
       format('table name failed regex: %L', t);
 
-    -- Per-table expected count for tenant A. Currently every tenant-scoped
-    -- table has exactly 1 A-row in the seed; the CASE keeps the shape
-    -- identical to Block 4 so future special-cases plug in mechanically.
-    expected := CASE t WHEN 'mcp_clients' THEN 1 ELSE 1 END;
-
     -- %I quotes the identifier safely; never widen to %s for table names.
     EXECUTE format('SELECT count(*) FROM %I', t) INTO n;
 
-    IF n <> expected THEN
-      RAISE NOTICE 'FAIL table=% block=verify-A tenant=A expected=% got=% — likely cause: policy bug (cross-tenant leak). Coverage already confirmed exactly 1 row in DB.',
-        t, expected, n;
+    IF n <> 1 THEN
+      RAISE NOTICE 'FAIL table=% block=verify-A tenant=A expected=1 got=% — likely cause: policy bug (cross-tenant leak). Coverage already confirmed exactly 1 row in DB.',
+        t, n;
       failures := failures + 1;
     END IF;
   END LOOP;
@@ -271,8 +266,8 @@ DO $$
 DECLARE
   t text;
   n bigint;
-  expected bigint;
   failures int := 0;
+  tenant_b constant uuid := '00000000-0000-0000-0000-0000000000B0';
 BEGIN
   SET LOCAL client_min_messages = 'NOTICE';
 
@@ -302,13 +297,11 @@ BEGIN
     ASSERT t ~ '^[a-z_][a-z0-9_]*$',
       format('table name failed regex: %L', t);
 
-    expected := CASE t WHEN 'mcp_clients' THEN 1 ELSE 1 END;
-
     EXECUTE format('SELECT count(*) FROM %I', t) INTO n;
 
-    IF n <> expected THEN
-      RAISE NOTICE 'FAIL table=% block=verify-B tenant=B expected=% got=% — likely cause: policy bug (cross-tenant leak). Coverage already confirmed exactly 1 row in DB.',
-        t, expected, n;
+    IF n <> 1 THEN
+      RAISE NOTICE 'FAIL table=% block=verify-B tenant=B expected=1 got=% — likely cause: policy bug (cross-tenant leak). Coverage already confirmed exactly 1 row in DB.',
+        t, n;
       failures := failures + 1;
     END IF;
   END LOOP;
@@ -334,22 +327,16 @@ DECLARE
   expected bigint;
   filter_clause text;
   failures int := 0;
+  tenant_a constant uuid := '00000000-0000-0000-0000-0000000000A0';
+  tenant_b constant uuid := '00000000-0000-0000-0000-0000000000B0';
+  -- Cannot use `RESET app.tenant_id`: Postgres custom-GUC quirk — once SET in
+  -- a session, current_setting returns '' rather than NULL even after RESET,
+  -- and `''::uuid` errors before the OR-bypass clause can short-circuit. The
+  -- nil sentinel parses cleanly and matches no real tenant_id.
+  nil_sentinel constant uuid := '00000000-0000-0000-0000-000000000000';
 BEGIN
   SET LOCAL client_min_messages = 'NOTICE';
 
-  -- IMPORTANT: cannot use `RESET app.tenant_id` here. Postgres quirk: once a
-  -- custom GUC has been SET (or SET LOCAL'd) in a session, subsequent calls
-  -- to `current_setting('app.tenant_id', true)` return the empty string ''
-  -- — NOT NULL — even after RESET / DISCARD ALL. The policy's USING clause
-  -- then evaluates `tenant_id = ''::uuid`, which raises
-  -- `invalid input syntax for type uuid: ""` BEFORE the OR-bypass branch
-  -- can short-circuit. (Confirmed empirically against postgres:16-alpine.)
-  --
-  -- The fix: set app.tenant_id to a valid sentinel UUID that cannot match
-  -- any real tenant_id. The all-zeros nil-UUID is the canonical choice —
-  -- it parses cleanly, matches no seeded row (tenants A/B use ...000A0/B0),
-  -- and lets the OR-bypass clause exclusively drive the visibility result.
-  -- Net effect: same semantic intent as "tenant filter disabled, bypass-only".
   SET LOCAL app.tenant_id = '00000000-0000-0000-0000-000000000000';
   SET LOCAL app.bypass_rls = 'on';
 
@@ -377,20 +364,16 @@ BEGIN
 
     expected := CASE t WHEN 'mcp_clients' THEN 3 ELSE 2 END;
 
-    -- filter_clause is built from CONSTANTS only (UUID literals from the
-    -- seed). %L quotes them as SQL literals; the cast to ::uuid is added
-    -- explicitly. NEVER widen this to interpolate user input — it is
-    -- inlined into a larger format() via %s and that is only safe because
-    -- the only input shape here is a constant UUID literal.
+    -- filter_clause is inlined into the outer format() via %s. Only safe
+    -- because the inputs are PL/pgSQL constants (tenant_a/tenant_b UUIDs);
+    -- never widen this to interpolate user input.
     filter_clause := CASE t
       WHEN 'mcp_clients' THEN format(
         'tenant_id IN (%L::uuid, %L::uuid) OR tenant_id IS NULL',
-        '00000000-0000-0000-0000-0000000000A0',
-        '00000000-0000-0000-0000-0000000000B0')
+        tenant_a, tenant_b)
       ELSE format(
         'tenant_id IN (%L::uuid, %L::uuid)',
-        '00000000-0000-0000-0000-0000000000A0',
-        '00000000-0000-0000-0000-0000000000B0')
+        tenant_a, tenant_b)
     END;
 
     EXECUTE format('SELECT count(*) FILTER (WHERE %s) FROM %I', filter_clause, t) INTO n;


### PR DESCRIPTION
## Summary

Add a CI gate that catches RLS policy predicate bugs at runtime by seeding two tenants and asserting per-tenant exactly-1 row visibility via a NOSUPERUSER `passwd_app` session. Previously CI verified only policy presence (`check-migration-drift.mjs`) and grants (`rls-smoke` job) — a `CREATE POLICY ... USING (true)` or hardcoded-tenant predicate would silently allow cross-tenant reads.

The gate runs as four new steps in the existing `rls-smoke` job:

1. **Cross-tenant seed** (SUPERUSER) — 53 manifest tables × 2 tenants + a NULL-tenant row for `mcp_clients`
2. **Coverage check** — exactly 1 row per tenant in seed (catches seed drift; fail message points at the seed file)
3. **RLS predicate verify** (NOSUPERUSER) — 5 DO blocks with 10 stable `[E-RLS-*]` error codes (role flags / discovery accessibility / NULL-clause / USING==WITH CHECK symmetry / column parity / manifest parity / per-tenant count / bypass-channel sanity)
4. **Negative test** (gate self-check) — 8 cases (Case 0 pre-flight + Cases 1-7 deliberate failures) against an ephemeral throwaway table; verifies the gate correctly fires its own `[E-RLS-*]` codes

Discovery uses `pg_catalog.pg_policy` directly (avoids the `pg_policies` view's role-USAGE filter that would hide policies from non-owner roles). The `scripts/rls-cross-tenant-tables.manifest` file replaces a soft numeric floor — adding/removing a tenant-scoped table requires an explicit table-name diff.

## Notable design points

- **Block 4 uses `SET LOCAL app.tenant_id = nil-UUID`** instead of `RESET` (Postgres quirk: once a custom GUC is touched, `current_setting` returns `''` rather than `NULL` after RESET, and the policy's `::uuid` cast errors before the OR-bypass clause can short-circuit). See `docs/archive/review/verify-rls-predicate-deviation.md`.
- **Stable `[E-RLS-*]` error codes** are part of the public contract — the gate self-check uses literal-string match (`grep -qF`) so message-prose changes don't silently break coverage.
- **`pre-pr.sh`** gets a new `Static: rls-cross-tenant SQL parse` step (skipped gracefully when local Postgres isn't running).

## Process

The change went through the full triangulate workflow:

- Plan review: 5 rounds → READY TO MERGE convergence (`docs/archive/review/verify-rls-predicate-review.md`)
- Code review: 2 rounds → READY TO MERGE convergence (`docs/archive/review/verify-rls-predicate-code-review.md`)
- 4 implementation deviations recorded in `docs/archive/review/verify-rls-predicate-deviation.md`
- `/simplify` pass: 5 cleanup fixes + 3 architectural deferrals documented

End-to-end verified against local docker stack (`postgres:16-alpine`): seed → coverage → verify → negative test (8 cases) all green; `pre-pr.sh` 13/13 pass.

## Test plan

- [ ] CI `rls-smoke` job passes all 7 steps (3 existing + 4 new)
- [ ] CI `rls-smoke` correctly fails when a `tenant_isolation` policy is mutated to `USING (true)` (manual mutation test)
- [ ] CI `rls-smoke` correctly fails when a tenant_id column is added without a corresponding policy
- [ ] `pre-pr.sh` locally with docker stack up: 14/14 pass

Closes #434