### PR TITLE
Revert PR #465 — OWASP Top 10 hardening (post-merge review found Critical defects)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,13 +38,6 @@ DATABASE_URL=postgresql://passwd_app:pass@localhost:5432/passwd_sso
 # Optional — falls back to DATABASE_URL if unset.
 # DCR_CLEANUP_DATABASE_URL=postgresql://passwd_dcr_cleanup_worker:pass@localhost:5432/passwd_sso
 
-# Docker Compose database passwords. These replace hardcoded credentials
-# in docker-compose.yml. Set unique values per deployment.
-# DB_SUPERUSER_PASSWORD=changeme
-# DB_APP_PASSWORD=changeme
-# DB_OUTBOX_WORKER_PASSWORD=changeme
-# DB_DCR_CLEANUP_PASSWORD=changeme
-
 
 # --- Auth ---
 

--- a/cli/src/lib/api-client.ts
+++ b/cli/src/lib/api-client.ts
@@ -16,11 +16,6 @@ let cachedClientId: string | null = null;
 
 export function setInsecure(enabled: boolean): void {
   if (enabled) {
-    if (process.env.NODE_ENV === "production") {
-      throw new Error(
-        "Refusing to disable TLS verification in production mode. Set NODE_ENV=development to proceed.",
-      );
-    }
     process.stderr.write(
       "WARNING: TLS certificate verification is disabled. Your credentials may be intercepted.\n",
     );

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -26,8 +26,8 @@ services:
       # See docker-compose.yml app service for the .env vs .env.local note.
       - .env
     environment:
-      - OUTBOX_WORKER_DATABASE_URL=postgresql://passwd_outbox_worker:${DB_OUTBOX_WORKER_PASSWORD:-passwd_outbox_pass}@db:5432/passwd_sso
-      - DATABASE_URL=postgresql://passwd_app:${DB_APP_PASSWORD:-passwd_app_pass}@db:5432/passwd_sso
+      - OUTBOX_WORKER_DATABASE_URL=postgresql://passwd_outbox_worker:passwd_outbox_pass@db:5432/passwd_sso
+      - DATABASE_URL=postgresql://passwd_app:passwd_app_pass@db:5432/passwd_sso
     depends_on:
       db:
         condition: service_healthy
@@ -57,8 +57,8 @@ services:
       # See docker-compose.yml app service for the .env vs .env.local note.
       - .env
     environment:
-      - DCR_CLEANUP_DATABASE_URL=postgresql://passwd_dcr_cleanup_worker:${DB_DCR_CLEANUP_PASSWORD:-passwd_dcr_pass}@db:5432/passwd_sso
-      - DATABASE_URL=postgresql://passwd_app:${DB_APP_PASSWORD:-passwd_app_pass}@db:5432/passwd_sso
+      - DCR_CLEANUP_DATABASE_URL=postgresql://passwd_dcr_cleanup_worker:passwd_dcr_pass@db:5432/passwd_sso
+      - DATABASE_URL=postgresql://passwd_app:passwd_app_pass@db:5432/passwd_sso
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       # path through src/lib/load-env.ts.
       - .env
     environment:
-      - DATABASE_URL=postgresql://passwd_app:${DB_APP_PASSWORD:-passwd_app_pass}@db:5432/passwd_sso
+      - DATABASE_URL=postgresql://passwd_app:passwd_app_pass@db:5432/passwd_sso
       - JACKSON_URL=http://jackson:5225
       - REDIS_URL=redis://redis:6379
     depends_on:
@@ -36,9 +36,9 @@ services:
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: passwd_user
-      POSTGRES_PASSWORD: ${DB_SUPERUSER_PASSWORD:-passwd_pass}
+      POSTGRES_PASSWORD: passwd_pass
       POSTGRES_DB: passwd_sso
-      PASSWD_APP_PASSWORD: ${DB_APP_PASSWORD:-passwd_app_pass}
+      PASSWD_APP_PASSWORD: passwd_app_pass
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./infra/postgres/initdb:/docker-entrypoint-initdb.d:ro
@@ -58,7 +58,7 @@ services:
       JACKSON_API_KEYS: ${JACKSON_API_KEY:?JACKSON_API_KEY is required}
       DB_ENGINE: sql
       DB_TYPE: postgres
-      DB_URL: postgresql://passwd_user:${DB_SUPERUSER_PASSWORD:-passwd_pass}@db:5432/jackson
+      DB_URL: postgresql://passwd_user:passwd_pass@db:5432/jackson
       NEXTAUTH_URL: http://localhost:5225
       EXTERNAL_URL: http://localhost:5225
       NEXTAUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET is required}
@@ -91,7 +91,7 @@ services:
     environment:
       # MIGRATION_DATABASE_URL is the canonical name for the SUPERUSER URL
       # used by Prisma CLI (see prisma.config.ts); matches .env.example.
-      - MIGRATION_DATABASE_URL=postgresql://passwd_user:${DB_SUPERUSER_PASSWORD:-passwd_pass}@db:5432/passwd_sso
+      - MIGRATION_DATABASE_URL=postgresql://passwd_user:passwd_pass@db:5432/passwd_sso
     depends_on:
       db:
         condition: service_healthy

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,15 +4,6 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { extractRequestMeta } from "@/lib/audit/audit";
 import { sessionMetaStorage } from "@/lib/auth/session/session-meta";
 import { tenantClaimStorage } from "@/lib/tenant/tenant-claim-storage";
-import { createRateLimiter } from "@/lib/security/rate-limit";
-import { extractClientIp } from "@/lib/auth/policy/ip-access";
-import { rateLimited } from "@/lib/http/api-response";
-import { MS_PER_MINUTE } from "@/lib/constants/time";
-
-const oauthCallbackLimiter = createRateLimiter({
-  windowMs: 1 * MS_PER_MINUTE,
-  max: 60,
-});
 
 export const runtime = "nodejs";
 
@@ -51,15 +42,6 @@ function withAuthBasePath<H extends RouteHandler>(handler: H): H {
 
 function withSessionMeta<H extends RouteHandler>(handler: H): H {
   const wrapped = async (request: NextRequest, ...rest: unknown[]) => {
-    // Rate limit OAuth callbacks per client IP
-    if (request.method === "POST") {
-      const ip = extractClientIp(request) ?? "unknown";
-      const rl = await oauthCallbackLimiter.check(`rl:oauth_callback:${ip}`);
-      if (!rl.allowed) {
-        return rateLimited(rl.retryAfterMs) as unknown as Response;
-      }
-    }
-
     const meta = extractRequestMeta(request);
     return sessionMetaStorage.run(meta, () =>
       tenantClaimStorage.run({ tenantClaim: null }, () =>

--- a/src/app/api/vault/setup/route.ts
+++ b/src/app/api/vault/setup/route.ts
@@ -37,8 +37,6 @@ export const runtime = "nodejs";
 
 const setupLimiter = createRateLimiter({ windowMs: 5 * MS_PER_MINUTE, max: 5 });
 
-const MIN_ENTROPY_BITS = 40;
-
 const kdfParamsSchema = z.discriminatedUnion("kdfType", [
   z.object({
     kdfType: z.literal(0),
@@ -59,7 +57,6 @@ const setupSchema = z.object({
   accountSalt: hexSalt,
   authHash: hexHash,
   verifierHash: hexHash,
-  entropyBits: z.number().int().min(MIN_ENTROPY_BITS).optional(),
   verificationArtifact: verificationArtifactSchema,
   // ECDH key pair for team E2E encryption
   ecdhPublicKey: z.string().min(1),
@@ -103,14 +100,6 @@ async function handlePOST(request: NextRequest) {
   const result = await parseBody(request, setupSchema);
   if (!result.ok) return result.response;
   const data = result.data;
-
-  // Warn if client did not provide entropy estimate
-  if (data.entropyBits == null) {
-    getLogger().warn(
-      { userId: session.user.id },
-      "vault.setup.missing_entropy_bits",
-    );
-  }
 
   // Apply KDF defaults if client omits kdfParams
   const kdfType = data.kdfParams?.kdfType ?? 0;

--- a/src/app/api/vault/unlock/route.ts
+++ b/src/app/api/vault/unlock/route.ts
@@ -9,7 +9,6 @@ import { VERIFIER_VERSION } from "@/lib/crypto/verifier-version";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { getLogger } from "@/lib/logger";
 import { checkLockout, recordFailure, resetLockout } from "@/lib/auth/policy/account-lockout";
-import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { z } from "zod";
 import { errorResponse, rateLimited, unauthorized } from "@/lib/http/api-response";
@@ -49,9 +48,7 @@ async function handlePOST(request: NextRequest) {
     });
   }
 
-  const clientIp = extractClientIp(request);
-  const ipSuffix = clientIp ? `:${rateLimitKeyFromIp(clientIp)}` : "";
-  const rateKey = `rl:vault_unlock:${session.user.id}${ipSuffix}`;
+  const rateKey = `rl:vault_unlock:${session.user.id}`;
   const rl = await unlockLimiter.check(rateKey);
   if (!rl.allowed) {
     getLogger().warn({ userId: session.user.id }, "vault.unlock.rateLimited");

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -128,14 +128,12 @@ export default {
   cookies: {
     sessionToken: {
       name: useSecureCookies
-        ? process.env.NEXT_PUBLIC_BASE_PATH
-          ? "__Secure-authjs.session-token"
-          : "__Host-authjs.session-token"
+        ? "__Secure-authjs.session-token"
         : "authjs.session-token",
       options: {
         path: `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/`,
         httpOnly: true,
-        sameSite: "strict" as const,
+        sameSite: "lax" as const,
         secure: useSecureCookies,
       },
     },

--- a/src/lib/auth/tokens/extension-token.ts
+++ b/src/lib/auth/tokens/extension-token.ts
@@ -212,7 +212,7 @@ export async function issueExtensionToken(params: {
       select: { extensionTokenIdleTimeoutMinutes: true },
     }),
   BYPASS_PURPOSE.TOKEN_LIFECYCLE);
-  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? 4320;
+  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? 10080;
   const expiresAt = new Date(now.getTime() + idleMinutes * MS_PER_MINUTE);
 
   const plaintext = generateShareToken();


### PR DESCRIPTION
## Summary

Reverts `#465` (commit `c14d4dfc`). Post-merge `/triangulate` review surfaced **4 Critical** and **13 Major** findings; the PR is a net regression rather than a hardening.

## Why revert instead of fix-forward?

The Critical defects span 5 files and require coordinated changes (cookie-name helper extraction across 4 sites, postgres init env-var plumbing, env-allowlist update, test rewrite). A single fix-forward PR would essentially rewrite `#465`. Reverting cleanly first lets each hardening be reintroduced in its own focused, tested PR.

## Critical findings (independently grep-verified)

1. **`__Host-authjs.session-token` not propagated to 3 consumer sites** — `auth.config.ts` issues the new cookie name but `src/lib/proxy/auth-gate.ts:30`, `src/app/api/auth/passkey/verify/route.ts:25-27`, and `src/app/api/sessions/helpers.ts:18-22` still only know `__Secure-`/plain. Production deployments with `useSecureCookies && !NEXT_PUBLIC_BASE_PATH` (the default config) cannot validate sessions → users locked out, passkey sign-in broken.

2. **Postgres init scripts ignore 2 of 4 new env vars** — `db` service env block forwards only `POSTGRES_PASSWORD` / `PASSWD_APP_PASSWORD`. `infra/postgres/initdb/02,03-*.sql` expects `PASSWD_OUTBOX_WORKER_PASSWORD` / `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` which are never set. Operator setting `DB_OUTBOX_WORKER_PASSWORD=secret` → role created with fallback `passwd_outbox_pass` → worker auth fails.

3. **`npm run check:env-docs` is RED on main** — 8 violations across `.env.example` and `docker-compose*.yml` (4 new keys missing from `scripts/env-allowlist.ts`). PR `#465` merged with the env drift CI check failing.

4. **Vault unlock test is a vacuous pass** (RT4) — `src/app/api/vault/unlock/route.test.ts:199-206` asserts `userId-only` rate key, the literal opposite of the new behavior. Passes only because the fixture provides no IP.

## Major findings (selected)

- Extension token "10080→4320" is effectively a no-op — Prisma schema default is still 10080 and `refresh/route.ts` / `tenant/policy/route.ts` still default to 10080.
- `entropyBits` is validated then discarded; no client transmits it; warn-log fires on every vault setup.
- OAuth callback rate limit covers ALL Auth.js POSTs (not just callbacks) and misses Google OIDC's GET callback entirely.
- docker-compose `:-fallback` defaults restore the public-known DB passwords (fail-OPEN); should be `\${VAR:?}` like `JACKSON_API_KEY`.
- CLI TLS guard relies on `NODE_ENV=production` which is rarely set on end-user CLI invocations.
- No tests added for any of the 7 new behaviors.
- No manual-test artifact (R35 Tier-2 obligation for auth + session + deployment changes).

Full report: \`docs/archive/review/owasp-pr465-code-review.md\` on branch \`fix/owasp-pr465-review\` (also kept in stash).

## Coordination

- **PR \`#466\` (release-please v0.4.49)** is already in **draft** with a hold comment to prevent the broken release from cutting a tag.
- After this revert merges, release-please will regenerate \`#466\` against the reverted main.

## Test plan

- [ ] `npx vitest run` — full unit test suite passes (the test that vacuously asserted userId-only key now passes legitimately again).
- [ ] `npm run check:env-docs` — drift check returns to green.
- [ ] `npx next build` — production build succeeds.
- [ ] Smoke-test login + vault unlock in dev (HTTP no basePath).

Reverts #465