### PR TITLE
chore(deps): bump hono override to 4.12.18 to close 4 Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12131,9 +12131,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   },
   "overrides": {
     "qs": "6.14.2",
-    "hono": "4.12.14",
+    "hono": "4.12.18",
     "@hono/node-server": "1.19.13",
     "lodash": "4.17.23",
     "cross-spawn": "7.0.6",


### PR DESCRIPTION
## Summary
- Bump `hono` override from `4.12.14` → `4.12.18` in `package.json`
- `hono` is an indirect dependency only via `@prisma/dev` and `shadcn` dev tooling — no impact on app runtime code
- Closes 4 open Dependabot alerts (all patched in `4.12.18`)

## Alerts resolved
- `#96` (medium) — `hono/jsx` Unvalidated JSX Tag Names → HTML Injection
- `#98` (medium) — Cache Middleware ignores `Vary: Authorization` / `Vary: Cookie` → cross-user cache leakage
- `#99` (low)    — Improper validation of NumericDate claims (`exp`, `nbf`, `iat`) in `JWT verify()`
- `#100` (medium) — CSS Declaration Injection via Style Object Values in JSX SSR

## Test plan
- [x] `npm run pre-pr` — 18/18 passed (build + lint + test + license + drift)
- [x] `npm ls hono` confirms `4.12.18` resolved everywhere (deduped via override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)