### PR TITLE
fix(vault): close upload TOCTOU by moving cekKeyVersion check into tx

### DIFF
--- a/src/__tests__/api/passwords/attachments.test.ts
+++ b/src/__tests__/api/passwords/attachments.test.ts
@@ -9,6 +9,8 @@ const {
   mockAttachmentCount,
   mockAttachmentCreate,
   mockUserFindUnique,
+  mockTransaction,
+  mockExecuteRaw,
   mockPutObject,
   mockDeleteObject,
   mockWithUserTenantRls,
@@ -20,11 +22,20 @@ const {
   mockAttachmentCount: vi.fn(),
   mockAttachmentCreate: vi.fn(),
   mockUserFindUnique: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockExecuteRaw: vi.fn(),
   mockPutObject: vi.fn(),
   mockDeleteObject: vi.fn(),
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
   mockRateLimitCheck: vi.fn(),
 }));
+
+// Tx mock — upload now wraps user.findUnique + attachment.create in a tx.
+const txMock = {
+  $executeRaw: mockExecuteRaw,
+  user: { findUnique: mockUserFindUnique },
+  attachment: { create: mockAttachmentCreate },
+};
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/security/rate-limit", () => ({ createRateLimiter: vi.fn(() => ({ check: mockRateLimitCheck, clear: vi.fn() })) }));
@@ -37,8 +48,18 @@ vi.mock("@/lib/prisma", () => ({
       create: mockAttachmentCreate,
     },
     user: { findUnique: mockUserFindUnique },
+    $transaction: mockTransaction,
   },
 }));
+vi.mock("@/lib/vault/rotate-key-server", () => {
+  class LegacyAttachmentInconsistentVersionError extends Error {
+    constructor() {
+      super("ATTACHMENT_INCONSISTENT_VERSION");
+      this.name = "LegacyAttachmentInconsistentVersionError";
+    }
+  }
+  return { LegacyAttachmentInconsistentVersionError };
+});
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: vi.fn(),
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
@@ -153,6 +174,13 @@ describe("POST /api/passwords/[id]/attachments", () => {
     // Tests that exercise the upload happy path rely on this match; tests
     // exercising the keyVersion-mismatch case override per call.
     mockUserFindUnique.mockResolvedValue({ keyVersion: 1 });
+    // Wire the tx callback so user.findUnique + attachment.create resolve
+    // through the same mocks they used pre-tx.
+    mockTransaction.mockImplementation(async (fn: (tx: typeof txMock) => unknown) => fn(txMock));
+    mockExecuteRaw.mockResolvedValue(undefined);
+    // deleteObject must return a Promise — the route's tx-failure cleanup
+    // calls `.catch()` on its return value.
+    mockDeleteObject.mockResolvedValue(undefined);
   });
 
   it("returns 401 when not authenticated", async () => {

--- a/src/app/api/passwords/[id]/attachments/route.test.ts
+++ b/src/app/api/passwords/[id]/attachments/route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 import { AAD_VERSION } from "@/lib/crypto/crypto-aad";
 
-const { mockAuth, mockPrismaPasswordEntry, mockPrismaAttachment, mockPrismaUser, mockWithUserTenantRls, mockRateLimitCheck, mockPutObject, mockDeleteObject } = vi.hoisted(() => ({
+const { mockAuth, mockPrismaPasswordEntry, mockPrismaAttachment, mockPrismaUser, mockPrismaTransaction, mockWithUserTenantRls, mockRateLimitCheck, mockPutObject, mockDeleteObject } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockPrismaPasswordEntry: {
     findUnique: vi.fn(),
@@ -15,11 +15,23 @@ const { mockAuth, mockPrismaPasswordEntry, mockPrismaAttachment, mockPrismaUser,
   mockPrismaUser: {
     findUnique: vi.fn(),
   },
+  mockPrismaTransaction: vi.fn(),
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
   mockRateLimitCheck: vi.fn().mockResolvedValue({ allowed: true }),
   mockPutObject: vi.fn(),
   mockDeleteObject: vi.fn(),
 }));
+
+// Tx mock: the upload route now wraps the user.keyVersion check + the
+// attachment.create in a single tx with an advisory lock. We point the tx
+// surface back at the existing `mockPrismaUser` / `mockPrismaAttachment`
+// hoists so existing test setup (.mockResolvedValue, .toHaveBeenCalledWith)
+// keeps working without per-test churn.
+const txMock = {
+  $executeRaw: vi.fn(),
+  user: mockPrismaUser,
+  attachment: mockPrismaAttachment,
+};
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/security/rate-limit", () => ({
@@ -30,9 +42,19 @@ vi.mock("@/lib/prisma", () => ({
     passwordEntry: mockPrismaPasswordEntry,
     attachment: mockPrismaAttachment,
     user: mockPrismaUser,
+    $transaction: mockPrismaTransaction,
     auditLog: { create: vi.fn().mockResolvedValue({}) },
   },
 }));
+vi.mock("@/lib/vault/rotate-key-server", () => {
+  class LegacyAttachmentInconsistentVersionError extends Error {
+    constructor() {
+      super("ATTACHMENT_INCONSISTENT_VERSION");
+      this.name = "LegacyAttachmentInconsistentVersionError";
+    }
+  }
+  return { LegacyAttachmentInconsistentVersionError };
+});
 vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,
 }));
@@ -156,6 +178,13 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockPrismaUser.findUnique.mockResolvedValue({ keyVersion: 1 });
     mockRateLimitCheck.mockResolvedValue({ allowed: true });
     mockPutObject.mockResolvedValue(Buffer.from("stored-bytes"));
+    // deleteObject must return a Promise — the route's tx-failure cleanup
+    // calls `.catch()` on its return value.
+    mockDeleteObject.mockResolvedValue(undefined);
+    // Wire prisma.$transaction to invoke the callback with our tx mock so
+    // upload's user.keyVersion re-check + attachment.create both run.
+    mockPrismaTransaction.mockImplementation(async (fn: (tx: typeof txMock) => unknown) => fn(txMock));
+    txMock.$executeRaw.mockResolvedValue(undefined);
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -544,7 +573,8 @@ describe("POST /api/passwords/[id]/attachments", () => {
     );
   });
 
-  // Fix #2: server-side cekKeyVersion validation against user.keyVersion
+  // Server-side cekKeyVersion validation against user.keyVersion (now
+  // performed INSIDE the upload tx, after the advisory lock).
 
   it("rejects upload when cekKeyVersion does not match user.keyVersion → 409 ATTACHMENT_INCONSISTENT_VERSION", async () => {
     // User has keyVersion 2 (e.g., a recent rotation in another tab),
@@ -566,9 +596,11 @@ describe("POST /api/passwords/[id]/attachments", () => {
     expect(res.status).toBe(409);
     const json = await res.json();
     expect(json.error).toBe("ATTACHMENT_INCONSISTENT_VERSION");
-    // Must reject before persisting anything to the blob store / DB.
-    expect(mockPutObject).not.toHaveBeenCalled();
+    // No DB row written.
     expect(mockPrismaAttachment.create).not.toHaveBeenCalled();
+    // Blob saved before tx; on failure it is deleted as part of cleanup.
+    expect(mockPutObject).toHaveBeenCalledTimes(1);
+    expect(mockDeleteObject).toHaveBeenCalledTimes(1);
   });
 
   it("rejects upload when user record is missing → 404", async () => {
@@ -588,6 +620,44 @@ describe("POST /api/passwords/[id]/attachments", () => {
     );
     expect(res.status).toBe(404);
     expect(mockPrismaAttachment.create).not.toHaveBeenCalled();
+    expect(mockDeleteObject).toHaveBeenCalledTimes(1);
+  });
+
+  it("acquires the advisory lock before reading user.keyVersion (TOCTOU-safe)", async () => {
+    // Drive the order of operations inside the tx by recording call sequence.
+    const calls: string[] = [];
+    txMock.$executeRaw.mockImplementationOnce(async () => {
+      calls.push("advisory_lock");
+    });
+    mockPrismaUser.findUnique.mockImplementationOnce(async () => {
+      calls.push("user.findUnique");
+      return { keyVersion: 1 };
+    });
+    mockPrismaAttachment.create.mockImplementationOnce(async (args: unknown) => {
+      calls.push("attachment.create");
+      return {
+        id: (args as { data: { id: string } }).data.id,
+        filename: "test.pdf",
+        contentType: "application/pdf",
+        sizeBytes: 100,
+        createdAt: now,
+      };
+    });
+
+    const res = await POST(
+      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+        file: new Blob(["encrypted-data"]),
+        iv: "a".repeat(24),
+        authTag: "b".repeat(32),
+        filename: "test.pdf",
+        contentType: "application/pdf",
+        sizeBytes: "100",
+        ...validCekFields(),
+      }),
+      createParams("pw-1"),
+    );
+    expect(res.status).toBe(201);
+    expect(calls).toEqual(["advisory_lock", "user.findUnique", "attachment.create"]);
   });
 
   it("rejects upload with oversized cekEncrypted → 400 VALIDATION_ERROR", async () => {

--- a/src/app/api/passwords/[id]/attachments/route.ts
+++ b/src/app/api/passwords/[id]/attachments/route.ts
@@ -19,6 +19,7 @@ import { AAD_VERSION } from "@/lib/crypto/crypto-aad";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { errorResponse, forbidden, notFound, unauthorized, rateLimited } from "@/lib/http/api-response";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { LegacyAttachmentInconsistentVersionError } from "@/lib/vault/rotate-key-server";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -170,26 +171,10 @@ async function handlePOST(
     return errorResponse(API_ERROR.VALIDATION_ERROR, 400);
   }
 
-  // Reject uploads whose cekKeyVersion does not match the user's current
-  // vault keyVersion. A stale client (e.g., another tab that did not
-  // observe a recent rotation) would otherwise persist a row whose
-  // cek_key_version is below the user's current keyVersion, which
-  // poisons the next rotation's manifest consistency check and bricks
-  // future rotations until the row is migrated. A residual TOCTOU
-  // window between this read and the attachment.create remains and is
-  // acceptable: the rotation manifest check is the backstop.
-  const user = await withUserTenantRls(session.user.id, async () =>
-    prisma.user.findUnique({
-      where: { id: session.user.id },
-      select: { keyVersion: true },
-    }),
-  );
-  if (!user) {
-    return errorResponse(API_ERROR.NOT_FOUND, 404);
-  }
-  if (cekKeyVersion !== user.keyVersion) {
-    return errorResponse(API_ERROR.ATTACHMENT_INCONSISTENT_VERSION, 409);
-  }
+  // The cekKeyVersion ↔ user.keyVersion equality check happens INSIDE the
+  // advisory-locked transaction below (just before attachment.create), so a
+  // rotation that commits between request boundary and lock acquisition
+  // cannot land a stale-cekKeyVersion row in the DB.
 
   // I3.3: keyVersion from request is ignored in mode-2 uploads
   if (keyVersion !== null) {
@@ -237,46 +222,74 @@ async function handlePOST(
   const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   const attachmentId = (clientId && UUID_V4_RE.test(clientId)) ? clientId.toLowerCase() : crypto.randomUUID();
   const blobContext = { attachmentId, entryId: id };
-  const storedBlob = await blobStore.putObject(buffer, blobContext);
+  // Validate aadVersion BEFORE blob storage to avoid leaking a stored blob
+  // when the request is rejected.
   const aadVersion = aadVersionStr ? parseInt(aadVersionStr, 10) : AAD_VERSION;
   if (Number.isNaN(aadVersion) || aadVersion < 1 || aadVersion > 1) {
     return errorResponse(API_ERROR.VALIDATION_ERROR, 400);
   }
+  const storedBlob = await blobStore.putObject(buffer, blobContext);
   let attachment;
   try {
     attachment = await withUserTenantRls(session.user.id, async () =>
-      prisma.attachment.create({
-        data: {
-          id: attachmentId,
-          filename: sanitizedFilename,
-          contentType,
-          sizeBytes: originalSize,
-          encryptedData: Buffer.from(storedBlob),
-          iv,
-          authTag,
-          // keyVersion from request is intentionally omitted (I3.3): server sets encryptionMode: 2
-          aadVersion,
-          encryptionMode: 2,
-          cekEncrypted: Buffer.from(cekEncrypted, "base64"),
-          cekIv,
-          cekAuthTag,
-          cekKeyVersion,
-          cekWrapAadVersion,
-          tenantId: entry.tenantId,
-          passwordEntryId: id,
-          createdById: session.user.id,
-        },
-        select: {
-          id: true,
-          filename: true,
-          contentType: true,
-          sizeBytes: true,
-          createdAt: true,
-        },
+      prisma.$transaction(async (tx) => {
+        // Advisory lock serializes upload against any concurrent vault key
+        // rotation for the same user. Holding the lock across the
+        // user.keyVersion read AND attachment.create closes the TOCTOU
+        // window — a rotation that commits between our read and create
+        // can no longer land a stale-cekKeyVersion mode-2 row.
+        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${session.user.id}::text))`;
+
+        const currentUser = await tx.user.findUnique({
+          where: { id: session.user.id },
+          select: { keyVersion: true },
+        });
+        if (!currentUser) {
+          throw new Error("USER_NOT_FOUND");
+        }
+        if (cekKeyVersion !== currentUser.keyVersion) {
+          throw new LegacyAttachmentInconsistentVersionError();
+        }
+
+        return tx.attachment.create({
+          data: {
+            id: attachmentId,
+            filename: sanitizedFilename,
+            contentType,
+            sizeBytes: originalSize,
+            encryptedData: Buffer.from(storedBlob),
+            iv,
+            authTag,
+            // keyVersion from request is intentionally omitted (I3.3): server sets encryptionMode: 2
+            aadVersion,
+            encryptionMode: 2,
+            cekEncrypted: Buffer.from(cekEncrypted, "base64"),
+            cekIv,
+            cekAuthTag,
+            cekKeyVersion,
+            cekWrapAadVersion,
+            tenantId: entry.tenantId,
+            passwordEntryId: id,
+            createdById: session.user.id,
+          },
+          select: {
+            id: true,
+            filename: true,
+            contentType: true,
+            sizeBytes: true,
+            createdAt: true,
+          },
+        });
       }),
     );
   } catch (error) {
     await blobStore.deleteObject(storedBlob, blobContext).catch(() => {});
+    if (error instanceof LegacyAttachmentInconsistentVersionError) {
+      return errorResponse(API_ERROR.ATTACHMENT_INCONSISTENT_VERSION, 409);
+    }
+    if (error instanceof Error && error.message === "USER_NOT_FOUND") {
+      return notFound();
+    }
     throw error;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to PR `#445`. The post-merge review of `#445` flagged that the
`cekKeyVersion === user.keyVersion` check on attachment upload still lived
**outside** the advisory lock, which left a stale-keyVersion race window:

```
1. upload reads user.keyVersion = 5
2. concurrent rotation commits, bumps user.keyVersion → 6
3. upload writes attachment with cekKeyVersion = 5
4. next rotation refuses to proceed (manifest consistency check)
```

The rotation manifest check is **not** a real backstop — it blocks future
rotations rather than the broken write itself. This PR moves the
`cekKeyVersion` check into the same advisory-locked `prisma.$transaction`
as `attachment.create`, mirroring the pattern already in place on the
migrate route. The race window is closed structurally.

## Changes

- [`route.ts`](https://github.com/ngc-shj/passwd-sso/blob/fix/upload-attachment-cek-keyversion-tx/src/app/api/passwords/%5Bid%5D/attachments/route.ts):
  - Drop the outside-tx `prisma.user.findUnique` check.
  - Wrap `attachment.create` in `prisma.$transaction` with
    `pg_advisory_xact_lock(hashtext(userId))` → fresh `tx.user.findUnique` →
    equality check → `tx.attachment.create`.
  - Map `LegacyAttachmentInconsistentVersionError` → `409 ATTACHMENT_INCONSISTENT_VERSION`,
    sentinel `USER_NOT_FOUND` → `404`. Existing blob-cleanup path
    (`blobStore.deleteObject` on any tx failure) covers both.
  - Move `aadVersion` validation ahead of `blobStore.putObject` so a
    request with invalid `aadVersion` no longer leaks a stored blob (a
    pre-existing leak that became more visible after the refactor).

## Test plan

- [x] New test: `acquires the advisory lock before reading user.keyVersion (TOCTOU-safe)` — records the in-tx call order and asserts `["advisory_lock", "user.findUnique", "attachment.create"]`.
- [x] Updated tests: stale-`cekKeyVersion` and missing-user cases now assert `mockDeleteObject` was called (blob cleanup runs).
- [x] Full vitest: **10087 / 10088** pass (1 pre-existing skip).
- [x] Lint clean on changed files; `npx next build` succeeds.
- [x] `scripts/pre-pr.sh` (PREPR_SKIP_INTEGRATION=1): **15/15 pass**.
- [x] Integration: `vault-rotate-key-attachments.integration.test.ts` **14/14 pass** (covers advisory-lock contention).

## Notes

No schema migration. No client-visible behavior change beyond the
TOCTOU window being closed — the response codes for stale-`cekKeyVersion`
(`409`) and missing-user (`404`) are unchanged from `#445`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)