### PR TITLE
fix: address OWASP Top 10 findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,13 @@ DATABASE_URL=postgresql://passwd_app:pass@localhost:5432/passwd_sso
 # Optional — falls back to DATABASE_URL if unset.
 # DCR_CLEANUP_DATABASE_URL=postgresql://passwd_dcr_cleanup_worker:pass@localhost:5432/passwd_sso
 
+# Docker Compose database passwords. These replace hardcoded credentials
+# in docker-compose.yml. Set unique values per deployment.
+# DB_SUPERUSER_PASSWORD=changeme
+# DB_APP_PASSWORD=changeme
+# DB_OUTBOX_WORKER_PASSWORD=changeme
+# DB_DCR_CLEANUP_PASSWORD=changeme
+
 
 # --- Auth ---
 

--- a/cli/src/lib/api-client.ts
+++ b/cli/src/lib/api-client.ts
@@ -16,6 +16,11 @@ let cachedClientId: string | null = null;
 
 export function setInsecure(enabled: boolean): void {
   if (enabled) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(
+        "Refusing to disable TLS verification in production mode. Set NODE_ENV=development to proceed.",
+      );
+    }
     process.stderr.write(
       "WARNING: TLS certificate verification is disabled. Your credentials may be intercepted.\n",
     );

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -26,8 +26,8 @@ services:
       # See docker-compose.yml app service for the .env vs .env.local note.
       - .env
     environment:
-      - OUTBOX_WORKER_DATABASE_URL=postgresql://passwd_outbox_worker:passwd_outbox_pass@db:5432/passwd_sso
-      - DATABASE_URL=postgresql://passwd_app:passwd_app_pass@db:5432/passwd_sso
+      - OUTBOX_WORKER_DATABASE_URL=postgresql://passwd_outbox_worker:${DB_OUTBOX_WORKER_PASSWORD:-passwd_outbox_pass}@db:5432/passwd_sso
+      - DATABASE_URL=postgresql://passwd_app:${DB_APP_PASSWORD:-passwd_app_pass}@db:5432/passwd_sso
     depends_on:
       db:
         condition: service_healthy
@@ -57,8 +57,8 @@ services:
       # See docker-compose.yml app service for the .env vs .env.local note.
       - .env
     environment:
-      - DCR_CLEANUP_DATABASE_URL=postgresql://passwd_dcr_cleanup_worker:passwd_dcr_pass@db:5432/passwd_sso
-      - DATABASE_URL=postgresql://passwd_app:passwd_app_pass@db:5432/passwd_sso
+      - DCR_CLEANUP_DATABASE_URL=postgresql://passwd_dcr_cleanup_worker:${DB_DCR_CLEANUP_PASSWORD:-passwd_dcr_pass}@db:5432/passwd_sso
+      - DATABASE_URL=postgresql://passwd_app:${DB_APP_PASSWORD:-passwd_app_pass}@db:5432/passwd_sso
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       # path through src/lib/load-env.ts.
       - .env
     environment:
-      - DATABASE_URL=postgresql://passwd_app:passwd_app_pass@db:5432/passwd_sso
+      - DATABASE_URL=postgresql://passwd_app:${DB_APP_PASSWORD:-passwd_app_pass}@db:5432/passwd_sso
       - JACKSON_URL=http://jackson:5225
       - REDIS_URL=redis://redis:6379
     depends_on:
@@ -36,9 +36,9 @@ services:
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: passwd_user
-      POSTGRES_PASSWORD: passwd_pass
+      POSTGRES_PASSWORD: ${DB_SUPERUSER_PASSWORD:-passwd_pass}
       POSTGRES_DB: passwd_sso
-      PASSWD_APP_PASSWORD: passwd_app_pass
+      PASSWD_APP_PASSWORD: ${DB_APP_PASSWORD:-passwd_app_pass}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./infra/postgres/initdb:/docker-entrypoint-initdb.d:ro
@@ -58,7 +58,7 @@ services:
       JACKSON_API_KEYS: ${JACKSON_API_KEY:?JACKSON_API_KEY is required}
       DB_ENGINE: sql
       DB_TYPE: postgres
-      DB_URL: postgresql://passwd_user:passwd_pass@db:5432/jackson
+      DB_URL: postgresql://passwd_user:${DB_SUPERUSER_PASSWORD:-passwd_pass}@db:5432/jackson
       NEXTAUTH_URL: http://localhost:5225
       EXTERNAL_URL: http://localhost:5225
       NEXTAUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET is required}
@@ -91,7 +91,7 @@ services:
     environment:
       # MIGRATION_DATABASE_URL is the canonical name for the SUPERUSER URL
       # used by Prisma CLI (see prisma.config.ts); matches .env.example.
-      - MIGRATION_DATABASE_URL=postgresql://passwd_user:passwd_pass@db:5432/passwd_sso
+      - MIGRATION_DATABASE_URL=postgresql://passwd_user:${DB_SUPERUSER_PASSWORD:-passwd_pass}@db:5432/passwd_sso
     depends_on:
       db:
         condition: service_healthy

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,6 +4,15 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { extractRequestMeta } from "@/lib/audit/audit";
 import { sessionMetaStorage } from "@/lib/auth/session/session-meta";
 import { tenantClaimStorage } from "@/lib/tenant/tenant-claim-storage";
+import { createRateLimiter } from "@/lib/security/rate-limit";
+import { extractClientIp } from "@/lib/auth/policy/ip-access";
+import { rateLimited } from "@/lib/http/api-response";
+import { MS_PER_MINUTE } from "@/lib/constants/time";
+
+const oauthCallbackLimiter = createRateLimiter({
+  windowMs: 1 * MS_PER_MINUTE,
+  max: 60,
+});
 
 export const runtime = "nodejs";
 
@@ -42,6 +51,15 @@ function withAuthBasePath<H extends RouteHandler>(handler: H): H {
 
 function withSessionMeta<H extends RouteHandler>(handler: H): H {
   const wrapped = async (request: NextRequest, ...rest: unknown[]) => {
+    // Rate limit OAuth callbacks per client IP
+    if (request.method === "POST") {
+      const ip = extractClientIp(request) ?? "unknown";
+      const rl = await oauthCallbackLimiter.check(`rl:oauth_callback:${ip}`);
+      if (!rl.allowed) {
+        return rateLimited(rl.retryAfterMs) as unknown as Response;
+      }
+    }
+
     const meta = extractRequestMeta(request);
     return sessionMetaStorage.run(meta, () =>
       tenantClaimStorage.run({ tenantClaim: null }, () =>

--- a/src/app/api/vault/setup/route.ts
+++ b/src/app/api/vault/setup/route.ts
@@ -37,6 +37,8 @@ export const runtime = "nodejs";
 
 const setupLimiter = createRateLimiter({ windowMs: 5 * MS_PER_MINUTE, max: 5 });
 
+const MIN_ENTROPY_BITS = 40;
+
 const kdfParamsSchema = z.discriminatedUnion("kdfType", [
   z.object({
     kdfType: z.literal(0),
@@ -57,6 +59,7 @@ const setupSchema = z.object({
   accountSalt: hexSalt,
   authHash: hexHash,
   verifierHash: hexHash,
+  entropyBits: z.number().int().min(MIN_ENTROPY_BITS).optional(),
   verificationArtifact: verificationArtifactSchema,
   // ECDH key pair for team E2E encryption
   ecdhPublicKey: z.string().min(1),
@@ -100,6 +103,14 @@ async function handlePOST(request: NextRequest) {
   const result = await parseBody(request, setupSchema);
   if (!result.ok) return result.response;
   const data = result.data;
+
+  // Warn if client did not provide entropy estimate
+  if (data.entropyBits == null) {
+    getLogger().warn(
+      { userId: session.user.id },
+      "vault.setup.missing_entropy_bits",
+    );
+  }
 
   // Apply KDF defaults if client omits kdfParams
   const kdfType = data.kdfParams?.kdfType ?? 0;

--- a/src/app/api/vault/unlock/route.ts
+++ b/src/app/api/vault/unlock/route.ts
@@ -9,6 +9,7 @@ import { VERIFIER_VERSION } from "@/lib/crypto/verifier-version";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { getLogger } from "@/lib/logger";
 import { checkLockout, recordFailure, resetLockout } from "@/lib/auth/policy/account-lockout";
+import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { z } from "zod";
 import { errorResponse, rateLimited, unauthorized } from "@/lib/http/api-response";
@@ -48,7 +49,9 @@ async function handlePOST(request: NextRequest) {
     });
   }
 
-  const rateKey = `rl:vault_unlock:${session.user.id}`;
+  const clientIp = extractClientIp(request);
+  const ipSuffix = clientIp ? `:${rateLimitKeyFromIp(clientIp)}` : "";
+  const rateKey = `rl:vault_unlock:${session.user.id}${ipSuffix}`;
   const rl = await unlockLimiter.check(rateKey);
   if (!rl.allowed) {
     getLogger().warn({ userId: session.user.id }, "vault.unlock.rateLimited");

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -128,12 +128,14 @@ export default {
   cookies: {
     sessionToken: {
       name: useSecureCookies
-        ? "__Secure-authjs.session-token"
+        ? process.env.NEXT_PUBLIC_BASE_PATH
+          ? "__Secure-authjs.session-token"
+          : "__Host-authjs.session-token"
         : "authjs.session-token",
       options: {
         path: `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/`,
         httpOnly: true,
-        sameSite: "lax" as const,
+        sameSite: "strict" as const,
         secure: useSecureCookies,
       },
     },

--- a/src/lib/auth/tokens/extension-token.ts
+++ b/src/lib/auth/tokens/extension-token.ts
@@ -212,7 +212,7 @@ export async function issueExtensionToken(params: {
       select: { extensionTokenIdleTimeoutMinutes: true },
     }),
   BYPASS_PURPOSE.TOKEN_LIFECYCLE);
-  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? 10080;
+  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? 4320;
   const expiresAt = new Date(now.getTime() + idleMinutes * MS_PER_MINUTE);
 
   const plaintext = generateShareToken();


### PR DESCRIPTION
> ⚠️ **REVERTED.** This PR was reverted by #467 after a post-merge review
> found **4 Critical + 13 Major** defects. The salvageable items were
> re-implemented correctly in #468; certain items were intentionally
> dropped as not worth fixing. Full review:
> [`docs/security/owasp-top10-2026-05.md`](../blob/main/docs/security/owasp-top10-2026-05.md).
>
> ### Why reverted
> - **Cookie name flip to `__Host-authjs.session-token` was not propagated to
>   3 consumer sites** (`src/lib/proxy/auth-gate.ts`,
>   `src/app/api/auth/passkey/verify/route.ts`,
>   `src/app/api/sessions/helpers.ts`) — broke authentication entirely in
>   HTTPS production deployments without `NEXT_PUBLIC_BASE_PATH` (the
>   default configuration).
> - **2 of 4 new docker-compose env vars** (`DB_OUTBOX_WORKER_PASSWORD`,
>   `DB_DCR_CLEANUP_PASSWORD`) were not wired into the postgres initdb
>   scripts; setting them affirmatively broke worker authentication
>   instead of improving security.
> - **`npm run check:env-docs` (CI gate) was failing** on main after the
>   merge (4 keys missing from `scripts/env-allowlist.ts`).
> - **Vault unlock test was a vacuous pass** — asserted the opposite of the
>   new behavior; passed only because the request fixture provided no IP.
> - **Several advertised hardenings were no-ops**: the extension-token
>   default flip was shadowed by the Prisma schema default; `entropyBits`
>   was validated but never persisted; the OAuth callback rate limit only
>   covered POSTs and missed Google OIDC's GET callback entirely; the
>   docker-compose \`:-fallback\` defaults preserved the public-known
>   passwords (fail-OPEN).
>
> ### Items dropped (not re-implemented in #468)
> - **A02 CLI TLS guard** (\`NODE_ENV=production\` check) — end-user CLI
>   invocations almost never set \`NODE_ENV\`, so the guard was ineffective
>   in practice. A URL-host-based gate would be the correct hardening.
> - **A07 vault setup \`entropyBits\` validation** — in the zero-knowledge
>   E2E-encrypted model the server cannot independently verify the
>   estimate, no client transmits it, and the field was never persisted.
>   Pure log noise without client-side enforcement.

---

## Original Summary (preserved for historical context)

Security improvements based on the OWASP Top 10 (2021) code review.

### Changes

#### 🔴 High Priority
- **A07**: Added IP-based rate limiting (60/min) to OAuth callback POSTs.
- **A02**: Guarded CLI TLS verification disable
  (\`NODE_TLS_REJECT_UNAUTHORIZED=0\`) to throw an error when
  \`NODE_ENV=production\`.
- **A05**: Replaced hardcoded DB passwords in docker-compose with
  environment variable references (\`DB_SUPERUSER_PASSWORD\`,
  \`DB_APP_PASSWORD\`, \`DB_OUTBOX_WORKER_PASSWORD\`,
  \`DB_DCR_CLEANUP_PASSWORD\`).

#### 🟡 Medium Priority
- **A07**: Changed session cookie \`sameSite\` from \`lax\` → \`strict\`. Uses
  \`__Host-\` prefix when \`NEXT_PUBLIC_BASE_PATH\` is unset.
- **A07**: Included client IP in the vault-unlock rate-limit key
  (\`rl:vault_unlock:{userId}:{ip}\`).
- **A07**: Reduced extension token default idle timeout from 7 days
  (10080 min) → 3 days (4320 min).
- **A07**: Added optional server-side \`entropyBits >= 40\` validation on
  vault setup. Warning log when omitted.

### Verification (at time of original merge)
- \`npm run lint\` ✅
- \`npx next build\` ✅
- \`npx vitest run\` (869 files, 10287 tests) ✅
- CLI TypeScript compilation ✅

Verification passed locally but did not exercise the production-only
HTTPS-no-basePath cookie path; the broken cookie propagation surfaced
only in the post-merge \`/triangulate\` review.