### PR TITLE
refactor: extract BRIDGE_CODE_LENGTH constant + post-#489 minor fixes

### DIFF
--- a/docs/architecture/extension-token-bridge.md
+++ b/docs/architecture/extension-token-bridge.md
@@ -222,7 +222,7 @@ After the 2026-04 cleanup the postMessage column is no longer reachable from any
 | `src/lib/inject-extension-bridge-code.ts` | Web app: dispatches `postMessage` with bridge code (replaces `inject-extension-token.ts`) |
 | `src/app/api/extension/bridge-code/route.ts` | Web app endpoint: issues a one-time code (Auth.js session required) |
 | `src/app/api/extension/token/exchange/route.ts` | Web app endpoint: atomically consumes a code, returns a token (no session) |
-| `src/lib/auth/tokens/extension-token.ts` | Shared `issueExtensionToken()` helper used by legacy POST + new exchange |
+| `src/lib/auth/tokens/extension-token.ts` | Shared `issueExtensionToken()` helper used by `/api/extension/token/exchange` (legacy POST `/api/extension/token` was retired — see Migration status below) |
 | `src/lib/constants/integrations/extension.ts` | Shared constants: `BRIDGE_CODE_MSG_TYPE`, `BRIDGE_CODE_TTL_MS`, `BRIDGE_CODE_MAX_ACTIVE` |
 | `extension/src/content/token-bridge.js` | Content script (ISOLATED): receives postMessage, exchanges bridge code, forwards token to background. Plain JS — see project memory `project_extension_parallel_impl.md`. |
 | `extension/src/content/token-bridge-lib.ts` | TypeScript version of content script (for tests only — not registered at runtime) |
@@ -237,10 +237,14 @@ After the 2026-04 cleanup the postMessage column is no longer reachable from any
 
 The legacy `TOKEN_BRIDGE_MSG_TYPE` postMessage relay path was removed in the
 2026-04 cleanup; the extension content script no longer accepts that message
-type. The legacy `POST /api/extension/token` endpoint remains operational and
-continues to emit a structured log entry (`event: extension_token_legacy_issuance`)
-on every call so we can measure when legacy traffic drops to zero — that
-endpoint's removal is tracked separately.
+type. The legacy `POST /api/extension/token` endpoint was retired in the
+`deprecate-legacy-extension-token` PR (2026-05) and now always returns
+HTTP 410 Gone with `Deprecation: true` + `Cache-Control: no-store` headers.
+Calls are still observable via `event: extension_token_legacy_issuance_blocked`
+(warn-level structured log) and the `EXTENSION_TOKEN_LEGACY_ISSUANCE_BLOCKED`
+audit action; expected post-deploy count on both is zero. The full handler
+deletion is scheduled for the next Minor release after one observation window
+of zero surprise traffic.
 
 ---
 

--- a/extension/src/content/token-bridge-lib.ts
+++ b/extension/src/content/token-bridge-lib.ts
@@ -1,5 +1,8 @@
-import { BRIDGE_CODE_MSG_TYPE } from "../lib/constants";
+import { BRIDGE_CODE_MSG_TYPE, BRIDGE_CODE_LENGTH } from "../lib/constants";
 import { EXT_API_PATH } from "../lib/api-paths";
+
+// Mirror of server-side Zod schema in src/app/api/extension/token/exchange/route.ts
+const BRIDGE_CODE_RE = new RegExp(`^[a-f0-9]{${BRIDGE_CODE_LENGTH}}$`);
 
 function isContextValid(): boolean {
   try { return !!chrome.runtime?.id; }
@@ -33,7 +36,7 @@ function forwardToken(token: string, expiresAtMs: number): void {
  */
 async function handleBridgeCodeMessage(event: MessageEvent): Promise<boolean> {
   const { code, expiresAt } = event.data ?? {};
-  if (typeof code !== "string" || code.length !== 64) return false;
+  if (typeof code !== "string" || !BRIDGE_CODE_RE.test(code)) return false;
   if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) return false;
   if (!isContextValid()) return false;
 

--- a/extension/src/content/token-bridge.js
+++ b/extension/src/content/token-bridge.js
@@ -12,6 +12,8 @@
 // src/__tests__/i18n/extension-constants-sync.test.ts enforces this.
 
 var BRIDGE_CODE_MSG_TYPE = "PASSWD_SSO_BRIDGE_CODE";
+var BRIDGE_CODE_LENGTH = 64;
+var BRIDGE_CODE_RE = new RegExp("^[a-f0-9]{" + BRIDGE_CODE_LENGTH + "}$");
 var EXCHANGE_PATH = "/api/extension/token/exchange";
 
 function isContextValid() {
@@ -47,7 +49,7 @@ function forwardToken(token, expiresAtMs) {
 function handleBridgeCodeMessage(event) {
   var code = event.data.code;
   var expiresAt = event.data.expiresAt;
-  if (typeof code !== "string" || code.length !== 64) return;
+  if (typeof code !== "string" || !BRIDGE_CODE_RE.test(code)) return;
   if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) return;
   if (!isContextValid()) return;
 

--- a/extension/src/lib/constants.ts
+++ b/extension/src/lib/constants.ts
@@ -9,6 +9,8 @@ export const TOKEN_READY_EVENT = "passwd-sso-token-ready";
 export const BRIDGE_CODE_MSG_TYPE = "PASSWD_SSO_BRIDGE_CODE";
 export const BRIDGE_CODE_TTL_MS = 60 * 1000;
 export const BRIDGE_CODE_MAX_ACTIVE = 3;
+// Bridge code wire format (mirror of web app constant — sync test enforces equality)
+export const BRIDGE_CODE_LENGTH = 64;
 
 // ── Session storage ──
 export const SESSION_KEY = "authState";

--- a/src/__tests__/i18n/extension-constants-sync.test.ts
+++ b/src/__tests__/i18n/extension-constants-sync.test.ts
@@ -18,6 +18,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
+  BRIDGE_CODE_LENGTH,
   BRIDGE_CODE_MAX_ACTIVE,
   BRIDGE_CODE_MSG_TYPE,
   BRIDGE_CODE_TTL_MS,
@@ -59,5 +60,9 @@ describe("extension constants sync (web app ↔ extension repo)", () => {
 
   it("BRIDGE_CODE_MAX_ACTIVE matches between web app and extension", () => {
     expect(extractNumericConst("BRIDGE_CODE_MAX_ACTIVE")).toBe(BRIDGE_CODE_MAX_ACTIVE);
+  });
+
+  it("BRIDGE_CODE_LENGTH matches between web app and extension", () => {
+    expect(extractNumericConst("BRIDGE_CODE_LENGTH")).toBe(BRIDGE_CODE_LENGTH);
   });
 });

--- a/src/app/api/extension/token/exchange/route.ts
+++ b/src/app/api/extension/token/exchange/route.ts
@@ -39,7 +39,7 @@ import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { getLogger } from "@/lib/logger";
 import { parseBody } from "@/lib/http/parse-body";
 import { withRequestLog } from "@/lib/http/with-request-log";
-import { AUDIT_ACTION } from "@/lib/constants";
+import { AUDIT_ACTION, BRIDGE_CODE_LENGTH } from "@/lib/constants";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 
 export const runtime = "nodejs";
@@ -51,7 +51,7 @@ const exchangeLimiter = createRateLimiter({
 });
 
 const ExchangeRequestSchema = z.object({
-  code: z.string().length(64).regex(/^[a-f0-9]+$/),
+  code: z.string().length(BRIDGE_CODE_LENGTH).regex(/^[a-f0-9]+$/),
 });
 
 async function handlePOST(req: NextRequest) {

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -43,6 +43,7 @@ export {
   BRIDGE_CODE_MSG_TYPE,
   BRIDGE_CODE_TTL_MS,
   BRIDGE_CODE_MAX_ACTIVE,
+  BRIDGE_CODE_LENGTH,
   EXT_CONNECT_PARAM,
 } from "./integrations/extension";
 export { API_PATH, apiPath } from "./auth/api-path";

--- a/src/lib/constants/integrations/extension.ts
+++ b/src/lib/constants/integrations/extension.ts
@@ -17,5 +17,13 @@ export const BRIDGE_CODE_TTL_MS = MS_PER_MINUTE; // 60 seconds
 // Maximum unused bridge codes per user (oldest auto-revoked when exceeded).
 export const BRIDGE_CODE_MAX_ACTIVE = 3;
 
+// Bridge code wire format: 64 hex chars (32 random bytes → hex-encoded by
+// generateShareToken). Length and character set are validated symmetrically
+// on the server (Zod schema in exchange/route.ts) and on the extension
+// content script. Mirrored to `extension/src/lib/constants.ts`; the sync
+// test at `src/__tests__/i18n/extension-constants-sync.test.ts` enforces
+// equality.
+export const BRIDGE_CODE_LENGTH = 64;
+
 // ── URL params ──
 export const EXT_CONNECT_PARAM = "ext_connect";


### PR DESCRIPTION
## Summary

External re-review of #489 identified the bridge-code hex regex was duplicated in 4 places with the literal `64` hardcoded, plus 2 minor follow-ups. R2 / RT3.

- Introduce `BRIDGE_CODE_LENGTH = 64` in `src/lib/constants/integrations/extension.ts`; re-export from `src/lib/constants`.
- Server Zod schema (`exchange/route.ts`) consumes the constant.
- Extension mirrors the constant in `extension/src/lib/constants.ts`; both `token-bridge.js` (plain JS) and `token-bridge-lib.ts` (TS test version) build `BRIDGE_CODE_RE` from it.
- Cross-repo sync test (`extension-constants-sync.test.ts`) extended to verify `BRIDGE_CODE_LENGTH` matches.
- Tighten extension client validation from length-only to the same hex regex the server enforces (defense-in-depth — server is the authority but matching the contract locally fails closed faster).
- Doc fix: `docs/architecture/extension-token-bridge.md` "Migration status" still claimed the legacy POST endpoint "remains operational" with the info-level metric; updated to reflect the 410 Gone + warn-level `extension_token_legacy_issuance_blocked` event landed in #489.

## Not in scope

- One reviewer-claimed finding (duplicate `token: plaintext` in `issueExtensionToken()`) was verified at `src/lib/auth/tokens/extension-token.ts:259-263` to NOT exist; rejected as hallucinated.
- P1 architectural work (bind bridge-code flow to extension-held proof so XSS cannot complete it alone) remains tracked separately per the #489 plan §4 deferral.

## Test plan

- [x] `bash scripts/pre-pr.sh` — 29/29 pass locally
- [ ] CI: lint + test + build on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)