### PR TITLE
harden: state-machine strictness + RLS FORCE/SECDEF + crypto adversarial follow-up

### DIFF
--- a/docs/archive/review/centralize-state-transitions-manual-test.md
+++ b/docs/archive/review/centralize-state-transitions-manual-test.md
@@ -160,3 +160,42 @@ ORDER BY created_at;
 Pure code change — no DB schema migration. To roll back: `git revert <merge-commit-sha>`. Pre-revert sanity: `git diff main..<feature-branch> -- prisma/migrations/` must be empty.
 
 After revert: routes fall back to inline `prisma.<table>.updateMany({ where: ..., data: { status: ... } })`; the CI guard reverts too. State data in `emergency_access_grants` and `access_requests` is untouched.
+
+---
+
+## Follow-up delta: PR `#443` (harden — strictness + RLS FORCE/SECDEF + crypto adversarial)
+
+This section is a **delta**, not a re-execution. The parent plan above stays the source of truth for the centralize-state-transitions surface; only the manual-only items below were added by `#443`.
+
+### What is automation-covered (do NOT re-execute manually)
+
+- `transition()` strict-throw on `count > 1` — covered by unit-mocked tests in `src/lib/{emergency-access,access-request}/*-state.test.ts` (per-file `transition() return-value strictness` describe block, 3 cases each).
+- MATRIX const usage (`EA_ACTOR.*` / `AR_ACTOR.*`) — compile-time + the existing `EXPECTED_TRANSITIONS` drift detector.
+- State-mutation lint extensions (`upsert`, computed property names, `as`-cast unwrap) — covered by `scripts/__tests__/check-state-mutation-centralization.test.ts` against the 8 expanded bad-fixture cases.
+- T17 `[false, true]` shape + `loser.reason === "not_eligible"` — covered by `centralize-state-transitions.integration.test.ts` (already in the parent plan's automated suite).
+- RLS `[E-RLS-FORCE]` and `[E-RLS-SECDEF]` — covered by `scripts/rls-cross-tenant-negative-test.sh` Cases 8 and 9 (CI gate).
+- Crypto nonce uniqueness / GCM authenticity / rotation rollback — covered by the five `*.adversarial.test.ts` files.
+
+### What genuinely needs manual eyes (M4: access-request UI smoke, ~5 min)
+
+Why manual: the `access-request-card` component re-renders status filter dropdown items + per-request status badges + the conditional approve/deny button via the new `AR_STATUS` constants. Type-checking + the component unit test confirm the values, but the visual rendering of badges (variant mapping `STATUS_VARIANTS[req.status]`) and the locale-bound label (`statusLabel` reading from `t("arStatus*")`) is not exercised by automation against a real request set.
+
+Pre-conditions: all from the parent plan's "Pre-conditions" section, plus at least one tenant member with `service-account.write` permission and one service account.
+
+Steps:
+
+1. As tenant admin, navigate to `/<locale>/dashboard/settings/developer` → "Access Requests" card.
+2. Click **+** to create a new request: pick the seeded service account, request scopes `credentials:list,credentials:use`, justification `<placeholder>`, expiry 60 minutes. Submit.
+3. The new request renders with a `Pending` badge — confirm the badge variant is `default` (not destructive / outline) and the locale label matches `arStatusPending`.
+4. Use the status filter dropdown: cycle through `ALL → PENDING → APPROVED → DENIED → EXPIRED`. Each option must select-and-render correctly; the request created in step 2 should appear under `ALL` and `PENDING`, disappear under the others.
+5. Approve the pending request. Badge flips to `Approved` (variant `secondary`). Confirm the approve/deny buttons are no longer visible (the `req.status === AR_STATUS.PENDING` guard hides them).
+6. Create a second request, deny it. Badge flips to `Denied` (variant `destructive`).
+
+Expected: every status badge maps to the documented variant, the locale label matches `t("arStatus*")` for all four statuses, and the approve/deny buttons appear only in the `PENDING` state.
+
+Adversarial scenario (M4-adv, optional): in DevTools, manually mutate the rendered `req.status` via React DevTools to a string not in `AR_STATUS` (e.g., `"FAKE"`). The badge should fall back gracefully — if it crashes the component, the runtime narrowing has a gap. Not a regression vector this PR introduces; included for thoroughness.
+
+### Sign-off addendum
+
+- [ ] M4 executed; status filter cycles through all five options; badges render with documented variants; approve/deny buttons appear only on `PENDING`.
+- [ ] No `transition: where matched >1 row` server-log entry observed during M4 (the strict-throw never fires under normal UI flows).

--- a/scripts/__fixtures__/state-mutation-bad.ts
+++ b/scripts/__fixtures__/state-mutation-bad.ts
@@ -1,21 +1,97 @@
-// Self-test fixture — BAD: contains an inline status mutation outside the allowlist.
-// The CI guard MUST flag this file.
+// Self-test fixture — BAD: contains inline status mutations outside the allowlist.
+// The CI guard MUST flag every mutation site below.
 // DO NOT import or use this file in production code.
 
-// Placeholder type to avoid requiring a real Prisma import in the fixture.
+// Placeholder types to avoid requiring a real Prisma import in the fixture.
+type UpdateArgs = { where: object; data: object };
+type UpsertArgs = { where: object; create: object; update: object };
 const prisma = {} as {
   emergencyAccessGrant: {
-    updateMany: (args: { where: object; data: object }) => Promise<{ count: number }>;
+    update: (args: UpdateArgs) => Promise<unknown>;
+    updateMany: (args: UpdateArgs) => Promise<{ count: number }>;
+    upsert: (args: UpsertArgs) => Promise<unknown>;
+  };
+  accessRequest: {
+    update: (args: UpdateArgs) => Promise<unknown>;
+    updateMany: (args: UpdateArgs) => Promise<{ count: number }>;
   };
 };
+const tx = prisma; // simulate `prisma.$transaction((tx) => ...)` shape
 
-async function badRevoke(grantId: string): Promise<void> {
-  // BAD: writes data: { status: ... } directly — should go through transition()
+// 1) updateMany + literal status
+async function badRevokeUpdateMany(grantId: string): Promise<void> {
   await prisma.emergencyAccessGrant.updateMany({
     where: { id: grantId },
     data: { status: "REVOKED" },
   });
 }
 
-void badRevoke;
+// 2) update + variable status (variable initializer)
+async function badRevokeUpdateVar(grantId: string): Promise<void> {
+  const next = "REVOKED";
+  await prisma.emergencyAccessGrant.update({
+    where: { id: grantId },
+    data: { status: next },
+  });
+}
+
+// 3) upsert with status in `update` payload
+async function badUpsertUpdate(grantId: string): Promise<void> {
+  await prisma.emergencyAccessGrant.upsert({
+    where: { id: grantId },
+    create: { /* shape elided */ } as object,
+    update: { status: "REVOKED" },
+  });
+}
+
+// 4) upsert with status in `create` payload (the other key payload checked)
+async function badUpsertCreate(grantId: string): Promise<void> {
+  await prisma.emergencyAccessGrant.upsert({
+    where: { id: grantId },
+    create: { status: "PENDING" } as object,
+    update: { /* no status */ } as object,
+  });
+}
+
+// 5) tx.<model>.update — transaction-prefixed call (any identifier alias)
+async function badRevokeViaTx(grantId: string): Promise<void> {
+  await tx.accessRequest.update({
+    where: { id: grantId },
+    data: { status: "DENIED" },
+  });
+}
+
+// 6) Computed property name — opaque escape hatch, MUST be flagged
+async function badComputedKey(grantId: string): Promise<void> {
+  const k = "status";
+  await prisma.emergencyAccessGrant.updateMany({
+    where: { id: grantId },
+    data: { [k]: "REVOKED" },
+  });
+}
+
+// 7) Shorthand `{ status }` — variable name is "status"
+async function badShorthand(grantId: string, status: string): Promise<void> {
+  await prisma.emergencyAccessGrant.updateMany({
+    where: { id: grantId },
+    data: { status },
+  });
+}
+
+// 8) Spread + status — the plain status property AFTER the spread is caught
+async function badSpreadThenStatus(grantId: string, extra: object): Promise<void> {
+  await prisma.emergencyAccessGrant.updateMany({
+    where: { id: grantId },
+    data: { ...extra, status: "REVOKED" },
+  });
+}
+
+void badRevokeUpdateMany;
+void badRevokeUpdateVar;
+void badUpsertUpdate;
+void badUpsertCreate;
+void badRevokeViaTx;
+void badComputedKey;
+void badShorthand;
+void badSpreadThenStatus;
 export {};

--- a/scripts/__fixtures__/state-mutation-good.ts
+++ b/scripts/__fixtures__/state-mutation-good.ts
@@ -1,21 +1,68 @@
-// Self-test fixture — GOOD: updates emergencyAccessGrant without touching status.
-// The CI guard MUST NOT flag this file.
+// Self-test fixture — GOOD: every mutation either skips the status column or
+// is on a non-target model. The CI guard MUST NOT flag any line in this file.
 // DO NOT import or use this file in production code.
 
-// Placeholder type to avoid requiring a real Prisma import in the fixture.
+type UpdateArgs = { where: object; data: object };
+type UpsertArgs = { where: object; create: object; update: object };
 const prisma = {} as {
   emergencyAccessGrant: {
-    updateMany: (args: { where: object; data: object }) => Promise<{ count: number }>;
+    update: (args: UpdateArgs) => Promise<unknown>;
+    updateMany: (args: UpdateArgs) => Promise<{ count: number }>;
+    upsert: (args: UpsertArgs) => Promise<unknown>;
+  };
+  accessRequest: {
+    updateMany: (args: UpdateArgs) => Promise<{ count: number }>;
+  };
+  // Non-target model — status writes here are out of scope.
+  user: {
+    update: (args: UpdateArgs) => Promise<unknown>;
   };
 };
 
+// 1) Updates a non-status column on a target model — fine
 async function clearEphemeralKey(ownerId: string): Promise<void> {
-  // GOOD: updates revokedAt (not status) — within policy for inline mutations
   await prisma.emergencyAccessGrant.updateMany({
     where: { ownerId },
     data: { revokedAt: new Date() },
   });
 }
 
+// 2) status: null is a clear (allowed; the lint allows null literal explicitly)
+async function clearStatusField(grantId: string): Promise<void> {
+  await prisma.emergencyAccessGrant.update({
+    where: { id: grantId },
+    data: { status: null },
+  });
+}
+
+// 3) Upsert without status in either payload
+async function upsertWithoutStatus(grantId: string): Promise<void> {
+  await prisma.emergencyAccessGrant.upsert({
+    where: { id: grantId },
+    create: { revokedAt: null } as object,
+    update: { revokedAt: new Date() } as object,
+  });
+}
+
+// 4) status write on a NON-target model — out of scope for this lint
+async function userStatusFieldUnrelated(userId: string): Promise<void> {
+  await prisma.user.update({
+    where: { id: userId },
+    data: { status: "ACTIVE" },
+  });
+}
+
+// 5) accessRequest update with non-status field
+async function rotateApprovedBy(reqId: string, approver: string): Promise<void> {
+  await prisma.accessRequest.updateMany({
+    where: { id: reqId },
+    data: { approvedById: approver },
+  });
+}
+
 void clearEphemeralKey;
+void clearStatusField;
+void upsertWithoutStatus;
+void userStatusFieldUnrelated;
+void rotateApprovedBy;
 export {};

--- a/scripts/__tests__/check-state-mutation-centralization.test.ts
+++ b/scripts/__tests__/check-state-mutation-centralization.test.ts
@@ -34,14 +34,24 @@ function run(fixturePath: string): { stdout: string; stderr: string; exitCode: n
 }
 
 describe("check-state-mutation-centralization", () => {
-  it("exits 1 and reports violation on the bad fixture", () => {
+  it("exits 1 and flags every mutation pattern in the bad fixture", () => {
     const badFixture = resolve(FIXTURES, "state-mutation-bad.ts");
     const { exitCode, stderr } = run(badFixture);
 
     expect(exitCode).toBe(1);
-    // Output should contain the fixture filename and the violation marker
     expect(stderr).toContain("state-mutation-bad.ts");
-    expect(stderr).toContain("data:{status:...} mutation outside allowlist");
+
+    // Every distinct mutation pattern in the fixture must produce a violation.
+    // Counted by counting lines containing the file path inside the violation list.
+    const violationLines = stderr.split("\n").filter((l) => l.includes("state-mutation-bad.ts"));
+    expect(violationLines.length).toBeGreaterThanOrEqual(8);
+
+    // Per-pattern coverage assertions — these document WHICH patterns the lint catches.
+    expect(stderr).toMatch(/updateMany\(\{data:\{status:\.\.\.}\}/); // patterns 1, 7, 8
+    expect(stderr).toMatch(/update\(\{data:\{status:\.\.\.}\}/); // pattern 2, 5
+    expect(stderr).toMatch(/upsert\(\{update:\{status:\.\.\.}\}/); // pattern 3
+    expect(stderr).toMatch(/upsert\(\{create:\{status:\.\.\.}\}/); // pattern 4
+    expect(stderr).toMatch(/computed property name is opaque/); // pattern 6
   });
 
   it("exits 0 with no violation on the good fixture", () => {
@@ -49,8 +59,8 @@ describe("check-state-mutation-centralization", () => {
     const { exitCode, stdout, stderr } = run(goodFixture);
 
     expect(exitCode).toBe(0);
-    // Must not flag anything
-    expect(stderr).not.toContain("data:{status:...}");
+    expect(stderr).not.toContain("mutation outside allowlist");
+    expect(stderr).not.toContain("computed property name is opaque");
     expect(stdout).toContain("OK");
   });
 });

--- a/scripts/check-state-mutation-centralization.ts
+++ b/scripts/check-state-mutation-centralization.ts
@@ -1,12 +1,14 @@
 /**
  * CI guard (C8): AST-based check that no file outside the allowlist writes
- * `data: { status: <value> }` against emergencyAccessGrant or accessRequest
- * tables via Prisma's update / updateMany calls.
+ * `status: <value>` against emergencyAccessGrant or accessRequest tables via
+ * Prisma's update / updateMany / upsert calls.
  *
  * Uses ts-morph to walk the AST so it catches:
  *   - data: { status: "REVOKED" }
  *   - data: { status: someConst }
  *   - data: { ...rest, status: x }
+ *   - update: { status: ... } / create: { status: ... } in upsert
+ *   - { [computedKey]: ... } escape hatch (flagged unconditionally — opaque)
  *   - multi-line / reformatted variants
  *
  * Exit 0 → no violations. Exit 1 → violations found (printed to stdout).
@@ -46,7 +48,16 @@ const TARGET_MODELS = new Set([
 ]);
 
 // ─── Prisma mutating methods ─────────────────────────────────────────────────
-const MUTATING_METHODS = new Set(["update", "updateMany"]);
+// `upsert` carries status writes on `create` and/or `update` keys (not `data`),
+// so it MUST be checked alongside update / updateMany.
+const MUTATING_METHODS = new Set(["update", "updateMany", "upsert"]);
+
+// Top-level keys that hold the status-bearing payload, indexed by mutating method.
+const PAYLOAD_KEYS_BY_METHOD: Record<string, ReadonlyArray<string>> = {
+  update: ["data"],
+  updateMany: ["data"],
+  upsert: ["update", "create"],
+};
 
 // ─── Argument parsing ────────────────────────────────────────────────────────
 const args = process.argv.slice(2);
@@ -89,14 +100,45 @@ if (fixturePath) {
 const violations: string[] = [];
 
 /**
- * Recursively walk an ObjectLiteralExpression looking for a `status` property
- * whose initializer is not `null` and not a function/arrow-function.
- * Returns true if such a property is found.
+ * Walk an ObjectLiteralExpression looking for a status assignment.
+ * Returns a finding kind:
+ *   - "status" — explicit `status: <value>` or `{ status }` shorthand
+ *   - "computed" — `{ [key]: ... }` whose key cannot be statically resolved;
+ *     flagged as a violation regardless because it is an escape hatch that
+ *     can hide a status write
+ *   - null — no violation
+ *
+ * Computed property names are intentionally flagged unconditionally (no
+ * partial-resolution attempts) — partial resolution invites bypass via
+ * indirection (`const k = "stat" + "us"`). If a legitimate use case appears,
+ * add the file to ALLOWED.
  */
-function hasStatusAssignment(objLiteral: Node): boolean {
-  if (!Node.isObjectLiteralExpression(objLiteral)) return false;
-  for (const prop of objLiteral.getProperties()) {
+type StatusFinding = "status" | "computed" | null;
+
+/** Unwrap `(expr)`, `expr as T`, `<T>expr`, `expr satisfies T` chains. */
+function unwrap(node: Node): Node {
+  let n = node;
+  while (
+    Node.isParenthesizedExpression(n) ||
+    Node.isAsExpression(n) ||
+    Node.isTypeAssertion(n) ||
+    Node.isSatisfiesExpression(n)
+  ) {
+    n = n.getExpression();
+  }
+  return n;
+}
+
+function findStatusAssignment(objLiteral: Node): StatusFinding {
+  const target = unwrap(objLiteral);
+  if (!Node.isObjectLiteralExpression(target)) return null;
+  for (const prop of target.getProperties()) {
     if (Node.isPropertyAssignment(prop)) {
+      const nameNode = prop.getNameNode();
+      // Computed property name: `{ [key]: value }` — cannot statically resolve.
+      if (Node.isComputedPropertyName(nameNode)) {
+        return "computed";
+      }
       const name = prop.getName();
       if (name === "status") {
         const init = prop.getInitializer();
@@ -108,26 +150,26 @@ function hasStatusAssignment(objLiteral: Node): boolean {
           Node.isFunctionExpression(init) ||
           Node.isArrowFunction(init)
         ) continue;
-        return true;
+        return "status";
       }
     } else if (Node.isShorthandPropertyAssignment(prop)) {
       // { status } shorthand — the variable name is "status"
-      if (prop.getName() === "status") return true;
+      if (prop.getName() === "status") return "status";
     } else if (Node.isSpreadAssignment(prop)) {
-      // { ...extraData, status: ... } — recursively check the spread source?
-      // We cannot statically resolve the spread variable, so ignore it.
-      // The plain property following a spread will still be caught.
+      // { ...extraData, status: ... } — cannot statically resolve the spread.
+      // The plain property following a spread will still be caught on its own.
       continue;
     }
   }
-  return false;
+  return null;
 }
 
 /**
- * Given a call expression, check whether it is a Prisma update/updateMany
- * call on a target model and has a data:{status:...} argument.
+ * Given a call expression, check whether it is a Prisma mutating call on a
+ * target model with a status-bearing payload.
  *
  * Matches: <x>.emergencyAccessGrant.update({ data: { status: ... } })
+ *          <x>.accessRequest.upsert({ update: { status: ... }, create: {...} })
  * where <x> is any identifier (prisma, tx, db, etc.).
  */
 function checkCallExpression(call: Node, filePath: string): void {
@@ -144,27 +186,30 @@ function checkCallExpression(call: Node, filePath: string): void {
   const modelName = modelExpr.getName();
   if (!TARGET_MODELS.has(modelName)) return;
 
-  // Found a relevant call — now inspect the `data` property
+  // Found a relevant call — inspect the method-specific payload key(s)
   const callArgs = call.getArguments();
   if (callArgs.length === 0) return;
   const firstArg = callArgs[0];
   if (!Node.isObjectLiteralExpression(firstArg)) return;
 
+  const payloadKeys = PAYLOAD_KEYS_BY_METHOD[methodName] ?? [];
   for (const prop of firstArg.getProperties()) {
-    if (
-      Node.isPropertyAssignment(prop) &&
-      prop.getName() === "data"
-    ) {
-      const dataValue = prop.getInitializer();
-      if (dataValue && hasStatusAssignment(dataValue)) {
-        const pos = call.getStartLineNumber();
-        const col = call.getStart() - call.getSourceFile().getFullText().lastIndexOf("\n", call.getStart());
-        const rel = filePath.startsWith(ROOT)
-          ? relative(ROOT, filePath)
-          : filePath;
-        violations.push(`${rel}:${pos}:${col} data:{status:...} mutation outside allowlist`);
-      }
-    }
+    if (!Node.isPropertyAssignment(prop)) continue;
+    if (!payloadKeys.includes(prop.getName())) continue;
+    const payloadValue = prop.getInitializer();
+    if (!payloadValue) continue;
+    const finding = findStatusAssignment(payloadValue);
+    if (!finding) continue;
+    const line = call.getStartLineNumber();
+    const col = call.getStart() - call.getSourceFile().getFullText().lastIndexOf("\n", call.getStart());
+    const rel = filePath.startsWith(ROOT)
+      ? relative(ROOT, filePath)
+      : filePath;
+    const detail =
+      finding === "computed"
+        ? `${methodName}({${prop.getName()}:{[<computed>]:...}}) — computed property name is opaque, refactor to a plain key`
+        : `${methodName}({${prop.getName()}:{status:...}}) mutation outside allowlist`;
+    violations.push(`${rel}:${line}:${col} ${detail}`);
   }
 }
 

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -50,7 +50,7 @@ if command -v docker >/dev/null 2>&1 && docker exec passwd-sso-db-1 pg_isready -
     out=$(cat scripts/rls-cross-tenant-verify.sql | docker exec -i passwd-sso-db-1 \
       psql -U passwd_app -d passwd_sso -v ON_ERROR_STOP=1 -v expected_tables="$EXPECTED_TABLES" 2>&1) && ec=0 || ec=$?
     # Whitelist exact codes — typos like [E-RLS-NUL] would otherwise pass.
-    if (( ec == 0 )) || grep -qE "\[E-RLS-(MANIFEST-(EXTRA|MISSING)|COLPARITY|COUNT-A|COUNT-B|NULL|SYM|BYPASS|DISCOVER|ROLE|COVERAGE)\]" <<<"$out"; then
+    if (( ec == 0 )) || grep -qE "\[E-RLS-(MANIFEST-(EXTRA|MISSING)|COLPARITY|COUNT-A|COUNT-B|NULL|SYM|BYPASS|DISCOVER|ROLE|COVERAGE|FORCE|SECDEF)\]" <<<"$out"; then
       exit 0
     fi
     printf "%s\n" "$out"

--- a/scripts/rls-cross-tenant-negative-test.sh
+++ b/scripts/rls-cross-tenant-negative-test.sh
@@ -2,7 +2,7 @@
 # rls-cross-tenant-negative-test.sh — gate self-check
 #
 # Runs a Case 0 pre-flight calibration (canonical policy → exit 0) plus
-# 7 distinct failure shapes against an ephemeral throwaway table to verify
+# 9 distinct failure shapes against an ephemeral throwaway table to verify
 # the cross-tenant verify SQL correctly detects each:
 #   0. canonical policy + correct manifest (sanity: harness calibrated)
 #   1. permissive symmetric → [E-RLS-COUNT-A]
@@ -12,6 +12,8 @@
 #   5. manifest drift (canonical policy + manifest missing throwaway) → [E-RLS-MANIFEST-MISSING]
 #   6. manifest contains a name not in DB → [E-RLS-MANIFEST-EXTRA]
 #   7. column-parity probe (tenant_id column without policy) → [E-RLS-COLPARITY]
+#   8. FORCE ROW LEVEL SECURITY dropped on a tenant_isolation table → [E-RLS-FORCE]
+#   9. SECURITY DEFINER function created in public schema → [E-RLS-SECDEF]
 #
 # Codes NOT exercised here (acceptable coverage gaps):
 #   - [E-RLS-COUNT-B]: structurally identical to [E-RLS-COUNT-A] (Block 3 mirrors Block 2).
@@ -61,7 +63,7 @@ VERIFY_SQL="$SCRIPT_DIR/rls-cross-tenant-verify.sql"
 # before/after either table has been created.
 cleanup() {
   psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=0 -q \
-    -c "DROP TABLE IF EXISTS rls_negative_test CASCADE; DROP TABLE IF EXISTS rls_colparity_probe CASCADE;" >/dev/null 2>&1 || true
+    -c "DROP TABLE IF EXISTS rls_negative_test CASCADE; DROP TABLE IF EXISTS rls_colparity_probe CASCADE; DROP FUNCTION IF EXISTS rls_negative_secdef_probe();" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
 
@@ -253,6 +255,69 @@ run_case_7_colparity() {
   printf 'PASS case 7 (matched [E-RLS-COLPARITY])\n'
 }
 run_case_7_colparity || total_failures=$((total_failures + 1))
+
+# Case 8: FORCE ROW LEVEL SECURITY dropped on rls_negative_test → Block 1
+# [E-RLS-FORCE] fires before manifest assertions because FORCE check runs in
+# Block 1 after column parity. Restores FORCE after the case so subsequent
+# runs (or trap-clean re-creates) start from a known-good state.
+run_case_8_force_rls() {
+  # Reset to canonical policy + drop FORCE.
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
+    -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test; $CANONICAL_POLICY_SQL;
+        ALTER TABLE rls_negative_test NO FORCE ROW LEVEL SECURITY;"
+  local expected_tables="${manifest_entries},rls_negative_test"
+  local out ec
+  out=$(psql "$APP_DATABASE_URL" -v ON_ERROR_STOP=1 \
+    -v expected_tables="$expected_tables" \
+    -f "$VERIFY_SQL" 2>&1) && ec=0 || ec=$?
+  # Restore FORCE before returning regardless of result.
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=0 -q \
+    -c "ALTER TABLE rls_negative_test FORCE ROW LEVEL SECURITY;" >/dev/null 2>&1 || true
+  if (( ec == 0 )); then
+    printf 'FAIL case 8: verify exited 0 with FORCE RLS dropped — gate is broken\n'
+    return 1
+  fi
+  if ! grep -qF -- "[E-RLS-FORCE]" <<<"$out"; then
+    printf 'FAIL case 8: verify failed but expected code [E-RLS-FORCE] not found in output:\n%s\n' "$out"
+    return 1
+  fi
+  printf 'PASS case 8 (matched [E-RLS-FORCE])\n'
+}
+run_case_8_force_rls || total_failures=$((total_failures + 1))
+
+# Case 9: SECURITY DEFINER function created in public schema → Block 1
+# [E-RLS-SECDEF]. Function is owned by passwd_user (created via SUPERUSER
+# connection) and immediately becomes an RLS-bypass surface. Trap also
+# drops the function as a safety net.
+run_case_9_secdef() {
+  # Reset to canonical policy so SYM/NULL/COUNT/COLPARITY all pass.
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q \
+    -c "DROP POLICY IF EXISTS rls_negative_test_tenant_isolation ON rls_negative_test; $CANONICAL_POLICY_SQL;"
+  # Create a minimal SECURITY DEFINER function in public.
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=1 -q -c "
+    CREATE OR REPLACE FUNCTION rls_negative_secdef_probe() RETURNS int AS \$\$
+      SELECT 1;
+    \$\$ LANGUAGE sql SECURITY DEFINER;
+  "
+  local expected_tables="${manifest_entries},rls_negative_test"
+  local out ec
+  out=$(psql "$APP_DATABASE_URL" -v ON_ERROR_STOP=1 \
+    -v expected_tables="$expected_tables" \
+    -f "$VERIFY_SQL" 2>&1) && ec=0 || ec=$?
+  # Drop the probe function regardless (trap also covers).
+  psql "$MIGRATION_DATABASE_URL" -v ON_ERROR_STOP=0 -q \
+    -c "DROP FUNCTION IF EXISTS rls_negative_secdef_probe();" >/dev/null 2>&1 || true
+  if (( ec == 0 )); then
+    printf 'FAIL case 9: verify exited 0 with SECURITY DEFINER function present — gate is broken\n'
+    return 1
+  fi
+  if ! grep -qF -- "[E-RLS-SECDEF]" <<<"$out"; then
+    printf 'FAIL case 9: verify failed but expected code [E-RLS-SECDEF] not found in output:\n%s\n' "$out"
+    return 1
+  fi
+  printf 'PASS case 9 (matched [E-RLS-SECDEF])\n'
+}
+run_case_9_secdef || total_failures=$((total_failures + 1))
 
 if (( total_failures > 0 )); then
   printf '\n%d negative-test cases failed.\n' "$total_failures"

--- a/scripts/rls-cross-tenant-verify.sql
+++ b/scripts/rls-cross-tenant-verify.sql
@@ -39,6 +39,13 @@ SET app.expected_tables TO :'expected_tables';
 --   5. [E-RLS-COLPARITY]          column count vs discovery count parity
 --   6. [E-RLS-MANIFEST-EXTRA]     manifest \ discovery
 --   7. [E-RLS-MANIFEST-MISSING]   discovery \ manifest
+--   8. [E-RLS-FORCE]              FORCE ROW LEVEL SECURITY enabled on every
+--                                 tenant_isolation table — table-owner roles
+--                                 (e.g., passwd_user used by migrations) bypass
+--                                 RLS unless the table has FORCE set
+--   9. [E-RLS-SECDEF]             no SECURITY DEFINER functions in public —
+--                                 a passwd_user-owned secdef function callable
+--                                 by passwd_app is an RLS-bypass surface
 -- =====================================================================
 DO $$
 DECLARE
@@ -191,6 +198,56 @@ BEGIN
         AND c.relname NOT IN (
           SELECT m.t FROM unnest(string_to_array(current_setting('app.expected_tables', true), ',')) AS m(t)
         )
+    ));
+
+  -- 8. FORCE ROW LEVEL SECURITY guard.
+  --    Without FORCE, the table-owner role (passwd_user, used by migrations and
+  --    Prisma's `migrate dev`) bypasses RLS even when policies exist. A migration
+  --    that drops FORCE on a single table is a silent cross-tenant regression
+  --    for every code path running as the owner. Asserts `relrowsecurity = true`
+  --    AND `relforcerowsecurity = true` on every table that has a tenant_isolation
+  --    policy.
+  ASSERT NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+      AND (NOT c.relrowsecurity OR NOT c.relforcerowsecurity)
+  ),
+    format('[E-RLS-FORCE] Tables with tenant_isolation policy missing FORCE/ENABLE RLS: %s', (
+      SELECT string_agg(c.relname || ' (rls=' || c.relrowsecurity || ', force=' || c.relforcerowsecurity || ')', ',')
+      FROM pg_catalog.pg_policy p
+      JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+      JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND (p.polname = 'tenant_isolation' OR p.polname LIKE '%\_tenant_isolation' ESCAPE '\')
+        AND (NOT c.relrowsecurity OR NOT c.relforcerowsecurity)
+    ));
+
+  -- 9. SECURITY DEFINER function audit.
+  --    A SECURITY DEFINER function in `public` runs with the function-owner's
+  --    privileges. If the owner is passwd_user (SUPERUSER) and EXECUTE is granted
+  --    to passwd_app (or PUBLIC), the function becomes an RLS-bypass primitive:
+  --    its body executes with BYPASSRLS regardless of the calling role. This file
+  --    asserts the absence of such functions; if a future migration introduces a
+  --    legitimate SECURITY DEFINER (e.g., a tightly-scoped audit-rotation helper),
+  --    add a per-name allowlist alongside this ASSERT and document the safety
+  --    argument inline. Trigger functions invoked implicitly by row events are in
+  --    scope — a SECURITY DEFINER trigger on a tenant table bypasses RLS the
+  --    same way a directly-called function would.
+  ASSERT NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_proc pr
+    JOIN pg_catalog.pg_namespace n ON n.oid = pr.pronamespace
+    WHERE n.nspname = 'public'
+      AND pr.prosecdef = true
+  ),
+    format('[E-RLS-SECDEF] SECURITY DEFINER functions exist in public schema: %s — these bypass RLS when called by passwd_app. Add an allowlist + safety justification next to this ASSERT before merging.', (
+      SELECT string_agg(pr.proname || ' (owner=' || (SELECT rolname FROM pg_roles WHERE oid = pr.proowner) || ')', ',')
+      FROM pg_catalog.pg_proc pr
+      JOIN pg_catalog.pg_namespace n ON n.oid = pr.pronamespace
+      WHERE n.nspname = 'public'
+        AND pr.prosecdef = true
     ));
 END $$;
 

--- a/src/__tests__/db-integration/centralize-state-transitions.integration.test.ts
+++ b/src/__tests__/db-integration/centralize-state-transitions.integration.test.ts
@@ -388,8 +388,19 @@ describe("centralize-state-transitions — integration", () => {
       ),
     ]);
 
-    const successCount = [a, b].filter((r) => r.ok).length;
-    expect(successCount).toBe(1);
+    // RT4 (race-test vacuous-pass guard): assert the EXACT pair shape, not
+    // just the success count. `[false, true]` proves BOTH branches occurred —
+    // a winner (CAS landed) AND a loser (CAS rejected). A bare
+    // `successCount === 1` passes vacuously when the second call short-circuits
+    // before the CAS (e.g., setup races, eligibility check coincidentally fails).
+    const okShape = [a.ok, b.ok].sort();
+    expect(okShape).toEqual([false, true]);
+
+    // The loser must report the CAS-loss reason. Any other reason means the
+    // failure happened upstream of the contested transition, masking races.
+    const loser = a.ok ? b : a;
+    if (loser.ok) throw new Error("unreachable: shape assertion guarantees one loser");
+    expect(loser.reason).toBe("not_eligible");
 
     // Exactly one EMERGENCY_ACCESS_ACTIVATE audit row should exist.
     // logAuditAsync is async / outbox-based, so we poll audit_logs until the

--- a/src/app/api/tenant/access-requests/route.ts
+++ b/src/app/api/tenant/access-requests/route.ts
@@ -9,7 +9,7 @@ import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { parseBody } from "@/lib/http/parse-body";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
-import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
+import { AUDIT_ACTION, AUDIT_TARGET_TYPE, AR_STATUS } from "@/lib/constants";
 import { ACTOR_TYPE } from "@/lib/constants/audit/audit";
 import { withTenantRls, withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/http/with-request-log";
@@ -23,7 +23,12 @@ const accessRequestCreateLimiter = createRateLimiter({ windowMs: MS_PER_HOUR, ma
 
 export const runtime = "nodejs";
 
-const VALID_ACCESS_REQUEST_STATUSES = ["PENDING", "APPROVED", "DENIED", "EXPIRED"] as const;
+const VALID_ACCESS_REQUEST_STATUSES = [
+  AR_STATUS.PENDING,
+  AR_STATUS.APPROVED,
+  AR_STATUS.DENIED,
+  AR_STATUS.EXPIRED,
+] as const;
 
 // Admin creates request on behalf of SA
 const adminCreateSchema = z.object({

--- a/src/components/settings/developer/access-request-card.tsx
+++ b/src/components/settings/developer/access-request-card.tsx
@@ -38,13 +38,13 @@ import {
 } from "@/components/ui/dialog";
 import { Loader2, CheckCircle, XCircle, Plus, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
-import { apiPath } from "@/lib/constants";
+import { apiPath, AR_STATUS } from "@/lib/constants";
 import { SA_TOKEN_SCOPES } from "@/lib/constants/auth/service-account";
 import { formatDateTime } from "@/lib/format/format-datetime";
 import { ScopeBadges } from "@/components/settings/developer/scope-badges";
 import { fetchApi } from "@/lib/url-helpers";
 
-type AccessRequestStatus = "PENDING" | "APPROVED" | "DENIED" | "EXPIRED";
+import type { AccessRequestStatus } from "@prisma/client";
 
 interface ServiceAccountRef {
   id: string;
@@ -66,10 +66,10 @@ const STATUS_VARIANTS: Record<
   AccessRequestStatus,
   "default" | "secondary" | "destructive" | "outline"
 > = {
-  PENDING: "default",
-  APPROVED: "secondary",
-  DENIED: "destructive",
-  EXPIRED: "outline",
+  [AR_STATUS.PENDING]: "default",
+  [AR_STATUS.APPROVED]: "secondary",
+  [AR_STATUS.DENIED]: "destructive",
+  [AR_STATUS.EXPIRED]: "outline",
 };
 
 export function AccessRequestCard() {
@@ -227,10 +227,10 @@ export function AccessRequestCard() {
 
   const statusLabel = (status: AccessRequestStatus) => {
     const map: Record<AccessRequestStatus, string> = {
-      PENDING: "arStatusPending",
-      APPROVED: "arStatusApproved",
-      DENIED: "arStatusDenied",
-      EXPIRED: "arStatusExpired",
+      [AR_STATUS.PENDING]: "arStatusPending",
+      [AR_STATUS.APPROVED]: "arStatusApproved",
+      [AR_STATUS.DENIED]: "arStatusDenied",
+      [AR_STATUS.EXPIRED]: "arStatusExpired",
     };
     return t(map[status]);
   };
@@ -260,10 +260,10 @@ export function AccessRequestCard() {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="ALL">{t("arStatusAll")}</SelectItem>
-            <SelectItem value="PENDING">{t("arStatusPending")}</SelectItem>
-            <SelectItem value="APPROVED">{t("arStatusApproved")}</SelectItem>
-            <SelectItem value="DENIED">{t("arStatusDenied")}</SelectItem>
-            <SelectItem value="EXPIRED">{t("arStatusExpired")}</SelectItem>
+            <SelectItem value={AR_STATUS.PENDING}>{t("arStatusPending")}</SelectItem>
+            <SelectItem value={AR_STATUS.APPROVED}>{t("arStatusApproved")}</SelectItem>
+            <SelectItem value={AR_STATUS.DENIED}>{t("arStatusDenied")}</SelectItem>
+            <SelectItem value={AR_STATUS.EXPIRED}>{t("arStatusExpired")}</SelectItem>
           </SelectContent>
         </Select>
         <Button variant="outline" size="sm" onClick={openCreate}>
@@ -301,7 +301,7 @@ export function AccessRequestCard() {
                   <span className="text-xs text-muted-foreground">
                     {t("arCreatedAt", { date: formatDateTime(req.createdAt, locale) })}
                   </span>
-                {req.status === "PENDING" && (
+                {req.status === AR_STATUS.PENDING && (
                   <div className="flex items-center gap-1">
                     <Button
                       variant="outline"

--- a/src/lib/access-request/access-request-state.test.ts
+++ b/src/lib/access-request/access-request-state.test.ts
@@ -1,6 +1,13 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import { AccessRequestStatus } from "@prisma/client";
-import { MATRIX, canTransition, AR_ACTOR, type ArActor } from "./access-request-state";
+import {
+  MATRIX,
+  canTransition,
+  transition,
+  AR_ACTOR,
+  AR_STATUS,
+  type ArActor,
+} from "./access-request-state";
 
 const ALL_STATUSES = Object.values(AccessRequestStatus) as AccessRequestStatus[];
 const AR_ACTORS = Object.values(AR_ACTOR);
@@ -91,5 +98,46 @@ describe("terminal states", () => {
 describe("future EXPIRED cron readiness", () => {
   test("PENDING → EXPIRED is permitted for SYSTEM (future cron placeholder)", () => {
     expect(canTransition("PENDING", "EXPIRED", "SYSTEM")).toBe(true);
+  });
+});
+
+describe("transition() return-value strictness", () => {
+  function makeDb(updateManyCount: number) {
+    return {
+      accessRequest: {
+        updateMany: vi.fn().mockResolvedValue({ count: updateManyCount }),
+      },
+    } as unknown as Parameters<typeof transition>[0]["db"];
+  }
+
+  test("count === 1 returns ok:true", async () => {
+    const result = await transition({
+      db: makeDb(1),
+      where: { id: "req-1", tenantId: "tenant-1" },
+      to: AR_STATUS.APPROVED,
+      actor: AR_ACTOR.ADMIN,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("count === 0 returns ok:false", async () => {
+    const result = await transition({
+      db: makeDb(0),
+      where: { id: "req-1", tenantId: "tenant-1" },
+      to: AR_STATUS.APPROVED,
+      actor: AR_ACTOR.ADMIN,
+    });
+    expect(result).toEqual({ ok: false });
+  });
+
+  test("count > 1 throws — non-unique where is a programmer error", async () => {
+    await expect(
+      transition({
+        db: makeDb(2),
+        where: { tenantId: "tenant-1" },
+        to: AR_STATUS.APPROVED,
+        actor: AR_ACTOR.ADMIN,
+      }),
+    ).rejects.toThrow(/where matched >1 row/);
   });
 });

--- a/src/lib/access-request/access-request-state.ts
+++ b/src/lib/access-request/access-request-state.ts
@@ -12,21 +12,12 @@
  */
 import type { AccessRequestStatus, Prisma } from "@prisma/client";
 import type { TxOrPrisma } from "@/lib/prisma";
+import { AR_STATUS, AR_ACTOR, type ArActor } from "@/lib/constants";
 import { isBypassRlsActive } from "@/lib/tenant-rls";
 
-export const AR_ACTOR = {
-  ADMIN: "ADMIN",
-  SYSTEM: "SYSTEM",
-} as const;
-
-export type ArActor = (typeof AR_ACTOR)[keyof typeof AR_ACTOR];
-
-export const AR_STATUS = {
-  PENDING: "PENDING",
-  APPROVED: "APPROVED",
-  DENIED: "DENIED",
-  EXPIRED: "EXPIRED",
-} as const satisfies Record<AccessRequestStatus, AccessRequestStatus>;
+// Re-export for backward compatibility with importers that already pull from here.
+// Canonical location: src/lib/constants/integrations/access-request.ts (client-safe).
+export { AR_STATUS, AR_ACTOR, type ArActor };
 
 /**
  * Exhaustive transition matrix. Empty array = forbidden transition.
@@ -37,10 +28,10 @@ export const MATRIX: Record<
   Record<AccessRequestStatus, ReadonlyArray<ArActor>>
 > = {
   [AR_STATUS.PENDING]: {
-    [AR_STATUS.APPROVED]: ["ADMIN"],
-    [AR_STATUS.DENIED]: ["ADMIN"],
+    [AR_STATUS.APPROVED]: [AR_ACTOR.ADMIN],
+    [AR_STATUS.DENIED]: [AR_ACTOR.ADMIN],
     // TODO(centralize-state-transitions-followup): no caller transitions to EXPIRED yet — implement cron in a follow-up PR
-    [AR_STATUS.EXPIRED]: ["SYSTEM"],
+    [AR_STATUS.EXPIRED]: [AR_ACTOR.SYSTEM],
     [AR_STATUS.PENDING]: [],
   },
   [AR_STATUS.APPROVED]: {
@@ -125,7 +116,12 @@ export async function transition(args: {
     where: { ...args.where, status: { in: allowedFroms } },
     data: { ...args.extraData, status: args.to },
   });
-  return result.count >= 1 ? { ok: true } : { ok: false };
+  if (result.count > 1) {
+    throw new Error(
+      "transition: where matched >1 row; pass a unique-id predicate or use bulkTransition",
+    );
+  }
+  return result.count === 1 ? { ok: true } : { ok: false };
 }
 
 /**

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -28,6 +28,9 @@ export type { TenantRoleValue } from "./auth/tenant-role";
 export { EA_STATUS, EA_ACTOR } from "./integrations/emergency-access";
 export type { EaStatusValue, EaActor } from "./integrations/emergency-access";
 
+export { AR_STATUS, AR_ACTOR } from "./integrations/access-request";
+export type { ArStatusValue, ArActor } from "./integrations/access-request";
+
 export { INVITATION_STATUS } from "./integrations/invitation";
 export type { InvitationStatusValue } from "./integrations/invitation";
 

--- a/src/lib/constants/integrations/access-request.ts
+++ b/src/lib/constants/integrations/access-request.ts
@@ -1,0 +1,17 @@
+import type { AccessRequestStatus } from "@prisma/client";
+
+export const AR_STATUS = {
+  PENDING: "PENDING",
+  APPROVED: "APPROVED",
+  DENIED: "DENIED",
+  EXPIRED: "EXPIRED",
+} as const satisfies Record<AccessRequestStatus, AccessRequestStatus>;
+
+export type ArStatusValue = AccessRequestStatus;
+
+export const AR_ACTOR = {
+  ADMIN: "ADMIN",
+  SYSTEM: "SYSTEM",
+} as const;
+
+export type ArActor = (typeof AR_ACTOR)[keyof typeof AR_ACTOR];

--- a/src/lib/crypto/account-token-crypto.adversarial.test.ts
+++ b/src/lib/crypto/account-token-crypto.adversarial.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { randomBytes } from "node:crypto";
 import * as cryptoServer from "@/lib/crypto/crypto-server";
+import { parseEnvelope, SENTINEL } from "./envelope";
 import {
   encryptAccountToken,
   decryptAccountToken,
@@ -89,6 +90,56 @@ describe("account-token-crypto adversarial: ciphertext-swap across master keys",
       const ct = encryptAccountToken("plaintext-aad-swap", aadA);
       expect(decryptAccountToken(ct, aadA)).toBe("plaintext-aad-swap");
       expect(() => decryptAccountToken(ct, aadB)).toThrow();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("encryptAccountToken produces unique IVs across 16 calls under the same master key", () => {
+    // Token re-encryption (e.g., after master-key rotation) must not collapse
+    // to a single IV under AES-GCM.
+    const k = randomBytes(32);
+    const aad = {
+      userId: "00000000-0000-0000-0000-0000000000aa",
+      provider: "google",
+      providerAccountId: "google-A",
+    };
+    const spy = vi
+      .spyOn(cryptoServer, "getMasterKeyByVersion")
+      .mockImplementation(() => k);
+    try {
+      const ivs = new Set<string>();
+      for (let i = 0; i < 16; i++) {
+        const ct = encryptAccountToken("same-token-plaintext", aad);
+        const env = parseEnvelope(ct);
+        ivs.add(env.iv.toString("hex"));
+      }
+      expect(ivs.size).toBe(16);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("flipping one byte of envelope ciphertext rejects decryption (authenticity)", () => {
+    // Envelope shape: SENTINEL + <version> + ":" + base64url(iv || tag || ct).
+    // Tamper by parsing, mutating the first ciphertext byte, and re-packing.
+    const k = randomBytes(32);
+    const aad = {
+      userId: "00000000-0000-0000-0000-0000000000aa",
+      provider: "google",
+      providerAccountId: "google-A",
+    };
+    const spy = vi
+      .spyOn(cryptoServer, "getMasterKeyByVersion")
+      .mockImplementation(() => k);
+    try {
+      const ct = encryptAccountToken("authentic-token", aad);
+      const env = parseEnvelope(ct);
+      const tamperedCipher = Buffer.from(env.ciphertext);
+      tamperedCipher[0] ^= 0xff;
+      const blob = Buffer.concat([env.iv, env.tag, tamperedCipher]).toString("base64url");
+      const tampered = `${SENTINEL}${env.version}:${blob}`;
+      expect(() => decryptAccountToken(tampered, aad)).toThrow();
     } finally {
       spy.mockRestore();
     }

--- a/src/lib/crypto/crypto-client.adversarial.test.ts
+++ b/src/lib/crypto/crypto-client.adversarial.test.ts
@@ -94,3 +94,124 @@ describe("crypto-client adversarial: ciphertext-swap across personal-vault keys"
     expect(thrownError).not.toBeNull();
   });
 });
+
+describe("crypto-client adversarial: nonce uniqueness across repeated encryptions", () => {
+  // AES-GCM nonce reuse under the same key is catastrophic (loss of confidentiality
+  // AND authenticity). Vault rotation, delegation, and any flow that re-encrypts
+  // under a stable key is a candidate failure site. The contract we assert is
+  // simply: every encryption under the same key produces a distinct IV. The IV
+  // generator is `crypto.getRandomValues` (96 bits of entropy) — a collision
+  // across N=64 calls has probability ≈ N²/2^97, statistically zero.
+  it("encryptData produces unique IVs across 64 calls under the same key", async () => {
+    const k = await deriveEncryptionKey(generateSecretKey());
+    const ivs = new Set<string>();
+    for (let i = 0; i < 64; i++) {
+      const c = await encryptData("same-plaintext", k);
+      ivs.add(c.iv);
+    }
+    expect(ivs.size).toBe(64);
+  });
+
+  it("encryptBinary produces unique IVs across 64 calls under the same key", async () => {
+    const k = await deriveEncryptionKey(generateSecretKey());
+    const data = new Uint8Array(256);
+    crypto.getRandomValues(data);
+    const ivs = new Set<string>();
+    for (let i = 0; i < 64; i++) {
+      const c = await encryptBinary(
+        data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
+        k,
+      );
+      ivs.add(c.iv);
+    }
+    expect(ivs.size).toBe(64);
+  });
+});
+
+describe("crypto-client adversarial: AES-GCM authenticity (ciphertext / tag mutation)", () => {
+  // AES-GCM provides authenticated encryption — flipping a single bit of either
+  // the ciphertext OR the authTag must reject decryption. Without this property,
+  // an attacker who controls server-stored blobs can mutate decrypted plaintext.
+  it("flipping one byte of ciphertext rejects decryption", async () => {
+    const k = await deriveEncryptionKey(generateSecretKey());
+    const original = await encryptData("authentic-plaintext", k);
+    // Flip the first byte of ciphertext (hex string — flip the first hex digit).
+    const tampered = {
+      ...original,
+      ciphertext:
+        ((parseInt(original.ciphertext[0], 16) ^ 0xf).toString(16)) +
+        original.ciphertext.slice(1),
+    };
+    let thrownError: unknown = null;
+    try {
+      await decryptData(tampered, k);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(thrownError).not.toBeNull();
+  });
+
+  it("flipping one byte of authTag rejects decryption", async () => {
+    const k = await deriveEncryptionKey(generateSecretKey());
+    const original = await encryptData("authentic-plaintext", k);
+    const tampered = {
+      ...original,
+      authTag:
+        ((parseInt(original.authTag[0], 16) ^ 0xf).toString(16)) +
+        original.authTag.slice(1),
+    };
+    let thrownError: unknown = null;
+    try {
+      await decryptData(tampered, k);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(thrownError).not.toBeNull();
+  });
+
+  it("truncating the authTag rejects decryption", async () => {
+    const k = await deriveEncryptionKey(generateSecretKey());
+    const original = await encryptData("authentic-plaintext", k);
+    // Drop the last 2 hex digits (1 byte) from the tag — should be rejected
+    // as the GCM 128-bit tag length is enforced.
+    const truncated = { ...original, authTag: original.authTag.slice(0, -2) };
+    let thrownError: unknown = null;
+    try {
+      await decryptData(truncated, k);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(thrownError).not.toBeNull();
+  });
+});
+
+describe("crypto-client adversarial: vault key rotation rollback", () => {
+  // Threat: an attacker who retains the OLD vault key (e.g., by capturing a
+  // memory snapshot before rotation) must NOT be able to decrypt content that
+  // was re-encrypted under the NEW key after rotation. This is the symmetric
+  // dual of the existing K1→K2 swap test. The property follows from AES-GCM
+  // tag authenticity but warrants an explicit regression test because rotation
+  // is the place a future implementation might inadvertently re-use IVs across
+  // keys, weaken the key derivation, or skip the re-encrypt step entirely.
+  it("ciphertext encrypted under K_new cannot be decrypted by leaked K_old", async () => {
+    const kOld = await deriveEncryptionKey(generateSecretKey());
+    const kNew = await deriveEncryptionKey(generateSecretKey());
+
+    // Pre-rotation: content was encrypted under kOld
+    const preRotation = await encryptData("vault-secret-pre", kOld);
+    // Sanity: kOld decrypts its own ciphertext
+    expect(await decryptData(preRotation, kOld)).toBe("vault-secret-pre");
+
+    // Rotation: content is re-encrypted under kNew
+    const postRotation = await encryptData("vault-secret-post", kNew);
+
+    // Adversary still holds kOld but the new ciphertext was sealed under kNew.
+    let thrownError: unknown = null;
+    try {
+      await decryptData(postRotation, kOld);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(thrownError).not.toBeNull();
+  });
+});

--- a/src/lib/crypto/crypto-team-attachment.adversarial.test.ts
+++ b/src/lib/crypto/crypto-team-attachment.adversarial.test.ts
@@ -65,4 +65,36 @@ describe("crypto-team attachment adversarial: ciphertext-swap across team keys",
     }
     expect(thrownError).not.toBeNull();
   });
+
+  it("encryptTeamAttachment produces unique IVs across 16 calls under the same key", async () => {
+    // Nonce-reuse across re-uploaded / re-encrypted attachments must not happen.
+    const k = await deriveTeamEncryptionKey(generateTeamSymmetricKey());
+    const data = new Uint8Array(512);
+    crypto.getRandomValues(data);
+    const buf = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+    const ivs = new Set<string>();
+    for (let i = 0; i < 16; i++) {
+      const c = await encryptTeamAttachment(buf, k);
+      ivs.add(c.iv);
+    }
+    expect(ivs.size).toBe(16);
+  });
+
+  it("flipping one byte of attachment ciphertext rejects decryption", async () => {
+    const k = await deriveTeamEncryptionKey(generateTeamSymmetricKey());
+    const data = new Uint8Array(256);
+    crypto.getRandomValues(data);
+    const buf = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+    const original = await encryptTeamAttachment(buf, k);
+    const tamperedBytes = new Uint8Array(original.ciphertext);
+    tamperedBytes[0] ^= 0xff;
+    const tampered = { ...original, ciphertext: tamperedBytes };
+    let rejected = false;
+    try {
+      await decryptTeamAttachment(tampered, k);
+    } catch {
+      rejected = true;
+    }
+    expect(rejected).toBe(true);
+  });
 });

--- a/src/lib/crypto/crypto-team.adversarial.test.ts
+++ b/src/lib/crypto/crypto-team.adversarial.test.ts
@@ -85,4 +85,51 @@ describe("crypto-team adversarial: ciphertext-swap across team keys", () => {
     }
     expect(rejected).toBe(true);
   });
+
+  it("encryptTeamEntry produces unique IVs across 32 calls under the same team key", async () => {
+    // Nonce-reuse property at the team-vault surface — a key-rotation flow that
+    // re-encrypts every entry under a new key must NOT collapse to a single IV.
+    const k = await deriveTeamEncryptionKey(generateTeamSymmetricKey());
+    const ivs = new Set<string>();
+    for (let i = 0; i < 32; i++) {
+      const c = await encryptTeamEntry("same-team-entry", k);
+      ivs.add(c.iv);
+    }
+    expect(ivs.size).toBe(32);
+  });
+
+  it("flipping one byte of team-entry ciphertext rejects decryption (AES-GCM authenticity)", async () => {
+    const k = await deriveTeamEncryptionKey(generateTeamSymmetricKey());
+    const original = await encryptTeamEntry("team-authentic", k);
+    const tampered = {
+      ...original,
+      ciphertext:
+        ((parseInt(original.ciphertext[0], 16) ^ 0xf).toString(16)) +
+        original.ciphertext.slice(1),
+    };
+    let rejected = false;
+    try {
+      await decryptTeamEntry(tampered, k);
+    } catch {
+      rejected = true;
+    }
+    expect(rejected).toBe(true);
+  });
+
+  it("rotation rollback: ciphertext under K_new cannot be decrypted with leaked K_old", async () => {
+    const kOld = await deriveTeamEncryptionKey(generateTeamSymmetricKey());
+    const kNew = await deriveTeamEncryptionKey(generateTeamSymmetricKey());
+
+    const preRotation = await encryptTeamEntry("pre", kOld);
+    expect(await decryptTeamEntry(preRotation, kOld)).toBe("pre");
+
+    const postRotation = await encryptTeamEntry("post", kNew);
+    let rejected = false;
+    try {
+      await decryptTeamEntry(postRotation, kOld);
+    } catch {
+      rejected = true;
+    }
+    expect(rejected).toBe(true);
+  });
 });

--- a/src/lib/emergency-access/emergency-access-state.test.ts
+++ b/src/lib/emergency-access/emergency-access-state.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import { EmergencyAccessStatus } from "@prisma/client";
-import { MATRIX, canTransition } from "./emergency-access-state";
+import { MATRIX, canTransition, transition } from "./emergency-access-state";
 import { EA_STATUS, EA_ACTOR, type EaActor } from "@/lib/constants";
 
 const ALL_STATUSES = Object.values(EmergencyAccessStatus) as EmergencyAccessStatus[];
@@ -136,5 +136,46 @@ describe("security invariants", () => {
       );
       expect(used, `${actor} must appear in matrix`).toBe(true);
     }
+  });
+});
+
+describe("transition() return-value strictness", () => {
+  function makeDb(updateManyCount: number) {
+    return {
+      emergencyAccessGrant: {
+        updateMany: vi.fn().mockResolvedValue({ count: updateManyCount }),
+      },
+    } as unknown as Parameters<typeof transition>[0]["db"];
+  }
+
+  test("count === 1 returns ok:true", async () => {
+    const result = await transition({
+      db: makeDb(1),
+      where: { id: "grant-1", ownerId: "owner-1" },
+      to: EA_STATUS.REVOKED,
+      actor: EA_ACTOR.OWNER,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("count === 0 returns ok:false (eligible from-state mismatch)", async () => {
+    const result = await transition({
+      db: makeDb(0),
+      where: { id: "grant-1", ownerId: "owner-1" },
+      to: EA_STATUS.REVOKED,
+      actor: EA_ACTOR.OWNER,
+    });
+    expect(result).toEqual({ ok: false });
+  });
+
+  test("count > 1 throws — non-unique where is a programmer error, not a silent multi-row write", async () => {
+    await expect(
+      transition({
+        db: makeDb(2),
+        where: { ownerId: "owner-1" },
+        to: EA_STATUS.REVOKED,
+        actor: EA_ACTOR.OWNER,
+      }),
+    ).rejects.toThrow(/where matched >1 row/);
   });
 });

--- a/src/lib/emergency-access/emergency-access-state.ts
+++ b/src/lib/emergency-access/emergency-access-state.ts
@@ -27,9 +27,9 @@ export const MATRIX: Record<
   Record<EmergencyAccessStatus, ReadonlyArray<EaActor>>
 > = {
   [EA_STATUS.PENDING]: {
-    [EA_STATUS.ACCEPTED]: ["GRANTEE"],
-    [EA_STATUS.REJECTED]: ["GRANTEE"],
-    [EA_STATUS.REVOKED]: ["OWNER"],
+    [EA_STATUS.ACCEPTED]: [EA_ACTOR.GRANTEE],
+    [EA_STATUS.REJECTED]: [EA_ACTOR.GRANTEE],
+    [EA_STATUS.REVOKED]: [EA_ACTOR.OWNER],
     [EA_STATUS.IDLE]: [],
     [EA_STATUS.STALE]: [],
     [EA_STATUS.REQUESTED]: [],
@@ -37,8 +37,8 @@ export const MATRIX: Record<
     [EA_STATUS.PENDING]: [],
   },
   [EA_STATUS.ACCEPTED]: {
-    [EA_STATUS.IDLE]: ["OWNER"],
-    [EA_STATUS.REVOKED]: ["OWNER"],
+    [EA_STATUS.IDLE]: [EA_ACTOR.OWNER],
+    [EA_STATUS.REVOKED]: [EA_ACTOR.OWNER],
     [EA_STATUS.PENDING]: [],
     [EA_STATUS.ACCEPTED]: [],
     [EA_STATUS.REJECTED]: [],
@@ -47,9 +47,9 @@ export const MATRIX: Record<
     [EA_STATUS.ACTIVATED]: [],
   },
   [EA_STATUS.IDLE]: {
-    [EA_STATUS.REQUESTED]: ["GRANTEE"],
-    [EA_STATUS.STALE]: ["SYSTEM"],
-    [EA_STATUS.REVOKED]: ["OWNER"],
+    [EA_STATUS.REQUESTED]: [EA_ACTOR.GRANTEE],
+    [EA_STATUS.STALE]: [EA_ACTOR.SYSTEM],
+    [EA_STATUS.REVOKED]: [EA_ACTOR.OWNER],
     [EA_STATUS.PENDING]: [],
     [EA_STATUS.ACCEPTED]: [],
     [EA_STATUS.REJECTED]: [],
@@ -57,8 +57,8 @@ export const MATRIX: Record<
     [EA_STATUS.IDLE]: [],
   },
   [EA_STATUS.STALE]: {
-    [EA_STATUS.IDLE]: ["OWNER"],
-    [EA_STATUS.REVOKED]: ["OWNER"],
+    [EA_STATUS.IDLE]: [EA_ACTOR.OWNER],
+    [EA_STATUS.REVOKED]: [EA_ACTOR.OWNER],
     [EA_STATUS.PENDING]: [],
     [EA_STATUS.ACCEPTED]: [],
     [EA_STATUS.REJECTED]: [],
@@ -70,18 +70,18 @@ export const MATRIX: Record<
   // Removing this row allows an in-flight grantee to wait out waitExpiresAt
   // and unwrap the owner's pre-rotation secretKey via the stale escrow.
   [EA_STATUS.REQUESTED]: {
-    [EA_STATUS.ACTIVATED]: ["OWNER", "SYSTEM"],
-    [EA_STATUS.IDLE]: ["OWNER"],
-    [EA_STATUS.STALE]: ["SYSTEM"],
-    [EA_STATUS.REVOKED]: ["OWNER"],
+    [EA_STATUS.ACTIVATED]: [EA_ACTOR.OWNER, EA_ACTOR.SYSTEM],
+    [EA_STATUS.IDLE]: [EA_ACTOR.OWNER],
+    [EA_STATUS.STALE]: [EA_ACTOR.SYSTEM],
+    [EA_STATUS.REVOKED]: [EA_ACTOR.OWNER],
     [EA_STATUS.PENDING]: [],
     [EA_STATUS.ACCEPTED]: [],
     [EA_STATUS.REJECTED]: [],
     [EA_STATUS.REQUESTED]: [],
   },
   [EA_STATUS.ACTIVATED]: {
-    [EA_STATUS.STALE]: ["SYSTEM"],
-    [EA_STATUS.REVOKED]: ["OWNER"],
+    [EA_STATUS.STALE]: [EA_ACTOR.SYSTEM],
+    [EA_STATUS.REVOKED]: [EA_ACTOR.OWNER],
     [EA_STATUS.PENDING]: [],
     [EA_STATUS.ACCEPTED]: [],
     [EA_STATUS.REJECTED]: [],
@@ -176,7 +176,12 @@ export async function transition(args: {
     where: { ...args.where, status: { in: allowedFroms } },
     data: { ...args.extraData, status: args.to },
   });
-  return result.count >= 1 ? { ok: true } : { ok: false };
+  if (result.count > 1) {
+    throw new Error(
+      "transition: where matched >1 row; pass a unique-id predicate or use bulkTransition",
+    );
+  }
+  return result.count === 1 ? { ok: true } : { ok: false };
 }
 
 /**

--- a/src/lib/vault/admin-reset-token-crypto.adversarial.test.ts
+++ b/src/lib/vault/admin-reset-token-crypto.adversarial.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { randomBytes } from "node:crypto";
 import * as cryptoServer from "@/lib/crypto/crypto-server";
+import { parseEnvelope, SENTINEL } from "@/lib/crypto/envelope";
 import {
   encryptResetToken,
   decryptResetToken,
@@ -86,6 +87,52 @@ describe("admin-reset-token-crypto adversarial: ciphertext-swap across master ke
       expect(decryptResetToken(ct, aadInitial)).toBe("reset-token-X");
       // FR12: target user changed email between initiate and approve → reject.
       expect(() => decryptResetToken(ct, aadChanged)).toThrow();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("encryptResetToken produces unique IVs across 16 calls under the same master key", () => {
+    const k = randomBytes(32);
+    const aad = {
+      tenantId: "00000000-0000-0000-0000-000000000050",
+      resetId: "00000000-0000-0000-0000-000000000060",
+      targetEmailAtInitiate: "<iv-uniqueness-target>@example.com",
+    };
+    const spy = vi
+      .spyOn(cryptoServer, "getMasterKeyByVersion")
+      .mockImplementation(() => k);
+    try {
+      const ivs = new Set<string>();
+      for (let i = 0; i < 16; i++) {
+        const ct = encryptResetToken("same-reset-token", aad);
+        const env = parseEnvelope(ct);
+        ivs.add(env.iv.toString("hex"));
+      }
+      expect(ivs.size).toBe(16);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("flipping one byte of envelope ciphertext rejects decryption (authenticity)", () => {
+    const k = randomBytes(32);
+    const aad = {
+      tenantId: "00000000-0000-0000-0000-000000000070",
+      resetId: "00000000-0000-0000-0000-000000000080",
+      targetEmailAtInitiate: "<authenticity-target>@example.com",
+    };
+    const spy = vi
+      .spyOn(cryptoServer, "getMasterKeyByVersion")
+      .mockImplementation(() => k);
+    try {
+      const ct = encryptResetToken("authentic-reset-token", aad);
+      const env = parseEnvelope(ct);
+      const tamperedCipher = Buffer.from(env.ciphertext);
+      tamperedCipher[0] ^= 0xff;
+      const blob = Buffer.concat([env.iv, env.tag, tamperedCipher]).toString("base64url");
+      const tampered = `${SENTINEL}${env.version}:${blob}`;
+      expect(() => decryptResetToken(tampered, aad)).toThrow();
     } finally {
       spy.mockRestore();
     }


### PR DESCRIPTION
## Summary

Follow-up hardening for the four recently merged PRs: `#436` / `#442` (state-machine centralization), `#435` (MCP refresh race + adversarial), `#440` (RLS verify), `#438` (crypto rotation). Triangulated review of the merged code surfaced four residual gaps; this PR closes them.

- **state-machine**: `transition()` was returning `{ ok: true }` on `count >= 1`, masking non-unique-where misuse. Now strict: `count === 1` → `ok: true`, `> 1` → throw, `0` → `ok: false`. MATRIX values now reference `EA_ACTOR.*` / `AR_ACTOR.*` (typos surface at compile time). `AR_STATUS` / `AR_ACTOR` relocated to `src/lib/constants/integrations/access-request.ts` (client-safe, mirrors EA pattern); `access-request-card` and the tenant API route adopt the constants.
- **state mutation lint**: `upsert` was not in `MUTATING_METHODS`, computed property names (`{ [k]: status }`) were not inspected, and `as`-cast / parenthesised / satisfies-wrapped object literals slipped through. All three closed; fixtures expanded from 1 bad case to 8 with per-pattern coverage assertions.
- **T17 race assertion**: was `successCount === 1` (vacuous-pass risk if the second call short-circuits before the CAS). Now asserts the exact `[false, true]` shape AND `loser.reason === "not_eligible"` — proves both winner and loser branches actually occurred, and that the loser failed at the CAS not upstream (RT4).
- **RLS verify**: two latent regression vectors were uncovered. `[E-RLS-FORCE]` blocks any `tenant_isolation` table missing `relforcerowsecurity = true` (table-owner role bypasses RLS without FORCE). `[E-RLS-SECDEF]` blocks `SECURITY DEFINER` functions in `public` schema (a `passwd_user`-owned secdef function callable by `passwd_app` is a ready-made RLS-bypass primitive). Negative test Cases 8 and 9 prove the gates fire on each failure shape; `pre-pr.sh` allowlist regex extended.
- **crypto adversarial**: existing files covered key-swap + AAD-swap. Three regression vectors added: nonce uniqueness across re-encryptions under the same key (16-64 calls / IV set size), AES-GCM authenticity on ciphertext / authTag mutation + tag truncation, and rotation rollback (`K_new` ciphertext rejected by leaked `K_old`). Coverage extended to all five adversarial files (entries, attachments, account tokens, admin reset tokens).

Local gates: `npx vitest run` 10066/10067 ✓ (1 skipped pre-existing), `npx next build` ✓, `bash scripts/pre-pr.sh` 14/14 ✓.

## Test plan

- [ ] CI: state-mutation centralization lint runs against the 8 expanded bad-fixture cases (incl. `upsert`, computed key, `as object`)
- [ ] CI: RLS cross-tenant negative test exercises Cases 8 (`[E-RLS-FORCE]`) and 9 (`[E-RLS-SECDEF]`) end-to-end
- [ ] CI: crypto adversarial suite covers nonce-uniqueness + GCM authenticity + rotation rollback across 5 surfaces
- [ ] Manual: M4 access-request UI smoke per `docs/archive/review/centralize-state-transitions-manual-test.md` "Follow-up delta" section — status filter cycle, badge variants, conditional approve/deny visibility

## Manual test plan

Appended as a delta to the parent plan at `docs/archive/review/centralize-state-transitions-manual-test.md` (Follow-up delta section). Most of this PR is automation-covered; only the access-request-card UI rendering with the new `AR_STATUS` constants needs human eyes (~5 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)