### PR TITLE
fix(env): require AUDIT_ANCHOR_PUBLISHER_ENABLED in production (A08-3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -369,6 +369,10 @@ DCR_CLEANUP_EMIT_HEARTBEAT_AUDIT=false
 # Master switch for the audit-anchor publisher worker. Default: false.
 # When true, the worker boots and publishes daily manifests; when false,
 # the worker process is a no-op (signing/tag keys not validated).
+# REQUIRED in production (NODE_ENV=production fails startup if unset)
+# — without external anchor publish, audit chain tampering is only
+# detectable within the database boundary. Pair with at least one
+# destination (S3 / GitHub / FS) plus signing key + tag secret.
 AUDIT_ANCHOR_PUBLISHER_ENABLED=false
 
 # PostgreSQL connection URL for the audit-anchor publisher role

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,14 @@ jobs:
       # Dummy auth provider — production env validation requires at least one
       AUTH_GOOGLE_ID: "ci-google-id.apps.googleusercontent.com"
       AUTH_GOOGLE_SECRET: "ci-google-secret"
+      # A08-3: production env validation now requires the audit anchor
+      # publisher to be enabled + configured (signing key + tag secret +
+      # at least one destination). E2E runs a real production build so
+      # the validation fires.
+      AUDIT_ANCHOR_PUBLISHER_ENABLED: "true"
+      AUDIT_ANCHOR_SIGNING_KEY: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      AUDIT_ANCHOR_TAG_SECRET: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      AUDIT_ANCHOR_DESTINATION_FS_PATH: "/tmp/ci-anchors"
     steps:
       - uses: actions/checkout@v6
 

--- a/scripts/env-descriptions.ts
+++ b/scripts/env-descriptions.ts
@@ -874,7 +874,11 @@ export const descriptions: Record<
     description:
       "Master switch for the audit-anchor publisher worker. Default: false.\n" +
       "When true, the worker boots and publishes daily manifests; when false,\n" +
-      "the worker process is a no-op (signing/tag keys not validated).",
+      "the worker process is a no-op (signing/tag keys not validated).\n" +
+      "REQUIRED in production (NODE_ENV=production fails startup if unset)\n" +
+      "— without external anchor publish, audit chain tampering is only\n" +
+      "detectable within the database boundary. Pair with at least one\n" +
+      "destination (S3 / GitHub / FS) plus signing key + tag secret.",
     example: "false",
   },
   AUDIT_ANCHOR_PUBLISHER_DATABASE_URL: {

--- a/src/__tests__/env.test.ts
+++ b/src/__tests__/env.test.ts
@@ -25,6 +25,13 @@ function setFullProdEnv() {
   process.env.AUTH_URL = "https://app.example.com";
   process.env.AUTH_GOOGLE_ID = "google-id";
   process.env.AUTH_GOOGLE_SECRET = "google-secret";
+  // A08-3: production gate now requires anchor publisher to be fully
+  // configured. Provide minimal valid values so prod-validation tests
+  // pass for unrelated concerns.
+  process.env.AUDIT_ANCHOR_PUBLISHER_ENABLED = "true";
+  process.env.AUDIT_ANCHOR_SIGNING_KEY = "c".repeat(64);
+  process.env.AUDIT_ANCHOR_TAG_SECRET = "d".repeat(64);
+  process.env.AUDIT_ANCHOR_DESTINATION_FS_PATH = "/var/anchors";
 }
 
 function resetEnv() {

--- a/src/lib/env-schema.test.ts
+++ b/src/lib/env-schema.test.ts
@@ -244,6 +244,134 @@ describe("envSchema (with superRefine cross-field rules)", () => {
     }
   });
 
+  // A08-3: production deployment must enable the anchor publisher so
+  // audit chain integrity is externally evidentiary (not detection-only).
+  describe("A08-3: AUDIT_ANCHOR_PUBLISHER_ENABLED production gate", () => {
+    const validProdBase = {
+      NODE_ENV: "production",
+      AUTH_SECRET: "x".repeat(32),
+      AUTH_URL: "https://app.example.com",
+      VERIFIER_PEPPER_KEY: VALID_HEX_64,
+      REDIS_URL: "redis://localhost:6379",
+      AUTH_GOOGLE_ID: "id",
+      AUTH_GOOGLE_SECRET: "secret",
+    };
+
+    it("rejects production when AUDIT_ANCHOR_PUBLISHER_ENABLED is false (default)", () => {
+      const result = envSchema.safeParse(baseEnv(validProdBase));
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some(
+            (i) => i.path[0] === "AUDIT_ANCHOR_PUBLISHER_ENABLED",
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it("rejects when ENABLED=true but signing key is missing", () => {
+      const result = envSchema.safeParse(
+        baseEnv({
+          ...validProdBase,
+          AUDIT_ANCHOR_PUBLISHER_ENABLED: "true",
+          AUDIT_ANCHOR_TAG_SECRET: VALID_HEX_64,
+          AUDIT_ANCHOR_DESTINATION_FS_PATH: "/var/anchors",
+        }),
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some(
+            (i) => i.path[0] === "AUDIT_ANCHOR_SIGNING_KEY",
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it("rejects when ENABLED=true but tag secret is missing", () => {
+      const result = envSchema.safeParse(
+        baseEnv({
+          ...validProdBase,
+          AUDIT_ANCHOR_PUBLISHER_ENABLED: "true",
+          AUDIT_ANCHOR_SIGNING_KEY: VALID_HEX_64,
+          AUDIT_ANCHOR_DESTINATION_FS_PATH: "/var/anchors",
+        }),
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some(
+            (i) => i.path[0] === "AUDIT_ANCHOR_TAG_SECRET",
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it("rejects when ENABLED=true but no destination is configured", () => {
+      const result = envSchema.safeParse(
+        baseEnv({
+          ...validProdBase,
+          AUDIT_ANCHOR_PUBLISHER_ENABLED: "true",
+          AUDIT_ANCHOR_SIGNING_KEY: VALID_HEX_64,
+          AUDIT_ANCHOR_TAG_SECRET: VALID_HEX_64,
+        }),
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some(
+            (i) => i.path[0] === "AUDIT_ANCHOR_DESTINATION_S3_BUCKET",
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it("accepts production when publisher fully configured (fs destination)", () => {
+      const result = envSchema.safeParse(
+        baseEnv({
+          ...validProdBase,
+          AUDIT_ANCHOR_PUBLISHER_ENABLED: "true",
+          AUDIT_ANCHOR_SIGNING_KEY: VALID_HEX_64,
+          AUDIT_ANCHOR_TAG_SECRET: VALID_HEX_64,
+          AUDIT_ANCHOR_DESTINATION_FS_PATH: "/var/anchors",
+        }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts production with S3 destination", () => {
+      const result = envSchema.safeParse(
+        baseEnv({
+          ...validProdBase,
+          AUDIT_ANCHOR_PUBLISHER_ENABLED: "true",
+          AUDIT_ANCHOR_SIGNING_KEY: VALID_HEX_64,
+          AUDIT_ANCHOR_TAG_SECRET: VALID_HEX_64,
+          AUDIT_ANCHOR_DESTINATION_S3_BUCKET: "my-bucket",
+        }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts production with GitHub destination", () => {
+      const result = envSchema.safeParse(
+        baseEnv({
+          ...validProdBase,
+          AUDIT_ANCHOR_PUBLISHER_ENABLED: "true",
+          AUDIT_ANCHOR_SIGNING_KEY: VALID_HEX_64,
+          AUDIT_ANCHOR_TAG_SECRET: VALID_HEX_64,
+          AUDIT_ANCHOR_DESTINATION_GH_REPO: "owner/repo",
+          AUDIT_ANCHOR_DESTINATION_GH_TOKEN: "ghp_xxx",
+        }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts development without publisher (no production gate)", () => {
+      const result = envSchema.safeParse(baseEnv({ NODE_ENV: "development" }));
+      expect(result.success).toBe(true);
+    });
+  });
+
   it("requires AZURE_KV_URL when KEY_PROVIDER=azure-kv (any NODE_ENV)", () => {
     const result = envSchema.safeParse(
       baseEnv({ KEY_PROVIDER: "azure-kv" }),

--- a/src/lib/env-schema.ts
+++ b/src/lib/env-schema.ts
@@ -484,6 +484,66 @@ export const envSchema = envObject.superRefine((data, ctx) => {
           "RESEND_API_KEY is required when EMAIL_PROVIDER=resend in production",
       });
     }
+
+    // A08-3 (OWASP audit batch 3 follow-up): audit chain HMAC integrity is
+    // observable only by detection, not prevention. Without an external
+    // anchor publish, a compromised DB could rewrite history undetected.
+    // Production deployments MUST enable the publisher (and configure its
+    // required keys) so the chain is evidentiary. Tampering window is
+    // bounded by anchor cadence + verifier worker.
+    if (!data.AUDIT_ANCHOR_PUBLISHER_ENABLED) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["AUDIT_ANCHOR_PUBLISHER_ENABLED"],
+        message:
+          "AUDIT_ANCHOR_PUBLISHER_ENABLED=true is required in production. " +
+          "Without external anchor publish the audit chain detects tampering " +
+          "only within the database boundary; an attacker with DB write access " +
+          "can rewrite history undetected. See docs/operations/alerts.md " +
+          "for destination options.",
+      });
+    } else {
+      // When enabled, the signing key + tag secret + at least one destination
+      // must also be configured. Otherwise the publisher boots but produces
+      // no externally-anchored output.
+      if (!data.AUDIT_ANCHOR_SIGNING_KEY) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["AUDIT_ANCHOR_SIGNING_KEY"],
+          message:
+            "AUDIT_ANCHOR_SIGNING_KEY is required when " +
+            "AUDIT_ANCHOR_PUBLISHER_ENABLED=true in production",
+        });
+      }
+      if (!data.AUDIT_ANCHOR_TAG_SECRET) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["AUDIT_ANCHOR_TAG_SECRET"],
+          message:
+            "AUDIT_ANCHOR_TAG_SECRET is required when " +
+            "AUDIT_ANCHOR_PUBLISHER_ENABLED=true in production",
+        });
+      }
+      const hasS3 = !!data.AUDIT_ANCHOR_DESTINATION_S3_BUCKET;
+      const hasGh = !!(
+        data.AUDIT_ANCHOR_DESTINATION_GH_REPO &&
+        data.AUDIT_ANCHOR_DESTINATION_GH_TOKEN
+      );
+      const hasFs = !!data.AUDIT_ANCHOR_DESTINATION_FS_PATH;
+      if (!hasS3 && !hasGh && !hasFs) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["AUDIT_ANCHOR_DESTINATION_S3_BUCKET"],
+          message:
+            "At least one anchor destination must be configured when " +
+            "AUDIT_ANCHOR_PUBLISHER_ENABLED=true in production: " +
+            "S3 (AUDIT_ANCHOR_DESTINATION_S3_BUCKET), " +
+            "GitHub (AUDIT_ANCHOR_DESTINATION_GH_REPO + " +
+            "AUDIT_ANCHOR_DESTINATION_GH_TOKEN), or " +
+            "filesystem (AUDIT_ANCHOR_DESTINATION_FS_PATH).",
+        });
+      }
+    }
   }
 
   // ── Cloud key provider requirements (A10-A11, always enforced) ──

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -87,6 +87,11 @@ describe("env validation", () => {
       REDIS_URL: "redis://localhost:6379",
       AUTH_GOOGLE_ID: "google-id",
       AUTH_GOOGLE_SECRET: "google-secret",
+      // A08-3: production gate requires anchor publisher fully configured.
+      AUDIT_ANCHOR_PUBLISHER_ENABLED: "true",
+      AUDIT_ANCHOR_SIGNING_KEY: "b".repeat(64),
+      AUDIT_ANCHOR_TAG_SECRET: "c".repeat(64),
+      AUDIT_ANCHOR_DESTINATION_FS_PATH: "/var/anchors",
     });
     const { env } = await import("./env");
     expect(env.NODE_ENV).toBe("production");
@@ -142,6 +147,11 @@ describe("env validation", () => {
       REDIS_URL: "redis://localhost:6379",
       EMAIL_PROVIDER: "smtp",
       SMTP_HOST: "smtp.example.com",
+      // A08-3.
+      AUDIT_ANCHOR_PUBLISHER_ENABLED: "true",
+      AUDIT_ANCHOR_SIGNING_KEY: "b".repeat(64),
+      AUDIT_ANCHOR_TAG_SECRET: "c".repeat(64),
+      AUDIT_ANCHOR_DESTINATION_FS_PATH: "/var/anchors",
     });
     const { env } = await import("./env");
     expect(env.EMAIL_PROVIDER).toBe("smtp");


### PR DESCRIPTION
## Summary

Closes OWASP audit batch 3 finding **A08-3** (Low): production startup must gate on the audit anchor publisher being enabled + configured. Single-finding follow-up to PRs #482 / #484.

### Why

The HMAC audit chain added in batch 3 (C13) detects tampering by re-hashing the chain. If an attacker can write to the DB, they can rewrite history AND recompute the chain hashes to match — the in-DB check just verifies the rewritten state.

External anchor publish (manifests signed by `AUDIT_ANCHOR_SIGNING_KEY` and pushed to S3 / GitHub / filesystem) breaks this: the externally-recorded chain head can be compared against the live DB at audit time, and any divergence is provable.

Without `AUDIT_ANCHOR_PUBLISHER_ENABLED=true`, audit chain is detection-only inside the DB boundary. Production deployments must not silently run without it.

### Implementation

`envSchema.superRefine` adds 4 production checks:
1. `AUDIT_ANCHOR_PUBLISHER_ENABLED=true` is required
2. When enabled: `AUDIT_ANCHOR_SIGNING_KEY` is required
3. When enabled: `AUDIT_ANCHOR_TAG_SECRET` is required
4. When enabled: at least one destination must be configured (`*_S3_BUCKET`, `*_GH_REPO + *_GH_TOKEN`, or `*_FS_PATH`)

Dev/test environments are unaffected.

### Test coverage
- 8 new test cases under `A08-3:` describe block (rejection paths + happy paths for each destination type + dev allowance)
- Existing production-env tests in `src/__tests__/env.test.ts` and `src/lib/env.test.ts` updated to provide the new required fields

## Test plan

- [x] `npx vitest run` — all tests pass (10493 tests, 1 skip)
- [x] `bash scripts/pre-pr.sh` — 19/19 checks pass
- [x] `npx next build` — production build succeeds
- [x] Local migration verification: no schema changes in this PR
- [ ] **Operator action required before deploy**: existing production
  deployments that don't have `AUDIT_ANCHOR_PUBLISHER_ENABLED=true`
  set will fail startup after this PR merges. Coordinate with ops:
  - Run `npm run generate:audit-anchor-signing-key` and
    `npm run generate:audit-anchor-tag-secret`
  - Set `AUDIT_ANCHOR_PUBLISHER_ENABLED=true` + the generated keys + at
    least one destination env var
  - Restart the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)