### PR TITLE
feat(extension): click-driven ext_connect + userActivation gate (C15-v2)

### DIFF
--- a/docs/archive/review/ext-connect-user-activation-gate-manual-test.md
+++ b/docs/archive/review/ext-connect-user-activation-gate-manual-test.md
@@ -1,0 +1,181 @@
+# Manual Test: ext-connect-user-activation-gate (C15-v2)
+
+Date: 2026-05-28
+Branch: `feat/ext-connect-user-activation-gate`
+R35 tier: **Tier-2** (content script is extension-deployed; security control)
+
+## Pre-conditions
+
+- Dev environment running: `npm run dev` (web app at http://localhost:3000)
+- Docker DB + Redis + Jackson up: `npm run docker:up`
+- Extension built (`cd extension && npm run build`) and loaded unpacked in
+  Chrome (`chrome://extensions` → Load unpacked → `extension/dist`)
+- `EXTENSION_BRIDGE_CODE_ALLOWED_ORIGINS` in `.env` includes the unpacked
+  extension's origin (already present for known IDs in `.env`)
+- A test user account with vault initialized + signed in once before
+  testing
+
+## Test scenarios
+
+### TC1 — Legitimate flow (canonical happy path)
+
+**Steps**:
+1. Open a fresh Chrome window. Visit any non-passwd-sso page to ensure no
+   stale activation.
+2. Click the extension toolbar icon → click **Connect**.
+3. Sign in if prompted; complete vault unlock if prompted.
+4. The page lands on `/<locale>/dashboard?ext_connect=1`.
+5. The AWAITING_CLICK card is displayed: **拡張機能との接続を許可しますか?**
+   / "Allow extension connection?" + Allow button.
+6. Click the **拡張機能との接続を許可** / "Allow extension connection" button.
+
+**Expected result**:
+- CONNECTING state briefly visible, then CONNECTED ("接続が完了しました" /
+  "Connection complete") within ~3 seconds.
+- URL no longer contains `ext_connect=1` (replaced via `history.replaceState`).
+- "ダッシュボードへ" / "Go to dashboard" button returns to the dashboard.
+
+**Rollback**: revert the PR; the auto-fire flow resumes.
+
+### TC2 — XSS autonomous fire (adversarial)
+
+**Steps**:
+1. Complete TC1 so the extension is connected and the dashboard is open.
+2. Open Chrome DevTools → Console.
+3. Paste and run:
+   ```js
+   window.postMessage(
+     {type: "PASSWD_SSO_EXT_CONNECT_REQUEST", reqId: "xss-tc2"},
+     location.origin,
+   );
+   ```
+4. Do NOT click anything else for 10 seconds.
+
+**Expected result**:
+- No `PASSWD_SSO_EXT_CONNECT_READY` reply appears in the console (no
+  message-event handler logs anything for `reqId: "xss-tc2"`).
+- No new audit log entry for `EXTENSION_BRIDGE_CODE_ISSUE_FAILURE`
+  in `audit_logs` for this user (verify via DB query if access is
+  available; otherwise skip and rely on the absence of EXT_CONNECT_READY
+  as the primary observable).
+
+**Why this matters**: confirms the silent-drop semantics. Any
+EXT_CONNECT_READY would indicate the gate is broken.
+
+### TC3 — Programmatic `.click()` on Allow button (adversarial)
+
+**Steps**:
+1. Sign out, then re-open the extension popup → click Connect → reach the
+   AWAITING_CLICK page (do NOT click Allow yet).
+2. Open DevTools → Console.
+3. Paste and run:
+   ```js
+   document.querySelector("button[data-c15-action='allow-connect']").click();
+   ```
+4. Observe behavior.
+
+**Expected result** (one of):
+- **(a)** The `connect()` runs (the click handler fires per React's
+  synthetic-event behavior), `requestExtensionConnect()` posts a
+  EXT_CONNECT_REQUEST, but the content-script silently drops it
+  (programmatic `.click()` does NOT set `navigator.userActivation.isActive`
+  per HTML User Activation v2). After 8 seconds, the page shows the
+  EXTENSION_ABSENT failure state (the `requestExtensionConnect` timeout).
+- **(b)** Some browsers may now disable programmatic `.click()` on buttons
+  whose handlers require activation — record whichever path was observed.
+
+**Pass condition**: connection does NOT complete successfully (no
+"接続が完了しました" / "Connection complete" state). Either outcome is
+acceptable; record which one for the PR review.
+
+### TC4 — Documented 5-second race-window limitation (adversarial)
+
+**Steps**:
+1. Reach the AWAITING_CLICK page as in TC3.
+2. Pre-stage the DevTools console with:
+   ```js
+   setTimeout(() => window.postMessage(
+     {type: "PASSWD_SSO_EXT_CONNECT_REQUEST", reqId: "race-tc4"},
+     location.origin,
+   ), 1500);
+   console.log("[TC4] queued");
+   ```
+3. Press Enter (the "queued" log confirms staging).
+4. Immediately (within 1 second) click the Allow button.
+
+**Expected result**:
+- The legitimate Allow click completes the connection (CONNECTED state
+  observed within ~3s).
+- About 1500ms after the Allow click, a SECOND
+  `PASSWD_SSO_EXT_CONNECT_READY` postMessage is dispatched for
+  `reqId: "race-tc4"` — observable by adding the listener below before
+  step 3:
+  ```js
+  window.addEventListener("message", e => {
+    if (e.data?.type === "PASSWD_SSO_EXT_CONNECT_READY") {
+      console.log("[TC4 reply]", performance.now(), e.data);
+    }
+  });
+  ```
+- Record whether the vault remains unlocked (i.e., no
+  `tokenChanged → clearVault()` is triggered) or whether the user is
+  forced to re-unlock. **Either outcome is acceptable per plan §S6**, but
+  the actual behavior MUST be documented in the PR description so future
+  reviewers know the residual damage profile.
+
+**Why this matters**: pins the documented limitation that the gate cannot
+distinguish a legitimate click from an XSS payload that races within the
+transient activation window (~5 s).
+
+### TC5 — Timeout-collapse confirmation (informational)
+
+**Steps**:
+1. From any dashboard page (extension connected or not), open DevTools.
+2. Paste:
+   ```js
+   window.addEventListener("message", e => {
+     if (e.data?.type === "PASSWD_SSO_EXT_CONNECT_READY") {
+       console.log("[TC5 reply]", performance.now(), e.data);
+     }
+   });
+   window.postMessage(
+     {type: "PASSWD_SSO_EXT_CONNECT_REQUEST", reqId: "tc5"},
+     location.origin,
+   );
+   ```
+3. Wait 10 seconds.
+
+**Expected result**:
+- No `[TC5 reply]` log appears (silent drop because no activation).
+- This is indistinguishable from "extension not installed" at the page
+  level — the web app's `requestExtensionConnect` helper has an 8-second
+  timeout that returns EXTENSION_ABSENT in both cases.
+
+**Why this matters**: confirms the timeout-collapse property that closes
+the oracle — XSS cannot distinguish "extension installed, my activation
+is bad" from "extension absent."
+
+## Adversarial scenarios summary
+
+| ID | Attack | Expected gate behavior |
+|----|--------|------------------------|
+| TC2 | XSS fires postMessage without activation | Silent drop (no EXT_CONNECT_READY) |
+| TC3 | XSS calls `.click()` programmatically | Silent drop at content script (programmatic .click does not set activation) |
+| TC4 | XSS races a real click within 5s | **Documented limitation**: SW accepts. Damage limited to duplicate fetch + audit noise + possible vault relock |
+| TC5 | XSS observes timing of silent drop | Closed via 8s page-side timeout collapsing all failure paths to EXTENSION_ABSENT |
+
+## Out of scope
+
+- SW-side `_sender.tab?.url` whitelisting on `START_CONNECT` — separate
+  defense-in-depth hardening, tracked as future work. See plan §"Out of scope".
+- Frame-ancestors enforcement — owned by `src/lib/proxy/security-headers.ts`,
+  not subsumed by C15-v2.
+
+## Rollback
+
+If the gate breaks the legitimate flow for any user segment:
+1. Revert the PR (single squash commit).
+2. The previous auto-fire useEffect is restored; URL retention reverts to
+   immediate-removal.
+3. No DB migration to undo. No schema change. No server-side change.
+4. Extension content script reverts on the next extension build/publish.

--- a/docs/archive/review/ext-connect-user-activation-gate-manual-test.md
+++ b/docs/archive/review/ext-connect-user-activation-gate-manual-test.md
@@ -127,6 +127,36 @@ acceptable; record which one for the PR review.
 distinguish a legitimate click from an XSS payload that races within the
 transient activation window (~5 s).
 
+### TC4b — Post-passkey-reauth retry (regression for C15-v2 reauth bug)
+
+**Why this exists**: an earlier iteration auto-called `connect()` after a
+successful passkey re-auth. `navigator.credentials.get()` consumes the
+page's transient user activation, so the subsequent postMessage was
+silent-dropped by the content-script gate → page showed "extension
+absent" after the 8-second timeout. This TC pins the regression.
+
+**Steps**:
+1. Sign in normally so the dashboard loads.
+2. Wait long enough that the session no longer satisfies the bridge-code
+   route's step-up-auth requirement (or trigger step-up some other way).
+3. Open the extension popup → click Connect → land on
+   `/<locale>/dashboard?ext_connect=1`.
+4. AWAITING_CLICK card appears → click **拡張機能との接続を許可**.
+5. `connect()` returns `SESSION_STEP_UP_REQUIRED` → FAILED state shows
+   "ブラウザでの再認証が必要です" + **Passkey で再認証** button.
+6. Click **Passkey で再認証** → complete the WebAuthn ceremony.
+
+**Expected result**:
+- After the passkey ceremony succeeds, the **AWAITING_CLICK card is
+  shown AGAIN** (not an immediate transition to CONNECTING / CONNECTED /
+  EXTENSION_ABSENT).
+- The user clicks **拡張機能との接続を許可** a second time.
+- `connect()` runs with fresh activation → CONNECTING → CONNECTED.
+
+**Pass condition**: the second Allow click reaches CONNECTED. If the
+page reaches EXTENSION_ABSENT after the reauth step, the regression has
+returned.
+
 ### TC5 — Timeout-collapse confirmation (informational)
 
 **Steps**:

--- a/docs/archive/review/ext-connect-user-activation-gate-plan.md
+++ b/docs/archive/review/ext-connect-user-activation-gate-plan.md
@@ -1,0 +1,546 @@
+# Plan: ext-connect-user-activation-gate (C15-v2)
+
+Date: 2026-05-27
+Branch: `feat/ext-connect-user-activation-gate`
+
+## Project context
+
+- Type: **web app + browser extension** (Next.js 16 + Chrome MV3 extension)
+- Test infrastructure: **unit + integration + CI** (vitest both sides, GitHub Actions)
+- Predecessors:
+  - PR #491: DPoP sender-constrained tokens (RFC 9449)
+  - PR #492: SW-initiated bridge-code + cnf_jkt trust path
+  - PR #495 (C14): EXTENSION_BRIDGE_CODE_ISSUE_FAILURE audit emission
+  - C15 v1 (naive `isActive` gate on useEffect): **rejected**
+    — see `docs/archive/review/c15-user-activation-validation.md`
+  - C15-v2 prototype (`prototype/click-driven-ext-connect`): UX-validated by
+    end user (違和感ない after wording change to "拡張機能との接続を許可"),
+    empirical confirmation `isActive: true, hasBeenActive: true` at click.
+
+## Objective
+
+Close the residual XSS-on-page-load auto-fire of `PASSWD_SSO_EXT_CONNECT_REQUEST`
+by combining:
+
+1. **Web-app side**: replace the `?ext_connect=1` auto-firing useEffect with an
+   explicit click-driven confirmation step ("拡張機能との接続を許可"). The user
+   must click before `window.postMessage(EXT_CONNECT_REQUEST, ...)` fires.
+2. **Content-script side**: gate the `EXT_CONNECT_REQUEST` handler on
+   `navigator.userActivation.isActive`. Drop silently (no `EXT_CONNECT_READY`
+   response) when activation is false — oracle prevention.
+
+Together these enforce: any `EXT_CONNECT_REQUEST` that the SW processes was
+the direct consequence of a real user gesture within the past 5 seconds.
+Programmatic `.click()` and synthesized `MouseEvent` do NOT set user
+activation per the HTML User Activation v2 spec — so XSS in the host page
+cannot forge it.
+
+## Requirements
+
+### Functional
+
+- The legitimate `?ext_connect=1` flow ends with the extension connected,
+  same as today. Cost: one additional click on a confirmation card.
+- Non-`?ext_connect=1` dashboard pages are unchanged.
+- The content-script gate applies to `EXT_CONNECT_REQUEST` messages
+  regardless of whether the page is on `/dashboard?ext_connect=1` or any
+  other dashboard route — XSS could fire from anywhere, so the gate must
+  protect everywhere.
+- The drop on activation failure is **silent** (no `EXT_CONNECT_READY`
+  reply) — preventing an XSS oracle that could distinguish "extension
+  installed but I lack activation" from "extension absent."
+
+### Non-functional
+
+- No new audit emission introduced by this PR (the drop happens entirely
+  in the extension content script; the server is never reached). The
+  existing C14 `EXTENSION_BRIDGE_CODE_ISSUE_FAILURE` audit still fires
+  if XSS ever bypasses the gate and reaches the server.
+- No change to the server-side bridge-code route, no DB migration, no
+  enum addition, no schema change.
+- No change to `extension/manifest.json` permissions.
+
+## Technical approach
+
+### Content-script gate (the actual security mechanism)
+
+`extension/src/content/token-bridge-lib.ts` (and the parallel
+`extension/src/content/token-bridge.js` per
+`project_extension_parallel_impl` memory):
+
+```ts
+// Pseudo — body in implementation phase
+async function handleConnectRequestMessage(event: MessageEvent): Promise<boolean> {
+  const { reqId } = (event.data ?? {}) as { reqId?: unknown };
+  if (typeof reqId !== "string" || reqId.length === 0) return false;
+
+  // C15-v2 gate: require fresh user activation in the host page. Silent
+  // drop — no postReady — so XSS cannot distinguish "no activation" from
+  // "extension absent." Real users always have activation because the
+  // legitimate flow only sends EXT_CONNECT_REQUEST from an onClick handler.
+  if (!navigator.userActivation?.isActive) return false;
+
+  if (!isContextValid()) { /* unchanged */ }
+  // ... unchanged
+}
+```
+
+Property: when the API is unavailable (`navigator.userActivation` is
+undefined on a very old browser), the check fails-closed (`undefined?.isActive`
+is `undefined` → falsy → drop). The extension targets Chrome MV3 where the
+API has been stable since Chrome 88 (Jan 2021) — older browsers cannot run
+the extension at all, so fail-closed is safe.
+
+### Web-app click-driven flow (provides activation for the legitimate path)
+
+`src/components/extension/auto-extension-connect.tsx`:
+
+- New `CONNECT_STATUS.AWAITING_CLICK` state.
+- `useEffect` on `?ext_connect=1` sets status to `AWAITING_CLICK` instead of
+  auto-firing `connect()`.
+- New `handleConnectClick` callback removes `?ext_connect=1` from URL and
+  calls `connect()`. The click guarantees `userActivation.isActive === true`
+  at the postMessage moment.
+- New i18n labels: `awaitingClickTitle`, `awaitingClickDescription`,
+  `awaitingClickAction` ("拡張機能との接続を許可" / "Allow extension connection")
+  — already drafted on the prototype branch.
+
+`src/lib/constants/integrations/connect-status.ts`: add
+`AWAITING_CLICK: "awaiting_click"`.
+
+### Tests
+
+- **New**: `extension/src/__tests__/content/token-bridge-user-activation.test.ts`
+  — explicitly tests the new gate (accept when `isActive: true`, silent drop
+  when `isActive: false`, drop when `navigator.userActivation` is undefined).
+  Mock `navigator.userActivation` in `beforeEach`.
+- **Update**: existing `token-bridge.test.ts` tests must inject
+  `navigator.userActivation = { isActive: true }` in `beforeEach` so the
+  existing happy-path tests don't regress.
+- **Rewrite**: `src/components/extension/auto-extension-connect.test.tsx`
+  with click-driven assertions. Restore the file structure from git history
+  (commit `c0a459d8^` has the original) but insert a `userEvent.click(...)`
+  step where the old tests assumed auto-fire.
+- **No new** server-side test (no server change).
+
+### Manual test artifact (R35)
+
+`docs/archive/review/ext-connect-user-activation-gate-manual-test.md` — Tier-1
+(content script is extension-deployed). Required sections per R35: Pre-conditions
+/ Steps / Expected result / Rollback. Manual test scenarios:
+
+- **TC1**: legitimate flow (extension popup Connect → sign-in → Allow click)
+  → SW receives START_CONNECT → bridge-code issued → extension connected.
+- **TC2**: XSS simulation (run `window.postMessage(EXT_CONNECT_REQUEST, ...)`
+  from DevTools console without user gesture) → silent drop, no
+  EXT_CONNECT_READY response observed.
+- **TC3**: programmatic `.click()` on the Allow button via DevTools console
+  → activation NOT set → postMessage either does not fire (web-side guarded
+  via the click handler being attached to a real onClick) OR fires but is
+  dropped by content-script gate. Verify by observing absence of audit row.
+- **TC4**: rapid-fire test — user clicks Allow, then within 5 seconds XSS
+  fires another postMessage with a fake reqId → activation is still true
+  → SW processes the duplicate. Documented limitation.
+
+## Contracts
+
+### C1 — Content-script gate (locked)
+
+- File: `extension/src/content/token-bridge-lib.ts` AND the parallel JS twin
+  `extension/src/content/token-bridge.js`. **Both files must be edited
+  symmetrically** per memory `project_extension_parallel_impl` — the `.js`
+  file is the production artifact, `-lib.ts` is test-only. Divergence
+  silently disables the gate in production.
+- In `handleConnectRequestMessage`, after the `reqId` validation and BEFORE
+  the `isContextValid()` check:
+  - `.ts` version: `if (!navigator.userActivation?.isActive) return false;`
+  - `.js` version: `if (!navigator.userActivation || !navigator.userActivation.isActive) return;`
+    (returns void — matches the file's existing return discipline since the
+    .js handler does not propagate boolean to the listener)
+- The drop is silent — no `postReady(...)` call. The early return matches
+  the existing "ignore-unknown-type" oracle-prevention pattern.
+- **Invariants**:
+  - The gate fires AFTER `reqId` shape validation (so malformed payloads are
+    still rejected cheaply).
+  - The gate fires BEFORE `isContextValid()`. **Rationale is oracle
+    prevention, not performance**: `isContextValid()` failure path emits
+    `postReady(reqId, false, "EXTENSION_ABSENT")` — if it ran first, an
+    XSS could observe the EXTENSION_ABSENT reply and learn the extension's
+    presence without needing activation. Placing the gate before
+    isContextValid keeps the silent-drop semantics intact.
+  - **No `postReady` on activation failure**. Any code path that adds a
+    `postReady` between `reqId` validation and the SW call would re-open
+    the oracle.
+  - `navigator.userActivation` is checked with optional chaining
+    (`?.isActive`) so undefined-API environments fail-closed.
+  - **Only `isActive` matters, NOT `hasBeenActive`.** Sticky activation
+    (`hasBeenActive: true, isActive: false`) is post-expiry state — XSS
+    can race after activation expires and observe `hasBeenActive: true`
+    indefinitely. A regression that switches `isActive` → `hasBeenActive`
+    silently defeats the gate.
+- **Sync test extension** (token-bridge-js-sync.test.ts): the existing
+  parallel-impl sync test currently only checks for three message-type
+  string literals. It MUST gain an assertion that `token-bridge.js`
+  contains the literal `navigator.userActivation` to guard against the
+  RT4 vacuous-test pattern (gate exists in `.ts` only, production `.js`
+  silently lacks it, all unit tests still green).
+- **Acceptance**: unit tests cover (a) accept when isActive=true,
+  (b) silent drop when isActive=false, (c) silent drop when
+  navigator.userActivation is undefined, (d) silent drop when
+  navigator.userActivation is `{}` (no isActive property),
+  (e) silent drop when navigator.userActivation is
+  `{ isActive: false, hasBeenActive: true }` (pins isActive-not-hasBeenActive
+  invariant), (f) gate fires after reqId validation,
+  (g) gate fires before isContextValid (verified by stubbing
+  chrome.runtime to undefined AND isActive=false → no postReady),
+  (h) gate is pathname-independent (set window.location to a non-/dashboard
+  path, gate still fires).
+- **Forbidden patterns** (grep, applied to token-bridge-lib.ts and
+  token-bridge.js):
+  - No `postReady(...)` between the reqId-validation line and the SW
+    round-trip call site. Structural rule: the only statements between
+    `if (typeof reqId ...)` and `chrome.runtime.sendMessage` are the
+    activation gate and the `isContextValid()` branch.
+  - No `console.log` / `console.warn` describing the activation drop
+    (would create an oracle via the page's `console` interception).
+
+### C2 — Web app click-driven flow (locked)
+
+- `src/lib/constants/integrations/connect-status.ts`: extend `CONNECT_STATUS`
+  with `AWAITING_CLICK: "awaiting_click"`.
+- `src/components/extension/auto-extension-connect.tsx`:
+  - `useEffect` on `?ext_connect=1`: sets `status` to
+    `CONNECT_STATUS.AWAITING_CLICK`. Does NOT remove the URL param yet
+    (so reload reproduces the prompt; param removed on click).
+  - `useEffect` dependency array: empty `[]` (one-shot per mount).
+    `didRunRef` still guards against React StrictMode double-invoke.
+  - New `handleConnectClick` callback:
+    1. Remove `?ext_connect=1` from URL via `history.replaceState`.
+    2. Call `connect()` (existing function, unchanged).
+  - New UI branch for `AWAITING_CLICK`:
+    - Icon: `<KeyRound />` (reused from header)
+    - Title: `t("awaitingClickTitle")`
+    - Description: `t("awaitingClickDescription")`
+    - **Single button** (no "Go to dashboard" subnav — per UX feedback)
+      labelled `t("awaitingClickAction")`
+- **Invariants**:
+  - The click handler MUST be attached to `onClick={handleConnectClick}`
+    (a React synthetic-event onClick), NOT a `setTimeout` or other indirect
+    trigger. Programmatic `.click()` is acceptable in tests (we mock
+    `navigator.userActivation`), but in production the only path to
+    `handleConnectClick` is a real user gesture.
+  - The URL param removal happens INSIDE `handleConnectClick` (not in
+    `useEffect`) so reload of the awaiting-click page reproduces the prompt
+    rather than auto-firing.
+  - The Allow button MUST carry `data-c15-action="allow-connect"` attribute
+    so the C5 manual test snippet (`document.querySelector("button[data-c15-action]")`)
+    is stable across i18n / icon changes.
+  - `useEffect` dependency array is `[]`. `setStatus` from useState is
+    stable; if the project's lint enforces `react-hooks/exhaustive-deps`
+    and flags this, add `// eslint-disable-next-line react-hooks/exhaustive-deps`
+    with a one-line reason ("setStatus is stable").
+  - `ExtConnectBanner` (`src/components/extension/ext-connect-banner.tsx`)
+    also reads `?ext_connect=1` and renders an inline "connecting" banner.
+    Under the new URL-retention model, the banner co-renders with the
+    AWAITING_CLICK overlay. The overlay (z-50, `fixed inset-0`) visually
+    masks the banner, but the banner DOM remains. **Verify**: banner has
+    no `aria-live` region — if it does, the duplicate announcement would
+    be a real a11y bug to fix in this PR. If it doesn't (visual-only),
+    document the behavior as accepted.
+- **Acceptance**: component tests cover (a) `?ext_connect=1` →
+  AWAITING_CLICK state, no postMessage yet, (b) click → CONNECTING →
+  CONNECTED, (c) reload of AWAITING_CLICK page re-prompts (URL still has
+  `?ext_connect=1` until click).
+- **Forbidden patterns** (grep on auto-extension-connect.tsx):
+  - `console\.log\(.*C15-v2` — reason: prototype instrumentation; must be
+    absent in production code.
+  - `connect\(\)` call inside a `useEffect` body — reason: the only place
+    that calls connect() is `handleConnectClick`.
+
+### C3 — i18n parity (locked)
+
+- `messages/en/Extension.json` and `messages/ja/Extension.json` each gain
+  three new keys: `awaitingClickTitle`, `awaitingClickDescription`,
+  `awaitingClickAction`.
+- ja translations are user-approved (from prototype):
+  - title: `拡張機能との接続を許可しますか?`
+  - description: `意図しない自動操作を防ぐため、下のボタンで接続を許可してください。`
+  - action: `拡張機能との接続を許可`
+- en translations:
+  - title: `Allow extension connection?`
+  - description: `To prevent unintended automated actions, allow the connection using the button below.`
+  - action: `Allow extension connection`
+- **Invariant**: en + ja key sets are identical (enforced by the existing
+  i18n parity tests).
+- **Acceptance**: `i18n-key-parity.test.ts` (or whatever the project's
+  i18n parity test is called) passes without modification.
+
+### C4 — Test coverage (locked)
+
+**Mock pattern for `navigator.userActivation` (mandatory)**:
+```ts
+let originalUserActivationDescriptor: PropertyDescriptor | undefined;
+beforeEach(() => {
+  originalUserActivationDescriptor = Object.getOwnPropertyDescriptor(
+    Navigator.prototype, "userActivation"
+  );
+  Object.defineProperty(navigator, "userActivation", {
+    value: { isActive: true, hasBeenActive: true },
+    configurable: true, writable: true,
+  });
+});
+afterEach(() => {
+  delete (navigator as Navigator & { userActivation?: unknown }).userActivation;
+  if (originalUserActivationDescriptor) {
+    Object.defineProperty(Navigator.prototype, "userActivation",
+      originalUserActivationDescriptor);
+  }
+});
+```
+Do NOT use `vi.stubGlobal("navigator", ...)` — it overwrites the whole
+`navigator` object and loses prototype accessors (userAgent, language, etc.)
+that other code under test may read. Pattern reference:
+`extension/src/__tests__/content/autofill-identity.test.ts`.
+
+**NEW** `extension/src/__tests__/content/token-bridge-user-activation.test.ts`:
+- `it("processes EXT_CONNECT_REQUEST when navigator.userActivation.isActive is true")`
+- `it("silently drops when isActive is false (no EXT_CONNECT_READY emitted)")`
+- `it("silently drops when navigator.userActivation is undefined")`
+- `it("silently drops when navigator.userActivation is {} (no isActive property)")`
+- `it("silently drops when navigator.userActivation is { isActive:false, hasBeenActive:true } (sticky-only)")`
+   — pins the "isActive not hasBeenActive" invariant
+- `it("activation check fires after reqId validation")`
+- `it("activation check fires before isContextValid (no EXTENSION_ABSENT reply on activation-fail)")`
+- `it("applies gate regardless of host page URL (XSS could fire from any dashboard route)")`
+
+**NEW** sync-test addition in
+`extension/src/__tests__/content/token-bridge-js-sync.test.ts`:
+- `it("token-bridge.js contains the navigator.userActivation gate")` —
+   read the .js file as raw text, assert `/navigator\.userActivation/.test(file)`.
+   Closes the RT4 vacuous-test gap where the gate could exist only in `.ts`.
+
+**UPDATE** existing `extension/src/__tests__/content/token-bridge.test.ts`:
+- Add the `Object.defineProperty(navigator, "userActivation", ...)` from
+  the mandatory pattern above in beforeEach (with cleanup in afterEach).
+  Default value `{ isActive: true }` so happy-path tests pass unchanged.
+
+**REWRITE** `src/components/extension/auto-extension-connect.test.tsx`:
+- The file still exists on `main` (was deleted only on the prototype branch).
+  **Modify in place**, do NOT restore from git history.
+- Per-test transformation rules (mechanical-click-insert is INSUFFICIENT;
+  follow these explicitly):
+  1. Tests that originally observed mount-time auto-fire MUST first assert
+     AWAITING_CLICK state + no `mockRequestExtensionConnect` call, then
+     `userEvent.click` the Allow button, then await final state.
+  2. Tests that asserted `replaceStateSpy` was called (URL cleanup) MUST
+     verify the call happens AFTER the click, not on mount.
+  3. The "Go to dashboard" subnav button no longer exists on the
+     AWAITING_CLICK state (per UX feedback) — drop any test that clicks it
+     from this state. Tests that click it from CONNECTED state are unchanged.
+- **NEW** tests for the click-driven invariants:
+  - `it("?ext_connect=1 shows AWAITING_CLICK prompt with no postMessage yet")`
+  - `it("does NOT call requestExtensionConnect on mount (click is the only trigger)")`
+    — render with `?ext_connect=1`, flush microtasks + a tick, assert
+    `mockRequestExtensionConnect` not called. Closes the RT4 "test the lock
+    but not the door" pattern.
+  - `it("keeps ?ext_connect=1 in URL while AWAITING_CLICK (reload re-prompts)")`
+    — assert `replaceStateSpy` NOT called and `window.location.search`
+    still contains the param.
+  - `it("removes ?ext_connect=1 only after the user clicks Allow")` —
+    click then assert `replaceStateSpy` called exactly once with the param
+    removed.
+  - `it("S3: re-rendering with ?ext_connect=1 retained shows the prompt again")`
+    — unmount + remount with same searchParams, assert AWAITING_CLICK appears.
+- `getByRole("button", { name: ... })` not `getByText` for button queries.
+- DO NOT drop `await waitFor(...)` blocks even though click is synchronous —
+  `userEvent.click` is async and the subsequent setState is batched.
+
+**i18n parity test**: the project does NOT currently enforce
+`Object.keys(en) === Object.keys(ja)` for `Extension.json`. Add a small
+parity assertion in C4:
+- File: `src/__tests__/i18n/extension-parity.test.ts` (new) or fold into
+  an existing keys-coverage test if one exists.
+- `it("Extension.json en and ja have matching key sets")` — import both
+  JSON files, assert `Object.keys(en).sort()` equals `Object.keys(ja).sort()`.
+
+**NO** new server-side test (no server change).
+
+### C5 — Manual test artifact (locked, R35-mandatory)
+
+- File: `docs/archive/review/ext-connect-user-activation-gate-manual-test.md`.
+- Sections required by R35 Tier-2: Pre-conditions, Steps, Expected result,
+  Rollback, **Adversarial scenarios**.
+- Each adversarial scenario MUST specify (a) a copy-pasteable DevTools
+  snippet, (b) the precise observable to record (no "absence of audit
+  row" — that requires DB access; instead observe browser-side signals).
+- Adversarial scenarios:
+  - **TC2 (XSS autonomous fire)**: paste
+    `window.postMessage({type:"PASSWD_SSO_EXT_CONNECT_REQUEST", reqId:"xss-1"}, location.origin)`
+    in DevTools console without any preceding click. **Observable**: no
+    `[PASSWD_SSO_EXT_CONNECT_READY]` postMessage observed in DevTools
+    "Sources → Event Listener Breakpoints → message" (or the page's
+    response handler). Pass: no reply within 5 seconds.
+  - **TC3 (programmatic .click)**: paste
+    `document.querySelector("button[data-c15-action]")?.click()` in
+    DevTools console. (Note: C2 implementation MUST add the
+    `data-c15-action` attribute to the Allow button to make this snippet
+    work.) **Observable**: either no `connect()` runs (handler-level
+    drop) OR connect() runs and the content-script silently drops
+    (no EXT_CONNECT_READY response).
+  - **TC4 (5-second race)**: pre-stage a DevTools console with:
+    ```js
+    setTimeout(() => window.postMessage(
+      {type:"PASSWD_SSO_EXT_CONNECT_REQUEST", reqId:"race-1"},
+      location.origin
+    ), 1500);
+    ```
+    Press Enter to queue, then within 1 second click the Allow button.
+    **Observable**: the legitimate connect succeeds AND a second
+    EXT_CONNECT_READY arrives ~1500ms later for `reqId:"race-1"`.
+    This is the **documented limitation** (5s transient activation
+    window allows race). Pass condition: legitimate vault state survives
+    (vault still unlocked) — i.e., the race causes audit noise + rate-limit
+    consumption but no user-visible vault relock. If the user IS forced to
+    re-unlock, that's the worst-case documented residual; either outcome
+    is acceptable per plan §S6 but the manual test must record which one.
+  - **TC5 (timeout collapse)**: paste a DevTools listener:
+    ```js
+    window.addEventListener("message", e => {
+      if (e.data?.type === "PASSWD_SSO_EXT_CONNECT_READY")
+        console.log("[reply]", performance.now(), e.data);
+    });
+    ```
+    Then fire `window.postMessage` from TC2. **Observable**: no `[reply]`
+    log within 10 seconds. Confirms silent-drop (no EXT_CONNECT_READY).
+    Distinguishes from "extension not installed" only because the
+    web-app's `requestExtensionConnect` 8-second timeout coerces both
+    cases to the same EXTENSION_ABSENT result on the page side.
+
+## Consumer-flow walkthrough
+
+This change affects two consumers:
+
+- **Consumer A** (`AutoExtensionConnect` component): reads
+  `CONNECT_STATUS.AWAITING_CLICK` in its render branch. After C2 lands the
+  type union includes the new value; the exhaustive-switch (if any) must
+  handle it. **Verified**: the component does NOT use an exhaustive switch
+  — it uses `if (status === X)` chained checks. Missing a branch produces
+  "render nothing" (safe fallback). No additional consumer guard needed.
+- **Consumer B** (content script's `handlePostMessage`): the new gate
+  in `handleConnectRequestMessage` returns `false` on activation failure.
+  The outer `handlePostMessage` propagates the boolean. No web-app consumer
+  reads this return value (it's used only by tests). **Verified**: grep for
+  `handlePostMessage` callers shows only the test file + the
+  `startPostMessageListener` wrapper which discards the return value via
+  `void`. Safe.
+
+## Testing strategy
+
+1. **Web-app vitest**: rewritten component tests cover click-driven flow.
+2. **Extension vitest**: new content-script test for the gate; existing
+   tests extended with the activation stub.
+3. **`scripts/pre-pr.sh`**: full gate including next build, lint, all
+   vitest runs, static checks.
+4. **Manual test artifact**: documented per R35; tester runs each scenario
+   on a fresh Chrome with the production-built extension.
+
+## Considerations & constraints
+
+- **5-second race window**: after a legitimate click, transient activation
+  persists for ~5 seconds. XSS that fires within that window passes the
+  gate. This is a documented limitation — the gate raises the bar for
+  autonomous XSS (which is the common case), not for XSS that races a
+  user click. Mitigations beyond this PR's scope:
+  - Server-side: rate-limit and per-user limit on bridge-code route
+    (already in place, PR #491+#492).
+  - Forensic: C14 audit emission ensures the abnormal flow is observable.
+  - Token binding: DPoP cnf_jkt (PR #491) ensures the issued token cannot
+    be exfiltrated even if XSS succeeds.
+
+- **Reload behaviour**: C2 keeps `?ext_connect=1` in the URL until the
+  user clicks. Reload re-prompts. This matches the user's mental model
+  ("I came here to connect; let me do that again if I reload").
+
+- **Browser support**: `navigator.userActivation` is Chrome 88+ (Jan 2021),
+  Edge 88+, Firefox 134+ (Jan 2025), Safari TP. The extension targets
+  Chrome MV3 only; non-Chromium browsers are out of scope. Fail-closed
+  on undefined API is safe-by-design.
+
+- **Test-hygiene check**: the prototype branch used `describe.skip` which
+  is forbidden by `scripts/checks/check-test-hygiene.sh`. This plan
+  REWRITES the test file (not skips). The new file passes the check.
+
+- **Out of scope**:
+  - SW-side `pendingConnect` flag (Option C from prior discussion) — alternative
+    design considered, not adopted.
+  - Extension popup → SW direct fetch (Option A) — significant
+    architectural change, out of C15's scope.
+  - Modifying the C14 audit emission — server-side is untouched.
+  - **SW-side sender check for `START_CONNECT`**: the SW
+    (`extension/src/background/index.ts`) currently trusts any extension-internal
+    sender of `START_CONNECT`. The C15-v2 gate is enforced only in the
+    token-bridge content script. The C15 threat model is host-page XSS,
+    which cannot reach the SW except through token-bridge (chrome's
+    isolated-world boundary), so the gate is sufficient for the stated
+    threat. Defense-in-depth via `_sender.tab?.url` whitelisting in the
+    SW handler is a separate hardening opportunity — track as future work,
+    not blocking for C15-v2.
+  - **Frame-ancestors / clickjacking**: the user activation gate accepts
+    clicks inside an iframed dashboard. Frame-ancestors enforcement is an
+    orthogonal control owned by `src/lib/proxy/security-headers.ts`.
+    C15-v2 does not subsume that control; verify the dashboard's
+    frame-ancestors is restrictive enough at review time but no change
+    required in this PR.
+
+- **5-second transient activation window — observable damage profile**:
+  the user activation duration is **implementation-defined** per the HTML
+  spec (https://html.spec.whatwg.org/multipage/interaction.html#tracking-user-activation
+  §"User activation processing"); Chromium/Firefox/Safari all use ~5s but
+  no normative number exists. Within that window, an XSS that races a
+  legitimate user click can:
+  - cause a duplicate bridge-code fetch (consumes per-user 10/15min +
+    per-IP 60/min rate-limit budgets)
+  - if the token rotation triggers `tokenChanged` in the SW, force
+    `clearVault()` → user-visible vault relock prompt
+  - generate a C14 `EXTENSION_BRIDGE_CODE_ISSUE_FAILURE` audit row if
+    the second call hits any failure path
+  - NOT exfiltrate the token (DPoP cnf_jkt binds it to the SW's IDB key,
+    which is not reachable from MAIN-world XSS).
+
+  TC4 in C5 must record whether the legitimate vault survives the race
+  or is force-relocked — either outcome is acceptable but the actual
+  behavior must be documented.
+
+- **Anti-deferral**: every contract listed above is in this PR's acceptance.
+  No "we'll fix in next PR" entries.
+
+## User operation scenarios
+
+- **S1 (canonical)**: user clicks extension popup Connect → signs in →
+  lands on `/dashboard?ext_connect=1` → sees "拡張機能との接続を許可しますか?"
+  card → clicks "拡張機能との接続を許可" button → connection completes →
+  dashboard shows.
+- **S2 (already-signed-in)**: user with active session clicks extension
+  popup Connect → tab opens at `/dashboard?ext_connect=1` (no sign-in
+  step) → vault unlock (if locked) → Allow click → connection completes.
+- **S3 (reload before click)**: user lands on AWAITING_CLICK page → reloads
+  → sees the prompt again → clicks → connection completes.
+- **S4 (close without clicking)**: user lands on AWAITING_CLICK page →
+  closes tab. No side effects on server, no audit row.
+- **S5 (XSS attempt — page-load auto-fire)**: XSS payload runs on dashboard
+  load → fires `postMessage(EXT_CONNECT_REQUEST, ...)` → activation is
+  false (no preceding gesture) → content-script silently drops → no
+  EXT_CONNECT_READY → no audit row → attacker observes no oracle signal.
+- **S6 (XSS attempt — race after user gesture)**: documented limitation —
+  XSS that fires within 5s of any user gesture passes the gate. Defense:
+  C14 audit + DPoP cnf_jkt + rate-limit.
+
+## Go/No-Go Gate
+
+| ID  | Subject                                       | Status |
+|-----|-----------------------------------------------|--------|
+| C1  | Content-script userActivation gate            | locked |
+| C2  | Web-app click-driven flow + AWAITING_CLICK    | locked |
+| C3  | i18n parity (en + ja, 3 new keys)             | locked |
+| C4  | Test coverage (content script + component)    | locked |
+| C5  | Manual test artifact (R35 Tier-2)             | locked |

--- a/docs/archive/review/ext-connect-user-activation-gate-review.md
+++ b/docs/archive/review/ext-connect-user-activation-gate-review.md
@@ -1,0 +1,97 @@
+# Plan Review: ext-connect-user-activation-gate
+
+Date: 2026-05-28
+Review round: 1
+
+## Changes from Previous Round
+
+Initial review. Three expert sub-agents (Functionality, Security, Testing) ran
+in parallel against the locked plan. The prototype branch is UX-validated and
+empirically confirmed (`isActive: true` at click handler entry); this PR
+formalizes the production implementation.
+
+## Resolution Summary
+
+### Critical / Major (all addressed)
+
+| Finding | Disposition |
+|---------|-------------|
+| Test F3: `token-bridge-js-sync.test.ts` doesn't assert gate presence in `.js` (RT4 vacuous-test risk — gate could exist only in `.ts`, production-deployed `.js` silently lacks it) | **Accepted** — C1 + C4 now mandate a sync test that greps for `navigator.userActivation` in the `.js` file. |
+| Test F1+F11: `vi.stubGlobal("navigator", ...)` overwrites prototype accessors and has no cleanup | **Accepted** — C4 mandates `Object.defineProperty` pattern with explicit before/after cleanup, referencing `autofill-identity.test.ts` as precedent. |
+| Test F4: "mechanical click insert" framing under-counts test rework (URL-timing assertions need to move) | **Accepted** — C4 contains per-test transformation rules instead of a single shortcut sentence. |
+| Test F5: URL persistence tests missing (reload-re-prompt invariant) | **Accepted** — C4 adds three explicit tests for URL retention through AWAITING_CLICK / removal on click / S3 reload. |
+| Test F9: no test asserts "click is the only trigger" (RT4 pattern — test the gate but not the door) | **Accepted** — C4 adds `it("does NOT call requestExtensionConnect on mount")`. |
+| Test F8: TC4 manual test has TTV (timing) issues, observable undefined | **Accepted** — C5 now provides copy-pasteable DevTools snippets and concrete browser-side observables; "absence of audit row" removed (required DB access). |
+| Func F5: `ext-connect-banner.tsx` co-renders with AWAITING_CLICK due to URL retention | **Accepted** — C2 invariants now require verifying the banner has no `aria-live` (or fixing it if it does). |
+| Sec F1: SW trusts START_CONNECT from any extension-internal sender (gate is layer-1 only) | **Documented as out-of-scope** with rationale — C15 threat model is host-page XSS, which cannot reach SW except through token-bridge content script (chrome isolated-world boundary). SW-side sender check is a separate hardening opportunity, tracked as future work. |
+
+### Minor (folded into plan)
+
+| Finding | Disposition |
+|---------|-------------|
+| Func F1: .js returns void vs .ts returns false | C1 explicitly distinguishes the two return disciplines. |
+| Func F2: ordering rationale should be oracle-prevention not performance | C1 invariant text reframed. |
+| Func F4: file still exists on `main`; modify in place, don't restore from git | C4 reflects this. |
+| Func F6: `useEffect` `[]` deps may trip `react-hooks/exhaustive-deps` | C2 pre-acknowledges the eslint-disable case. |
+| Func F9: 5s is implementation-defined, not spec value | "Considerations" updated; HTML spec link added. |
+| Sec F2: enumerate `tokenChanged → clearVault()` damage profile | "Considerations" expanded with full damage profile + TC4 must record actual behavior. |
+| Sec F3: TC4 observable needs to be concrete | C5 updated per above. |
+| Sec F5: forbidden-pattern grep too narrow | C1 replaced with structural rule ("no postReady between reqId-validation and SW round-trip"). |
+| Sec F6: spec citation | Added link to https://html.spec.whatwg.org/multipage/interaction.html . |
+| Sec F7: frame-ancestors note | Added to "Out of scope" with verify-at-review-time pointer. |
+| Sec F8: `vi.stubGlobal` cleanup hazard | Folded into Test F1+F11. |
+| Test F2: edge case tests (hasBeenActive only, empty object) | Added to C4. |
+| Test F10: i18n parity test missing | C4 adds a 10-line parity test. |
+| Test F12: pathname-independent gate test | Added to C4 acceptance. |
+
+### Skipped with rationale
+
+| Finding | Rationale |
+|---------|-----------|
+| Sec F4: timing-distinguishable paths between activation-fail and reqId-fail | Reviewer self-concluded "effectively closed via timeout-collapse on page side" (page-side `requestExtensionConnect` 8-second timeout makes all silent-drop paths look identical to the page). No code change; the 8s timeout is an existing invariant. |
+
+## Adjacent Findings
+
+- [Adjacent] Sec → Func: SW handler trusts all internal senders. Functionality unaffected (legitimate code paths are unchanged); only relevant if a future feature adds a new internal sender of `START_CONNECT`. Documented as out-of-scope follow-up.
+- [Adjacent] Test → Sec: F3 (sync test gap) is both a test-quality issue and a security-control assurance issue. Resolution covers both.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R9 (async-in-tx): N/A — no DB transactions.
+- R10 (circular imports): No new cross-module imports. Pass.
+- R12 (audit coverage): N/A — no new server-side action.
+- R16 (no any): Pass — `?.isActive` is typed.
+- R35 (manual test artifact): Pass — C5 commits to Tier-2 artifact.
+- `project_extension_parallel_impl`: Pass — C1 explicitly covers both files + sync test extension.
+
+### Security expert
+- RS1 (timing-safe compare): N/A.
+- R23 (no secrets in logs): Pass — no new logging.
+- R25 (METADATA_BLOCKLIST): N/A.
+- R31 (no destructive DB ops): N/A.
+- R35 (manual test artifact, Tier-2 Adversarial): Pass.
+
+### Testing expert
+- RT4 (race-test vacuous guard): **Two RT4-shaped findings raised and resolved** — F3 (JS-sync test) and F9 (no-auto-fire negative test). Both are now explicit acceptance criteria.
+- `feedback_const_object_for_string_literals`: Pass — CONNECT_STATUS extension.
+- `feedback_e2e_aria_label_phantom_match`: addressed — `getByRole({name})` mandated for button queries.
+- `feedback_subagent_findings_essence_filter`: applied during this synthesis — speculative findings (e.g., "what if HTML spec v3 changes") not pursued.
+
+## Conclusion
+
+All Critical and Major findings resolved in plan. Minor findings folded into
+acceptance criteria. One finding explicitly scoped out (Sec F1 SW sender
+check) with rationale documented.
+
+Go/No-Go Gate from the plan:
+
+| ID | Subject                                     | Status |
+|----|---------------------------------------------|--------|
+| C1 | Content-script userActivation gate          | locked |
+| C2 | Web-app click-driven flow + AWAITING_CLICK  | locked |
+| C3 | i18n parity (en + ja, 3 new keys)           | locked |
+| C4 | Test coverage (content script + component)  | locked |
+| C5 | Manual test artifact (R35 Tier-2)           | locked |
+
+Transitioning to Phase 2 (implementation).

--- a/extension/src/__tests__/content/token-bridge-js-sync.test.ts
+++ b/extension/src/__tests__/content/token-bridge-js-sync.test.ts
@@ -24,4 +24,15 @@ describe("token-bridge.js sync", () => {
     const { default: file } = await import("../../content/token-bridge.js?raw");
     expect(file).toContain(`"START_CONNECT"`);
   });
+
+  it("contains the C15-v2 navigator.userActivation gate", async () => {
+    // The gate is a security control. token-bridge.js is the production
+    // artifact loaded into the host page; token-bridge-lib.ts is test-only.
+    // A regression that adds the gate to -lib.ts but not .js would silently
+    // disable the gate in production while all unit tests pass (RT4 vacuous
+    // guard). This assertion closes that gap.
+    const { default: file } = await import("../../content/token-bridge.js?raw");
+    expect(file).toContain("navigator.userActivation");
+    expect(file).toContain(".isActive");
+  });
 });

--- a/extension/src/__tests__/content/token-bridge-user-activation.test.ts
+++ b/extension/src/__tests__/content/token-bridge-user-activation.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * C15-v2 — token-bridge userActivation gate.
+ *
+ * The gate drops EXT_CONNECT_REQUEST silently (no EXT_CONNECT_READY reply)
+ * when navigator.userActivation.isActive is false. This prevents XSS in the
+ * host page from autonomously triggering the SW's connect flow:
+ * programmatic .click() and dispatchEvent(MouseEvent) do not set
+ * userActivation per HTML User Activation v2, so an XSS payload cannot
+ * forge the flag.
+ *
+ * Why silent drop: any postReady on activation failure would create an
+ * oracle ("extension installed but I lack activation" vs "extension
+ * absent"). The page-side requestExtensionConnect helper has an 8-second
+ * timeout that collapses both cases to EXTENSION_ABSENT.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { handlePostMessage } from "../../content/token-bridge-lib";
+import {
+  EXT_CONNECT_REQUEST_MSG_TYPE,
+} from "../../lib/constants";
+
+describe("token-bridge userActivation gate", () => {
+  let mockSendMessage: ReturnType<typeof vi.fn>;
+  let postedMessages: Array<{ data: unknown; targetOrigin: string }>;
+  let originalPostMessage: typeof window.postMessage;
+  let originalUserActivationDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    mockSendMessage = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("chrome", {
+      runtime: {
+        id: "test-extension-id",
+        sendMessage: mockSendMessage,
+      },
+    });
+
+    postedMessages = [];
+    originalPostMessage = window.postMessage.bind(window);
+    window.postMessage = ((data: unknown, targetOrigin: string) => {
+      postedMessages.push({ data, targetOrigin });
+    }) as typeof window.postMessage;
+
+    // Save prototype descriptor (jsdom may or may not provide one). Use
+    // Object.defineProperty rather than vi.stubGlobal("navigator",...) to
+    // avoid clobbering other navigator accessors.
+    originalUserActivationDescriptor = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(navigator) as object,
+      "userActivation",
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.postMessage = originalPostMessage;
+    delete (navigator as Navigator & { userActivation?: unknown }).userActivation;
+    if (originalUserActivationDescriptor) {
+      Object.defineProperty(
+        Object.getPrototypeOf(navigator) as object,
+        "userActivation",
+        originalUserActivationDescriptor,
+      );
+    }
+  });
+
+  function setUserActivation(value: unknown): void {
+    Object.defineProperty(navigator, "userActivation", {
+      value,
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  function makeEvent(
+    data: unknown,
+    source: unknown = window,
+    origin = window.location.origin,
+  ): MessageEvent {
+    return { data, source, origin } as unknown as MessageEvent;
+  }
+
+  it("processes EXT_CONNECT_REQUEST when isActive is true", async () => {
+    setUserActivation({ isActive: true, hasBeenActive: true });
+    const ok = await handlePostMessage(
+      makeEvent({ type: EXT_CONNECT_REQUEST_MSG_TYPE, reqId: "req-1" }),
+    );
+    expect(ok).toBe(true);
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("silently drops when isActive is false (no EXT_CONNECT_READY emitted)", async () => {
+    setUserActivation({ isActive: false, hasBeenActive: false });
+    const ok = await handlePostMessage(
+      makeEvent({ type: EXT_CONNECT_REQUEST_MSG_TYPE, reqId: "req-1" }),
+    );
+    expect(ok).toBe(false);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(postedMessages).toHaveLength(0);
+  });
+
+  it("silently drops when navigator.userActivation is undefined", async () => {
+    setUserActivation(undefined);
+    const ok = await handlePostMessage(
+      makeEvent({ type: EXT_CONNECT_REQUEST_MSG_TYPE, reqId: "req-1" }),
+    );
+    expect(ok).toBe(false);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(postedMessages).toHaveLength(0);
+  });
+
+  it("silently drops when navigator.userActivation is {} (no isActive property)", async () => {
+    setUserActivation({});
+    const ok = await handlePostMessage(
+      makeEvent({ type: EXT_CONNECT_REQUEST_MSG_TYPE, reqId: "req-1" }),
+    );
+    expect(ok).toBe(false);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(postedMessages).toHaveLength(0);
+  });
+
+  it("silently drops when only hasBeenActive is true (sticky activation does NOT bypass gate)", async () => {
+    // Pins the invariant that ONLY transient activation matters. Sticky
+    // activation persists for the document lifetime and would defeat the
+    // gate if hasBeenActive were used.
+    setUserActivation({ isActive: false, hasBeenActive: true });
+    const ok = await handlePostMessage(
+      makeEvent({ type: EXT_CONNECT_REQUEST_MSG_TYPE, reqId: "req-1" }),
+    );
+    expect(ok).toBe(false);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(postedMessages).toHaveLength(0);
+  });
+
+  it("activation check fires after reqId validation (malformed payload still rejected)", async () => {
+    setUserActivation({ isActive: true });
+    const ok = await handlePostMessage(
+      makeEvent({ type: EXT_CONNECT_REQUEST_MSG_TYPE /* no reqId */ }),
+    );
+    expect(ok).toBe(false);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("activation check fires before isContextValid (no EXTENSION_ABSENT oracle when activation is missing)", async () => {
+    // isActive=false + chrome.runtime undefined → gate fires first → silent
+    // drop, NOT the EXTENSION_ABSENT postReady that isContextValid would
+    // otherwise emit.
+    vi.stubGlobal("chrome", {} as unknown);
+    setUserActivation({ isActive: false });
+    const ok = await handlePostMessage(
+      makeEvent({ type: EXT_CONNECT_REQUEST_MSG_TYPE, reqId: "req-1" }),
+    );
+    expect(ok).toBe(false);
+    expect(postedMessages).toHaveLength(0);
+  });
+
+  it("gate body does not reference window.location (pathname-independent)", () => {
+    // jsdom does not allow redefining window.location.pathname, so we pin
+    // the requirement via static source inspection. A future regression
+    // that adds `if (location.pathname === "/dashboard") return;` would be
+    // caught — the gate must remain location-agnostic so XSS firing from
+    // any dashboard route is equally blocked.
+    const file = readFileSync(
+      resolve(__dirname, "../../content/token-bridge-lib.ts"),
+      "utf8",
+    );
+    const fnMatch = file.match(
+      /async function handleConnectRequestMessage[\s\S]+?\n\}/,
+    );
+    expect(fnMatch, "could not locate handleConnectRequestMessage").not.toBeNull();
+    const body = fnMatch?.[0] ?? "";
+    expect(body).not.toMatch(/\blocation\b/);
+  });
+});

--- a/extension/src/__tests__/content/token-bridge.test.ts
+++ b/extension/src/__tests__/content/token-bridge.test.ts
@@ -33,11 +33,21 @@ describe("token bridge (postMessage) — EXT_CONNECT_REQUEST relay", () => {
     window.postMessage = ((data: unknown, targetOrigin: string) => {
       postedMessages.push({ data, targetOrigin });
     }) as typeof window.postMessage;
+
+    // C15-v2 gate: default to a fresh user activation so existing tests
+    // exercise the post-gate paths. The gate itself is covered by
+    // token-bridge-user-activation.test.ts.
+    Object.defineProperty(navigator, "userActivation", {
+      value: { isActive: true, hasBeenActive: true },
+      configurable: true,
+      writable: true,
+    });
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     window.postMessage = originalPostMessage;
+    delete (navigator as Navigator & { userActivation?: unknown }).userActivation;
   });
 
   function makeEvent(

--- a/extension/src/content/token-bridge-lib.ts
+++ b/extension/src/content/token-bridge-lib.ts
@@ -46,6 +46,17 @@ function postReady(reqId: string, ok: boolean, errorCode?: string): void {
 async function handleConnectRequestMessage(event: MessageEvent): Promise<boolean> {
   const { reqId } = (event.data ?? {}) as { reqId?: unknown };
   if (typeof reqId !== "string" || reqId.length === 0) return false;
+
+  // C15-v2 user-activation gate: drop silently when no transient activation
+  // is present (XSS firing window.postMessage autonomously cannot forge
+  // userActivation per HTML User Activation v2 — programmatic .click() and
+  // dispatchEvent(MouseEvent) do not set the flag). MUST fire BEFORE
+  // isContextValid: the EXTENSION_ABSENT postReady on that path would
+  // otherwise leak an oracle ("extension installed but I lack activation"
+  // vs "extension absent"). Only `isActive` (transient) is checked —
+  // `hasBeenActive` (sticky) persists forever and would defeat the gate.
+  if (!navigator.userActivation?.isActive) return false;
+
   if (!isContextValid()) {
     postReady(reqId, false, "EXTENSION_ABSENT");
     return true;

--- a/extension/src/content/token-bridge.js
+++ b/extension/src/content/token-bridge.js
@@ -33,6 +33,14 @@ function postReady(reqId, ok, errorCode) {
 function handleConnectRequestMessage(event) {
   var reqId = event.data && event.data.reqId;
   if (typeof reqId !== "string" || reqId.length === 0) return;
+
+  // C15-v2 user-activation gate. Mirror of token-bridge-lib.ts — see that
+  // file for the full rationale (oracle prevention via silent drop before
+  // isContextValid; isActive-not-hasBeenActive to defeat sticky-activation
+  // bypass). MUST stay in sync with token-bridge-lib.ts; token-bridge-js-sync
+  // test enforces the substring `navigator.userActivation` is present here.
+  if (!navigator.userActivation || !navigator.userActivation.isActive) return;
+
   if (!isContextValid()) {
     postReady(reqId, false, "EXTENSION_ABSENT");
     return;

--- a/messages/en/Extension.json
+++ b/messages/en/Extension.json
@@ -1,5 +1,8 @@
 {
   "connect": "Connect Extension",
+  "awaitingClickTitle": "Allow extension connection?",
+  "awaitingClickDescription": "To prevent unintended automated actions, allow the connection using the button below.",
+  "awaitingClickAction": "Allow extension connection",
   "connecting": "Connecting...",
   "connected": "Connected!",
   "failed": "Connection failed",

--- a/messages/ja/Extension.json
+++ b/messages/ja/Extension.json
@@ -1,5 +1,8 @@
 {
   "connect": "拡張機能を接続",
+  "awaitingClickTitle": "拡張機能との接続を許可しますか?",
+  "awaitingClickDescription": "意図しない自動操作を防ぐため、下のボタンで接続を許可してください。",
+  "awaitingClickAction": "拡張機能との接続を許可",
   "connecting": "接続中...",
   "connected": "接続完了",
   "failed": "接続失敗",

--- a/src/__tests__/i18n/extension-parity.test.ts
+++ b/src/__tests__/i18n/extension-parity.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readExtension(locale: string): Record<string, string> {
+  return JSON.parse(
+    readFileSync(
+      join(process.cwd(), "messages", locale, "Extension.json"),
+      "utf8",
+    ),
+  ) as Record<string, string>;
+}
+
+describe("Extension.json en/ja parity", () => {
+  it("en and ja have identical key sets", () => {
+    const en = readExtension("en");
+    const ja = readExtension("ja");
+    expect(Object.keys(en).sort()).toEqual(Object.keys(ja).sort());
+  });
+
+  it("every value is a non-empty string in both locales", () => {
+    const en = readExtension("en");
+    const ja = readExtension("ja");
+    for (const [k, v] of Object.entries(en)) {
+      expect(typeof v).toBe("string");
+      expect(v.length).toBeGreaterThan(0);
+      expect(typeof ja[k]).toBe("string");
+      expect(ja[k].length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/components/extension/auto-extension-connect.test.tsx
+++ b/src/components/extension/auto-extension-connect.test.tsx
@@ -2,14 +2,15 @@
 /**
  * AutoExtensionConnect — Client Component test (jsdom)
  *
- * Post-C7 (SW-initiated handshake): the component drives a single helper
- * `requestExtensionConnect()` and reacts to its `{ ok, errorCode }` result.
- * It no longer does any bridge-code fetch itself — that logic lives in the
- * extension SW now.
+ * C15-v2 (click-driven flow): when `?ext_connect=1` is on the URL, the
+ * component renders an AWAITING_CLICK confirmation card. `connect()` only
+ * runs when the user clicks the Allow button — never from useEffect. The
+ * click satisfies `navigator.userActivation.isActive`, which the extension
+ * content-script then verifies as the unforgeable XSS gate.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 
@@ -72,6 +73,19 @@ function setSearchParams(search: string) {
   });
 }
 
+/**
+ * Render the component, wait for the AWAITING_CLICK prompt, then click the
+ * Allow button. Use this in any test that asserts on post-click state.
+ */
+async function renderAndClickAllow() {
+  render(<AutoExtensionConnect />);
+  const button = await screen.findByRole("button", {
+    name: "awaitingClickAction",
+  });
+  const user = userEvent.setup();
+  await user.click(button);
+}
+
 beforeEach(() => {
   originalLocation = window.location;
   replaceStateSpy = vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
@@ -98,35 +112,74 @@ describe("AutoExtensionConnect", () => {
     expect(mockRequestExtensionConnect).not.toHaveBeenCalled();
   });
 
-  it("removes ext_connect from URL when present", async () => {
+  it("?ext_connect=1 shows AWAITING_CLICK prompt with no postMessage yet", async () => {
+    setSearchParams("?ext_connect=1");
+    render(<AutoExtensionConnect />);
+    expect(
+      await screen.findByText("awaitingClickTitle"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("awaitingClickDescription")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "awaitingClickAction" }),
+    ).toBeInTheDocument();
+    expect(mockRequestExtensionConnect).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call requestExtensionConnect on mount (click is the only trigger)", async () => {
+    // RT4 negative test: closes the "test the gate but not the door" pattern.
+    setSearchParams("?ext_connect=1");
+    render(<AutoExtensionConnect />);
+    // Flush microtasks + a tick to defeat any deferred auto-fire.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(mockRequestExtensionConnect).not.toHaveBeenCalled();
+    expect(screen.getByText("awaitingClickTitle")).toBeInTheDocument();
+  });
+
+  it("keeps ?ext_connect=1 in URL while AWAITING_CLICK (reload re-prompts)", async () => {
+    setSearchParams("?ext_connect=1");
+    render(<AutoExtensionConnect />);
+    await screen.findByText("awaitingClickTitle");
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+    expect(window.location.search).toBe("?ext_connect=1");
+  });
+
+  it("removes ?ext_connect=1 only after the user clicks Allow", async () => {
     setSearchParams("?ext_connect=1");
     mockRequestExtensionConnect.mockResolvedValue({ ok: true });
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(replaceStateSpy).toHaveBeenCalledWith(null, "", "/en/dashboard");
     });
   });
 
-  it("preserves other query params when removing ext_connect", async () => {
+  it("S3: re-rendering with ?ext_connect=1 retained shows the prompt again", async () => {
+    setSearchParams("?ext_connect=1");
+    const { unmount } = render(<AutoExtensionConnect />);
+    await screen.findByText("awaitingClickTitle");
+    unmount();
+    // Re-mount simulates page reload while URL still has the param.
+    render(<AutoExtensionConnect />);
+    expect(
+      await screen.findByText("awaitingClickTitle"),
+    ).toBeInTheDocument();
+    expect(mockRequestExtensionConnect).not.toHaveBeenCalled();
+  });
+
+  it("preserves other query params when removing ext_connect after click", async () => {
     setSearchParams("?ext_connect=1&foo=bar");
     mockRequestExtensionConnect.mockResolvedValue({ ok: true });
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(replaceStateSpy).toHaveBeenCalledWith(null, "", "/en/dashboard?foo=bar");
     });
   });
 
-  it("calls requestExtensionConnect and shows CONNECTED on ok:true", async () => {
+  it("calls requestExtensionConnect and shows CONNECTED on ok:true (post-click)", async () => {
     setSearchParams("?ext_connect=1");
     mockRequestExtensionConnect.mockResolvedValue({ ok: true });
-
-    render(<AutoExtensionConnect />);
-
-    expect(screen.getByText("connecting")).toBeInTheDocument();
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(screen.getByText("connectedTitle")).toBeInTheDocument();
     });
@@ -139,9 +192,7 @@ describe("AutoExtensionConnect", () => {
       ok: false,
       errorCode: "EXTENSION_ABSENT",
     });
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(screen.getByText("extensionRequired")).toBeInTheDocument();
     });
@@ -154,9 +205,7 @@ describe("AutoExtensionConnect", () => {
       ok: false,
       errorCode: "GENERIC_FAILURE",
     });
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(screen.getByText("connectFailedTitle")).toBeInTheDocument();
     });
@@ -170,9 +219,7 @@ describe("AutoExtensionConnect", () => {
       errorCode: "SESSION_STEP_UP_REQUIRED",
     });
     mockCanUsePasskeyRecovery.mockResolvedValue(true);
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(screen.getByText("connectReauthTitle")).toBeInTheDocument();
     });
@@ -189,16 +236,12 @@ describe("AutoExtensionConnect", () => {
       ok: true,
       verifiedAt: "2099-01-01T00:00:00Z",
     });
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(screen.getByText("connectReauthTitle")).toBeInTheDocument();
     });
-
     const user = userEvent.setup();
     await user.click(screen.getByText("connectReauthAction"));
-
     await waitFor(() => {
       expect(mockReauthenticateWithPasskey).toHaveBeenCalledTimes(1);
     });
@@ -218,16 +261,12 @@ describe("AutoExtensionConnect", () => {
       ok: false,
       error: "AUTHENTICATION_CANCELLED",
     });
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(screen.getByText("connectReauthTitle")).toBeInTheDocument();
     });
-
     const user = userEvent.setup();
     await user.click(screen.getByText("connectReauthAction"));
-
     await waitFor(() => {
       expect(screen.getByText("connectReauthCancelled")).toBeInTheDocument();
     });
@@ -240,16 +279,12 @@ describe("AutoExtensionConnect", () => {
       errorCode: "SESSION_STEP_UP_REQUIRED",
     });
     mockCanUsePasskeyRecovery.mockResolvedValue(false);
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(screen.getByText("connectRecentSessionTitle")).toBeInTheDocument();
     });
-
     const user = userEvent.setup();
     await user.click(screen.getByText("connectRecentSessionAction"));
-
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalledTimes(1);
     });
@@ -260,74 +295,65 @@ describe("AutoExtensionConnect", () => {
     mockRequestExtensionConnect
       .mockResolvedValueOnce({ ok: false, errorCode: "GENERIC_FAILURE" })
       .mockResolvedValueOnce({ ok: true });
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(screen.getByText("connectFailedTitle")).toBeInTheDocument();
     });
-
     const user = userEvent.setup();
     await user.click(screen.getByText("retry"));
-
     await waitFor(() => {
       expect(screen.getByText("connectedTitle")).toBeInTheDocument();
     });
   });
 
-  it("'Go to dashboard' button returns to IDLE (renders nothing)", async () => {
+  it("'Go to dashboard' button (from CONNECTED) returns to IDLE", async () => {
     setSearchParams("?ext_connect=1");
     mockRequestExtensionConnect.mockResolvedValue({ ok: true });
-
     const { container } = render(<AutoExtensionConnect />);
-
+    const allowButton = await screen.findByRole("button", {
+      name: "awaitingClickAction",
+    });
+    const user = userEvent.setup();
+    await user.click(allowButton);
     await waitFor(() => {
       expect(screen.getByText("connectedTitle")).toBeInTheDocument();
     });
-
-    const user = userEvent.setup();
     await user.click(screen.getByText("goToDashboard"));
-
     expect(container.innerHTML).toBe("");
   });
 
-  it("displays APP_NAME in branding section", async () => {
+  it("displays APP_NAME in branding section (AWAITING_CLICK + post-click)", async () => {
     setSearchParams("?ext_connect=1");
-    mockRequestExtensionConnect.mockResolvedValue({ ok: true });
-
     render(<AutoExtensionConnect />);
-
-    await waitFor(() => {
-      expect(screen.getByText("connectedTitle")).toBeInTheDocument();
-    });
-
+    await screen.findByText("awaitingClickTitle");
     // APP_NAME defaults to "passwd-sso" (from NEXT_PUBLIC_APP_NAME env)
     expect(screen.getByText("passwd-sso")).toBeInTheDocument();
+  });
+
+  it("sets data-overlay-active on overlay div in AWAITING_CLICK", async () => {
+    setSearchParams("?ext_connect=1");
+    render(<AutoExtensionConnect />);
+    await screen.findByText("awaitingClickTitle");
+    expect(document.querySelector("[data-overlay-active]")).not.toBeNull();
   });
 
   it("sets data-overlay-active on overlay div when CONNECTED", async () => {
     setSearchParams("?ext_connect=1");
     mockRequestExtensionConnect.mockResolvedValue({ ok: true });
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(screen.getByText("connectedTitle")).toBeInTheDocument();
     });
-
     expect(document.querySelector("[data-overlay-active]")).not.toBeNull();
   });
 
   it("sets data-overlay-active on overlay div when CONNECTING", async () => {
     setSearchParams("?ext_connect=1");
     mockRequestExtensionConnect.mockReturnValue(new Promise(() => {}));
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(screen.getByText("connecting")).toBeInTheDocument();
     });
-
     expect(document.querySelector("[data-overlay-active]")).not.toBeNull();
   });
 
@@ -337,21 +363,26 @@ describe("AutoExtensionConnect", () => {
       ok: false,
       errorCode: "GENERIC_FAILURE",
     });
-
-    render(<AutoExtensionConnect />);
-
+    await renderAndClickAllow();
     await waitFor(() => {
       expect(screen.getByText("connectFailedTitle")).toBeInTheDocument();
     });
-
     expect(document.querySelector("[data-overlay-active]")).not.toBeNull();
   });
 
   it("does not have data-overlay-active when IDLE (no ext_connect)", () => {
     setSearchParams("");
     render(<AutoExtensionConnect />);
-
     expect(document.querySelector("[data-overlay-active]")).toBeNull();
+  });
+
+  it("Allow button has data-c15-action attribute (stable selector for manual tests)", async () => {
+    setSearchParams("?ext_connect=1");
+    render(<AutoExtensionConnect />);
+    const button = await screen.findByRole("button", {
+      name: "awaitingClickAction",
+    });
+    expect(button.getAttribute("data-c15-action")).toBe("allow-connect");
   });
 });
 

--- a/src/components/extension/auto-extension-connect.test.tsx
+++ b/src/components/extension/auto-extension-connect.test.tsx
@@ -226,7 +226,12 @@ describe("AutoExtensionConnect", () => {
     expect(screen.getByText("connectReauthDescription")).toBeInTheDocument();
   });
 
-  it("reauthenticates and retries when retry is clicked from reauth-required state", async () => {
+  it("re-prompts AWAITING_CLICK after passkey reauth (C15-v2: credentials.get consumes activation)", async () => {
+    // navigator.credentials.get() inside reauthenticateWithPasskey consumes
+    // the page's transient user activation. The content-script gate would
+    // silent-drop a subsequent auto-retry's postMessage. Verify the
+    // component surfaces AWAITING_CLICK again so the user re-authorizes
+    // with a fresh gesture.
     setSearchParams("?ext_connect=1");
     mockRequestExtensionConnect
       .mockResolvedValueOnce({ ok: false, errorCode: "SESSION_STEP_UP_REQUIRED" })
@@ -245,9 +250,20 @@ describe("AutoExtensionConnect", () => {
     await waitFor(() => {
       expect(mockReauthenticateWithPasskey).toHaveBeenCalledTimes(1);
     });
+    // After successful reauth, AWAITING_CLICK is shown again — NOT an
+    // auto-retry into CONNECTED.
+    await waitFor(() => {
+      expect(screen.getByText("awaitingClickTitle")).toBeInTheDocument();
+    });
+    expect(mockRequestExtensionConnect).toHaveBeenCalledTimes(1); // not retried automatically
+    // User provides the fresh gesture; connect() runs and succeeds.
+    await user.click(
+      screen.getByRole("button", { name: "awaitingClickAction" }),
+    );
     await waitFor(() => {
       expect(screen.getByText("connectedTitle")).toBeInTheDocument();
     });
+    expect(mockRequestExtensionConnect).toHaveBeenCalledTimes(2);
   });
 
   it("shows cancellation feedback when reauth is cancelled", async () => {

--- a/src/components/extension/auto-extension-connect.tsx
+++ b/src/components/extension/auto-extension-connect.tsx
@@ -148,10 +148,16 @@ export function AutoExtensionConnect() {
         return;
       }
 
-      const retryResult = await connect();
-      if (!retryResult.ok && retryResult.requiresReauth) {
-        setReauthError(t("connectReauthStillRequired"));
-      }
+      // C15-v2: navigator.credentials.get() inside reauthenticateWithPasskey
+      // CONSUMES the page's transient user activation per HTML User
+      // Activation v2. A subsequent connect() → postMessage would be silent-
+      // dropped by the content-script gate. Surface AWAITING_CLICK so the
+      // user provides a fresh gesture to authorize the now-step-up'd
+      // connection. The "再認証完了" framing is conveyed by transitioning
+      // back to the same Allow prompt — the user already saw the reauth
+      // ceremony complete, so the second Allow click reads as "finish
+      // connecting now that re-auth is done."
+      setStatus(CONNECT_STATUS.AWAITING_CLICK);
     } finally {
       setReauthenticating(false);
     }

--- a/src/components/extension/auto-extension-connect.tsx
+++ b/src/components/extension/auto-extension-connect.tsx
@@ -94,14 +94,25 @@ export function AutoExtensionConnect() {
 
     didRunRef.current = true;
 
-    // Remove ext_connect from URL immediately to prevent re-fire on reload
+    // C15-v2: surface the AWAITING_CLICK confirmation card instead of auto-
+    // firing connect(). The user click on the Allow button satisfies
+    // navigator.userActivation.isActive at the moment of postMessage; the
+    // content-script gate then refuses XSS-issued postMessages that arrive
+    // without that activation. URL param removal is deferred to the click
+    // handler so reload reproduces the prompt.
+    setStatus(CONNECT_STATUS.AWAITING_CLICK);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleConnectClick = useCallback(async () => {
+    const params = new URLSearchParams(window.location.search);
     params.delete(EXT_CONNECT_PARAM);
     const newSearch = params.toString();
     const newUrl =
       window.location.pathname + (newSearch ? `?${newSearch}` : "") + window.location.hash;
     window.history.replaceState(null, "", newUrl);
 
-    connect();
+    await connect();
   }, [connect]);
 
   const handleRetry = async () => {
@@ -154,6 +165,11 @@ export function AutoExtensionConnect() {
       <Card className="w-full max-w-md">
         <CardContent className="flex flex-col items-center text-center pt-8 pb-8 space-y-6">
           {/* Icon */}
+          {status === CONNECT_STATUS.AWAITING_CLICK && (
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+              <KeyRound className="h-8 w-8 text-primary" />
+            </div>
+          )}
           {status === CONNECT_STATUS.CONNECTING && (
             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
               <Loader2 className="h-8 w-8 animate-spin text-primary" />
@@ -177,6 +193,14 @@ export function AutoExtensionConnect() {
           </div>
 
           {/* Title & Description */}
+          {status === CONNECT_STATUS.AWAITING_CLICK && (
+            <div className="space-y-2">
+              <h1 className="text-xl font-semibold">{t("awaitingClickTitle")}</h1>
+              <p className="text-sm text-muted-foreground">
+                {t("awaitingClickDescription")}
+              </p>
+            </div>
+          )}
           {status === CONNECT_STATUS.CONNECTING && (
             <div className="space-y-2">
               <h1 className="text-xl font-semibold">{t("connecting")}</h1>
@@ -217,6 +241,17 @@ export function AutoExtensionConnect() {
           )}
 
           {/* Actions */}
+          {status === CONNECT_STATUS.AWAITING_CLICK && (
+            <div className="flex flex-col gap-3 w-full max-w-xs">
+              <Button
+                onClick={handleConnectClick}
+                className="w-full"
+                data-c15-action="allow-connect"
+              >
+                {t("awaitingClickAction")}
+              </Button>
+            </div>
+          )}
           {status === CONNECT_STATUS.CONNECTED && (
             <div className="flex flex-col gap-3 w-full max-w-xs">
               <Button

--- a/src/lib/constants/integrations/connect-status.ts
+++ b/src/lib/constants/integrations/connect-status.ts
@@ -1,5 +1,12 @@
 export const CONNECT_STATUS = {
   IDLE: "idle",
+  // Shown after `?ext_connect=1` is detected on the page but before the user
+  // has confirmed via the Allow button. The click satisfies
+  // navigator.userActivation.isActive at the moment of window.postMessage,
+  // which the extension content script requires (C15-v2 gate). Programmatic
+  // `.click()` does NOT set userActivation per HTML User Activation v2, so
+  // XSS in the host page cannot reach this state's downstream postMessage.
+  AWAITING_CLICK: "awaiting_click",
   CONNECTING: "connecting",
   CONNECTED: "connected",
   FAILED: "failed",


### PR DESCRIPTION
## Summary

Closes the residual XSS-on-page-load auto-fire of `PASSWD_SSO_EXT_CONNECT_REQUEST` by combining:

1. **Web-app side** — replace the `?ext_connect=1` auto-firing useEffect with an explicit click-driven confirmation step ("拡張機能との接続を許可" / "Allow extension connection"). The user must click before `window.postMessage(EXT_CONNECT_REQUEST, ...)` fires.
2. **Content-script side** — gate the `EXT_CONNECT_REQUEST` handler on `navigator.userActivation.isActive`. Drop silently when activation is false. Programmatic `.click()` and `dispatchEvent(MouseEvent)` do NOT set userActivation per W3C User Activation v2, so XSS in the host page cannot forge it.

Follow-up to PR #495 (C14 audit emission) and PR #492 (SW-initiated trust path). C15-v1 (naive `isActive` gate on auto-fire useEffect) was rejected after empirical validation — see `docs/archive/review/c15-user-activation-validation.md`. This PR is C15-v2: re-design that adopts the same security primitive after restructuring the legitimate flow to provide the activation.

## Threat model

| Attack scenario | Before this PR | After this PR |
|---|---|---|
| XSS-on-page-load fires postMessage autonomously | Bridge-code issued, audit row, rate-limit consumed | **Silently dropped at content script** (no postMessage observable; no server reach) |
| XSS races within 5s of a real user gesture | Same as above | Documented residual: still passes gate. Damage bounded (DPoP cnf_jkt prevents token exfiltration; C14 audit visibility; rate-limit) |
| XSS forges via `element.click()` or `dispatchEvent(MouseEvent)` | (no defense) | Silently dropped (spec: programmatic click does not set userActivation) |

## UX

The legitimate flow gains one confirmation click. User-validated on the prototype branch: rewording from "Connect" → "Allow extension connection" eliminated the "click duplication" concern (extension popup Connect → web page Allow reads as OAuth-style consent).

## Changes

- `extension/src/content/{token-bridge-lib.ts, token-bridge.js}` — `navigator.userActivation?.isActive` gate, silent drop. Symmetric across the parallel impl.
- `src/components/extension/auto-extension-connect.tsx` — `CONNECT_STATUS.AWAITING_CLICK` state, `handleConnectClick` callback, single Allow button with `data-c15-action="allow-connect"`.
- `src/lib/constants/integrations/connect-status.ts` — new `AWAITING_CLICK` value with rationale comment.
- `messages/{en,ja}/Extension.json` — three new i18n keys.
- Tests:
  - **new** `extension/.../token-bridge-user-activation.test.ts` — 8 gate cases (accept/drop matrix + ordering + sticky-vs-transient + pathname-independent static check)
  - **extended** `token-bridge-js-sync.test.ts` — RT4 closure: asserts `.js` production file contains the gate string
  - **extended** `token-bridge.test.ts` — activation stub in `beforeEach` so existing tests exercise post-gate paths
  - **rewritten** `auto-extension-connect.test.tsx` — click-driven assertions, URL-retention invariants, no-auto-fire negative test (RT4 closure)
  - **new** `src/__tests__/i18n/extension-parity.test.ts` — en/ja key parity for `Extension.json`
- Manual test artifact: `docs/archive/review/ext-connect-user-activation-gate-manual-test.md` (R35 Tier-2 with 5 scenarios incl. adversarial TC2/TC3/TC4)

## Out of scope

- **SW-side `_sender` check on `START_CONNECT`**: defense-in-depth opportunity (a future content script could forward arbitrary messages to SW bypassing the gate). C15 threat model is host-page XSS, which cannot reach SW except through token-bridge content script per chrome isolated-world rules. Tracked as future hardening.
- **Frame-ancestors enforcement**: orthogonal control owned by `src/lib/proxy/security-headers.ts`.

## Documentation

- Plan: `docs/archive/review/ext-connect-user-activation-gate-plan.md`
- Plan review (round 1, 3 expert sub-agents): `docs/archive/review/ext-connect-user-activation-gate-review.md`
- Manual test (R35 Tier-2): `docs/archive/review/ext-connect-user-activation-gate-manual-test.md`

## Test plan

- [x] `scripts/pre-pr.sh` — 29/29 gates pass locally
- [x] All vitest tests pass (extension 145/145, web 32/32 covering the changed surface)
- [x] Plan review round 1: Critical/Major all addressed, one finding scoped-out with rationale
- [x] Phase 3 code review (3 expert sub-agents): no Critical/Major findings
- [ ] Manual TC1 (canonical happy path) — run after extension CI build
- [ ] Manual TC2/TC3/TC4/TC5 (adversarial scenarios) — record TC4 race outcome (vault relock vs survives) in PR review

Refs: #492 #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)