### PR TITLE
fix(security): batch 1 — critical + high findings from codebase audit

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -2,7 +2,7 @@
 
 This document presents a systematic STRIDE-based threat analysis for passwd-sso.
 
-Last updated: 2026-04-28
+Last updated: 2026-05-21
 
 ---
 
@@ -168,3 +168,5 @@ TB7: Extension Passkey Provider (MAIN world <-> content script <-> Service Worke
 4. **Compromised IdP**: A compromised Google/SAML identity provider could issue valid authentication tokens. Mitigated by vault passphrase requirement (IdP compromise alone does not decrypt vault data).
 
 5. **Offline brute force against exported data**: An attacker with a database dump can attempt offline brute force against PBKDF2/Argon2id-protected wrapping keys. Mitigated by high iteration counts and memory-hard KDF (Argon2id).
+
+6. **Travel Mode is a client-side UX hint, NOT a security boundary**: `User.travelModeActive` only signals the client to apply `filterTravelSafe()` in `src/lib/auth/policy/travel-mode.ts`. The per-entry `travelSafe` flag is stored INSIDE the E2E-encrypted blob, so the server cannot enforce filtering — `/api/passwords` returns every encrypted entry regardless of the user's travel-mode state. An attacker who obtains a valid session token (device seizure at a border, exported extension token, etc.) can still call the API directly, retrieve every ciphertext, and decrypt anything for which they can compel the passphrase. Travel Mode is therefore useful for in-app discoverability only ("hide sensitive accounts from the picker while traveling"), and MUST NOT be relied on as a defense against compelled access or stolen credentials. Promoting Travel Mode to a real boundary would require either (a) moving `travelSafe` to a non-encrypted column — leaking which entries the user has marked sensitive, or (b) refusing all entry-list responses while `travelModeActive=true` — breaking the in-app UX during travel. Both have substantial UX/privacy costs; the current accepted posture is to keep Travel Mode as a client-side hint and document the limitation here (audit finding H1, 2026-05).

--- a/messages/en/ApiErrors.json
+++ b/messages/en/ApiErrors.json
@@ -123,6 +123,7 @@
   "saTokenLimitExceeded": "Maximum number of tokens per service account reached.",
   "saTokenNotFound": "Service account token not found.",
   "saTokenAlreadyRevoked": "Service account token has already been revoked.",
+  "saAccessRequestExpired": "This access request has expired and can no longer be approved.",
   "operatorTokenLimitExceeded": "Maximum number of operator tokens per tenant reached. Please revoke unused tokens first.",
   "operatorTokenNotFound": "Operator token not found.",
   "operatorTokenStaleSession": "Re-authenticate within the last 15 minutes to continue this action, then try again.",

--- a/messages/ja/ApiErrors.json
+++ b/messages/ja/ApiErrors.json
@@ -123,6 +123,7 @@
   "saTokenLimitExceeded": "サービスアカウントのトークン上限に達しました。",
   "saTokenNotFound": "サービスアカウントトークンが見つかりません。",
   "saTokenAlreadyRevoked": "サービスアカウントトークンは既に取り消されています。",
+  "saAccessRequestExpired": "このアクセス要求は有効期限切れのため承認できません。",
   "operatorTokenLimitExceeded": "テナントごとの運用者トークン上限に達しました。不要なトークンを取り消してください。",
   "operatorTokenNotFound": "運用者トークンが見つかりません。",
   "operatorTokenStaleSession": "この操作を続行するには、過去 15 分以内に再認証してください。再認証後にもう一度お試しください。",

--- a/scripts/checks/check-bypass-rls.mjs
+++ b/scripts/checks/check-bypass-rls.mjs
@@ -65,7 +65,11 @@ const ALLOWED_USAGE = new Map([
   ["src/app/api/auth/passkey/options/email/route.ts", ["user", "webAuthnCredential"]],
   ["src/app/api/auth/passkey/reauth/options/route.ts", ["webAuthnCredential"]],
   ["src/app/api/auth/passkey/reauth/verify/route.ts", ["webAuthnCredential", "session"]],
-  ["src/lib/auth/session/user-session-invalidation.ts", ["session", "extensionToken", "apiKey"]],
+  ["src/lib/auth/session/user-session-invalidation.ts", [
+    "session", "extensionToken", "apiKey",
+    "mcpAccessToken", "mcpRefreshToken", "delegationSession",
+    "operatorToken",
+  ]],
   ["src/app/api/tenant/policy/route.ts", ["user", "tenant", "teamPolicy"]],
   ["src/lib/auth/policy/access-restriction.ts", ["tenant"]],
   ["src/lib/team/team-policy.ts", ["teamMember", "teamPolicy", "tenant"]],

--- a/scripts/rotate-master-key.sh
+++ b/scripts/rotate-master-key.sh
@@ -12,7 +12,9 @@
 #   ADMIN_API_TOKEN  (required) Per-operator op_* bearer token (op_<43-base64url>)
 #   TARGET_VERSION   (required) Target key version (must match SHARE_MASTER_KEY_CURRENT_VERSION)
 #   APP_URL          (optional) Application URL (default: http://localhost:3000)
-#   REVOKE_SHARES    (optional) Revoke shares encrypted with older versions (default: false)
+#   REVOKE_SHARES    (optional) Revoke shares encrypted with older versions (default: true)
+#                    Set to "false" only for a dry-run / rehearsal — the
+#                    audit log will flag the bypass as shareRevocationSkipped.
 #   INSECURE         (optional) Skip TLS certificate verification (default: false)
 #
 # Exit codes:
@@ -24,7 +26,7 @@ set -euo pipefail
 APP_URL="${APP_URL:-http://localhost:3000}"
 ADMIN_API_TOKEN="${ADMIN_API_TOKEN:-}"
 TARGET_VERSION="${TARGET_VERSION:-}"
-REVOKE_SHARES="${REVOKE_SHARES:-false}"
+REVOKE_SHARES="${REVOKE_SHARES:-true}"
 
 if ! [[ "$ADMIN_API_TOKEN" =~ ^op_[A-Za-z0-9_-]{43}$ ]]; then
   echo "[ERROR] ADMIN_API_TOKEN must be op_<43-base64url> (mint via /dashboard/tenant/operator-tokens)" >&2

--- a/src/__tests__/integration/jit-workflow.test.ts
+++ b/src/__tests__/integration/jit-workflow.test.ts
@@ -172,6 +172,7 @@ describe("Scenario 1: Full JIT workflow", () => {
       serviceAccountId: SA_ID,
       requestedScope: "passwords:read,passwords:list",
       status: "PENDING",
+      expiresAt: new Date(Date.now() + MS_PER_HOUR),
       serviceAccount: { isActive: true },
     });
     mockTenantFindUnique.mockResolvedValue(null); // use defaults
@@ -291,6 +292,7 @@ describe("Scenario 3: Double approval prevention", () => {
       serviceAccountId: SA_ID,
       requestedScope: "passwords:read",
       status: "PENDING",
+      expiresAt: new Date(Date.now() + MS_PER_HOUR),
       serviceAccount: { isActive: true },
     });
     mockTenantFindUnique.mockResolvedValue(null);
@@ -393,6 +395,7 @@ describe("Scenario 4: Inactive SA JIT rejection", () => {
       serviceAccountId: SA_ID,
       requestedScope: "passwords:read",
       status: "PENDING",
+      expiresAt: new Date(Date.now() + MS_PER_HOUR),
       serviceAccount: { isActive: false },
     });
 
@@ -405,5 +408,69 @@ describe("Scenario 4: Inactive SA JIT rejection", () => {
 
     expect(status).toBe(409);
     expect(json.error).toBe("SA_INACTIVE");
+  });
+});
+
+describe("Scenario 5: Expired access request rejection (regression)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // A stale PENDING request whose expiresAt has already passed must NOT be
+  // approvable. The state-machine transition() gates only on status, so without
+  // an explicit expiry check an admin could revive a stale request and issue a
+  // fresh JIT token long after the requester's intent has expired.
+  it("approving an expired PENDING request returns 410 SA_ACCESS_REQUEST_EXPIRED", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockAuthOrToken.mockResolvedValue({ type: "session", userId: DEFAULT_SESSION.user.id });
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockAccessRequestFindUnique.mockResolvedValue({
+      id: REQUEST_ID,
+      tenantId: "a0000000-0000-4000-8000-000000000001",
+      serviceAccountId: SA_ID,
+      requestedScope: "passwords:read",
+      status: "PENDING",
+      // Expired 1 minute ago — must be rejected even though status is PENDING.
+      expiresAt: new Date(Date.now() - 60_000),
+      serviceAccount: { isActive: true },
+    });
+
+    const req = createRequest(
+      "POST",
+      `http://localhost/api/tenant/access-requests/${REQUEST_ID}/approve`,
+    );
+    const res = await approveAccessRequest(req, createParams({ id: REQUEST_ID }));
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(410);
+    expect(json.error).toBe("SA_ACCESS_REQUEST_EXPIRED");
+    // Must NOT have started the issue-token transaction.
+    expect(mockPrismaTransaction).not.toHaveBeenCalled();
+  });
+
+  it("approving at exactly expiresAt is rejected (boundary)", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockAuthOrToken.mockResolvedValue({ type: "session", userId: DEFAULT_SESSION.user.id });
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    const now = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    mockAccessRequestFindUnique.mockResolvedValue({
+      id: REQUEST_ID,
+      tenantId: "a0000000-0000-4000-8000-000000000001",
+      serviceAccountId: SA_ID,
+      requestedScope: "passwords:read",
+      status: "PENDING",
+      expiresAt: new Date(now), // exactly now
+      serviceAccount: { isActive: true },
+    });
+
+    const req = createRequest(
+      "POST",
+      `http://localhost/api/tenant/access-requests/${REQUEST_ID}/approve`,
+    );
+    const res = await approveAccessRequest(req, createParams({ id: REQUEST_ID }));
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(410);
+    expect(json.error).toBe("SA_ACCESS_REQUEST_EXPIRED");
+    vi.restoreAllMocks();
   });
 });

--- a/src/app/api/admin/rotate-master-key/route.test.ts
+++ b/src/app/api/admin/rotate-master-key/route.test.ts
@@ -195,10 +195,13 @@ describe("POST /api/admin/rotate-master-key", () => {
 
   // ─── Success ──────────────────────────────────────────────
 
-  it("returns 200 with targetVersion and revokedShares=0 when no shares to revoke", async () => {
+  it("returns 200 with revokedShares=0 when revokeShares=false and audit flags the bypass", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
 
-    const req = createRequest({ targetVersion: 2 }, VALID_OP_TOKEN);
+    // H3: revokeShares now defaults to true. To exercise the no-revoke path
+    // we must opt out explicitly, and the audit must surface that fact via
+    // shareRevocationSkipped so post-incident review can flag bypasses.
+    const req = createRequest({ targetVersion: 2, revokeShares: false }, VALID_OP_TOKEN);
     const res = await POST(req);
     expect(res.status).toBe(200);
 
@@ -218,6 +221,7 @@ describe("POST /api/admin/rotate-master-key", () => {
           tokenId: TOKEN_ID,
           targetVersion: 2,
           revokedShares: 0,
+          shareRevocationSkipped: true,
         }),
       }),
     );
@@ -247,6 +251,11 @@ describe("POST /api/admin/rotate-master-key", () => {
         }),
       }),
     );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ shareRevocationSkipped: false }),
+      }),
+    );
   });
 
   it("does not call shareUpdateMany when revokeShares is false", async () => {
@@ -257,5 +266,32 @@ describe("POST /api/admin/rotate-master-key", () => {
     expect(res.status).toBe(200);
 
     expect(mockShareUpdateMany).not.toHaveBeenCalled();
+  });
+
+  // H3 regression: an operator who omits revokeShares during a
+  // compromise-response rotation must NOT silently leave old shares
+  // decryptable. The default flipped from false → true; the audit reflects
+  // shareRevocationSkipped=false so a reviewer can see the rotation
+  // completed its full intent.
+  it("defaults revokeShares to TRUE when body omits the flag (H3 regression)", async () => {
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+    mockShareUpdateMany.mockResolvedValue({ count: 7 });
+
+    const req = createRequest({ targetVersion: 2 }, VALID_OP_TOKEN);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.revokedShares).toBe(7);
+
+    expect(mockShareUpdateMany).toHaveBeenCalledTimes(1);
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          revokedShares: 7,
+          shareRevocationSkipped: false,
+        }),
+      }),
+    );
   });
 });

--- a/src/app/api/admin/rotate-master-key/route.ts
+++ b/src/app/api/admin/rotate-master-key/route.ts
@@ -5,8 +5,13 @@
  *
  * Note:
  * - Team vault encryption is E2E-only; server-side team key re-wrap is removed.
- * - This endpoint validates the target master key version and optionally
- *   revokes old-version PasswordShare rows.
+ * - This endpoint validates the target master key version and revokes
+ *   old-version PasswordShare rows. `revokeShares` defaults to **true** —
+ *   the entire reason an operator runs a rotation is usually that the old
+ *   key may be compromised, so leaving stale share rows decryptable by the
+ *   old key defeats the purpose. Callers must explicitly pass `false` to
+ *   opt out (e.g. for a rehearsal / dry-run); the choice is reflected in
+ *   the audit metadata so post-incident review can flag bypasses.
  * Authenticated via per-operator op_* token (mint via /dashboard/tenant/operator-tokens).
  *
  * Body: { targetVersion: number, revokeShares?: boolean }
@@ -34,7 +39,10 @@ const rateLimiter = createRateLimiter({ windowMs: 60_000, max: 1 });
 
 const bodySchema = z.object({
   targetVersion: z.number().int().min(MASTER_KEY_VERSION_MIN).max(MASTER_KEY_VERSION_MAX),
-  revokeShares: z.boolean().default(false),
+  // SECURITY: defaults to true so an operator who forgets the flag during a
+  // compromise-response rotation still revokes old-version shares. Pass
+  // `false` explicitly only for a dry-run / rehearsal.
+  revokeShares: z.boolean().default(true),
 });
 
 async function handlePOST(req: NextRequest) {
@@ -109,6 +117,10 @@ async function handlePOST(req: NextRequest) {
       tokenId: auth.tokenId,
       targetVersion,
       revokedShares,
+      // Flag explicit opt-outs so post-incident review can detect a rotation
+      // that left old-version shares decryptable by the (potentially leaked)
+      // previous key.
+      shareRevocationSkipped: !revokeShares,
     },
   });
 

--- a/src/app/api/scim/v2/Users/[id]/route.ts
+++ b/src/app/api/scim/v2/Users/[id]/route.ts
@@ -6,7 +6,10 @@ import { parseUserPatchOps, PatchParseError } from "@/lib/scim/patch-parser";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTenantRls } from "@/lib/tenant-rls";
-import { invalidateUserSessions } from "@/lib/auth/session/user-session-invalidation";
+import {
+  invalidateUserSessions,
+  type InvalidateUserSessionsResult,
+} from "@/lib/auth/session/user-session-invalidation";
 import { getLogger } from "@/lib/logger";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { scimParseBody } from "@/lib/scim/parse-body";
@@ -80,7 +83,7 @@ async function handlePUT(req: NextRequest, { params }: Params): Promise<Response
   const { resource, userId, auditAction, needsSessionInvalidation } = serviceResult;
 
   // Session invalidation on deactivation (fail-open)
-  let invalidationCounts: { sessions: number; extensionTokens: number; apiKeys: number } | undefined;
+  let invalidationCounts: InvalidateUserSessionsResult | undefined;
   let sessionInvalidationFailed = false;
   if (needsSessionInvalidation) {
     try {
@@ -147,7 +150,7 @@ async function handlePATCH(req: NextRequest, { params }: Params): Promise<Respon
   const { resource, userId, auditAction, needsSessionInvalidation } = serviceResult;
 
   // Session invalidation on deactivation (fail-open)
-  let patchInvalidationCounts: { sessions: number; extensionTokens: number; apiKeys: number } | undefined;
+  let patchInvalidationCounts: InvalidateUserSessionsResult | undefined;
   let patchSessionInvalidationFailed = false;
   if (needsSessionInvalidation) {
     try {
@@ -203,7 +206,7 @@ async function handleDELETE(req: NextRequest, { params }: Params): Promise<Respo
   const { userId, userEmail, needsSessionInvalidation } = serviceResult;
 
   // Session invalidation after deletion (fail-open)
-  let deleteInvalidationCounts: { sessions: number; extensionTokens: number; apiKeys: number } | undefined;
+  let deleteInvalidationCounts: InvalidateUserSessionsResult | undefined;
   let deleteSessionInvalidationFailed = false;
   if (needsSessionInvalidation) {
     try {

--- a/src/app/api/sends/file/route.test.ts
+++ b/src/app/api/sends/file/route.test.ts
@@ -213,4 +213,105 @@ describe("POST /api/sends/file", () => {
     expect(mockAggregate).toHaveBeenCalledOnce();
     expect(mockUserFindUnique).toHaveBeenCalledOnce();
   });
+
+  // H5 regression tests — the magic-byte gate previously accepted any file
+  // whose declared Content-Type was application/octet-stream, including
+  // SVG/HTML/JS payloads. Defense-in-depth: also deny by filename extension
+  // so a renamed .html → .txt can't smuggle markup through the text/* path.
+
+  it("rejects SVG declared as application/octet-stream (magic-byte denylist)", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    // file-type detects the real bytes as image/svg+xml even though the
+    // client labeled them as octet-stream.
+    mockFileTypeFromBuffer.mockResolvedValueOnce({ mime: "image/svg+xml", ext: "svg" });
+
+    const svgBytes = new TextEncoder().encode("<svg><script>alert(1)</script></svg>");
+    const file = new File([svgBytes], "image.bin", {
+      type: "application/octet-stream",
+    });
+    const fd = createFormData({ file });
+    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const res = await POST(req as never);
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(400);
+    expect(json.error).toBe("SEND_FILE_TYPE_NOT_ALLOWED");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects HTML by filename extension even when bytes have no signature", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    // Plain-text HTML has no file-type magic — detected stays undefined.
+    mockFileTypeFromBuffer.mockResolvedValueOnce(undefined);
+
+    const html = new TextEncoder().encode("<html><script>alert(1)</script></html>");
+    const file = new File([html], "page.html", { type: "text/plain" });
+    const fd = createFormData({ file });
+    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const res = await POST(req as never);
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(400);
+    expect(json.error).toBe("SEND_FILE_TYPE_NOT_ALLOWED");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("stores the magic-byte MIME, not the client-declared type, when they match", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockFileTypeFromBuffer.mockResolvedValueOnce({ mime: "image/png", ext: "png" });
+    const expiresAt = new Date(Date.now() + 86400_000);
+    mockCreate.mockResolvedValue({ id: "share-mime", expiresAt });
+
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const file = new File([png], "image.png", { type: "image/png" });
+    const fd = createFormData({ file });
+    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    await POST(req as never);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ sendContentType: "image/png" }),
+      }),
+    );
+  });
+
+  it("rejects when declared MIME mismatches the magic-byte MIME (strict consistency)", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockFileTypeFromBuffer.mockResolvedValueOnce({ mime: "image/png", ext: "png" });
+
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    // A real PNG is being labeled as something else by the client — refuse,
+    // both to flag tampering and to avoid storing a misleading content-type.
+    const file = new File([png], "image.png", { type: "image/jpeg" });
+    const fd = createFormData({ file });
+    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const res = await POST(req as never);
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(400);
+    expect(json.error).toBe("SEND_FILE_TYPE_NOT_ALLOWED");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("falls back sendContentType to application/octet-stream for unsigned text files (does NOT trust client-declared type)", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    // file-type returns undefined for unsigned text — server must NOT
+    // store the client-supplied content-type as authoritative.
+    mockFileTypeFromBuffer.mockResolvedValueOnce(undefined);
+    const expiresAt = new Date(Date.now() + 86400_000);
+    mockCreate.mockResolvedValue({ id: "share-text", expiresAt });
+
+    const file = new File(["hello"], "notes.txt", { type: "text/plain" });
+    const fd = createFormData({ file });
+    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    await POST(req as never);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          sendContentType: "application/octet-stream",
+        }),
+      }),
+    );
+  });
 });

--- a/src/app/api/sends/file/route.ts
+++ b/src/app/api/sends/file/route.ts
@@ -87,17 +87,60 @@ async function handlePOST(req: NextRequest) {
   // Read file bytes
   const fileBuffer = Buffer.from(await file.arrayBuffer());
 
-  // Magic byte verification
+  // H5: Magic-byte verification + active-content denylist.
+  //
+  // Prior shape `declaredType === "application/octet-stream"` was a hole:
+  // a client could upload an SVG (or anything else) with
+  // Content-Type: application/octet-stream to skip the MIME consistency
+  // check entirely. We now require detected.mime === declared (or accept
+  // detected.mime when declared is missing/octet-stream), AND deny known
+  // active-content types regardless of how they're labeled.
+  //
+  // The download route already hard-codes Content-Type: application/octet-stream
+  // + X-Content-Type-Options: nosniff + Content-Disposition: attachment,
+  // so the practical XSS path is closed there too. This is the upload-side
+  // defense-in-depth.
   const { fileTypeFromBuffer } = await import("file-type");
   const detected = await fileTypeFromBuffer(fileBuffer);
-  // If file-type detects a type, verify against declared content type
+
+  // Active-content MIME types we refuse to host as a Send, even if the
+  // bytes look benign on the surface. Adding more here is cheap; removing
+  // requires understanding why something showed up on the list.
+  const ACTIVE_CONTENT_MIME = new Set([
+    "text/html",
+    "application/xhtml+xml",
+    "image/svg+xml",
+    "application/javascript",
+    "text/javascript",
+    "application/x-msdownload", // .exe / .dll
+    "application/x-mach-binary",
+  ]);
+  // Filename-extension allowlist mirror — a renamed .html → .txt could still
+  // smuggle markup past the magic-byte check (text/* has no signature).
+  const ACTIVE_CONTENT_EXT = /\.(html?|xhtml|svg|js|mjs|wasm|exe|dll|sh|bat|ps1)$/i;
+
+  if (ACTIVE_CONTENT_EXT.test(filename)) {
+    return errorResponse(API_ERROR.SEND_FILE_TYPE_NOT_ALLOWED);
+  }
+  if (detected && ACTIVE_CONTENT_MIME.has(detected.mime)) {
+    return errorResponse(API_ERROR.SEND_FILE_TYPE_NOT_ALLOWED);
+  }
   if (detected) {
-    const declaredType = file.type || "application/octet-stream";
-    if (declaredType !== detected.mime && declaredType !== "application/octet-stream") {
+    // Strict consistency: when we have a magic-byte answer, the declared
+    // type must match it OR be unspecified (empty / octet-stream is the
+    // browser's "I don't know" answer, not an authorization to skip the
+    // check). detected.mime is then the source of truth for storage.
+    const declaredType = file.type;
+    if (
+      declaredType &&
+      declaredType !== "application/octet-stream" &&
+      declaredType !== detected.mime
+    ) {
       return errorResponse(API_ERROR.SEND_FILE_TYPE_NOT_ALLOWED);
     }
   }
-  // If detected is undefined (text files like .txt, .csv, .json), trust declared content type
+  // If detected is undefined (plain-text .txt/.csv/.json with no signature),
+  // we already enforced the active-content extension denylist above.
 
   // Storage limit check and actor (tenantId) lookup are independent — run in parallel
   const now = new Date();
@@ -153,7 +196,11 @@ async function handlePOST(req: NextRequest) {
   const tokenHash = hashToken(token);
 
   const expiresAt = new Date(Date.now() + SEND_EXPIRY_MAP[meta.expiresIn]);
-  const contentType = detected?.mime ?? file.type ?? "application/octet-stream";
+  // Always prefer the magic-byte-derived MIME. When unavailable (text-like
+  // files with no signature), fall back to a generic safe value rather than
+  // trusting the client-declared header — the download route forces
+  // application/octet-stream anyway, so this is only used for UI display.
+  const contentType = detected?.mime ?? "application/octet-stream";
 
   const share = await withUserTenantRls(session.user.id, async () =>
     prisma.passwordShare.create({

--- a/src/app/api/teams/[teamId]/members/[memberId]/route.ts
+++ b/src/app/api/teams/[teamId]/members/[memberId]/route.ts
@@ -11,7 +11,10 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { parseBody } from "@/lib/http/parse-body";
 import { TEAM_PERMISSION, TEAM_ROLE, AUDIT_TARGET_TYPE, AUDIT_ACTION } from "@/lib/constants";
 import { withTeamTenantRls } from "@/lib/tenant-context";
-import { invalidateUserSessions } from "@/lib/auth/session/user-session-invalidation";
+import {
+  invalidateUserSessions,
+  type InvalidateUserSessionsResult,
+} from "@/lib/auth/session/user-session-invalidation";
 import { getLogger } from "@/lib/logger";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { errorResponse, handleAuthError, unauthorized } from "@/lib/http/api-response";
@@ -197,7 +200,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
   );
 
   // Session/token invalidation — outside transaction (fail-open)
-  let invalidationCounts: { sessions: number; extensionTokens: number; apiKeys: number } | undefined;
+  let invalidationCounts: InvalidateUserSessionsResult | undefined;
   let sessionInvalidationFailed = false;
   try {
     invalidationCounts = await invalidateUserSessions(target.userId, {

--- a/src/app/api/tenant/access-requests/[id]/approve/route.test.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.test.ts
@@ -99,6 +99,10 @@ const makeAccessRequest = (overrides: Record<string, unknown> = {}) => ({
   serviceAccountId: SA_ID,
   requestedScope: "passwords:read",
   status: "PENDING",
+  // C1: approve handler now enforces expiresAt. Default fixtures use a
+  // future deadline so non-expiry scenarios still succeed; expiry tests
+  // override with a past Date explicitly.
+  expiresAt: new Date(Date.now() + 60 * 60 * 1000),
   serviceAccount: { isActive: true },
   ...overrides,
 });
@@ -354,5 +358,28 @@ describe("POST /api/tenant/access-requests/[id]/approve", () => {
 
     expect(status).toBe(400);
     expect(json.error).toBe("SA_INVALID_SCOPE");
+  });
+
+  // C1 regression: state-machine transition() gates only on status=PENDING,
+  // not on the request's own expiresAt deadline. An admin must not be able to
+  // resurrect a stale PENDING request and issue a fresh short-lived token.
+  it("returns 410 SA_ACCESS_REQUEST_EXPIRED for a PENDING request past expiresAt", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockAccessRequestFindUnique.mockResolvedValue(
+      makeAccessRequest({ expiresAt: new Date(Date.now() - 60_000) }),
+    );
+
+    const req = createRequest(
+      "POST",
+      `http://localhost/api/tenant/access-requests/${REQUEST_ID}/approve`,
+    );
+    const res = await POST(req, createParams({ id: REQUEST_ID }));
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(410);
+    expect(json.error).toBe("SA_ACCESS_REQUEST_EXPIRED");
+    // The transaction that would issue the JIT token MUST NOT have started.
+    expect(mockPrismaTransaction).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/tenant/access-requests/[id]/approve/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.ts
@@ -74,6 +74,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
         serviceAccountId: true,
         requestedScope: true,
         status: true,
+        expiresAt: true,
         serviceAccount: { select: { isActive: true } },
       },
     }),
@@ -81,6 +82,14 @@ async function handlePOST(req: NextRequest, { params }: Params) {
 
   if (!request || request.tenantId !== actor.tenantId) {
     return notFound();
+  }
+
+  // Reject approval of expired requests — the state-machine transition() only
+  // gates on status (PENDING), not on the request's own deadline. Without this
+  // check, an admin could revive a stale request and issue a fresh JIT token
+  // long after the requester's intent has expired.
+  if (request.expiresAt.getTime() <= Date.now()) {
+    return errorResponse(API_ERROR.SA_ACCESS_REQUEST_EXPIRED);
   }
 
   if (!request.serviceAccount.isActive) {

--- a/src/app/api/vault/admin-reset/route.ts
+++ b/src/app/api/vault/admin-reset/route.ts
@@ -162,6 +162,7 @@ async function handlePOST(req: NextRequest) {
       invalidatedMcpAccessTokens: invalidationResult.mcpAccessTokens,
       invalidatedMcpRefreshTokens: invalidationResult.mcpRefreshTokens,
       invalidatedDelegationSessions: invalidationResult.delegationSessions,
+      invalidatedOperatorTokens: invalidationResult.operatorTokens,
       cacheTombstoneFailures: invalidationResult.cacheTombstoneFailures,
     },
   });

--- a/src/app/api/vault/reset/route.ts
+++ b/src/app/api/vault/reset/route.ts
@@ -83,6 +83,7 @@ async function handlePOST(request: NextRequest) {
       invalidatedMcpAccessTokens: invalidationResult.mcpAccessTokens,
       invalidatedMcpRefreshTokens: invalidationResult.mcpRefreshTokens,
       invalidatedDelegationSessions: invalidationResult.delegationSessions,
+      invalidatedOperatorTokens: invalidationResult.operatorTokens,
       cacheTombstoneFailures: invalidationResult.cacheTombstoneFailures,
     },
   });

--- a/src/app/api/vault/rotate-key/route.ts
+++ b/src/app/api/vault/rotate-key/route.ts
@@ -256,6 +256,7 @@ async function handlePOST(request: NextRequest) {
       invalidatedMcpAccessTokens: invalidationResult?.mcpAccessTokens ?? null,
       invalidatedMcpRefreshTokens: invalidationResult?.mcpRefreshTokens ?? null,
       invalidatedDelegationSessions: invalidationResult?.delegationSessions ?? null,
+      invalidatedOperatorTokens: invalidationResult?.operatorTokens ?? null,
       cacheTombstoneFailures: invalidationResult?.cacheTombstoneFailures ?? null,
     },
   });

--- a/src/lib/auth/policy/travel-mode.ts
+++ b/src/lib/auth/policy/travel-mode.ts
@@ -7,6 +7,13 @@
  * Entries without a `travelSafe` field default to `true` (travel-safe)
  * to avoid hiding all entries for users who enable Travel Mode before
  * tagging any entries.
+ *
+ * SECURITY BOUNDARY: This is a UX hint, NOT an access-control boundary.
+ * `/api/passwords` returns every encrypted entry regardless of
+ * `User.travelModeActive`, so a stolen session token / compelled
+ * unlock at a border still exposes every entry. See
+ * `docs/security/threat-model.md` §5.6 (Residual Risks) for the
+ * accepted-risk rationale and design alternatives.
  */
 
 export interface TravelSafeEntry {

--- a/src/lib/auth/session/user-session-invalidation.test.ts
+++ b/src/lib/auth/session/user-session-invalidation.test.ts
@@ -7,6 +7,7 @@ const {
   mockMcpAccessToken,
   mockMcpRefreshToken,
   mockDelegationSession,
+  mockOperatorToken,
   mockWithBypassRls,
   mockInvalidateCachedSessions,
 } = vi.hoisted(() => ({
@@ -16,6 +17,7 @@ const {
   mockMcpAccessToken: { updateMany: vi.fn() },
   mockMcpRefreshToken: { updateMany: vi.fn() },
   mockDelegationSession: { updateMany: vi.fn() },
+  mockOperatorToken: { updateMany: vi.fn() },
   mockWithBypassRls: vi.fn(async (prisma: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
   mockInvalidateCachedSessions: vi
     .fn<(tokens: ReadonlyArray<string>) => Promise<{ total: number; failed: number }>>()
@@ -30,6 +32,7 @@ vi.mock("@/lib/prisma", () => ({
     mcpAccessToken: mockMcpAccessToken,
     mcpRefreshToken: mockMcpRefreshToken,
     delegationSession: mockDelegationSession,
+    operatorToken: mockOperatorToken,
   },
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
@@ -61,9 +64,10 @@ describe("invalidateUserSessions", () => {
     mockMcpAccessToken.updateMany.mockResolvedValue({ count: 4 });
     mockMcpRefreshToken.updateMany.mockResolvedValue({ count: 5 });
     mockDelegationSession.updateMany.mockResolvedValue({ count: 6 });
+    mockOperatorToken.updateMany.mockResolvedValue({ count: 7 });
   });
 
-  it("deletes sessions, revokes extension tokens, API keys, MCP access/refresh tokens, and delegation sessions", async () => {
+  it("deletes sessions, revokes extension tokens, API keys, MCP access/refresh tokens, delegation sessions, and operator tokens", async () => {
     const result = await invalidateUserSessions("user-1", { tenantId: "tenant-1" });
 
     expect(mockSession.deleteMany).toHaveBeenCalledWith({
@@ -89,6 +93,14 @@ describe("invalidateUserSessions", () => {
       where: { userId: "user-1", revokedAt: null, tenantId: "tenant-1" },
       data: { revokedAt: expect.any(Date) },
     });
+    // H4: OperatorToken uses subjectUserId (NOT userId) as the bound column.
+    // Without this revoke, a compromised admin's op_* tokens survive the
+    // session-invalidation that was supposed to lock them out, and they can
+    // still call rotate-master-key / purge-audit-logs / purge-history.
+    expect(mockOperatorToken.updateMany).toHaveBeenCalledWith({
+      where: { subjectUserId: "user-1", revokedAt: null, tenantId: "tenant-1" },
+      data: { revokedAt: expect.any(Date) },
+    });
     expect(result).toEqual({
       sessions: 2,
       extensionTokens: 1,
@@ -96,6 +108,7 @@ describe("invalidateUserSessions", () => {
       mcpAccessTokens: 4,
       mcpRefreshTokens: 5,
       delegationSessions: 6,
+      operatorTokens: 7,
       cacheTombstoneFailures: 0,
     });
   });
@@ -123,6 +136,11 @@ describe("invalidateUserSessions", () => {
         data: { revokedAt: expect.any(Date) },
       });
     }
+    // OperatorToken keys on subjectUserId instead of userId.
+    expect(mockOperatorToken.updateMany).toHaveBeenCalledWith({
+      where: { subjectUserId: "user-1", revokedAt: null, tenantId: "tenant-2" },
+      data: { revokedAt: expect.any(Date) },
+    });
   });
 
   it("propagates error when a database operation fails", async () => {
@@ -200,6 +218,10 @@ describe("invalidateUserSessions", () => {
         data: { revokedAt: expect.any(Date) },
       });
     }
+    expect(mockOperatorToken.updateMany).toHaveBeenCalledWith({
+      where: { subjectUserId: "user-1", revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
+    });
 
     // All cross-tenant tokens are tombstoned.
     expectInvalidatedAfterCommit(mockInvalidateCachedSessions, [
@@ -214,6 +236,7 @@ describe("invalidateUserSessions", () => {
       mcpAccessTokens: 4,
       mcpRefreshTokens: 5,
       delegationSessions: 6,
+      operatorTokens: 7,
       cacheTombstoneFailures: 0,
     });
   });

--- a/src/lib/auth/session/user-session-invalidation.ts
+++ b/src/lib/auth/session/user-session-invalidation.ts
@@ -36,6 +36,7 @@ export type InvalidateUserSessionsResult = {
   mcpAccessTokens: number;
   mcpRefreshTokens: number;
   delegationSessions: number;
+  operatorTokens: number;
   cacheTombstoneFailures: number;
 };
 
@@ -48,14 +49,27 @@ export type InvalidateUserSessionsResult = {
  *   - Session (DB row delete + cache tombstone)
  *   - ExtensionToken / ApiKey (revokedAt set)
  *   - McpAccessToken / McpRefreshToken / DelegationSession (revokedAt set)
+ *   - OperatorToken where subjectUserId === userId (revokedAt set)
  *
  * Why MCP tokens are included: a user who minted `mcp_*` tokens for AI
  * agents holds tokens that authenticate AS that user with credentials:list /
  * credentials:use scope. After a vault reset (or member removal) these
  * tokens must die — otherwise an attacker holding the token could re-attack
- * the freshly-set-up vault. WebAuthnCredential is intentionally NOT
- * revoked — it is the user's re-authentication path back into a fresh
- * vault setup.
+ * the freshly-set-up vault.
+ *
+ * Why OperatorToken (subjectUserId) is included: op_* tokens authenticate
+ * AS their subject user with maintenance scope (rotate-master-key,
+ * purge-audit-logs, purge-history). A compromised admin whose sessions are
+ * revoked but whose op_* tokens survive can still erase audit evidence and
+ * trigger destructive maintenance — exactly the attack path the
+ * invalidation is supposed to close. We do NOT revoke tokens by
+ * createdByUserId: those authenticate as someone else (their automation
+ * subject) and revoking would orphan unrelated operators' tokens. The
+ * audit trail of who created the surviving token is still preserved via
+ * the OperatorToken.createdByUserId column.
+ *
+ * WebAuthnCredential is intentionally NOT revoked — it is the user's
+ * re-authentication path back into a fresh vault setup.
  *
  * Uses withBypassRls() scoped to the target userId WHERE clause.
  */
@@ -90,6 +104,7 @@ export async function invalidateUserSessions(
       mcpAccessTokensResult,
       mcpRefreshTokensResult,
       delegationSessionsResult,
+      operatorTokensResult,
     ] = await Promise.all([
       tx.session.deleteMany({
         where: { userId, ...tenantFilter },
@@ -114,6 +129,13 @@ export async function invalidateUserSessions(
         where: { userId, revokedAt: null, ...tenantFilter },
         data: { revokedAt: now },
       }),
+      // OperatorToken uses subjectUserId (not userId) as the "authenticates
+      // as" column. Same tenantFilter semantics — all-tenants for vault
+      // reset, single-tenant for member removal.
+      tx.operatorToken.updateMany({
+        where: { subjectUserId: userId, revokedAt: null, ...tenantFilter },
+        data: { revokedAt: now },
+      }),
     ]);
 
     let cacheTombstoneFailures = 0;
@@ -131,6 +153,7 @@ export async function invalidateUserSessions(
       mcpAccessTokens: mcpAccessTokensResult.count,
       mcpRefreshTokens: mcpRefreshTokensResult.count,
       delegationSessions: delegationSessionsResult.count,
+      operatorTokens: operatorTokensResult.count,
       cacheTombstoneFailures,
     };
   }, BYPASS_PURPOSE.TOKEN_LIFECYCLE);

--- a/src/lib/http/api-error-codes.test.ts
+++ b/src/lib/http/api-error-codes.test.ts
@@ -121,7 +121,7 @@ describe("API_ERROR structural invariants", () => {
   it("code count matches expected (update this when adding new codes)", () => {
     // If this fails, you added a new code to API_ERROR.
     // Update this count AND add the code to API_ERROR_I18N + i18n messages.
-    expect(Object.keys(API_ERROR).length).toBe(157);
+    expect(Object.keys(API_ERROR).length).toBe(158);
   });
 });
 

--- a/src/lib/http/api-error-codes.ts
+++ b/src/lib/http/api-error-codes.ts
@@ -203,6 +203,7 @@ export const API_ERROR = {
   SA_TOKEN_LIMIT_EXCEEDED: "SA_TOKEN_LIMIT_EXCEEDED",
   SA_TOKEN_NOT_FOUND: "SA_TOKEN_NOT_FOUND",
   SA_TOKEN_ALREADY_REVOKED: "SA_TOKEN_ALREADY_REVOKED",
+  SA_ACCESS_REQUEST_EXPIRED: "SA_ACCESS_REQUEST_EXPIRED",
 
   // ── MCP Clients ──────────────────────────────────────────
   MCP_CLIENT_NAME_CONFLICT: "MCP_CLIENT_NAME_CONFLICT",
@@ -458,6 +459,7 @@ export const API_ERROR_STATUS = {
   SA_TOKEN_LIMIT_EXCEEDED: 409,
   SA_TOKEN_NOT_FOUND: 404,
   SA_TOKEN_ALREADY_REVOKED: 409,
+  SA_ACCESS_REQUEST_EXPIRED: 410,
 
   // ── MCP Clients ───────────────────────────────────────────
   // 422 chosen over 409 for tenant-quota rejection; UI consumer at
@@ -635,6 +637,7 @@ const API_ERROR_I18N: Record<ApiErrorCode, string> = {
   SA_TOKEN_LIMIT_EXCEEDED: "saTokenLimitExceeded",
   SA_TOKEN_NOT_FOUND: "saTokenNotFound",
   SA_TOKEN_ALREADY_REVOKED: "saTokenAlreadyRevoked",
+  SA_ACCESS_REQUEST_EXPIRED: "saAccessRequestExpired",
   MCP_CLIENT_NAME_CONFLICT: "mcpClientNameConflict",
   MCP_CLIENT_LIMIT_EXCEEDED: "mcpClientLimitExceeded",
   MCP_TOKEN_NOT_FOUND: "mcpTokenNotFound",

--- a/src/lib/webhook-dispatcher.test.ts
+++ b/src/lib/webhook-dispatcher.test.ts
@@ -212,6 +212,32 @@ describe("dispatchWebhook", () => {
     expect(opts.headers["X-Signature"]).toBe(`sha256=${expectedHmac}`);
   });
 
+  // H2 regression: receivers need the timestamp out-of-band (header, not body)
+  // to enforce a freshness window before they spend CPU parsing the JSON, and
+  // the timestamp must be bound into a separate signature so an attacker can't
+  // strip the X-Webhook-Timestamp header without invalidating the HMAC.
+  it("emits Stripe-style X-Webhook-Timestamp + X-Webhook-Signature bound to t.body", async () => {
+    mockPrismaTeamWebhook.findMany.mockResolvedValue([WEBHOOK]);
+    mockFetch.mockResolvedValue({ ok: true });
+
+    dispatchWebhook(EVENT);
+    await vi.advanceTimersByTimeAsync(100);
+
+    const payload = JSON.stringify(EVENT);
+    const expectedV1 = createHmac("sha256", "test-hmac-secret")
+      .update(`${EVENT.timestamp}.${payload}`, "utf8")
+      .digest("hex");
+
+    const [, opts] = mockFetch.mock.calls[0];
+    expect(opts.headers["X-Webhook-Timestamp"]).toBe(EVENT.timestamp);
+    expect(opts.headers["X-Webhook-Signature"]).toBe(
+      `t=${EVENT.timestamp},v1=${expectedV1}`,
+    );
+    // Backward-compat header must still be present so existing receivers
+    // keep verifying. Removal is a separate breaking change.
+    expect(opts.headers["X-Signature"]).toMatch(/^sha256=/);
+  });
+
   it("retries and updates failCount on persistent failure", async () => {
     mockPrismaTeamWebhook.findMany.mockResolvedValue([WEBHOOK]);
     mockFetch.mockResolvedValue({ ok: false, status: 500 });

--- a/src/lib/webhook-dispatcher.ts
+++ b/src/lib/webhook-dispatcher.ts
@@ -75,13 +75,33 @@ function computeHmac(secret: string, payload: string): string {
   return createHmac("sha256", secret).update(payload, "utf8").digest("hex");
 }
 
+/**
+ * Compute Stripe-style timestamped signature: HMAC-SHA256 over `${ts}.${body}`.
+ * Binding the timestamp into the signed string prevents an attacker from
+ * stripping/forging the X-Webhook-Timestamp header — any change to ts changes
+ * the signature too. Receivers verify by checking (now - ts) < window AND
+ * recomputing v1 over the same `${ts}.${body}` concatenation.
+ */
+function computeTimestampedHmac(secret: string, timestamp: string, payload: string): string {
+  return createHmac("sha256", secret).update(`${timestamp}.${payload}`, "utf8").digest("hex");
+}
+
 /** Recursively strip keys in EXTERNAL_DELIVERY_METADATA_BLOCKLIST. */
 const sanitizeWebhookData = sanitizeForExternalDelivery;
+
+interface SignatureHeaders {
+  /** Legacy: HMAC-SHA256(secret, body) hex. Receivers should migrate to v1. */
+  legacySignature: string;
+  /** Stripe-style: HMAC-SHA256(secret, `${ts}.${body}`) hex. */
+  v1Signature: string;
+  /** ISO-8601 UTC timestamp matching event.timestamp. */
+  timestamp: string;
+}
 
 async function deliverWithRetry(
   url: string,
   payload: string,
-  signature: string,
+  signatures: SignatureHeaders,
 ): Promise<boolean> {
   const hostname = new URL(url).hostname;
 
@@ -98,7 +118,15 @@ async function deliverWithRetry(
         headers: {
           "Content-Type": "application/json",
           "User-Agent": USER_AGENT,
-          "X-Signature": `sha256=${signature}`,
+          // Legacy header — kept for backward compatibility. Will be removed
+          // in a future major version. New receivers should use the v1 below.
+          "X-Signature": `sha256=${signatures.legacySignature}`,
+          // Stripe-style timestamped signature. Receivers MUST:
+          //   1. Reject if Math.abs(now - parseISO(X-Webhook-Timestamp)) > 5min
+          //   2. Recompute HMAC over `${X-Webhook-Timestamp}.${body}` and
+          //      constant-time compare to the v1 hex in X-Webhook-Signature.
+          "X-Webhook-Timestamp": signatures.timestamp,
+          "X-Webhook-Signature": `t=${signatures.timestamp},v1=${signatures.v1Signature}`,
         },
         body: payload,
         signal: AbortSignal.timeout(10_000),
@@ -123,6 +151,7 @@ async function deliverWithRetry(
 async function deliverSingleWebhook(
   webhook: WebhookRecord,
   payload: string,
+  timestamp: string,
   onSuccess: (id: string) => Promise<void>,
   onFailure: (id: string, failCount: number, url: string) => Promise<void>,
 ): Promise<void> {
@@ -165,8 +194,12 @@ async function deliverSingleWebhook(
       return;
     }
 
-    const signature = computeHmac(secret, payload);
-    const ok = await deliverWithRetry(webhook.url, payload, signature);
+    const signatures: SignatureHeaders = {
+      legacySignature: computeHmac(secret, payload),
+      v1Signature: computeTimestampedHmac(secret, timestamp, payload),
+      timestamp,
+    };
+    const ok = await deliverWithRetry(webhook.url, payload, signatures);
 
     if (ok) {
       await onSuccess(webhook.id);
@@ -186,6 +219,7 @@ async function deliverSingleWebhook(
 async function dispatchToWebhooks(
   webhooks: WebhookRecord[],
   payload: string,
+  timestamp: string,
   onSuccess: (id: string) => Promise<void>,
   onFailure: (id: string, failCount: number, url: string) => Promise<void>,
 ): Promise<void> {
@@ -193,7 +227,7 @@ async function dispatchToWebhooks(
     const chunk = webhooks.slice(i, i + WEBHOOK_CONCURRENCY);
     await Promise.allSettled(
       chunk.map((webhook) =>
-        deliverSingleWebhook(webhook, payload, onSuccess, onFailure),
+        deliverSingleWebhook(webhook, payload, timestamp, onSuccess, onFailure),
       ),
     );
   }
@@ -242,6 +276,7 @@ export function dispatchWebhook(event: TeamWebhookEvent): void {
     await dispatchToWebhooks(
       webhooks,
       payload,
+      event.timestamp,
       async (id) => {
         await withBypassRls(prisma, async (tx) =>
           tx.teamWebhook.update({
@@ -328,6 +363,7 @@ export function dispatchTenantWebhook(event: TenantWebhookEvent): void {
     await dispatchToWebhooks(
       webhooks,
       payload,
+      event.timestamp,
       async (id) => {
         await withBypassRls(prisma, async (tx) =>
           tx.tenantWebhook.update({


### PR DESCRIPTION
## Summary

Six security findings from a full-codebase audit, grouped by severity. PR 1 of 2 (PR 2 follows with Medium + Low).

| # | Severity | Title |
|---|----------|-------|
| C1 | Critical | Reject approval of expired JIT access requests |
| H1 | High | Document Travel Mode as UX hint, not access boundary (ADR only) |
| H2 | High | Stripe-style timestamped webhook signature (backward-compatible) |
| H3 | High | Flip rotate-master-key `revokeShares` default to true |
| H4 | High | Revoke OperatorToken on user-session invalidation |
| H5 | High | Close Send-file MIME bypass via `application/octet-stream` |

## Per-finding rationale

**C1** — `/api/tenant/access-requests/[id]/approve` validated status (PENDING) via the state machine but never checked the request's own `expiresAt`. An admin could resurrect a stale request and issue a fresh short-lived JIT token long after the requester's intent expired. New `SA_ACCESS_REQUEST_EXPIRED` (410) error; two regression tests (strict + boundary).

**H1** — Travel Mode's `travelSafe` flag lives inside the E2E-encrypted blob, so the server cannot enforce filtering and `/api/passwords` returns every encrypted entry regardless of `User.travelModeActive`. Promoting it to a real boundary requires either leaking which entries are sensitive (move flag to plaintext column) or breaking entry listing during travel. Documented as accepted residual risk #6 in `threat-model.md` with a code-level pointer from `travel-mode.ts`; no code change.

**H2** — Existing `X-Signature: sha256=<hex>` signs the body (which already contains `event.timestamp`), but receivers had to parse JSON before they could enforce a replay window, and there was no out-of-band binding between freshness and signature. Now emits `X-Webhook-Timestamp` + `X-Webhook-Signature: t=<ts>,v1=<hex>` where `v1 = HMAC(secret, \`${ts}.${body}\`)`. Existing `X-Signature` header preserved — fully backward-compatible.

**H3** — A master-key rotation is almost always triggered because the previous key may be compromised. `revokeShares` was opt-in (default false), so an operator running the rotation script without the flag left every PasswordShare row decryptable by the old key. Default flipped to true; opt-outs flagged in audit metadata as `shareRevocationSkipped: true` for post-incident review.

**H4** — `OperatorToken` (`op_*`) authenticates AS its `subjectUserId` with the `maintenance` scope (rotate-master-key, purge-audit-logs, purge-history). `invalidateUserSessions()` enumerated every other user-bound token class but NOT OperatorToken, so a compromised admin whose sessions were just blown away by a co-admin could still call destructive maintenance endpoints. Revoke by `subjectUserId` in the same Promise.all; downstream audit metadata gains `invalidatedOperatorTokens` for forensics. SCIM + team-member routes had hand-narrowed local types that lost the mcp/delegation counts on spread — replaced with the proper `InvalidateUserSessionsResult` so the drift can't reoccur.

**H5** — The prior magic-byte check treated `Content-Type: application/octet-stream` as "skip the check", so an SVG/HTML/JS payload labeled octet-stream walked straight through. The download route already hard-codes octet-stream + nosniff + attachment, so practical XSS was blocked there too — this is the upload-side defense-in-depth. Now strict MIME consistency + active-content denylist (`image/svg+xml`, `text/html`, `*javascript`, native binaries) + extension mirror (renamed `.html → .txt` can't smuggle markup through the text/* path). Stored `sendContentType` is the magic-byte answer, never the client's declared type.

## Out of scope

- Travel Mode server-side enforcement (H1 fix). Requires schema migration or UX regression — see `docs/security/threat-model.md` §5.6.
- Medium + Low findings (M1-M5, L1-L3) — PR 2 follows.

## Test plan
- [x] `npm run pre-pr` — all 19 checks pass (lint, type, bypass-rls, build, full vitest)
- [x] New regression tests added for each finding (C1: 2, H2: 1, H3: 1, H4: 1, H5: 3)
- [x] Backward compatibility verified for H2 (X-Signature header preserved)
- [ ] Reviewer to confirm H1 (Travel Mode) accepted-risk framing matches operator intent before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)