### PR TITLE
Surface failure context cleanly in pre-pr.sh

### DIFF
--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -24,27 +24,52 @@ show_failure_context() {
   local label="$1"
   local logfile="$2"
   local markers='(FAIL |Failed Tests|AssertionError|TypeError|ReferenceError|SyntaxError|^Error:|error TS[0-9]+|FORBIDDEN:|✗ |violations in)'
+  # Audit dead-letter test fixtures emit pino JSON containing "TypeError"
+  # inside the error field — exclude those structured-log lines so the
+  # marker scan surfaces real failures, not log-shaped noise.
+  local noise='"_logType":'
   local matches
+  local fail_summary_line
+  local fail_count
   local first_line
   local start_line
   local end_line
 
   printf "\n${BOLD}▸ %s${RESET}" "$label"
   if [ -n "$logfile" ]; then
-    printf "  %s\n" "$logfile"
-  else
+    printf "  %s" "$logfile"
+    # `|| true` keeps `set -e + pipefail` from killing the function when
+    # the inner greps find no match (common: not a vitest run).
+    fail_count=$({ grep -oE 'Failed Tests [0-9]+' "$logfile" || true; } \
+      | tail -1 | { grep -oE '[0-9]+' || true; })
+    if [ -n "$fail_count" ]; then
+      printf "  ${RED}(%s failed)${RESET}" "$fail_count"
+    fi
     printf "\n"
-    printf "  (no captured logfile; see output above)\n"
+  else
+    printf "\n  (no captured logfile; see output above)\n"
     return
   fi
 
-  matches=$(grep -nE "$markers" "$logfile" | head -30 || true)
+  matches=$({ grep -nE "$markers" "$logfile" || true; } \
+    | { grep -v "$noise" || true; } | head -30)
   if [ -n "$matches" ]; then
     printf "%s\n" "$matches"
-    first_line=$(printf "%s\n" "$matches" | head -1 | cut -d: -f1)
-    start_line=$(( first_line > 5 ? first_line - 5 : 1 ))
-    end_line=$(( start_line + 24 ))
     echo ""
+
+    # Prefer vitest's "Failed Tests N" summary line as the context anchor —
+    # it marks the start of the actual failure block. Fall back to the
+    # first non-noise marker for non-vitest failures (lint, build, etc.).
+    fail_summary_line=$({ grep -nE 'Failed Tests [0-9]+' "$logfile" || true; } \
+      | tail -1 | cut -d: -f1)
+    if [ -n "$fail_summary_line" ]; then
+      start_line=$(( fail_summary_line > 3 ? fail_summary_line - 3 : 1 ))
+      end_line=$(( start_line + 60 ))
+    else
+      first_line=$(printf "%s\n" "$matches" | head -1 | cut -d: -f1)
+      start_line=$(( first_line > 5 ? first_line - 5 : 1 ))
+      end_line=$(( start_line + 24 ))
+    fi
     sed -n "${start_line},${end_line}p" "$logfile"
   else
     tail -20 "$logfile"

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -11,19 +11,74 @@ RESET='\033[0m'
 passed=0
 failed=0
 failures=()
+tempfiles=()
+
+cleanup_tempfiles() {
+  local logfile
+  for logfile in "${tempfiles[@]:-}"; do
+    [ -n "$logfile" ] && [ -f "$logfile" ] && rm -f "$logfile"
+  done
+}
+
+show_failure_context() {
+  local label="$1"
+  local logfile="$2"
+  local markers='(FAIL |Failed Tests|AssertionError|TypeError|ReferenceError|SyntaxError|^Error:|error TS[0-9]+|FORBIDDEN:|✗ |violations in)'
+  local matches
+  local first_line
+  local start_line
+  local end_line
+
+  printf "\n${BOLD}▸ %s${RESET}" "$label"
+  if [ -n "$logfile" ]; then
+    printf "  %s\n" "$logfile"
+  else
+    printf "\n"
+    printf "  (no captured logfile; see output above)\n"
+    return
+  fi
+
+  matches=$(grep -nE "$markers" "$logfile" | head -30 || true)
+  if [ -n "$matches" ]; then
+    printf "%s\n" "$matches"
+    first_line=$(printf "%s\n" "$matches" | head -1 | cut -d: -f1)
+    start_line=$(( first_line > 5 ? first_line - 5 : 1 ))
+    end_line=$(( start_line + 24 ))
+    echo ""
+    sed -n "${start_line},${end_line}p" "$logfile"
+  else
+    tail -20 "$logfile"
+  fi
+}
+
+trap cleanup_tempfiles EXIT
 
 run_step() {
   local label="$1"
   shift
+  local logfile
+  local ec
+
+  logfile=$(mktemp -t "pre-pr.XXXXXX")
+  tempfiles+=("$logfile")
   printf "${BOLD}▸ %s${RESET}\n" "$label"
-  if "$@"; then
+
+  set +e
+  "$@" 2>&1 | tee "$logfile"
+  ec=${PIPESTATUS[0]}
+  set -e
+
+  if [ "$ec" -eq 0 ]; then
     printf "${GREEN}  ✓ %s${RESET}\n\n" "$label"
     passed=$((passed + 1))
   else
     printf "${RED}  ✗ %s${RESET}\n\n" "$label"
     failed=$((failed + 1))
-    failures+=("$label")
+    failures+=("$label|$logfile")
+    return
   fi
+
+  rm -f "$logfile"
 }
 
 echo ""
@@ -93,7 +148,7 @@ else
     echo "$LEAK_OUTPUT"
     echo "Install gitleaks for full-coverage scanning (brew install gitleaks / apt install gitleaks)."
     failed=$((failed + 1))
-    failures+=("Secret scan (gitleaks fallback)")
+    failures+=("Secret scan (gitleaks fallback)|")
   fi
 fi
 
@@ -107,7 +162,7 @@ if git diff --name-only main...HEAD | grep -q '^src/app/\[locale\]/admin/'; then
   if ! git diff --name-only --diff-filter=A main...HEAD | grep -q '^docs/archive/review/.*-manual-test\.md$'; then
     printf "${RED}ERROR: admin/ changes detected but no docs/archive/review/*-manual-test.md added (R35 Tier-1)${RESET}\n" >&2
     failed=$((failed + 1))
-    failures+=("Manual-test artifact gate (R35 Tier-1)")
+    failures+=("Manual-test artifact gate (R35 Tier-1)|")
   else
     printf "${GREEN}  ✓ Manual-test artifact gate (R35 Tier-1)${RESET}\n\n"
     passed=$((passed + 1))
@@ -144,8 +199,13 @@ printf "${GREEN}  Passed: %d${RESET}\n" "$passed"
 
 if [ "$failed" -gt 0 ]; then
   printf "${RED}  Failed: %d${RESET}\n" "$failed"
-  for f in "${failures[@]}"; do
-    printf "${RED}    - %s${RESET}\n" "$f"
+  for failure in "${failures[@]}"; do
+    printf "${RED}    - %s${RESET}\n" "${failure%%|*}"
+  done
+  echo ""
+  printf "${BOLD}═══ Failure Context ═══${RESET}\n"
+  for failure in "${failures[@]}"; do
+    show_failure_context "${failure%%|*}" "${failure#*|}"
   done
   echo ""
   printf "${RED}${BOLD}✗ Pre-PR checks failed. Fix the above before creating a PR.${RESET}\n"


### PR DESCRIPTION
## Summary
`scripts/pre-pr.sh` previously reported failures with only a label
(`Failed: - Test`) — the actual error was buried in hundreds of lines
of streamed output and required a separate `vitest run` to locate.
This PR surfaces the failure context inline so a developer reading
the terminal tail can immediately see what failed and where.

## Changes
- **Per-step output capture** — each `run_step` tees stdout+stderr to
  a tempfile (live stream preserved); tempfiles are cleaned up via
  `trap` on exit.
- **Failure Context section** at the end of the run lists each failed
  step with:
  - the captured logfile path
  - vitest's `Failed Tests N` count in the header
    (`▸ Test  /tmp/...  (2 failed)`)
  - a marker-based grep extract (`FAIL `, `AssertionError`, `error TS\d+`,
    `FORBIDDEN:`, `violations in`, …)
  - a 60-line context window anchored on vitest's `Failed Tests N`
    summary line (or fall back to the first marker for non-vitest
    failures)
- **JSON-log noise filter** — audit-dead-letter test fixtures emit
  pino JSON containing `"error":"TypeError: ..."`; those lines are
  filtered out so the marker scan does not push the real failure off
  the visible head.
- **`set -e + pipefail` hardening** — inner greps wrapped with
  `|| true` so the function does not exit early when a probe finds
  no match.

## Verification
Reproduced three failure shapes (test-hygiene `FORBIDDEN:`,
api-error-codes count assertion, proxy.test.ts `AssertionError`)
on this branch and confirmed:

- `Failed: 2` summary lists both failures
- Failure Context shows file:line for each AssertionError + the
  offending source code (vitest's framed snippet) without scrolling
- No JSON-log noise in the marker matches
- `(2 failed)` appears in the `▸ Test` header

`bash scripts/pre-pr.sh` on a clean tree still reports `Passed: 15` /
`✓ All pre-PR checks passed`.

## Test plan
- [x] Reproduce failure → confirm `Failure Context` shows real
      assertion + line numbers
- [x] Confirm clean run still passes
- [ ] Watch a real CI-vs-local divergence (next time pre-pr.sh
      catches a CI failure locally) to validate the diagnostic value

🤖 Generated with [Claude Code](https://claude.com/claude-code)