### PR TITLE
fix(auth): preserve freshly-issued session in passkey re-auth cascade

### DIFF
--- a/src/app/api/auth/passkey/verify/route.test.ts
+++ b/src/app/api/auth/passkey/verify/route.test.ts
@@ -16,6 +16,7 @@ const {
   mockWithBypassRls,
   mockInvalidateCachedSessions,
   mockResolveEffectiveSessionTimeouts,
+  mockInvalidateUserSessions,
 } = vi.hoisted(() => ({
   mockAssertOrigin: vi.fn(),
   mockRateLimiterCheck: vi.fn(),
@@ -29,6 +30,16 @@ const {
   mockWithBypassRls: vi.fn(),
   mockInvalidateCachedSessions: vi.fn().mockResolvedValue(undefined),
   mockResolveEffectiveSessionTimeouts: vi.fn(),
+  mockInvalidateUserSessions: vi.fn().mockResolvedValue({
+    sessions: 0,
+    extensionTokens: 0,
+    apiKeys: 0,
+    mcpAccessTokens: 0,
+    mcpRefreshTokens: 0,
+    delegationSessions: 0,
+    operatorTokens: 0,
+    cacheTombstoneFailures: 0,
+  }),
 }));
 
 vi.mock("@/lib/auth/session/csrf", () => ({
@@ -92,7 +103,7 @@ vi.mock("@/lib/http/with-request-log", () => ({
 }));
 
 vi.mock("@/lib/auth/session/user-session-invalidation", () => ({
-  invalidateUserSessions: vi.fn().mockResolvedValue({ sessions: 0, extensionTokens: 0, apiKeys: 0, mcpAccessTokens: 0, mcpRefreshTokens: 0, delegationSessions: 0, operatorTokens: 0, cacheTombstoneFailures: 0 }),
+  invalidateUserSessions: mockInvalidateUserSessions,
 }));
 
 import { POST } from "./route";
@@ -214,6 +225,21 @@ describe("POST /api/auth/passkey/verify", () => {
         passkeyVerifiedAt: expect.any(Date),
       }),
     });
+
+    // Regression (bug fix): invalidateUserSessions must EXCLUDE the
+    // session token we just created — otherwise the cascade wipes our
+    // freshly-issued session and the client is bounced to sign-in on
+    // the next request.
+    expect(mockPrismaSessionCreate).toHaveBeenCalledOnce();
+    const createdSessionToken = mockPrismaSessionCreate.mock.calls[0][0].data.sessionToken;
+    expect(createdSessionToken).toEqual(expect.any(String));
+    expect(mockInvalidateUserSessions).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({
+        allTenants: true,
+        excludeSessionToken: createdSessionToken,
+      }),
+    );
   });
 
   it("calls deleteMany before create", async () => {
@@ -286,6 +312,31 @@ describe("POST /api/auth/passkey/verify", () => {
         userAgent: null,
       }),
     );
+  });
+
+  it("returns 500 SESSION_INVALIDATE_FAILED when the cascade throws and does NOT set a session cookie", async () => {
+    // F1: cascade failure is fail-closed — the new session row is committed
+    // by the inner tx but no cookie is sent, so the orphan row is cleaned
+    // up by the next sign-in's `tx.session.deleteMany`. Specific error code
+    // gives the client a stable failure mode (no leak of cascade internals).
+    mockInvalidateUserSessions.mockRejectedValueOnce(new Error("transient redis fail"));
+
+    const req = createRequest("POST", ROUTE_URL, {
+      body: validBody,
+      headers: { origin: "http://localhost:3000" },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("SESSION_INVALIDATE_FAILED");
+    expect(res.headers.get("set-cookie")).toBeNull();
+
+    // AUTH_LOGIN audit must NOT fire — sign-in did not complete.
+    const authLoginCalls = mockLogAudit.mock.calls.filter(
+      (args: unknown[]) => (args[0] as { action: string }).action === "AUTH_LOGIN",
+    );
+    expect(authLoginCalls).toHaveLength(0);
   });
 
   it("returns 403 when origin is invalid", async () => {

--- a/src/app/api/auth/passkey/verify/route.ts
+++ b/src/app/api/auth/passkey/verify/route.ts
@@ -23,6 +23,7 @@ import { invalidateUserSessions } from "@/lib/auth/session/user-session-invalida
 import { invalidateCachedSessions } from "@/lib/auth/session/session-cache-helpers";
 import { resolveEffectiveSessionTimeouts } from "@/lib/auth/session/session-timeout";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
+import { getLogger } from "@/lib/logger";
 
 export const runtime = "nodejs";
 
@@ -165,10 +166,35 @@ async function handlePOST(req: NextRequest) {
   // Session deletion above already removed Session rows; this covers
   // the remaining bearer-class models. Sessions/tokens are scoped to
   // global User (not tenant), so allTenants=true matches.
-  await invalidateUserSessions(user.id, {
-    allTenants: true,
-    reason: "passkey_reauth",
-  });
+  // Exclude the just-created session token: invalidateUserSessions revokes
+  // ALL sessions across tenants, which would wipe the session we just
+  // committed above and leave the client with a cookie pointing at a
+  // non-existent Session row (next request → 401 → bounced to sign-in).
+  //
+  // Failure here returns 500 without setting the session cookie — matches
+  // the fail-closed pattern of change-passphrase / recovery-recover.
+  // The orphan Session row from line 139 is cleaned up by `tx.session.deleteMany`
+  // on the next sign-in attempt (line 125). Returning a specific error code
+  // gives the client a stable failure mode for retry logic.
+  try {
+    const result = await invalidateUserSessions(user.id, {
+      allTenants: true,
+      reason: "passkey_reauth",
+      excludeSessionToken: sessionToken,
+    });
+    if (result.cacheTombstoneFailures > 0) {
+      getLogger().warn(
+        { userId: user.id, failures: result.cacheTombstoneFailures },
+        "auth.passkey.verify.tombstoneFailures",
+      );
+    }
+  } catch (err) {
+    getLogger().error(
+      { userId: user.id, err },
+      "auth.passkey.verify.invalidateFailed",
+    );
+    return errorResponse(API_ERROR.SESSION_INVALIDATE_FAILED);
+  }
 
   // Audit log
   if (evictedCount > 0) {

--- a/src/app/api/vault/change-passphrase/route.test.ts
+++ b/src/app/api/vault/change-passphrase/route.test.ts
@@ -1,12 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockPrismaUser, mockRateLimiter, mockLogAudit, mockWithUserTenantRls } = vi.hoisted(() => ({
+const { mockAuth, mockPrismaUser, mockRateLimiter, mockLogAudit, mockWithUserTenantRls, mockInvalidateUserSessions } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockPrismaUser: { findUnique: vi.fn(), update: vi.fn() },
   mockRateLimiter: { check: vi.fn() },
   mockLogAudit: vi.fn(),
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
+  mockInvalidateUserSessions: vi.fn().mockResolvedValue({
+    sessions: 0,
+    extensionTokens: 0,
+    apiKeys: 0,
+    mcpAccessTokens: 0,
+    mcpRefreshTokens: 0,
+    delegationSessions: 0,
+    operatorTokens: 0,
+    cacheTombstoneFailures: 0,
+  }),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -40,7 +50,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 vi.mock("@/lib/auth/session/user-session-invalidation", () => ({
-  invalidateUserSessions: vi.fn().mockResolvedValue({ sessions: 0, extensionTokens: 0, apiKeys: 0, mcpAccessTokens: 0, mcpRefreshTokens: 0, delegationSessions: 0, operatorTokens: 0, cacheTombstoneFailures: 0 }),
+  invalidateUserSessions: mockInvalidateUserSessions,
 }));
 
 import { POST } from "./route";
@@ -171,6 +181,28 @@ describe("POST /api/vault/change-passphrase", () => {
           secretKeyAuthTag: validBody.secretKeyAuthTag,
         }),
       })
+    );
+  });
+
+  it("passes excludeSessionToken to invalidateUserSessions to preserve the caller's current session", async () => {
+    // Regression guard for the bug class fixed in passkey/verify:
+    // a successful passphrase change must NOT wipe the caller's own
+    // session via the global cascade. The excludeSessionToken option
+    // (resolved from the request cookie) is the mechanism that keeps
+    // the caller signed in while every other bearer credential is
+    // revoked.
+    const SESSION_TOKEN = "test-session-cookie-value";
+    const res = await POST(createRequest("POST", "http://localhost/api/vault/change-passphrase", {
+      body: validBody,
+      headers: { cookie: `authjs.session-token=${SESSION_TOKEN}` },
+    }));
+    expect(res.status).toBe(200);
+    expect(mockInvalidateUserSessions).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({
+        allTenants: true,
+        excludeSessionToken: SESSION_TOKEN,
+      }),
     );
   });
 

--- a/src/app/api/vault/recovery-key/recover/route.test.ts
+++ b/src/app/api/vault/recovery-key/recover/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockPrismaUser, mockVerifyCheck, mockResetCheck, mockResetClear, mockLogAudit, mockWithUserTenantRls } = vi.hoisted(() => ({
+const { mockAuth, mockPrismaUser, mockVerifyCheck, mockResetCheck, mockResetClear, mockLogAudit, mockWithUserTenantRls, mockInvalidateUserSessions } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockPrismaUser: { findUnique: vi.fn(), update: vi.fn() },
   mockVerifyCheck: vi.fn().mockResolvedValue({ allowed: true }),
@@ -9,6 +9,16 @@ const { mockAuth, mockPrismaUser, mockVerifyCheck, mockResetCheck, mockResetClea
   mockResetClear: vi.fn(),
   mockLogAudit: vi.fn(),
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
+  mockInvalidateUserSessions: vi.fn().mockResolvedValue({
+    sessions: 0,
+    extensionTokens: 0,
+    apiKeys: 0,
+    mcpAccessTokens: 0,
+    mcpRefreshTokens: 0,
+    delegationSessions: 0,
+    operatorTokens: 0,
+    cacheTombstoneFailures: 0,
+  }),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -40,7 +50,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 vi.mock("@/lib/auth/session/user-session-invalidation", () => ({
-  invalidateUserSessions: vi.fn().mockResolvedValue({ sessions: 0, extensionTokens: 0, apiKeys: 0, mcpAccessTokens: 0, mcpRefreshTokens: 0, delegationSessions: 0, operatorTokens: 0, cacheTombstoneFailures: 0 }),
+  invalidateUserSessions: mockInvalidateUserSessions,
 }));
 
 import { POST } from "./route";
@@ -215,6 +225,28 @@ describe("POST /api/vault/recovery-key/recover", () => {
             recoveryKeyRegenerated: true,
             lockoutReset: true,
           }),
+        }),
+      );
+    });
+
+    it("passes excludeSessionToken to invalidateUserSessions to preserve the caller's current session", async () => {
+      // Regression guard for the bug class fixed in passkey/verify:
+      // a successful recovery reset must NOT wipe the caller's own
+      // session via the global cascade. The excludeSessionToken option
+      // (resolved from the request cookie) is the mechanism that keeps
+      // the caller signed in while every other bearer credential is
+      // revoked.
+      const SESSION_TOKEN = "test-session-cookie-value";
+      const res = await POST(createRequest("POST", URL, {
+        body: resetBody,
+        headers: { cookie: `authjs.session-token=${SESSION_TOKEN}` },
+      }));
+      expect(res.status).toBe(200);
+      expect(mockInvalidateUserSessions).toHaveBeenCalledWith(
+        "user-1",
+        expect.objectContaining({
+          allTenants: true,
+          excludeSessionToken: SESSION_TOKEN,
         }),
       );
     });


### PR DESCRIPTION
## Summary
- Passkey sign-in created a new DB session, then `invalidateUserSessions({allTenants:true})`
  ran immediately after — deleting the just-committed session. The cookie was issued but
  the Session row no longer existed, so the next request 401'd and bounced the user back
  to sign-in.
- Fix: pass `excludeSessionToken: sessionToken` so the cascade preserves the freshly-issued
  token while still revoking all other bearer credentials (C7/AAL3 invariant intact).
- Hardening (F1): wrap the cascade in `try/catch` returning `SESSION_INVALIDATE_FAILED` on
  transient failure, matching the fail-closed pattern used by `change-passphrase` and
  `recovery-key/recover`.
- Regression guards: add `excludeSessionToken` assertions to all three excludeSessionToken-
  using routes' tests so future drops of the option fail tests instead of shipping silently.

## Origin
- PR #482 (batch 3, C7) replaced `revokeAllExtensionTokensForUser` with
  `invalidateUserSessions` to revoke all bearer credentials on passkey re-auth.
- PR #484 added the `excludeSessionToken` option and applied it to `change-passphrase`
  and `recovery-key/recover` — but missed this route. This PR closes that propagation gap.

## Files
- `src/app/api/auth/passkey/verify/route.ts` — pass `excludeSessionToken`; wrap cascade in
  `try/catch` returning `SESSION_INVALIDATE_FAILED`; warn on `cacheTombstoneFailures > 0`.
- `src/app/api/auth/passkey/verify/route.test.ts` — regression assertion + cascade-failure
  path test; promote `invalidateUserSessions` mock to `vi.hoisted()`; drop unsafe cast in
  favor of `toHaveBeenCalledOnce()` precondition.
- `src/app/api/vault/change-passphrase/route.test.ts` — regression assertion (no production
  change; route already had `excludeSessionToken` from PR #484).
- `src/app/api/vault/recovery-key/recover/route.test.ts` — same as above.

## Out of scope (verified, not changed)
- `src/app/api/vault/rotate-key/route.ts` does not pass `excludeSessionToken` — verified
  intentional per PR #438 (vault key rotation requires fresh re-sign-in so all bearer
  caches pick up the new key cleanly).

## Test plan
- [x] `npx vitest run` — 874 files / 10,491 tests pass (+3 new: regression in 3 routes + F1
  cascade-failure path)
- [x] `npx next build` — production build succeeds
- [ ] Manual: sign in with passkey, confirm dashboard loads without redirect to sign-in
- [ ] Manual: change passphrase / recover via recovery-key, confirm current session preserved
- [ ] Manual (R35 Tier-2): inject cascade failure (Redis down) → confirm 500
  `SESSION_INVALIDATE_FAILED` returned, no session cookie set, no `AUTH_LOGIN` audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)