### PR TITLE
fix(extension): clearer disconnect icon + accurate login-prompt wording

### DIFF
--- a/extension/src/messages/en.json
+++ b/extension/src/messages/en.json
@@ -3,7 +3,7 @@
     "title": "passwd-sso",
     "settings": "Settings",
     "loading": "Loading...",
-    "signIn": "Sign in to passwd-sso to use the extension.",
+    "signIn": "Allow the connection in passwd-sso to use the extension.",
     "openApp": "Connect",
     "unlockDescription": "Enter your passphrase to unlock the vault.",
     "passphrasePlaceholder": "Passphrase",

--- a/extension/src/messages/ja.json
+++ b/extension/src/messages/ja.json
@@ -3,7 +3,7 @@
     "title": "passwd-sso",
     "settings": "設定",
     "loading": "読み込み中...",
-    "signIn": "拡張機能を使うには passwd-sso にサインインしてください。",
+    "signIn": "拡張機能を使うには passwd-sso で接続を許可してください。",
     "openApp": "接続",
     "unlockDescription": "保管庫をアンロックするためにパスフレーズを入力してください。",
     "passphrasePlaceholder": "パスフレーズ",

--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -95,7 +95,7 @@ export function App() {
               title={t("popup.disconnect")}
               className="p-1.5 rounded-md text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors"
             >
-              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m19 5 3-3"/><path d="m2 22 3-3"/><path d="M6.3 20.3a2.4 2.4 0 0 0 3.4 0L12 18l-6-6-2.3 2.3a2.4 2.4 0 0 0 0 3.4Z"/><path d="M7.5 13.5 10 11"/><path d="M10.5 16.5 13 14"/><path d="m15 3 2.3 2.3a2.4 2.4 0 0 1 0 3.4L15 11l-6-6 2.3-2.3a2.4 2.4 0 0 1 3.4 0Z"/></svg>
+              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 7h2a5 5 0 0 1 4 8"/><path d="M9 17H7A5 5 0 0 1 7 7"/><line x1="8" y1="12" x2="12" y2="12"/></svg>
             </button>
           )}
           <button

--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -95,7 +95,7 @@ export function App() {
               title={t("popup.disconnect")}
               className="p-1.5 rounded-md text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors"
             >
-              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m19 5 3-3"/><path d="m2 22 3-3"/><path d="M6.3 20.3a2.4 2.4 0 0 0 3.4 0L12 18l-6-6-2.3 2.3a2.4 2.4 0 0 0 0 3.4Z"/><path d="M7.5 13.5 10 11"/><path d="M10.5 16.5 13 14"/><path d="m15 3 2.3 2.3a2.4 2.4 0 0 1 0 3.4L15 11l-6-6 2.3-2.3a2.4 2.4 0 0 1 3.4 0Z"/></svg>
             </button>
           )}
           <button

--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -95,7 +95,7 @@ export function App() {
               title={t("popup.disconnect")}
               className="p-1.5 rounded-md text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors"
             >
-              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 7h2a5 5 0 0 1 4 8"/><path d="M9 17H7A5 5 0 0 1 7 7"/><line x1="8" y1="12" x2="12" y2="12"/></svg>
+              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="6" y="9" width="8" height="6" rx="1"/><line x1="14" y1="12" x2="18" y2="12"/><line x1="9" y1="6" x2="9" y2="9"/><line x1="11" y1="6" x2="11" y2="9"/><line x1="3" y1="21" x2="21" y2="3"/></svg>
             </button>
           )}
           <button

--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -95,7 +95,7 @@ export function App() {
               title={t("popup.disconnect")}
               className="p-1.5 rounded-md text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors"
             >
-              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="6" y="9" width="8" height="6" rx="1"/><line x1="14" y1="12" x2="18" y2="12"/><line x1="9" y1="6" x2="9" y2="9"/><line x1="11" y1="6" x2="11" y2="9"/><line x1="3" y1="21" x2="21" y2="3"/></svg>
+              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2v10"/><path d="M18.4 6.6a9 9 0 1 1-12.77.04"/></svg>
             </button>
           )}
           <button


### PR DESCRIPTION
## Summary

Two small UX clarity fixes in the browser-extension popup:

1. **Disconnect button icon**
   - Old: a log-out arrow (door + arrow). Visually read as "sign out", which conflicted with the web app's separate Auth.js sign-out concept.
   - New: a Power glyph (open-top circle + vertical bar). A universal "off / end session" symbol that stays legible at 16×16. Tried Unplug / Unlink2 / plug-with-slash first; each lost detail at small size. Power was the clearest at the actual rendered size.
   - The button's title attribute (\`popup.disconnect\` = 接続解除 / Disconnect) is unchanged.

2. **Login-prompt wording**
   - Old: 「拡張機能を使うには passwd-sso にサインインしてください」 / "Sign in to passwd-sso to use the extension."
   - New: 「拡張機能を使うには passwd-sso で接続を許可してください」 / "Allow the connection in passwd-sso to use the extension."
   - The previous wording over-promised that sign-in is always required. In practice, when the web session already exists, only a vault unlock and the connection-allow click are needed. The new wording is accurate for both paths and matches the "拡張機能との接続を許可" button label introduced in \`#497\` (C15-v2).

## Out of scope

- The button's localized title (\`popup.disconnect\` = 接続解除) is already correct; only the icon was misleading.

## Test plan

- [x] \`scripts/pre-pr.sh\` — 29/29 gates pass
- [ ] Manual: load extension unpacked, open the popup in the not-logged-in state and confirm the new prompt wording; sign in and confirm the disconnect (Power) icon is visually unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)