### PR TITLE
fix(security): pre-v1.0 XSS hardening — in-memory PRF handoff + API baseline headers

### DIFF
--- a/docs/archive/review/prf-handoff-api-headers-code-review.md
+++ b/docs/archive/review/prf-handoff-api-headers-code-review.md
@@ -1,0 +1,89 @@
+# Code Review: prf-handoff-and-api-headers (PR #502)
+
+Date: 2026-05-30
+Review round: 1
+Branch: security/prf-handoff-and-api-headers
+
+## Changes from Previous Round
+
+Initial review (Phase 3 standalone, no plan). Triangulate three-expert review of the
+two pre-v1.0 security follow-ups: ① PRF login+unlock hand-off moved from sessionStorage
+to an in-memory module channel; ② baseline security headers applied to API routes.
+
+## Summary
+
+All three experts independently converged on the same Critical defect: the PRF migration
+(①) was **incomplete**. Only one of the two passkey sign-in writers was migrated to the
+in-memory channel, and the consumer gate that decides whether to auto-unlock was left
+reading the now-never-written sessionStorage keys. The API-header change (②) is correct
+and complete.
+
+## Functionality Findings
+
+### F1/S2 [Critical] — Consumer gate still reads sessionStorage → discoverable-passkey auto-unlock dead + in-memory PRF lingers uncleared
+- File: src/components/vault/vault-lock-screen.tsx:162-167
+- Evidence: `hasStoredPrf = !!(sessionStorage.getItem("psso:prf-output") && sessionStorage.getItem("psso:prf-data"))`; passkey-signin-button.tsx:82 now writes via `stashPrf`, never to those keys.
+- Problem: For the discoverable-passkey flow (migrated to `stashPrf`), nothing writes those sessionStorage keys → `hasStoredPrf` is always false → `unlockWithStoredPrf()` (which calls `takePrf()`) is never invoked. Auto-unlock is silently dead, and the in-memory `pending` is never consumed → cleared-on-read invariant defeated, PRF material held for the whole session.
+- Fix: Gate on a non-consuming `hasPrf()` peek into the in-memory channel instead of sessionStorage.
+
+### F2/S1 [Critical] — Security-key (email) sign-in still writes PRF to sessionStorage → XSS exposure NOT removed + spurious unlock error
+- File: src/components/auth/security-key-signin-form.tsx:20-21,94-96
+- Evidence: `SS_PRF_OUTPUT`/`SS_PRF_DATA` constants + `sessionStorage.setItem(SS_PRF_OUTPUT, hexEncode(prfOutput))` / `setItem(SS_PRF_DATA, JSON.stringify(verifyData.prf))` unchanged on this branch.
+- Problem: The email/security-key flow still persists PRF output + PRF-wrapped key to sessionStorage — the exact XSS exposure prior finding ① set out to remove. Combined with F1's gate, this path triggers `hasStoredPrf=true` → `unlockWithStoredPrf` → `takePrf()` empty → returns false → lock screen shows `unlockError`. And nothing now removes those keys → stale secret material accrues.
+- Fix: Migrate to `stashPrf({ prfOutputHex: hexEncode(prfOutput), prfData: verifyData.prf })`, drop the two constants and setItem calls (mirror passkey-signin-button.tsx).
+
+### F4 [Minor] — Stale "sessionStorage" wording in unlockWithStoredPrf docstring
+- File: src/lib/vault/vault-context.tsx:654-657
+- Fix: Update docstring to "handed off in-memory during sign-in".
+
+## Security Findings
+
+(S1, S2 merged into F2/F1 above — same root cause, security severity confirmed Critical.)
+- S1 escalate: true (multi-step WebAuthn auth flow, security-state boundary, R3 propagation gap)
+- S2 escalate: true (chained with S1; wrong fix re-introduces sessionStorage or leaves in-memory secret uncleared)
+
+### S3 [Info] — docs claim sessionStorage PRF keys gone while code still uses them
+- Resolved once F1+F2 fixed; then remove all `psso:prf-output`/`psso:prf-data` references.
+
+Security expert confirmed (no finding): server-side module-state leak NOT possible
+(prf-handoff.ts imported only by "use client" components; stashPrf only in event handlers);
+takePrf nulls on read; prfOutput.fill(0) preserved; no PRF logging; HSTS derives from
+AUTH_URL env (not spoofable); Referrer-Policy strict-origin-when-cross-origin not too loose;
+all API response paths in handleApiAuth receive baseline headers (no bypass).
+
+## Testing Findings
+
+### T1 [Major] — unlockWithStoredPrf / takePrf consumer path has zero coverage
+- File: src/lib/vault/vault-context.tsx:659-774; vault-context.test.tsx (none)
+- Fix: Add renderHook tests: success (stash → unlock true → 2nd call false) + null-fallback (no stash → false, status unchanged).
+
+### T2 [Major] — passkey-signin-button test asserts fictional prfData shape (RT1 mock-reality divergence)
+- File: src/components/auth/passkey-signin-button.test.tsx:106-119
+- Evidence: test uses `prf: { wrappedKey, iv }`; real shape is `{ prfEncryptedSecretKey, prfSecretKeyIv, prfSecretKeyAuthTag }` (verify route + PrfHandoff + unlockWithStoredPrf).
+- Fix: Use real field names in the mocked verify response and the stashPrf assertion.
+
+### T3 [Major] — proxy.ts applying baseline headers to API responses not tested at orchestrator level
+- File: src/proxy.ts:20-23; src/__tests__/proxy.test.ts (untouched)
+- Fix: Add a proxy() API-route test asserting `X-Content-Type-Options: nosniff` + Referrer-Policy on the response.
+
+### T4 [Minor] — baseline-suite HSTS branch coverage gap
+- File: src/lib/proxy/security-headers.test.ts
+- Fix: Add a baseline-suite assertion that HSTS is null in the default (HTTP) test env. True-side (isHttps) is import-time constant; do not force a brittle module mock.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1: PASS (applyBaselineSecurityHeaders single source; stashPrf is the intended shared util)
+- R3: FAIL → F1, F2 (incomplete propagation of sessionStorage→stashPrf migration)
+- R25: FAIL → old persist keys still written/read after boundary moved in-memory
+
+### Security expert
+- RS1: PASS / RS2: FAIL (S1/S2) / RS3: N/A / RS4: PASS (headers)
+- R3: FAIL (S1/S2) / R25: FAIL / R36: PASS
+
+### Testing expert
+- RT1: FAIL → T2 / RT2: OK (surface testable) / RT3: Minor (folded into T2) / RT4: FAIL (producer↔consumer untested) / RT5: OK
+- R7: FAIL (no E2E passkey/PRF auto-unlock test exists) / R19: OK
+
+## Resolution Status
+(updated after fixes below)

--- a/docs/archive/review/prf-handoff-api-headers-code-review.md
+++ b/docs/archive/review/prf-handoff-api-headers-code-review.md
@@ -86,4 +86,44 @@ all API response paths in handleApiAuth receive baseline headers (no bypass).
 - R7: FAIL (no E2E passkey/PRF auto-unlock test exists) / R19: OK
 
 ## Resolution Status
-(updated after fixes below)
+
+### F1/S2 [Critical] Consumer gate read sessionStorage → auto-unlock dead + uncleared in-memory PRF
+- Action: Added non-consuming `hasPrf()` peek to prf-handoff.ts; vault-lock-screen.tsx gate now `if (hasPrf())` instead of sessionStorage probe. Preserves "PRF present but unlock fails → error" vs "no PRF → silent manual fallback".
+- Modified: src/lib/auth/prf-handoff.ts:34-36, src/components/vault/vault-lock-screen.tsx:11,162-165
+
+### F2/S1 [Critical] Security-key sign-in still wrote PRF to sessionStorage
+- Action: Migrated security-key-signin-form.tsx to `stashPrf(...)`; removed SS_PRF_OUTPUT/SS_PRF_DATA constants and both setItem calls; kept prfOutput.fill(0) + webauthn-signin flag. Migrated its test to assert stashPrf.
+- Modified: src/components/auth/security-key-signin-form.tsx:18,92-97; security-key-signin-form.test.tsx
+
+### F4 [Minor] Stale "sessionStorage" docstring
+- Action: Updated unlockWithStoredPrf docstring to "handed off in-memory during sign-in".
+- Modified: src/lib/vault/vault-context.tsx:655
+
+### T1 [Major] unlockWithStoredPrf/takePrf path untested
+- Action: Added 2 tests (real-crypto unlock round-trip + single-use consume; null-fallback) using wrapSecretKeyWithPrf — no mock-policy violation.
+- Modified: src/lib/vault/vault-context.test.tsx
+
+### T2 [Major] passkey test fictional PRF shape (RT1)
+- Action: Replaced `{wrappedKey, iv}` with real `{prfEncryptedSecretKey, prfSecretKeyIv, prfSecretKeyAuthTag}` in mock + assertion.
+- Modified: src/components/auth/passkey-signin-button.test.tsx
+
+### T3 [Major] proxy-level baseline-header wiring untested
+- Action: Added proxy() test asserting nosniff + Referrer-Policy present, CSP/X-Frame-Options absent on API response.
+- Modified: src/__tests__/proxy.test.ts
+
+### T4 [Minor] baseline HSTS branch coverage
+- Action: Added baseline-suite assertion (HSTS null on default HTTP env).
+- Modified: src/lib/proxy/security-headers.test.ts
+
+### S3/F3 [Info] docs claimed PRF keys gone while code used them
+- Action: Resolved transitively — after F1+F2, no PRF material touches sessionStorage; existing docs now accurate.
+
+## Round 2 — verification (inline; sub-agent API transiently 529)
+- F1/S2 gate fix: hasPrf() confirmed non-mutating peek; error semantics preserved; no TOCTOU (single effect tick). VERIFIED.
+- F2/S1 migration: zero `psso:prf-*`/`SS_PRF` in non-test code; both sign-in producers use stashPrf. VERIFIED.
+- Server-side leak: all 4 consumers are "use client". VERIFIED.
+- R3 propagation: only 2 sign-in→handoff producers exist (both migrated); other startPasskeyAuthentication callers consume PRF in-place (unlock/reauth/settings), need no hand-off. VERIFIED.
+- Regression: hasPrfPasskeys (state) ≠ hasPrf (import); webauthn-signin one-shot consumption intact. VERIFIED.
+- Verification: 124 targeted tests + 29/29 pre-pr gates pass.
+
+**Verdict: Round 2 all Round-1 fixes verified, no new findings. Review complete.**

--- a/docs/security/considerations/en.md
+++ b/docs/security/considerations/en.md
@@ -49,7 +49,7 @@ Browser -> Auth Provider/NextAuth -> session established
 [Sign-in: Passkey (discoverable)]
 Browser -> navigator.credentials.get(allowCredentials:[]) -> authenticator
   -> POST /api/auth/passkey/verify -> session established
-  -> PRF output (if supported) -> vault auto-unlock via sessionStorage
+  -> PRF output (if supported) -> vault auto-unlock via in-memory hand-off
 
 [Sign-in: Email + Security Key (non-discoverable)]
 Browser -> POST /api/auth/passkey/options/email {email}
@@ -360,13 +360,12 @@ so there is no immediate break scenario. Still, long-term migration planning is 
 - `memory`:
   - `encryptionKey` (`CryptoKey`)
   - `secretKeyRef` (`Uint8Array`)
-  - Rationale: keep decryption material out of persistent storage
+  - PRF hand-off (`src/lib/auth/prf-handoff.ts`): the PRF output and PRF-wrapped secret key are passed from sign-in to vault auto-unlock via a module-level in-memory variable, NOT sessionStorage (which XSS can enumerate). Single-use (cleared on read); survives the client-side `router.push` but not a full reload (then auto-unlock degrades to the manual prompt).
+  - Rationale: keep decryption material out of any persistent / DOM-readable storage
 - `sessionStorage`:
-  - `psso:prf-output` (PRF-derived key material, zeroed after single use; lifespan: sign-in to vault unlock)
-  - `psso:prf-data` (PRF-wrapped secret key from server, cleared after single use)
-  - `psso:webauthn-signin` (UX flag, no secrets)
+  - `psso:webauthn-signin` (UX trigger flag, no secrets)
   - Previous `psso:skip-beforeunload-once` flag removed; dirty-state guards now use in-memory React state only
-  - Rationale: PRF output is stored only transiently across page navigation during the single-ceremony sign-in flow
+  - Rationale: only a non-sensitive boolean trigger lives here; PRF material moved to the in-memory hand-off above
 - `localStorage`:
   - Watchtower UI helper state (e.g., display/ack timestamps)
   - Rationale: usability only; no secret material

--- a/docs/security/considerations/ja.md
+++ b/docs/security/considerations/ja.md
@@ -49,7 +49,7 @@ Browser -> Auth Provider/NextAuth -> session established
 [Sign-in: Passkey (discoverable)]
 Browser -> navigator.credentials.get(allowCredentials:[]) -> authenticator
   -> POST /api/auth/passkey/verify -> session established
-  -> PRF output (if supported) -> vault auto-unlock via sessionStorage
+  -> PRF output (if supported) -> vault auto-unlock via in-memory hand-off
 
 [Sign-in: Email + Security Key (non-discoverable)]
 Browser -> POST /api/auth/passkey/options/email {email}
@@ -360,13 +360,12 @@ Client(valid時):
 - `memory`:
   - `encryptionKey`（`CryptoKey`）
   - `secretKeyRef`（`Uint8Array`）
-  - 理由: 復号鍵を永続ストレージへ置かないため（攻撃面を最小化）
+  - PRF ハンドオフ（`src/lib/auth/prf-handoff.ts`）: PRF 出力と PRF ラップ済みシークレットキーは、サインインからボールト自動アンロックへ **sessionStorage ではなくモジュールレベルのインメモリ変数**で受け渡す（sessionStorage は XSS から列挙可能なため）。1回使用（読取りで即クリア）。クライアント遷移（`router.push`）は跨ぐがフルリロードでは消失（その場合は手動アンロックへ degrade）
+  - 理由: 復号鍵を永続／DOM から読取り可能なストレージへ一切置かないため
 - `sessionStorage`:
-  - `psso:prf-output`（PRF 由来の鍵素材、1回使用後にゼロ化。寿命: サインイン～ボールトアンロック間）
-  - `psso:prf-data`（サーバーから取得した PRF ラップ済みシークレットキー、1回使用後に削除）
-  - `psso:webauthn-signin`（UX フラグ、秘密情報なし）
+  - `psso:webauthn-signin`（UX トリガフラグ、秘密情報なし）
   - 旧 `psso:skip-beforeunload-once` フラグは削除済み。ダーティステートガードは React のインメモリ state のみで管理
-  - 理由: PRF 出力はシングルセレモニーサインインフロー中のページ遷移間のみ一時的に保存
+  - 理由: 非機密の boolean トリガのみを保持。PRF 素材は上記インメモリハンドオフへ移動
 - `localStorage`:
   - Watchtower の表示設定/最終確認時刻等の UI 補助情報
   - 理由: 利便性向上。秘密情報は保存しない

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -165,6 +165,21 @@ describe("proxy — handleApiAuth Bearer bypass", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("applies baseline security headers to API responses (orchestrator wiring)", async () => {
+    const res = await proxy(
+      createApiRequest("/api/v1/passwords"),
+      dummyOptions,
+    );
+    // proxy() must wrap handleApiAuth's response with applyBaselineSecurityHeaders.
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+    // CSP / X-Frame-Options stay page-only — not applied to API responses.
+    expect(res.headers.get("Content-Security-Policy")).toBeNull();
+    expect(res.headers.get("X-Frame-Options")).toBeNull();
+  });
+
   it("allows /api/v1/vault/status without session (public API)", async () => {
     const res = await proxy(
       createApiRequest("/api/v1/vault/status"),

--- a/src/components/auth/passkey-signin-button.test.tsx
+++ b/src/components/auth/passkey-signin-button.test.tsx
@@ -10,6 +10,7 @@ const {
   mockHexEncode,
   mockRouterPush,
   mockFetch,
+  mockStashPrf,
   prfSentinel,
 } = vi.hoisted(() => ({
   mockStartPasskeyAuthentication: vi.fn(),
@@ -19,8 +20,13 @@ const {
   ),
   mockRouterPush: vi.fn(),
   mockFetch: vi.fn(),
+  mockStashPrf: vi.fn(),
   // Sentinel: 0xAB repeated. Tests check zeroization by post-hoc inspection.
   prfSentinel: { current: null as Uint8Array | null },
+}));
+
+vi.mock("@/lib/auth/prf-handoff", () => ({
+  stashPrf: (h: unknown) => mockStashPrf(h),
 }));
 
 vi.mock("next-intl", () => ({
@@ -90,7 +96,7 @@ describe("PasskeySignInButton — §Sec-7 WebAuthn / PRF", () => {
     expect(screen.getByRole("button", { name: /signInWithPasskey/ })).not.toBeDisabled();
   });
 
-  it("(success) writes hex(prfOutput) to sessionStorage, then zeroizes prfOutput", async () => {
+  it("(success) hands PRF material to the in-memory channel (NOT sessionStorage), then zeroizes prfOutput", async () => {
     const prfBytes = makePrfSentinel();
     mockStartPasskeyAuthentication.mockResolvedValueOnce({
       responseJSON: { id: "cred-1" },
@@ -106,12 +112,18 @@ describe("PasskeySignInButton — §Sec-7 WebAuthn / PRF", () => {
     // Hex of 32 bytes of 0xAB
     const expectedHex = "ab".repeat(32);
     await waitFor(() => {
-      expect(sessionStorage.getItem("psso:prf-output")).toBe(expectedHex);
+      // PRF material goes to the in-memory hand-off, never to XSS-readable storage.
+      expect(mockStashPrf).toHaveBeenCalledWith({
+        prfOutputHex: expectedHex,
+        prfData: { wrappedKey: "wk", iv: "iv" },
+      });
+      // Only the non-sensitive trigger flag is in sessionStorage.
       expect(sessionStorage.getItem("psso:webauthn-signin")).toBe("1");
-      expect(sessionStorage.getItem("psso:prf-data")).not.toBeNull();
+      expect(sessionStorage.getItem("psso:prf-output")).toBeNull();
+      expect(sessionStorage.getItem("psso:prf-data")).toBeNull();
     });
 
-    // Zeroization invariant: source line 85 calls prfOutput.fill(0) after persist.
+    // Zeroization invariant: source calls prfOutput.fill(0) after the hand-off.
     expect(prfBytes.every((b) => b === 0)).toBe(true);
 
     expect(mockRouterPush).toHaveBeenCalledWith("/dashboard");
@@ -138,9 +150,8 @@ describe("PasskeySignInButton — §Sec-7 WebAuthn / PRF", () => {
     // Zeroization in failure path (source line 73 prfOutput?.fill(0))
     expect(prfBytes.every((b) => b === 0)).toBe(true);
 
-    // No PRF/session keys persisted
-    expect(sessionStorage.getItem("psso:prf-output")).toBeNull();
-    expect(sessionStorage.getItem("psso:prf-data")).toBeNull();
+    // No PRF handed off and no session keys persisted
+    expect(mockStashPrf).not.toHaveBeenCalled();
     expect(sessionStorage.getItem("psso:webauthn-signin")).toBeNull();
 
     // No nav on failure
@@ -157,8 +168,7 @@ describe("PasskeySignInButton — §Sec-7 WebAuthn / PRF", () => {
     await waitFor(() => {
       expect(screen.getByText("passkeySignInCancelled")).toBeInTheDocument();
     });
-    expect(sessionStorage.getItem("psso:prf-output")).toBeNull();
-    expect(sessionStorage.getItem("psso:prf-data")).toBeNull();
+    expect(mockStashPrf).not.toHaveBeenCalled();
     expect(sessionStorage.getItem("psso:webauthn-signin")).toBeNull();
   });
 

--- a/src/components/auth/passkey-signin-button.test.tsx
+++ b/src/components/auth/passkey-signin-button.test.tsx
@@ -104,7 +104,17 @@ describe("PasskeySignInButton — §Sec-7 WebAuthn / PRF", () => {
     });
     mockFetch
       .mockResolvedValueOnce(okJson({ options: {}, challengeId: "ch-1", prfSalt: "salt" })) // /options
-      .mockResolvedValueOnce(okJson({ ok: true, prf: { wrappedKey: "wk", iv: "iv" } })); // /verify
+      .mockResolvedValueOnce(
+        okJson({
+          ok: true,
+          // Real PRF-wrapped key bundle shape (matches /verify route + PrfHandoff).
+          prf: {
+            prfEncryptedSecretKey: "ct",
+            prfSecretKeyIv: "iv",
+            prfSecretKeyAuthTag: "tag",
+          },
+        }),
+      ); // /verify
 
     render(<PasskeySignInButton />);
     fireEvent.click(screen.getByRole("button", { name: /signInWithPasskey/ }));
@@ -115,7 +125,11 @@ describe("PasskeySignInButton — §Sec-7 WebAuthn / PRF", () => {
       // PRF material goes to the in-memory hand-off, never to XSS-readable storage.
       expect(mockStashPrf).toHaveBeenCalledWith({
         prfOutputHex: expectedHex,
-        prfData: { wrappedKey: "wk", iv: "iv" },
+        prfData: {
+          prfEncryptedSecretKey: "ct",
+          prfSecretKeyIv: "iv",
+          prfSecretKeyAuthTag: "tag",
+        },
       });
       // Only the non-sensitive trigger flag is in sessionStorage.
       expect(sessionStorage.getItem("psso:webauthn-signin")).toBe("1");

--- a/src/components/auth/passkey-signin-button.tsx
+++ b/src/components/auth/passkey-signin-button.tsx
@@ -10,10 +10,7 @@ import { API_PATH } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
 import { useCallbackUrl } from "@/hooks/use-callback-url";
 import { callbackUrlToHref } from "@/lib/auth/session/callback-url";
-
-/** sessionStorage keys for passing PRF data to vault auto-unlock */
-const SS_PRF_OUTPUT = "psso:prf-output";
-const SS_PRF_DATA = "psso:prf-data";
+import { stashPrf } from "@/lib/auth/prf-handoff";
 
 export function PasskeySignInButton() {
   const t = useTranslations("Auth");
@@ -78,10 +75,11 @@ export function PasskeySignInButton() {
       const verifyData = await verifyRes.json();
 
       // 4. If PRF output was obtained and server returned PRF-wrapped key,
-      // store both in sessionStorage for vault auto-unlock (no second ceremony).
+      // hand both to the dashboard in-memory (NOT sessionStorage, which XSS can
+      // read) for vault auto-unlock without a second ceremony. Survives the
+      // client-side router.push below; a full reload drops it → manual unlock.
       if (prfOutput && verifyData.prf) {
-        sessionStorage.setItem(SS_PRF_OUTPUT, hexEncode(prfOutput));
-        sessionStorage.setItem(SS_PRF_DATA, JSON.stringify(verifyData.prf));
+        stashPrf({ prfOutputHex: hexEncode(prfOutput), prfData: verifyData.prf });
         prfOutput.fill(0);
       }
 

--- a/src/components/auth/security-key-signin-form.test.tsx
+++ b/src/components/auth/security-key-signin-form.test.tsx
@@ -9,6 +9,7 @@ const {
   mockHexEncode,
   mockRouterPush,
   mockFetch,
+  mockStashPrf,
   prfSentinel,
 } = vi.hoisted(() => ({
   mockStartPasskeyAuthentication: vi.fn(),
@@ -18,7 +19,12 @@ const {
   ),
   mockRouterPush: vi.fn(),
   mockFetch: vi.fn(),
+  mockStashPrf: vi.fn(),
   prfSentinel: { current: null as Uint8Array | null },
+}));
+
+vi.mock("@/lib/auth/prf-handoff", () => ({
+  stashPrf: (h: unknown) => mockStashPrf(h),
 }));
 
 vi.mock("next-intl", () => ({
@@ -99,7 +105,7 @@ describe("SecurityKeySignInForm — §Sec-7 WebAuthn / PRF", () => {
     expect(mockStartPasskeyAuthentication).not.toHaveBeenCalled();
   });
 
-  it("(success) persists PRF hex to sessionStorage and zeroizes prfOutput", async () => {
+  it("(success) hands PRF material to the in-memory channel (NOT sessionStorage), then zeroizes prfOutput", async () => {
     const prfBytes = makePrfSentinel();
     mockStartPasskeyAuthentication.mockResolvedValueOnce({
       responseJSON: { id: "cred-1" },
@@ -107,7 +113,17 @@ describe("SecurityKeySignInForm — §Sec-7 WebAuthn / PRF", () => {
     });
     mockFetch
       .mockResolvedValueOnce(okJson({ options: {}, challengeId: "ch-1", prfSalt: "salt" }))
-      .mockResolvedValueOnce(okJson({ ok: true, prf: { wrappedKey: "wk" } }));
+      .mockResolvedValueOnce(
+        okJson({
+          ok: true,
+          // Real PRF-wrapped key bundle shape (matches /verify route + PrfHandoff).
+          prf: {
+            prfEncryptedSecretKey: "ct",
+            prfSecretKeyIv: "iv",
+            prfSecretKeyAuthTag: "tag",
+          },
+        }),
+      );
 
     render(<SecurityKeySignInForm />);
     fireEvent.change(screen.getByPlaceholderText("emailForSecurityKey"), {
@@ -117,14 +133,25 @@ describe("SecurityKeySignInForm — §Sec-7 WebAuthn / PRF", () => {
 
     const expectedHex = "ab".repeat(32);
     await waitFor(() => {
-      expect(sessionStorage.getItem("psso:prf-output")).toBe(expectedHex);
+      // PRF material goes to the in-memory hand-off, never to XSS-readable storage.
+      expect(mockStashPrf).toHaveBeenCalledWith({
+        prfOutputHex: expectedHex,
+        prfData: {
+          prfEncryptedSecretKey: "ct",
+          prfSecretKeyIv: "iv",
+          prfSecretKeyAuthTag: "tag",
+        },
+      });
+      // Only the non-sensitive trigger flag is in sessionStorage.
       expect(sessionStorage.getItem("psso:webauthn-signin")).toBe("1");
+      expect(sessionStorage.getItem("psso:prf-output")).toBeNull();
+      expect(sessionStorage.getItem("psso:prf-data")).toBeNull();
     });
     expect(prfBytes.every((b) => b === 0)).toBe(true);
     expect(mockRouterPush).toHaveBeenCalledWith("/dashboard");
   });
 
-  it("(verify-failure) zeroizes prfOutput AND writes NO PRF/webauthn-signin keys to sessionStorage", async () => {
+  it("(verify-failure) zeroizes prfOutput AND hands off NO PRF / writes no webauthn-signin key", async () => {
     const prfBytes = makePrfSentinel();
     mockStartPasskeyAuthentication.mockResolvedValueOnce({
       responseJSON: { id: "cred-1" },
@@ -144,13 +171,12 @@ describe("SecurityKeySignInForm — §Sec-7 WebAuthn / PRF", () => {
       expect(screen.getByText("securityKeySignInFailed")).toBeInTheDocument();
     });
     expect(prfBytes.every((b) => b === 0)).toBe(true);
-    expect(sessionStorage.getItem("psso:prf-output")).toBeNull();
-    expect(sessionStorage.getItem("psso:prf-data")).toBeNull();
+    expect(mockStashPrf).not.toHaveBeenCalled();
     expect(sessionStorage.getItem("psso:webauthn-signin")).toBeNull();
     expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
-  it("(AUTHENTICATION_CANCELLED) renders cancellation copy and writes NO PRF keys", async () => {
+  it("(AUTHENTICATION_CANCELLED) renders cancellation copy and hands off NO PRF", async () => {
     mockFetch.mockResolvedValueOnce(okJson({ options: {}, challengeId: "ch-1", prfSalt: "salt" }));
     mockStartPasskeyAuthentication.mockRejectedValueOnce(new Error("AUTHENTICATION_CANCELLED"));
 
@@ -163,8 +189,7 @@ describe("SecurityKeySignInForm — §Sec-7 WebAuthn / PRF", () => {
     await waitFor(() => {
       expect(screen.getByText("securityKeySignInCancelled")).toBeInTheDocument();
     });
-    expect(sessionStorage.getItem("psso:prf-output")).toBeNull();
-    expect(sessionStorage.getItem("psso:prf-data")).toBeNull();
+    expect(mockStashPrf).not.toHaveBeenCalled();
     expect(sessionStorage.getItem("psso:webauthn-signin")).toBeNull();
   });
 });

--- a/src/components/auth/security-key-signin-form.tsx
+++ b/src/components/auth/security-key-signin-form.tsx
@@ -15,10 +15,7 @@ import { API_PATH } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
 import { useCallbackUrl } from "@/hooks/use-callback-url";
 import { callbackUrlToHref } from "@/lib/auth/session/callback-url";
-
-/** sessionStorage keys for passing PRF data to vault auto-unlock */
-const SS_PRF_OUTPUT = "psso:prf-output";
-const SS_PRF_DATA = "psso:prf-data";
+import { stashPrf } from "@/lib/auth/prf-handoff";
 
 export function SecurityKeySignInForm() {
   const t = useTranslations("Auth");
@@ -89,10 +86,11 @@ export function SecurityKeySignInForm() {
 
       const verifyData = await verifyRes.json();
 
-      // 4. PRF data for vault auto-unlock
+      // 4. Hand PRF data to the dashboard in-memory (NOT sessionStorage, which
+      // XSS can read) for vault auto-unlock. Survives the client-side router.push
+      // below; a full reload drops it → manual unlock.
       if (prfOutput && verifyData.prf) {
-        sessionStorage.setItem(SS_PRF_OUTPUT, hexEncode(prfOutput));
-        sessionStorage.setItem(SS_PRF_DATA, JSON.stringify(verifyData.prf));
+        stashPrf({ prfOutputHex: hexEncode(prfOutput), prfData: verifyData.prf });
         prfOutput.fill(0);
       }
 

--- a/src/components/vault/vault-lock-screen.tsx
+++ b/src/components/vault/vault-lock-screen.tsx
@@ -8,6 +8,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { API_PATH } from "@/lib/constants";
 import { preventIMESubmit } from "@/lib/ui/ime-guard";
 import { isWebAuthnSupported } from "@/lib/auth/webauthn/webauthn-client";
+import { hasPrf } from "@/lib/auth/prf-handoff";
 import { fetchApi } from "@/lib/url-helpers";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -159,12 +160,9 @@ export function VaultLockScreen() {
     webauthnSignInRef.current = false;
     sessionStorage.removeItem("psso:webauthn-signin");
 
-    const hasStoredPrf = !!(
-      sessionStorage.getItem("psso:prf-output") &&
-      sessionStorage.getItem("psso:prf-data")
-    );
-
-    if (hasStoredPrf) {
+    // PRF material is handed off in-memory (not sessionStorage) and consumed by
+    // unlockWithStoredPrf; peek without consuming to decide whether to attempt.
+    if (hasPrf()) {
       // Single-ceremony flow: use PRF output from sign-in (no second QR scan)
       setPasskeyLoading(true);
       unlockWithStoredPrf()

--- a/src/lib/auth/prf-handoff.test.ts
+++ b/src/lib/auth/prf-handoff.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { stashPrf, takePrf, clearPrf } from "./prf-handoff";
+
+const sample = {
+  prfOutputHex: "ab".repeat(32),
+  prfData: {
+    prfEncryptedSecretKey: "ct",
+    prfSecretKeyIv: "iv",
+    prfSecretKeyAuthTag: "tag",
+  },
+};
+
+describe("prf-handoff", () => {
+  beforeEach(() => {
+    clearPrf();
+  });
+
+  it("returns null when nothing is stashed", () => {
+    expect(takePrf()).toBeNull();
+  });
+
+  it("returns the stashed material once, then clears (single-use)", () => {
+    stashPrf(sample);
+    expect(takePrf()).toEqual(sample);
+    // Second read is empty — material is not retained.
+    expect(takePrf()).toBeNull();
+  });
+
+  it("clearPrf drops material without consuming it", () => {
+    stashPrf(sample);
+    clearPrf();
+    expect(takePrf()).toBeNull();
+  });
+
+  it("stashPrf overwrites a prior pending value", () => {
+    stashPrf(sample);
+    const next = { ...sample, prfOutputHex: "cd".repeat(32) };
+    stashPrf(next);
+    expect(takePrf()).toEqual(next);
+  });
+});

--- a/src/lib/auth/prf-handoff.ts
+++ b/src/lib/auth/prf-handoff.ts
@@ -31,6 +31,11 @@ export function stashPrf(handoff: PrfHandoff): void {
   pending = handoff;
 }
 
+/** Whether PRF material is stashed, without consuming it (gate before takePrf). */
+export function hasPrf(): boolean {
+  return pending !== null;
+}
+
 /** Return the stashed PRF material and clear it (single-use). */
 export function takePrf(): PrfHandoff | null {
   const value = pending;

--- a/src/lib/auth/prf-handoff.ts
+++ b/src/lib/auth/prf-handoff.ts
@@ -1,0 +1,44 @@
+/**
+ * In-memory hand-off of PRF material from the passkey sign-in ceremony to the
+ * dashboard's vault auto-unlock.
+ *
+ * The PRF output and the PRF-wrapped secret key are NOT placed in sessionStorage
+ * (which an XSS payload can enumerate). Instead they live in a module-level
+ * variable that survives a client-side `router.push` (same JS context, no full
+ * reload) but is gone after a real page reload — in which case auto-unlock
+ * degrades gracefully to the manual unlock prompt (the same path a non-PRF
+ * passkey takes). `takePrf()` clears on read so the material is held only for
+ * the single sign-in→dashboard transition.
+ *
+ * Client-only: imported solely by "use client" components.
+ */
+
+export interface PrfHandoff {
+  /** PRF output as hex (consumer hex-decodes, uses, then zeroes the buffer). */
+  prfOutputHex: string;
+  /** Server-returned PRF-wrapped secret key bundle. */
+  prfData: {
+    prfEncryptedSecretKey: string;
+    prfSecretKeyIv: string;
+    prfSecretKeyAuthTag: string;
+  };
+}
+
+let pending: PrfHandoff | null = null;
+
+/** Stash PRF material for the upcoming vault auto-unlock. Overwrites any prior. */
+export function stashPrf(handoff: PrfHandoff): void {
+  pending = handoff;
+}
+
+/** Return the stashed PRF material and clear it (single-use). */
+export function takePrf(): PrfHandoff | null {
+  const value = pending;
+  pending = null;
+  return value;
+}
+
+/** Drop any stashed material without consuming it (e.g. on sign-in failure). */
+export function clearPrf(): void {
+  pending = null;
+}

--- a/src/lib/proxy/security-headers.test.ts
+++ b/src/lib/proxy/security-headers.test.ts
@@ -18,6 +18,14 @@ describe("applyBaselineSecurityHeaders (API + pages)", () => {
     expect(res.headers.get("X-Frame-Options")).toBeNull();
     expect(res.headers.get("Permissions-Policy")).toBeNull();
   });
+
+  it("omits Strict-Transport-Security when not over HTTPS (default test env)", () => {
+    // isHttps is import-time false (no AUTH_URL in setup.ts) — documents the
+    // baseline path's HSTS-off behavior on plain HTTP; the HTTPS branch mirrors
+    // applySecurityHeaders and is exercised there.
+    const res = applyBaselineSecurityHeaders(new NextResponse());
+    expect(res.headers.get("Strict-Transport-Security")).toBeNull();
+  });
 });
 
 describe("applySecurityHeaders", () => {

--- a/src/lib/proxy/security-headers.test.ts
+++ b/src/lib/proxy/security-headers.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect } from "vitest";
 import { NextResponse } from "next/server";
-import { applySecurityHeaders } from "./security-headers";
+import { applySecurityHeaders, applyBaselineSecurityHeaders } from "./security-headers";
 import { PERMISSIONS_POLICY } from "@/lib/security/security-headers";
 
 const dummyOptions = { cspHeader: "default-src 'self'", nonce: "n0nc3-XYZ" };
+
+describe("applyBaselineSecurityHeaders (API + pages)", () => {
+  it("sets the non-CSP baseline: nosniff + Referrer-Policy", () => {
+    const res = applyBaselineSecurityHeaders(new NextResponse());
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+  });
+
+  it("does NOT set page-only headers (CSP / X-Frame-Options / Permissions-Policy)", () => {
+    const res = applyBaselineSecurityHeaders(new NextResponse());
+    expect(res.headers.get("Content-Security-Policy")).toBeNull();
+    expect(res.headers.get("X-Frame-Options")).toBeNull();
+    expect(res.headers.get("Permissions-Policy")).toBeNull();
+  });
+});
 
 describe("applySecurityHeaders", () => {
   it("sets Content-Security-Policy from cspHeader option", () => {

--- a/src/lib/proxy/security-headers.ts
+++ b/src/lib/proxy/security-headers.ts
@@ -16,6 +16,24 @@ export type SecurityHeadersOptions = {
   nonce: string;
 };
 
+/**
+ * Baseline, content-agnostic security headers safe for ANY response (pages and
+ * API alike): nosniff, Referrer-Policy, and HSTS over HTTPS. Deliberately
+ * excludes CSP / X-Frame-Options / Permissions-Policy / the nonce cookie, which
+ * are page-rendering concerns applied by {@link applySecurityHeaders}.
+ */
+export function applyBaselineSecurityHeaders(response: NextResponse): NextResponse {
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  if (isHttps) {
+    response.headers.set(
+      "Strict-Transport-Security",
+      "max-age=63072000; includeSubDomains; preload",
+    );
+  }
+  return response;
+}
+
 export function applySecurityHeaders(
   response: NextResponse,
   { cspHeader, nonce }: SecurityHeadersOptions,
@@ -36,15 +54,8 @@ export function applySecurityHeaders(
     `csp-endpoint="${cspReportUrl}"`,
   );
 
-  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
-  response.headers.set("X-Content-Type-Options", "nosniff");
+  applyBaselineSecurityHeaders(response);
   response.headers.set("X-Frame-Options", "DENY");
-  if (isHttps) {
-    response.headers.set(
-      "Strict-Transport-Security",
-      "max-age=63072000; includeSubDomains; preload",
-    );
-  }
   response.headers.set("Permissions-Policy", PERMISSIONS_POLICY);
 
   response.cookies.set("csp-nonce", nonce, {

--- a/src/lib/vault/vault-context.test.tsx
+++ b/src/lib/vault/vault-context.test.tsx
@@ -20,6 +20,8 @@ import {
   notifyUnlockFailure,
   VaultUnlockError,
 } from "./vault-context";
+import { stashPrf, clearPrf } from "@/lib/auth/prf-handoff";
+import { wrapSecretKeyWithPrf, hexEncode } from "@/lib/auth/webauthn/webauthn-client";
 
 const PASSPHRASE = "correct horse battery staple";
 
@@ -340,6 +342,81 @@ describe("VaultProvider — verifyPassphrase before unlock", () => {
     });
     expect(valid).toBe(false);
   });
+});
+
+describe("VaultProvider — unlockWithStoredPrf (in-memory PRF hand-off)", () => {
+  it("returns false and leaves the vault locked when no PRF was handed off (full-reload fallback)", async () => {
+    clearPrf();
+    const { fetchMock } = makeFetchEnv(null);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useVault(), { wrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.unlockWithStoredPrf();
+    });
+    expect(ok).toBe(false);
+    expect(result.current.encryptionKey).toBeNull();
+  });
+
+  it(
+    "unlocks using the in-memory PRF hand-off, then consumes it (second attempt falls back)",
+    async () => {
+      const { fetchMock } = makeFetchEnv(null);
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const { result } = renderHook(() => useVault(), { wrapper });
+
+      // Setup produces the real secretKey + verificationArtifact in the store.
+      await act(async () => {
+        await result.current.setup(PASSPHRASE);
+      });
+      const secretKey = result.current.getSecretKey();
+      expect(secretKey).toBeInstanceOf(Uint8Array);
+
+      // PRF-wrap the real secret key so unlockWithStoredPrf can unwrap+verify it.
+      const prfOutput = new Uint8Array(32).fill(0x5a);
+      const wrapped = await wrapSecretKeyWithPrf(secretKey!, prfOutput);
+      stashPrf({
+        prfOutputHex: hexEncode(prfOutput),
+        prfData: {
+          prfEncryptedSecretKey: wrapped.ciphertext,
+          prfSecretKeyIv: wrapped.iv,
+          prfSecretKeyAuthTag: wrapped.authTag,
+        },
+      });
+
+      // Lock, then unlock via the hand-off (no second authenticator ceremony).
+      act(() => {
+        result.current.lock();
+      });
+      expect(result.current.encryptionKey).toBeNull();
+
+      let ok = false;
+      await act(async () => {
+        ok = await result.current.unlockWithStoredPrf();
+      });
+      expect(ok).toBe(true);
+      expect(result.current.encryptionKey).toBeInstanceOf(CryptoKey);
+
+      // Single-use: the hand-off was cleared on read, so a second attempt
+      // (after re-lock) falls back to false rather than re-using stale material.
+      act(() => {
+        result.current.lock();
+      });
+      let second = true;
+      await act(async () => {
+        second = await result.current.unlockWithStoredPrf();
+      });
+      expect(second).toBe(false);
+      expect(result.current.encryptionKey).toBeNull();
+    },
+    60_000,
+  );
 });
 
 describe("VaultProvider — session-driven status", () => {

--- a/src/lib/vault/vault-context.tsx
+++ b/src/lib/vault/vault-context.tsx
@@ -48,6 +48,7 @@ import type { VaultStatus } from "@/lib/constants";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { fetchApi } from "@/lib/url-helpers";
 import { hexDecode, hexEncode } from "../crypto/crypto-utils";
+import { takePrf } from "@/lib/auth/prf-handoff";
 import {
   startPasskeyAuthentication,
   unwrapSecretKeyWithPrf,
@@ -656,18 +657,14 @@ export function VaultProvider({ children }: { children: ReactNode }) {
    * reusing the PRF output obtained during the sign-in ceremony.
    */
   const unlockWithStoredPrf = useCallback(async (): Promise<boolean> => {
-    const prfOutputHex = sessionStorage.getItem("psso:prf-output");
-    const prfDataStr = sessionStorage.getItem("psso:prf-data");
-
-    // Always clean up immediately
-    sessionStorage.removeItem("psso:prf-output");
-    sessionStorage.removeItem("psso:prf-data");
-
-    if (!prfOutputHex || !prfDataStr) return false;
+    // PRF material is handed off in-memory (not sessionStorage) and cleared on
+    // read; absent after a full reload → caller falls back to manual unlock.
+    const handoff = takePrf();
+    if (!handoff) return false;
 
     try {
-      const prfOutput = hexDecode(prfOutputHex);
-      const prfData = JSON.parse(prfDataStr);
+      const prfOutput = hexDecode(handoff.prfOutputHex);
+      const prfData = handoff.prfData;
 
       // Fetch vault data
       const dataRes = await fetchApi(API_PATH.VAULT_UNLOCK_DATA);

--- a/src/lib/vault/vault-context.tsx
+++ b/src/lib/vault/vault-context.tsx
@@ -652,7 +652,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
   // ─── Unlock with stored PRF (single-ceremony sign-in flow) ──────
 
   /**
-   * Unlock the vault using PRF output stored in sessionStorage during sign-in.
+   * Unlock the vault using PRF output handed off in-memory during sign-in.
    * This avoids a second authenticator interaction (e.g., QR code scan) by
    * reusing the PRF output obtained during the sign-in ceremony.
    */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,6 +3,7 @@ import { API_PATH } from "./lib/constants";
 import { handleApiAuth } from "./lib/proxy/api-route";
 import { handlePageRoute, type ProxyOptions } from "./lib/proxy/page-route";
 import { normalizeForwardedHeaders } from "./lib/proxy/forwarded-headers";
+import { applyBaselineSecurityHeaders } from "./lib/proxy/security-headers";
 
 export async function proxy(request: NextRequest, options: ProxyOptions) {
   // `tailscale serve` mis-populates X-Forwarded-Port with the backend port
@@ -13,9 +14,12 @@ export async function proxy(request: NextRequest, options: ProxyOptions) {
   const normalized = normalizeForwardedHeaders(request);
   const { pathname } = normalized.nextUrl;
 
-  // API routes: dispatch to api-route handler (no security headers).
+  // API routes: dispatch to api-route handler, then apply the baseline
+  // (non-CSP) security headers — nosniff / Referrer-Policy / HSTS — to every
+  // API response (CSP / X-Frame-Options stay page-only).
   if (pathname.startsWith(`${API_PATH.API_ROOT}/`)) {
-    return handleApiAuth(normalized);
+    const apiResponse = await handleApiAuth(normalized);
+    return applyBaselineSecurityHeaders(apiResponse);
   }
 
   // Page routes: i18n, auth, access restriction, passkey enforcement.


### PR DESCRIPTION
## Summary

Addresses the two residual concerns from the PR #500 security review (grade A-:
"well-designed, but Vault-unlock material is exposed under XSS"). Both were
deferred there as pre-v1.0 follow-ups.

## ① PRF output no longer placed in sessionStorage (main concern)

The one-ceremony passkey login+unlock stored the PRF output (`SS_PRF_OUTPUT`) and
the PRF-wrapped secret key (`SS_PRF_DATA`) in sessionStorage, which an XSS payload
could enumerate during the sign-in→dashboard window.

- New `src/lib/auth/prf-handoff.ts` — a module-level in-memory channel
  (`stashPrf` / `takePrf`, single-use, cleared on read). It survives the
  client-side `router.push` but is gone after a full reload, in which case
  auto-unlock degrades gracefully to the manual unlock prompt (same path a
  non-PRF passkey takes).
- `passkey-signin-button.tsx` → `stashPrf(...)`; `vault-context.tsx`
  `unlockWithStoredPrf` → `takePrf()`. Existing read-then-delete and
  `prfOutput.fill(0)` zeroization are preserved.
- Only the non-sensitive `psso:webauthn-signin` trigger flag remains in
  sessionStorage.
- Docs updated: `docs/security/considerations/{en,ja}.md`.

## ② Baseline security headers on API routes

API responses previously got no security headers (page routes only). Add a
shared `applyBaselineSecurityHeaders` — `X-Content-Type-Options: nosniff`,
`Referrer-Policy`, and HSTS over HTTPS — reused by both the page helper
(`applySecurityHeaders`) and the proxy's API path. CSP / X-Frame-Options /
Permissions-Policy stay page-only.

## Tests

- New `prf-handoff` unit test (stash/take single-use, clear, overwrite).
- `passkey-signin-button` test updated: asserts PRF goes to the in-memory channel
  (not sessionStorage) on success, and is never handed off on failure/cancel.
- New `applyBaselineSecurityHeaders` test (sets the non-CSP baseline; does NOT set
  CSP/X-Frame-Options/Permissions-Policy).

## Verification

- `npx vitest run` + `npx next build` green; `scripts/pre-pr.sh` 29/29.
- E2E passkey-unlock flow re-runs in the CI E2E job (the in-memory handoff must
  survive the SPA navigation; full-reload fallback to manual unlock is expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)