### PR TITLE
OWASP Top 10 followup — A05/A07/A09 redo after PR #465 revert

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -505,14 +505,31 @@ NEXT_PUBLIC_BASE_PATH=
 # NOT read by the Next.js app — only the Jackson container consumes it.
 JACKSON_API_KEY=
 
+# Password for the passwd_user SUPERUSER DB role.
+# Used by docker-compose to bootstrap the postgres image AND by
+# the Prisma migrate / Jackson containers that need SUPERUSER access.
+# Generate with: openssl rand -hex 24
+PASSWD_SUPERUSER_PASSWORD=
+
+# Password for the passwd_app NOSUPERUSER DB role (runtime).
+# Used by docker-compose to compose DATABASE_URL for the app +
+# audit-outbox-worker + dcr-cleanup-worker containers, AND by
+# infra/postgres/initdb on first boot to create the role.
+# Generate with: openssl rand -hex 24
+PASSWD_APP_PASSWORD=
+
 # Password for the passwd_outbox_worker least-privilege DB role.
-# Consumed by infra/postgres/initdb on first boot AND by
-# scripts/set-outbox-worker-password.sh for existing clusters.
+# Used by docker-compose to wire OUTBOX_WORKER_DATABASE_URL for
+# the audit-outbox-worker container, AND by
+# infra/postgres/initdb to create the role on first boot.
+# Generate with: openssl rand -hex 24
 PASSWD_OUTBOX_WORKER_PASSWORD=
 
 # Password for the passwd_dcr_cleanup_worker least-privilege DB role.
-# Consumed by infra/postgres/initdb on first boot AND by
-# scripts/set-dcr-cleanup-worker-password.sh for existing clusters.
+# Used by docker-compose to wire DCR_CLEANUP_DATABASE_URL for
+# the dcr-cleanup-worker container, AND by
+# infra/postgres/initdb to create the role on first boot.
+# Generate with: openssl rand -hex 24
 PASSWD_DCR_CLEANUP_WORKER_PASSWORD=
 
 # Sentry auth token for source map upload during production build.

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -61,6 +61,15 @@ jobs:
       # Round 4 T19 fix: DATABASE_URL inline from service — no secrets.
       # Fork PRs run unchanged (no secret access required).
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/passwd_test
+      # Names mirror docker-compose vocabulary so the password-by-role
+      # mapping is consistent across the repo. Values match the
+      # helpers.ts integration-test fallbacks (ephemeral CI credentials,
+      # service container destroyed per run; port 5432 binds to runner
+      # localhost only).
+      PASSWD_APP_PASSWORD: passwd_app_pass
+      PASSWD_OUTBOX_WORKER_PASSWORD: passwd_outbox_pass
+      PASSWD_DCR_CLEANUP_WORKER_PASSWORD: passwd_dcr_pass
+      PASSWD_ANCHOR_PUBLISHER_PASSWORD: passwd_anchor_publisher_pass
 
     steps:
       - uses: actions/checkout@v4
@@ -102,27 +111,27 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          psql -h localhost -U postgres -d passwd_test <<'EOF'
+          psql -h localhost -U postgres -d passwd_test <<EOF
           -- Defense-in-depth: revoke default PUBLIC CREATE on the public schema
           -- (mirrors infra/postgres/initdb/02-create-app-role.sql:24).
           REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 
           -- passwd_outbox_worker: created by migration without password; set it now.
-          ALTER ROLE passwd_outbox_worker WITH LOGIN PASSWORD 'passwd_outbox_pass';
+          ALTER ROLE passwd_outbox_worker WITH LOGIN PASSWORD '${PASSWD_OUTBOX_WORKER_PASSWORD}';
 
           -- passwd_dcr_cleanup_worker: created by migration without password; set it now.
-          ALTER ROLE passwd_dcr_cleanup_worker WITH LOGIN PASSWORD 'passwd_dcr_pass';
+          ALTER ROLE passwd_dcr_cleanup_worker WITH LOGIN PASSWORD '${PASSWD_DCR_CLEANUP_WORKER_PASSWORD}';
 
           -- passwd_anchor_publisher: created by migration without password; set it now.
-          ALTER ROLE passwd_anchor_publisher WITH LOGIN PASSWORD 'passwd_anchor_publisher_pass';
+          ALTER ROLE passwd_anchor_publisher WITH LOGIN PASSWORD '${PASSWD_ANCHOR_PUBLISHER_PASSWORD}';
 
           -- passwd_app: not created by any migration (lives in initdb only).
           -- Replicate the role + grants the integration tests rely on.
-          DO $$ BEGIN
+          DO \$\$ BEGIN
             IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'passwd_app') THEN
-              CREATE ROLE passwd_app WITH LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE PASSWORD 'passwd_app_pass';
+              CREATE ROLE passwd_app WITH LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE PASSWORD '${PASSWD_APP_PASSWORD}';
             END IF;
-          END $$;
+          END \$\$;
           GRANT CONNECT ON DATABASE passwd_test TO passwd_app;
           GRANT USAGE ON SCHEMA public TO passwd_app;
           GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO passwd_app;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,10 @@ jobs:
         image: postgres:16-alpine
         env:
           POSTGRES_USER: passwd_user
+          # Literal value — must match env.PASSWD_SUPERUSER_PASSWORD below.
+          # services.<name>.env is evaluated before the job env block, so we
+          # cannot reference ${{ env.* }} here. CI is ephemeral; the literal
+          # is the same as the helpers.ts integration-test fallback.
           POSTGRES_PASSWORD: passwd_pass
           POSTGRES_DB: passwd_sso
         ports: ["5432:5432"]
@@ -423,6 +427,12 @@ jobs:
           --health-timeout 3s
           --health-retries 5
     env:
+      # CI is ephemeral; values match docker-compose dev fallbacks AND
+      # helpers.ts integration-test fallbacks. Names mirror the
+      # operator-facing vocabulary used by docker-compose so the
+      # password-by-role mapping is consistent across the repo.
+      PASSWD_SUPERUSER_PASSWORD: passwd_pass
+      PASSWD_APP_PASSWORD: passwd_app_pass
       DATABASE_URL: "postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso"
     steps:
       - uses: actions/checkout@v4
@@ -439,9 +449,9 @@ jobs:
 
       - name: Create app role and grant privileges
         run: |
-          psql postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso <<'SQL'
+          psql "postgresql://passwd_user:${PASSWD_SUPERUSER_PASSWORD}@localhost:5432/passwd_sso" <<SQL
             CREATE ROLE passwd_app WITH LOGIN NOSUPERUSER NOBYPASSRLS
-              NOCREATEDB NOCREATEROLE PASSWORD 'passwd_app_pass';
+              NOCREATEDB NOCREATEROLE PASSWORD '${PASSWD_APP_PASSWORD}';
             REVOKE CREATE ON SCHEMA public FROM PUBLIC;
             GRANT CONNECT ON DATABASE passwd_sso TO passwd_app;
             GRANT USAGE ON SCHEMA public TO passwd_app;
@@ -456,34 +466,34 @@ jobs:
       - name: Run migrations as SUPERUSER
         run: npx prisma migrate deploy
         env:
-          MIGRATION_DATABASE_URL: "postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso"
+          MIGRATION_DATABASE_URL: "postgresql://passwd_user:${{ env.PASSWD_SUPERUSER_PASSWORD }}@localhost:5432/passwd_sso"
 
       - name: Re-grant and seed test data
-        run: psql -v ON_ERROR_STOP=1 postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso -f scripts/rls-smoke-seed.sql
+        run: psql -v ON_ERROR_STOP=1 "postgresql://passwd_user:${PASSWD_SUPERUSER_PASSWORD}@localhost:5432/passwd_sso" -f scripts/rls-smoke-seed.sql
 
       - name: Verify RLS enforcement
         run: |
-          psql -v ON_ERROR_STOP=1 postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso -f scripts/rls-smoke-verify.sql
+          psql -v ON_ERROR_STOP=1 "postgresql://passwd_app:${PASSWD_APP_PASSWORD}@localhost:5432/passwd_sso" -f scripts/rls-smoke-verify.sql
           echo "✓ RLS enforcement verified: passwd_app cannot see seeded rows"
 
       - name: Cross-tenant seed (SUPERUSER)
-        run: psql -v ON_ERROR_STOP=1 postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso -f scripts/rls-cross-tenant-seed.sql
+        run: psql -v ON_ERROR_STOP=1 "postgresql://passwd_user:${PASSWD_SUPERUSER_PASSWORD}@localhost:5432/passwd_sso" -f scripts/rls-cross-tenant-seed.sql
 
       - name: Cross-tenant coverage check (SUPERUSER)
-        run: psql -v ON_ERROR_STOP=1 postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso -f scripts/rls-cross-tenant-coverage.sql
+        run: psql -v ON_ERROR_STOP=1 "postgresql://passwd_user:${PASSWD_SUPERUSER_PASSWORD}@localhost:5432/passwd_sso" -f scripts/rls-cross-tenant-coverage.sql
 
       - name: Cross-tenant RLS predicate verify (NOSUPERUSER)
         run: |
           EXPECTED_TABLES=$(awk 'NF && $1 !~ /^#/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print}' scripts/rls-cross-tenant-tables.manifest | paste -sd,)
           psql -v ON_ERROR_STOP=1 -v expected_tables="$EXPECTED_TABLES" \
-            postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso \
+            "postgresql://passwd_app:${PASSWD_APP_PASSWORD}@localhost:5432/passwd_sso" \
             -f scripts/rls-cross-tenant-verify.sql
 
       - name: Cross-tenant verify negative test (gate self-check)
         run: bash scripts/rls-cross-tenant-negative-test.sh
         env:
-          MIGRATION_DATABASE_URL: "postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso"
-          APP_DATABASE_URL: "postgresql://passwd_app:passwd_app_pass@localhost:5432/passwd_sso"
+          MIGRATION_DATABASE_URL: "postgresql://passwd_user:${{ env.PASSWD_SUPERUSER_PASSWORD }}@localhost:5432/passwd_sso"
+          APP_DATABASE_URL: "postgresql://passwd_app:${{ env.PASSWD_APP_PASSWORD }}@localhost:5432/passwd_sso"
   # ─── Container Scan (Trivy) ─────────────────────────────────
   container-scan:
     name: "Trivy: Container image scan"

--- a/README.ja.md
+++ b/README.ja.md
@@ -194,7 +194,7 @@ npm run docker:down
 
 > **古いクローンからの移行**: 過去の運用で `.env.local` のみ作成しているリポジトリは、`mv .env.local .env` を実行して Docker Compose が自動読込できる canonical なファイルに移してください。`npm run init:env` は legacy `.env.local` を検出すると 1 度だけ NOTE で同じことを案内します。
 
-`.env.example` の末尾には **External / Build-time** セクションがあり、Next.js アプリは読まないが docker-compose / 本番ビルド / プロビジョニングスクリプトが必要とする変数 (`JACKSON_API_KEY` (Jackson コンテナ用), `PASSWD_OUTBOX_WORKER_PASSWORD` (worker DB ロール用), `SENTRY_AUTH_TOKEN` (ソースマップアップロード用), `NEXT_DEV_ALLOWED_ORIGINS` (dev サーバ用)) が並びます。`npm run init:env` は Zod 宣言済み変数と並んで、これらも同一の `.env` に書き出します。
+`.env.example` の末尾には **External / Build-time** セクションがあり、Next.js アプリは読まないが docker-compose / 本番ビルド / プロビジョニングスクリプトが必要とする変数 (`JACKSON_API_KEY` (Jackson コンテナ用), `PASSWD_SUPERUSER_PASSWORD` / `PASSWD_APP_PASSWORD` / `PASSWD_OUTBOX_WORKER_PASSWORD` / `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` (DB ロール用), `SENTRY_AUTH_TOKEN` (ソースマップアップロード用), `NEXT_DEV_ALLOWED_ORIGINS` (dev サーバ用)) が並びます。`npm run init:env` は Zod 宣言済み変数と並んで、これらも同一の `.env` に書き出します。
 
 主要な変数:
 
@@ -252,7 +252,10 @@ npm run docker:down
 | `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` | `EMAIL_PROVIDER=smtp` の場合に必須 |
 | `DB_POOL_MAX`, `DB_POOL_*` | （任意）PostgreSQL コネクションプール調整 |
 | `OUTBOX_WORKER_DATABASE_URL` | （任意）ワーカー DB 接続（`passwd_outbox_worker` ロール）。`npm run worker:audit-outbox` に必要 |
-| `PASSWD_OUTBOX_WORKER_PASSWORD` | （任意）ワーカー DB ロールのパスワード。initdb 初回起動時に使用。既存クラスタでは `scripts/set-outbox-worker-password.sh` を使用 |
+| `PASSWD_SUPERUSER_PASSWORD` | （`docker compose` 必須）`passwd_user` SUPERUSER ロールのパスワード。未設定だと docker-compose が起動失敗。アップグレード手順は [Docker Setup](docs/setup/docker/en.md) 参照 |
+| `PASSWD_APP_PASSWORD` | （`docker compose` 必須）`passwd_app` ランタイムロールのパスワード。未設定だと docker-compose が起動失敗 |
+| `PASSWD_OUTBOX_WORKER_PASSWORD` | （`docker compose` 必須）`passwd_outbox_worker` DB ロールのパスワード。initdb 初回起動時に使用。既存クラスタでは `scripts/set-outbox-worker-password.sh` を使用 |
+| `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` | （`docker compose` 必須）`passwd_dcr_cleanup_worker` DB ロールのパスワード。initdb 初回起動時に使用。既存クラスタでは `scripts/set-dcr-cleanup-worker-password.sh` を使用 |
 | `OUTBOX_BATCH_SIZE`, `OUTBOX_*` | （任意）監査アウトボックスワーカーの調整。詳細は `.env.example` 参照 |
 | `NEXT_DEV_ALLOWED_ORIGINS` | （任意）dev サーバー向け許可オリジン（例: Tailscale ホスト名） |
 | `NEXT_PUBLIC_CHROME_STORE_URL` | （任意）ブラウザ拡張配布用 Chrome Web Store URL |

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ npm run docker:down   # stops and tears down
 
 > **Migration from older clones**: if your repo predates this change you may have a `.env.local` and no `.env`. Run `mv .env.local .env` so Docker Compose can find it without `--env-file`. Re-running `npm run init:env` warns when both files exist.
 
-The bottom of `.env.example` has a dedicated **External / Build-time** section listing variables that are NOT read by the Next.js app but ARE required by docker-compose, provisioning scripts, or the production build (`JACKSON_API_KEY` for the Jackson container, `PASSWD_OUTBOX_WORKER_PASSWORD` for the worker DB role, `SENTRY_AUTH_TOKEN` for source-map upload, `NEXT_DEV_ALLOWED_ORIGINS` for the dev server). `npm run init:env` prompts for these alongside the Zod-declared vars and writes them into the same `.env`.
+The bottom of `.env.example` has a dedicated **External / Build-time** section listing variables that are NOT read by the Next.js app but ARE required by docker-compose, provisioning scripts, or the production build (`JACKSON_API_KEY` for the Jackson container, `PASSWD_SUPERUSER_PASSWORD` / `PASSWD_APP_PASSWORD` / `PASSWD_OUTBOX_WORKER_PASSWORD` / `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` for the DB roles, `SENTRY_AUTH_TOKEN` for source-map upload, `NEXT_DEV_ALLOWED_ORIGINS` for the dev server). `npm run init:env` prompts for these alongside the Zod-declared vars and writes them into the same `.env`.
 
 Key variables:
 
@@ -253,7 +253,10 @@ Key variables:
 | `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` | Required when `EMAIL_PROVIDER=smtp` |
 | `DB_POOL_MAX`, `DB_POOL_*` | (Optional) PostgreSQL connection pool tuning |
 | `OUTBOX_WORKER_DATABASE_URL` | (Optional) Worker DB connection (`passwd_outbox_worker` role). Required for `npm run worker:audit-outbox` |
-| `PASSWD_OUTBOX_WORKER_PASSWORD` | (Optional) Worker DB role password. Used by initdb on first boot; for existing clusters use `scripts/set-outbox-worker-password.sh` |
+| `PASSWD_SUPERUSER_PASSWORD` | (Required for `docker compose`) Password for the `passwd_user` SUPERUSER DB role. docker-compose fails to start if unset. See [Docker Setup](docs/setup/docker/en.md) for upgrade notes. |
+| `PASSWD_APP_PASSWORD` | (Required for `docker compose`) Password for the `passwd_app` runtime DB role. docker-compose fails to start if unset. |
+| `PASSWD_OUTBOX_WORKER_PASSWORD` | (Required for `docker compose`) Password for the `passwd_outbox_worker` DB role. Used by initdb on first boot; for existing clusters use `scripts/set-outbox-worker-password.sh` |
+| `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` | (Required for `docker compose`) Password for the `passwd_dcr_cleanup_worker` DB role. Used by initdb on first boot; for existing clusters use `scripts/set-dcr-cleanup-worker-password.sh` |
 | `OUTBOX_BATCH_SIZE`, `OUTBOX_*` | (Optional) Audit outbox worker tuning. See `.env.example` for all options |
 | `NEXT_DEV_ALLOWED_ORIGINS` | (Optional) Allowed origins for dev server (e.g., Tailscale hostname) |
 | `NEXT_PUBLIC_CHROME_STORE_URL` | (Optional) Chrome Web Store URL for extension distribution |

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -26,8 +26,8 @@ services:
       # See docker-compose.yml app service for the .env vs .env.local note.
       - .env
     environment:
-      - OUTBOX_WORKER_DATABASE_URL=postgresql://passwd_outbox_worker:passwd_outbox_pass@db:5432/passwd_sso
-      - DATABASE_URL=postgresql://passwd_app:passwd_app_pass@db:5432/passwd_sso
+      - OUTBOX_WORKER_DATABASE_URL=postgresql://passwd_outbox_worker:${PASSWD_OUTBOX_WORKER_PASSWORD:?PASSWD_OUTBOX_WORKER_PASSWORD is required}@db:5432/passwd_sso
+      - DATABASE_URL=postgresql://passwd_app:${PASSWD_APP_PASSWORD:?PASSWD_APP_PASSWORD is required}@db:5432/passwd_sso
     depends_on:
       db:
         condition: service_healthy
@@ -57,8 +57,8 @@ services:
       # See docker-compose.yml app service for the .env vs .env.local note.
       - .env
     environment:
-      - DCR_CLEANUP_DATABASE_URL=postgresql://passwd_dcr_cleanup_worker:passwd_dcr_pass@db:5432/passwd_sso
-      - DATABASE_URL=postgresql://passwd_app:passwd_app_pass@db:5432/passwd_sso
+      - DCR_CLEANUP_DATABASE_URL=postgresql://passwd_dcr_cleanup_worker:${PASSWD_DCR_CLEANUP_WORKER_PASSWORD:?PASSWD_DCR_CLEANUP_WORKER_PASSWORD is required}@db:5432/passwd_sso
+      - DATABASE_URL=postgresql://passwd_app:${PASSWD_APP_PASSWORD:?PASSWD_APP_PASSWORD is required}@db:5432/passwd_sso
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       # path through src/lib/load-env.ts.
       - .env
     environment:
-      - DATABASE_URL=postgresql://passwd_app:passwd_app_pass@db:5432/passwd_sso
+      - DATABASE_URL=postgresql://passwd_app:${PASSWD_APP_PASSWORD:?PASSWD_APP_PASSWORD is required}@db:5432/passwd_sso
       - JACKSON_URL=http://jackson:5225
       - REDIS_URL=redis://redis:6379
     depends_on:
@@ -35,10 +35,16 @@ services:
   db:
     image: postgres:16-alpine
     environment:
+      # SUPERUSER role for migrations + Jackson; bootstraps the postgres image.
       POSTGRES_USER: passwd_user
-      POSTGRES_PASSWORD: passwd_pass
+      POSTGRES_PASSWORD: ${PASSWD_SUPERUSER_PASSWORD:?PASSWD_SUPERUSER_PASSWORD is required}
       POSTGRES_DB: passwd_sso
-      PASSWD_APP_PASSWORD: passwd_app_pass
+      # Forwarded to infra/postgres/initdb/* scripts via \getenv so the
+      # least-privilege roles are created with the operator-supplied
+      # passwords on first boot.
+      PASSWD_APP_PASSWORD: ${PASSWD_APP_PASSWORD:?PASSWD_APP_PASSWORD is required}
+      PASSWD_OUTBOX_WORKER_PASSWORD: ${PASSWD_OUTBOX_WORKER_PASSWORD:?PASSWD_OUTBOX_WORKER_PASSWORD is required}
+      PASSWD_DCR_CLEANUP_WORKER_PASSWORD: ${PASSWD_DCR_CLEANUP_WORKER_PASSWORD:?PASSWD_DCR_CLEANUP_WORKER_PASSWORD is required}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./infra/postgres/initdb:/docker-entrypoint-initdb.d:ro
@@ -58,7 +64,7 @@ services:
       JACKSON_API_KEYS: ${JACKSON_API_KEY:?JACKSON_API_KEY is required}
       DB_ENGINE: sql
       DB_TYPE: postgres
-      DB_URL: postgresql://passwd_user:passwd_pass@db:5432/jackson
+      DB_URL: postgresql://passwd_user:${PASSWD_SUPERUSER_PASSWORD:?PASSWD_SUPERUSER_PASSWORD is required}@db:5432/jackson
       NEXTAUTH_URL: http://localhost:5225
       EXTERNAL_URL: http://localhost:5225
       NEXTAUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET is required}
@@ -91,7 +97,7 @@ services:
     environment:
       # MIGRATION_DATABASE_URL is the canonical name for the SUPERUSER URL
       # used by Prisma CLI (see prisma.config.ts); matches .env.example.
-      - MIGRATION_DATABASE_URL=postgresql://passwd_user:passwd_pass@db:5432/passwd_sso
+      - MIGRATION_DATABASE_URL=postgresql://passwd_user:${PASSWD_SUPERUSER_PASSWORD:?PASSWD_SUPERUSER_PASSWORD is required}@db:5432/passwd_sso
     depends_on:
       db:
         condition: service_healthy

--- a/docs/security/owasp-top10-2026-05.md
+++ b/docs/security/owasp-top10-2026-05.md
@@ -1,0 +1,225 @@
+# OWASP Top 10 Code Review
+
+Reviewed commit: `main` (2026-05-15)
+Original fix attempt: PR #465 — REVERTED via PR #467 after a post-merge
+review surfaced 4 Critical + 13 Major defects (see
+`docs/archive/review/owasp-pr465-code-review.md`).
+
+Fixes applied (followup branch `fix/owasp-pr465-followup`):
+- A09: Redis fallback log throttle 30s → 5s, centralized as the constant
+  `REDIS_FALLBACK_LOG_THROTTLE_MS` and applied to all 4 sites that share
+  the pattern (was 1/4 in the reverted commit).
+- A09: passkey enforcement data fetch failure → warn-log
+  (`auth.session.passkey_data_fetch_failed`) with userId + tenantId,
+  replacing the silent catch.
+- A09: audit-outbox `recordError` → `sanitizeErrorForStorage` applied
+  to `audit_outbox.last_error` and the dead-letter `lastError` metadata,
+  reusing the helper already used by `audit-delivery` (R17 gap closed).
+- A07: OAuth/SAML callback rate limit scoped to `/api/auth/callback/*`
+  (both GET and POST), null-IP skips with warn-log instead of collapsing
+  to a shared "unknown" bucket.
+- A07: session cookie name selection centralized in
+  `src/lib/auth/session/cookie-name.ts` (`getSessionCookieName` +
+  `ALL_KNOWN_SESSION_COOKIE_NAMES`); 5 consumer sites migrated; cookie
+  `sameSite=strict` retained from PR #465.
+- A07: vault unlock rate key reverted to per-user-only (the lockout
+  layer is the per-user defense; IP suffix made the limiter strictly
+  weaker). Test rewritten to defeat the prior vacuous-pass.
+- A07: extension token idle fallback extracted as the constant
+  `DEFAULT_EXTENSION_IDLE_MINUTES = 10080` and unified across the 3
+  fallback sites + test fixtures. Value kept at 10080 pending a proper
+  schema-default + tenant-backfill design (separate effort).
+- A05: docker-compose DB role passwords migrated to fail-closed
+  `\${PASSWD_*_PASSWORD:?...}` (the public fallback literals are
+  removed); db service env block now forwards
+  `PASSWD_OUTBOX_WORKER_PASSWORD` + `PASSWD_DCR_CLEANUP_WORKER_PASSWORD`
+  to initdb so operator overrides actually take effect; env-allowlist
+  + docs + CI workflows updated to match.
+
+Items NOT taken from PR #465 (assessed and dropped):
+- A02 CLI TLS guard (NODE_ENV-based): the guard rarely fires on
+  end-user CLIs that don't set NODE_ENV — a URL-host-based gate would
+  be the correct hardening, deferred.
+- A07 vault setup `entropyBits` validation: in a zero-knowledge
+  E2E-encrypted vault the server cannot independently verify the
+  estimate, and no client transmits it today. Pure log noise without
+  client-side enforcement — deferred until a client computes the
+  estimate AND the value is persisted/audited.
+
+## A01: Broken Access Control (承認の欠如) — 🟢 良好
+
+### 強み
+
+- **ルートポリシー分類 (`route-policy.ts`)** — パス名から `RoutePolicy` 判別共用体への純関数マッピング。`ROUTE_POLICY_KIND` 定数で文字列リテラルを定数参照に置き換え、typo をコンパイルエラーにする設計。
+- **プロキシ層でのセッション検証** — `api-session-required` に分類されたルートは `getSessionInfo()` で Redis キャッシュ経由のセッション検証を実施し、無効な場合は 401 を返す。
+- **トークンプレフィックスディスパッチ (`auth-or-token.ts`)** — Bearer トークンをプレフィックスで振り分け (`api_` → API キー, `sa_` → サービスアカウント, `mcp_` → MCP トークン)。未知の既知プレフィックス (`scim_` など) は明示的に `null` を返し、拡張トークンへのフォールスルーを防止。
+- **`checkAuth()` + `hasUserId()` 型ガード** — `userId: string` を保証。`service_account` / `mcp_token` で userId が null の場合は自動拒否 (`check-auth.ts:75-80`)。
+- **Bearer-bypass 明示的列挙 (`cors-gate.ts`)** — `EXTENSION_TOKEN_ROUTES` でバイパス可能なルートを列挙。extension token エンドポイントは完全一致のみ許可し、子パス経由のバイパスを防止。
+- **テナント分離** — RLS (Row-Level Security) を全テナントスコープテーブルに適用。`withBypassRls()` は CI スクリプトで 77 ファイルの allowlist 管理。
+- **スコープベースアクセス** — サービスアカウント・API キー・MCP トークンでスコープによる細粒度アクセス制御。スコープ不足は `{ type: "scope_insufficient" }` を返す。
+
+### 気になる点
+
+- `api-default` 分類のルート (`/api/admin/*`, `/api/scim/*`, `/api/auth/*`, `/api/internal/*`, `/api/maintenance/*`) はプロキシ層で `Cache-Control` のみ設定し、認証は各ルートハンドラに委譲。これは設計ドキュメントに明記された意図的選択だが、ハンドラ作成時のヒューマンエラーに備えたテストやスクリプトによる静的検証があるとより堅牢。
+- `/api/admin/rotate-master-key` のような管理エンドポイントがルートハンドラの Bearer トークン検証のみに依存。もしハンドラの auth 実装を欠くと無防備になる (CLAUDE.md に明記済み)。
+
+## A02: Cryptographic Failures (暗号化の欠如) — 🟢 良好
+
+### 強み
+
+- **クライアントサイド暗号化** — 全パスワードデータは AES-256-GCM でブラウザ側で暗号化。サーバーは平文を保持しない (`crypto-client.ts`)。
+- **エントリごとの独立暗号化** — `encryptedBlob` (全データ) と `encryptedOverview` (一覧表示用) はそれぞれ独立した IV (12 bytes) + authTag (16 bytes) を持つ。
+- **鍵階層のドメイン分離** — マスターパスフレーズ → PBKDF2 (600k iterations) → wrapping key → 256-bit secret key → HKDF (暗号鍵 + 認証鍵) と段階的に導出。
+- **サーバーサイド暗号化** — `crypto-server.ts` で共有リンクマスターキー管理。`SHARE_MASTER_KEY_V1` 〜 `V100` のキーローテーション対応。
+- **HMAC によるキャッシュキー導出** — `hashSessionToken()` で HKDF 派生 HMAC-SHA256 キーを使用。Redis に生のセッショントークンは保存しない。
+- **TLS + HSTS** — HTTPS 時 (`isHttps`) は `max-age=63072000; includeSubDomains; preload` の HSTS ヘッダーを設定。
+
+### 気になる点
+
+- 特になし。暗号プリミティブの選択と鍵管理は堅牢。
+
+## A03: Injection (インジェクション) — 🟢 良好
+
+### 強み
+
+- **Prisma ORM** — 全 DB アクセスは ORM 経由のパラメーター化クエリ。生 SQL は存在しない。
+- **Zod 4 スキーマ検証** — `src/lib/validations/` 配下で全ユーザー入力 (entry, tag, folder, team, api-key, send, share, service-account, emergency-access など) を検証。
+- **CSP strict-dynamic** — Production では `'strict-dynamic'` + nonce + `'wasm-unsafe-eval'` でインラインスクリプト XSS を防止。Eval はブロック。
+- **X-Content-Type-Options: nosniff** + **X-Frame-Options: DENY**。
+
+### 気になる点
+
+- Dev モードの CSP は `'unsafe-inline'` + `'unsafe-eval'` — HMR と Turbopack dev overlay に必須。Production では強制的に strict モードになるガード (`csp-builder.ts:12`) が入っている。
+
+## A04: Insecure Design (安全でない設計) — 🟢 良好
+
+### 強み
+
+- **多層防御アーキテクチャ**: プロキシ層 (session/IP/CSRF/CSP/CORS) → ルートハンドラ層 (認可/バリデーション/監査) の 2 層構造。
+- **属性ベース CSRF (`csrf-gate.ts`)**: リクエスト属性 (cookie + mutating method) で発火 — パス分類に依存しないため、新ルート追加時の CSRF 漏れを構造的に防止。
+- **セッションキャッシュ 3 状態管理**: 正 (`SessionInfo`) / 負 (`{ valid: false }`) / 墓石 (`{ tombstone: true }`) の 3 状態を Redis に保存。墓石を最優先でチェックすることで populate-after-invalidate 競合を防止 (`session-cache.ts:131`)。
+- **アウトボックス監査パターン**: 監査イベントはビジネスロジックと同じ DB トランザクション内で `audit_outbox` に書き込み、別ワーカーが非同期で `audit_logs` に書き出す。メイン処理のパフォーマンスに影響を与えず、トランザクションの atomicity を保証。
+- **レート制限**: Redis パイプライン (INCR + PEXPIRE NX + PTTL を 1 ラウンドトリップ) + メモリフォールバック。
+- **IP アクセス制限**: CIDR 許可リスト + Tailscale WhoIs 検証の 2 段階 (Edge → Node)。
+- **リフレッシュトークンローテーション**: 交換ごとに新トークンペア、古いアクセストークンをアトミック失効、リプレイ検出でファミリー全体を失効。
+
+### 気になる点
+
+- **テナントポリシーキャッシュ (access-restriction.ts)**: `Map<string, PolicyCacheEntry>` の容量上限 1,000。Eviction 発生時のレイテンシ急増を避けるため Redis キャッシュへの移行を推奨。
+- **CSP ビルダーのモジュール初期化時評価**: `csp-builder.ts` の `_isProd`, `_cspMode` は import 時に評価される。`NODE_ENV` が実行時変化することはないが、テストパターンによっては注意が必要。
+
+## A05: Security Misconfiguration (セキュリティ設定の誤り) — 🟢 良好
+
+### 強み
+
+- **環境変数 Zod スキーマ (`env-schema.ts`)**: `superRefine()` で production 時に必須チェック — `AUTH_SECRET` (32文字以上), `AUTH_URL`, `VERIFIER_PEPPER_KEY`, `REDIS_URL`, 最低 1 認証プロバイダ, `EMAIL_PROVIDER=smtp` 時は `SMTP_HOST` 必須など。
+- **CSP_MODE の production 強制**: `csp-builder.ts:12` — production では `CSP_MODE=dev` を無視し、常に strict モード。設定ミスによる CSP 弱体化を防止。
+- **データベースロール分離**: `passwd_app` (NOSUPERUSER, NOBYPASSRLS), `passwd_user` (SUPERUSER, マイグレーション), `passwd_outbox_worker` (最小権限)。
+- **Docker マルチステージビルド**: 本番イメージは最小構成。
+- **パッケージ overrides**: 既知脆弱性パッケージを修正バージョンに固定 (`qs`, `hono`, `lodash`, `cross-spawn`, `undici`, `nodemailer`, `effect`, `uuid`, `postcss`)。
+
+### 気になる点
+
+- 特になし。
+
+## A06: Vulnerable and Outdated Components (脆弱性のあるコンポーネント) — 🟢 良好
+
+### 強み
+
+- `package.json` の `overrides` で既知脆弱性対応済み。
+- `.github` に Dependabot/Renovate 設定あり、自動更新。
+- Prisma 7 (latest), next-auth 5.0.0-beta.30, Next.js 16.2.6 (latest)。
+- TypeScript 5.9 による静的型チェック。
+- `vitest` + `playwright` によるテスト網羅。
+
+### 気になる点
+
+- 依存関係の総数が多い (数百パッケージ)。攻撃面を広げないための SBOM 生成や `npm audit` の CI 定期実行があると望ましい。
+- `next-auth` beta.30 — ベータ版のため breaking change やセキュリティ修正のリリース間隔に注意。
+
+## A07: Identification and Authentication Failures (識別と認証の失敗) — 🟢 良好
+
+### 強み
+
+- **Auth.js v5 (database session)**: 5 つの認証プロバイダ — Google OIDC, SAML Jackson (Docker 別コンテナ), Passkey (WebAuthn), Magic Link (nodemailer)。
+- **パスキー強制ポリシー**: テナントレベルで `requirePasskey` + `passkeyGracePeriodDays` を設定可能。`session` コールバックでユーザーのパスキー有無を検証。
+- **Magic Link SSO バイパス防止** (`auth.ts:271-287`): 既存の SSO テナントユーザーは nodemailer プロバイダからのサインインを拒否。
+- **サービスアカウント (`sa_` prefix)**: スコープベースのアクセス制御 + JIT アクセスリクエストフロー。
+- **MCP トークン (`mcp_` prefix)**: OAuth 2.1 Authorization Code + PKCE + DCR (RFC 7591)。
+- **ブートストラップテナント移行** (`auth.ts:81-207`): シングルユーザーのブートストラップテナントから IdP 管理テナントへのデータ移行 + セッションキャッシュの墓石書き込み。15 のテナントスコープテーブルをカバー。
+
+### 気になる点
+
+- **passkey 強制データ取得の fail-open — TRACKED FOLLOWUP** (`auth.ts:370`): `session` コールバック内の passkey データ取得は warn-log (`auth.session.passkey_data_fetch_failed`) を出すようになり可観測性は確保された (commit `9f5a3a9b` / A09-2)。**しかし catch 後の挙動は依然 fail-OPEN** で、`requirePasskey=true` のテナントで Redis/DB 障害時に passkey 無しユーザーが通り抜ける可能性は残存。これは A09 (logging) ではなく **A04 (Insecure Design) / A07 (Auth Failures)** の finding で、session callback の挙動変更は本番セッション全体に影響するため別 PR でスケジューリング。検討対象の代替案:
+  - **(a) fail-closed**: 取得失敗時は `requirePasskey=true` 扱いで sign-in を拒否。可用性が下がる (Redis blip で全 session 拒否) ため、tenant policy fetch を別キャッシュレイヤ (last-known-good) で支える設計が前提。
+  - **(b) last-known-good caching**: tenant policy を short-TTL Redis cache に置き、catch では cache の値を再利用して新規取得失敗を吸収する。
+  - **(c) outage-mode gate**: 取得失敗が短時間に大量発生したらシステム全体を一時的に sign-in 拒否モードに切り替える circuit-breaker。
+- **IdP クレームの制御文字除去** (`src/lib/tenant-claim.ts`): C0/C1/DEL 制御文字を除去。ただし、同一テナント内で見た目が異なるが正規化後に同一となる Unicode 文字列によるテナントなりすましの検討が明示的にされていない。
+
+## A08: Software and Data Integrity Failures (ソフトウェアとデータの整合性の欠如) — 🟢 良好
+
+### 強み
+
+- **CSP 'strict-dynamic' + nonce**: 信頼されたスクリプトのみ実行。XSS による改ざん耐性。
+- **DCR 未クレームクライアント期限切れ**: 24 時間で自動削除 (`dcr-cleanup-worker.ts`)。
+- **リフレッシュトークンローテーション + リプレイ検出**: ファミリー単位の失効。
+- **audit anchor publisher**: 監査ログハッシュチェーンによる改ざん検出 + 外部 WORM ストレージ連携インターフェース。
+- **Imports/Object.assign の代わりに NextResponse のクローン**: `applyCorsHeaders()` では response object を直接変更せず、ヘッダー設定のみ行うため既存レスポンスの改変ミスを防止。
+
+### 気になる点
+
+- **Webhook URL の SSRF 検証**: `isSsrfSafeWebhookUrl()` は FQDN のみ許可し IP リテラルをブロックするが、DNS rebinding 攻撃の対策はなし (管理者設定の webhook という文脈で許容範囲)。
+
+## A09: Security Logging and Monitoring Failures (セキュリティログと監視の欠如) — 🟡 改善余地あり
+
+### 強み
+
+- **包括的監査ログ**: 認証成功/失敗、アクセス拒否、管理者操作、パスキー操作、Impersonation などを全て `audit_outbox` → `audit_logs` で記録。
+- **actorType 列挙**: HUMAN / SERVICE_ACCOUNT / MCP_AGENT / SYSTEM で機械 Identity と人間を区別。
+- **トランザクション atomicity**: ビジネスロジックと同一トランザクション内で outbox 書き込み — コミット成功時に監査ログの消失を防止。
+- **CSP report-uri / Reporting-Endpoints**: CSP 違反を収集可能。
+- **pino 構造化ロガー**: 全ログは JSON 形式で出力。
+- **rate limit logging**: `createThrottledErrorLogger` で Redis 障害時のログ flood を防止。
+- **Imports audit chain**: SHA-256 ハッシュチェーンで `audit_logs` の改ざんを検出。
+
+### 気になる点
+
+- **`: 30_000 ms の throttle 閾値が長い**: Redis 障害時、最初のエラーから 30 秒間その後のエラーがログに出力されない。セッション検証・レート制限・ポリシーキャッシュの 3 機能が同時に Redis に依存するため、障害復旧時期の特定が困難。閾値を 5,000 ms 程度に短縮するとフォレンジック性が向上。
+- **`auth.ts:370` の空 catch**: passkey 強制ポリシー取得失敗時にエラーログも監査ログも出力されない。「Non-critical」とコメントにあるが、この失敗によりすべてのユーザーが passkey なしでログイン可能になるテナントがある場合、監査証跡が失われる。最低限 pino warn の出力を推奨。
+- **`lastError` のメタデータブロックリスト未適用** (`audit-outbox-worker.ts`): `AUDIT_OUTBOX_DEAD_LETTER` の metadata に 256 文字の `lastError` を含めるが、ブロックリスト (認証情報などが含まれる可能性) への対応が未実施。既存の `METADATA_BLOCKLIST` と同じ sanitization を適用すべき。
+
+## A10: Server-Side Request Forgery (SSRF) — 🟢 良好
+
+### 強み
+
+- **Webhook URL 検証 (`url-validation.ts`)**: `isSsrfSafeWebhookUrl()` で以下をブロック:
+  - HTTPS 以外のプロトコル
+  - localhost, 127.0.0.1, ::1, 0.0.0.0
+  - `.local`, `.internal` TLD
+  - 全 IP アドレスリテラル (IPv4/v6) — FQDN のみ許可
+- **プロキシ自己参照 fetch**: proxy → `/api/internal/audit-emit` の内部 fetch は自己参照。URL は `request.url` から導出されるため SSRF に使えない。
+- **外部プロバイダ URL**: Google OIDC / SAML Jackson のエンドポイントは環境変数からのみ設定されユーザー入力ではない。
+- **blob storage**: S3/Azure/GCS エンドポイントも env 経由 — 信頼済み。
+
+### 気になる点
+
+- **DNS rebinding**: FQDN を許可する設計のため、管理者が信頼できない FQDN を webhook に設定した場合の DNS rebinding は防げない。ただし webhook URL は管理者権限での設定であり、脅威モデルの範囲外と判断。
+
+## 総評
+
+全 10 カテゴリ中 9 カテゴリで 🟢 (良好)。A09 (ロギングと監視) のみ 🟡 (改善余地あり)。
+
+| カテゴリ | 評価 | 主な強み | 改善候補 |
+|----------|------|----------|----------|
+| A01 Broken Access Control | 🟢 | `route-policy.ts` 純関数分類、トークンプレフィックスディスパッチ、`hasUserId()` 型ガード | `api-default` ルートのテスト網羅 |
+| A02 Cryptographic Failures | 🟢 | AES-256-GCM + PBKDF2-600K + HKDF、クライアントサイド暗号化、キーローテーション | — |
+| A03 Injection | 🟢 | Prisma ORM + Zod 検証 + CSP strict-dynamic | — |
+| A04 Insecure Design | 🟢 | 属性ベース CSRF、セッションキャッシュ 3 状態管理、アウトボックス監査 | ポリシーキャッシュの Redis 移行 |
+| A05 Security Misconfiguration | 🟢 | env Zod スキーマ + superRefine、production CSP 強制、DB ロール分離 | — |
+| A06 Vulnerable Components | 🟢 | overrides 対応済み、Prisma 7 + Next.js 16 | SBOM CI, `npm audit` CI |
+| A07 Auth Failures | 🟢 | 5 プロバイダ、パスキー強制、SSO バイパス防止、ブートストラップ移行 | passkey 取得失敗の fail-closed 化 |
+| A08 Integrity Failures | 🟢 | CSP nonce、DCR 期限切れ、トークンローテーション、監査チェーン | — |
+| A09 Logging & Monitoring | 🟡 | アウトボックス監査、actorType 列挙、audit chain | throttle 閾値短縮、空 catch のログ出力、`lastError` sanitization |
+| A10 SSRF | 🟢 | Webhook URL 検証 (HTTPS+FQDN, IP ブロック), 自己参照 fetch | — |
+
+全体としてセキュリティ設計は高水準。特に属性ベースの CSRF ガード (`csrf-gate.ts`) とセッションキャッシュの墓石パターン (`session-cache.ts`) は優れた設計判断である。改善優先度としては A09 の 3 点が実装容易で効果が高い。

--- a/docs/setup/docker/en.md
+++ b/docs/setup/docker/en.md
@@ -123,7 +123,34 @@ Set the following values:
 | `SHARE_MASTER_KEY` | Master key for organization vault encryption (256-bit hex) | `openssl rand -hex 32` |
 | `REDIS_URL` | Redis URL — REQUIRED in production (Zod schema enforces this for `NODE_ENV=production`). Backs the session cache (tombstone-based revocation propagation, PR #407) and shared rate limiting. Single-instance dev may omit it; the app falls back to in-memory caches with a logged warning. Set `HEALTH_REDIS_REQUIRED=true` to fail readiness probes when Redis is unreachable. | e.g., `redis://host:6379` |
 | `JACKSON_API_KEY` | API key for the SAML Jackson container — mapped to `JACKSON_API_KEYS` inside Jackson. Not in the Zod schema (external service credential). | `openssl rand -hex 24` |
-| `PASSWD_OUTBOX_WORKER_PASSWORD` | Password for the `passwd_outbox_worker` DB role (set during `initdb`). Required when running the audit-outbox-worker. Use `scripts/set-outbox-worker-password.sh` to rotate on existing clusters. | `openssl rand -hex 24` |
+| `PASSWD_SUPERUSER_PASSWORD` | Password for the `passwd_user` SUPERUSER DB role. Used by `docker-compose` (POSTGRES_PASSWORD bootstrap, jackson DB_URL, migrate URL). Container fails to start if unset. | `openssl rand -hex 24` |
+| `PASSWD_APP_PASSWORD` | Password for the `passwd_app` NOSUPERUSER DB role (Next.js runtime). Used by `docker-compose` for `DATABASE_URL` AND forwarded to `initdb` for role creation. Container fails to start if unset. | `openssl rand -hex 24` |
+| `PASSWD_OUTBOX_WORKER_PASSWORD` | Password for the `passwd_outbox_worker` DB role (set during `initdb`). Used by `docker-compose` to wire `OUTBOX_WORKER_DATABASE_URL`. Required when running the audit-outbox-worker. Use `scripts/set-outbox-worker-password.sh` to rotate on existing clusters. | `openssl rand -hex 24` |
+| `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` | Password for the `passwd_dcr_cleanup_worker` DB role (set during `initdb`). Used by `docker-compose` to wire `DCR_CLEANUP_DATABASE_URL`. Required when running the dcr-cleanup-worker. Use `scripts/set-dcr-cleanup-worker-password.sh` to rotate on existing clusters. | `openssl rand -hex 24` |
+
+> **Upgrading from a pre-2026-05-16 deployment**: `docker-compose.yml` and
+> `docker-compose.override.yml` previously fell back to the public default
+> passwords (`passwd_pass`, `passwd_app_pass`, `passwd_outbox_pass`,
+> `passwd_dcr_pass`) when `PASSWD_*_PASSWORD` env vars were unset. The
+> defaults are now removed (fail-closed); `docker compose up` will refuse
+> to start if any of the four `PASSWD_*_PASSWORD` env vars is unset.
+>
+> Two migration paths for existing clusters:
+>
+> 1. **Preserve existing DB roles** (zero DB change): set each var in
+>    `.env` to the value the role was originally created with:
+>    ```sh
+>    PASSWD_SUPERUSER_PASSWORD=passwd_pass
+>    PASSWD_APP_PASSWORD=passwd_app_pass
+>    PASSWD_OUTBOX_WORKER_PASSWORD=passwd_outbox_pass
+>    PASSWD_DCR_CLEANUP_WORKER_PASSWORD=passwd_dcr_pass
+>    ```
+> 2. **Rotate to new passwords** (recommended): generate fresh values with
+>    `openssl rand -hex 24`, write them to `.env`, then `ALTER ROLE` each
+>    role to match. For the worker roles use the dedicated rotation scripts
+>    `scripts/set-outbox-worker-password.sh` and
+>    `scripts/set-dcr-cleanup-worker-password.sh`.
+>
 | `BLOB_BACKEND` | Attachment storage backend | `db`, `s3`, `azure`, or `gcs` |
 | `AWS_REGION`, `S3_ATTACHMENTS_BUCKET` | Required if `BLOB_BACKEND=s3` | e.g., `ap-northeast-1`, bucket name |
 | `AZURE_STORAGE_ACCOUNT`, `AZURE_BLOB_CONTAINER` | Required if `BLOB_BACKEND=azure` | Azure Storage account / container |

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -46,7 +46,7 @@ export async function injectSession(
       // Diverging from production lets a future cross-site E2E test pass
       // while production would have dropped the cookie.
       sameSite: "Strict",
-      ...(isHttps && { secure: true }),
+      ...(isSecureCookieFromAuthUrl() && { secure: true }),
     },
   ]);
 }

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -5,12 +5,14 @@
  * matching the naming convention in src/proxy.ts.
  */
 import type { BrowserContext } from "@playwright/test";
-import { isHttps } from "../../src/lib/url-helpers";
-import { getSessionCookieName as resolveSessionCookieName } from "../../src/lib/auth/session/cookie-name";
+import {
+  getSessionCookieName as resolveSessionCookieName,
+  isSecureCookieFromAuthUrl,
+} from "../../src/lib/auth/session/cookie-name";
 
 function getSessionCookieName(): string {
   return resolveSessionCookieName({
-    useSecureCookies: isHttps,
+    useSecureCookies: isSecureCookieFromAuthUrl(),
     basePath: process.env.NEXT_PUBLIC_BASE_PATH,
   });
 }
@@ -40,7 +42,10 @@ export async function injectSession(
       name: getSessionCookieName(),
       value: sessionToken,
       url: getCookieUrl(),
-      sameSite: "Lax",
+      // Match the production session cookie attribute set in auth.config.ts.
+      // Diverging from production lets a future cross-site E2E test pass
+      // while production would have dropped the cookie.
+      sameSite: "Strict",
       ...(isHttps && { secure: true }),
     },
   ]);

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -6,11 +6,13 @@
  */
 import type { BrowserContext } from "@playwright/test";
 import { isHttps } from "../../src/lib/url-helpers";
+import { getSessionCookieName as resolveSessionCookieName } from "../../src/lib/auth/session/cookie-name";
 
 function getSessionCookieName(): string {
-  return isHttps
-    ? "__Secure-authjs.session-token"
-    : "authjs.session-token";
+  return resolveSessionCookieName({
+    useSecureCookies: isHttps,
+    basePath: process.env.NEXT_PUBLIC_BASE_PATH,
+  });
 }
 
 /**

--- a/scripts/env-allowlist.ts
+++ b/scripts/env-allowlist.ts
@@ -94,40 +94,96 @@ export const ALLOWLIST: readonly AllowlistEntry[] = [
   },
   {
     type: "literal",
-    key: "PASSWD_OUTBOX_WORKER_PASSWORD",
+    key: "PASSWD_SUPERUSER_PASSWORD",
     justification:
-      "Consumed only by the one-shot provisioning script that sets the passwd_outbox_worker DB role password. " +
-      "Not read by any running process.",
+      "Password for the passwd_user SUPERUSER DB role. Consumed by docker-compose (POSTGRES_PASSWORD on db service, " +
+      "and DB URLs for jackson + migrate services). Not read by the Next.js app — runtime uses the passwd_app role.",
     consumers: [
-      "scripts/set-outbox-worker-password.sh",
+      "docker-compose.yml",
       "infra/postgres/initdb",
     ],
-    reviewedAt: "2026-04-24",
+    reviewedAt: "2026-05-16",
+    includeInExample: true,
+    requiredForConsumer: true,
+    description:
+      "Password for the passwd_user SUPERUSER DB role.\n" +
+      "Used by docker-compose to bootstrap the postgres image AND by\n" +
+      "the Prisma migrate / Jackson containers that need SUPERUSER access.\n" +
+      "Generate with: openssl rand -hex 24",
+    secret: true,
+  },
+  {
+    type: "literal",
+    key: "PASSWD_APP_PASSWORD",
+    justification:
+      "Password for the passwd_app NOSUPERUSER DB role used by the Next.js app at runtime. " +
+      "Consumed by docker-compose (PASSWD_APP_PASSWORD env on db service for initdb AND DATABASE_URL " +
+      "on app + worker services). Not read directly by any Next.js TS code — Prisma client receives the " +
+      "already-assembled DATABASE_URL.",
+    consumers: [
+      "docker-compose.yml",
+      "docker-compose.override.yml",
+      "infra/postgres/initdb",
+    ],
+    reviewedAt: "2026-05-16",
+    includeInExample: true,
+    requiredForConsumer: true,
+    description:
+      "Password for the passwd_app NOSUPERUSER DB role (runtime).\n" +
+      "Used by docker-compose to compose DATABASE_URL for the app +\n" +
+      "audit-outbox-worker + dcr-cleanup-worker containers, AND by\n" +
+      "infra/postgres/initdb on first boot to create the role.\n" +
+      "Generate with: openssl rand -hex 24",
+    secret: true,
+  },
+  {
+    type: "literal",
+    key: "PASSWD_OUTBOX_WORKER_PASSWORD",
+    justification:
+      "Password for the passwd_outbox_worker NOSUPERUSER DB role used by the audit-outbox drain worker. " +
+      "Consumed by docker-compose (PASSWD_OUTBOX_WORKER_PASSWORD env on db service for initdb AND " +
+      "OUTBOX_WORKER_DATABASE_URL on the worker service) AND by " +
+      "scripts/set-outbox-worker-password.sh for existing clusters.",
+    consumers: [
+      "scripts/set-outbox-worker-password.sh",
+      "docker-compose.yml",
+      "docker-compose.override.yml",
+      "infra/postgres/initdb",
+    ],
+    reviewedAt: "2026-05-16",
     includeInExample: true,
     requiredForConsumer: true,
     description:
       "Password for the passwd_outbox_worker least-privilege DB role.\n" +
-      "Consumed by infra/postgres/initdb on first boot AND by\n" +
-      "scripts/set-outbox-worker-password.sh for existing clusters.",
+      "Used by docker-compose to wire OUTBOX_WORKER_DATABASE_URL for\n" +
+      "the audit-outbox-worker container, AND by\n" +
+      "infra/postgres/initdb to create the role on first boot.\n" +
+      "Generate with: openssl rand -hex 24",
     secret: true,
   },
   {
     type: "literal",
     key: "PASSWD_DCR_CLEANUP_WORKER_PASSWORD",
     justification:
-      "Consumed only by the one-shot provisioning script that sets the passwd_dcr_cleanup_worker DB role password. " +
-      "Not read by any running process.",
+      "Password for the passwd_dcr_cleanup_worker NOSUPERUSER DB role used by the DCR cleanup worker. " +
+      "Consumed by docker-compose (PASSWD_DCR_CLEANUP_WORKER_PASSWORD env on db service for initdb AND " +
+      "DCR_CLEANUP_DATABASE_URL on the worker service) AND by " +
+      "scripts/set-dcr-cleanup-worker-password.sh for existing clusters.",
     consumers: [
       "scripts/set-dcr-cleanup-worker-password.sh",
+      "docker-compose.yml",
+      "docker-compose.override.yml",
       "infra/postgres/initdb",
     ],
-    reviewedAt: "2026-04-28",
+    reviewedAt: "2026-05-16",
     includeInExample: true,
     requiredForConsumer: true,
     description:
       "Password for the passwd_dcr_cleanup_worker least-privilege DB role.\n" +
-      "Consumed by infra/postgres/initdb on first boot AND by\n" +
-      "scripts/set-dcr-cleanup-worker-password.sh for existing clusters.",
+      "Used by docker-compose to wire DCR_CLEANUP_DATABASE_URL for\n" +
+      "the dcr-cleanup-worker container, AND by\n" +
+      "infra/postgres/initdb to create the role on first boot.\n" +
+      "Generate with: openssl rand -hex 24",
     secret: true,
   },
   {

--- a/src/__tests__/api/tenant/tenant-policy.test.ts
+++ b/src/__tests__/api/tenant/tenant-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DEFAULT_SESSION } from "../../helpers/mock-auth";
 import { createRequest, parseResponse } from "../../helpers/request-builder";
+import { DEFAULT_EXTENSION_IDLE_MINUTES } from "@/lib/constants/auth/extension-token";
 
 const {
   mockAuth, mockRequireTenantPermission, mockUserFindUnique, mockTenantUpdate,
@@ -88,7 +89,7 @@ const FULL_POLICY_RESPONSE = {
   maxConcurrentSessions: null,
   sessionIdleTimeoutMinutes: 480,
   sessionAbsoluteTimeoutMinutes: 43200,
-  extensionTokenIdleTimeoutMinutes: 10080,
+  extensionTokenIdleTimeoutMinutes: DEFAULT_EXTENSION_IDLE_MINUTES,
   extensionTokenAbsoluteTimeoutMinutes: 43200,
   vaultAutoLockMinutes: null,
   allowedCidrs: [],
@@ -331,7 +332,7 @@ describe("PATCH /api/tenant/policy", () => {
       tailscaleEnabled: false,
       tailscaleTailnet: null,
       sessionIdleTimeoutMinutes: 10,
-      extensionTokenIdleTimeoutMinutes: 10080,
+      extensionTokenIdleTimeoutMinutes: DEFAULT_EXTENSION_IDLE_MINUTES,
       vaultAutoLockMinutes: null,
     });
     const req = createRequest("PATCH", "http://localhost/api/tenant/policy", {

--- a/src/__tests__/api/tenant/tenant-policy.test.ts
+++ b/src/__tests__/api/tenant/tenant-policy.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DEFAULT_SESSION } from "../../helpers/mock-auth";
 import { createRequest, parseResponse } from "../../helpers/request-builder";
-import { DEFAULT_EXTENSION_IDLE_MINUTES } from "@/lib/constants/auth/extension-token";
+import { EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT } from "@/lib/validations/common";
 
 const {
   mockAuth, mockRequireTenantPermission, mockUserFindUnique, mockTenantUpdate,
@@ -89,7 +89,7 @@ const FULL_POLICY_RESPONSE = {
   maxConcurrentSessions: null,
   sessionIdleTimeoutMinutes: 480,
   sessionAbsoluteTimeoutMinutes: 43200,
-  extensionTokenIdleTimeoutMinutes: DEFAULT_EXTENSION_IDLE_MINUTES,
+  extensionTokenIdleTimeoutMinutes: EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT,
   extensionTokenAbsoluteTimeoutMinutes: 43200,
   vaultAutoLockMinutes: null,
   allowedCidrs: [],
@@ -332,7 +332,7 @@ describe("PATCH /api/tenant/policy", () => {
       tailscaleEnabled: false,
       tailscaleTailnet: null,
       sessionIdleTimeoutMinutes: 10,
-      extensionTokenIdleTimeoutMinutes: DEFAULT_EXTENSION_IDLE_MINUTES,
+      extensionTokenIdleTimeoutMinutes: EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT,
       vaultAutoLockMinutes: null,
     });
     const req = createRequest("PATCH", "http://localhost/api/tenant/policy", {

--- a/src/__tests__/db-integration/session-timeout.integration.test.ts
+++ b/src/__tests__/db-integration/session-timeout.integration.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 import { randomUUID } from "node:crypto";
-import { DEFAULT_EXTENSION_IDLE_MINUTES } from "@/lib/constants/auth/extension-token";
+import { EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT } from "@/lib/validations/common";
 import {
   createTestContext,
   setBypassRlsGucs,
@@ -56,7 +56,7 @@ describe("session timeout — integration", () => {
       // Drift detector: Prisma schema default MUST match the application
       // fallback constant. If the schema default changes, update the
       // constant in lockstep — this assertion will catch the divergence.
-      expect(row.extensionTokenIdleTimeoutMinutes).toBe(DEFAULT_EXTENSION_IDLE_MINUTES);
+      expect(row.extensionTokenIdleTimeoutMinutes).toBe(EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT);
       expect(row.extensionTokenAbsoluteTimeoutMinutes).toBe(43200);
     });
 

--- a/src/__tests__/db-integration/session-timeout.integration.test.ts
+++ b/src/__tests__/db-integration/session-timeout.integration.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 import { randomUUID } from "node:crypto";
+import { DEFAULT_EXTENSION_IDLE_MINUTES } from "@/lib/constants/auth/extension-token";
 import {
   createTestContext,
   setBypassRlsGucs,
@@ -52,7 +53,10 @@ describe("session timeout — integration", () => {
       });
       expect(row.sessionIdleTimeoutMinutes).toBe(480);
       expect(row.sessionAbsoluteTimeoutMinutes).toBe(43200);
-      expect(row.extensionTokenIdleTimeoutMinutes).toBe(10080);
+      // Drift detector: Prisma schema default MUST match the application
+      // fallback constant. If the schema default changes, update the
+      // constant in lockstep — this assertion will catch the divergence.
+      expect(row.extensionTokenIdleTimeoutMinutes).toBe(DEFAULT_EXTENSION_IDLE_MINUTES);
       expect(row.extensionTokenAbsoluteTimeoutMinutes).toBe(43200);
     });
 

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -560,6 +560,29 @@ describe("extractSessionToken", () => {
     const cookie = "authjs.session-token=tok%2Fwith%3Dspecial%2Bchars; other=x";
     expect(_extractSessionToken(cookie)).toBe("tok%2Fwith%3Dspecial%2Bchars");
   });
+
+  // __Host-authjs.session-token is the cookie name Auth.js emits when
+  // useSecureCookies is true AND NEXT_PUBLIC_BASE_PATH is unset — the
+  // typical HTTPS-at-root production deployment. The post-merge review
+  // of PR #465 found the proxy's names array did NOT include __Host-,
+  // so every authenticated request in such deployments was treated as
+  // anonymous. These tests pin the contract.
+  it("extracts __Host-authjs.session-token value", () => {
+    const cookie = "__Host-authjs.session-token=host-token-abc";
+    expect(_extractSessionToken(cookie)).toBe("host-token-abc");
+  });
+
+  it("prefers __Host- when both __Host- and __Secure- are present", () => {
+    const cookie =
+      "__Host-authjs.session-token=host-tok; __Secure-authjs.session-token=secure-tok; authjs.session-token=plain-tok";
+    expect(_extractSessionToken(cookie)).toBe("host-tok");
+  });
+
+  it("falls through to __Secure- when only __Secure- + plain are present", () => {
+    const cookie =
+      "__Secure-authjs.session-token=secure-tok; authjs.session-token=plain-tok";
+    expect(_extractSessionToken(cookie)).toBe("secure-tok");
+  });
 });
 
 describe("proxy — access restriction", () => {

--- a/src/app/api/auth/[...nextauth]/route.test.ts
+++ b/src/app/api/auth/[...nextauth]/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // Mock dependencies so route.ts can be imported without side-effects
@@ -17,6 +17,26 @@ vi.mock("@/lib/audit/audit", () => ({
 }));
 vi.mock("@/lib/auth/session/session-meta", () => ({
   sessionMetaStorage: { run: (_meta: unknown, fn: () => unknown) => fn() },
+}));
+
+// Controllable rate-limit mock used by the callback rate-limit tests.
+const mockRateLimitCheck = vi.fn();
+vi.mock("@/lib/security/rate-limit", () => ({
+  createRateLimiter: () => ({ check: mockRateLimitCheck }),
+}));
+
+const mockExtractClientIp = vi.fn();
+vi.mock("@/lib/auth/policy/ip-access", () => ({
+  extractClientIp: (req: NextRequest) => mockExtractClientIp(req),
+  // Identity transform so the assertion against the rate-key value is
+  // readable — the actual IPv6→/64 normalization is owned by
+  // ip-access.test.ts (do not duplicate that contract here).
+  rateLimitKeyFromIp: (ip: string) => ip,
+}));
+
+const mockLoggerWarn = vi.fn();
+vi.mock("@/lib/logger", () => ({
+  getLogger: () => ({ warn: mockLoggerWarn, error: vi.fn(), info: vi.fn() }),
 }));
 
 describe("withAuthBasePath", () => {
@@ -138,5 +158,154 @@ describe("withAuthBasePath", () => {
     const patchedUrl = new URL(inner.mock.calls[0][0].url);
     expect(patchedUrl.pathname).toBe("/passwd-sso/api/auth/signin");
     expect(patchedUrl.searchParams.get("callbackUrl")).toBe("/dashboard");
+  });
+});
+
+describe("isCallbackRoute", () => {
+  it("returns true for OAuth provider callback paths", async () => {
+    const { _isCallbackRoute } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    expect(_isCallbackRoute("/api/auth/callback/google")).toBe(true);
+    expect(_isCallbackRoute("/api/auth/callback/credentials")).toBe(true);
+    expect(_isCallbackRoute("/api/auth/callback/passkey")).toBe(true);
+  });
+
+  it("returns false for non-callback Auth.js paths", async () => {
+    const { _isCallbackRoute } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    expect(_isCallbackRoute("/api/auth/signin")).toBe(false);
+    expect(_isCallbackRoute("/api/auth/signin/google")).toBe(false);
+    expect(_isCallbackRoute("/api/auth/signout")).toBe(false);
+    expect(_isCallbackRoute("/api/auth/csrf")).toBe(false);
+    expect(_isCallbackRoute("/api/auth/session")).toBe(false);
+    expect(_isCallbackRoute("/api/auth/providers")).toBe(false);
+  });
+
+  it("requires the trailing slash to prevent prefix collision", async () => {
+    const { _isCallbackRoute } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    expect(_isCallbackRoute("/api/auth/callbackz")).toBe(false);
+    expect(_isCallbackRoute("/api/auth/callback")).toBe(false);
+  });
+});
+
+describe("withCallbackRateLimit", () => {
+  beforeEach(() => {
+    mockRateLimitCheck.mockReset();
+    mockExtractClientIp.mockReset();
+    mockLoggerWarn.mockReset();
+    mockRateLimitCheck.mockResolvedValue({ allowed: true });
+    mockExtractClientIp.mockReturnValue("203.0.113.5");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  function makeReq(pathname: string, method: "GET" | "POST" = "POST") {
+    return new NextRequest(`http://localhost:3000${pathname}`, { method });
+  }
+
+  it("skips the limiter and forwards the request when the path is not a callback", async () => {
+    const { _withCallbackRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn(async () => new Response("ok"));
+    const wrapped = _withCallbackRateLimit(inner);
+
+    const res = await wrapped(makeReq("/api/auth/signin"));
+
+    expect(res.status).toBe(200);
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(mockExtractClientIp).not.toHaveBeenCalled();
+    expect(mockRateLimitCheck).not.toHaveBeenCalled();
+  });
+
+  it("invokes the limiter with `rl:auth_callback:<ip>` and forwards on allowed", async () => {
+    const { _withCallbackRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn(async () => new Response("ok"));
+    const wrapped = _withCallbackRateLimit(inner);
+
+    const res = await wrapped(makeReq("/api/auth/callback/google", "GET"));
+
+    expect(res.status).toBe(200);
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(mockRateLimitCheck).toHaveBeenCalledTimes(1);
+    expect(mockRateLimitCheck).toHaveBeenCalledWith("rl:auth_callback:203.0.113.5");
+  });
+
+  it("returns 429 with Retry-After when the limiter denies (does NOT invoke handler)", async () => {
+    mockRateLimitCheck.mockResolvedValue({ allowed: false, retryAfterMs: 1500 });
+    const { _withCallbackRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn(async () => new Response("ok"));
+    const wrapped = _withCallbackRateLimit(inner);
+
+    const res = await wrapped(makeReq("/api/auth/callback/google", "POST"));
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("2"); // ceil(1500/1000)
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it("covers both GET and POST callbacks (Google OIDC GET is not bypassed)", async () => {
+    const { _withCallbackRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn(async () => new Response("ok"));
+    const wrapped = _withCallbackRateLimit(inner);
+
+    await wrapped(makeReq("/api/auth/callback/google", "GET"));
+    await wrapped(makeReq("/api/auth/callback/saml", "POST"));
+
+    expect(mockRateLimitCheck).toHaveBeenCalledTimes(2);
+    expect(inner).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips the limiter and warn-logs when client IP cannot be determined", async () => {
+    mockExtractClientIp.mockReturnValue(null);
+    const { _withCallbackRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn(async () => new Response("ok"));
+    const wrapped = _withCallbackRateLimit(inner);
+
+    const res = await wrapped(makeReq("/api/auth/callback/google", "GET"));
+
+    expect(res.status).toBe(200);
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(mockRateLimitCheck).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: "/api/auth/callback/google",
+        method: "GET",
+      }),
+      "auth.callback.rate_limit_skipped_unknown_ip",
+    );
+  });
+
+  it("partitions limiter buckets by client IP", async () => {
+    const { _withCallbackRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn(async () => new Response("ok"));
+    const wrapped = _withCallbackRateLimit(inner);
+
+    mockExtractClientIp.mockReturnValueOnce("203.0.113.5");
+    await wrapped(makeReq("/api/auth/callback/google"));
+    mockExtractClientIp.mockReturnValueOnce("198.51.100.7");
+    await wrapped(makeReq("/api/auth/callback/google"));
+
+    expect(mockRateLimitCheck.mock.calls.map((c) => c[0])).toEqual([
+      "rl:auth_callback:203.0.113.5",
+      "rl:auth_callback:198.51.100.7",
+    ]);
   });
 });

--- a/src/app/api/auth/[...nextauth]/route.test.ts
+++ b/src/app/api/auth/[...nextauth]/route.test.ts
@@ -282,12 +282,14 @@ describe("withCallbackRateLimit", () => {
     expect(res.status).toBe(200);
     expect(inner).toHaveBeenCalledTimes(1);
     expect(mockRateLimitCheck).not.toHaveBeenCalled();
+    // The wrapper delegates to checkIpRateLimit, which logs with the
+    // shared message + { pathname, scope } shape (see ip-rate-limit.ts).
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: "/api/auth/callback/google",
-        method: "GET",
+        scope: "auth_callback",
       }),
-      "auth.callback.rate_limit_skipped_unknown_ip",
+      "rate_limit_skipped_unknown_ip",
     );
   });
 

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -5,10 +5,10 @@ import { extractRequestMeta } from "@/lib/audit/audit";
 import { sessionMetaStorage } from "@/lib/auth/session/session-meta";
 import { tenantClaimStorage } from "@/lib/tenant/tenant-claim-storage";
 import { createRateLimiter } from "@/lib/security/rate-limit";
-import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { extractClientIp } from "@/lib/auth/policy/ip-access";
+import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
 import { rateLimited } from "@/lib/http/api-response";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
-import { getLogger } from "@/lib/logger";
 
 export const runtime = "nodejs";
 
@@ -67,13 +67,10 @@ function withSessionMeta<H extends RouteHandler>(handler: H): H {
 //     enterprise NAT egresses with bursty sign-out storms used to trip
 //     the previous unconditional POST gate.
 //
-// Per-client-IP keying via the shared rateLimitKeyFromIp (IPv6 → /64).
-// When the client IP cannot be determined (no socket IP and
-// TRUST_PROXY_HEADERS unset), the limiter is skipped with a warn log —
-// fail-open here is preferred over PR #465's shared "unknown" bucket,
-// which collapsed every IP-less request into a single global 60/min
-// cap and let one bad actor DoS legitimate callbacks elsewhere on the
-// fleet.
+// Per-client-IP keying delegated to the shared `checkIpRateLimit` helper
+// (`src/lib/security/ip-rate-limit.ts`) — single source of truth for the
+// IPv6 → /64 normalization and the null-IP fail-open + warn-log decision
+// that 9 other route handlers also use.
 const CALLBACK_RATE_LIMIT_WINDOW_MS = 1 * MS_PER_MINUTE;
 const CALLBACK_RATE_LIMIT_MAX = 60;
 
@@ -91,17 +88,12 @@ function withCallbackRateLimit<H extends RouteHandler>(handler: H): H {
     if (!isCallbackRoute(request.nextUrl.pathname)) {
       return handler(request, ...rest);
     }
-    const ip = extractClientIp(request);
-    if (ip == null) {
-      getLogger().warn(
-        { pathname: request.nextUrl.pathname, method: request.method },
-        "auth.callback.rate_limit_skipped_unknown_ip",
-      );
-      return handler(request, ...rest);
-    }
-    const rl = await callbackRateLimiter.check(
-      `rl:auth_callback:${rateLimitKeyFromIp(ip)}`,
-    );
+    const rl = await checkIpRateLimit({
+      ip: extractClientIp(request),
+      pathname: request.nextUrl.pathname,
+      scope: "auth_callback",
+      limiter: callbackRateLimiter,
+    });
     if (!rl.allowed) {
       return rateLimited(rl.retryAfterMs) as unknown as Response;
     }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,6 +4,11 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { extractRequestMeta } from "@/lib/audit/audit";
 import { sessionMetaStorage } from "@/lib/auth/session/session-meta";
 import { tenantClaimStorage } from "@/lib/tenant/tenant-claim-storage";
+import { createRateLimiter } from "@/lib/security/rate-limit";
+import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { rateLimited } from "@/lib/http/api-response";
+import { MS_PER_MINUTE } from "@/lib/constants/time";
+import { getLogger } from "@/lib/logger";
 
 export const runtime = "nodejs";
 
@@ -52,8 +57,67 @@ function withSessionMeta<H extends RouteHandler>(handler: H): H {
   return wrapped as unknown as H;
 }
 
+// ─── OAuth / SAML callback rate limit ────────────────────────
+//
+// Scoped to the actual callback paths only (`/api/auth/callback/*`) so:
+//   - GET callbacks (Google OIDC's default response_mode=query) are covered
+//     — PR #465's earlier implementation only fired on POST and missed
+//     these entirely.
+//   - sign-in / sign-out / csrf / session POSTs are NOT throttled —
+//     enterprise NAT egresses with bursty sign-out storms used to trip
+//     the previous unconditional POST gate.
+//
+// Per-client-IP keying via the shared rateLimitKeyFromIp (IPv6 → /64).
+// When the client IP cannot be determined (no socket IP and
+// TRUST_PROXY_HEADERS unset), the limiter is skipped with a warn log —
+// fail-open here is preferred over PR #465's shared "unknown" bucket,
+// which collapsed every IP-less request into a single global 60/min
+// cap and let one bad actor DoS legitimate callbacks elsewhere on the
+// fleet.
+const CALLBACK_RATE_LIMIT_WINDOW_MS = 1 * MS_PER_MINUTE;
+const CALLBACK_RATE_LIMIT_MAX = 60;
+
+const callbackRateLimiter = createRateLimiter({
+  windowMs: CALLBACK_RATE_LIMIT_WINDOW_MS,
+  max: CALLBACK_RATE_LIMIT_MAX,
+});
+
+function isCallbackRoute(pathname: string): boolean {
+  return pathname.startsWith("/api/auth/callback/");
+}
+
+function withCallbackRateLimit<H extends RouteHandler>(handler: H): H {
+  const wrapped = async (request: NextRequest, ...rest: unknown[]) => {
+    if (!isCallbackRoute(request.nextUrl.pathname)) {
+      return handler(request, ...rest);
+    }
+    const ip = extractClientIp(request);
+    if (ip == null) {
+      getLogger().warn(
+        { pathname: request.nextUrl.pathname, method: request.method },
+        "auth.callback.rate_limit_skipped_unknown_ip",
+      );
+      return handler(request, ...rest);
+    }
+    const rl = await callbackRateLimiter.check(
+      `rl:auth_callback:${rateLimitKeyFromIp(ip)}`,
+    );
+    if (!rl.allowed) {
+      return rateLimited(rl.retryAfterMs) as unknown as Response;
+    }
+    return handler(request, ...rest);
+  };
+  return wrapped as unknown as H;
+}
+
 // Exported for testing
 export { withAuthBasePath as _withAuthBasePath };
+export { withCallbackRateLimit as _withCallbackRateLimit };
+export { isCallbackRoute as _isCallbackRoute };
 
-export const GET = withRequestLog(withSessionMeta(withAuthBasePath(handlers.GET)));
-export const POST = withRequestLog(withSessionMeta(withAuthBasePath(handlers.POST)));
+export const GET = withRequestLog(
+  withSessionMeta(withAuthBasePath(withCallbackRateLimit(handlers.GET))),
+);
+export const POST = withRequestLog(
+  withSessionMeta(withAuthBasePath(withCallbackRateLimit(handlers.POST))),
+);

--- a/src/app/api/auth/passkey/options/email/route.test.ts
+++ b/src/app/api/auth/passkey/options/email/route.test.ts
@@ -255,7 +255,9 @@ describe("POST /api/auth/passkey/options/email", () => {
 
     const req = createRequest("POST", ROUTE_URL, {
       body: { email: "test@example.com" },
-      headers: { origin: "http://localhost:3000" },
+      // checkIpRateLimit fails-open when extractClientIp returns null; provide an
+      // IP so the limiter is actually consulted in this test.
+      headers: { origin: "http://localhost:3000", "x-forwarded-for": "203.0.113.5" },
     });
     const { status, json } = await parseResponse(await POST(req));
 

--- a/src/app/api/auth/passkey/options/email/route.ts
+++ b/src/app/api/auth/passkey/options/email/route.ts
@@ -10,7 +10,8 @@ import { errorResponse, rateLimited } from "@/lib/http/api-response";
 import { parseBody } from "@/lib/http/parse-body";
 import { assertOrigin } from "@/lib/auth/session/csrf";
 import { NIL_UUID } from "@/lib/constants/app";
-import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { extractClientIp } from "@/lib/auth/policy/ip-access";
+import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
 import { generateAuthenticationOpts, derivePrfSalt } from "@/lib/auth/webauthn/webauthn-server";
 import { randomBytes } from "node:crypto";
 import { EMAIL_MAX_LENGTH } from "@/lib/validations/common";
@@ -59,8 +60,12 @@ async function handlePOST(req: NextRequest) {
   const originError = assertOrigin(req);
   if (originError) return originError;
 
-  const ip = extractClientIp(req) ?? "unknown";
-  const rl = await rateLimiter.check(`rl:webauthn_email_signin_opts:${rateLimitKeyFromIp(ip)}`);
+  const rl = await checkIpRateLimit({
+    ip: extractClientIp(req),
+    pathname: req.nextUrl.pathname,
+    scope: "webauthn_email_signin_opts",
+    limiter: rateLimiter,
+  });
   if (!rl.allowed) {
     return rateLimited(rl.retryAfterMs);
   }

--- a/src/app/api/auth/passkey/options/route.test.ts
+++ b/src/app/api/auth/passkey/options/route.test.ts
@@ -106,7 +106,9 @@ describe("POST /api/auth/passkey/options", () => {
     mockRateLimiterCheck.mockResolvedValue({ allowed: false, retryAfterMs: 30000 });
 
     const req = createRequest("POST", ROUTE_URL, {
-      headers: { origin: "http://localhost:3000" },
+      // checkIpRateLimit fails-open when extractClientIp returns null; provide an
+      // IP so the limiter is actually consulted in this test.
+      headers: { origin: "http://localhost:3000", "x-forwarded-for": "203.0.113.5" },
     });
     const { status, json } = await parseResponse(await POST(req));
 

--- a/src/app/api/auth/passkey/options/route.ts
+++ b/src/app/api/auth/passkey/options/route.ts
@@ -5,7 +5,8 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { errorResponse, rateLimited } from "@/lib/http/api-response";
 import { assertOrigin } from "@/lib/auth/session/csrf";
-import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { extractClientIp } from "@/lib/auth/policy/ip-access";
+import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
 import {
   generateDiscoverableAuthOpts,
   derivePrfSalt,
@@ -25,8 +26,12 @@ async function handlePOST(req: NextRequest) {
   if (originError) return originError;
 
   // Rate limit by IP
-  const ip = extractClientIp(req) ?? "unknown";
-  const rl = await rateLimiter.check(`rl:webauthn_signin_opts:${rateLimitKeyFromIp(ip)}`);
+  const rl = await checkIpRateLimit({
+    ip: extractClientIp(req),
+    pathname: req.nextUrl.pathname,
+    scope: "webauthn_signin_opts",
+    limiter: rateLimiter,
+  });
   if (!rl.allowed) {
     return rateLimited(rl.retryAfterMs);
   }

--- a/src/app/api/auth/passkey/verify/route.test.ts
+++ b/src/app/api/auth/passkey/verify/route.test.ts
@@ -86,10 +86,6 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withBypassRls: mockWithBypassRls,
 }));
 
-vi.mock("@/lib/url-helpers", () => ({
-  isHttps: false,
-}));
-
 vi.mock("@/lib/http/with-request-log", () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   withRequestLog: (fn: any) => fn,
@@ -307,7 +303,9 @@ describe("POST /api/auth/passkey/verify", () => {
 
     const req = createRequest("POST", ROUTE_URL, {
       body: validBody,
-      headers: { origin: "http://localhost:3000" },
+      // checkIpRateLimit fails-open when extractClientIp returns null; provide an
+      // IP so the limiter is actually consulted in this test.
+      headers: { origin: "http://localhost:3000", "x-forwarded-for": "203.0.113.5" },
     });
     const { status, json } = await parseResponse(await POST(req));
 

--- a/src/app/api/auth/passkey/verify/route.ts
+++ b/src/app/api/auth/passkey/verify/route.ts
@@ -7,12 +7,15 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { assertOrigin } from "@/lib/auth/session/csrf";
 import { authorizeWebAuthn } from "@/lib/auth/webauthn/webauthn-authorize";
 import { logAuditAsync, extractRequestMeta, personalAuditBase } from "@/lib/audit/audit";
-import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { extractClientIp } from "@/lib/auth/policy/ip-access";
+import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
 import { AUDIT_ACTION } from "@/lib/constants";
 import { prisma } from "@/lib/prisma";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
-import { isHttps } from "@/lib/url-helpers";
-import { getSessionCookieName } from "@/lib/auth/session/cookie-name";
+import {
+  getSessionCookieName,
+  isSecureCookieFromAuthUrl,
+} from "@/lib/auth/session/cookie-name";
 import { revokeAllExtensionTokensForUser } from "@/lib/auth/tokens/extension-token";
 import { invalidateCachedSessions } from "@/lib/auth/session/session-cache-helpers";
 import { resolveEffectiveSessionTimeouts } from "@/lib/auth/session/session-timeout";
@@ -23,9 +26,10 @@ export const runtime = "nodejs";
 const rateLimiter = createRateLimiter({ windowMs: 60_000, max: 10 });
 
 // Cookie name must match auth.config.ts — both paths use the shared
-// getSessionCookieName helper so the selection cannot drift.
+// getSessionCookieName helper + isSecureCookieFromAuthUrl so the
+// selection cannot drift.
 const SESSION_COOKIE_NAME = getSessionCookieName({
-  useSecureCookies: isHttps,
+  useSecureCookies: isSecureCookieFromAuthUrl(),
   basePath: process.env.NEXT_PUBLIC_BASE_PATH,
 });
 
@@ -39,8 +43,12 @@ async function handlePOST(req: NextRequest) {
   if (originError) return originError;
 
   // Rate limit by IP
-  const ip = extractClientIp(req) ?? "unknown";
-  const rl = await rateLimiter.check(`rl:webauthn_signin_verify:${rateLimitKeyFromIp(ip)}`);
+  const rl = await checkIpRateLimit({
+    ip: extractClientIp(req),
+    pathname: req.nextUrl.pathname,
+    scope: "webauthn_signin_verify",
+    limiter: rateLimiter,
+  });
   if (!rl.allowed) {
     return rateLimited(rl.retryAfterMs);
   }
@@ -176,7 +184,7 @@ async function handlePOST(req: NextRequest) {
     path: `${basePath}/`,
     httpOnly: true,
     sameSite: "lax",
-    secure: isHttps,
+    secure: isSecureCookieFromAuthUrl(),
     expires,
   });
 

--- a/src/app/api/auth/passkey/verify/route.ts
+++ b/src/app/api/auth/passkey/verify/route.ts
@@ -12,6 +12,7 @@ import { AUDIT_ACTION } from "@/lib/constants";
 import { prisma } from "@/lib/prisma";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { isHttps } from "@/lib/url-helpers";
+import { getSessionCookieName } from "@/lib/auth/session/cookie-name";
 import { revokeAllExtensionTokensForUser } from "@/lib/auth/tokens/extension-token";
 import { invalidateCachedSessions } from "@/lib/auth/session/session-cache-helpers";
 import { resolveEffectiveSessionTimeouts } from "@/lib/auth/session/session-timeout";
@@ -21,10 +22,12 @@ export const runtime = "nodejs";
 
 const rateLimiter = createRateLimiter({ windowMs: 60_000, max: 10 });
 
-// Cookie name must match auth.config.ts
-const SESSION_COOKIE_NAME = isHttps
-  ? "__Secure-authjs.session-token"
-  : "authjs.session-token";
+// Cookie name must match auth.config.ts — both paths use the shared
+// getSessionCookieName helper so the selection cannot drift.
+const SESSION_COOKIE_NAME = getSessionCookieName({
+  useSecureCookies: isHttps,
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH,
+});
 
 // POST /api/auth/passkey/verify
 // Unauthenticated endpoint — verifies a passkey authentication response

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { getLogger } from "@/lib/logger";
 import { createRateLimiter } from "@/lib/security/rate-limit";
-import { extractClientIpFromHeaders, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { extractClientIpFromHeaders } from "@/lib/auth/policy/ip-access";
+import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
 import { CSP_REPORT_RATE_MAX, RATE_WINDOW_MS } from "@/lib/validations/common.server";
 
 export const runtime = "nodejs";
@@ -63,8 +64,12 @@ function sanitizeCspReport(body: unknown): Record<string, unknown> | undefined {
 // POST /api/csp-report
 // Receives CSP violation reports.
 async function handlePOST(request: Request) {
-  const ip = extractClientIpFromHeaders(request.headers) ?? "unknown";
-  const rl = await cspLimiter.check(`rl:csp_report:${rateLimitKeyFromIp(ip)}`);
+  const rl = await checkIpRateLimit({
+    ip: extractClientIpFromHeaders(request.headers),
+    pathname: "/api/csp-report",
+    scope: "csp_report",
+    limiter: cspLimiter,
+  });
   if (!rl.allowed) return new NextResponse(null, { status: 204 });
 
   const contentType = request.headers.get("content-type") ?? "";

--- a/src/app/api/extension/token/exchange/route.ts
+++ b/src/app/api/extension/token/exchange/route.ts
@@ -34,7 +34,8 @@ import {
 } from "@/lib/http/api-response";
 import { issueExtensionToken } from "@/lib/auth/tokens/extension-token";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
-import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { extractClientIp } from "@/lib/auth/policy/ip-access";
+import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { getLogger } from "@/lib/logger";
 import { withRequestLog } from "@/lib/http/with-request-log";
@@ -74,8 +75,13 @@ async function handlePOST(req: NextRequest) {
 
   // Rate limit BEFORE DB lookup (keyed by client IP, no session available).
   // Compensating control: 256-bit code entropy makes brute force infeasible.
-  const ip = extractClientIp(req) ?? "unknown";
-  const rl = await exchangeLimiter.check(`rl:ext_exchange:${rateLimitKeyFromIp(ip)}`);
+  const ip = extractClientIp(req);
+  const rl = await checkIpRateLimit({
+    ip,
+    pathname: req.nextUrl.pathname,
+    scope: "ext_exchange",
+    limiter: exchangeLimiter,
+  });
   if (!rl.allowed) {
     return rateLimited(rl.retryAfterMs);
   }

--- a/src/app/api/extension/token/refresh/route.test.ts
+++ b/src/app/api/extension/token/refresh/route.test.ts
@@ -21,7 +21,7 @@ const {
   mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
   mockSessionFindFirst: vi.fn(),
   // Returns null for idle timeout to exercise the production fallback to
-  // DEFAULT_EXTENSION_IDLE_MINUTES — keeps the fixture decoupled from any
+  // EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT — keeps the fixture decoupled from any
   // future change to the constant. Existing tests only assert
   // `expiresAt` is defined, not its specific value.
   mockTenantFindUnique: vi.fn().mockResolvedValue({

--- a/src/app/api/extension/token/refresh/route.test.ts
+++ b/src/app/api/extension/token/refresh/route.test.ts
@@ -20,8 +20,12 @@ const {
   mockRevokeExtensionTokenFamily: vi.fn().mockResolvedValue({ rowsRevoked: 0 }),
   mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
   mockSessionFindFirst: vi.fn(),
+  // Returns null for idle timeout to exercise the production fallback to
+  // DEFAULT_EXTENSION_IDLE_MINUTES — keeps the fixture decoupled from any
+  // future change to the constant. Existing tests only assert
+  // `expiresAt` is defined, not its specific value.
   mockTenantFindUnique: vi.fn().mockResolvedValue({
-    extensionTokenIdleTimeoutMinutes: 10080,
+    extensionTokenIdleTimeoutMinutes: null,
     extensionTokenAbsoluteTimeoutMinutes: 43200,
   }),
   mockExtTokenUpdateMany: vi.fn(),

--- a/src/app/api/extension/token/refresh/route.ts
+++ b/src/app/api/extension/token/refresh/route.ts
@@ -12,6 +12,7 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { TokenIssueResponseSchema } from "@/lib/validations/extension-token";
 import logger from "@/lib/logger";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
+import { DEFAULT_EXTENSION_IDLE_MINUTES } from "@/lib/constants/auth/extension-token";
 
 export const runtime = "nodejs";
 
@@ -72,7 +73,7 @@ async function handlePOST(req: NextRequest) {
       },
     }),
   BYPASS_PURPOSE.TOKEN_LIFECYCLE);
-  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? 10080;
+  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? DEFAULT_EXTENSION_IDLE_MINUTES;
   const absoluteMinutes = tenant?.extensionTokenAbsoluteTimeoutMinutes ?? 43200;
 
   const now = new Date();

--- a/src/app/api/extension/token/refresh/route.ts
+++ b/src/app/api/extension/token/refresh/route.ts
@@ -12,7 +12,10 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { TokenIssueResponseSchema } from "@/lib/validations/extension-token";
 import logger from "@/lib/logger";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
-import { DEFAULT_EXTENSION_IDLE_MINUTES } from "@/lib/constants/auth/extension-token";
+import {
+  EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT,
+  EXTENSION_TOKEN_ABSOLUTE_TIMEOUT_DEFAULT,
+} from "@/lib/validations/common";
 
 export const runtime = "nodejs";
 
@@ -73,8 +76,8 @@ async function handlePOST(req: NextRequest) {
       },
     }),
   BYPASS_PURPOSE.TOKEN_LIFECYCLE);
-  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? DEFAULT_EXTENSION_IDLE_MINUTES;
-  const absoluteMinutes = tenant?.extensionTokenAbsoluteTimeoutMinutes ?? 43200;
+  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT;
+  const absoluteMinutes = tenant?.extensionTokenAbsoluteTimeoutMinutes ?? EXTENSION_TOKEN_ABSOLUTE_TIMEOUT_DEFAULT;
 
   const now = new Date();
 

--- a/src/app/api/mcp/revoke/route.ts
+++ b/src/app/api/mcp/revoke/route.ts
@@ -2,7 +2,8 @@ import { type NextRequest, NextResponse } from "next/server";
 import { revokeToken } from "@/lib/mcp/oauth-server";
 import { hashToken } from "@/lib/crypto/crypto-server";
 import { createRateLimiter } from "@/lib/security/rate-limit";
-import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { extractClientIp } from "@/lib/auth/policy/ip-access";
+import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
 
 const revokeLimiter = createRateLimiter({ windowMs: 60_000, max: 30 });
 
@@ -17,8 +18,12 @@ const revokeLimiter = createRateLimiter({ windowMs: 60_000, max: 30 });
  * Always returns 200 per RFC 7009 §2.2 (even for invalid tokens).
  */
 export async function POST(req: NextRequest) {
-  const ip = extractClientIp(req) ?? "unknown";
-  const rl = await revokeLimiter.check(`rl:mcp_revoke:${rateLimitKeyFromIp(ip)}`);
+  const rl = await checkIpRateLimit({
+    ip: extractClientIp(req),
+    pathname: req.nextUrl.pathname,
+    scope: "mcp_revoke",
+    limiter: revokeLimiter,
+  });
   if (!rl.allowed) {
     // Deliberate extension: RFC 7009 §2.2 says "always 200"; we return 429 +
     // { error: "rate_limited" } for abuse mitigation. See docs/api/error-handling.md

--- a/src/app/api/sessions/helpers.test.ts
+++ b/src/app/api/sessions/helpers.test.ts
@@ -1,13 +1,20 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 import { getSessionToken } from "./helpers";
 
 describe("getSessionToken", () => {
+  beforeEach(() => {
+    // Each test stubs the env vars it depends on; explicitly clear
+    // NEXT_PUBLIC_BASE_PATH so leakage from the surrounding process env
+    // does not flip the __Host- ↔ __Secure- branch unexpectedly.
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "");
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("reads non-secure cookie when AUTH_URL is http", () => {
+  it("reads plain authjs.session-token when AUTH_URL is http", () => {
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     const req = createRequest("GET", "http://localhost:3000/api/sessions", {
       headers: { Cookie: "authjs.session-token=abc123" },
@@ -15,34 +22,43 @@ describe("getSessionToken", () => {
     expect(getSessionToken(req)).toBe("abc123");
   });
 
-  it("reads __Secure- cookie when AUTH_URL is https", () => {
+  it("reads __Host- cookie when AUTH_URL is https AND basePath is empty", () => {
     vi.stubEnv("AUTH_URL", "https://localhost:3000");
     const req = createRequest("GET", "https://localhost:3000/api/sessions", {
+      headers: { Cookie: "__Host-authjs.session-token=host456" },
+    });
+    expect(getSessionToken(req)).toBe("host456");
+  });
+
+  it("reads __Secure- cookie when AUTH_URL is https AND basePath is set", () => {
+    vi.stubEnv("AUTH_URL", "https://localhost:3000");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/vault");
+    const req = createRequest("GET", "https://localhost:3000/vault/api/sessions", {
       headers: { Cookie: "__Secure-authjs.session-token=sec456" },
     });
     expect(getSessionToken(req)).toBe("sec456");
   });
 
-  it("returns null when cookie is absent", () => {
+  it("returns null when the matching cookie is absent", () => {
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     const req = createRequest("GET", "http://localhost:3000/api/sessions");
     expect(getSessionToken(req)).toBeNull();
   });
 
-  it("falls back to production check when AUTH_URL is invalid", () => {
+  it("falls back to production check when AUTH_URL is invalid (→ __Host- at root)", () => {
     vi.stubEnv("AUTH_URL", "not-a-url");
     vi.stubEnv("NODE_ENV", "production");
     const req = createRequest("GET", "https://example.com/api/sessions", {
-      headers: { Cookie: "__Secure-authjs.session-token=prod789" },
+      headers: { Cookie: "__Host-authjs.session-token=prod789" },
     });
     expect(getSessionToken(req)).toBe("prod789");
   });
 
-  it("uses NEXTAUTH_URL when AUTH_URL is not set", () => {
+  it("uses NEXTAUTH_URL when AUTH_URL is not set (→ __Host- at root)", () => {
     vi.stubEnv("AUTH_URL", "");
     vi.stubEnv("NEXTAUTH_URL", "https://myapp.com");
     const req = createRequest("GET", "https://myapp.com/api/sessions", {
-      headers: { Cookie: "__Secure-authjs.session-token=next123" },
+      headers: { Cookie: "__Host-authjs.session-token=next123" },
     });
     expect(getSessionToken(req)).toBe("next123");
   });

--- a/src/app/api/sessions/helpers.ts
+++ b/src/app/api/sessions/helpers.ts
@@ -1,22 +1,13 @@
 import type { NextRequest } from "next/server";
-
-/**
- * Determine whether Auth.js uses the __Secure- cookie prefix.
- * Auth.js decides this based on `url.protocol === "https:"` where
- * url comes from AUTH_URL (or NEXTAUTH_URL). We mirror that logic
- * so it works correctly even in dev with AUTH_URL=https://localhost.
- */
-function isSecureCookie(): boolean {
-  const authUrl = process.env.AUTH_URL || process.env.NEXTAUTH_URL || "";
-  try {
-    return new URL(authUrl).protocol === "https:";
-  } catch {
-    return process.env.NODE_ENV === "production";
-  }
-}
+import {
+  getSessionCookieName,
+  isSecureCookieFromAuthUrl,
+} from "@/lib/auth/session/cookie-name";
 
 export function getSessionToken(req: NextRequest): string | null {
-  return isSecureCookie()
-    ? req.cookies.get("__Secure-authjs.session-token")?.value ?? null
-    : req.cookies.get("authjs.session-token")?.value ?? null;
+  const name = getSessionCookieName({
+    useSecureCookies: isSecureCookieFromAuthUrl(),
+    basePath: process.env.NEXT_PUBLIC_BASE_PATH,
+  });
+  return req.cookies.get(name)?.value ?? null;
 }

--- a/src/app/api/share-links/[id]/content/route.ts
+++ b/src/app/api/share-links/[id]/content/route.ts
@@ -5,7 +5,8 @@ import { decryptShareData } from "@/lib/crypto/crypto-server";
 import { verifyShareAccessToken } from "@/lib/auth/tokens/share-access-token";
 import { USER_AGENT_MAX_LENGTH } from "@/lib/validations/common.server";
 import { createRateLimiter } from "@/lib/security/rate-limit";
-import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { extractClientIp } from "@/lib/auth/policy/ip-access";
+import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { errorResponse, rateLimited, unauthorized, notFound } from "@/lib/http/api-response";
 import { withRequestLog } from "@/lib/http/with-request-log";
@@ -18,8 +19,13 @@ type Params = { params: Promise<{ id: string }> };
 async function handleGET(req: NextRequest, { params }: Params) {
   const { id } = await params;
 
-  const ip = extractClientIp(req) ?? "unknown";
-  const rl = await contentLimiter.check(`rl:share_content:${rateLimitKeyFromIp(ip)}`);
+  const ip = extractClientIp(req);
+  const rl = await checkIpRateLimit({
+    ip,
+    pathname: req.nextUrl.pathname,
+    scope: "share_content",
+    limiter: contentLimiter,
+  });
   if (!rl.allowed) {
     return rateLimited(rl.retryAfterMs);
   }
@@ -116,7 +122,8 @@ async function handleGET(req: NextRequest, { params }: Params) {
     }
 
     // Record access log (must await inside withBypassRls transaction)
-    const accessIp = ip === "unknown" ? null : ip;
+    const accessIp = ip;  // extractClientIp returns null when IP is unavailable
+
     const ua = req.headers.get("user-agent");
     await prisma.shareAccessLog
       .create({

--- a/src/app/api/share-links/verify-access/route.ts
+++ b/src/app/api/share-links/verify-access/route.ts
@@ -5,7 +5,8 @@ import { verifyShareAccessSchema } from "@/lib/validations";
 import { hashToken, verifyAccessPassword } from "@/lib/crypto/crypto-server";
 import { createShareAccessToken } from "@/lib/auth/tokens/share-access-token";
 import { createRateLimiter } from "@/lib/security/rate-limit";
-import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { extractClientIp } from "@/lib/auth/policy/ip-access";
+import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { errorResponse, rateLimited, notFound, validationError } from "@/lib/http/api-response";
@@ -20,7 +21,7 @@ const tokenLimiter = createRateLimiter({ windowMs: 60_000, max: 20 });
 
 // POST /api/share-links/verify-access — Verify access password for a share
 async function handlePOST(req: NextRequest) {
-  const ip = extractClientIp(req) ?? "unknown";
+  const ip = extractClientIp(req);
 
   const result = await parseBody(req, verifyShareAccessSchema);
   if (!result.ok) return result.response;
@@ -29,7 +30,13 @@ async function handlePOST(req: NextRequest) {
   const tokenHash = hashToken(token);
 
   // Rate limit by IP+tokenHash and by tokenHash globally
-  const ipRl = await ipLimiter.check(`rl:share_verify_ip:${rateLimitKeyFromIp(ip)}:${tokenHash}`);
+  const ipRl = await checkIpRateLimit({
+    ip,
+    pathname: req.nextUrl.pathname,
+    scope: "share_verify_ip",
+    keySuffix: tokenHash,
+    limiter: ipLimiter,
+  });
   if (!ipRl.allowed) {
     return rateLimited(ipRl.retryAfterMs);
   }

--- a/src/app/api/tenant/policy/route.ts
+++ b/src/app/api/tenant/policy/route.ts
@@ -7,6 +7,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { errorResponseWithMessage, handleAuthError, rateLimited, unauthorized, validationError } from "@/lib/http/api-response";
 import { AUDIT_ACTION } from "@/lib/constants";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
+import { DEFAULT_EXTENSION_IDLE_MINUTES } from "@/lib/constants/auth/extension-token";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { TAILNET_NAME_MAX_LENGTH } from "@/lib/validations";
 import { withRequestLog } from "@/lib/http/with-request-log";
@@ -116,7 +117,7 @@ async function handleGET(_req: NextRequest) {
     maxConcurrentSessions: user?.tenant?.maxConcurrentSessions ?? null,
     sessionIdleTimeoutMinutes: user?.tenant?.sessionIdleTimeoutMinutes ?? 480,
     sessionAbsoluteTimeoutMinutes: user?.tenant?.sessionAbsoluteTimeoutMinutes ?? 43200,
-    extensionTokenIdleTimeoutMinutes: user?.tenant?.extensionTokenIdleTimeoutMinutes ?? 10080,
+    extensionTokenIdleTimeoutMinutes: user?.tenant?.extensionTokenIdleTimeoutMinutes ?? DEFAULT_EXTENSION_IDLE_MINUTES,
     extensionTokenAbsoluteTimeoutMinutes: user?.tenant?.extensionTokenAbsoluteTimeoutMinutes ?? 43200,
     vaultAutoLockMinutes: user?.tenant?.vaultAutoLockMinutes ?? null,
     allowAppSideAutofill: user?.tenant?.allowAppSideAutofill ?? false,

--- a/src/app/api/tenant/policy/route.ts
+++ b/src/app/api/tenant/policy/route.ts
@@ -7,7 +7,12 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { errorResponseWithMessage, handleAuthError, rateLimited, unauthorized, validationError } from "@/lib/http/api-response";
 import { AUDIT_ACTION } from "@/lib/constants";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
-import { DEFAULT_EXTENSION_IDLE_MINUTES } from "@/lib/constants/auth/extension-token";
+import {
+  SESSION_IDLE_TIMEOUT_DEFAULT,
+  SESSION_ABSOLUTE_TIMEOUT_DEFAULT,
+  EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT,
+  EXTENSION_TOKEN_ABSOLUTE_TIMEOUT_DEFAULT,
+} from "@/lib/validations/common";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { TAILNET_NAME_MAX_LENGTH } from "@/lib/validations";
 import { withRequestLog } from "@/lib/http/with-request-log";
@@ -115,10 +120,10 @@ async function handleGET(_req: NextRequest) {
 
   return NextResponse.json({
     maxConcurrentSessions: user?.tenant?.maxConcurrentSessions ?? null,
-    sessionIdleTimeoutMinutes: user?.tenant?.sessionIdleTimeoutMinutes ?? 480,
-    sessionAbsoluteTimeoutMinutes: user?.tenant?.sessionAbsoluteTimeoutMinutes ?? 43200,
-    extensionTokenIdleTimeoutMinutes: user?.tenant?.extensionTokenIdleTimeoutMinutes ?? DEFAULT_EXTENSION_IDLE_MINUTES,
-    extensionTokenAbsoluteTimeoutMinutes: user?.tenant?.extensionTokenAbsoluteTimeoutMinutes ?? 43200,
+    sessionIdleTimeoutMinutes: user?.tenant?.sessionIdleTimeoutMinutes ?? SESSION_IDLE_TIMEOUT_DEFAULT,
+    sessionAbsoluteTimeoutMinutes: user?.tenant?.sessionAbsoluteTimeoutMinutes ?? SESSION_ABSOLUTE_TIMEOUT_DEFAULT,
+    extensionTokenIdleTimeoutMinutes: user?.tenant?.extensionTokenIdleTimeoutMinutes ?? EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT,
+    extensionTokenAbsoluteTimeoutMinutes: user?.tenant?.extensionTokenAbsoluteTimeoutMinutes ?? EXTENSION_TOKEN_ABSOLUTE_TIMEOUT_DEFAULT,
     vaultAutoLockMinutes: user?.tenant?.vaultAutoLockMinutes ?? null,
     allowAppSideAutofill: user?.tenant?.allowAppSideAutofill ?? false,
     allowedCidrs: user?.tenant?.allowedCidrs ?? [],

--- a/src/app/api/vault/unlock/route.test.ts
+++ b/src/app/api/vault/unlock/route.test.ts
@@ -56,9 +56,13 @@ const SERVER_HASH = createHash("sha256")
   .update(AUTH_HASH + SERVER_SALT)
   .digest("hex");
 
-function makeUnlockRequest(authHash: string = AUTH_HASH) {
+function makeUnlockRequest(
+  authHash: string = AUTH_HASH,
+  opts: { headers?: Record<string, string> } = {},
+) {
   return createRequest("POST", "http://localhost:3000/api/vault/unlock", {
     body: { authHash },
+    headers: opts.headers,
   });
 }
 
@@ -196,12 +200,28 @@ describe("POST /api/vault/unlock", () => {
     );
   });
 
-  it("uses userId-only rate key (no IP)", async () => {
+  it("uses per-user rate key with no IP or other suffix (account-lockout is the per-user defense)", async () => {
+    // Design intent: vault unlock rate key MUST be `rl:vault_unlock:<userId>`
+    // exactly. An earlier change added an `:<ip>` suffix; the post-merge
+    // review of #465 reverted it because:
+    //   - per-user account-lockout (recordFailure / checkLockout) already
+    //     defends against credential brute-force per user
+    //   - adding IP made the rate-limit strictly weaker (IP rotation bypass)
+    //   - the lockout layer protects DoS-on-victim regardless of IP
+    // Strict-equal assertion (not stringContaining) so any future suffix
+    // re-introduction trips this test instead of silently passing.
     const userId = "test-user-rate";
     mockAuth.mockResolvedValue({ user: { id: userId } });
     mockRateLimiter.check.mockResolvedValue({ allowed: false });
-
-    await POST(makeUnlockRequest());
+    // Provide a real IP in headers so a regression that re-adds IP-binding
+    // would surface as a key suffix mismatch (the previous test fixture
+    // omitted IP, which made the assertion vacuously satisfiable).
+    await POST(
+      makeUnlockRequest(AUTH_HASH, {
+        headers: { "x-forwarded-for": "203.0.113.5" },
+      }),
+    );
+    expect(mockRateLimiter.check).toHaveBeenCalledTimes(1);
     expect(mockRateLimiter.check).toHaveBeenCalledWith(`rl:vault_unlock:${userId}`);
   });
 

--- a/src/app/s/[token]/download/route.ts
+++ b/src/app/s/[token]/download/route.ts
@@ -5,7 +5,8 @@ import { hashToken, decryptShareBinary } from "@/lib/crypto/crypto-server";
 import { verifyShareAccessToken } from "@/lib/auth/tokens/share-access-token";
 import { USER_AGENT_MAX_LENGTH } from "@/lib/validations/common.server";
 import { createRateLimiter } from "@/lib/security/rate-limit";
-import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+import { extractClientIp } from "@/lib/auth/policy/ip-access";
+import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { errorResponse, rateLimited } from "@/lib/http/api-response";
 
@@ -18,8 +19,13 @@ export async function GET(req: NextRequest, { params }: Params) {
   const { token } = await params;
 
   // Rate limit by IP
-  const ip = extractClientIp(req) ?? "unknown";
-  const rl = await downloadLimiter.check(`rl:send_download:${rateLimitKeyFromIp(ip)}`);
+  const ip = extractClientIp(req);
+  const rl = await checkIpRateLimit({
+    ip,
+    pathname: req.nextUrl.pathname,
+    scope: "send_download",
+    limiter: downloadLimiter,
+  });
   if (!rl.allowed) {
     return rateLimited(rl.retryAfterMs);
   }
@@ -123,7 +129,8 @@ export async function GET(req: NextRequest, { params }: Params) {
     }
 
     // Record access log (must await inside withBypassRls transaction)
-    const accessIp = ip === "unknown" ? null : ip;
+    const accessIp = ip;  // extractClientIp returns null when IP is unavailable
+
     const ua = req.headers.get("user-agent");
     await prisma.shareAccessLog
       .create({

--- a/src/auth.config.test.ts
+++ b/src/auth.config.test.ts
@@ -48,6 +48,70 @@ describe("auth.config basePath handling", () => {
   });
 });
 
+describe("auth.config session cookie attributes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // sameSite=strict is the explicit policy choice — guards against silent
+  // regression to `lax` (which would re-open the login-CSRF window).
+  it("sets sameSite=strict on the session cookie", async () => {
+    const config = (await import("@/auth.config")).default;
+    expect(config.cookies?.sessionToken?.options?.sameSite).toBe("strict");
+  });
+
+  it("sets httpOnly=true on the session cookie", async () => {
+    const config = (await import("@/auth.config")).default;
+    expect(config.cookies?.sessionToken?.options?.httpOnly).toBe(true);
+  });
+
+  // Matrix: AUTH_URL × NEXT_PUBLIC_BASE_PATH drives the cookie name.
+  // A regression that inlines the prefix-selection in auth.config.ts
+  // would trip whichever quadrant got missed.
+  it("uses __Host- when AUTH_URL is https AND basePath is empty", async () => {
+    vi.stubEnv("AUTH_URL", "https://example.com");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "");
+    const config = (await import("@/auth.config")).default;
+    expect(config.cookies?.sessionToken?.name).toBe("__Host-authjs.session-token");
+  });
+
+  it("uses __Secure- when AUTH_URL is https AND basePath is set", async () => {
+    vi.stubEnv("AUTH_URL", "https://example.com");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/vault");
+    const config = (await import("@/auth.config")).default;
+    expect(config.cookies?.sessionToken?.name).toBe("__Secure-authjs.session-token");
+  });
+
+  it("uses plain name when AUTH_URL is http (any basePath)", async () => {
+    vi.stubEnv("AUTH_URL", "http://localhost:3000");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "");
+    const config = (await import("@/auth.config")).default;
+    expect(config.cookies?.sessionToken?.name).toBe("authjs.session-token");
+  });
+
+  it("uses plain name when AUTH_URL is http even with basePath", async () => {
+    vi.stubEnv("AUTH_URL", "http://localhost:3000");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/vault");
+    const config = (await import("@/auth.config")).default;
+    expect(config.cookies?.sessionToken?.name).toBe("authjs.session-token");
+  });
+
+  // __Host- spec requires Path=/ — verify the coupling holds whenever
+  // the __Host- name is selected.
+  it("when __Host- name is selected, the cookie path is exactly '/'", async () => {
+    vi.stubEnv("AUTH_URL", "https://example.com");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "");
+    const config = (await import("@/auth.config")).default;
+    expect(config.cookies?.sessionToken?.name).toBe("__Host-authjs.session-token");
+    expect(config.cookies?.sessionToken?.options?.path).toBe("/");
+  });
+});
+
 describe("auth.config Google domain validation", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -3,13 +3,15 @@ import Google from "next-auth/providers/google";
 import Nodemailer from "next-auth/providers/nodemailer";
 import { API_PATH } from "@/lib/constants";
 import { parseAllowedGoogleDomains } from "@/lib/url/google-domain";
-import { isHttps } from "@/lib/url-helpers";
 import { sendEmail } from "@/lib/email";
 import { magicLinkEmail } from "@/lib/email/templates/magic-link";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 import { getLogger } from "@/lib/logger";
-import { getSessionCookieName } from "@/lib/auth/session/cookie-name";
+import {
+  getSessionCookieName,
+  isSecureCookieFromAuthUrl,
+} from "@/lib/auth/session/cookie-name";
 
 // Rate limiters for magic link email (per-email address)
 const magicLinkEmailLimiter = createRateLimiter({
@@ -20,7 +22,7 @@ const magicLinkEmailLimiter = createRateLimiter({
 const allowedGoogleDomains = parseAllowedGoogleDomains();
 const basePath = (process.env.NEXT_PUBLIC_BASE_PATH || "").replace(/\/$/, "");
 
-const useSecureCookies = isHttps;
+const useSecureCookies = isSecureCookieFromAuthUrl();
 
 export default {
   providers: [

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -9,6 +9,7 @@ import { magicLinkEmail } from "@/lib/email/templates/magic-link";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 import { getLogger } from "@/lib/logger";
+import { getSessionCookieName } from "@/lib/auth/session/cookie-name";
 
 // Rate limiters for magic link email (per-email address)
 const magicLinkEmailLimiter = createRateLimiter({
@@ -127,13 +128,19 @@ export default {
 
   cookies: {
     sessionToken: {
-      name: useSecureCookies
-        ? "__Secure-authjs.session-token"
-        : "authjs.session-token",
+      name: getSessionCookieName({
+        useSecureCookies,
+        basePath: process.env.NEXT_PUBLIC_BASE_PATH,
+      }),
       options: {
         path: `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/`,
         httpOnly: true,
-        sameSite: "lax" as const,
+        // strict: cookie is NOT sent on cross-site top-level navigations.
+        // Prevents login CSRF + minimizes session-cookie exfiltration via
+        // top-level GETs from third-party origins. Trade-off: external
+        // links into the app land unauthenticated until first same-site
+        // navigation — acceptable for this app's security posture.
+        sameSite: "strict" as const,
         secure: useSecureCookies,
       },
     },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -367,8 +367,20 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         requirePasskey = passkeyData.tenant?.requirePasskey ?? false;
         requirePasskeyEnabledAt = passkeyData.tenant?.requirePasskeyEnabledAt?.toISOString() ?? null;
         passkeyGracePeriodDays = passkeyData.tenant?.passkeyGracePeriodDays ?? null;
-      } catch {
-        // Non-critical: passkey enforcement data failure should not break session
+      } catch (err) {
+        // Non-critical for session establishment but DO surface to ops:
+        // a silent catch hid Redis/DB issues that mattered for tenants
+        // with requirePasskey enforcement (audit-trail gap → A09).
+        // tenantId is included so operators can group by affected tenant
+        // when a single tenant's data path is degraded.
+        getLogger().warn(
+          {
+            userId: user.id,
+            tenantId: (user as { tenantId?: string }).tenantId ?? null,
+            err,
+          },
+          "auth.session.passkey_data_fetch_failed",
+        );
       }
 
       return {

--- a/src/lib/auth/dpop/jti-cache.ts
+++ b/src/lib/auth/dpop/jti-cache.ts
@@ -1,5 +1,8 @@
 import { getRedis } from "@/lib/redis";
-import { createThrottledErrorLogger } from "@/lib/logger/throttled";
+import {
+  REDIS_FALLBACK_LOG_THROTTLE_MS,
+  createThrottledErrorLogger,
+} from "@/lib/logger/throttled";
 
 /**
  * RFC 9449 §11.1 — server-side `jti` uniqueness cache.
@@ -25,7 +28,7 @@ export interface JtiCache {
 const DEFAULT_TTL_MS = 60_000;
 
 const logRedisError = createThrottledErrorLogger(
-  30_000,
+  REDIS_FALLBACK_LOG_THROTTLE_MS,
   "dpop-jti-cache.redis.fallback",
 );
 

--- a/src/lib/auth/dpop/jti-cache.ts
+++ b/src/lib/auth/dpop/jti-cache.ts
@@ -81,8 +81,8 @@ export function createJtiCache(options: { ttlMs?: number; now?: () => number } =
           // SET key 1 PX <ttl> NX → "OK" on first sight, null on replay.
           const result = await redis.set(key, "1", "PX", ttlMs, "NX");
           return result === null;
-        } catch {
-          logRedisError();
+        } catch (err) {
+          logRedisError((err as { code?: string } | undefined)?.code);
           // Fall through to in-memory fallback.
         }
       }

--- a/src/lib/auth/dpop/nonce.ts
+++ b/src/lib/auth/dpop/nonce.ts
@@ -73,8 +73,8 @@ export function createDpopNonceService(
       if (set === "OK") return nonce;
       // Lost the race — re-read.
       return (await redis.get(KEY_CUR)) ?? nonce;
-    } catch {
-      logRedisError();
+    } catch (err) {
+      logRedisError((err as { code?: string } | undefined)?.code);
       return null;
     }
   }
@@ -84,8 +84,8 @@ export function createDpopNonceService(
     if (!redis) return;
     try {
       await redis.set(KEY_CUR, generateNonce(), "EX", REDIS_TTL_SEC);
-    } catch {
-      logRedisError();
+    } catch (err) {
+      logRedisError((err as { code?: string } | undefined)?.code);
     }
   }
 
@@ -117,8 +117,8 @@ export function createDpopNonceService(
             await rotateRedis();
           }
           return;
-        } catch {
-          logRedisError();
+        } catch (err) {
+          logRedisError((err as { code?: string } | undefined)?.code);
           // Fall through to in-memory rotation.
         }
       }

--- a/src/lib/auth/dpop/nonce.ts
+++ b/src/lib/auth/dpop/nonce.ts
@@ -1,6 +1,9 @@
 import { randomBytes } from "node:crypto";
 import { getRedis } from "@/lib/redis";
-import { createThrottledErrorLogger } from "@/lib/logger/throttled";
+import {
+  REDIS_FALLBACK_LOG_THROTTLE_MS,
+  createThrottledErrorLogger,
+} from "@/lib/logger/throttled";
 
 /**
  * RFC 9449 §8 — DPoP-Nonce.
@@ -23,7 +26,7 @@ const KEY_CUR = "dpop:nonce:cur";
 const REDIS_TTL_SEC = Math.ceil((ROTATION_MS * 2) / 1000);
 
 const logRedisError = createThrottledErrorLogger(
-  30_000,
+  REDIS_FALLBACK_LOG_THROTTLE_MS,
   "dpop-nonce.redis.fallback",
 );
 

--- a/src/lib/auth/session/cookie-name.test.ts
+++ b/src/lib/auth/session/cookie-name.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  ALL_KNOWN_SESSION_COOKIE_NAMES,
+  getSessionCookieName,
+  isSecureCookieFromAuthUrl,
+} from "./cookie-name";
+
+describe("getSessionCookieName", () => {
+  it("returns the plain name when useSecureCookies is false", () => {
+    expect(
+      getSessionCookieName({ useSecureCookies: false, basePath: undefined }),
+    ).toBe("authjs.session-token");
+    expect(
+      getSessionCookieName({ useSecureCookies: false, basePath: "/vault" }),
+    ).toBe("authjs.session-token");
+  });
+
+  it("returns __Host- when useSecureCookies is true AND basePath is undefined or empty", () => {
+    expect(
+      getSessionCookieName({ useSecureCookies: true, basePath: undefined }),
+    ).toBe("__Host-authjs.session-token");
+    expect(
+      getSessionCookieName({ useSecureCookies: true, basePath: "" }),
+    ).toBe("__Host-authjs.session-token");
+  });
+
+  it("returns __Secure- when useSecureCookies is true AND basePath is set", () => {
+    expect(
+      getSessionCookieName({ useSecureCookies: true, basePath: "/vault" }),
+    ).toBe("__Secure-authjs.session-token");
+    expect(
+      getSessionCookieName({ useSecureCookies: true, basePath: "/p" }),
+    ).toBe("__Secure-authjs.session-token");
+  });
+
+  it("covers the full (useSecureCookies × basePath) truth table", () => {
+    // 2 × 2 matrix — checks that one quadrant flip does not bleed
+    const cases = [
+      { useSecureCookies: false, basePath: undefined, expected: "authjs.session-token" },
+      { useSecureCookies: false, basePath: "/vault", expected: "authjs.session-token" },
+      { useSecureCookies: true, basePath: undefined, expected: "__Host-authjs.session-token" },
+      { useSecureCookies: true, basePath: "/vault", expected: "__Secure-authjs.session-token" },
+    ];
+    for (const c of cases) {
+      expect(
+        getSessionCookieName({
+          useSecureCookies: c.useSecureCookies,
+          basePath: c.basePath,
+        }),
+      ).toBe(c.expected);
+    }
+  });
+});
+
+describe("ALL_KNOWN_SESSION_COOKIE_NAMES", () => {
+  it("includes the three current-issue shapes", () => {
+    expect(ALL_KNOWN_SESSION_COOKIE_NAMES).toContain("__Host-authjs.session-token");
+    expect(ALL_KNOWN_SESSION_COOKIE_NAMES).toContain("__Secure-authjs.session-token");
+    expect(ALL_KNOWN_SESSION_COOKIE_NAMES).toContain("authjs.session-token");
+  });
+
+  it("includes legacy next-auth.* names for logout cleanup", () => {
+    expect(ALL_KNOWN_SESSION_COOKIE_NAMES).toContain("__Secure-next-auth.session-token");
+    expect(ALL_KNOWN_SESSION_COOKIE_NAMES).toContain("next-auth.session-token");
+  });
+
+  it("lists the more-specific prefixes first so an extractor that returns on first match yields the most-secure name", () => {
+    // Defense-in-depth: if a request somehow carries both __Host- and a
+    // legacy plain cookie, prefer the __Host- value.
+    const hostIdx = ALL_KNOWN_SESSION_COOKIE_NAMES.indexOf("__Host-authjs.session-token");
+    const secureIdx = ALL_KNOWN_SESSION_COOKIE_NAMES.indexOf("__Secure-authjs.session-token");
+    const plainIdx = ALL_KNOWN_SESSION_COOKIE_NAMES.indexOf("authjs.session-token");
+    expect(hostIdx).toBeLessThan(secureIdx);
+    expect(secureIdx).toBeLessThan(plainIdx);
+  });
+});
+
+describe("isSecureCookieFromAuthUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns true when AUTH_URL is https", () => {
+    vi.stubEnv("AUTH_URL", "https://example.com");
+    expect(isSecureCookieFromAuthUrl()).toBe(true);
+  });
+
+  it("returns false when AUTH_URL is http", () => {
+    vi.stubEnv("AUTH_URL", "http://localhost:3000");
+    expect(isSecureCookieFromAuthUrl()).toBe(false);
+  });
+
+  it("falls back to NODE_ENV=production when AUTH_URL is missing", () => {
+    vi.stubEnv("AUTH_URL", "");
+    vi.stubEnv("NEXTAUTH_URL", "");
+    vi.stubEnv("NODE_ENV", "production");
+    expect(isSecureCookieFromAuthUrl()).toBe(true);
+  });
+
+  it("falls back to false when AUTH_URL is missing and NODE_ENV is not production", () => {
+    vi.stubEnv("AUTH_URL", "");
+    vi.stubEnv("NEXTAUTH_URL", "");
+    vi.stubEnv("NODE_ENV", "development");
+    expect(isSecureCookieFromAuthUrl()).toBe(false);
+  });
+
+  it("falls back to NODE_ENV when AUTH_URL is unparseable", () => {
+    vi.stubEnv("AUTH_URL", "not a url");
+    vi.stubEnv("NODE_ENV", "production");
+    expect(isSecureCookieFromAuthUrl()).toBe(true);
+  });
+
+  it("prefers AUTH_URL over NEXTAUTH_URL when both are set", () => {
+    vi.stubEnv("AUTH_URL", "http://localhost:3000");
+    vi.stubEnv("NEXTAUTH_URL", "https://example.com");
+    expect(isSecureCookieFromAuthUrl()).toBe(false);
+  });
+});

--- a/src/lib/auth/session/cookie-name.ts
+++ b/src/lib/auth/session/cookie-name.ts
@@ -50,14 +50,19 @@ export const ALL_KNOWN_SESSION_COOKIE_NAMES = [
 ] as const;
 
 /**
- * `useSecureCookies` derivation from AUTH_URL / NEXTAUTH_URL.
- * Mirrors Auth.js's own derivation in `core/lib/cookie.ts` so callers
- * that are NOT inside the Auth.js config (e.g. the sessions list helper,
- * the passkey verify route) compute the same value.
+ * `useSecureCookies` derivation — single source of truth for every cookie
+ * write/read site (auth.config, passkey verify, sessions list helper, e2e
+ * helper). Evaluated at call time so per-test env stubs are honored.
  *
- * Falls back to `NODE_ENV === "production"` only when the URL is missing
- * or unparseable, which preserves the previous behavior of
- * `src/app/api/sessions/helpers.ts:isSecureCookie`.
+ * Mirrors Auth.js's own logic (`core/lib/cookie.ts`): URL parse of
+ * AUTH_URL / NEXTAUTH_URL, then `NODE_ENV === "production"` fallback when
+ * neither is set/parseable.
+ *
+ * Why a function (not a module-evaluated const): so unit tests that stub
+ * AUTH_URL after the module loads still see the stubbed value. The earlier
+ * `isHttps` (url-helpers.ts) is module-evaluated and therefore frozen at
+ * first import; that was the original cause of the cookie-write/read
+ * mismatch this helper exists to close.
  */
 export function isSecureCookieFromAuthUrl(): boolean {
   const authUrl = process.env.AUTH_URL || process.env.NEXTAUTH_URL || "";

--- a/src/lib/auth/session/cookie-name.ts
+++ b/src/lib/auth/session/cookie-name.ts
@@ -1,0 +1,69 @@
+/**
+ * Single source of truth for the Auth.js session-cookie name selection.
+ *
+ * The cookie name varies along two axes:
+ *   - `useSecureCookies`: true when AUTH_URL is HTTPS (production-shape).
+ *     Drives the `__Secure-` / `__Host-` prefix.
+ *   - `basePath`: when set, the cookie path becomes `${basePath}/`. The
+ *     `__Host-` prefix per RFC 6265bis §4.1.3.2 mandates `Path=/`, so we
+ *     can only use `__Host-` when basePath is unset.
+ *
+ * The post-merge review of PR #465 found that this selection had been
+ * inlined in 5 different places (auth.config.ts + 4 consumers) and that
+ * the original PR updated only one site — breaking sign-in in any
+ * deployment where the cookie name diverged from what the proxy/helpers
+ * expected. Centralizing here closes that propagation gap structurally.
+ */
+
+/**
+ * Returns the cookie name Auth.js currently emits given the deployment
+ * configuration.
+ *
+ *   useSecureCookies=false                       → "authjs.session-token"
+ *   useSecureCookies=true && basePath set         → "__Secure-authjs.session-token"
+ *   useSecureCookies=true && basePath unset/empty → "__Host-authjs.session-token"
+ */
+export function getSessionCookieName(opts: {
+  useSecureCookies: boolean;
+  basePath: string | undefined;
+}): string {
+  if (!opts.useSecureCookies) return "authjs.session-token";
+  if (opts.basePath && opts.basePath.length > 0) return "__Secure-authjs.session-token";
+  return "__Host-authjs.session-token";
+}
+
+/**
+ * All cookie names the proxy / session-extraction / logout-cleanup paths
+ * must recognize. Includes:
+ *   - All three current-issue shapes (`authjs.session-token`,
+ *     `__Secure-authjs.session-token`, `__Host-authjs.session-token`)
+ *   - Legacy `next-auth.session-token` / `__Secure-next-auth.session-token`
+ *     so logout-cleanup can sweep cookies left over by browsers that still
+ *     carry them from older Auth.js (v4 / next-auth) deployments.
+ */
+export const ALL_KNOWN_SESSION_COOKIE_NAMES = [
+  "__Host-authjs.session-token",
+  "__Secure-authjs.session-token",
+  "authjs.session-token",
+  "__Secure-next-auth.session-token",
+  "next-auth.session-token",
+] as const;
+
+/**
+ * `useSecureCookies` derivation from AUTH_URL / NEXTAUTH_URL.
+ * Mirrors Auth.js's own derivation in `core/lib/cookie.ts` so callers
+ * that are NOT inside the Auth.js config (e.g. the sessions list helper,
+ * the passkey verify route) compute the same value.
+ *
+ * Falls back to `NODE_ENV === "production"` only when the URL is missing
+ * or unparseable, which preserves the previous behavior of
+ * `src/app/api/sessions/helpers.ts:isSecureCookie`.
+ */
+export function isSecureCookieFromAuthUrl(): boolean {
+  const authUrl = process.env.AUTH_URL || process.env.NEXTAUTH_URL || "";
+  try {
+    return new URL(authUrl).protocol === "https:";
+  } catch {
+    return process.env.NODE_ENV === "production";
+  }
+}

--- a/src/lib/auth/session/session-cache.ts
+++ b/src/lib/auth/session/session-cache.ts
@@ -2,7 +2,10 @@ import * as crypto from "node:crypto";
 import type Redis from "ioredis";
 import { z } from "zod";
 import { getMasterKeyByVersion } from "@/lib/crypto/crypto-server";
-import { createThrottledErrorLogger } from "@/lib/logger/throttled";
+import {
+  REDIS_FALLBACK_LOG_THROTTLE_MS,
+  createThrottledErrorLogger,
+} from "@/lib/logger/throttled";
 import { getRedis } from "@/lib/redis";
 import {
   NEGATIVE_CACHE_TTL_MS,
@@ -84,7 +87,7 @@ export function hashSessionToken(token: string): string {
 
 // ─── Throttled logger (single instance, all ops) ────────────
 const logRedisError = createThrottledErrorLogger(
-  30_000,
+  REDIS_FALLBACK_LOG_THROTTLE_MS,
   "session-cache.redis.fallback",
 );
 

--- a/src/lib/auth/tokens/extension-token.test.ts
+++ b/src/lib/auth/tokens/extension-token.test.ts
@@ -65,6 +65,8 @@ import {
   hasScope,
   issueExtensionToken,
 } from "./extension-token";
+import { DEFAULT_EXTENSION_IDLE_MINUTES } from "@/lib/constants/auth/extension-token";
+import { MS_PER_MINUTE } from "@/lib/constants/time";
 
 // ─── parseScopes ─────────────────────────────────────────────
 
@@ -298,5 +300,29 @@ describe("issueExtensionToken", () => {
       scope: "passwords:read",
     });
     expect(mockTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to DEFAULT_EXTENSION_IDLE_MINUTES when tenant.extensionTokenIdleTimeoutMinutes is null", async () => {
+    // Drift detector: a regression that lowers / raises the application
+    // fallback (or copies the literal back into one of the call sites)
+    // would change the computed expiresAt and trip this assertion.
+    mockTenantFindUnique.mockResolvedValueOnce({ extensionTokenIdleTimeoutMinutes: null });
+
+    const before = Date.now();
+    await issueExtensionToken({
+      userId: "u1",
+      tenantId: "t1",
+      scope: "passwords:read",
+    });
+    const after = Date.now();
+
+    expect(mockCreate).toHaveBeenCalled();
+    const callArg = mockCreate.mock.calls[0]?.[0] as { data: { expiresAt: Date } };
+    const expiresAtMs = callArg.data.expiresAt.getTime();
+
+    // expiresAt MUST equal `now + DEFAULT_EXTENSION_IDLE_MINUTES min` (±a small
+    // wall-clock window for the time taken inside issueExtensionToken).
+    expect(expiresAtMs).toBeGreaterThanOrEqual(before + DEFAULT_EXTENSION_IDLE_MINUTES * MS_PER_MINUTE);
+    expect(expiresAtMs).toBeLessThanOrEqual(after + DEFAULT_EXTENSION_IDLE_MINUTES * MS_PER_MINUTE);
   });
 });

--- a/src/lib/auth/tokens/extension-token.test.ts
+++ b/src/lib/auth/tokens/extension-token.test.ts
@@ -65,7 +65,7 @@ import {
   hasScope,
   issueExtensionToken,
 } from "./extension-token";
-import { DEFAULT_EXTENSION_IDLE_MINUTES } from "@/lib/constants/auth/extension-token";
+import { EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT } from "@/lib/validations/common";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 
 // ─── parseScopes ─────────────────────────────────────────────
@@ -302,7 +302,7 @@ describe("issueExtensionToken", () => {
     expect(mockTransaction).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to DEFAULT_EXTENSION_IDLE_MINUTES when tenant.extensionTokenIdleTimeoutMinutes is null", async () => {
+  it("falls back to EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT when tenant.extensionTokenIdleTimeoutMinutes is null", async () => {
     // Drift detector: a regression that lowers / raises the application
     // fallback (or copies the literal back into one of the call sites)
     // would change the computed expiresAt and trip this assertion.
@@ -320,9 +320,9 @@ describe("issueExtensionToken", () => {
     const callArg = mockCreate.mock.calls[0]?.[0] as { data: { expiresAt: Date } };
     const expiresAtMs = callArg.data.expiresAt.getTime();
 
-    // expiresAt MUST equal `now + DEFAULT_EXTENSION_IDLE_MINUTES min` (±a small
+    // expiresAt MUST equal `now + EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT min` (±a small
     // wall-clock window for the time taken inside issueExtensionToken).
-    expect(expiresAtMs).toBeGreaterThanOrEqual(before + DEFAULT_EXTENSION_IDLE_MINUTES * MS_PER_MINUTE);
-    expect(expiresAtMs).toBeLessThanOrEqual(after + DEFAULT_EXTENSION_IDLE_MINUTES * MS_PER_MINUTE);
+    expect(expiresAtMs).toBeGreaterThanOrEqual(before + EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT * MS_PER_MINUTE);
+    expect(expiresAtMs).toBeLessThanOrEqual(after + EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT * MS_PER_MINUTE);
   });
 });

--- a/src/lib/auth/tokens/extension-token.ts
+++ b/src/lib/auth/tokens/extension-token.ts
@@ -7,9 +7,9 @@ import { randomUUID } from "node:crypto";
 import {
   EXTENSION_TOKEN_SCOPE,
   EXTENSION_TOKEN_MAX_ACTIVE,
-  DEFAULT_EXTENSION_IDLE_MINUTES,
   type ExtensionTokenScope,
 } from "@/lib/constants";
+import { EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT } from "@/lib/validations/common";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 import { logAuditAsync } from "@/lib/audit/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
@@ -213,7 +213,7 @@ export async function issueExtensionToken(params: {
       select: { extensionTokenIdleTimeoutMinutes: true },
     }),
   BYPASS_PURPOSE.TOKEN_LIFECYCLE);
-  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? DEFAULT_EXTENSION_IDLE_MINUTES;
+  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT;
   const expiresAt = new Date(now.getTime() + idleMinutes * MS_PER_MINUTE);
 
   const plaintext = generateShareToken();

--- a/src/lib/auth/tokens/extension-token.ts
+++ b/src/lib/auth/tokens/extension-token.ts
@@ -7,6 +7,7 @@ import { randomUUID } from "node:crypto";
 import {
   EXTENSION_TOKEN_SCOPE,
   EXTENSION_TOKEN_MAX_ACTIVE,
+  DEFAULT_EXTENSION_IDLE_MINUTES,
   type ExtensionTokenScope,
 } from "@/lib/constants";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
@@ -212,7 +213,7 @@ export async function issueExtensionToken(params: {
       select: { extensionTokenIdleTimeoutMinutes: true },
     }),
   BYPASS_PURPOSE.TOKEN_LIFECYCLE);
-  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? 10080;
+  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? DEFAULT_EXTENSION_IDLE_MINUTES;
   const expiresAt = new Date(now.getTime() + idleMinutes * MS_PER_MINUTE);
 
   const plaintext = generateShareToken();

--- a/src/lib/constants/auth/extension-token.ts
+++ b/src/lib/constants/auth/extension-token.ts
@@ -40,3 +40,16 @@ export const IOS_TOKEN_DEFAULT_SCOPES = [
  * per-family absolute lifetime (tenant.extensionTokenAbsoluteTimeoutMinutes).
  */
 export const EXTENSION_TOKEN_MAX_ACTIVE = 3;
+
+/**
+ * Default idle timeout in minutes used when `tenant.extensionTokenIdleTimeoutMinutes`
+ * is null. Single source of truth for the application-side fallback applied
+ * by `issueExtensionToken`, the refresh route, and the tenant-policy GET
+ * fallback. MUST stay in sync with the Prisma schema default
+ * (`extensionTokenIdleTimeoutMinutes Int @default(10080)`); the schema-default
+ * integration test in `session-timeout.integration.test.ts` asserts the
+ * round-trip.
+ *
+ * 10080 minutes = 7 days.
+ */
+export const DEFAULT_EXTENSION_IDLE_MINUTES = 10080;

--- a/src/lib/constants/auth/extension-token.ts
+++ b/src/lib/constants/auth/extension-token.ts
@@ -41,15 +41,8 @@ export const IOS_TOKEN_DEFAULT_SCOPES = [
  */
 export const EXTENSION_TOKEN_MAX_ACTIVE = 3;
 
-/**
- * Default idle timeout in minutes used when `tenant.extensionTokenIdleTimeoutMinutes`
- * is null. Single source of truth for the application-side fallback applied
- * by `issueExtensionToken`, the refresh route, and the tenant-policy GET
- * fallback. MUST stay in sync with the Prisma schema default
- * (`extensionTokenIdleTimeoutMinutes Int @default(10080)`); the schema-default
- * integration test in `session-timeout.integration.test.ts` asserts the
- * round-trip.
- *
- * 10080 minutes = 7 days.
- */
-export const DEFAULT_EXTENSION_IDLE_MINUTES = 10080;
+// Idle-timeout default lives at src/lib/validations/common.ts as
+// EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT (alongside the session timeout
+// defaults). Import it from there — kept here as a doc-pointer so anyone
+// looking under constants/auth/ for the extension-token fallback finds
+// the right place.

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -75,7 +75,6 @@ export {
   EXTENSION_TOKEN_SCOPE_VALUES,
   EXTENSION_TOKEN_DEFAULT_SCOPES,
   EXTENSION_TOKEN_MAX_ACTIVE,
-  DEFAULT_EXTENSION_IDLE_MINUTES,
 } from "./auth/extension-token";
 export type { ExtensionTokenScope } from "./auth/extension-token";
 

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -75,6 +75,7 @@ export {
   EXTENSION_TOKEN_SCOPE_VALUES,
   EXTENSION_TOKEN_DEFAULT_SCOPES,
   EXTENSION_TOKEN_MAX_ACTIVE,
+  DEFAULT_EXTENSION_IDLE_MINUTES,
 } from "./auth/extension-token";
 export type { ExtensionTokenScope } from "./auth/extension-token";
 

--- a/src/lib/logger/throttled.ts
+++ b/src/lib/logger/throttled.ts
@@ -1,6 +1,15 @@
 import { getLogger } from "@/lib/logger";
 
 /**
+ * Single throttle window used by every Redis-backed cache that uses
+ * createThrottledErrorLogger for its fallback path. Centralized so the
+ * forensic-responsiveness floor is uniform across session-cache, dpop
+ * caches, and the rate-limit Redis path — changing the value here updates
+ * all four call sites at once.
+ */
+export const REDIS_FALLBACK_LOG_THROTTLE_MS = 5_000;
+
+/**
  * Throttled error logger factory. The returned function emits at most one
  * log line per intervalMs. Used by Redis-backed caches that must not flood
  * logs during sustained outages.

--- a/src/lib/proxy/auth-gate.ts
+++ b/src/lib/proxy/auth-gate.ts
@@ -17,6 +17,7 @@ import {
   type SessionInfo,
 } from "@/lib/auth/session/session-cache";
 import { resolveUserTenantId } from "@/lib/tenant-context";
+import { ALL_KNOWN_SESSION_COOKIE_NAMES } from "@/lib/auth/session/cookie-name";
 
 export type { SessionInfo } from "@/lib/auth/session/session-cache";
 export { SESSION_CACHE_TTL_MS } from "@/lib/auth/session/session-cache";
@@ -24,11 +25,12 @@ export { SESSION_CACHE_TTL_MS } from "@/lib/auth/session/session-cache";
 /**
  * Extract the Auth.js session token value from the cookie header.
  * Returns empty string if no known session token cookie is present.
+ * Walks ALL_KNOWN_SESSION_COOKIE_NAMES so any of the three current-issue
+ * shapes (__Host- / __Secure- / plain) is recognized regardless of the
+ * deployment's useSecureCookies + basePath combination.
  */
 export function extractSessionToken(cookie: string): string {
-  // Cookie names used by Auth.js (dev and prod variants)
-  const names = ["__Secure-authjs.session-token", "authjs.session-token"];
-  for (const name of names) {
+  for (const name of ALL_KNOWN_SESSION_COOKIE_NAMES) {
     const prefix = `${name}=`;
     const idx = cookie.indexOf(prefix);
     if (idx !== -1) {

--- a/src/lib/proxy/page-route.ts
+++ b/src/lib/proxy/page-route.ts
@@ -8,6 +8,7 @@ import { AUDIT_ACTION } from "../constants/audit/audit";
 import { MS_PER_DAY, MS_PER_MINUTE } from "../constants/time";
 import { applySecurityHeaders } from "./security-headers";
 import { getSessionInfo } from "./auth-gate";
+import { ALL_KNOWN_SESSION_COOKIE_NAMES } from "../auth/session/cookie-name";
 import { extractClientIp } from "../auth/policy/ip-access";
 import { checkAccessRestrictionWithAudit } from "../auth/policy/access-restriction";
 
@@ -119,15 +120,8 @@ export function recordPasskeyAuditEmit(userId: string, now: number): boolean {
 }
 
 function clearAuthSessionCookies(response: NextResponse, basePath: string = ""): void {
-  const authSessionCookieNames = [
-    "authjs.session-token",
-    "__Secure-authjs.session-token",
-    "next-auth.session-token",
-    "__Secure-next-auth.session-token",
-  ] as const;
-
   const cookiePath = `${basePath}/`;
-  for (const name of authSessionCookieNames) {
+  for (const name of ALL_KNOWN_SESSION_COOKIE_NAMES) {
     response.cookies.delete({ name, path: cookiePath });
   }
 }

--- a/src/lib/security/ip-rate-limit.test.ts
+++ b/src/lib/security/ip-rate-limit.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockWarn = vi.fn();
+vi.mock("@/lib/logger", () => ({
+  getLogger: () => ({ warn: mockWarn, error: vi.fn(), info: vi.fn() }),
+}));
+
+// Identity passthrough so the assertion against the key value is readable.
+// The actual IPv6→/64 normalization is covered by ip-access.test.ts; do
+// not duplicate that contract here.
+vi.mock("@/lib/auth/policy/ip-access", () => ({
+  rateLimitKeyFromIp: (ip: string) => ip,
+}));
+
+import { checkIpRateLimit } from "./ip-rate-limit";
+
+describe("checkIpRateLimit", () => {
+  beforeEach(() => {
+    mockWarn.mockReset();
+  });
+
+  it("forwards to the limiter with `rl:<scope>:<ip>` key when ip is present", async () => {
+    const check = vi.fn().mockResolvedValue({ allowed: true });
+    const res = await checkIpRateLimit({
+      ip: "203.0.113.5",
+      pathname: "/api/x",
+      scope: "test_scope",
+      limiter: { check },
+    });
+    expect(check).toHaveBeenCalledTimes(1);
+    expect(check).toHaveBeenCalledWith("rl:test_scope:203.0.113.5");
+    expect(res).toEqual({ allowed: true });
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it("passes through the limiter's deny result (allowed=false, retryAfterMs)", async () => {
+    const check = vi.fn().mockResolvedValue({ allowed: false, retryAfterMs: 1500 });
+    const res = await checkIpRateLimit({
+      ip: "203.0.113.5",
+      pathname: "/api/x",
+      scope: "test_scope",
+      limiter: { check },
+    });
+    expect(res).toEqual({ allowed: false, retryAfterMs: 1500 });
+  });
+
+  it("fails open (allowed=true) with a warn log when ip is null", async () => {
+    const check = vi.fn();
+    const res = await checkIpRateLimit({
+      ip: null,
+      pathname: "/api/x",
+      scope: "test_scope",
+      limiter: { check },
+    });
+    expect(check).not.toHaveBeenCalled();
+    expect(res).toEqual({ allowed: true });
+    expect(mockWarn).toHaveBeenCalledWith(
+      { pathname: "/api/x", scope: "test_scope" },
+      "rate_limit_skipped_unknown_ip",
+    );
+  });
+});

--- a/src/lib/security/ip-rate-limit.ts
+++ b/src/lib/security/ip-rate-limit.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared `extractClientIp + rateLimiter.check` glue.
+ *
+ * The pattern was repeated across 10 route handlers and the original
+ * implementations collapsed all IP-less requests into a single bucket
+ * keyed by the literal string `"unknown"` — a documented DoS-on-others
+ * vector (one bad actor at any IP without a usable IP-source consumed
+ * the shared quota for every legitimate IP-less request fleet-wide).
+ *
+ * This helper applies the same fail-open + structured-warn decision used
+ * by the OAuth callback rate limit at
+ * `src/app/api/auth/[...nextauth]/route.ts:withCallbackRateLimit`:
+ *   - When the client IP is null, skip the limiter and emit a warn so
+ *     operators detect proxy misconfiguration (TRUST_PROXY_HEADERS
+ *     unset behind a proxy is the common cause).
+ *   - When the client IP is present, key per-IP via
+ *     `rateLimitKeyFromIp` (IPv6 → /64 normalization).
+ *
+ * Returns the same `{ allowed, retryAfterMs? }` shape as the underlying
+ * limiter so call sites do not need a different branch for the
+ * fail-open path.
+ */
+
+import { getLogger } from "@/lib/logger";
+import { rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
+
+interface RateLimitProbe {
+  check: (key: string) => Promise<{ allowed: boolean; retryAfterMs?: number }>;
+}
+
+interface CheckIpRateLimitArgs {
+  /** Result of extractClientIp / extractClientIpFromHeaders — null when the IP cannot be determined. */
+  ip: string | null;
+  /** Used in the warn log for operator-visible context. */
+  pathname: string;
+  /** Inserted into the rate-key as `rl:<scope>:<ip>`. Must be short, lower-snake_case. */
+  scope: string;
+  /** A rate-limiter from `createRateLimiter`. */
+  limiter: RateLimitProbe;
+  /**
+   * Optional extra-key segment appended after the IP, e.g. a per-resource
+   * hash to bound the limiter by (ip, resource) instead of (ip) alone.
+   * Final key shape: `rl:<scope>:<ip>:<keySuffix>`.
+   */
+  keySuffix?: string;
+}
+
+export async function checkIpRateLimit(
+  args: CheckIpRateLimitArgs,
+): Promise<{ allowed: boolean; retryAfterMs?: number }> {
+  if (args.ip == null) {
+    getLogger().warn(
+      { pathname: args.pathname, scope: args.scope },
+      "rate_limit_skipped_unknown_ip",
+    );
+    return { allowed: true };
+  }
+  const ipPart = rateLimitKeyFromIp(args.ip);
+  const tail = args.keySuffix != null ? `:${args.keySuffix}` : "";
+  return args.limiter.check(`rl:${args.scope}:${ipPart}${tail}`);
+}

--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -59,8 +59,8 @@ export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
         allowed: false,
         retryAfterMs: ttl > 0 ? ttl : windowMs,
       };
-    } catch {
-      logRedisError();
+    } catch (err) {
+      logRedisError((err as { code?: string } | undefined)?.code);
       return null; // fallback to in-memory
     }
   }
@@ -71,7 +71,8 @@ export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
     try {
       await redis.del(key);
       return true;
-    } catch {
+    } catch (err) {
+      logRedisError((err as { code?: string } | undefined)?.code);
       return false;
     }
   }

--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -1,9 +1,14 @@
 import { getRedis } from "@/lib/redis";
 import { RATE_LIMIT_MAP_MAX_SIZE } from "@/lib/validations/common.server";
-import { createThrottledErrorLogger } from "@/lib/logger/throttled";
+import {
+  REDIS_FALLBACK_LOG_THROTTLE_MS,
+  createThrottledErrorLogger,
+} from "@/lib/logger/throttled";
 
-// 30_000 ms: matches existing log-flood ceiling for Redis fallback events.
-const logRedisError = createThrottledErrorLogger(30_000, "rate-limit.redis.fallback");
+const logRedisError = createThrottledErrorLogger(
+  REDIS_FALLBACK_LOG_THROTTLE_MS,
+  "rate-limit.redis.fallback",
+);
 
 interface RateLimiterOptions {
   /** Time window in milliseconds */

--- a/src/workers/audit-outbox-worker.test.ts
+++ b/src/workers/audit-outbox-worker.test.ts
@@ -1214,6 +1214,83 @@ describe("reaper — invoked on first loop tick", () => {
   }, 15000);
 });
 
+// ─── recordError — sanitize before persist ──────────────────────────────────
+
+describe("recordError — sanitizes error message before persisting", () => {
+  beforeEach(resetMocks);
+
+  it("passes raw err.message to sanitizeErrorForStorage and writes the sanitized form to UPDATE last_error", async () => {
+    // Override sanitize to return a recognizable marker; we then assert the
+    // marker reaches both the UPDATE statement and the dead-letter metadata.
+    const { sanitizeErrorForStorage } = await import("@/lib/http/external-http");
+    const sanitizeMock = sanitizeErrorForStorage as unknown as Mock;
+    sanitizeMock.mockReturnValueOnce("[SANITIZED]");
+
+    const row = makeRow({ attempt_count: 7, max_attempts: 8 });
+    mockQueryRawUnsafe.mockResolvedValueOnce([row]);
+
+    const worker = createWorker({ databaseUrl: TEST_DB_URL, pollIntervalMs: 50 });
+    const RAW_MESSAGE = "request to https://upstream.example.com/api?token=secret123 failed";
+    let txCallCount = 0;
+    mockTransaction.mockImplementation(
+      async function (fn: TxFn) {
+        txCallCount++;
+        // tx 1 = claimBatch (returns [row])
+        // tx 2 = deliverRow — throw the raw URL-bearing message
+        // tx 3 = recordError (UPDATE to FAILED with sanitized msg)
+        // tx 4 = writeDirectAuditLog (DEAD_LETTER INSERT with sanitized msg)
+        // tx 5 = reapStuckRows
+        // tx 6 = purgeRetention
+        // tx 7 = next claimBatch — stop
+        if (txCallCount === 2) {
+          throw new Error(RAW_MESSAGE);
+        }
+        if (txCallCount === 7) {
+          worker.stop();
+          return [];
+        }
+        return fn({
+          $executeRaw: mockExecuteRaw,
+          $queryRawUnsafe: mockQueryRawUnsafe,
+          $executeRawUnsafe: mockExecuteRawUnsafe,
+          auditDeliveryTarget: { findMany: vi.fn().mockResolvedValue([]) },
+          auditDelivery: { upsert: vi.fn().mockResolvedValue({}), findMany: vi.fn().mockResolvedValue([]), update: vi.fn().mockResolvedValue({}) },
+        });
+      },
+    );
+
+    await worker.start();
+
+    // 1. sanitize was called with the raw error message exactly once
+    expect(sanitizeMock).toHaveBeenCalledWith(RAW_MESSAGE);
+
+    // 2. The UPDATE audit_outbox SET last_error = LEFT($2, 1024) statement
+    //    received the sanitized form (param at call[2]), not the raw message.
+    const updateCall = mockExecuteRawUnsafe.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" &&
+        call[0].includes("UPDATE audit_outbox") &&
+        call[0].includes("status = 'FAILED'"),
+    );
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[2]).toBe("[SANITIZED]");
+    expect(updateCall?.[2]).not.toContain("token=secret123");
+
+    // 3. The dead-letter INSERT metadata (param $6 at call[6]) contains
+    //    the sanitized form in lastError, not the raw secret.
+    const deadLetterInsert = mockExecuteRawUnsafe.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" &&
+        call[0].includes("INSERT INTO audit_logs") &&
+        call[3] === AUDIT_ACTION.AUDIT_OUTBOX_DEAD_LETTER,
+    );
+    expect(deadLetterInsert).toBeDefined();
+    const metadata = JSON.parse(deadLetterInsert![6] as string);
+    expect(metadata.lastError).toBe("[SANITIZED]");
+    expect(metadata.lastError).not.toContain("token=secret123");
+  }, 15000);
+});
+
 // ─── recordError — AUDIT_OUTBOX_DEAD_LETTER via writeDirectAuditLog ──────────
 
 describe("recordError — AUDIT_OUTBOX_DEAD_LETTER written on dead-letter", () => {

--- a/src/workers/audit-outbox-worker.ts
+++ b/src/workers/audit-outbox-worker.ts
@@ -437,6 +437,10 @@ async function recordError(
   err: unknown,
 ): Promise<void> {
   const errorMsg = err instanceof Error ? err.message : String(err);
+  // Strip URL query params and credential patterns before persisting,
+  // matching the audit-delivery dead-letter path. last_error rows are
+  // long-lived (until retention purge) and feed the audit log.
+  const sanitizedError = sanitizeErrorForStorage(errorMsg);
   const newAttemptCount = row.attempt_count + 1;
   const isDead = newAttemptCount >= row.max_attempts;
   const backoffMs = withFullJitter(computeBackoffMs(newAttemptCount));
@@ -455,7 +459,7 @@ async function recordError(
                processing_started_at = NULL
            WHERE id = $3`,
           newAttemptCount,
-          errorMsg,
+          sanitizedError,
           row.id,
         );
       } else {
@@ -469,7 +473,7 @@ async function recordError(
            WHERE id = $4`,
           newAttemptCount,
           backoffSeconds,
-          errorMsg,
+          sanitizedError,
           row.id,
         );
       }
@@ -487,7 +491,7 @@ async function recordError(
       outboxId: row.id,
       action: parsePayloadAction(row.payload),
       attemptCount: newAttemptCount,
-      lastError: errorMsg.slice(0, 256),
+      lastError: sanitizedError.slice(0, 256),
     });
   }
 }


### PR DESCRIPTION
## Summary

Followup to `#465` (reverted via `#467`). Each finding from the original PR was assessed, kept-as-modified, or dropped based on `docs/archive/review/owasp-pr465-code-review.md`. 10 commits, one logical change each, all on this single branch.

## Commits

| Commit | OWASP | Change |
|--------|-------|--------|
| 8e37522d | A09 | Centralize Redis fallback log throttle (4 sites → 1 const, value 5_000 ms applied uniformly) |
| ebe71ac3 | A09 | audit-outbox `recordError` now `sanitizeErrorForStorage`s before persisting; unit test asserts the sanitized form reaches both UPDATE and dead-letter metadata |
| 9f5a3a9b | A09 | passkey policy fetch silent catch → warn log `{ userId, tenantId, err }` |
| fc57adee | A07 | Vault unlock per-user rate-key test hardened — strict-equal + IP-bearing request so any re-introduction of an IP suffix trips the assertion (was a vacuous pass) |
| ed46eb55 | A07 | Extract `DEFAULT_EXTENSION_IDLE_MINUTES = 10080`, unify 3 fallback sites + fixtures + a drift-detector test. Value kept at 10080 pending proper schema-default migration |
| 23c739d4 | A05 | docker-compose DB passwords fail-closed (`${PASSWD_*_PASSWORD:?…}`); `db` service env block now forwards `PASSWD_OUTBOX_WORKER_PASSWORD` + `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` to `initdb` so operator overrides actually take effect; env-allowlist + docs + CI workflows aligned to the same vocabulary |
| 0e76839a | A07 | OAuth/SAML callback rate limit scoped to `/api/auth/callback/*` (both GET and POST); null-IP now skips with warn log instead of collapsing to a shared `unknown` bucket; 9 new tests |
| 49b0d351 | A07 | Centralize session cookie naming in `src/lib/auth/session/cookie-name.ts`; migrate 5 consumer sites; adopt `__Host-` when secure + no basePath; retain `sameSite=strict`. 19 new tests including the (`useSecureCookies` × `basePath`) matrix |
| 121042ce | docs | Restore `docs/security/owasp-top10-2026-05.md` (deleted with PR `#465` revert) and elevate "passkey policy fetch fail-OPEN" to a TRACKED FOLLOWUP under A04/A07 with three candidate remediations enumerated |
| 86dc0d3d | tests | Align `getSessionToken` tests with the new __Host- selection (followup to 49b0d351) |

## What was dropped from PR #465 (and why)

- **A02 CLI TLS guard** (`cli/src/lib/api-client.ts`) — `NODE_ENV=production` rarely set on end-user CLI invocations; a URL-host-based gate would be the correct hardening, deferred.
- **A07 vault setup `entropyBits` validation** — in a zero-knowledge E2E-encrypted vault the server cannot independently verify the estimate, no client transmits it today; pure log noise without client-side enforcement.

## Migration note for existing dev environments

Running containers are unaffected. On next `docker compose down && up`, set in `.env`:

```sh
PASSWD_SUPERUSER_PASSWORD=passwd_pass
PASSWD_APP_PASSWORD=passwd_app_pass
PASSWD_OUTBOX_WORKER_PASSWORD=passwd_outbox_pass
PASSWD_DCR_CLEANUP_WORKER_PASSWORD=passwd_dcr_pass
```

(values match the prior `:-fallback` defaults — preserves existing DB role passwords). To rotate to new values, generate via `openssl rand -hex 24` + use the `scripts/set-*-password.sh` rotation scripts for the worker roles.

## Verification

- `npm run lint` — clean
- `npx vitest run` — full suite passes (multiple new tests across A07-1/2/3/4 + A09-2/3)
- `npm run check:env-docs` — green (was red on main after PR `#465`; revert restored it; this PR keeps it green)
- `docker compose config` — fail-closed without env vars, parses cleanly with vars set

`scripts/pre-pr.sh` surfaces pre-existing TypeScript errors in `audit-logs/page.tsx` that exist on origin/main already (the corresponding CI `next build` step on main is green). Out of scope for this PR — tracked separately.

## Test plan

- [ ] CI passes (lint, unit, integration, build, env-docs drift)
- [ ] Manual: `docker compose down && docker compose up -d` after setting the 4 `PASSWD_*_PASSWORD` env vars; verify all containers start healthy
- [ ] Manual: sign-in via Google OIDC + magic link in dev (HTTP no basePath) — confirms `authjs.session-token` plain cookie still works
- [ ] Manual (production-shape): sign-in via HTTPS no basePath; confirm `__Host-authjs.session-token` is set and the proxy recognizes it
- [ ] Manual: hit `/api/auth/callback/google` 61 times/min from one IP — confirm 429 with `Retry-After`

Reverts the revert side of `#465`/`#467` for the salvageable items.