### PR TITLE
refactor(extension): remove legacy SET_TOKEN message; refresh C15-v2 arch doc

### DIFF
--- a/docs/architecture/extension-token-bridge.md
+++ b/docs/architecture/extension-token-bridge.md
@@ -272,38 +272,44 @@ reqId: ...})` to trigger a connect attempt, but:
 | Cross-tenant escalation via tampered request | N/A — server-side identity resolution | Same |
 | Replay (after legitimate consume) | Atomic UPDATE returns count=0 → 401 | CAS predicate (`usedAt: null`) returns count=0 → 401 |
 | DevTools / memory forensics | Memory only | Memory only |
-| Page-script triggers unauthorized connect | N/A | **Residual** — XSS can trigger START_CONNECT (same as XSS-acts-as-user; token lands in SW, not page) |
+| Page-script triggers unauthorized connect | N/A | **Blocked at content-script gate** — `EXT_CONNECT_REQUEST` is silently dropped unless `navigator.userActivation.isActive` is true; programmatic `.click()` and synthesized `MouseEvent` do not set activation per HTML User Activation v2 |
 
-### Residual: XSS-acts-as-user (deferred)
+### XSS-acts-as-user mitigation: user-activation gate (C15-v2)
 
-A MAIN-world XSS retains the ability to trigger `START_CONNECT` and cause
-the extension to (re-)connect. The attacker does NOT obtain the token or
-the bridge code; the residual harm is limited to:
+The content-script relay (`extension/src/content/token-bridge-lib.ts` and
+the parallel `token-bridge.js`) requires
+`navigator.userActivation.isActive` before forwarding
+`EXT_CONNECT_REQUEST` to the service worker. The web app cooperates by
+**not** auto-connecting on `?ext_connect=1`; it renders an
+`AWAITING_CLICK` confirmation card and calls `requestExtensionConnect()`
+only from the Allow button's onClick handler, so a legitimate flow
+always carries fresh transient activation at the `postMessage` site.
 
-- Triggering an unnecessary bridge-code + exchange round-trip
-- Generating audit log noise
-- Consuming the per-user + per-IP rate-limit budget
+Activation failure is a **silent drop** — no `EXT_CONNECT_READY` reply,
+no audit emission — to avoid an `EXTENSION_ABSENT` oracle that would
+distinguish "extension installed but lacking activation" from
+"extension absent." The page-side
+`requestExtensionConnect()` 8-second timeout collapses both cases to
+`EXTENSION_ABSENT` from the page's perspective.
 
-The primary defenses against XSS-driven spam are the server-side
-limiters already in place: per-IP 60/min on `/api/extension/bridge-code`
-(see `ipLimiter` in `src/app/api/extension/bridge-code/route.ts`),
-per-user 10/15 min on the same route (`bridgeCodeLimiter`), and
-per-IP 10/15 min on `/api/extension/token/exchange` (`exchangeLimiter`).
-Together these bound the attack rate without needing extension-side
-suppression.
+The gate reads `isActive` (transient activation, ~5 s implementation-
+defined window) and never `hasBeenActive` (sticky activation persists
+for the document lifetime and would defeat the gate).
 
-**Deferred (XSS-acts-as-user follow-up)**: `userActivation.isActive`
-gating in the content-script handler and any SW-side fresh-token
-suppression. An earlier follow-up draft added a SW-side fresh-token
-no-op guard, but a code review surfaced that the guard also suppresses
-the legitimate user-switch reconnect path (where `setToken`'s
-`tokenChanged` branch would normally `clearVault()` and replace the
-heap state). The guard was reverted. A future iteration that wants to
-suppress XSS-trigger spam must either: (a) pass the current `userId`
-in `EXT_CONNECT_REQUEST` and skip suppression on mismatch, or (b)
-gate on `userActivation.isActive` in the content script — pending
-empirical Chrome validation that the legitimate `?ext_connect=1`
-useEffect flow carries transient activation.
+**Residual** (acknowledged limitations):
+
+- A same-origin XSS that races a real user gesture within the
+  transient-activation window may still trigger a connect "as the
+  user." The attacker does NOT obtain the token, the bridge code, or
+  the DPoP key (all SW-confined); the observable harm is limited to
+  one extra bridge-code + exchange round-trip, audit-log noise, and
+  rate-limit budget consumption.
+- The bridge-code route's per-IP (60/min) and per-user (10/15 min)
+  rate limiters bound the attack rate; `EXTENSION_BRIDGE_CODE_ISSUE_FAILURE`
+  audit emissions provide forensic visibility.
+- A SW-side `_sender.tab?.url` sender check on `START_CONNECT` is a
+  separate defense-in-depth opportunity (not blocking; tracked as
+  future hardening).
 
 ## File Map
 

--- a/extension/src/__tests__/background-commands.test.ts
+++ b/extension/src/__tests__/background-commands.test.ts
@@ -142,12 +142,14 @@ function sendMessage(message: unknown): Promise<unknown> {
   });
 }
 
+let bgModule: typeof import("../background/index") | null = null;
+function applyToken(token: string, expiresAt: number, cnfJkt: string): void {
+  if (!bgModule) throw new Error("background module must be loaded before applyToken()");
+  bgModule.applyToken(token, expiresAt, cnfJkt);
+}
+
 async function unlockVault(chromeMock: ReturnType<typeof installChromeMock>) {
-  await sendMessage({
-    type: "SET_TOKEN",
-    token: "t",
-    expiresAt: Date.now() + 60_000,
-  });
+  applyToken("t", Date.now() + 60_000, "");
   await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 }
 
@@ -246,7 +248,7 @@ describe("X-4 keyboard shortcut commands", () => {
       }),
     );
 
-    await import("../background/index");
+    bgModule = await import("../background/index");
   });
 
   it("copy-password copies password to clipboard via offscreen document", async () => {
@@ -306,11 +308,7 @@ describe("X-4 keyboard shortcut commands", () => {
 
   it("copy-password does nothing when vault is locked", async () => {
     // Don't unlock — vault is locked
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
 
     const handler = commandHandlers[0];
     await handler(CMD_COPY_PASSWORD);

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -161,8 +161,13 @@ function installChromeMock() {
   return chromeMock;
 }
 
+let bgModule: typeof import("../background/index") | null = null;
 async function loadBackground() {
-  await import("../background/index");
+  bgModule = await import("../background/index");
+}
+function applyToken(token: string, expiresAt: number, cnfJkt: string): void {
+  if (!bgModule) throw new Error("loadBackground() must be called before applyToken()");
+  bgModule.applyToken(token, expiresAt, cnfJkt);
 }
 
 function sendMessage(message: unknown): Promise<unknown> {
@@ -243,11 +248,7 @@ describe("background message flow", () => {
   });
 
   it("unlocks the vault and reports vaultUnlocked status", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
 
     const res = await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
     expect(res).toEqual({ type: "UNLOCK_VAULT", ok: true });
@@ -270,11 +271,7 @@ describe("background message flow", () => {
   });
 
   it("sends stop-keepalive on LOCK_VAULT", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
     (chromeMock?.runtime.sendMessage as ReturnType<typeof vi.fn>).mockClear();
 
@@ -292,11 +289,7 @@ describe("background message flow", () => {
   });
 
   it("relocks vault when token value changes", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t-1",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t-1", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const before = await sendMessage({ type: "GET_STATUS" });
@@ -304,11 +297,7 @@ describe("background message flow", () => {
       expect.objectContaining({ type: "GET_STATUS", hasToken: true, vaultUnlocked: true }),
     );
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t-2",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t-2", Date.now() + 60_000, "");
 
     const after = await sendMessage({ type: "GET_STATUS" });
     expect(after).toEqual(
@@ -319,11 +308,7 @@ describe("background message flow", () => {
 
   it("returns error on invalid passphrase", async () => {
     cryptoMocks.unwrapSecretKey.mockRejectedValueOnce(new Error("bad passphrase"));
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
 
     const res = await sendMessage({ type: "UNLOCK_VAULT", passphrase: "bad" });
     expect(res).toEqual(
@@ -332,12 +317,7 @@ describe("background message flow", () => {
   });
 
   it("removes persisted vault secret on LOCK_VAULT", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-      cnfJkt: STATIC_TEST_JKT,
-    });
+    applyToken("t", Date.now() + 60_000, STATIC_TEST_JKT);
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
     await sendMessage({ type: "LOCK_VAULT" });
 
@@ -355,11 +335,7 @@ describe("background message flow", () => {
       serverUrl: "https://localhost:3000",
       autoLockMinutes: 0,
     });
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
     expect(chromeMock?.alarms.create).not.toHaveBeenCalledWith(
       ALARM_VAULT_LOCK,
@@ -368,11 +344,7 @@ describe("background message flow", () => {
   });
 
   it("updates auto-lock timer when settings change", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const handler = storageChangeHandlers[0];
@@ -385,11 +357,7 @@ describe("background message flow", () => {
   });
 
   it("clears auto-lock timer when set to 0", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const handler = storageChangeHandlers[0];
@@ -425,11 +393,7 @@ describe("background message flow", () => {
   });
 
   it("updates badge when token is set and vault unlocked", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
     await vi.waitFor(() => {
       expect(chromeMock?.action.setBadgeText).toHaveBeenCalledWith({ text: "" });
@@ -439,11 +403,7 @@ describe("background message flow", () => {
   });
 
   it("clears all tab badges on vault lock", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
     chromeMock?.action.setBadgeText.mockClear();
 
@@ -458,11 +418,7 @@ describe("background message flow", () => {
   });
 
   it("clears all tab badges on disconnect", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     chromeMock?.action.setBadgeText.mockClear();
 
     await sendMessage({ type: "CLEAR_TOKEN" });
@@ -474,11 +430,7 @@ describe("background message flow", () => {
   });
 
   it("handles trigger-autofill command by requesting inline suggestions", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const handler = commandHandlers[0];
@@ -501,11 +453,7 @@ describe("background message flow", () => {
       .mockRejectedValueOnce(new Error("Could not establish connection. Receiving end does not exist."))
       .mockResolvedValueOnce({});
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const handler = commandHandlers[0];
@@ -521,11 +469,7 @@ describe("background message flow", () => {
   });
 
   it("fetches and decrypts password overviews", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({ type: "FETCH_PASSWORDS" });
@@ -560,11 +504,7 @@ describe("background message flow", () => {
     cryptoMocks.decryptData.mockResolvedValueOnce(
       JSON.stringify({ password: "secret" })
     );
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({ type: "COPY_PASSWORD", entryId: "pw-1" });
@@ -603,11 +543,7 @@ describe("background message flow", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({ type: "COPY_PASSWORD", entryId: "pw-1" });
@@ -628,11 +564,7 @@ describe("background message flow", () => {
       .mockResolvedValueOnce(JSON.stringify({ password: "secret" }))
       .mockResolvedValueOnce(JSON.stringify({ username: "alice" }));
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({ type: "AUTOFILL", entryId: "pw-1", tabId: 1 });
@@ -651,11 +583,7 @@ describe("background message flow", () => {
       )
       .mockResolvedValueOnce(JSON.stringify({ username: null }));
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({ type: "AUTOFILL", entryId: "pw-1", tabId: 1 });
@@ -681,11 +609,7 @@ describe("background message flow", () => {
       )
       .mockResolvedValueOnce(JSON.stringify({ username: "alice" }));
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({ type: "AUTOFILL", entryId: "pw-1", tabId: 1 });
@@ -709,11 +633,7 @@ describe("background message flow", () => {
       }),
     );
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({
@@ -744,11 +664,7 @@ describe("background message flow", () => {
   });
 
   it("does not suppress inline matches when scheme differs from serverUrl", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({
@@ -766,11 +682,7 @@ describe("background message flow", () => {
   });
 
   it("suppresses inline matches using topUrl from iframe context", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({
@@ -788,11 +700,7 @@ describe("background message flow", () => {
   });
 
   it("suppresses using topUrl even when frame url is external", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({
@@ -815,11 +723,7 @@ describe("background message flow", () => {
       return { serverUrl: "https://localhost:3000", autoLockMinutes: 15 };
     });
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({
@@ -864,11 +768,7 @@ describe("background message flow", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({ type: "AUTOFILL", entryId: "pw-1", tabId: 1 });
@@ -882,11 +782,7 @@ describe("background message flow", () => {
       .mockResolvedValueOnce(JSON.stringify({ password: "secret" }))
       .mockResolvedValueOnce(JSON.stringify({ username: "alice" }));
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({ type: "AUTOFILL", entryId: "pw-1", tabId: 1 });
@@ -908,11 +804,7 @@ describe("background message flow", () => {
       .mockRejectedValueOnce(new Error("Value is unserializable"))
       .mockResolvedValueOnce([]);
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await new Promise((resolve) => {
@@ -971,10 +863,10 @@ describe("session persistence", () => {
     await loadBackground();
   });
 
-  it("persists state to session storage after SET_TOKEN", async () => {
+  it("persists state to session storage after a token is set", async () => {
     const expiresAt = Date.now() + 600_000;
-    await sendMessage({ type: "SET_TOKEN", token: "tok-1", expiresAt, cnfJkt: STATIC_TEST_JKT });
-    // userId is not set yet at SET_TOKEN time, so persistState requires all 3 fields.
+    applyToken("tok-1", expiresAt, STATIC_TEST_JKT);
+    // userId is not set yet at token-set time, so persistState requires all 3 fields.
     // After UNLOCK_VAULT, userId is set and persistState is called.
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
@@ -987,12 +879,7 @@ describe("session persistence", () => {
   });
 
   it("clears session storage on CLEAR_TOKEN", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "tok-1",
-      expiresAt: Date.now() + 600_000,
-      cnfJkt: STATIC_TEST_JKT,
-    });
+    applyToken("tok-1", Date.now() + 600_000, STATIC_TEST_JKT);
     await sendMessage({ type: "CLEAR_TOKEN" });
 
     expect(sessionStorageMocks.clearSession).toHaveBeenCalled();
@@ -1009,22 +896,14 @@ describe("session persistence", () => {
   });
 
   it("clears refresh alarm on CLEAR_TOKEN", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "tok-1",
-      expiresAt: Date.now() + 600_000,
-    });
+    applyToken("tok-1", Date.now() + 600_000, "");
     await sendMessage({ type: "CLEAR_TOKEN" });
 
     expect(chromeMock?.alarms.clear).toHaveBeenCalledWith(ALARM_TOKEN_REFRESH);
   });
 
   it("still clears local state when revoke API fails on CLEAR_TOKEN", async () => {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "tok-1",
-      expiresAt: Date.now() + 600_000,
-    });
+    applyToken("tok-1", Date.now() + 600_000, "");
     const fetchMock = vi
       .fn()
       .mockRejectedValueOnce(new Error("network"))
@@ -1038,9 +917,9 @@ describe("session persistence", () => {
     expect(chromeMock?.alarms.clear).toHaveBeenCalledWith(ALARM_TOKEN_REFRESH);
   });
 
-  it("schedules refresh alarm on SET_TOKEN", async () => {
+  it("schedules refresh alarm when a token is set", async () => {
     const expiresAt = Date.now() + 600_000;
-    await sendMessage({ type: "SET_TOKEN", token: "tok-1", expiresAt });
+    applyToken("tok-1", expiresAt, "");
 
     expect(chromeMock?.alarms.create).toHaveBeenCalledWith(
       ALARM_TOKEN_REFRESH,
@@ -1054,7 +933,7 @@ describe("session persistence", () => {
     // storm the refresh endpoint; with the clamp it should fire at ~30s.
     const now = Date.now();
     const expiresAt = now + 60_000; // 1 minute
-    await sendMessage({ type: "SET_TOKEN", token: "tok-short", expiresAt });
+    applyToken("tok-short", expiresAt, "");
 
     const alarmCalls = (chromeMock?.alarms.create as ReturnType<typeof vi.fn>).mock.calls.filter(
       ([name]) => name === ALARM_TOKEN_REFRESH,
@@ -1073,7 +952,7 @@ describe("session persistence", () => {
   it("uses the 2-min buffer for long-lived tokens (existing behavior)", async () => {
     const now = Date.now();
     const expiresAt = now + 10 * 60_000; // 10 minutes
-    await sendMessage({ type: "SET_TOKEN", token: "tok-long", expiresAt });
+    applyToken("tok-long", expiresAt, "");
 
     const alarmCalls = (chromeMock?.alarms.create as ReturnType<typeof vi.fn>).mock.calls.filter(
       ([name]) => name === ALARM_TOKEN_REFRESH,
@@ -1246,12 +1125,7 @@ describe("token refresh alarm", () => {
     await loadBackground();
 
     // Set token and unlock vault
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "original-tok",
-      expiresAt: Date.now() + 600_000,
-      cnfJkt: STATIC_TEST_JKT,
-    });
+    applyToken("original-tok", Date.now() + 600_000, STATIC_TEST_JKT);
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     // Trigger refresh alarm
@@ -1300,11 +1174,7 @@ describe("token refresh alarm", () => {
 
     await loadBackground();
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "tok",
-      expiresAt: Date.now() + 600_000,
-    });
+    applyToken("tok", Date.now() + 600_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     // Trigger refresh alarm
@@ -1350,11 +1220,7 @@ describe("token refresh alarm", () => {
 
     await loadBackground();
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "tok",
-      expiresAt: Date.now() + 600_000,
-    });
+    applyToken("tok", Date.now() + 600_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     chromeMock?.alarms.create.mockClear();
@@ -1407,11 +1273,7 @@ describe("token refresh alarm", () => {
 
     await loadBackground();
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "tok",
-      expiresAt: Date.now() + 600_000,
-    });
+    applyToken("tok", Date.now() + 600_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     chromeMock?.alarms.create.mockClear();
@@ -1456,14 +1318,10 @@ describe("token refresh alarm", () => {
 
     await loadBackground();
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "tok",
-      expiresAt: Date.now() + 600_000,
-    });
+    applyToken("tok", Date.now() + 600_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
-    // Clear create calls from SET_TOKEN so we can check the retry
+    // Clear create calls from the token-set step so we can check the retry
     chromeMock?.alarms.create.mockClear();
 
     const handler = alarmHandlers[0];
@@ -1537,53 +1395,6 @@ describe("hydration edge cases", () => {
 });
 
 describe("failsafe responses", () => {
-  it("returns type-safe failsafe when handleMessage throws for GET_STATUS", async () => {
-    vi.resetModules();
-    vi.clearAllMocks();
-    chromeMock = installChromeMock();
-
-    // Make hydration promise reject to trigger the failsafe catch
-    chromeMock.storage.session.get.mockImplementation(async () => {
-      throw new Error("fatal");
-    });
-
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => ({ ok: false, json: async () => ({}) })),
-    );
-
-    await loadBackground();
-
-    // Patch handleMessage to throw after hydration by making
-    // the hydration itself fail — the failsafe catch should fire.
-    // Since hydrationPromise.catch(() => {}) swallows the error,
-    // hydration resolves normally but with empty state.
-    // To truly trigger the failsafe, we need handleMessage itself to throw.
-    // We can achieve this by corrupting the message handler's dependencies.
-    const handler = messageHandlers[0];
-
-    // Send a message with a type that will cause a runtime error inside handleMessage
-    // by temporarily breaking a dependency after hydration
-    const originalCreateAlarm = chromeMock.alarms.create;
-    chromeMock.alarms.create = vi.fn(() => {
-      throw new Error("simulated crash");
-    });
-
-    const res = await new Promise((resolve) => {
-      handler(
-        { type: "SET_TOKEN", token: "t", expiresAt: Date.now() + 60_000 },
-        {},
-        (resp) => resolve(resp),
-      );
-    });
-
-    // The failsafe should return a generic error for SET_TOKEN (default branch)
-    expect(res).toEqual(
-      expect.objectContaining({ ok: false, error: "INTERNAL_ERROR" }),
-    );
-
-    chromeMock.alarms.create = originalCreateAlarm;
-  });
 
   it("returns type-safe failsafe for FETCH_PASSWORDS on unexpected error", async () => {
     vi.resetModules();
@@ -1619,11 +1430,7 @@ describe("failsafe responses", () => {
 
     await loadBackground();
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     const res = await sendMessage({ type: "FETCH_PASSWORDS" });
@@ -1647,7 +1454,7 @@ describe("failsafe responses", () => {
     );
 
     await loadBackground();
-    // Vault is locked (no SET_TOKEN / UNLOCK_VAULT) — handler returns the locked-state response.
+    // Vault is locked (no token, no UNLOCK_VAULT) — handler returns the locked-state response.
     // senderUrl must match rpId for the auth check to pass and reach the vault-locked path.
     const res = await sendMessageWithSender(
       { type: "PASSKEY_GET_MATCHES", rpId: "example.com" },
@@ -1848,11 +1655,7 @@ describe("CHECK_PENDING_SAVE host validation", () => {
     await loadBackground();
 
     // Unlock vault
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
   });
 
@@ -1987,11 +1790,7 @@ describe("LOGIN_DETECTED suppresses on own app", () => {
     await loadBackground();
 
     // Unlock vault
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
   });
 
@@ -2105,11 +1904,7 @@ describe("PASSKEY handlers suppress on own app", () => {
 
     await loadBackground();
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
   });
 
@@ -2234,11 +2029,7 @@ describe("tab event badge updates", () => {
 
     await loadBackground();
 
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
     // Populate cache by fetching entries

--- a/extension/src/__tests__/background/team-entries.test.ts
+++ b/extension/src/__tests__/background/team-entries.test.ts
@@ -111,8 +111,13 @@ function installChromeMock() {
   return chromeMock;
 }
 
+let bgModule: typeof import("../../background/index") | null = null;
 async function loadBackground() {
-  await import("../../background/index");
+  bgModule = await import("../../background/index");
+}
+function applyToken(token: string, expiresAt: number, cnfJkt: string): void {
+  if (!bgModule) throw new Error("loadBackground() must be called before applyToken()");
+  bgModule.applyToken(token, expiresAt, cnfJkt);
 }
 
 function sendMessage(message: unknown): Promise<unknown> {
@@ -285,11 +290,7 @@ describe("team entries in background", () => {
   });
 
   async function unlockVault() {
-    await sendMessage({
-      type: "SET_TOKEN",
-      token: "t",
-      expiresAt: Date.now() + 60_000,
-    });
+    applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
   }
 

--- a/extension/src/__tests__/background/totp-handlers.test.ts
+++ b/extension/src/__tests__/background/totp-handlers.test.ts
@@ -106,8 +106,13 @@ function installChromeMock() {
   return chromeMock;
 }
 
+let bgModule: typeof import("../../background/index") | null = null;
 async function loadBackground() {
-  await import("../../background/index");
+  bgModule = await import("../../background/index");
+}
+function applyToken(token: string, expiresAt: number, cnfJkt: string): void {
+  if (!bgModule) throw new Error("loadBackground() must be called before applyToken()");
+  bgModule.applyToken(token, expiresAt, cnfJkt);
 }
 
 function sendMsg(message: unknown): Promise<unknown> {
@@ -118,11 +123,7 @@ function sendMsg(message: unknown): Promise<unknown> {
 }
 
 async function unlockVault() {
-  await sendMsg({
-    type: "SET_TOKEN",
-    token: "t",
-    expiresAt: Date.now() + 60_000,
-  });
+  applyToken("t", Date.now() + 60_000, "");
   await sendMsg({ type: "UNLOCK_VAULT", passphrase: "pw" });
 }
 

--- a/extension/src/__tests__/lib/messaging.test.ts
+++ b/extension/src/__tests__/lib/messaging.test.ts
@@ -35,17 +35,15 @@ describe("sendMessage", () => {
   });
 
   it("passes message payload to chrome.runtime.sendMessage", async () => {
-    mockSendMessage.mockResolvedValue({ type: "SET_TOKEN", ok: true });
+    mockSendMessage.mockResolvedValue({ type: "COPY_PASSWORD", ok: true });
 
     await sendMessage({
-      type: "SET_TOKEN",
-      token: "tok-1",
-      expiresAt: 999,
+      type: "COPY_PASSWORD",
+      entryId: "id-1",
     });
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
-      type: "SET_TOKEN",
-      token: "tok-1",
-      expiresAt: 999,
+      type: "COPY_PASSWORD",
+      entryId: "id-1",
     });
   });
 

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -261,6 +261,49 @@ function clearToken(): void {
   void updateBadge();
 }
 
+/**
+ * Install a freshly-issued token into the SW state. Single source of truth
+ * for the post-issuance bookkeeping (vault relock on user/session switch,
+ * alarm scheduling, persistence). The production caller is the START_CONNECT
+ * handler's `setToken` callback (see `token-handler.ts`).
+ *
+ * There is intentionally NO `chrome.runtime.onMessage` route into this
+ * function. The previous `EXT_MSG.SET_TOKEN` message has been removed to
+ * shrink the SW's attack surface — a renegade content script can no longer
+ * inject a token by faking a chrome runtime message. The export exists so
+ * tests can bootstrap SW token state directly without driving the full
+ * bridge-code + exchange round-trip; tests run in the same JS context as
+ * the SW under jsdom and have unrestricted module access.
+ */
+export function applyToken(
+  token: string,
+  expiresAt: number,
+  cnfJkt: string,
+): void {
+  const tokenChanged = currentToken !== null && currentToken !== token;
+  if (tokenChanged) {
+    // A new token may represent a different auth session/user.
+    // Force vault relock to avoid carrying unlocked state across token rotation.
+    clearVault();
+  }
+
+  currentToken = token;
+  tokenExpiresAt = expiresAt;
+  currentCnfJkt = cnfJkt;
+
+  const delayMs = expiresAt - Date.now();
+  if (delayMs > 0) {
+    chrome.alarms.create(ALARM_TOKEN_TTL, { when: expiresAt });
+    scheduleRefreshAlarm(expiresAt);
+    persistState();
+  } else {
+    // Already expired
+    clearToken();
+  }
+
+  void updateBadge();
+}
+
 function clearVault(): void {
   encryptionKey = null;
   currentUserId = null;
@@ -1633,22 +1676,7 @@ async function handleMessage(
       // bridge code, or DPoP key material is ever exposed to MAIN-world JS
       // (content script forwards only the request/response envelope).
       const result = await startConnect({
-        setToken: (token, expiresAt, cnfJkt) => {
-          const tokenChanged = currentToken !== null && currentToken !== token;
-          if (tokenChanged) clearVault();
-          currentToken = token;
-          tokenExpiresAt = expiresAt;
-          currentCnfJkt = cnfJkt;
-          const delayMs = expiresAt - Date.now();
-          if (delayMs > 0) {
-            chrome.alarms.create(ALARM_TOKEN_TTL, { when: expiresAt });
-            scheduleRefreshAlarm(expiresAt);
-            persistState();
-          } else {
-            clearToken();
-          }
-          void updateBadge();
-        },
+        setToken: (token, expiresAt, cnfJkt) => applyToken(token, expiresAt, cnfJkt),
       });
       const response: ExtensionResponse = {
         type: EXT_MSG.START_CONNECT,
@@ -1656,36 +1684,6 @@ async function handleMessage(
         ...(result.errorCode ? { errorCode: result.errorCode } : {}),
       };
       sendResponse(response);
-      return;
-    }
-
-    case EXT_MSG.SET_TOKEN: {
-      const tokenChanged = currentToken !== null && currentToken !== message.token;
-      if (tokenChanged) {
-        // A new token may represent a different auth session/user.
-        // Force vault relock to avoid carrying unlocked state across token rotation.
-        clearVault();
-      }
-
-      currentToken = message.token;
-      tokenExpiresAt = message.expiresAt;
-      currentCnfJkt = message.cnfJkt;
-
-      // Set alarm for TTL expiry
-      const delayMs = message.expiresAt - Date.now();
-      if (delayMs > 0) {
-        chrome.alarms.create(ALARM_TOKEN_TTL, {
-          when: message.expiresAt,
-        });
-        scheduleRefreshAlarm(message.expiresAt);
-        persistState();
-      } else {
-        // Already expired
-        clearToken();
-      }
-
-      sendResponse({ type: EXT_MSG.SET_TOKEN, ok: true });
-      void updateBadge();
       return;
     }
 

--- a/extension/src/lib/constants.ts
+++ b/extension/src/lib/constants.ts
@@ -60,7 +60,6 @@ export const EXT_MSG = {
   // The SW signs DPoP + fetches /api/extension/bridge-code (credentialed) +
   // /api/extension/token/exchange + persists the resulting token.
   START_CONNECT: "START_CONNECT",
-  SET_TOKEN: "SET_TOKEN",
   GET_TOKEN: "GET_TOKEN",
   CLEAR_TOKEN: "CLEAR_TOKEN",
   GET_STATUS: "GET_STATUS",

--- a/extension/src/types/messages.ts
+++ b/extension/src/types/messages.ts
@@ -4,7 +4,6 @@ import { EXT_MSG } from "../lib/constants";
 
 export type ExtensionMessage =
   | { type: typeof EXT_MSG.START_CONNECT }
-  | { type: typeof EXT_MSG.SET_TOKEN; token: string; expiresAt: number; cnfJkt: string }
   | { type: typeof EXT_MSG.GET_TOKEN }
   | { type: typeof EXT_MSG.CLEAR_TOKEN }
   | { type: typeof EXT_MSG.GET_STATUS }
@@ -103,7 +102,6 @@ export interface SerializedAttestationResponse {
 
 export type ExtensionResponse =
   | { type: typeof EXT_MSG.START_CONNECT; ok: boolean; errorCode?: string }
-  | { type: typeof EXT_MSG.SET_TOKEN; ok: true }
   | { type: typeof EXT_MSG.GET_TOKEN; token: string | null }
   | { type: typeof EXT_MSG.CLEAR_TOKEN; ok: true }
   | { type: typeof EXT_MSG.GET_STATUS; hasToken: boolean; expiresAt: number | null; vaultUnlocked: boolean; tenantAutoLockMinutes?: number | null }

--- a/src/__tests__/db-integration/extension-token-migration.integration.test.ts
+++ b/src/__tests__/db-integration/extension-token-migration.integration.test.ts
@@ -19,9 +19,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 import { randomUUID } from "node:crypto";
-import { NextRequest } from "next/server";
 import { createTestContext, setBypassRlsGucs, type TestContext } from "./helpers";
-import { validateExtensionToken } from "@/lib/auth/tokens/extension-token";
 import { hashToken } from "@/lib/crypto/crypto-server";
 
 describe("extension_tokens migration backward compatibility (T23)", () => {


### PR DESCRIPTION
## Summary

Three trivial follow-ups surfaced after C15-v2 (\`#497\`) was squash-merged.

1. **\`docs/architecture/extension-token-bridge.md\`** — the §"Residual: XSS-acts-as-user (deferred)" section still described the user-activation gate as a future task. Rewritten to reflect the shipped mitigation:
   - Content-script gate on \`navigator.userActivation.isActive\` (silent drop)
   - Web app side: \`AWAITING_CLICK\` click-driven flow (no auto-fire)
   - Oracle prevention via silent drop + page-side 8s timeout collapse
   - Documented residuals: 5s race window, SW-side \`_sender\` check as future hardening

2. **\`src/__tests__/db-integration/extension-token-migration.integration.test.ts\`** — two unused imports flagged by GitHub Code Scanning (\`js/unused-local-variable\`):
   - \`NextRequest\` from \`next/server\`
   - \`validateExtensionToken\` from \`@/lib/auth/tokens/extension-token\`

   Both referenced only inside a comment/string, not actual code.

3. **Physically delete \`EXT_MSG.SET_TOKEN\`** — flagged by the reviewer of \`#497\` as legacy. The production SW-initiated flow (PR \`#492\` / C7 and PR \`#497\` / C15-v2) ends with the SW calling its internal \`setToken\` callback from inside the START_CONNECT handler; no external \`chrome.runtime.sendMessage\` path is required. The message was kept alive purely by test fixtures.
   - Extract the bookkeeping body into a single internal \`applyToken(token, expiresAt, cnfJkt)\` function. START_CONNECT and tests both call it directly. No test-only wrapper.
   - Remove \`EXT_MSG.SET_TOKEN\` from constants, \`ExtensionMessage\` / \`ExtensionResponse\` type unions, and the chrome.runtime.onMessage router case.
   - Replace all \`await sendMessage({ type: "SET_TOKEN", ... })\` test call sites (49 across 4 background test files) with direct calls to the loaded module's exported \`applyToken\`. Each test file gets a small \`bgModule\` cache + typed \`applyToken\` wrapper so the \`vi.resetModules()\` reload pattern keeps working.
   - \`lib/messaging.test.ts\` case that exercised the generic sendMessage helper now uses COPY_PASSWORD as its example message.
   - Delete the SET_TOKEN-specific failsafe test — its setup monkey-patched \`chrome.alarms.create\` to force a throw from SET_TOKEN's body; with SET_TOKEN gone the contrived setup no longer applies. The same failsafe property is covered functionally by the adjacent FETCH_PASSWORDS failsafe test for inner-path errors. The outer-catch default branch is now exercised only structurally — accepted as a minor known gap.

   Net: production no longer carries a token-injection runtime message that only existed as test scaffolding.

## Test plan

- [x] \`scripts/pre-pr.sh\` — 29/29 gates pass
- [x] Extension vitest — 694/694 tests pass
- [x] \`gh api repos/.../code-scanning/alerts\` — only the two flagged alerts were open; both fixed here
- [x] Triangulate Phase 3 (3 expert sub-agents): no Critical/Major findings. One shared Minor finding (deleted failsafe test → unexercised default branch) documented above as accepted gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)