### PR TITLE
fix(security): PR #470 followup — intra-user IDOR + AAD re-wrap + 2 minor

### DIFF
--- a/src/app/api/api-keys/[id]/route.test.ts
+++ b/src/app/api/api-keys/[id]/route.test.ts
@@ -6,6 +6,7 @@ const {
   mockCheckAuth,
   mockPrismaApiKey,
   mockWithUserTenantRls,
+  mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockCheckAuth: vi.fn(),
   mockPrismaApiKey: {
@@ -13,10 +14,14 @@ const {
     update: vi.fn(),
   },
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
+  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/lib/auth/session/check-auth", () => ({
   checkAuth: mockCheckAuth,
+}));
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: mockRequireRecentSession,
 }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {
@@ -54,6 +59,7 @@ describe("DELETE /api/api-keys/[id]", () => {
     mockCheckAuth.mockReset();
     mockPrismaApiKey.findUnique.mockReset();
     mockPrismaApiKey.update.mockReset();
+    mockRequireRecentSession.mockResolvedValue(null);
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -99,6 +105,28 @@ describe("DELETE /api/api-keys/[id]", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.success).toBe(true);
+  });
+
+  it("returns 403 when session step-up is required", async () => {
+    mockCheckAuth.mockResolvedValue({
+      ok: true,
+      auth: { type: "session", userId: "u1" },
+    });
+    mockRequireRecentSession.mockResolvedValueOnce(
+      Response.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const res = await DELETE(
+      createRequest("DELETE", "http://localhost:3000/api/api-keys/key-1"),
+      createParams({ id: "key-1" }),
+    );
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
+    // Must NOT reach DB lookup or update when step-up gate denies
+    expect(mockPrismaApiKey.findUnique).not.toHaveBeenCalled();
+    expect(mockPrismaApiKey.update).not.toHaveBeenCalled();
   });
 
   it("returns 404 when key not found", async () => {

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -7,14 +7,19 @@ import { errorResponse } from "@/lib/http/api-response";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 
-// DELETE /api/api-keys/[id] — Revoke an API key (session only)
+// DELETE /api/api-keys/[id] — Revoke an API key (session only + step-up)
 async function handleDELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const authed = await checkAuth(req);
   if (!authed.ok) return authed.response;
+  // Step-up parity with POST: API-key revocation is a management op affecting
+  // availability, so require the same recent re-auth bar as issuance.
+  const stepUpError = await requireRecentCurrentAuthMethod(req);
+  if (stepUpError) return stepUpError;
   const { userId } = authed.auth;
 
   const { id } = await params;

--- a/src/app/api/vault/delegation/check/route.test.ts
+++ b/src/app/api/vault/delegation/check/route.test.ts
@@ -134,7 +134,9 @@ describe("GET /api/vault/delegation/check", () => {
       userId: "user-1",
       tenantId: "tenant-1",
       tokenId: "tok-1",
-      mcpClientId: "mcpc_abc",
+      // Token must own the queried clientId — intra-user IDOR guard runs
+      // AFTER enforceAccessRestriction, so we still need IP-range denial first.
+      mcpClientId: VALID_CLIENT_ID,
       scopes: ["delegation:check"],
     });
     const denied = new Response(
@@ -149,6 +151,28 @@ describe("GET /api/vault/delegation/check", () => {
     // Must not look up delegation or log audit when IP is denied
     expect(mockPrismaDelegationSession.findFirst).not.toHaveBeenCalled();
     expect(mockLogAudit).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when MCP token's mcpClientId does not match query clientId (intra-user IDOR guard)", async () => {
+    // Token issued for one MCP client cannot query delegation state of another
+    // MCP client owned by the same user.
+    const OTHER_CLIENT_ID = "mcpc_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    mockAuthOrToken.mockResolvedValue({
+      type: "mcp_token",
+      userId: "user-1",
+      tenantId: "tenant-1",
+      tokenId: "tok-1",
+      mcpClientId: OTHER_CLIENT_ID,
+      scopes: ["delegation:check"],
+    });
+
+    const res = await GET(makeRequest({ clientId: VALID_CLIENT_ID, entryId: VALID_ENTRY_ID }));
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.authorized).toBe(false);
+    // Lookup MUST NOT run — guard fires before the DB query
+    expect(mockPrismaDelegationSession.findFirst).not.toHaveBeenCalled();
   });
 
   it("returns 429 when rate limited", async () => {

--- a/src/app/api/vault/delegation/check/route.ts
+++ b/src/app/api/vault/delegation/check/route.ts
@@ -77,6 +77,13 @@ export async function GET(request: NextRequest) {
 
   const { clientId, entryId } = parsed.data;
 
+  // Intra-user IDOR guard: an MCP token may only check its own client's
+  // delegation. Without this, a user-X token issued for client A could
+  // probe delegation state of the same user's other MCP client B.
+  if (authResult.type === "mcp_token" && authResult.mcpClientId !== clientId) {
+    return NextResponse.json({ authorized: false, reason: "unauthorized" }, { status: 403 });
+  }
+
   // Find active delegation session via MCP client's public clientId
   const { prisma } = await import("@/lib/prisma");
   const { withBypassRls, BYPASS_PURPOSE } = await import("@/lib/tenant-rls");
@@ -86,6 +93,10 @@ export async function GET(request: NextRequest) {
       where: {
         userId,
         mcpAccessToken: {
+          // When auth is MCP token, also bind the lookup to the calling
+          // token's tokenId — defense-in-depth on top of the clientId
+          // equality check above.
+          ...(authResult.type === "mcp_token" ? { tokenId: authResult.tokenId } : {}),
           mcpClient: { clientId },
         },
         revokedAt: null,

--- a/src/lib/services/team-password-service.test.ts
+++ b/src/lib/services/team-password-service.test.ts
@@ -300,9 +300,30 @@ describe("createTeamPassword", () => {
     }).catch((e) => e);
 
     expect(err).toBeInstanceOf(TeamPasswordServiceError);
-    expect(err.code).toBe("NOT_FOUND");
+    expect(err.code).toBe(API_ERROR.NOT_FOUND);
     expect(err.statusHint).toBe(404);
     expect(mockTeamPasswordEntryCreate).not.toHaveBeenCalled();
+  });
+
+  it("accepts duplicate tagIds — deduplicates before comparing to teamTag.count", async () => {
+    // A client may legitimately send ["tag-1","tag-1"] (e.g. UI bug); without
+    // dedup the count check would fail spuriously because teamTag.count returns
+    // distinct rows (1) while the raw input length is 2.
+    mockTeamFindUnique.mockResolvedValue(DEFAULT_TEAM);
+    mockTeamTagCount.mockResolvedValue(1);
+    const created = { id: "entry-1", tags: [] };
+    mockTeamPasswordEntryCreate.mockResolvedValue(created);
+
+    const result = await createTeamPassword(TEAM_ID, {
+      ...BASE_CREATE_INPUT,
+      tagIds: ["tag-1", "tag-1"],
+    });
+
+    expect(result).toBe(created);
+    // count must be queried with the deduped IDs ([tag-1]), not the raw input
+    expect(mockTeamTagCount).toHaveBeenCalledWith({
+      where: { id: { in: ["tag-1"] }, teamId: TEAM_ID },
+    });
   });
 });
 
@@ -558,8 +579,55 @@ describe("updateTeamPassword", () => {
 
     const err = await updateTeamPassword(TEAM_ID, PASSWORD_ID, input).catch((e) => e);
     expect(err).toBeInstanceOf(TeamPasswordServiceError);
-    expect(err.code).toBe("ITEM_KEY_REQUIRED");
+    expect(err.code).toBe(API_ERROR.ITEM_KEY_REQUIRED);
     expect(err.statusHint).toBe(400);
+  });
+
+  it("throws ITEM_KEY_REQUIRED when teamKeyVersion changes with itemKeyVersion>=1 but no encryptedItemKey (re-wrap required)", async () => {
+    // buildItemKeyWrapAAD binds the wrapped item key to teamKeyVersion. When
+    // teamKeyVersion rotates from 3 → 4 and the entry holds an item key
+    // (itemKeyVersion=1), the wrapped key MUST be re-wrapped with the new
+    // team key — otherwise the AAD no longer matches and the entry breaks.
+    const input: UpdateTeamPasswordInput = {
+      encryptedBlob: ENCRYPTED_BLOB,
+      encryptedOverview: ENCRYPTED_OVERVIEW,
+      aadVersion: 1,
+      teamKeyVersion: 4, // rotated from existing 3
+      itemKeyVersion: 1, // unchanged from existing
+      // encryptedItemKey deliberately absent
+      userId: USER_ID,
+      existingEntry: { ...BASE_EXISTING_ENTRY, teamKeyVersion: 3, itemKeyVersion: 1 },
+    };
+    mockTeamFindUnique.mockResolvedValue({ teamKeyVersion: 4 });
+
+    const err = await updateTeamPassword(TEAM_ID, PASSWORD_ID, input).catch((e) => e);
+    expect(err).toBeInstanceOf(TeamPasswordServiceError);
+    expect(err.code).toBe(API_ERROR.ITEM_KEY_REQUIRED);
+    expect(err.statusHint).toBe(400);
+    expect(mockTeamPasswordEntryUpdate).not.toHaveBeenCalled();
+  });
+
+  it("succeeds when teamKeyVersion change is paired with new encryptedItemKey re-wrap", async () => {
+    mockTeamFindUnique.mockResolvedValue({ teamKeyVersion: 4 });
+    mockTeamPasswordEntryHistoryCreate.mockResolvedValue({});
+    mockTeamPasswordEntryHistoryFindMany.mockResolvedValue([{ id: "h-1" }]);
+    const updated = { id: PASSWORD_ID, tags: [] };
+    mockTeamPasswordEntryUpdate.mockResolvedValue(updated);
+
+    const input: UpdateTeamPasswordInput = {
+      encryptedBlob: ENCRYPTED_BLOB,
+      encryptedOverview: ENCRYPTED_OVERVIEW,
+      aadVersion: 1,
+      teamKeyVersion: 4,
+      itemKeyVersion: 1,
+      encryptedItemKey: ENCRYPTED_ITEM_KEY, // re-wrap supplied
+      userId: USER_ID,
+      existingEntry: { ...BASE_EXISTING_ENTRY, teamKeyVersion: 3, itemKeyVersion: 1 },
+    };
+
+    const result = await updateTeamPassword(TEAM_ID, PASSWORD_ID, input);
+    expect(result).toBe(updated);
+    expect(mockTeamPasswordEntryUpdate).toHaveBeenCalledOnce();
   });
 
   it("succeeds when upgrading v0→v1 and encryptedItemKey is provided", async () => {

--- a/src/lib/services/team-password-service.ts
+++ b/src/lib/services/team-password-service.ts
@@ -112,10 +112,14 @@ async function assertTeamTagsOwnership(
   teamId: string,
 ): Promise<void> {
   if (!tagIds?.length) return;
+  // Normalize: a caller-supplied duplicate (e.g. ["t1","t1"]) should not
+  // count as a missing tag. teamTag.count returns distinct row count, so
+  // compare against the deduped input length, not the raw array length.
+  const uniqueTagIds = [...new Set(tagIds)];
   const count = await prisma.teamTag.count({
-    where: { id: { in: tagIds }, teamId },
+    where: { id: { in: uniqueTagIds }, teamId },
   });
-  if (count !== tagIds.length) {
+  if (count !== uniqueTagIds.length) {
     throw new TeamPasswordServiceError(API_ERROR.NOT_FOUND, 404);
   }
 }
@@ -405,6 +409,22 @@ export async function updateTeamPassword(
     itemKeyVersion !== undefined &&
     itemKeyVersion >= 1 &&
     existingVersion < 1 &&
+    !encryptedItemKey
+  ) {
+    throw new TeamPasswordServiceError(API_ERROR.ITEM_KEY_REQUIRED, 400);
+  }
+
+  // Re-wrap requirement: buildItemKeyWrapAAD binds the encryptedItemKey to
+  // teamKeyVersion. If teamKeyVersion changes (rotation) and the entry holds
+  // a wrapped item key (effective itemKeyVersion >= 1), the encryptedItemKey
+  // MUST be re-wrapped with the new team key — otherwise the existing wrap's
+  // AAD no longer matches and the item key (and thus the entry) becomes
+  // undecryptable.
+  const effectiveItemKeyVersion = itemKeyVersion ?? existingVersion;
+  if (
+    isFullUpdate &&
+    teamKeyVersionChanged &&
+    effectiveItemKeyVersion >= 1 &&
     !encryptedItemKey
   ) {
     throw new TeamPasswordServiceError(API_ERROR.ITEM_KEY_REQUIRED, 400);


### PR DESCRIPTION
## Summary

ChatGPT review of merged PR #470 surfaced 4 residual issues — 2 cryptographic correctness, 2 hardening. All resolved.

## What changed

**[A] `delegation/check`: bind lookup to the calling MCP token's `mcpClientId`**

Before: route trusted the query-string `clientId` to filter delegation sessions under the authenticated `userId`. A user-X token issued for client A could probe delegation state of the same user's other MCP client B (intra-user IDOR).

After: when auth is `mcp_token`, the lookup pins both `clientId` equality AND `mcpAccessToken.tokenId` (defense in depth). Non-matching `clientId` returns 403 BEFORE the DB query.

**[B] team-password update: require `encryptedItemKey` re-wrap when `teamKeyVersion` changes with `itemKeyVersion >= 1`**

Before: existing guard caught "version change without `encryptedBlob`" (no `isFullUpdate`). When `isFullUpdate=true` + `teamKeyVersion 1→2` + `itemKeyVersion=1` + no new `encryptedItemKey`, the request was accepted — but `buildItemKeyWrapAAD(teamId, entryId, teamKeyVersion)` binds the wrapped item key to `teamKeyVersion`. The existing wrap's AAD no longer matches → entry becomes undecryptable.

After: `ITEM_KEY_REQUIRED` 400 fires when the conditions hold.

**[C] team-password `tagIds`: deduplicate before count comparison**

Before: `assertTeamTagsOwnership` compared raw `tagIds.length` to `teamTag.count` (which returns distinct rows). Client sending `["t1","t1"]` got spurious 404.

After: `[...new Set(tagIds)]` normalized before query + length compare.

**[D] `DELETE /api/api-keys/[id]`: require step-up (parity with POST)**

API-key revocation is a management op affecting availability — same recent re-auth bar as issuance is policy-natural.

## Out of scope (separate sessions)

- Redis rate-limit fail-closed for auth-critical endpoints
- `EXTENSION_*` token naming reorg (browser-extension is a subset of the `ExtensionToken` class that also covers iOS host app; i18n message wording inconsistency tracked separately)

## Test plan
- [x] `npx vitest run` — 10367 tests pass, 1 skipped, 0 failed
- [x] `npx next build` — succeeds
- [x] `scripts/pre-pr.sh` — 18/18 checks pass
- [x] New test added per fix:
  - [A] `returns 403 when MCP token's mcpClientId does not match query clientId (intra-user IDOR guard)`
  - [B] `throws ITEM_KEY_REQUIRED when teamKeyVersion changes with itemKeyVersion>=1 but no encryptedItemKey` + positive case `succeeds when teamKeyVersion change is paired with new encryptedItemKey re-wrap`
  - [C] `accepts duplicate tagIds — deduplicates before comparing to teamTag.count`
  - [D] `returns 403 when session step-up is required`

## Refactor: API_ERROR constant usage

Replaced 8 raw `"FOLDER_NOT_FOUND"` strings with `API_ERROR.FOLDER_NOT_FOUND` (existing import) in `team-password-service.test.ts` — consistency cleanup that came up while editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)