### PR TITLE
Harden session-based credential issuance, CSRF, and SSRF gates

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -215,10 +215,10 @@ npm run docker:down
 | --- | --- |
 | `NEXT_PUBLIC_APP_NAME` | （任意）UI に表示するアプリ名 |
 | `NEXT_PUBLIC_BASE_PATH` | （任意）リバースプロキシ配下のサブパス（例: `/passwd-sso`）。ビルド前に設定 |
-| `APP_URL` | （任意）リバースプロキシ / CDN 配下の外部 URL（オリジンのみ） |
+| `APP_URL` | （推奨）リバースプロキシ / CDN 配下の外部 URL（オリジンのみ）。Cookie 認証 API の CSRF Origin 判定に使われます |
 | `DATABASE_URL` | PostgreSQL 接続文字列（アプリロール、例: `passwd_app`） |
 | `MIGRATION_DATABASE_URL` | マイグレーション用 PostgreSQL 接続（スーパーユーザーロール、例: `passwd_user`）。`npm run db:migrate` に必要 |
-| `AUTH_URL` | アプリケーションのオリジン（例: `http://localhost:3000`） |
+| `AUTH_URL` | アプリケーションのオリジン（例: `http://localhost:3000`）。`APP_URL` 未設定時の canonical Origin として使われます |
 | `AUTH_SECRET` | `openssl rand -base64 32` |
 | `AUTH_GOOGLE_ID` | Google OAuth クライアント ID |
 | `AUTH_GOOGLE_SECRET` | Google OAuth クライアントシークレット |
@@ -263,6 +263,8 @@ npm run docker:down
 </details>
 
 > **Redis は本番必須です。** 開発/テスト環境では `REDIS_URL` 未設定時に in-memory フォールバックを利用できます。
+>
+> **Cookie 認証の破壊的 API では canonical origin の設定が必要です。** `assertOrigin()` は `APP_URL` / `AUTH_URL` のどちらも無い場合、`Host` ヘッダーから same-origin を推測せず fail-closed で 403 を返します。
 
 ### 管理 / メンテナンススクリプト
 
@@ -322,7 +324,7 @@ cd extension && npm install && npm run build
 - **AAD バインディング** — 追加認証データで暗号文をユーザー・エントリ ID に紐付け
 - **セッションセキュリティ** — データベースセッション（JWT ではない）、テナント/チームポリシーによる絶対タイムアウト（デフォルト 30 日、ポリシーで最短 5 分まで設定可能）、15 分無操作または 5 分タブ非表示で自動ロック
 - **クリップボードクリア** — コピーしたパスワードは 30 秒後に自動消去
-- **CSRF 防御** — JSON body + SameSite Cookie + CSP + Origin ヘッダー検証
+- **CSRF 防御** — JSON body + SameSite Cookie + CSP + 設定済み `APP_URL` / `AUTH_URL` に対する Origin ヘッダー検証（未設定時は fail-closed）
 
 詳細は[暗号設計ホワイトペーパー](docs/security/cryptography-whitepaper.md)を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -216,10 +216,10 @@ Key variables:
 | --- | --- |
 | `NEXT_PUBLIC_APP_NAME` | (Optional) Display name shown in the UI |
 | `NEXT_PUBLIC_BASE_PATH` | (Optional) Sub-path for reverse proxy (e.g., `/passwd-sso`). Set before build |
-| `APP_URL` | (Optional) External URL when behind reverse proxy/CDN (origin only) |
+| `APP_URL` | (Recommended) External URL when behind reverse proxy/CDN (origin only). Used as the canonical Origin for cookie-auth CSRF checks |
 | `DATABASE_URL` | PostgreSQL connection string (app role, e.g. `passwd_app`) |
 | `MIGRATION_DATABASE_URL` | PostgreSQL connection for migrations (superuser role, e.g. `passwd_user`). Required for `npm run db:migrate` |
-| `AUTH_URL` | Application origin (e.g., `http://localhost:3000`) |
+| `AUTH_URL` | Application origin (e.g., `http://localhost:3000`). Used as the canonical Origin when `APP_URL` is unset |
 | `AUTH_SECRET` | `openssl rand -base64 32` |
 | `AUTH_GOOGLE_ID` | Google OAuth client ID |
 | `AUTH_GOOGLE_SECRET` | Google OAuth client secret |
@@ -264,6 +264,8 @@ Key variables:
 </details>
 
 > **Redis is required in production.** In dev/test, omit `REDIS_URL` for in-memory fallback.
+>
+> **Canonical origin is required for cookie-authenticated mutating APIs.** `assertOrigin()` now fails closed when neither `APP_URL` nor `AUTH_URL` is configured, instead of deriving same-origin from request `Host` headers.
 
 ### Admin / maintenance scripts
 
@@ -323,7 +325,7 @@ Zero-knowledge architecture — the server stores only ciphertext and cannot dec
 - **AAD binding** — Additional Authenticated Data ties ciphertext to user and entry IDs
 - **Session security** — Database sessions (not JWT), tenant/team-policy-driven absolute timeout (default 30 days, configurable down to 5 minutes per policy), auto-lock after 15 min idle or 5 min tab hidden
 - **Clipboard clear** — Copied passwords auto-clear after 30 seconds
-- **CSRF defense** — JSON body + SameSite cookie + CSP + Origin validation
+- **CSRF defense** — JSON body + SameSite cookie + CSP + Origin validation against configured `APP_URL` / `AUTH_URL` (fail-closed if unset)
 
 For the full design, see the [Cryptography Whitepaper](docs/security/cryptography-whitepaper.md).
 

--- a/docs/architecture/extension-token-bridge.md
+++ b/docs/architecture/extension-token-bridge.md
@@ -14,7 +14,8 @@ Token delivery uses a **one-time bridge code exchange**
 (introduced in PR #364):
 
 1. The web app's JavaScript obtains a single-use bridge code from
-   `POST /api/extension/bridge-code` (requires Auth.js session).
+   `POST /api/extension/bridge-code` (requires Auth.js session and a recent
+   sign-in within the shared step-up window).
 2. The web app posts the code via `window.postMessage` to the content script.
 3. The content script (ISOLATED world) calls `POST /api/extension/token/exchange`
    directly via `fetch()` to atomically consume the code and receive a token.
@@ -77,10 +78,10 @@ sequenceDiagram
 
 | Phase | Mechanism | TTL |
 |-------|-----------|-----|
-| **Issue (bridge code)** | `POST /api/extension/bridge-code` (requires Auth.js session) | 60 s code TTL |
+| **Issue (bridge code)** | `POST /api/extension/bridge-code` (requires Auth.js session + recent-session step-up) | 60 s code TTL |
 | **Code delivery** | `window.postMessage` (MAIN → ISOLATED) | instant |
 | **Code → token exchange** | `POST /api/extension/token/exchange` (no session, atomic single-use consume) | issues token with tenant-policy TTL (default 7d idle / 30d absolute) |
-| **Issue (legacy direct)** | `POST /api/extension/token` (Auth.js session) — **DEPRECATED** | tenant-policy TTL |
+| **Issue (legacy direct)** | `POST /api/extension/token` (Auth.js session + recent-session step-up) — **DEPRECATED** | tenant-policy TTL |
 | **Storage** | Encrypted with ephemeral AES-256-GCM key in `chrome.storage.session` | until browser close |
 | **Refresh** | `POST /api/extension/token/refresh` (Bearer + session) | tenant-policy TTL (new token) |
 | **Refresh trigger** | `ALARM_TOKEN_REFRESH` fires before idle expiry | — |
@@ -167,6 +168,14 @@ CSRF protection (`assertOrigin`) is intentionally NOT applied to this endpoint
 because the content script's effective origin may be `chrome-extension://`,
 which would fail any same-origin check. The compensating control is the
 256-bit single-use code.
+
+### Browser-session issuance hardening
+
+Both browser-session issuance paths (`POST /api/extension/bridge-code` and the
+legacy `POST /api/extension/token`) also require a recent Auth.js session via
+the shared `requireRecentSession()` helper. This prevents an attacker with a
+stolen but older dashboard session from upgrading it into a longer-lived
+extension credential.
 
 ## Threat Model
 

--- a/docs/architecture/machine-identity.md
+++ b/docs/architecture/machine-identity.md
@@ -360,6 +360,7 @@ Tenant audit log UI includes an actor type filter dropdown. The API accepts an o
 6. **Tenant isolation** — All models carry `tenantId`; RLS defense-in-depth on MCP client routes
 7. **Token lifecycle** — Deactivation immediately rejects all tokens; hard delete cascades
 8. **JIT atomicity** — Single transaction + optimistic lock prevents double-approval
+9. **Recent-session issuance hardening** — Browser-session endpoints that mint machine credentials require a recent Auth.js session (15-minute shared step-up window)
 
 ## Database Models
 
@@ -402,7 +403,8 @@ challenge: 1QqV6dforNv_7P9vVt611sRQDJ3SnU6jHJAbSV6bBuU
 
 ### Step 3: Authorize (Browser)
 
-Open this URL in a browser where you are logged into passwd-sso:
+Open this URL in a browser where you are logged into passwd-sso with a recent
+session:
 
 ```
 https://<your-server>/api/mcp/authorize?\
@@ -416,6 +418,27 @@ https://<your-server>/api/mcp/authorize?\
 ```
 
 The browser redirects to `http://localhost:3000/callback?code=<AUTH_CODE>&state=test`. Copy the `code` value from the URL.
+
+If the browser session is older than the step-up window, the authorize route
+returns `SESSION_STEP_UP_REQUIRED`; re-authenticate in the dashboard and retry.
+
+### Recent-session requirement for browser-issued credentials
+
+The shared `requireRecentSession()` guard applies to browser-session routes
+that mint non-session credentials:
+
+- `GET /api/mcp/authorize`
+- `POST /api/mcp/authorize/consent`
+- `GET /api/mobile/authorize`
+- `POST /api/extension/bridge-code`
+- `POST /api/extension/token` (legacy direct issuance)
+- `POST /api/tenant/scim-tokens`
+- `POST /api/tenant/service-accounts/[id]/tokens`
+- `POST /api/tenant/operator-tokens`
+
+Refresh, revoke, and one-time code exchange endpoints are not part of this
+step-up boundary because they are already authenticated by existing bearer
+credentials or single-use codes.
 
 ### Step 4: Exchange Code for Token
 

--- a/docs/archive/review/security-credential-issuance-hardening-manual-test.md
+++ b/docs/archive/review/security-credential-issuance-hardening-manual-test.md
@@ -1,0 +1,74 @@
+# Security Credential Issuance Hardening Manual Test
+
+Date: 2026-05-06
+Branch: `fix/security-network-gates`
+
+## Scope
+
+Tier-2 security changes verified in this branch:
+
+- proxy-enforced tenant access restriction for session-based issuance routes
+- recent-session step-up for sensitive credential issuance
+- CSRF fail-closed behavior without canonical origin config
+- SSRF rejection for hex-form IPv4-mapped IPv6 loopback/private targets
+
+## Manual Test Matrix
+
+1. Session-based issuance routes from allowed tenant network
+   Expected:
+   - `/api/mcp/authorize`
+   - `/api/mcp/authorize/consent`
+   - `/api/mobile/authorize`
+   proceed when the user has a valid recent session and the request originates from an allowed client IP.
+
+2. Session-based issuance routes from blocked tenant network
+   Expected:
+   - the same routes return `403 ACCESS_DENIED`
+   - proxy audit path records the denial
+
+3. Sensitive issuance after stale session
+   Targets:
+   - MCP authorize / consent
+   - mobile authorize
+   - extension bridge-code
+   - extension legacy token issuance
+   - API key creation via session auth
+   - SCIM token creation
+   - service-account token creation
+   - operator token creation
+   - MCP client creation
+   - access-request approve
+   Expected:
+   - returns `403 SESSION_STEP_UP_REQUIRED`
+   - operator tokens specifically return `403 OPERATOR_TOKEN_STALE_SESSION`
+   - no token / secret / authorization artifact is minted
+
+4. Service-account token listing with stale session
+   Expected:
+   - `GET /api/tenant/service-accounts/:id/tokens` remains readable for authorized users
+   - no step-up prompt is required
+
+5. API key creation via extension token auth
+   Expected:
+   - creation still succeeds for valid extension-token auth
+   - recent-session step-up is not applied because there is no browser session to step up
+
+6. CSRF origin without canonical app origin
+   Setup:
+   - unset `APP_URL` and `AUTH_URL`
+   Expected:
+   - mutating cookie-auth routes fail closed with `403 INVALID_ORIGIN`
+   - spoofed `Host` or `x-forwarded-proto` headers do not restore access
+
+7. External delivery SSRF guard
+   Targets:
+   - direct URL literals such as `https://[::ffff:7f00:1]/...`
+   - DNS answers such as `::FFFF:7F00:1` and `::ffff:7f00:0001`
+   Expected:
+   - requests are rejected before fetch with private-IP errors
+
+## Evidence
+
+- Automated route/unit coverage was expanded for all paths above.
+- Added real-DB contract test:
+  - `src/__tests__/db-integration/require-recent-session.integration.test.ts`

--- a/docs/archive/review/security-network-gates-code-review.md
+++ b/docs/archive/review/security-network-gates-code-review.md
@@ -1,0 +1,269 @@
+# Code Review: security-network-gates
+
+Date: 2026-05-05
+Branch: fix/security-network-gates
+Review round: 1
+
+## Changes from Previous Round
+Initial review.
+
+## Audit Baseline (External)
+
+The branch fixes 4 findings from an external static-review audit:
+
+1. **High** — Tenant network restrictions bypassable for `/api/mcp/*` and `/api/mobile/*` because proxy enforces `checkAccessRestrictionWithAudit` only for `API_SESSION_REQUIRED` paths, but these routes were `API_DEFAULT`.
+2. **Medium-High** — Stale web sessions can mint long-lived MCP/mobile credentials without step-up reauth.
+3. **Medium** — SSRF via hex-form IPv4-mapped IPv6 (`::ffff:7f00:1`) bypassing private-IP checks.
+4. **Low-Medium** — CSRF `assertOrigin` falls back to Host header when `APP_URL`/`AUTH_URL` unset.
+
+This review verifies the fixes are correct AND propagation-complete.
+
+## Functionality Findings
+
+### F1 [Major] SESSION_STEP_UP_REQUIRED renders user-facing string mentioning "operator token" for non-operator flows
+- File: `src/lib/http/api-error-codes.ts:371`; `messages/en/ApiErrors.json:114`; `messages/ja/ApiErrors.json:114`
+- Evidence: `SESSION_STEP_UP_REQUIRED → "operatorTokenStaleSession"` → `"Re-authenticate within the last 15 minutes to issue an operator token."` 6 routes (mcp/authorize, mcp/authorize/consent, mobile/authorize, extension/bridge-code, extension/token, scim-tokens, sa-tokens) emit this generic code via the helper default.
+- Problem: Generic step-up error mapped to operator-token-specific i18n key. Misleading UX in non-operator flows.
+- Impact: User confusion on stale-session step-up failures across 6 routes (R37 / `feedback_no_internal_jargon_in_user_strings`).
+- Fix: Add new i18n key `sessionStepUpRequired` ("Re-authenticate within the last 15 minutes to perform this action.") in en + ja `ApiErrors.json`; map `SESSION_STEP_UP_REQUIRED → sessionStepUpRequired`. Keep `OPERATOR_TOKEN_STALE_SESSION → operatorTokenStaleSession`.
+
+### F2 [Major] Long-lived API keys minted from session without step-up
+- File: `src/app/api/api-keys/route.ts:67-143`
+- Evidence: `handlePOST` uses `checkAuth()`, `randomBytes(48)` → `api_*` token, `expiresAt` from request body. No `requireRecentSession` call.
+- Problem: Same threat shape as audit finding #2 — stale session can mint long-lived bearer credential.
+- Impact: Bypass of step-up control's stated goal; path of least resistance shifts here.
+- Fix: Insert `const stepUpError = await requireRecentSession(req); if (stepUpError) return stepUpError;` after `checkAuth` in `handlePOST`.
+
+### F3 [Major] MCP client (long-lived clientSecret) created from session without step-up
+- File: `src/app/api/tenant/mcp-clients/route.ts:101-160`
+- Evidence: `handlePOST` → `auth()` → `randomBytes(32) → clientSecret` stored as `clientSecretHash`. No `requireRecentSession`.
+- Problem: `clientSecret` is the long-lived OAuth confidential-client credential. Issuing from stale session is the threat closed by this PR.
+- Impact: Stolen stale session can register attacker-controlled MCP client + secret + redirect_uri.
+- Fix: Add `requireRecentSession` after `requireTenantPermission`.
+
+### F4 [Minor] JIT SA token mint via approve has no step-up
+- File: `src/app/api/tenant/access-requests/[id]/approve/route.ts:30-145`
+- Evidence: `auth()` → `randomBytes(32)` → `sa_*` token. `ttlSec` capped by `jitTokenMaxTtlSec`.
+- Problem: Admin-side approval mints credential without step-up. Lower severity due to TTL cap.
+- Fix: Add `requireRecentSession` after `requireTenantPermission`, OR document exemption.
+
+### F5 [Minor] vault/admin-reset comment is now stale
+- File: `src/app/api/vault/admin-reset/route.ts:36-37`
+- Evidence: Comment says "Intentionally stricter than proxy CSRF gate (which skips when unset for dev convenience)". After this branch the proxy CSRF gate also fails closed.
+- Fix: Update comment — proxy gate now matches; the inline check is defense-in-depth and the 500 (vs 403) is intentional.
+
+### F6 [Minor] STEP_UP_WINDOW_MS not env-overridable
+- File: `src/lib/auth/session/step-up.ts:9`
+- Note: 15 min hardcoded. Optional improvement, skip per YAGNI unless requested.
+
+## Security Findings
+
+### S1 [Major] Step-up i18n message hardcodes "operator token", misleads every other site
+*Same root cause as F1.* See Finding F1.
+
+### S2 [Major] R3 propagation gap — long-lived credential issuance routes still without step-up
+*Same root cause as F2/F3/F4 combined.* `feedback_user_bound_token_enumeration.md` applies — when adding security-tightening to a token class, ALL siblings of that token class must be enumerated. Three siblings (api_*, MCP clientSecret, SA JIT token) are missing the gate.
+
+### S3 [Minor] Step-up denial emits no audit signal
+- File: `src/lib/auth/session/step-up.ts:43-49`
+- Evidence: 401/403 paths return without `logAuditAsync`.
+- Problem: Stale-session-attempt-to-mint-credential is a high-value SOC signal but currently invisible.
+- Fix: Optional follow-up. Add `SESSION_STEP_UP_DENIED` audit action; emit from helper or have callers wrap.
+
+### S4 [Minor] R35 — manual-test artifact missing for Tier-2 security change
+- File: `docs/archive/review/security-network-gates-manual-test.md` (does not exist)
+- Evidence: PR modifies `route-policy.ts` (proxy classifier), `csrf.ts` (auth fail-closed), adds `step-up.ts` (credential-issuance gate). All R35 Tier-2 (auth flow / authorization changes).
+- Fix: Add `docs/archive/review/security-network-gates-manual-test.md` with Pre-conditions / Steps / Expected result / Rollback / Adversarial scenarios.
+
+### S5 [Minor] APP_URL/AUTH_URL must now be set; existing deployments may 403 silently
+- File: `src/lib/auth/session/csrf.ts:36-37`; `src/lib/env-schema.ts:159,186`
+- Evidence: Both env vars are `.optional()`; `getAppOrigin()` returns `undefined` when both unset; `assertOrigin` returns 403.
+- Problem: Production deployments that relied on Host-fallback start 403'ing all cookie-bearing mutating requests after upgrade.
+- Fix: Optional. Add Zod `superRefine` to require `APP_URL || AUTH_URL` when `NODE_ENV === "production"`, OR emit startup warning, OR add explicit upgrade note in CHANGELOG.
+
+## Testing Findings
+
+### T1 [Major] GET /api/tenant/service-accounts/[id]/tokens has no step-up test
+- File: `src/app/api/tenant/service-accounts/[id]/tokens/route.test.ts`
+- Evidence: `route.ts handleGET` calls `requireRecentSession` (line 46-47); test file's GET describe block has no step-up case (only POST).
+- Fix: Add a GET test mocking `requireRecentSession` to return 403; assert 403 + the route does NOT proceed to `mockServiceAccountTokenFindMany`.
+
+### T2 [Major] Step-up tests do not assert credential-mint path was NOT taken (vacuous-pass risk)
+- Files: `mcp/authorize/consent/route.test.ts:185-200`; `tenant/scim-tokens/route.test.ts:169-182`; `tenant/service-accounts/[id]/tokens/route.test.ts:237-261`; `mcp/authorize/route.test.ts:91-105`
+- Evidence: 4 of 6 step-up tests assert only `res.status === 403`; do not assert mint side effect was skipped. (bridge-code + mobile/authorize tests DO assert — inconsistent.)
+- Problem: If step-up gate is moved AFTER mint, mock returns 403 by coincidence; mint runs; test still passes (RT5 vacuous-pass).
+- Fix: Add `expect(<MintFn>).not.toHaveBeenCalled()` in each missing test.
+
+### T3 [Minor] No coverage for hex-form IPv4-mapped IPv6 mixed-case nor bracketed-hex
+- File: `src/lib/auth/policy/ip-access.test.ts`
+- Fix: Add cases for `::FFFF:7F00:1` (uppercase), `[::ffff:7f00:1]` (bracketed-hex), `::ffff:c0a8:0001` (zero-padded).
+
+### T4 [Minor] external-http.test.ts does not cover uppercase DNS resolution
+- File: `src/lib/http/external-http.test.ts`
+- Fix: Add `it("hostname resolving to uppercase hex-form IPv4-mapped IPv6 loopback throws", ...)`.
+
+### T5 [Major] api-route.test.ts step-up tests do not assert mockCheckAccessWithAudit was actually invoked
+- File: `src/lib/proxy/api-route.test.ts:214-261`
+- Fix: Add `expect(mockCheckAccessWithAudit).toHaveBeenCalledOnce()`.
+
+### T6 [Major] No integration test for step-up window against real Postgres Session.createdAt
+- Evidence: No integration test exercises step-up.
+- Problem: Auth.js v5 `createdAt` semantics are undocumented; mock-only tests miss library upgrade drift (`project_integration_test_gap.md`).
+- Fix: Add 1 integration test creating a real `Session` row with stale and fresh `createdAt`; assert helper response in both modes.
+
+### T7 [Minor] Hardcoded `16 * 60 * 1000` in operator-tokens test instead of importing STEP_UP_WINDOW_MS
+- File: `src/app/api/tenant/operator-tokens/route.test.ts:92-94`
+- Fix: Import `STEP_UP_WINDOW_MS`; compute FRESH/STALE values from it.
+
+### T8 [Minor] csrf.test.ts does not explicitly assert removal of `x-forwarded-proto` trust
+- Fix: Add negative test asserting 403 even when `x-forwarded-proto` + `Host` could synthesize matching origin.
+
+### T9 [Minor] extension/token POST signature change — req-required contract not pinned
+- Negligible. No fix recommended.
+
+### T10 [Minor] Step-up test name could disambiguate gate
+- Cosmetic. Optional.
+
+## Adjacent Findings
+- [Adjacent] `tenant/members/[userId]/reset-vault` POST issues reset token from session without step-up (admin-side, same threat shape).
+- [Adjacent] `extension/token/refresh` extends Bearer-authenticated session indefinitely without fresh human session.
+- [Adjacent] SA token POST has no rate-limiter (pre-existing).
+- [Adjacent] `mcp/authorize/consent` and `mobile/authorize` lack rate-limiting (pre-existing).
+- [Adjacent] NAT64 (`64:ff9b::/96`) and 6to4 (`2002::/16`) not in `BLOCKED_CIDRS` (pre-existing, defense-in-depth).
+- [Adjacent] Bearer-authenticated MCP/mobile routes (`/api/mcp`, `/api/mcp/token`, `/api/mobile/token`) not gated by `enforceAccessRestriction` in handler (pre-existing inconsistency).
+- [Adjacent] api-route.test.ts other describe blocks may need APP_URL stub parity after fail-closed CSRF.
+- [Adjacent] No unit-test file for `step-up.ts` itself; helper has 4 distinct modes none of which are unit-tested at helper level.
+
+## Recurring Issue Check
+### Functionality expert
+- R3 (propagation): Findings F2/F3/F4
+- R17 (helper adoption — inverted perspective): Findings F2/F3/F4
+- R37 (jargon to user): Finding F1
+- Other R-rules: Checked or N/A
+
+### Security expert
+- R3 (propagation): FAIL — see S2
+- R31 (audit/observability): partial FAIL — see S3
+- R34 (adjacent enumeration): see S2
+- R35 (manual-test artifact): FAIL — see S4
+- R37 (jargon to user): FAIL — see S1
+- RS1-RS4: Checked or N/A
+- Other R-rules: Checked or N/A
+
+### Testing expert
+- RT3 (shared constants in tests): T7
+- RT5 (test call-path includes production primitive): T2, T5
+- Other RT/R rules: Checked or N/A
+
+## Resolution Status
+
+Round 1 findings were addressed by the user before Round 2. Verification reflects the actual diff in the working tree (un-committed) at the time of this update.
+
+### F1 / S1 [Major] Generic SESSION_STEP_UP_REQUIRED i18n key — Resolved
+- Action: Added `sessionStepUpRequired` key to `messages/en/ApiErrors.json:115` and `messages/ja/ApiErrors.json:115`. Re-mapped `SESSION_STEP_UP_REQUIRED → sessionStepUpRequired` in `src/lib/http/api-error-codes.ts:371`. `OPERATOR_TOKEN_STALE_SESSION` continues to map to `operatorTokenStaleSession`.
+- Verification: en string "Re-authenticate within the last 15 minutes to continue this sensitive action."; ja string「この重要な操作を続行するには、過去 15 分以内に再認証してください。」 — domain-neutral, covers all 6+ call sites.
+
+### F2 [Major] api-keys step-up — Resolved (session-only gating)
+- Action: `src/app/api/api-keys/route.ts:76-79` adds `if (authed.auth.type === "session") { stepUp }` guard. Extension-token (`type: "token"`) and service-account auth bypass step-up since neither has a browser session to re-authenticate.
+- Test: `route.test.ts:276-322` adds two cases — session step-up returns 403 with `mockPrismaApiKey.create` not called; extension-token path skips step-up and reaches mint successfully.
+
+### F3 [Major] mcp-clients step-up — Resolved
+- Action: `src/app/api/tenant/mcp-clients/route.ts:113-114` adds `requireRecentSession` after `requireTenantPermission`.
+- Test: `route.test.ts:328-349` asserts 403 + `mockMcpClientCreate` not called.
+
+### F4 [Minor → upgraded by user to fix] approve route step-up — Resolved
+- Action: `src/app/api/tenant/access-requests/[id]/approve/route.ts:46-47` adds `requireRecentSession`.
+- Test: `route.test.ts:279-296` asserts 403 + `mockPrismaTransaction` not called.
+
+### F5 [Minor] vault/admin-reset comment — Resolved
+- Action: `src/app/api/vault/admin-reset/route.ts:36-37` updated comment to "Intentionally stricter than the generic CSRF helper: admin vault reset must never run without an explicit canonical origin configuration."
+
+### F6 [Minor] STEP_UP_WINDOW_MS env override — Skipped (Anti-Deferral check)
+- **Anti-Deferral check**: out of scope (different feature)
+- **Justification**: TODO marker recorded as part of S5 follow-up tracking. The 15-min window is the operational default for the audit fix; making it configurable is a separate operational requirement, not a security finding.
+
+### S2 [Major] R3 propagation — Resolved (covered by F2/F3/F4)
+
+### S3 [Minor] Step-up audit signal — Skipped (Anti-Deferral check)
+- **Anti-Deferral check**: out of scope (different feature, no tracked plan yet)
+- **Justification**: SOC visibility into stale-session credential-mint attempts is a separate audit-emit hardening line. TODO marker:
+  ```
+  TODO(step-up-audit-signal): emit AUDIT_ACTION.SESSION_STEP_UP_DENIED from requireRecentSession
+  ```
+- **Orchestrator sign-off**: Cost-to-fix non-trivial (new audit action + i18n + emission ordering); not on the audit's stated risk path. Defer with TODO.
+
+### S4 [Minor] R35 manual-test artifact — Resolved
+- Action: Created `docs/archive/review/security-credential-issuance-hardening-manual-test.md` with 7 scenario sections covering proxy IP gate, step-up matrix, CSRF fail-closed, SSRF rejection, plus evidence references.
+
+### S5 [Minor] APP_URL/AUTH_URL strict-required in production — Skipped (Anti-Deferral check)
+- **Anti-Deferral check**: out of scope (operational-config hardening, separate concern)
+- **Justification**:
+  - Worst case: post-upgrade deployment 403's all cookie-bearing mutating requests until operator sets `APP_URL` or `AUTH_URL`
+  - Likelihood: medium for self-hosted operators that never ran `npm run init:env`
+  - Cost to fix: ~30 min (Zod superRefine + startup warning) but interacts with env-schema test fixtures and CI profiles — non-trivial
+- **Orchestrator sign-off**: Document this behavior change in CHANGELOG/upgrade notes when the next release-please PR is cut. The fail-closed change itself is the security correct outcome; the operational ergonomic improvement is separable.
+
+### T1 [Major] GET service-accounts step-up test — Resolved differently (revert + complementary test)
+- Action: `src/app/api/tenant/service-accounts/[id]/tokens/route.ts:43-45` reverted to NOT call `requireRecentSession` on GET — token metadata listing is read-only and does not mint credentials, so step-up is over-gating.
+- Test: `route.test.ts:142-157` adds positive assertion "does not require session step-up for listing tokens" verifying the GET path passes even when the helper would have returned 403, AND that `requireRecentSession` is not called.
+- Note: T1's original prescription assumed the GET step-up was intentional. The user correctly identified the over-gating and inverted the fix.
+
+### T2 [Major] Vacuous-pass guards on step-up tests — Resolved
+- Action: `expect(<Mint>).not.toHaveBeenCalled()` added to:
+  - `mcp/authorize/route.test.ts:105` — `mockFindFirst`
+  - `mcp/authorize/consent/route.test.ts:200` — `mockCreateAuthorizationCode`
+  - `tenant/scim-tokens/route.test.ts:182` — `mockPrismaScimToken.create`
+  - `tenant/service-accounts/[id]/tokens/route.test.ts:287` — `mockPrismaTransaction`
+
+### T3 [Minor] hex-form normalization tests — Resolved
+- Action: `src/lib/auth/policy/ip-access.test.ts:46-50, 62-64, 137-141` adds uppercase, zero-padded, and bracketed-hex variants for both `normalizeIp` and `isIpInCidr`.
+
+### T4 [Minor] external-http hex-form DNS tests — Resolved
+- Action: `src/lib/http/external-http.test.ts:124-132, 159-173` adds uppercase + zero-padded URL-literal AND DNS-resolution cases.
+
+### T5 [Major] mockCheckAccessWithAudit invocation assertion — Resolved
+- Action: `src/lib/proxy/api-route.test.ts:228-233, 251-256, 273-278` adds `expect(mockCheckAccessWithAudit).toHaveBeenCalledWith("t-1", null, "u-1", expect.any(NextRequest))` to all three new tests.
+
+### T6 [Major] Real-DB step-up integration test — Resolved
+- Action: New `src/__tests__/db-integration/require-recent-session.integration.test.ts` (129 lines) covers 4 modes — fresh session passes, stale session 403, missing cookie 401, missing row 401. Uses real Postgres `Session` row insert via `setBypassRlsGucs`.
+- Verification: `npm run test:integration -- require-recent-session.integration` reports 4 tests passed (per user).
+
+### T7 [Minor] Hardcoded 16-min in operator-tokens test — Resolved
+- Action: `src/app/api/tenant/operator-tokens/route.test.ts:3, 95-97` imports `MS_PER_MINUTE` and constructs `STALE_SESSION` from it.
+
+### T8 [Minor] x-forwarded-proto fail-closed negative test — Resolved
+- Action: `src/lib/auth/session/csrf.test.ts:60-71` adds "returns 403 when x-forwarded-proto suggests https but canonical origin is unset" with `host: localhost:3000`, `x-forwarded-proto: https`, both env vars deleted.
+
+### T9, T10 [Minor] — Skipped (cosmetic)
+- T9 (req-required contract test): Negligible — Next guarantees `req`. No change.
+- T10 (test name disambiguation): Cosmetic. Body assertion already disambiguates via `expect(json.error).toBe(...)`.
+
+### Adjacent findings — Tracked
+
+The following Adjacent findings remain out of scope for this branch:
+
+- `tenant/members/[userId]/reset-vault` POST step-up gap (admin-side, single-use token; separate threat shape)
+- `extension/token/refresh` lifetime extension (separate refresh-policy discussion)
+- SA token POST rate-limiter gap (pre-existing; separate hardening)
+- `mcp/authorize/consent` and `mobile/authorize` rate-limiter gap (pre-existing)
+- NAT64 / 6to4 not in `BLOCKED_CIDRS` (defense-in-depth follow-up)
+- Bearer-authenticated `/api/mcp`, `/api/mcp/token`, `/api/mobile/token` not gated by `enforceAccessRestriction` in handler (pre-existing inconsistency vs `extension/token`)
+- api-route.test.ts other describe blocks may need APP_URL stub parity (low risk; surfaces if their tests start failing)
+- No unit-test file for `step-up.ts` itself (T6 integration test substantially covers; helper-level unit tests are a follow-up)
+
+Recommend opening a tracking issue or a `security-followups-plan.md` to enumerate these for next iteration.
+
+## Verification
+
+User-reported test status:
+- `npx vitest run` on 12 affected test files: **239 tests passed**
+- `npm run test:integration -- require-recent-session.integration`: **4 tests passed**
+
+This orchestrator additionally verified:
+- ESLint clean on the 6 changed production files (`src/app/api/api-keys/route.ts`, `tenant/mcp-clients/route.ts`, `tenant/access-requests/[id]/approve/route.ts`, `tenant/service-accounts/[id]/tokens/route.ts`, `vault/admin-reset/route.ts`, `lib/http/api-error-codes.ts`)
+- `auth.type` enum values verified against `src/lib/auth/session/auth-or-token.ts` — the `api-keys` session-only gating correctly excludes `"token"` (extension), `"service_account"`, `"api_key"`, `"mcp_token"`
+
+Next steps (user-driven):
+- Full `npx next build` — recommended before committing per CLAUDE.md "Mandatory Checks"
+- Commit and push when ready
+

--- a/docs/operations/admin-tokens.md
+++ b/docs/operations/admin-tokens.md
@@ -135,7 +135,7 @@ Revoking sets `revokedAt`; the row remains for audit-trail forensics. Subsequent
 1. Revoke immediately (UI or API).
 2. Inspect `audit_logs` for `metadata.tokenId = <revoked id>` to enumerate everything the compromised token did.
 3. Mint a fresh token to resume operations.
-4. If the compromise vector is unclear, also revoke the operator's dashboard sessions (`DELETE /api/sessions/<id>`). The 15-minute step-up window means an attacker cannot mint a *new* operator token from a stolen session unless they can trigger a fresh sign-in within 15 minutes.
+4. If the compromise vector is unclear, also revoke the operator's dashboard sessions (`DELETE /api/sessions/<id>`). The 15-minute step-up window means an attacker cannot mint a *new* operator token from a stolen session unless they can trigger a fresh sign-in within 15 minutes. The same shared recent-session guard is also used by other browser-session credential issuance flows (MCP/mobile authorization, extension bridge/direct issuance, SCIM token creation, service-account token creation).
 
 ## Audit attribution
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -113,7 +113,7 @@ Prisma Migrate does not support automatic down migrations. To roll back a schema
 
 ## Sub-path Deployment Note
 
-When deploying at a sub-path (e.g., `https://example.com/passwd-sso`), set `NEXT_PUBLIC_BASE_PATH=/passwd-sso` **before** building the image. This is a build-time variable baked into the client bundle. Set `AUTH_URL` to the origin only (e.g., `https://example.com`) — do NOT include the basePath. Update OAuth redirect URIs to include the basePath. See `docs/setup/docker/en.md` for details.
+When deploying at a sub-path (e.g., `https://example.com/passwd-sso`), set `NEXT_PUBLIC_BASE_PATH=/passwd-sso` **before** building the image. This is a build-time variable baked into the client bundle. Set `AUTH_URL` to the origin only (e.g., `https://example.com`) — do NOT include the basePath. Set `APP_URL` as well when the public origin differs from the app's internal origin behind a reverse proxy/CDN. Cookie-authenticated mutating API routes now fail closed if neither canonical origin is configured. Update OAuth redirect URIs to include the basePath. See `docs/setup/docker/en.md` for details.
 
 ## Deploy Checklist
 

--- a/docs/security/cors-policy.md
+++ b/docs/security/cors-policy.md
@@ -32,7 +32,7 @@ CORS is a **browser-enforced constraint only**. Non-browser clients (curl, scrip
    - `src/app/api/auth/passkey/options/email/route.ts` — non-discoverable challenge generation
    - `src/app/api/auth/passkey/verify/route.ts` — pre-auth verification (creates session as output; WebAuthn `expectedOrigin` provides primary defense; inline `assertOrigin` is defense-in-depth)
 
-3. **Stricter post-baseline guard** (`src/app/api/vault/admin-reset/route.ts`): Keeps `if (!getAppOrigin()) return 500` check. The proxy CSRF gate uses Host-header fallback when `APP_URL` is unset; admin-reset intentionally disallows this fallback.
+3. **Stricter post-baseline guard** (`src/app/api/vault/admin-reset/route.ts`): Keeps `if (!getAppOrigin()) return 500` check. The shared `assertOrigin()` helper now fails closed when neither `APP_URL` nor `AUTH_URL` is configured; admin-reset preserves its explicit configuration requirement on top of that.
 
 ## Browser Extension
 

--- a/docs/security/policy-enforcement.md
+++ b/docs/security/policy-enforcement.md
@@ -20,7 +20,7 @@ Password content (plaintext) is encrypted client-side before reaching the server
 | `extensionTokenIdleTimeoutMinutes` | Blocking | Server | `src/lib/auth/tokens/extension-token.ts` `issueExtensionToken()` + `token/refresh/route.ts` | Access token `expiresAt = now + value` at issuance and on every refresh |
 | `extensionTokenAbsoluteTimeoutMinutes` | Blocking | Server | `src/lib/auth/tokens/extension-token.ts` + `token/refresh/route.ts` | Family is revoked and refresh rejected with `EXTENSION_TOKEN_FAMILY_EXPIRED` when `now - familyCreatedAt > value` |
 | `vaultAutoLockMinutes` | Timer | Client | `auto-lock-context.tsx` | Browser inactivity timer; server cannot know vault lock state |
-| `allowedCidrs` | Blocking | Server | `proxy.ts` + `access-restriction.ts` | Middleware (Edge) + route handler (Node.js); 60s cache |
+| `allowedCidrs` | Blocking | Server | `proxy.ts` + `access-restriction.ts` | Session-cookie routes are blocked in proxy (`API_SESSION_REQUIRED`, including MCP/mobile authorization issuance). Bearer and other non-session flows enforce the same policy in route handlers. 60s cache |
 | `tailscaleEnabled` / `tailscaleTailnet` | Blocking | Server | `access-restriction.ts` | Two-stage: Edge (CGNAT heuristic) + Node.js (WhoIs verify) |
 | `requireMinPinLength` | Blocking | Server | `webauthn/register/verify/route.ts` | Platform authenticators (Touch ID, etc.) exempt — they don't report PIN length |
 | `requirePasskey` | Blocking/Advisory | Server | `proxy.ts` middleware | After grace period: redirect (blocking) + audit via `/api/internal/audit-emit`. Within grace: advisory banner via `/api/user/passkey-status` |
@@ -41,6 +41,13 @@ Password content (plaintext) is encrypted client-side before reaching the server
 | `delegationDefaultTtlSec` | Blocking | Server | `vault/delegation/route.ts` | Default TTL for delegation sessions |
 | `delegationMaxTtlSec` | Blocking | Server | `vault/delegation/route.ts` | Hard ceiling for delegation TTL; enforced via `Math.min(requested, max)` |
 | `saTokenMaxExpiryDays` | Blocking | Server | `tenant/service-accounts/[id]/tokens/route.ts` | Caps SA token `expiresAt` to `now + saTokenMaxExpiryDays`; null = no limit. Admin UI: Security → Machine Identity → Token |
+
+## Credential Issuance Hardening
+
+Sensitive browser-session flows that mint non-session credentials require a recent Auth.js session (`requireRecentSession()`; default window: 15 minutes). This blocks stolen long-lived dashboard sessions from being upgraded into machine or automation credentials.
+
+- **Protected by recent-session step-up:** MCP authorize / consent, mobile authorize, extension bridge-code issuance, legacy direct extension token issuance, SCIM token creation, service-account token creation, operator token creation
+- **Not covered by this step-up:** refresh, revoke, and code/token exchange endpoints that are already authenticated by one-time codes or existing bearer credentials
 
 ## Team Policy Fields
 

--- a/docs/security/security-review.md
+++ b/docs/security/security-review.md
@@ -46,8 +46,8 @@ Evidence:
 5. Token lifecycle boundaries are explicit  
 Status: `PASS`  
 Evidence:
-- Issue (legacy direct) requires Auth.js session: `src/app/api/extension/token/route.ts`.
-- Issue (bridge code) requires Auth.js session + Origin check: `src/app/api/extension/bridge-code/route.ts`.
+- Issue (legacy direct) requires Auth.js session + recent-session step-up: `src/app/api/extension/token/route.ts`.
+- Issue (bridge code) requires Auth.js session + recent-session step-up: `src/app/api/extension/bridge-code/route.ts`.
 - Exchange consumes a one-time, server-side, atomically-claimed code (no session): `src/app/api/extension/token/exchange/route.ts`.
 - Revoke requires valid Bearer token: `src/app/api/extension/token/route.ts` (DELETE handler).
 - Refresh requires valid Bearer token + active DB session: `src/app/api/extension/token/refresh/route.ts`.

--- a/docs/setup/docker/en.md
+++ b/docs/setup/docker/en.md
@@ -110,7 +110,7 @@ Set the following values:
 | Variable | Description | How to Generate |
 |----------|-------------|-----------------|
 | `DATABASE_URL` | PostgreSQL connection string | Use default for development |
-| `AUTH_URL` | Application origin (e.g., `https://example.com`) — do NOT include path | `http://localhost:3000` for dev |
+| `AUTH_URL` | Application origin (e.g., `https://example.com`) — do NOT include path. Used as the canonical Origin for cookie-auth CSRF checks when `APP_URL` is unset | `http://localhost:3000` for dev |
 | `NEXT_PUBLIC_BASE_PATH` | (Optional) Sub-path for reverse proxy deployment | e.g., `/passwd-sso` |
 | `AUTH_SECRET` | NextAuth session signing key | `openssl rand -base64 32` |
 | `AUTH_GOOGLE_ID` | Google OAuth Client ID | From Google Cloud Console |
@@ -128,6 +128,11 @@ Set the following values:
 | `AWS_REGION`, `S3_ATTACHMENTS_BUCKET` | Required if `BLOB_BACKEND=s3` | e.g., `ap-northeast-1`, bucket name |
 | `AZURE_STORAGE_ACCOUNT`, `AZURE_BLOB_CONTAINER` | Required if `BLOB_BACKEND=azure` | Azure Storage account / container |
 | `GCS_ATTACHMENTS_BUCKET` | Required if `BLOB_BACKEND=gcs` | GCS bucket name |
+
+If both `APP_URL` and `AUTH_URL` are unset, cookie-authenticated mutating API
+requests fail closed at Origin validation time. Production deployments should
+always set at least `AUTH_URL`, and reverse-proxy/CDN deployments should set
+`APP_URL` to the external origin.
 
 > **Redis is REQUIRED in production.** The Zod schema (`src/lib/env-schema.ts:366-370`) enforces `REDIS_URL` for `NODE_ENV=production`. Redis backs the session cache introduced in PR #407 (tombstone-based revocation propagation across nodes) and shared rate limiting. In single-instance development you may omit `REDIS_URL`; the app falls back to in-memory caches and logs a warning. Set `HEALTH_REDIS_REQUIRED=true` to fail `/api/health/ready` when Redis is unreachable.
 

--- a/messages/en/ApiErrors.json
+++ b/messages/en/ApiErrors.json
@@ -112,6 +112,7 @@
   "operatorTokenLimitExceeded": "Maximum number of operator tokens per tenant reached. Please revoke unused tokens first.",
   "operatorTokenNotFound": "Operator token not found.",
   "operatorTokenStaleSession": "Re-authenticate within the last 15 minutes to issue an operator token.",
+  "sessionStepUpRequired": "Re-authenticate within the last 15 minutes to continue this sensitive action.",
   "mcpClientNameConflict": "An MCP client with this name already exists.",
   "mcpClientLimitExceeded": "Maximum number of MCP clients per tenant reached.",
   "mcpTokenNotFound": "MCP token not found or expired.",

--- a/messages/ja/ApiErrors.json
+++ b/messages/ja/ApiErrors.json
@@ -112,6 +112,7 @@
   "operatorTokenLimitExceeded": "テナントごとの運用者トークン上限に達しました。不要なトークンを取り消してください。",
   "operatorTokenNotFound": "運用者トークンが見つかりません。",
   "operatorTokenStaleSession": "運用者トークンを発行するには、過去 15 分以内に再認証してください。",
+  "sessionStepUpRequired": "この重要な操作を続行するには、過去 15 分以内に再認証してください。",
   "mcpClientNameConflict": "同じ名前のMCPクライアントが既に存在します。",
   "mcpClientLimitExceeded": "テナントごとのMCPクライアント上限に達しました。",
   "mcpTokenNotFound": "MCPトークンが見つからないか、有効期限が切れています。",

--- a/scripts/checks/check-bypass-rls.mjs
+++ b/scripts/checks/check-bypass-rls.mjs
@@ -41,6 +41,8 @@ const ALLOWED_USAGE = new Map([
   ["src/lib/auth/policy/account-lockout.ts", ["user", "tenant", "auditOutbox"]],
   ["src/lib/auth/policy/lockout-admin-notify.ts", ["user", "tenantMember"]],
   ["src/lib/auth/policy/new-device-detection.ts", ["session", "user"]],
+  // Shared step-up helper: reads Session.createdAt from the session-token cookie.
+  ["src/lib/auth/session/step-up.ts", ["session"]],
   ["src/lib/notification.ts", ["user", "notification"]],
   ["src/lib/webhook-dispatcher.ts", ["teamWebhook", "tenantWebhook"]],
   ["src/lib/auth/access/tenant-auth.ts", ["tenantMember"]],
@@ -101,9 +103,6 @@ const ALLOWED_USAGE = new Map([
   // Operator-token validator: cross-tenant lookup is required because the
   // bearer-token caller has no tenant context until the token row resolves it
   ["src/lib/auth/tokens/operator-token.ts", ["operatorToken"]],
-  // Operator-token issuance: reads Session.createdAt for step-up via session-token cookie
-  // (no tenant context available until session resolves to the actor's tenant)
-  ["src/app/api/tenant/operator-tokens/route.ts", ["session"]],
   ["src/lib/mcp/oauth-server.ts", ["mcpAuthorizationCode", "mcpAccessToken", "mcpRefreshToken"]],
   ["src/app/api/mcp/authorize/route.ts", ["mcpClient", "user"]],
   ["src/app/api/mcp/register/route.ts", ["mcpClient"]],

--- a/src/__tests__/api/mcp/authorize.test.ts
+++ b/src/__tests__/api/mcp/authorize.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockMcpClientFindFirst, mockWithBypassRls, mockServerAppUrl, mockDetectLocale, mockRateLimiterCheck } =
+const { mockAuth, mockMcpClientFindFirst, mockWithBypassRls, mockServerAppUrl, mockDetectLocale, mockRateLimiterCheck, mockRequireRecentSession } =
   vi.hoisted(() => ({
     mockAuth: vi.fn(),
     mockMcpClientFindFirst: vi.fn(),
@@ -9,9 +9,13 @@ const { mockAuth, mockMcpClientFindFirst, mockWithBypassRls, mockServerAppUrl, m
     mockServerAppUrl: vi.fn((path: string) => `http://localhost:3000${path}`),
     mockDetectLocale: vi.fn(() => "en"),
     mockRateLimiterCheck: vi.fn().mockResolvedValue({ allowed: true }),
+    mockRequireRecentSession: vi.fn().mockResolvedValue(null),
   }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
+}));
 vi.mock("@/lib/prisma", () => ({
   prisma: { mcpClient: { findFirst: mockMcpClientFindFirst } },
 }));

--- a/src/__tests__/api/tenant/scim-tokens.test.ts
+++ b/src/__tests__/api/tenant/scim-tokens.test.ts
@@ -14,6 +14,7 @@ const {
   mockScimTokenUpdate,
   mockDispatchTenantWebhook,
   mockRateLimitCheck,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockRequireTenantPermission: vi.fn(),
@@ -26,9 +27,13 @@ const {
   mockScimTokenUpdate: vi.fn(),
   mockDispatchTenantWebhook: vi.fn(),
   mockRateLimitCheck: vi.fn(),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
+}));
 vi.mock("@/lib/security/rate-limit", () => ({ createRateLimiter: vi.fn(() => ({ check: mockRateLimitCheck, clear: vi.fn() })) }));
 vi.mock("@/lib/auth/access/tenant-auth", () => {
   class TenantAuthError extends Error {

--- a/src/__tests__/db-integration/require-recent-session.integration.test.ts
+++ b/src/__tests__/db-integration/require-recent-session.integration.test.ts
@@ -11,6 +11,7 @@ import {
   describe,
   it,
   expect,
+  vi,
   beforeAll,
   afterAll,
   beforeEach,
@@ -22,7 +23,6 @@ import { requireRecentSession, STEP_UP_WINDOW_MS } from "@/lib/auth/session/step
 import { createTestContext, setBypassRlsGucs, type TestContext } from "./helpers";
 
 const hasDatabase = !!process.env.DATABASE_URL;
-const AUTH_URL_BEFORE = process.env.AUTH_URL;
 
 describe.skipIf(!hasDatabase)(
   "requireRecentSession (real DB)",
@@ -33,11 +33,11 @@ describe.skipIf(!hasDatabase)(
 
     beforeAll(async () => {
       ctx = await createTestContext();
-      process.env.AUTH_URL = "http://localhost:3000";
+      vi.stubEnv("AUTH_URL", "http://localhost:3000");
     });
 
     afterAll(async () => {
-      process.env.AUTH_URL = AUTH_URL_BEFORE;
+      vi.unstubAllEnvs();
       await ctx.cleanup();
     });
 

--- a/src/__tests__/db-integration/require-recent-session.integration.test.ts
+++ b/src/__tests__/db-integration/require-recent-session.integration.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Integration test (real DB): requireRecentSession contract against Auth.js
+ * Session.createdAt semantics.
+ *
+ * Run:
+ *   docker compose up -d db
+ *   npm run test:integration -- require-recent-session.integration
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { randomUUID } from "node:crypto";
+import { NextRequest } from "next/server";
+import { requireRecentSession, STEP_UP_WINDOW_MS } from "@/lib/auth/session/step-up";
+import { createTestContext, setBypassRlsGucs, type TestContext } from "./helpers";
+
+const hasDatabase = !!process.env.DATABASE_URL;
+const AUTH_URL_BEFORE = process.env.AUTH_URL;
+
+describe.skipIf(!hasDatabase)(
+  "requireRecentSession (real DB)",
+  () => {
+    let ctx: TestContext;
+    let tenantId: string;
+    let userId: string;
+
+    beforeAll(async () => {
+      ctx = await createTestContext();
+      process.env.AUTH_URL = "http://localhost:3000";
+    });
+
+    afterAll(async () => {
+      process.env.AUTH_URL = AUTH_URL_BEFORE;
+      await ctx.cleanup();
+    });
+
+    beforeEach(async () => {
+      tenantId = await ctx.createTenant();
+      userId = await ctx.createUser(tenantId);
+    });
+
+    afterEach(async () => {
+      await ctx.su.prisma.$transaction(async (tx) => {
+        await setBypassRlsGucs(tx);
+        await tx.$executeRawUnsafe(
+          `DELETE FROM sessions WHERE tenant_id = $1::uuid`,
+          tenantId,
+        );
+      });
+      await ctx.deleteTestData(tenantId);
+    });
+
+    async function insertSession(createdAt: Date): Promise<string> {
+      const token = `sess-${randomUUID()}`;
+      await ctx.su.prisma.$transaction(async (tx) => {
+        await setBypassRlsGucs(tx);
+        await tx.$executeRawUnsafe(
+          `INSERT INTO sessions (
+             id, session_token, user_id, tenant_id, expires, created_at, last_active_at
+           ) VALUES (
+             $1::uuid, $2, $3::uuid, $4::uuid,
+             now() + interval '1 day', $5, now()
+           )`,
+          randomUUID(),
+          token,
+          userId,
+          tenantId,
+          createdAt,
+        );
+      });
+      return token;
+    }
+
+    function makeRequest(sessionToken?: string): NextRequest {
+      const headers = new Headers();
+      if (sessionToken) {
+        headers.set("cookie", `authjs.session-token=${sessionToken}`);
+      }
+      return new NextRequest("http://localhost:3000/api/test-sensitive", {
+        method: "POST",
+        headers,
+      });
+    }
+
+    it("allows a recent Auth.js session row", async () => {
+      const sessionToken = await insertSession(
+        new Date(Date.now() - STEP_UP_WINDOW_MS + 30_000),
+      );
+
+      const result = await requireRecentSession(makeRequest(sessionToken));
+
+      expect(result).toBeNull();
+    });
+
+    it("rejects a stale Auth.js session row", async () => {
+      const sessionToken = await insertSession(
+        new Date(Date.now() - STEP_UP_WINDOW_MS - 30_000),
+      );
+
+      const result = await requireRecentSession(makeRequest(sessionToken));
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(403);
+      const body = await result!.json();
+      expect(body.error).toBe("SESSION_STEP_UP_REQUIRED");
+    });
+
+    it("returns 401 when the session cookie is missing", async () => {
+      const result = await requireRecentSession(makeRequest());
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(401);
+    });
+
+    it("returns 401 when the session row does not exist", async () => {
+      const result = await requireRecentSession(makeRequest(`missing-${randomUUID()}`));
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(401);
+    });
+  },
+);

--- a/src/__tests__/integration/jit-workflow.test.ts
+++ b/src/__tests__/integration/jit-workflow.test.ts
@@ -27,6 +27,7 @@ const {
   mockPrismaTransaction,
   mockHashToken,
   mockDispatchTenantWebhook,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockAuthOrToken: vi.fn(),
@@ -43,9 +44,13 @@ const {
   mockPrismaTransaction: vi.fn(),
   mockHashToken: vi.fn().mockReturnValue("hashed-token"),
   mockDispatchTenantWebhook: vi.fn(),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
+}));
 vi.mock("@/lib/auth/access/tenant-auth", () => {
   class TenantAuthError extends Error {
     status: number;

--- a/src/__tests__/integration/mcp-oauth-flow.test.ts
+++ b/src/__tests__/integration/mcp-oauth-flow.test.ts
@@ -36,6 +36,7 @@ const {
   mockHashToken,
   mockRateLimiterCheck,
   mockPrismaTransaction,
+  mockRequireRecentSession,
 } = vi.hoisted(() => {
   const mockPrismaTransaction = vi.fn(async (fn: (tx: unknown) => unknown) =>
     fn({
@@ -69,12 +70,17 @@ const {
     mockHashToken: vi.fn((token: string) => `hashed:${token}`),
     mockRateLimiterCheck: vi.fn().mockResolvedValue({ allowed: true }),
     mockPrismaTransaction,
+    mockRequireRecentSession: vi.fn().mockResolvedValue(null),
   };
 });
 
 // ─── Module mocks ─────────────────────────────────────────────
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
+
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
+}));
 
 vi.mock("@/lib/auth/access/tenant-auth", () => {
   class TenantAuthError extends Error {

--- a/src/__tests__/integration/mcp-oauth-flow.test.ts
+++ b/src/__tests__/integration/mcp-oauth-flow.test.ts
@@ -739,21 +739,17 @@ describe("Scenario 7: OAuth Discovery endpoint", () => {
   });
 
   it("discovery issuer matches APP_URL", async () => {
-    const prev = process.env.APP_URL;
-    process.env.APP_URL = "https://sso.example.com";
-    try {
-      const res = await getDiscovery();
-      const { status, json } = await parseResponse(res);
+    // setup.ts wires `vi.unstubAllEnvs()` in afterEach, so the stub
+    // is reverted automatically — no manual finally cleanup needed.
+    vi.stubEnv("APP_URL", "https://sso.example.com");
+    const res = await getDiscovery();
+    const { status, json } = await parseResponse(res);
 
-      expect(status).toBe(200);
-      expect(json.issuer).toBe("https://sso.example.com");
-      expect(json.authorization_endpoint).toBe("https://sso.example.com/api/mcp/authorize");
-      expect(json.token_endpoint).toBe("https://sso.example.com/api/mcp/token");
-      expect(json.registration_endpoint).toBe("https://sso.example.com/api/mcp/register");
-    } finally {
-      if (prev === undefined) delete process.env.APP_URL;
-      else process.env.APP_URL = prev;
-    }
+    expect(status).toBe(200);
+    expect(json.issuer).toBe("https://sso.example.com");
+    expect(json.authorization_endpoint).toBe("https://sso.example.com/api/mcp/authorize");
+    expect(json.token_endpoint).toBe("https://sso.example.com/api/mcp/token");
+    expect(json.registration_endpoint).toBe("https://sso.example.com/api/mcp/register");
   });
 
   it("response_types_supported includes 'code' only", async () => {

--- a/src/__tests__/integration/sa-lifecycle.test.ts
+++ b/src/__tests__/integration/sa-lifecycle.test.ts
@@ -34,6 +34,7 @@ const {
   mockServiceAccountTokenUpdateMany,
   mockPrismaTransaction,
   mockPasswordsAuthOrToken,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockRequireTenantPermission: vi.fn(),
@@ -53,11 +54,15 @@ const {
   mockServiceAccountTokenUpdateMany: vi.fn(),
   mockPrismaTransaction: vi.fn(),
   mockPasswordsAuthOrToken: vi.fn(),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 // ─── Module mocks ─────────────────────────────────────────────────────────────
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
+}));
 
 vi.mock("@/lib/auth/access/tenant-auth", () => {
   class TenantAuthError extends Error {

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -567,6 +567,10 @@ describe("proxy — access restriction", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // CSRF gate now fails closed without configured origin — must stub APP_URL
+    // so cookie-bearing mutating requests reach the access-restriction stage
+    // instead of short-circuiting at INVALID_ORIGIN.
+    vi.stubEnv("APP_URL", APP_ORIGIN);
     // Session returns valid user with ID
     fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ user: { id: "u1" } }), { status: 200 }),

--- a/src/app/api/api-keys/route.test.ts
+++ b/src/app/api/api-keys/route.test.ts
@@ -8,6 +8,7 @@ const {
   mockPrismaUser,
   mockWithUserTenantRls,
   mockRateLimitCheck,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockCheckAuth: vi.fn(),
   mockPrismaApiKey: {
@@ -18,6 +19,7 @@ const {
   mockPrismaUser: { findUnique: vi.fn() },
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
   mockRateLimitCheck: vi.fn().mockResolvedValue({ allowed: true }),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/lib/auth/session/check-auth", () => ({
@@ -37,6 +39,9 @@ vi.mock("@/lib/crypto/crypto-server", () => ({
 }));
 vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,
+}));
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
 }));
 vi.mock("@/lib/logger", () => {
   const noop = vi.fn();
@@ -170,6 +175,7 @@ describe("POST /api/api-keys", () => {
     mockPrismaApiKey.create.mockReset();
     mockPrismaUser.findUnique.mockReset();
     mockRateLimitCheck.mockResolvedValue({ allowed: true });
+    mockRequireRecentSession.mockResolvedValue(null);
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -265,6 +271,56 @@ describe("POST /api/api-keys", () => {
     );
     expect(res.status).toBe(429);
     expect(res.headers.get("Retry-After")).toBe("30");
+  });
+
+  it("returns 403 when session step-up is required for session auth", async () => {
+    mockCheckAuth.mockResolvedValue({
+      ok: true,
+      auth: { type: "session", userId: "u1" },
+    });
+    mockRequireRecentSession.mockResolvedValueOnce(
+      Response.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const res = await POST(
+      createRequest("POST", "http://localhost:3000/api/api-keys", {
+        body: { name: "test", scope: ["passwords:read"] },
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
+    expect(mockPrismaApiKey.create).not.toHaveBeenCalled();
+  });
+
+  it("skips session step-up for extension-token auth", async () => {
+    mockCheckAuth.mockResolvedValue({
+      ok: true,
+      auth: { type: "token", userId: "u2", scopes: [] },
+    });
+    mockPrismaApiKey.count.mockResolvedValue(0);
+    mockPrismaApiKey.create.mockResolvedValue({
+      id: "new-key",
+      prefix: "api_XXXX",
+      name: "Test",
+      scope: "passwords:read",
+      expiresAt: new Date("2026-06-01"),
+      createdAt: new Date("2026-01-01"),
+    });
+
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 30);
+
+    const res = await POST(
+      createRequest("POST", "http://localhost:3000/api/api-keys", {
+        body: { name: "Test", scope: ["passwords:read"], expiresAt: expiresAt.toISOString() },
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockRequireRecentSession).not.toHaveBeenCalled();
+    expect(mockPrismaApiKey.create).toHaveBeenCalledTimes(1);
   });
 
   it("creates API key for session auth", async () => {

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -18,6 +18,7 @@ import {
 import { API_KEY_TOKEN_LENGTH, API_KEY_PREFIX_LENGTH } from "@/lib/validations/common";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { MS_PER_HOUR } from "@/lib/constants/time";
+import { requireRecentSession } from "@/lib/auth/session/step-up";
 
 const apiKeyCreateLimiter = createRateLimiter({ windowMs: MS_PER_HOUR, max: 5 });
 
@@ -71,6 +72,10 @@ async function handlePOST(req: NextRequest) {
   // Only session and extension token can create API keys
   if (authed.auth.type === "api_key" || authed.auth.type === "mcp_token") {
     return unauthorized();
+  }
+  if (authed.auth.type === "session") {
+    const stepUpError = await requireRecentSession(req);
+    if (stepUpError) return stepUpError;
   }
   const { userId } = authed.auth;
 

--- a/src/app/api/extension/bridge-code/route.test.ts
+++ b/src/app/api/extension/bridge-code/route.test.ts
@@ -15,6 +15,7 @@ const {
   mockWithBypassRls,
   mockLogAudit,
   mockExtractClientIp,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockBridgeCodeCreate: vi.fn(),
@@ -26,6 +27,7 @@ const {
   mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
   mockLogAudit: vi.fn(),
   mockExtractClientIp: vi.fn(() => "1.2.3.4"),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -72,6 +74,9 @@ vi.mock("@/lib/audit/audit", () => ({
 vi.mock("@/lib/auth/policy/ip-access", () => ({
   extractClientIp: mockExtractClientIp,
 }));
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
+}));
 
 import { POST } from "./route";
 
@@ -91,6 +96,7 @@ describe("POST /api/extension/bridge-code", () => {
     mockUserFindUnique.mockResolvedValue({ tenantId: "tenant-1" });
     mockBridgeCodeFindMany.mockResolvedValue([]);
     mockBridgeCodeCreate.mockResolvedValue({});
+    mockRequireRecentSession.mockResolvedValue(null);
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -118,6 +124,20 @@ describe("POST /api/extension/bridge-code", () => {
     const { status, json } = await parseResponse(res);
     expect(status).toBe(429);
     expect(json.error).toBe("RATE_LIMIT_EXCEEDED");
+  });
+
+  it("returns 403 when session step-up is required", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireRecentSession.mockResolvedValueOnce(
+      Response.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const res = await POST(makeRequest());
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(403);
+    expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
+    expect(mockBridgeCodeCreate).not.toHaveBeenCalled();
   });
 
   it("issues a bridge code on success and emits an audit log", async () => {

--- a/src/app/api/extension/bridge-code/route.ts
+++ b/src/app/api/extension/bridge-code/route.ts
@@ -25,6 +25,7 @@ import {
   BRIDGE_CODE_MAX_ACTIVE,
 } from "@/lib/constants";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
+import { requireRecentSession } from "@/lib/auth/session/step-up";
 
 export const runtime = "nodejs";
 
@@ -39,6 +40,9 @@ async function handlePOST(req: NextRequest) {
   if (!session?.user?.id) {
     return unauthorized();
   }
+
+  const stepUpError = await requireRecentSession(req);
+  if (stepUpError) return stepUpError;
 
   // Per-user rate limit (matches existing tokenLimiter on POST /api/extension/token)
   const rl = await bridgeCodeLimiter.check(`rl:ext_bridge:${session.user.id}`);

--- a/src/app/api/extension/token/route.test.ts
+++ b/src/app/api/extension/token/route.test.ts
@@ -17,6 +17,7 @@ const {
   mockWithUserTenantRls,
   mockWithBypassRls,
   mockEnforceAccessRestriction,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockCreate: vi.fn(),
@@ -30,6 +31,7 @@ const {
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
   mockWithBypassRls: vi.fn(async (_prisma: unknown, fn: () => unknown) => fn()),
   mockEnforceAccessRestriction: vi.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue(null),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -71,6 +73,9 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
 vi.mock("@/lib/auth/policy/access-restriction", () => ({
   enforceAccessRestriction: mockEnforceAccessRestriction,
 }));
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
+}));
 
 import { POST, DELETE } from "./route";
 
@@ -80,6 +85,7 @@ describe("POST /api/extension/token", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUserFindUnique.mockResolvedValue({ tenantId: "tenant-1" });
+    mockRequireRecentSession.mockResolvedValue(null);
     // Default: transaction executes the callback with the mock prisma
     mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
       cb({
@@ -94,7 +100,7 @@ describe("POST /api/extension/token", () => {
 
   it("returns 401 when not authenticated", async () => {
     mockAuth.mockResolvedValue(null);
-    const res = await POST();
+    const res = await POST(createRequest("POST", "http://localhost/api/extension/token"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(401);
     expect(json.error).toBe("UNAUTHORIZED");
@@ -103,10 +109,24 @@ describe("POST /api/extension/token", () => {
   it("returns 429 when rate limited", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockCheck.mockResolvedValueOnce({ allowed: false });
-    const res = await POST();
+    const res = await POST(createRequest("POST", "http://localhost/api/extension/token"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(429);
     expect(json.error).toBe("RATE_LIMIT_EXCEEDED");
+  });
+
+  it("returns 403 when session step-up is required", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireRecentSession.mockResolvedValueOnce(
+      Response.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const res = await POST(createRequest("POST", "http://localhost/api/extension/token"));
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(403);
+    expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 
   it("issues a token successfully", async () => {
@@ -118,7 +138,7 @@ describe("POST /api/extension/token", () => {
       scope: "passwords:read,vault:unlock-data",
     });
 
-    const res = await POST();
+    const res = await POST(createRequest("POST", "http://localhost/api/extension/token"));
     const { status, json } = await parseResponse(res);
 
     expect(status).toBe(201);
@@ -145,7 +165,7 @@ describe("POST /api/extension/token", () => {
       scope: "passwords:read,vault:unlock-data",
     });
 
-    await POST();
+    await POST(createRequest("POST", "http://localhost/api/extension/token"));
 
     expect(mockUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/app/api/extension/token/route.ts
+++ b/src/app/api/extension/token/route.ts
@@ -12,6 +12,7 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { TokenIssueResponseSchema, TokenRevokeResponseSchema } from "@/lib/validations/extension-token";
 import logger from "@/lib/logger";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
+import { requireRecentSession } from "@/lib/auth/session/step-up";
 
 function internalError() {
   return errorResponse(API_ERROR.INTERNAL_ERROR, 500);
@@ -29,11 +30,14 @@ const tokenLimiter = createRateLimiter({
  * Requires Auth.js session (user must be logged in on the web app).
  * Returns the plaintext token (only visible once).
  */
-async function handlePOST() {
+async function handlePOST(req: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
     return unauthorized();
   }
+
+  const stepUpError = await requireRecentSession(req);
+  if (stepUpError) return stepUpError;
 
   const rl = await tokenLimiter.check(`rl:ext_token:${session.user.id}`);
   if (!rl.allowed) {

--- a/src/app/api/mcp/authorize/consent/route.test.ts
+++ b/src/app/api/mcp/authorize/consent/route.test.ts
@@ -11,6 +11,7 @@ const {
   mockMcpClientUpdateMany,
   mockMcpClientFindUnique,
   mockTxFindFirst,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockWithBypassRls: vi.fn(async (_p: unknown, fn: () => unknown) => fn()),
@@ -22,6 +23,7 @@ const {
   mockMcpClientUpdateMany: vi.fn().mockResolvedValue({ count: 1 }),
   mockMcpClientFindUnique: vi.fn(),
   mockTxFindFirst: vi.fn().mockResolvedValue(null),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/auth", () => ({
@@ -65,6 +67,10 @@ vi.mock("@/lib/audit/audit", () => ({
   personalAuditBase: (_req: unknown, userId: string) => ({ scope: "PERSONAL", userId, ip: "127.0.0.1", userAgent: "test-agent", acceptLanguage: null }),
   teamAuditBase: (_req: unknown, userId: string, teamId: string) => ({ scope: "TEAM", userId, teamId, ip: "127.0.0.1", userAgent: "test-agent", acceptLanguage: null }),
   tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test-agent", acceptLanguage: null }),
+}));
+
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
 }));
 
 import { POST } from "@/app/api/mcp/authorize/consent/route";
@@ -126,6 +132,7 @@ describe("POST /api/mcp/authorize/consent", () => {
     mockTxFindFirst.mockResolvedValue(null); // default: no existing same-name client
     mockMcpClientCount.mockResolvedValue(0);
     mockMcpClientUpdateMany.mockResolvedValue({ count: 1 });
+    mockRequireRecentSession.mockResolvedValue(null);
     mockCreateAuthorizationCode.mockResolvedValue({
       code: "auth-code-abc123",
       expiresAt: new Date(Date.now() + 60000),
@@ -173,6 +180,23 @@ describe("POST /api/mcp/authorize/consent", () => {
     expect(res.status).toBe(401);
     const json = await res.json();
     expect(json.error).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 when session step-up is required", async () => {
+    mockRequireRecentSession.mockResolvedValue(Response.json(
+      { error: "SESSION_STEP_UP_REQUIRED" },
+      { status: 403 },
+    ));
+
+    const req = createFormRequest(
+      "http://localhost/api/mcp/authorize/consent",
+      VALID_FORM_FIELDS,
+    );
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
   });
 
   it("returns 400 when client_id is missing", async () => {

--- a/src/app/api/mcp/authorize/consent/route.test.ts
+++ b/src/app/api/mcp/authorize/consent/route.test.ts
@@ -197,6 +197,7 @@ describe("POST /api/mcp/authorize/consent", () => {
     expect(res.status).toBe(403);
     const json = await res.json();
     expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
+    expect(mockCreateAuthorizationCode).not.toHaveBeenCalled();
   });
 
   it("returns 400 when client_id is missing", async () => {

--- a/src/app/api/mcp/authorize/consent/route.ts
+++ b/src/app/api/mcp/authorize/consent/route.ts
@@ -8,6 +8,7 @@ import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION } from "@/lib/constants/audit/audit";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { errorResponse, unauthorized } from "@/lib/http/api-response";
+import { requireRecentSession } from "@/lib/auth/session/step-up";
 
 export async function POST(req: NextRequest) {
   // Origin presence guard (early return / defense-in-depth).
@@ -27,6 +28,9 @@ export async function POST(req: NextRequest) {
   if (!session?.user?.id) {
     return unauthorized();
   }
+
+  const stepUpError = await requireRecentSession(req);
+  if (stepUpError) return stepUpError;
 
   // Parse form data submitted from the consent UI
   const formData = await req.formData();

--- a/src/app/api/mcp/authorize/route.test.ts
+++ b/src/app/api/mcp/authorize/route.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockAuth,
+  mockFindFirst,
+  mockWithBypassRls,
+  mockExtractClientIp,
+  mockCheckRateLimit,
+  mockRequireRecentSession,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockFindFirst: vi.fn(),
+  mockWithBypassRls: vi.fn(async (_p: unknown, fn: () => unknown) => fn()),
+  mockExtractClientIp: vi.fn(() => "203.0.113.10"),
+  mockCheckRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    mcpClient: {
+      findFirst: mockFindFirst,
+    },
+  },
+}));
+
+vi.mock("@/lib/tenant-rls", async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  withBypassRls: mockWithBypassRls,
+}));
+
+vi.mock("@/lib/security/rate-limit", () => ({
+  createRateLimiter: () => ({ check: mockCheckRateLimit }),
+}));
+
+vi.mock("@/lib/auth/policy/ip-access", () => ({
+  extractClientIp: mockExtractClientIp,
+  rateLimitKeyFromIp: (ip: string) => ip,
+}));
+
+vi.mock("@/lib/url-helpers", () => ({
+  serverAppUrl: (path: string) => `https://example.test${path}`,
+}));
+
+vi.mock("@/i18n/locale-utils", () => ({
+  detectBestLocaleFromAcceptLanguage: () => "en",
+}));
+
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
+}));
+
+import { GET } from "@/app/api/mcp/authorize/route";
+
+const VALID_CLIENT = {
+  redirectUris: ["https://client.example/callback"],
+};
+
+function createRequest(url: string) {
+  const req = new Request(url, { method: "GET" }) as Request & {
+    nextUrl: URL;
+  };
+  req.nextUrl = new URL(url);
+  return req;
+}
+
+describe("GET /api/mcp/authorize", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } });
+    mockFindFirst.mockResolvedValue(VALID_CLIENT);
+    mockWithBypassRls.mockImplementation(async (_p: unknown, fn: () => unknown) => fn());
+    mockCheckRateLimit.mockResolvedValue({ allowed: true });
+    mockRequireRecentSession.mockResolvedValue(null);
+  });
+
+  it("redirects authenticated users to consent when checks pass", async () => {
+    const req = createRequest(
+      "https://example.test/api/mcp/authorize?client_id=cli&redirect_uri=https://client.example/callback&response_type=code&scope=credentials:list&code_challenge=abc",
+    );
+    const res = await GET(req as unknown as import("next/server").NextRequest);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/en/mcp/authorize");
+  });
+
+  it("returns 403 when session step-up is required", async () => {
+    mockRequireRecentSession.mockResolvedValue(Response.json(
+      { error: "SESSION_STEP_UP_REQUIRED" },
+      { status: 403 },
+    ));
+
+    const req = createRequest(
+      "https://example.test/api/mcp/authorize?client_id=cli&redirect_uri=https://client.example/callback&response_type=code&scope=credentials:list&code_challenge=abc",
+    );
+    const res = await GET(req as unknown as import("next/server").NextRequest);
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
+  });
+});

--- a/src/app/api/mcp/authorize/route.test.ts
+++ b/src/app/api/mcp/authorize/route.test.ts
@@ -102,5 +102,6 @@ describe("GET /api/mcp/authorize", () => {
     expect(res.status).toBe(403);
     const json = await res.json();
     expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
+    expect(mockFindFirst).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/mcp/authorize/route.ts
+++ b/src/app/api/mcp/authorize/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { requireRecentSession } from "@/lib/auth/session/step-up";
 
 const authorizeLimiter = createRateLimiter({ windowMs: 60_000, max: 20 });
 
@@ -48,6 +49,9 @@ export async function GET(req: NextRequest) {
     const callbackUrl = serverAppUrl(req.nextUrl.pathname + req.nextUrl.search);
     return NextResponse.redirect(`${loginUrl}?callbackUrl=${encodeURIComponent(callbackUrl)}`);
   }
+
+  const stepUpError = await requireRecentSession(req);
+  if (stepUpError) return stepUpError;
 
   const sp = req.nextUrl.searchParams;
   const clientId = sp.get("client_id");

--- a/src/app/api/mobile/authorize/route.test.ts
+++ b/src/app/api/mobile/authorize/route.test.ts
@@ -9,6 +9,7 @@ const {
   mockWithBypassRls,
   mockWithUserTenantRls,
   mockGetAppOrigin,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockMobileBridgeCodeCreate: vi.fn(),
@@ -18,6 +19,7 @@ const {
       fn("22222222-2222-2222-2222-222222222222"),
   ),
   mockGetAppOrigin: vi.fn(() => "https://example.test"),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -51,6 +53,10 @@ vi.mock("@/lib/redis", () => ({
   validateRedisConfig: () => {},
 }));
 
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
+}));
+
 import { GET } from "./route";
 
 const VALID = {
@@ -78,6 +84,7 @@ describe("GET /api/mobile/authorize", () => {
       async (_u: string, fn: (tenantId: string) => unknown) =>
         fn("22222222-2222-2222-2222-222222222222"),
     );
+    mockRequireRecentSession.mockResolvedValue(null);
     mockMobileBridgeCodeCreate.mockResolvedValue({ id: "00000000-0000-4000-8000-000000000003" });
   });
 
@@ -104,6 +111,17 @@ describe("GET /api/mobile/authorize", () => {
     mockAuth.mockResolvedValue(null);
     const res = await GET(createRequest("GET", buildUrl(VALID)));
     expect(res.status).toBe(401);
+    expect(mockMobileBridgeCodeCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when session step-up is required", async () => {
+    mockRequireRecentSession.mockResolvedValue(Response.json(
+      { error: "SESSION_STEP_UP_REQUIRED" },
+      { status: 403 },
+    ));
+
+    const res = await GET(createRequest("GET", buildUrl(VALID)));
+    expect(res.status).toBe(403);
     expect(mockMobileBridgeCodeCreate).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/mobile/authorize/route.ts
+++ b/src/app/api/mobile/authorize/route.ts
@@ -37,6 +37,7 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { canonicalHtu } from "@/lib/auth/dpop/htu-canonical";
 import { BRIDGE_CODE_TTL_MS } from "@/lib/constants";
 import { generateShareToken } from "@/lib/crypto/crypto-server";
+import { requireRecentSession } from "@/lib/auth/session/step-up";
 
 export const runtime = "nodejs";
 
@@ -60,6 +61,9 @@ async function handleGET(req: NextRequest): Promise<Response> {
   if (!session?.user?.id) {
     return unauthorized();
   }
+
+  const stepUpError = await requireRecentSession(req);
+  if (stepUpError) return stepUpError;
 
   // 2. Validate query params.
   const url = new URL(req.url);

--- a/src/app/api/tenant/access-requests/[id]/approve/route.test.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.test.ts
@@ -17,6 +17,7 @@ const {
   mockTenantFindUnique,
   mockPrismaTransaction,
   mockHashToken,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockRequireTenantPermission: vi.fn(),
@@ -27,6 +28,7 @@ const {
   mockTenantFindUnique: vi.fn(),
   mockPrismaTransaction: vi.fn(),
   mockHashToken: vi.fn().mockReturnValue("hashed-token"),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -69,6 +71,9 @@ vi.mock("@/lib/http/with-request-log", () => ({
 }));
 vi.mock("@/lib/crypto/crypto-server", () => ({
   hashToken: mockHashToken,
+}));
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
 }));
 
 import { POST } from "@/app/api/tenant/access-requests/[id]/approve/route";
@@ -116,7 +121,10 @@ const makeTransactionSuccess = () => {
 };
 
 describe("POST /api/tenant/access-requests/[id]/approve", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireRecentSession.mockResolvedValue(null);
+  });
 
   it("approves pending request and returns JIT token", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
@@ -266,6 +274,25 @@ describe("POST /api/tenant/access-requests/[id]/approve", () => {
     const { status } = await parseResponse(res);
 
     expect(status).toBe(403);
+  });
+
+  it("returns 403 when session step-up is required", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockRequireRecentSession.mockResolvedValueOnce(
+      Response.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const req = createRequest(
+      "POST",
+      `http://localhost/api/tenant/access-requests/${REQUEST_ID}/approve`,
+    );
+    const res = await POST(req, createParams({ id: REQUEST_ID }));
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(403);
+    expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
+    expect(mockPrismaTransaction).not.toHaveBeenCalled();
   });
 
   it("returns 409 when service account is inactive", async () => {

--- a/src/app/api/tenant/access-requests/[id]/approve/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.ts
@@ -15,6 +15,7 @@ import { createRateLimiter } from "@/lib/security/rate-limit";
 import { SA_TOKEN_PREFIX, MAX_SA_TOKENS_PER_ACCOUNT } from "@/lib/constants/auth/service-account";
 import { parseSaTokenScopes } from "@/lib/auth/tokens/service-account-token";
 import { randomBytes } from "node:crypto";
+import { requireRecentSession } from "@/lib/auth/session/step-up";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -41,6 +42,9 @@ async function handlePOST(req: NextRequest, { params }: Params) {
   } catch (err) {
     return handleAuthError(err);
   }
+
+  const stepUpError = await requireRecentSession(req);
+  if (stepUpError) return stepUpError;
 
   const rl = await approveLimiter.check(`rl:access_request_approve:${actor.tenantId}`);
   if (!rl.allowed) return rateLimited(rl.retryAfterMs);

--- a/src/app/api/tenant/mcp-clients/route.test.ts
+++ b/src/app/api/tenant/mcp-clients/route.test.ts
@@ -14,6 +14,7 @@ const {
   mockMcpClientCreate,
   mockHashToken,
   mockUserFindMany,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockRequireTenantPermission: vi.fn(),
@@ -26,6 +27,7 @@ const {
   mockMcpClientCreate: vi.fn(),
   mockHashToken: vi.fn((token: string) => `hashed:${token}`),
   mockUserFindMany: vi.fn().mockResolvedValue([]),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -76,6 +78,9 @@ vi.mock("@/lib/security/rate-limit", () => ({
 }));
 vi.mock("@/lib/crypto/crypto-server", () => ({
   hashToken: mockHashToken,
+}));
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
 }));
 
 import { GET, POST } from "@/app/api/tenant/mcp-clients/route";
@@ -166,7 +171,10 @@ describe("GET /api/tenant/mcp-clients", () => {
 });
 
 describe("POST /api/tenant/mcp-clients", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireRecentSession.mockResolvedValue(null);
+  });
 
   it("creates a MCP client and returns clientSecret once", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
@@ -315,5 +323,27 @@ describe("POST /api/tenant/mcp-clients", () => {
     const { status } = await parseResponse(res);
 
     expect(status).toBe(403);
+  });
+
+  it("returns 403 when session step-up is required", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockRequireRecentSession.mockResolvedValueOnce(
+      Response.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const req = createRequest("POST", "http://localhost/api/tenant/mcp-clients", {
+      body: {
+        name: "my-mcp-client",
+        redirectUris: ["https://example.com/callback"],
+        allowedScopes: ["credentials:list", "credentials:use"],
+      },
+    });
+    const res = await POST(req);
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(403);
+    expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
+    expect(mockMcpClientCreate).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/tenant/mcp-clients/route.ts
+++ b/src/app/api/tenant/mcp-clients/route.ts
@@ -15,6 +15,7 @@ import { errorResponse, handleAuthError, unauthorized } from "@/lib/http/api-res
 import { parseBody } from "@/lib/http/parse-body";
 import { z } from "zod";
 import { withRequestLog } from "@/lib/http/with-request-log";
+import { requireRecentSession } from "@/lib/auth/session/step-up";
 
 const createSchema = z.object({
   name: z.string().min(1).max(100),
@@ -108,6 +109,9 @@ async function handlePOST(req: NextRequest) {
   } catch (err) {
     return handleAuthError(err);
   }
+
+  const stepUpError = await requireRecentSession(req);
+  if (stepUpError) return stepUpError;
 
   const result = await parseBody(req, createSchema);
   if (!result.ok) return result.response;

--- a/src/app/api/tenant/operator-tokens/route.test.ts
+++ b/src/app/api/tenant/operator-tokens/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
+import { MS_PER_MINUTE } from "@/lib/constants/time";
 
 const {
   mockAuth,
@@ -91,7 +92,9 @@ const ACTOR = {
 // A fresh session (just created)
 const FRESH_SESSION = { createdAt: new Date(Date.now() - 5 * 60 * 1000) }; // 5 min ago
 // A stale session (older than 15 min step-up window)
-const STALE_SESSION = { createdAt: new Date(Date.now() - 16 * 60 * 1000) }; // 16 min ago
+const STALE_SESSION = {
+  createdAt: new Date(Date.now() - 16 * MS_PER_MINUTE),
+};
 
 const SESSION_TOKEN_VALUE = "session-token-abc123";
 

--- a/src/app/api/tenant/operator-tokens/route.ts
+++ b/src/app/api/tenant/operator-tokens/route.ts
@@ -10,7 +10,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { parseBody } from "@/lib/http/parse-body";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
-import { withBypassRls, withTenantRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import {
   errorResponse,
@@ -19,8 +19,8 @@ import {
   unauthorized,
 } from "@/lib/http/api-response";
 import { createRateLimiter } from "@/lib/security/rate-limit";
-import { MS_PER_DAY, MS_PER_MINUTE } from "@/lib/constants/time";
-import { getSessionToken } from "@/app/api/sessions/helpers";
+import { MS_PER_DAY } from "@/lib/constants/time";
+import { requireRecentSession } from "@/lib/auth/session/step-up";
 import {
   OPERATOR_TOKEN_PREFIX,
   OPERATOR_TOKEN_DEFAULT_EXPIRES_DAYS,
@@ -32,7 +32,6 @@ import {
 
 export const runtime = "nodejs";
 
-const STEP_UP_WINDOW_MS = 15 * MS_PER_MINUTE;
 const TOKEN_LIMIT_PER_TENANT = 50;
 
 const createTokenLimiter = createRateLimiter({ windowMs: 60_000, max: 5 });
@@ -124,28 +123,10 @@ async function handlePOST(req: NextRequest) {
     return handleAuthError(err);
   }
 
-  // Step-up: session must have been created within the last 15 minutes.
-  // Read Session.createdAt directly from the DB (Auth.js v5 does not expose it
-  // on the returned session object).
-  const sessionToken = getSessionToken(req);
-  if (!sessionToken) {
-    return unauthorized();
-  }
-  const sessionRow = await withBypassRls(
-    prisma,
-    async () =>
-      prisma.session.findUnique({
-        where: { sessionToken },
-        select: { createdAt: true },
-      }),
-    BYPASS_PURPOSE.AUTH_FLOW,
-  );
-  if (!sessionRow) {
-    return unauthorized();
-  }
-  if (Date.now() - sessionRow.createdAt.getTime() > STEP_UP_WINDOW_MS) {
-    return errorResponse(API_ERROR.OPERATOR_TOKEN_STALE_SESSION, 403);
-  }
+  const stepUpError = await requireRecentSession(req, {
+    errorCode: API_ERROR.OPERATOR_TOKEN_STALE_SESSION,
+  });
+  if (stepUpError) return stepUpError;
 
   const rl = await createTokenLimiter.check(
     `rl:op_token_create:${actor.tenantId}`,

--- a/src/app/api/tenant/scim-tokens/route.test.ts
+++ b/src/app/api/tenant/scim-tokens/route.test.ts
@@ -179,6 +179,7 @@ describe("POST /api/tenant/scim-tokens", () => {
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error).toBe("SESSION_STEP_UP_REQUIRED");
+    expect(mockPrismaScimToken.create).not.toHaveBeenCalled();
   });
 
   it("returns 409 when token limit is exceeded", async () => {

--- a/src/app/api/tenant/scim-tokens/route.test.ts
+++ b/src/app/api/tenant/scim-tokens/route.test.ts
@@ -11,6 +11,7 @@ const {
   mockHashToken,
   mockGenerateScimToken,
   mockRateLimitCheck,
+  mockRequireRecentSession,
   TenantAuthError,
 } = vi.hoisted(() => {
   class _TenantAuthError extends Error {
@@ -34,6 +35,7 @@ const {
     mockHashToken: vi.fn((t: string) => `hashed:${t}`),
     mockGenerateScimToken: vi.fn(() => "scim_test_plaintext_token"),
     mockRateLimitCheck: vi.fn().mockResolvedValue({ allowed: true }),
+    mockRequireRecentSession: vi.fn().mockResolvedValue(null),
     TenantAuthError: _TenantAuthError,
   };
 });
@@ -65,6 +67,9 @@ vi.mock("@/lib/security/rate-limit", () => ({
     check: mockRateLimitCheck,
     clear: vi.fn(),
   })),
+}));
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
 }));
 
 import { GET, POST } from "./route";
@@ -124,6 +129,7 @@ describe("POST /api/tenant/scim-tokens", () => {
     mockRequireTenantPermission.mockResolvedValue(ACTOR);
     mockPrismaScimToken.count.mockResolvedValue(0);
     mockRateLimitCheck.mockResolvedValue({ allowed: true });
+    mockRequireRecentSession.mockResolvedValue(null);
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -158,6 +164,21 @@ describe("POST /api/tenant/scim-tokens", () => {
     });
     const res = await POST(req);
     expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when session step-up is required", async () => {
+    mockRequireRecentSession.mockResolvedValueOnce(
+      Response.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/tenant/scim-tokens", {
+        body: { description: "test" },
+      }),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("SESSION_STEP_UP_REQUIRED");
   });
 
   it("returns 409 when token limit is exceeded", async () => {

--- a/src/app/api/tenant/scim-tokens/route.ts
+++ b/src/app/api/tenant/scim-tokens/route.ts
@@ -21,6 +21,7 @@ import {
   SCIM_TOKEN_EXPIRY_DEFAULT_DAYS,
 } from "@/lib/validations/common";
 import { MS_PER_DAY, MS_PER_HOUR } from "@/lib/constants/time";
+import { requireRecentSession } from "@/lib/auth/session/step-up";
 
 const scimTokenCreateLimiter = createRateLimiter({ windowMs: MS_PER_HOUR, max: 5 });
 
@@ -86,6 +87,9 @@ async function handlePOST(req: NextRequest) {
   } catch (err) {
     return handleAuthError(err);
   }
+
+  const stepUpError = await requireRecentSession(req);
+  if (stepUpError) return stepUpError;
 
   const rl = await scimTokenCreateLimiter.check(`rl:scim_token_create:${actor.tenantId}`);
   if (!rl.allowed) return rateLimited(rl.retryAfterMs);

--- a/src/app/api/tenant/service-accounts/[id]/tokens/route.test.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/route.test.ts
@@ -15,6 +15,7 @@ const {
   mockServiceAccountTokenFindMany,
   mockPrismaTransaction,
   mockHashToken,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockRequireTenantPermission: vi.fn(),
@@ -24,6 +25,7 @@ const {
   mockServiceAccountTokenFindMany: vi.fn(),
   mockPrismaTransaction: vi.fn(),
   mockHashToken: vi.fn().mockReturnValue("hashed-token"),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -65,6 +67,9 @@ vi.mock("@/lib/http/with-request-log", () => ({
 }));
 vi.mock("@/lib/crypto/crypto-server", () => ({
   hashToken: mockHashToken,
+}));
+vi.mock("@/lib/auth/session/step-up", () => ({
+  requireRecentSession: mockRequireRecentSession,
 }));
 
 import { GET, POST } from "@/app/api/tenant/service-accounts/[id]/tokens/route";
@@ -160,7 +165,10 @@ describe("GET /api/tenant/service-accounts/[id]/tokens", () => {
 });
 
 describe("POST /api/tenant/service-accounts/[id]/tokens", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireRecentSession.mockResolvedValue(null);
+  });
 
   it("creates a token and returns plaintext once", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
@@ -224,6 +232,32 @@ describe("POST /api/tenant/service-accounts/[id]/tokens", () => {
     const { status } = await parseResponse(res);
 
     expect(status).toBe(409);
+  });
+
+  it("returns 403 when session step-up is required", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockRequireRecentSession.mockResolvedValueOnce(
+      Response.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const expiresAt = new Date(Date.now() + 30 * 24 * 3600 * 1000).toISOString();
+    const req = createRequest(
+      "POST",
+      `http://localhost/api/tenant/service-accounts/${SA_ID}/tokens`,
+      {
+        body: {
+          name: "deploy-token",
+          scope: ["passwords:read"],
+          expiresAt,
+        },
+      },
+    );
+    const res = await POST(req, createParams({ id: SA_ID }));
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(403);
+    expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
   });
 
   it("returns 409 when token limit is reached", async () => {

--- a/src/app/api/tenant/service-accounts/[id]/tokens/route.test.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/route.test.ts
@@ -114,7 +114,11 @@ const makeTransactionSuccess = () => {
 };
 
 describe("GET /api/tenant/service-accounts/[id]/tokens", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireRecentSession.mockReset();
+    mockRequireRecentSession.mockResolvedValue(null);
+  });
 
   it("returns list of tokens for a service account", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
@@ -133,6 +137,27 @@ describe("GET /api/tenant/service-accounts/[id]/tokens", () => {
     expect(Array.isArray(json)).toBe(true);
     expect(json).toHaveLength(1);
     expect(json[0].id).toBe(TOKEN_ID);
+    expect(mockRequireRecentSession).not.toHaveBeenCalled();
+  });
+
+  it("does not require session step-up for listing tokens", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockRequireRecentSession.mockResolvedValueOnce(
+      Response.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+    mockServiceAccountFindUnique.mockResolvedValue({ id: SA_ID, tenantId: "tenant-1" });
+    mockServiceAccountTokenFindMany.mockResolvedValue([makeToken()]);
+
+    const req = createRequest(
+      "GET",
+      `http://localhost/api/tenant/service-accounts/${SA_ID}/tokens`,
+    );
+    const res = await GET(req, createParams({ id: SA_ID }));
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(200);
+    expect(mockRequireRecentSession).not.toHaveBeenCalled();
   });
 
   it("returns 404 when service account not found", async () => {
@@ -167,6 +192,7 @@ describe("GET /api/tenant/service-accounts/[id]/tokens", () => {
 describe("POST /api/tenant/service-accounts/[id]/tokens", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRequireRecentSession.mockReset();
     mockRequireRecentSession.mockResolvedValue(null);
   });
 
@@ -258,6 +284,7 @@ describe("POST /api/tenant/service-accounts/[id]/tokens", () => {
 
     expect(status).toBe(403);
     expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
+    expect(mockPrismaTransaction).not.toHaveBeenCalled();
   });
 
   it("returns 409 when token limit is reached", async () => {

--- a/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/constants/auth/service-account";
 import { saTokenCreateSchema } from "@/lib/validations/service-account";
 import { MS_PER_DAY } from "@/lib/constants/time";
+import { requireRecentSession } from "@/lib/auth/session/step-up";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -41,6 +42,9 @@ async function handleGET(req: NextRequest, { params }: Params) {
   } catch (err) {
     return handleAuthError(err);
   }
+
+  const stepUpError = await requireRecentSession(req);
+  if (stepUpError) return stepUpError;
 
   const { id } = await params;
 
@@ -91,6 +95,9 @@ async function handlePOST(req: NextRequest, { params }: Params) {
   } catch (err) {
     return handleAuthError(err);
   }
+
+  const stepUpError = await requireRecentSession(req);
+  if (stepUpError) return stepUpError;
 
   const { id } = await params;
 

--- a/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
@@ -43,9 +43,6 @@ async function handleGET(req: NextRequest, { params }: Params) {
     return handleAuthError(err);
   }
 
-  const stepUpError = await requireRecentSession(req);
-  if (stepUpError) return stepUpError;
-
   const { id } = await params;
 
   const sa = await withTenantRls(prisma, actor.tenantId, async () =>

--- a/src/app/api/vault/admin-reset/route.ts
+++ b/src/app/api/vault/admin-reset/route.ts
@@ -33,8 +33,8 @@ const adminResetSchema = z.object({
 // Execute a vault reset initiated by a team admin.
 // The target user must be authenticated and submit the token + confirmation.
 async function handlePOST(req: NextRequest) {
-  // Intentionally stricter than proxy CSRF gate (which skips when unset for dev
-  // convenience): admin vault reset must never run without a configured origin.
+  // Intentionally stricter than the generic CSRF helper: admin vault reset
+  // must never run without an explicit canonical origin configuration.
   const appUrl = getAppOrigin();
   if (!appUrl) {
     return NextResponse.json(

--- a/src/lib/auth/policy/ip-access.test.ts
+++ b/src/lib/auth/policy/ip-access.test.ts
@@ -39,8 +39,16 @@ describe("normalizeIp", () => {
     expect(normalizeIp("::ffff:1.2.3.4")).toBe("1.2.3.4");
   });
 
+  it("normalizes hex-form IPv4-mapped IPv6 to dotted IPv4", () => {
+    expect(normalizeIp("::ffff:7f00:1")).toBe("127.0.0.1");
+  });
+
   it("trims surrounding whitespace", () => {
     expect(normalizeIp("  1.2.3.4 ")).toBe("1.2.3.4");
+  });
+
+  it("strips IPv6 literal brackets", () => {
+    expect(normalizeIp("[2001:db8::1]")).toBe("2001:db8::1");
   });
 
   it("passes through plain IPv4 unchanged", () => {
@@ -108,6 +116,10 @@ describe("isIpInCidr", () => {
 
   it("matches IPv4-mapped IPv6 against an IPv4 CIDR (after normalization)", () => {
     expect(isIpInCidr("::ffff:192.168.0.42", "192.168.0.0/24")).toBe(true);
+  });
+
+  it("matches hex-form IPv4-mapped IPv6 against an IPv4 CIDR", () => {
+    expect(isIpInCidr("::ffff:7f00:1", "127.0.0.0/8")).toBe(true);
   });
 });
 

--- a/src/lib/auth/policy/ip-access.test.ts
+++ b/src/lib/auth/policy/ip-access.test.ts
@@ -43,12 +43,24 @@ describe("normalizeIp", () => {
     expect(normalizeIp("::ffff:7f00:1")).toBe("127.0.0.1");
   });
 
+  it("normalizes uppercase hex-form IPv4-mapped IPv6 to dotted IPv4", () => {
+    expect(normalizeIp("::FFFF:7F00:1")).toBe("127.0.0.1");
+  });
+
+  it("normalizes zero-padded hex-form IPv4-mapped IPv6 to dotted IPv4", () => {
+    expect(normalizeIp("::ffff:7f00:0001")).toBe("127.0.0.1");
+  });
+
   it("trims surrounding whitespace", () => {
     expect(normalizeIp("  1.2.3.4 ")).toBe("1.2.3.4");
   });
 
   it("strips IPv6 literal brackets", () => {
     expect(normalizeIp("[2001:db8::1]")).toBe("2001:db8::1");
+  });
+
+  it("normalizes bracketed hex-form IPv4-mapped IPv6 to dotted IPv4", () => {
+    expect(normalizeIp("[::ffff:7f00:1]")).toBe("127.0.0.1");
   });
 
   it("passes through plain IPv4 unchanged", () => {
@@ -120,6 +132,14 @@ describe("isIpInCidr", () => {
 
   it("matches hex-form IPv4-mapped IPv6 against an IPv4 CIDR", () => {
     expect(isIpInCidr("::ffff:7f00:1", "127.0.0.0/8")).toBe(true);
+  });
+
+  it("matches uppercase hex-form IPv4-mapped IPv6 against an IPv4 CIDR", () => {
+    expect(isIpInCidr("::FFFF:7F00:1", "127.0.0.0/8")).toBe(true);
+  });
+
+  it("matches zero-padded hex-form IPv4-mapped IPv6 against an IPv4 CIDR", () => {
+    expect(isIpInCidr("::ffff:7f00:0001", "127.0.0.0/8")).toBe(true);
   });
 });
 

--- a/src/lib/auth/policy/ip-access.ts
+++ b/src/lib/auth/policy/ip-access.ts
@@ -108,20 +108,39 @@ function parseIpv6(ip: string): number[] | null {
   return [...left, ...new Array<number>(padding).fill(0), ...right];
 }
 
+function ipv4BytesFromMappedIpv6(ip: string): number[] | null {
+  const parsed = parseIpv6(ip);
+  if (!parsed || parsed.length !== 16) return null;
+
+  const hasMappedPrefix = parsed
+    .slice(0, 12)
+    .every((byte, index) => (index < 10 ? byte === 0 : byte === 0xff));
+  if (!hasMappedPrefix) return null;
+
+  return parsed.slice(12, 16);
+}
+
 /**
  * Normalize an IP address string.
  * Strips IPv4-mapped IPv6 prefix (::ffff:) and returns pure IPv4.
  */
 export function normalizeIp(ip: string): string {
   const trimmed = ip.trim();
+  const unwrapped =
+    trimmed.startsWith("[") && trimmed.endsWith("]")
+      ? trimmed.slice(1, -1)
+      : trimmed;
 
   // Strip IPv4-mapped IPv6 prefix
-  const v4MappedMatch = trimmed.match(
+  const v4MappedMatch = unwrapped.match(
     /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i,
   );
   if (v4MappedMatch) return v4MappedMatch[1];
 
-  return trimmed;
+  const mappedBytes = ipv4BytesFromMappedIpv6(unwrapped);
+  if (mappedBytes) return mappedBytes.join(".");
+
+  return unwrapped;
 }
 
 /**

--- a/src/lib/auth/session/csrf.test.ts
+++ b/src/lib/auth/session/csrf.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertOrigin } from "./csrf";
 
 function makeRequest(
@@ -13,33 +13,26 @@ function makeRequest(
   });
 }
 
+// setup.ts wires `vi.unstubAllEnvs()` in afterEach, so any vi.stubEnv()
+// here is reverted between tests automatically.
+
 describe("assertOrigin", () => {
-  const originalEnv = process.env;
-
-  beforeEach(() => {
-    process.env = { ...originalEnv };
-  });
-
-  afterEach(() => {
-    process.env = originalEnv;
-  });
-
   it("returns null (pass) when origin matches APP_URL", () => {
-    process.env.APP_URL = "http://localhost:3000";
+    vi.stubEnv("APP_URL", "http://localhost:3000");
     const result = assertOrigin(makeRequest("http://localhost:3000"));
     expect(result).toBeNull();
   });
 
   it("returns null when origin matches AUTH_URL (fallback)", () => {
-    delete process.env.APP_URL;
-    process.env.AUTH_URL = "http://localhost:3000";
+    vi.stubEnv("APP_URL", "");
+    vi.stubEnv("AUTH_URL", "http://localhost:3000");
     const result = assertOrigin(makeRequest("http://localhost:3000"));
     expect(result).toBeNull();
   });
 
   it("returns 403 when APP_URL and AUTH_URL are both unset even if Host matches", async () => {
-    delete process.env.APP_URL;
-    delete process.env.AUTH_URL;
+    vi.stubEnv("APP_URL", "");
+    vi.stubEnv("AUTH_URL", "");
     const result = assertOrigin(
       makeRequest("http://localhost:3000", { host: "localhost:3000" }),
     );
@@ -48,8 +41,8 @@ describe("assertOrigin", () => {
   });
 
   it("returns 403 when origin differs from Host and APP_URL/AUTH_URL are unset", async () => {
-    delete process.env.APP_URL;
-    delete process.env.AUTH_URL;
+    vi.stubEnv("APP_URL", "");
+    vi.stubEnv("AUTH_URL", "");
     const result = assertOrigin(
       makeRequest("http://evil.com", { host: "localhost:3000" }),
     );
@@ -58,8 +51,8 @@ describe("assertOrigin", () => {
   });
 
   it("returns 403 when x-forwarded-proto suggests https but canonical origin is unset", async () => {
-    delete process.env.APP_URL;
-    delete process.env.AUTH_URL;
+    vi.stubEnv("APP_URL", "");
+    vi.stubEnv("AUTH_URL", "");
     const result = assertOrigin(
       makeRequest("https://localhost:3000", {
         host: "localhost:3000",
@@ -71,23 +64,23 @@ describe("assertOrigin", () => {
   });
 
   it("returns 403 when origin is missing even if APP_URL/AUTH_URL are unset", async () => {
-    delete process.env.APP_URL;
-    delete process.env.AUTH_URL;
+    vi.stubEnv("APP_URL", "");
+    vi.stubEnv("AUTH_URL", "");
     const result = assertOrigin(makeRequest(undefined, { host: "localhost:3000" }));
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);
   });
 
   it("returns 403 when origin and Host are both missing and APP_URL is unset", async () => {
-    delete process.env.APP_URL;
-    delete process.env.AUTH_URL;
+    vi.stubEnv("APP_URL", "");
+    vi.stubEnv("AUTH_URL", "");
     const result = assertOrigin(makeRequest());
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);
   });
 
   it("returns 403 when origin is missing and APP_URL is set", async () => {
-    process.env.APP_URL = "http://localhost:3000";
+    vi.stubEnv("APP_URL", "http://localhost:3000");
     const result = assertOrigin(makeRequest());
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);
@@ -96,21 +89,21 @@ describe("assertOrigin", () => {
   });
 
   it("returns 403 when origin does not match", async () => {
-    process.env.APP_URL = "http://localhost:3000";
+    vi.stubEnv("APP_URL", "http://localhost:3000");
     const result = assertOrigin(makeRequest("http://evil.com"));
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);
   });
 
   it("returns 403 for malformed origin", async () => {
-    process.env.APP_URL = "http://localhost:3000";
+    vi.stubEnv("APP_URL", "http://localhost:3000");
     const result = assertOrigin(makeRequest("not-a-url"));
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);
   });
 
   it("matches origin ignoring path in APP_URL", () => {
-    process.env.APP_URL = "http://localhost:3000/some/path";
+    vi.stubEnv("APP_URL", "http://localhost:3000/some/path");
     const result = assertOrigin(makeRequest("http://localhost:3000"));
     expect(result).toBeNull();
   });

--- a/src/lib/auth/session/csrf.test.ts
+++ b/src/lib/auth/session/csrf.test.ts
@@ -37,16 +37,17 @@ describe("assertOrigin", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null when origin matches Host header (APP_URL/AUTH_URL unset)", () => {
+  it("returns 403 when APP_URL and AUTH_URL are both unset even if Host matches", async () => {
     delete process.env.APP_URL;
     delete process.env.AUTH_URL;
     const result = assertOrigin(
       makeRequest("http://localhost:3000", { host: "localhost:3000" }),
     );
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
   });
 
-  it("returns 403 when origin differs from Host (APP_URL/AUTH_URL unset)", async () => {
+  it("returns 403 when origin differs from Host and APP_URL/AUTH_URL are unset", async () => {
     delete process.env.APP_URL;
     delete process.env.AUTH_URL;
     const result = assertOrigin(

--- a/src/lib/auth/session/csrf.test.ts
+++ b/src/lib/auth/session/csrf.test.ts
@@ -57,6 +57,19 @@ describe("assertOrigin", () => {
     expect(result!.status).toBe(403);
   });
 
+  it("returns 403 when x-forwarded-proto suggests https but canonical origin is unset", async () => {
+    delete process.env.APP_URL;
+    delete process.env.AUTH_URL;
+    const result = assertOrigin(
+      makeRequest("https://localhost:3000", {
+        host: "localhost:3000",
+        "x-forwarded-proto": "https",
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
   it("returns 403 when origin is missing even if APP_URL/AUTH_URL are unset", async () => {
     delete process.env.APP_URL;
     delete process.env.AUTH_URL;

--- a/src/lib/auth/session/csrf.ts
+++ b/src/lib/auth/session/csrf.ts
@@ -21,11 +21,9 @@ const forbidden = (): NextResponse =>
  * Assert that the request's Origin header matches the application URL.
  * Returns null if valid, or a 403 NextResponse if invalid.
  *
- * Destructive endpoints always require an Origin header. When APP_URL /
- * AUTH_URL is not configured, the expected origin is derived from the Host
- * header. Note: `x-forwarded-proto` is only honored as a scheme hint — the
- * origin comparison still requires Host to match, so a spoofed proto alone
- * cannot forge a same-origin request.
+ * Destructive endpoints always require an Origin header. The expected
+ * origin must come from APP_URL / AUTH_URL; if neither is configured we
+ * fail closed rather than trusting request headers to define "same origin".
  *
  * Usage in route handlers:
  *   const originError = assertOrigin(request);
@@ -35,19 +33,11 @@ export function assertOrigin(request: Request): NextResponse | null {
   const origin = request.headers.get("origin");
   if (!origin) return forbidden();
 
-  let expectedOrigin: string;
   const appUrl = getAppOrigin();
-  if (appUrl) {
-    expectedOrigin = appUrl;
-  } else {
-    const host = request.headers.get("host");
-    if (!host) return forbidden();
-    const proto = request.headers.get("x-forwarded-proto") || "http";
-    expectedOrigin = `${proto}://${host}`;
-  }
+  if (!appUrl) return forbidden();
 
   try {
-    if (new URL(origin).origin !== new URL(expectedOrigin).origin) {
+    if (new URL(origin).origin !== new URL(appUrl).origin) {
       return forbidden();
     }
   } catch {

--- a/src/lib/auth/session/step-up.ts
+++ b/src/lib/auth/session/step-up.ts
@@ -1,0 +1,52 @@
+import type { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getSessionToken } from "@/app/api/sessions/helpers";
+import { API_ERROR, type ApiErrorCode } from "@/lib/http/api-error-codes";
+import { errorResponse, unauthorized } from "@/lib/http/api-response";
+import { MS_PER_MINUTE } from "@/lib/constants/time";
+import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+
+export const STEP_UP_WINDOW_MS = 15 * MS_PER_MINUTE;
+
+type RequireRecentSessionOptions = {
+  maxAgeMs?: number;
+  errorCode?: ApiErrorCode;
+};
+
+/**
+ * Require that the current Auth.js session was created recently enough for
+ * sensitive credential-issuance flows.
+ */
+export async function requireRecentSession(
+  req: NextRequest,
+  options: RequireRecentSessionOptions = {},
+) {
+  const {
+    maxAgeMs = STEP_UP_WINDOW_MS,
+    errorCode = API_ERROR.SESSION_STEP_UP_REQUIRED,
+  } = options;
+  const sessionToken = getSessionToken(req);
+  if (!sessionToken) {
+    return unauthorized();
+  }
+
+  const sessionRow = await withBypassRls(
+    prisma,
+    async () =>
+      prisma.session.findUnique({
+        where: { sessionToken },
+        select: { createdAt: true },
+      }),
+    BYPASS_PURPOSE.AUTH_FLOW,
+  );
+
+  if (!sessionRow) {
+    return unauthorized();
+  }
+
+  if (Date.now() - sessionRow.createdAt.getTime() > maxAgeMs) {
+    return errorResponse(errorCode, 403);
+  }
+
+  return null;
+}

--- a/src/lib/constants/auth/api-path.ts
+++ b/src/lib/constants/auth/api-path.ts
@@ -83,6 +83,9 @@ export const API_PATH = {
   USER_MCP_TOKENS: "/api/user/mcp-tokens",
   USER_AUTH_PROVIDER: "/api/user/auth-provider",
   USER_PASSKEY_STATUS: "/api/user/passkey-status",
+  MCP_AUTHORIZE: "/api/mcp/authorize",
+  MCP_AUTHORIZE_CONSENT: "/api/mcp/authorize/consent",
+  MOBILE_AUTHORIZE: "/api/mobile/authorize",
   INTERNAL_AUDIT_EMIT: "/api/internal/audit-emit",
 } as const;
 

--- a/src/lib/http/api-error-codes.test.ts
+++ b/src/lib/http/api-error-codes.test.ts
@@ -118,6 +118,6 @@ describe("API_ERROR structural invariants", () => {
   it("code count matches expected (update this when adding new codes)", () => {
     // If this fails, you added a new code to API_ERROR.
     // Update this count AND add the code to API_ERROR_I18N + i18n messages.
-    expect(Object.keys(API_ERROR).length).toBe(145);
+    expect(Object.keys(API_ERROR).length).toBe(146);
   });
 });

--- a/src/lib/http/api-error-codes.ts
+++ b/src/lib/http/api-error-codes.ts
@@ -368,7 +368,7 @@ const API_ERROR_I18N: Record<ApiErrorCode, string> = {
   DELEGATION_ENTRIES_NOT_FOUND: "delegationEntriesNotFound",
   NO_TENANT: "noTenant",
   INVALID_SESSION: "invalidSession",
-  SESSION_STEP_UP_REQUIRED: "operatorTokenStaleSession",
+  SESSION_STEP_UP_REQUIRED: "sessionStepUpRequired",
   INTERNAL_ERROR: "internalError",
 } satisfies Record<ApiErrorCode, string>;
 

--- a/src/lib/http/api-error-codes.ts
+++ b/src/lib/http/api-error-codes.ts
@@ -209,6 +209,7 @@ export const API_ERROR = {
   // ── Tenant / Session ────────────────────────────────────
   NO_TENANT: "NO_TENANT",
   INVALID_SESSION: "INVALID_SESSION",
+  SESSION_STEP_UP_REQUIRED: "SESSION_STEP_UP_REQUIRED",
   INTERNAL_ERROR: "INTERNAL_ERROR",
 } as const;
 
@@ -367,6 +368,7 @@ const API_ERROR_I18N: Record<ApiErrorCode, string> = {
   DELEGATION_ENTRIES_NOT_FOUND: "delegationEntriesNotFound",
   NO_TENANT: "noTenant",
   INVALID_SESSION: "invalidSession",
+  SESSION_STEP_UP_REQUIRED: "operatorTokenStaleSession",
   INTERNAL_ERROR: "internalError",
 } satisfies Record<ApiErrorCode, string>;
 

--- a/src/lib/http/external-http.test.ts
+++ b/src/lib/http/external-http.test.ts
@@ -121,6 +121,18 @@ describe("resolveAndValidateIps", () => {
     ).rejects.toThrow("Private IP rejected");
   });
 
+  it("uppercase IPv4-mapped IPv6 literal in hex form is rejected as private", async () => {
+    await expect(
+      resolveAndValidateIps("https://[::FFFF:7F00:1]/path"),
+    ).rejects.toThrow("Private IP rejected");
+  });
+
+  it("zero-padded IPv4-mapped IPv6 literal in hex form is rejected as private", async () => {
+    await expect(
+      resolveAndValidateIps("https://[::ffff:7f00:0001]/path"),
+    ).rejects.toThrow("Private IP rejected");
+  });
+
   it("hostname resolving to public IP returns IPs", async () => {
     mockResolve4.mockResolvedValue(["93.184.216.34"]);
     mockResolve6.mockResolvedValue([]);
@@ -139,6 +151,22 @@ describe("resolveAndValidateIps", () => {
   it("hostname resolving to hex-form IPv4-mapped IPv6 loopback throws", async () => {
     mockResolve4.mockResolvedValue([]);
     mockResolve6.mockResolvedValue(["::ffff:7f00:1"]);
+    await expect(
+      resolveAndValidateIps("https://evil.example.com/path"),
+    ).rejects.toThrow("private IP");
+  });
+
+  it("hostname resolving to uppercase hex-form IPv4-mapped IPv6 loopback throws", async () => {
+    mockResolve4.mockResolvedValue([]);
+    mockResolve6.mockResolvedValue(["::FFFF:7F00:1"]);
+    await expect(
+      resolveAndValidateIps("https://evil.example.com/path"),
+    ).rejects.toThrow("private IP");
+  });
+
+  it("hostname resolving to zero-padded hex-form IPv4-mapped IPv6 loopback throws", async () => {
+    mockResolve4.mockResolvedValue([]);
+    mockResolve6.mockResolvedValue(["::ffff:7f00:0001"]);
     await expect(
       resolveAndValidateIps("https://evil.example.com/path"),
     ).rejects.toThrow("private IP");

--- a/src/lib/http/external-http.test.ts
+++ b/src/lib/http/external-http.test.ts
@@ -115,6 +115,12 @@ describe("resolveAndValidateIps", () => {
     ).rejects.toThrow("Private IP rejected");
   });
 
+  it("IPv4-mapped IPv6 literal in hex form is rejected as private", async () => {
+    await expect(
+      resolveAndValidateIps("https://[::ffff:7f00:1]/path"),
+    ).rejects.toThrow("Private IP rejected");
+  });
+
   it("hostname resolving to public IP returns IPs", async () => {
     mockResolve4.mockResolvedValue(["93.184.216.34"]);
     mockResolve6.mockResolvedValue([]);
@@ -125,6 +131,14 @@ describe("resolveAndValidateIps", () => {
   it("hostname resolving to private IP throws", async () => {
     mockResolve4.mockResolvedValue(["192.168.1.1"]);
     mockResolve6.mockResolvedValue([]);
+    await expect(
+      resolveAndValidateIps("https://evil.example.com/path"),
+    ).rejects.toThrow("private IP");
+  });
+
+  it("hostname resolving to hex-form IPv4-mapped IPv6 loopback throws", async () => {
+    mockResolve4.mockResolvedValue([]);
+    mockResolve6.mockResolvedValue(["::ffff:7f00:1"]);
     await expect(
       resolveAndValidateIps("https://evil.example.com/path"),
     ).rejects.toThrow("private IP");

--- a/src/lib/proxy/api-route.test.ts
+++ b/src/lib/proxy/api-route.test.ts
@@ -225,6 +225,12 @@ describe("handleApiAuth — session-required + access restriction", () => {
     expect(res.status).toBe(403);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("ACCESS_DENIED");
+    expect(mockCheckAccessWithAudit).toHaveBeenCalledWith(
+      "t-1",
+      null,
+      "u-1",
+      expect.any(NextRequest),
+    );
   });
 
   it("applies access restriction to /api/mcp/authorize/consent after proxy classification", async () => {
@@ -242,6 +248,12 @@ describe("handleApiAuth — session-required + access restriction", () => {
     expect(res.status).toBe(403);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("ACCESS_DENIED");
+    expect(mockCheckAccessWithAudit).toHaveBeenCalledWith(
+      "t-1",
+      null,
+      "u-1",
+      expect.any(NextRequest),
+    );
   });
 
   it("applies access restriction to /api/mobile/authorize after proxy classification", async () => {
@@ -258,6 +270,12 @@ describe("handleApiAuth — session-required + access restriction", () => {
     expect(res.status).toBe(403);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("ACCESS_DENIED");
+    expect(mockCheckAccessWithAudit).toHaveBeenCalledWith(
+      "t-1",
+      null,
+      "u-1",
+      expect.any(NextRequest),
+    );
   });
 });
 

--- a/src/lib/proxy/api-route.test.ts
+++ b/src/lib/proxy/api-route.test.ts
@@ -174,6 +174,7 @@ describe("handleApiAuth — session-required + access restriction", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    vi.stubEnv("APP_URL", APP_ORIGIN);
     fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ user: { id: "u-1" } }), { status: 200 }),
     );
@@ -181,6 +182,7 @@ describe("handleApiAuth — session-required + access restriction", () => {
     mockResolveUserTenantId.mockResolvedValue(null);
   });
   afterEach(() => {
+    vi.unstubAllEnvs();
     fetchSpy.mockRestore();
   });
 
@@ -207,6 +209,55 @@ describe("handleApiAuth — session-required + access restriction", () => {
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("ACCESS_DENIED");
     expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("applies access restriction to /api/mcp/authorize after proxy classification", async () => {
+    mockResolveUserTenantId.mockResolvedValueOnce("t-1");
+    mockCheckAccessWithAudit.mockResolvedValueOnce({
+      allowed: false,
+      reason: "IP not in allowed CIDRs",
+    });
+    const res = await handleApiAuth(
+      makeRequest("/api/mcp/authorize", "GET", {
+        Cookie: "authjs.session-token=sess",
+      }),
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("ACCESS_DENIED");
+  });
+
+  it("applies access restriction to /api/mcp/authorize/consent after proxy classification", async () => {
+    mockResolveUserTenantId.mockResolvedValueOnce("t-1");
+    mockCheckAccessWithAudit.mockResolvedValueOnce({
+      allowed: false,
+      reason: "IP not in allowed CIDRs",
+    });
+    const res = await handleApiAuth(
+      makeRequest("/api/mcp/authorize/consent", "POST", {
+        Cookie: "authjs.session-token=sess",
+        origin: APP_ORIGIN,
+      }),
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("ACCESS_DENIED");
+  });
+
+  it("applies access restriction to /api/mobile/authorize after proxy classification", async () => {
+    mockResolveUserTenantId.mockResolvedValueOnce("t-1");
+    mockCheckAccessWithAudit.mockResolvedValueOnce({
+      allowed: false,
+      reason: "IP not in allowed CIDRs",
+    });
+    const res = await handleApiAuth(
+      makeRequest("/api/mobile/authorize", "GET", {
+        Cookie: "authjs.session-token=sess",
+      }),
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("ACCESS_DENIED");
   });
 });
 

--- a/src/lib/proxy/route-policy.test.ts
+++ b/src/lib/proxy/route-policy.test.ts
@@ -45,6 +45,9 @@ const POSITIVE_CASES: Record<RoutePolicyKind, readonly ClassifyCase[]> = {
     { pathname: "/api/folders", description: "folders prefix" },
     { pathname: "/api/notifications", description: "notifications prefix" },
     { pathname: "/api/extension/bridge-code", description: "extension non-token-exchange" },
+    { pathname: "/api/mcp/authorize", description: "mcp authorize exact path" },
+    { pathname: "/api/mcp/authorize/consent", description: "mcp consent exact path" },
+    { pathname: "/api/mobile/authorize", description: "mobile authorize exact path" },
   ],
   [ROUTE_POLICY_KIND.API_DEFAULT]: [
     { pathname: "/api/auth/session", description: "auth session" },
@@ -52,6 +55,8 @@ const POSITIVE_CASES: Record<RoutePolicyKind, readonly ClassifyCase[]> = {
     { pathname: "/api/maintenance/purge-history", description: "maintenance" },
     { pathname: "/api/scim/v2/Users", description: "scim (route-handler auth)" },
     { pathname: "/api/admin/rotate-master-key", description: "admin" },
+    { pathname: "/api/mcp/token", description: "mcp token remains route-authenticated" },
+    { pathname: "/api/mobile/token", description: "mobile token remains route-authenticated" },
   ],
   [ROUTE_POLICY_KIND.PAGE]: [
     { pathname: "/", description: "root" },

--- a/src/lib/proxy/route-policy.ts
+++ b/src/lib/proxy/route-policy.ts
@@ -73,6 +73,12 @@ const SESSION_REQUIRED_PREFIXES: readonly string[] = [
   API_PATH.WEBAUTHN,
 ];
 
+const SESSION_REQUIRED_EXACT_PATHS: readonly string[] = [
+  API_PATH.MCP_AUTHORIZE,
+  API_PATH.MCP_AUTHORIZE_CONSENT,
+  API_PATH.MOBILE_AUTHORIZE,
+];
+
 /**
  * Classify a request pathname. The CALLER is responsible for handling
  * preflight (OPTIONS method) before consulting this function — the
@@ -124,7 +130,10 @@ export function classifyRoute(pathname: string): RoutePolicy {
   // isBearerBypassRoute(pathname) directly to decide whether the
   // bypass dispatch is taken for a given request; the classification
   // stays "api-session-required" either way.
-  if (SESSION_REQUIRED_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+  if (
+    SESSION_REQUIRED_EXACT_PATHS.includes(pathname) ||
+    SESSION_REQUIRED_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+  ) {
     return { kind: ROUTE_POLICY_KIND.API_SESSION_REQUIRED };
   }
 


### PR DESCRIPTION
## Summary
External audit surfaced four security gaps in session-based credential
issuance and external network handling. This PR closes all four and
follows up on the triangulate code review.

## Audit findings addressed
1. **High** — Tenant network restrictions bypassable for `/api/mcp/*` and
   `/api/mobile/*` (proxy enforced `checkAccessRestrictionWithAudit` only
   for `API_SESSION_REQUIRED`, but these were `API_DEFAULT`).
2. **Medium-High** — Stale web sessions could mint long-lived MCP / mobile
   / extension / SCIM / SA / API-key / MCP-client credentials without
   step-up reauthentication.
3. **Medium** — SSRF via hex-form IPv4-mapped IPv6 (`::ffff:7f00:1`)
   bypassing private-IP checks.
4. **Low-Medium** — CSRF `assertOrigin` fell back to the `Host` header
   when `APP_URL` / `AUTH_URL` were unset.

## Implementation notes
- **Step-up gate** — new `requireRecentSession()` helper in
  `src/lib/auth/session/step-up.ts` (15-min `Session.createdAt` window).
  Applied to MCP / mobile authorize, MCP authorize/consent, extension
  bridge-code + token, SCIM tokens, SA tokens (POST), operator tokens,
  API keys (session-origin only), MCP clients, JIT access-request approve.
- **Generic step-up i18n** — added `sessionStepUpRequired` in
  `messages/{en,ja}/ApiErrors.json`; `SESSION_STEP_UP_REQUIRED` no longer
  inherits the operator-token-specific string.
- **Proxy classifier** — `SESSION_REQUIRED_EXACT_PATHS` now covers
  `/api/mcp/authorize`, `/api/mcp/authorize/consent`, `/api/mobile/authorize`
  so `checkAccessRestrictionWithAudit` fires.
- **CSRF fail-closed** — `assertOrigin` rejects when neither `APP_URL` nor
  `AUTH_URL` is configured (Host-fallback removed).
- **SSRF normalization** — `normalizeIp` now decodes every IPv4-mapped
  IPv6 form (uppercase / zero-padded / bracketed) to dotted IPv4 before
  CIDR comparison.
- **api-keys session-only gating** — extension-token (`auth.type === "token"`)
  and service-account flows bypass step-up; only browser sessions need it.

## Tests
- Unit tests (`vitest`): step-up + mint-not-called assertions for every
  gated route, hex-form IPv6 variants (uppercase / zero-padded / bracketed)
  in both `ip-access` and `external-http`, CSRF `x-forwarded-proto`
  fail-open negative test, proxy `mockCheckAccessWithAudit` invocation
  contract.
- New real-DB integration test
  `src/__tests__/db-integration/require-recent-session.integration.test.ts`
  pins the Auth.js v5 `Session.createdAt` contract (4 modes: fresh / stale
  / no cookie / no row).
- Manual test plan
  `docs/archive/review/security-credential-issuance-hardening-manual-test.md`
  covers Tier-2 scenarios (proxy IP gate, step-up matrix, CSRF fail-closed,
  SSRF rejection).
- Triangulate review log:
  `docs/archive/review/security-network-gates-code-review.md`.

## Test plan
- [x] `npx vitest run` — 239 tests passed (12 affected files)
- [x] `npm run test:integration -- require-recent-session.integration` — 4 passed
- [x] `npx next build` — Compiled successfully (234 static pages)
- [ ] Manual: stale-session mint attempts return `403 SESSION_STEP_UP_REQUIRED`
- [ ] Manual: cookie-bearing mutating routes return `403 INVALID_ORIGIN`
      when `APP_URL` / `AUTH_URL` unset
- [ ] Manual: external requests to `https://[::ffff:7f00:1]/` are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)