### PR TITLE
fix(security): sync personal-vault AAD to 3-field scheme (extension + iOS)

### DIFF
--- a/docs/archive/review/ext-personal-aad-3field-sync-plan.md
+++ b/docs/archive/review/ext-personal-aad-3field-sync-plan.md
@@ -1,0 +1,167 @@
+# Plan: Sync extension personal-vault AAD to the app's 3-field scheme
+
+Date: 2026-05-30
+Branch: `fix/ext-personal-aad-3field-sync`
+
+## Project context
+
+- **Type**: web app + browser extension (mixed). This change is scoped to the **browser extension** (`extension/`) plus one new cross-implementation parity test under the app test root (`src/__tests__/`).
+- **Test infrastructure**: unit + integration (Vitest). Two **separate** suites:
+  - Root: `npx vitest run` — collects `src/**/*.test.{ts,tsx}` only (per `vitest.config.ts`). This is a CLAUDE.md mandatory gate.
+  - Extension: `cd extension && npm test` (`vitest run`, no separate config) — collects `extension/**/*.test.ts`.
+  - Builds: `npx next build` (root, mandatory) and `cd extension && npm run build` (`tsc && vite build`).
+
+## Objective
+
+The browser extension cannot decrypt any **personal-vault** entry (login, credit card, identity, passkey — blob *or* overview) that was encrypted by the current web app. As a result such entries silently vanish from the extension (popup list, inline suggestions, manual fill). Restore decryptability by bringing the extension's personal-vault AAD to byte-parity with the app, and add a structural guard so the two implementations cannot silently diverge again.
+
+### Root cause (confirmed, byte-level)
+
+The web app migrated the **personal-vault** AAD from a 2-field shape to a 3-field shape in PR #482 (`d50c5fb5`, OWASP batch 3):
+
+- App `buildPersonalEntryAAD(userId, entryId, vaultType)` → `buildAADBytes("PV", 3, [userId, entryId, vaultType])` where `vaultType ∈ {"blob","overview"}` (`src/lib/crypto/crypto-aad.ts:122-128`, `VAULT_TYPE` at `:38-42`).
+- App encrypts the blob with `VAULT_TYPE.BLOB` and the overview with `VAULT_TYPE.OVERVIEW` (`src/lib/vault/personal-entry-save.ts:38-39`; read side `src/lib/vault/vault-context.tsx:1019-1022`).
+
+The extension was last touched on its crypto layer in PR #312 (`e11d4b87`) — **before** #482 — and still uses the old 2-field shape: `buildPersonalEntryAAD(userId, entryId)` → `buildAADBytes("PV", 2, [userId, entryId])` (`extension/src/lib/crypto.ts:255-260`). The `buildAADBytes` byte format is otherwise identical between the two codebases (scope[2] + version[1]=1 + nFields[1] + length-prefixed fields), so the **only** divergence is the `nFields` byte (2 vs 3) and the absence of the `vaultType` field. AES-256-GCM authentication fails on any AAD mismatch, so the extension's `decryptData` throws and the entry is silently dropped (`extension/src/background/index.ts:1014-1016`).
+
+The same #482 migration **was** propagated to the extension's **team** AAD (`extension/src/lib/crypto-team.ts:110-126`, 4-field with `vaultType`) — only the **personal** AAD was left behind. This is the exact gap the recurrence-prevention guard must close.
+
+### Second bug found alongside (in scope): dual-field paths share one AAD
+
+Four extension paths apply a **single** AAD object to **both** the blob and the overview field (encrypt and/or decrypt):
+
+- `extension/src/background/login-save.ts:139` (SAVE_LOGIN **create** — encrypts both fields with one `aad`)
+- `extension/src/background/passkey-provider.ts:366` (passkey **create** — encrypts both fields with one `aad`)
+- `extension/src/background/index.ts:1347` (`performAutofillForEntry` — **decrypts** both blob and overview with one `aad`; this is the handler `AUTOFILL` / `AUTOFILL_CREDIT_CARD` / `AUTOFILL_IDENTITY` invoke)
+- `extension/src/background/login-save.ts:215` (UPDATE_LOGIN — **decrypts** blob+overview and **re-encrypts** blob+overview, all with one `aad`)
+
+The app uses **distinct** AADs per field (BLOB vs OVERVIEW) precisely to prevent cross-field ciphertext replay. Even after the 3-field fix, sharing one AAD would (a) defeat the cross-field replay protection and (b) make exactly one of the two fields undecryptable by the app (and by the extension, for app-written entries). Each of these paths must compute `blobAad` (BLOB) and `overviewAad` (OVERVIEW) separately. `index.ts:1347` is the most user-impactful: it is the path that actually fills the credit card, so without fixing it the reported symptom is only half-resolved (card appears in the list but fill fails).
+
+## Requirements
+
+### Functional
+1. After the fix, the extension decrypts personal-vault **overviews** (popup list) and **blobs** (copy / fill / passkey assertion) that were produced by the current web app, for all personal entry types it supports (`LOGIN`, `CREDIT_CARD`, `IDENTITY`, `PASSKEY`).
+2. Entries the extension **creates** (`SAVE_LOGIN`, passkey registration) and **updates** (`UPDATE_LOGIN`) must be decryptable by the web app — i.e., the extension must write the blob with the BLOB AAD and the overview with the OVERVIEW AAD, `aadVersion: 1`.
+3. The `aadVersion`-gating behavior is preserved exactly: `aadVersion >= 1` → use the (now 3-field) AAD; `aadVersion` 0/absent → `undefined` (legacy no-AAD path), matching the app (`vault-context.tsx:1018-1022`).
+
+### Non-functional
+4. **No data migration** (explicit user constraint): the extension does **not** need to decrypt entries written by the *old* extension under the 2-field scheme. We adopt the app's current scheme wholesale; pre-existing 2-field-only data is out of scope (and is already unreadable by the app itself, per the #482 "BREAKING (pre-1.0)" note at `crypto-aad.ts:119-120`).
+5. **Recurrence prevention**: a test in the **root** suite (so it runs under the mandatory `npx vitest run`) asserts byte-identical AAD output between the app and extension personal builders across a representative input matrix, so a future one-sided change fails CI.
+
+## Technical approach
+
+- Mirror the app's personal AAD shape in `extension/src/lib/crypto.ts` exactly: add a `VAULT_TYPE` const object + `VaultType` type, and change `buildPersonalEntryAAD` to take `vaultType` and emit `buildAADBytes(SCOPE_PERSONAL, 3, [userId, entryId, vaultType])`. The existing extension `buildAADBytes` is already byte-identical to the app's, so no change there.
+- Thread the correct `vaultType` through **all 11** personal call sites across 3 files. Decrypt/encrypt of `encryptedBlob` → BLOB; decrypt/encrypt of `encryptedOverview` → OVERVIEW.
+- Split every dual-field path's single `aad` into separate `blobAad`/`overviewAad` (2 create + 1 autofill-decrypt + 1 update).
+- Update the extension test suite's fixtures/mocks/assertions that currently use the 2-arg builder.
+- Add the parity test importing both implementations' pure AAD builders, and wire CI so it runs on extension-side AAD changes too.
+
+This is deliberately a **minimal, in-place** change (no module extraction / refactor) — the extension already isolates team AAD in `crypto-team.ts`; the personal builder lives in `crypto.ts` and we keep it there.
+
+## Contracts
+
+### C1 — Extension personal AAD builder adopts the 3-field shape
+- **File**: `extension/src/lib/crypto.ts`
+- **Signature**:
+  - `export const VAULT_TYPE = { BLOB: "blob", OVERVIEW: "overview" } as const`
+  - `export type VaultType = (typeof VAULT_TYPE)[keyof typeof VAULT_TYPE]`
+  - `export function buildPersonalEntryAAD(userId: string, entryId: string, vaultType: VaultType): Uint8Array` → returns `buildAADBytes(SCOPE_PERSONAL, 3, [userId, entryId, vaultType])`
+- **Invariant**: byte output equals `src/lib/crypto/crypto-aad.ts`'s `buildPersonalEntryAAD` for identical `(userId, entryId, vaultType)`. The literal values `"blob"`/`"overview"` and `SCOPE_PERSONAL="PV"` and the AAD version byte `1` must match the app.
+- **Acceptance**: C5 parity test passes; `buildPersonalEntryAAD` has no remaining 2-arg overload.
+
+### C2 — All **blob-only** call sites pass `VAULT_TYPE.BLOB`
+Sites that decrypt and/or re-encrypt **only** `encryptedBlob`:
+  - `extension/src/background/index.ts:917` (COPY_PASSWORD / COPY_USERNAME blob decrypt)
+  - `extension/src/background/index.ts:1945` (EXT_MSG.COPY_PASSWORD blob decrypt) **(was missing — R1 finding)**
+  - `extension/src/background/index.ts:2023` (EXT_MSG.COPY_TOTP blob decrypt) **(was missing — R1 finding)**
+  - `extension/src/background/passkey-provider.ts:236` (assertion blob decrypt **and** the assertion-counter re-encrypt at ~268-271 — both BLOB)
+  - `extension/src/background/passkey-provider.ts:427` (replace-target blob decrypt)
+  - `extension/src/background/login-save.ts:92` (SAVE_LOGIN existing-entry blob decrypt)
+- **Acceptance**: every `buildPersonalEntryAAD(...)` on a blob-only path passes `VAULT_TYPE.BLOB`.
+
+### C3 — All **overview-only** call sites pass `VAULT_TYPE.OVERVIEW`
+  - `extension/src/background/index.ts:977` (`decryptOverviews` — the popup-list path; the user-reported symptom)
+- **Acceptance**: `decryptOverviews` passes `VAULT_TYPE.OVERVIEW`; popup list shows app-created CREDIT_CARD/IDENTITY/LOGIN/PASSKEY entries.
+
+### C4 — All **dual-field** paths use distinct blob/overview AADs
+Every path that touches **both** fields must compute two AADs — `blobAad = buildPersonalEntryAAD(id..., VAULT_TYPE.BLOB)` and `overviewAad = buildPersonalEntryAAD(id..., VAULT_TYPE.OVERVIEW)` — and never cross them:
+  - `extension/src/background/login-save.ts:139` (SAVE_LOGIN **create**: `encryptData(fullBlob, …, blobAad)`, `encryptData(overviewBlob, …, overviewAad)`)
+  - `extension/src/background/passkey-provider.ts:366` (passkey **create**: same split)
+  - `extension/src/background/index.ts:1347` (`performAutofillForEntry`: `decryptData(encryptedBlob, …, blobAad)`, `decryptData(encryptedOverview, …, overviewAad)`) **(was missing — the actual credit-card fill path)**
+  - `extension/src/background/login-save.ts:215` (UPDATE_LOGIN: blob decrypt+re-encrypt → blobAad; overview decrypt+re-encrypt → overviewAad) **(was missing)**
+- **Invariant**: the blob is never encrypted/decrypted with the OVERVIEW AAD or vice-versa. Create paths keep writing `aadVersion: 1`; UPDATE_LOGIN keeps `aadVersion: data.aadVersion ?? 1`. Note the `??` semantics precisely: it fires only on `null`/`undefined`, **not** on `0`. So an entry whose `aadVersion` is absent/null is written back as `1`; an explicit `aadVersion: 0` entry stays `0` and is re-encrypted with no AAD (`undefined`) — internally consistent and acceptable under the no-migration constraint. Do not add a 0→1 promotion branch.
+- **Consumer-flow walkthrough** (the app is the consumer of extension-written ciphertext):
+  - Consumer **app read path** (`src/lib/vault/vault-context.tsx:1019-1022`) reads `{ encryptedBlob, encryptedOverview, aadVersion, id }` and, for `aadVersion >= 1`, decrypts `encryptedBlob` with `buildPersonalEntryAAD(userId, id, BLOB)` and `encryptedOverview` with `buildPersonalEntryAAD(userId, id, OVERVIEW)`. Both fields the consumer needs (`id`, `aadVersion`) are present in the extension's POST/PUT body. After C4 the per-field AAD matches what the consumer computes → both decrypt. ✅
+  - Consumer **extension autofill read** (`index.ts:1347`) is itself fixed by C4 so it can read app-written entries field-by-field.
+
+### C5 — Recurrence-prevention parity test (root suite)
+- **File**: `src/__tests__/aad-parity.test.ts` (new) — under `src/**` so it runs in the mandatory `npx vitest run`, which is gated by the CI `app:` path filter (`src/**`). **This is the guard for the regression that actually occurred (#482: app AAD changed, extension forgotten): editing `src/lib/crypto/crypto-aad.ts` triggers `app-ci`, runs this test, and it fails the moment the app builder diverges from the extension builder — no CI-config change required.**
+- **Imports**: app builder from `@/lib/crypto/crypto-aad` (verified: zero top-level imports — pure leaf); extension builder from relative path `../../extension/src/lib/crypto` (verified: no module-level browser-API side effects; AAD functions use only `TextEncoder`/`DataView`, available in the node test env; root tsconfig includes the dom lib so `CryptoKey`/`AesGcmParams` types referenced elsewhere in that file resolve). **Pre-implementation verification step**: confirm the file imports/type-checks under the root config (a failing import is itself a finding). Fallback if import proves infeasible: assert each builder against the frozen golden hex (below).
+- **Cross-decrypt regression test** (same file): `import { encryptData } from "@/lib/crypto/crypto-client"` (app) and `import { decryptData } from "../../extension/src/lib/crypto"` (extension); generate one shared key with `crypto.subtle.generateKey({name:"AES-GCM",length:256}, …, ["encrypt","decrypt"])`, encrypt an overview with the app's OVERVIEW AAD and decrypt it via the extension's OVERVIEW AAD → asserts success. This is the test that fails before the fix and passes after.
+- **Assertions** (Arrange/Act/Assert, one concept each):
+  - personal BLOB AAD bytes equal across app vs extension for sample `(userId, entryId)`
+  - personal OVERVIEW AAD bytes equal across app vs extension
+  - both builders equal a **frozen golden hex** for a canonical `(userId, entryId, vaultType)` triple (pins the absolute shape so a PR that breaks BOTH sides identically still fails). **Derivation (T17)**: compute the expected bytes from the spec formula (`"PV"` + version `0x01` + nFields `0x03` + per-field `[u16 len][utf8 bytes]`) and cross-verify that BOTH implementations reproduce it before pinning — do NOT copy one implementation's output into both tests (that would only prove self-consistency, not cross-implementation parity).
+  - (structural lock) the AAD `nFields` byte is `3` and the decoded fields include the vaultType — differs from the legacy 2-field output
+  - (cross-field throw, T16) encrypt a field with the BLOB AAD and assert decrypting it with the OVERVIEW AAD **throws**, in the root suite too — symmetric to C6's extension-suite anti-vacuous test, so the per-field binding is verified even if a future hotfix touches only `src/`.
+  - non-ASCII `userId`/`entryId` (UTF-8 multibyte) produce equal bytes (guards encoder parity)
+- **Scope note (S5)**: C5 guards **personal** AAD only. Team/history/itemkey AADs (duplicated in `crypto-team.ts`) are NOT covered and are out of scope; reviewers must not read C5 as full-AAD coverage.
+- **Acceptance**: test fails if the app personal AAD shape changes without the extension matching; cross-decrypt regression passes.
+
+### C6 — Update existing extension tests to the 3-arg builder
+The extension suite currently encrypts fixtures and asserts call-args with the 2-arg builder; C1 breaks them. The Phase-2/3 forbidden-pattern grep (`buildPersonalEntryAAD\([^,]+,[^,)]+\)` across `extension/` **including tests**) is the completeness check — **after C6 it must return zero hits**. Files and their known 2-arg sites (counts are a starting list, not a cap — the grep is authoritative):
+  - `extension/src/__tests__/lib/crypto.test.ts` — **all ~8 calls in the `buildPersonalEntryAAD` describe block (~lines 221-248), not only the field-count assertion at 243.** For same-vaultType comparison tests (determinism, userId-differ, entryId-differ) use a consistent `VAULT_TYPE.BLOB`; flip the `aad[3]` assertion from `2` to `3`.
+  - `extension/src/__tests__/crypto-encrypt.test.ts` — ~5 sites: 2-arg → 3-arg with the vaultType matching the field round-tripped
+  - `extension/src/__tests__/background-login-save.test.ts` — ~8 sites
+  - `extension/src/__tests__/background-passkey-provider.test.ts` — ~8 sites
+  - `extension/src/__tests__/background.test.ts` (and audit `background-commands.test.ts`, `background/totp-handlers.test.ts`) — `toHaveBeenCalledWith(...)` mock-arg assertions gain the 3rd vaultType arg; the `mockReturnValue` stubs in commands/totp tests need no arg change (they assert no args), but confirm.
+- **Invariant (structural, T15)**: a round-trip/fixture assertion that decrypts `encryptedBlob` MUST use a `VAULT_TYPE.BLOB` AAD, and one that decrypts `encryptedOverview` MUST use a `VAULT_TYPE.OVERVIEW` AAD, held in **distinct variables** — never one shared AAD for both fields. A single shared (even if 3-arg) AAD across both decrypts passes vacuously while production is broken. This mirrors the C4 production split into the tests.
+- **Anti-vacuous test (required)**: add one extension-suite test (in `crypto.test.ts`) that encrypts a field with `VAULT_TYPE.BLOB` and asserts decrypting it with `VAULT_TYPE.OVERVIEW` **throws** (proves the per-field binding is active, not just present). C5 adds a symmetric throw in the root suite (T16). **Note (T18)**: the existing `crypto-encrypt.test.ts` "wrong-AAD" test varies userId/entryId (not vaultType), so after C6 the cross-field throw coverage lives specifically in `crypto.test.ts` (+ C5) — keep it there; do not let a future refactor orphan it.
+- **Note (T12, accepted)**: `background.test.ts` COPY_PASSWORD/AUTOFILL tests use a fixed-stub crypto mock and do not validate the vaultType argument. This is pre-existing weak coverage, not a regression; real per-field vaultType validation lives in the round-trip tests above and the anti-vacuous test. No action beyond the 3rd-arg assertion update.
+- **Acceptance**: `cd extension && npm test` green; forbidden-pattern grep returns zero 2-arg hits.
+
+### C7 — Extension-suite golden-vector parity guard (recurrence prevention, reverse direction)
+C5 (root suite, under `app-ci`) catches the app-side regression direction. This contract catches the reverse — an **extension-side** AAD change — under `extension-ci`, with **no CI-config coupling** (the rejected alternative of adding extension files to the `app:` filter would trigger the full ~15-min `app-ci` on extension-only changes and would silently miss any future new extension crypto file).
+- **File**: `extension/src/__tests__/lib/crypto.test.ts` (extend the existing personal-AAD describe block).
+- **Assertions**: `buildPersonalEntryAAD(u, e, VAULT_TYPE.BLOB)` and `(u, e, VAULT_TYPE.OVERVIEW)` each equal a **frozen golden hex** — the *same* canonical vectors asserted in C5's root test. The golden hex is the pinned cross-implementation spec: if the extension builder drifts, this test fails under `extension-ci`; if the app builder drifts, C5 fails under `app-ci`. Both directions covered by each package's native CI trigger.
+- **Acceptance**: editing `extension/src/lib/crypto.ts`'s AAD shape fails `extension-ci` via this test.
+
+### Forbidden patterns (Phase 2–3 grep gate)
+- pattern: `buildPersonalEntryAAD\([^,]+,[^,)]+\)` across `extension/` **including tests** — reason: a personal AAD call with exactly two arguments means a production site or test fixture was missed (every call must pass a third `vaultType` arg after C1).
+- pattern: `buildAADBytes(SCOPE_PERSONAL, 2,` — reason: the old 2-field personal shape must not remain anywhere in the extension.
+- pattern (dual-field paths): a single `const aad =` feeding both a blob and an overview `encryptData`/`decryptData` in `login-save.ts` / `passkey-provider.ts` / `index.ts:performAutofillForEntry` — reason: C4 requires distinct blob/overview AADs. Manual review (grep cannot reliably prove the two calls share the variable).
+
+## Testing strategy
+
+- **Extension suite** (`cd extension && npm test`): all existing tests updated per C6 must pass. Add an extension-side unit test that round-trips a personal entry through `buildPersonalEntryAAD` + `encryptData`/`decryptData` for both BLOB and OVERVIEW vaultTypes, asserting the **wrong** vaultType fails to decrypt (proves cross-field replay protection is active).
+- **Root suite** (`npx vitest run`): C5 parity + cross-decrypt regression test.
+- **Builds**: `npx next build` (root) and `cd extension && npm run build` (`tsc && vite build` — the `tsc` step is the compile-time net that surfaces every un-migrated call site as an error) both succeed.
+- **Both suites are mandatory** before completion: root `npx vitest run` does NOT collect `extension/**`, so `cd extension && npm test` must be run separately, plus both builds.
+- **Manual verification** (recorded in `…-manual-test.md`): load the built extension, unlock the vault on the dev account that has the `オリコ` CREDIT_CARD entry, open the popup on a web page — confirm the card appears under "Other entries"; then on the Apple checkout form click fill and confirm `performAutofillForEntry` fills the `cc-number`/`cc-exp`/`cc-csc` fields (this exercises the C4 `index.ts:1347` fix, which automated tests cover at the AAD layer but not at the DOM-fill layer).
+
+## Considerations & constraints
+
+- **Out of scope — inline in-page credit-card autofill wiring.** The extension has a credit-card form detector library (`extension/src/content/cc-form-detector-lib.ts`) and fill script (`autofill-cc.js`) that are never initialized, and `GET_MATCHES_FOR_URL` (`index.ts:2193`) returns LOGIN-only. This is a *separate feature* (a missing wiring, not a regression) and is explicitly **not** addressed here. This plan's fix makes credit cards appear in the popup list and fillable via the manual popup button; inline page suggestions remain a follow-up. Reviewers must not raise the absence of inline CC wiring as a finding against this plan.
+- **No data migration** (explicit constraint): old extension-written 2-field entries become unreadable by the new extension. Acceptable per the user; the app already cannot read pre-#482 2-field personal entries either.
+- **Two test suites / two builds**: the extension suite is not part of root `npx vitest run`. Both must be run before completion.
+- The extension's `buildAADBytes` is duplicated in `crypto.ts` and `crypto-team.ts`; de-duplicating it is *not* in scope (team AAD is already correct). The parity test (C5) is the chosen guard rather than a refactor.
+- **Accepted risk — server-controlled `aadVersion` downgrade (S3, Minor).** All personal decrypt paths except passkey (`passkey-provider.ts:233` rejects `<1`) fall back to a `undefined` AAD when the server returns `aadVersion: 0`. This is **not exploitable for plaintext exposure**: the stored ciphertext was encrypted *with* the AAD, so AES-GCM auth-tag verification fails on a no-AAD decrypt; forging a no-AAD ciphertext requires the vault key, which a server compromise does not yield. Worst case = decryption failure (UX/DoS); likelihood = low (requires server compromise); cost-to-fix = low but changes legacy `aadVersion:0` read behavior, which is migration-adjacent and explicitly out of scope per the no-migration constraint. We **do not** add a reject-guard (it would be speculative scaffolding for a non-exploitable path). Tracked: `TODO(ext-personal-aad-3field-sync): consider rejecting aadVersion<1 on personal LOGIN decrypt paths once legacy 0-version entries are confirmed absent.`
+
+## User operation scenarios
+
+1. **Popup list on a checkout page** (the reported case): user has one `CREDIT_CARD` entry created via the web app today; opens the extension popup on `secure9.store.apple.com`; before the fix the popup shows only "no matches for host" with no "Other entries"; after the fix the card appears under "Other entries" with a fill button.
+2. **Manual fill from popup**: clicking the card's fill button sends `AUTOFILL_CREDIT_CARD`; `autofill-cc.js` fills `autocomplete="cc-number"/"cc-exp"/"cc-csc"` fields (these resolve already; only the decryption was blocking the card from being listed).
+3. **Extension creates a login** (`SAVE_LOGIN`) then the **web app** opens that entry: with C4, the app decrypts both blob and overview.
+4. **Mixed-age vault**: entries created before #482 (2-field) are not expected to decrypt post-fix (no migration) — verify the extension does not crash, just omits them (existing `catch` at `index.ts:1014`).
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | Extension `buildPersonalEntryAAD` → 3-field with `VAULT_TYPE`/`VaultType` | locked |
+| C2 | All blob-only call sites pass `VAULT_TYPE.BLOB` (index.ts:917/1945/2023, passkey:236/427, login-save:92) | locked |
+| C3 | Overview-only call site passes `VAULT_TYPE.OVERVIEW` (index.ts:977 decryptOverviews) | locked |
+| C4 | All dual-field paths use distinct blob/overview AADs (login-save:139 create + :215 update, passkey:366 create, index.ts:1347 autofill) | locked |
+| C5 | Root-suite app↔extension AAD parity + golden vectors + cross-decrypt regression + structural lock (catches app-side drift under app-ci) | locked |
+| C6 | Update existing extension tests/fixtures/mocks to 3-arg; per-field BLOB/OVERVIEW structural rule + anti-vacuous throw test | locked |
+| C7 | Extension-suite golden-vector parity guard (catches extension-side drift under extension-ci; no ci.yml coupling) | locked |

--- a/docs/archive/review/ext-personal-aad-3field-sync-plan.md
+++ b/docs/archive/review/ext-personal-aad-3field-sync-plan.md
@@ -154,6 +154,16 @@ C5 (root suite, under `app-ci`) catches the app-side regression direction. This 
 3. **Extension creates a login** (`SAVE_LOGIN`) then the **web app** opens that entry: with C4, the app decrypts both blob and overview.
 4. **Mixed-age vault**: entries created before #482 (2-field) are not expected to decrypt post-fix (no migration) — verify the extension does not crash, just omits them (existing `catch` at `index.ts:1014`).
 
+## iOS (added mid-implementation — user-confirmed, same branch)
+
+The iOS app (`ios/`) is a **third** implementation of the personal-vault AAD and had the identical stale 2-field bug (team AAD was already 4-field/vaultType-aware; personal was forgotten — same shape as the extension). Its existing `AADParityTests.swift` pinned the **wrong** 2-field golden, which is exactly why it never caught the #482 divergence. Fixed in the same branch.
+
+- **C8** — `ios/Shared/Crypto/AAD.swift`: `buildPersonalEntryAAD(userId:entryId:vaultType:)` → 3-field; add a `VaultType` constant namespace (`blob`/`overview`) mirroring the app's `VAULT_TYPE`. `vaultType: String` (matches `buildTeamEntryAAD` and the String already threaded by callers). **No raw `"blob"`/`"overview"` literals anywhere in iOS** — all use `VaultType.blob` / `VaultType.overview` (per user request; also converted the pre-existing team-AAD literals in tests).
+- **C9** — `ios/Shared/Vault/EntryEncrypter.swift`: split the shared `aad` into `blobAAD`/`overviewAAD` per field.
+- **C10** — usage sites pass the correct vaultType: `CredentialResolver.swift:378` and `VaultViewModel.swift:103` thread their existing `vaultType` param into the personal branch (callers already pass `"overview"`/`"blob"` for decryptOverview/decryptDetail); `DebugVaultLoader.swift` splits blob/overview.
+- **C11** — iOS tests: `AADParityTests.swift` golden vectors → correct 3-field bytes (BLOB + OVERVIEW, plus a not-equal assertion); `EntryEncrypterTests`/`CredentialResolverTests` use distinct per-field AADs.
+- **Verification limitation**: this environment is Linux without Xcode — iOS changes were verified by inspection + the forbidden-pattern grep (zero 2-arg calls), but `xcodebuild`/`xctest` was NOT run. **iOS must be built and tested in Xcode before release.**
+
 ## Go/No-Go Gate
 
 | ID | Subject | Status |
@@ -165,3 +175,7 @@ C5 (root suite, under `app-ci`) catches the app-side regression direction. This 
 | C5 | Root-suite app↔extension AAD parity + golden vectors + cross-decrypt regression + structural lock (catches app-side drift under app-ci) | locked |
 | C6 | Update existing extension tests/fixtures/mocks to 3-arg; per-field BLOB/OVERVIEW structural rule + anti-vacuous throw test | locked |
 | C7 | Extension-suite golden-vector parity guard (catches extension-side drift under extension-ci; no ci.yml coupling) | locked |
+| C8 | iOS `buildPersonalEntryAAD` → 3-field + `VaultType` constant (no raw literals) | locked |
+| C9 | iOS `EntryEncrypter` splits blob/overview AADs | locked |
+| C10 | iOS usage sites thread correct vaultType (CredentialResolver/VaultViewModel/DebugVaultLoader) | locked |
+| C11 | iOS tests: 3-field golden vectors + per-field AADs | locked |

--- a/docs/archive/review/ext-personal-aad-3field-sync-review.md
+++ b/docs/archive/review/ext-personal-aad-3field-sync-review.md
@@ -1,0 +1,90 @@
+# Plan Review: ext-personal-aad-3field-sync
+
+Date: 2026-05-30
+Review round: 1
+
+## Changes from Previous Round
+
+Initial review.
+
+## Functionality Findings
+
+- **F1 [Critical]** — Call-site inventory incomplete. Plan says "8 sites"; there are **11** production sites. Missing: `index.ts:1347` (`performAutofillForEntry` — decrypts BOTH blob and overview with one AAD; this is the handler `AUTOFILL_CREDIT_CARD`/`AUTOFILL_IDENTITY`/`AUTOFILL` invoke, so the user's actual goal stays broken), `index.ts:1945` (COPY_PASSWORD), `index.ts:2023` (COPY_TOTP). Verified by orchestrator.
+- **F2 [Critical]** — `UPDATE_LOGIN` (`login-save.ts:213-227`) uses one `aad` for blob decrypt, overview decrypt, blob re-encrypt, AND overview re-encrypt. C3 mentions it vaguely ("if present"); C4 (the cross-field-AAD contract) does not list it. Must split into blobAad/overviewAad. Verified.
+- **F4 [Minor]** — Plan's "8 sites across 3 files" count is wrong (11 actual). Fix count.
+- (Adjacent→Func from Sec) aadVersion promotion: UPDATE_LOGIN writes `aadVersion: data.aadVersion ?? 1`; a 0-version legacy entry gets promoted to 1 on update. Acceptable under no-migration, but document.
+
+## Security Findings
+
+- **S1 [Major]** — (same root cause as F1) 3 undocumented call sites; after C1's 2→3-arg signature change TypeScript forces a compile error at each (good backstop), but the plan gives no vaultType guidance, and `index.ts:1347` needs the same blob/overview split as the create paths. Verified.
+- **S2 [Major]** — (same root cause as F2) UPDATE_LOGIN has the identical cross-field shared-AAD bug; must be added to C4. Verified.
+- **S3 [Minor]** — Server-controlled `aadVersion` downgrade: all personal decrypt paths except passkey (`passkey-provider.ts:233` rejects `<1`) silently fall back to `undefined` AAD when the server returns `aadVersion: 0`. **No plaintext-exposure vector** (the ciphertext was encrypted WITH AAD, so GCM auth-tag verification fails on the no-AAD decrypt; attacker would need the key to forge a no-AAD ciphertext). Worst case = decryption failure (UX/DoS), likelihood = requires server compromise, cost-to-fix = low but touches legacy-read behavior. Pre-existing in changed files. See orchestrator disposition.
+- **S4 [Minor → confirmed safe, no action]** — 2-field vs 3-field AAD cannot collide: the `nFields` byte (2 vs 3) is a structural discriminator even though the version byte stays `1`. Confirmed safe.
+- **S5 [Minor]** — C5 parity test covers only personal AAD; team/history/itemkey AADs (duplicated in `crypto-team.ts`) are not guarded. Document that C5 ≠ full AAD coverage so reviewers don't over-read it.
+
+## Testing Findings
+
+- **T1 [Critical]** — `extension/src/__tests__/lib/crypto.test.ts:243` asserts `expect(aad[3]).toBe(2)` (field count). C1 makes it 3 → extension CI red. Must update (and flip to `3`, becoming a co-equal structural guard — T5).
+- **T2 [Critical]** — `background-login-save.test.ts` (≈8 sites) encrypts fixtures with 2-arg `buildPersonalEntryAAD`; post-C1 fixtures mismatch production AAD → vacuous-pass or false-fail. Must update to 3-arg with matching vaultType; UPDATE tests must use separate blobAad/overviewAad.
+- **T3 [Critical]** — `background-passkey-provider.test.ts` (≈8 sites) — same class as T2.
+- **T4 [Major]** — `background.test.ts:488` asserts `toHaveBeenCalledWith("user-1","pw-1")` (2 args) → fails post-C1; needs 3rd arg. Audit `background-commands.test.ts` and `background/totp-handlers.test.ts` mocks too.
+- **T6 [Major]** — (same as F1/S1) 3 missing index.ts sites; `:1347` is a C4-class dual-field site.
+- **T5 [Major]** — C5 should also flip the extension's own `lib/crypto.test.ts:243` field-count assertion as an in-extension-suite structural guard.
+- **T9 [Minor → elevated by orchestrator for recurrence-prevention intent]** — CI: `app-ci` (runs the root parity test) triggers on the `app` path filter, which lacks `extension/**`. An extension-only AAD regression triggers only `extension-ci`, so the root parity test never runs → C5's recurrence-prevention purpose is defeated for the most likely future regression. Must wire CI.
+- **T7 [Minor]** — Verify `extension/src/lib/crypto.ts` (the imported module) compiles/loads under root tsconfig in the root suite. (Orchestrator: `crypto-aad.ts` has zero imports; `crypto.ts` AAD functions use only TextEncoder/DataView; root tsconfig includes dom lib. Low risk; add a verification step.)
+- **T8 [Minor]** — Name explicit import sources for the cross-decrypt regression test.
+- **T10 [Minor]** — `extension/src/__tests__/crypto-encrypt.test.ts` (5 sites) uses 2-arg calls → update.
+
+## Adjacent Findings
+
+- [Adjacent] (Sec→Func) aadVersion promotion on UPDATE_LOGIN — documented under F-disposition.
+- [Adjacent] (Func→Sec) `index.ts:1347` dual-field decrypt = read-side analogue of the C4 create-path replay-protection gap.
+
+## Recurring Issue Check
+
+### Functionality expert
+R3: **Finding F1/F4** (missed call sites). R17/R22: Finding F2 (UPDATE overview not named). R25: create paths write both fields (Finding F2 for UPDATE). R1,R2,R4–R16,R18–R37: N/A or Checked-no-issue. C5 import feasibility: confirmed.
+
+### Security expert
+R3: **Finding S1/S2**. RS2 (AAD binding completeness): Checked — userId+entryId+vaultType sufficient; no protection weakened. RS3 (aadVersion downgrade): **Finding S3**. RS4 (cross-field replay): **Finding S1/S2** (autofill + update paths). RS1: N/A. R25 security-downgrade: S3. R31 (broken crypto): Checked — random IV preserved, GCM throughout. All others N/A.
+
+### Testing expert
+RT1 (mock-reality): **Finding T2/T3/T4**. RT2 (testability): Checked — parity cross-import feasible. R19 (mock alignment): **T2/T3/T4**. R33 (CI cross-config): **Finding T9**. RT4/RT5: T2/T3/T9. Others Checked/N-A.
+
+## Orchestrator disposition (Round 1 → plan revision)
+
+- **F1/S1/T6 (Critical/Major)** → ADOPT. Expand C2 (add index.ts:1945, 2023), add new dual-field contract coverage for index.ts:1347 in C4.
+- **F2/S2 (Critical/Major)** → ADOPT. Add UPDATE_LOGIN (login-save.ts:215) to C4.
+- **T1/T2/T3/T4/T10/T5 (Critical/Major)** → ADOPT. New contract **C6**: update all existing extension test fixtures/mocks/assertions to the 3-arg form + flip the field-count assertion.
+- **T9 (recurrence-prevention)** → ADOPT. Add `extension/src/lib/crypto.ts` + `crypto-team.ts` to the CI `app:` path filter so the root parity test runs on extension-side AAD changes. New contract **C7**.
+- **T7/T8 (Minor)** → ADOPT into C5 text (verification step + explicit import sources).
+- **S5 (Minor)** → ADOPT into C5 considerations (scope note).
+- **S3 (Minor, security)** → **DOCUMENT as accepted risk, do NOT add reject-guard.** Anti-Deferral: Worst case = decryption failure only (no plaintext exposure — GCM tag fails without the key); Likelihood = low (requires server compromise); Cost-to-fix = low but changes legacy aadVersion-0 read behavior, which is migration-adjacent and explicitly out of scope per the user's "no data migration" constraint. Adding a reject-guard is speculative defensive scaffolding for a non-exploitable path; deferred with this justification. Tracked: `TODO(ext-personal-aad-3field-sync): consider rejecting aadVersion<1 on personal LOGIN decrypt paths if legacy 0-version entries are confirmed absent`.
+- **F4 (Minor)** → ADOPT (correct count to 11).
+
+---
+
+## Round 2
+
+Changes reviewed: expanded C2 (index.ts:1945/2023), C3 (index.ts:977), C4 (all 4 dual-field paths incl index.ts:1347 + login-save.ts:215), new C6 (test updates), new C7 (CI wiring), S3 disposition.
+
+All Round-1 Critical/Major confirmed RESOLVED. New findings:
+- **F5/T11 [Major]** — C6 under-scoped `lib/crypto.test.ts` (8 calls, not 1) → ADOPT: C6 now covers the whole describe block; grep is authoritative.
+- **F6 [Minor]** — C4 `??` wording wrong (`??` doesn't fire on 0) → ADOPT: corrected.
+- **T15 [Major]** — C6 "not vacuous" was a principle, not structural → ADOPT: per-field BLOB/OVERVIEW distinct-variable rule + required anti-vacuous throw test.
+- **T13 [Major] + S6 [Minor]** — C7 CI-filter coupling triggers full 15-min app-ci on extension-only changes + hardcodes files → ADOPT REDESIGN: C7 replaced with an extension-suite golden-vector guard (no ci.yml change). Root C5 catches app-side drift under app-ci (the #482 direction — the regression that actually happened); C7 extension golden test catches extension-side drift under extension-ci.
+- **T12 [Minor]** — background.test.ts stub-mock paths don't validate vaultType → ACCEPTED (pre-existing; real validation in round-trip + anti-vacuous tests).
+- **T14 [Minor]** — cross-decrypt test key unspecified → ADOPT (generateKey).
+
+## Round 3
+
+Changes reviewed: C4 wording fix, C5 golden vectors + generateKey, C6 full-file scope + structural per-field rule + anti-vacuous test, C7 redesign.
+
+- **Functionality**: No findings. All 11 production sites reconfirmed mapped to C2/C3/C4; C4/C6 corrections verified.
+- **Security**: No findings. Dual-suite golden-vector design closes both recurrence directions without ci.yml coupling; S3 + C4 still sound; cross-decrypt regression provides real-world decrypt signal beyond golden vectors.
+- **Testing**: 3 Minor doc/process notes → ALL ADOPTED:
+  - **T16** — add symmetric cross-field throw to C5 root suite.
+  - **T17** — derive golden hex from the byte spec and cross-verify both impls before pinning (don't copy one side).
+  - **T18** — cross-field throw coverage lives in crypto.test.ts (+C5); note so it isn't orphaned.
+
+**Convergence**: Functionality + Security clean at Round 3; Testing's residual items were Minor documentation notes, now incorporated. All 7 contracts locked. Plan ready for Phase 2.

--- a/extension/src/__tests__/background-commands.test.ts
+++ b/extension/src/__tests__/background-commands.test.ts
@@ -18,6 +18,7 @@ const cryptoMocks = vi.hoisted(() => ({
   decryptData: vi.fn(),
   buildPersonalEntryAAD: vi.fn().mockReturnValue(new Uint8Array([1, 2])),
   hexDecode: vi.fn().mockReturnValue(new Uint8Array([0, 1])),
+  VAULT_TYPE: { BLOB: "blob", OVERVIEW: "overview" },
 }));
 
 vi.mock("../lib/crypto", () => cryptoMocks);

--- a/extension/src/__tests__/background-login-save.test.ts
+++ b/extension/src/__tests__/background-login-save.test.ts
@@ -4,6 +4,7 @@ import {
   encryptData,
   decryptData,
   buildPersonalEntryAAD,
+  VAULT_TYPE,
 } from "../lib/crypto";
 
 // Must stub chrome before importing login-save
@@ -93,7 +94,7 @@ describe("login-save", () => {
     });
 
     it("returns 'none' when password matches existing entry", async () => {
-      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1);
+      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1, VAULT_TYPE.BLOB);
       const blob = JSON.stringify({ password: "same-password" });
       const encBlob = await encryptData(blob, testKey, aad);
 
@@ -114,7 +115,7 @@ describe("login-save", () => {
     });
 
     it("returns 'update' when existing entry has null password", async () => {
-      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1);
+      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1, VAULT_TYPE.BLOB);
       const blob = JSON.stringify({ password: null });
       const encBlob = await encryptData(blob, testKey, aad);
 
@@ -136,7 +137,7 @@ describe("login-save", () => {
     });
 
     it("returns 'update' when existing entry has undefined password", async () => {
-      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1);
+      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1, VAULT_TYPE.BLOB);
       const blob = JSON.stringify({ username: "alice" }); // no password field
       const encBlob = await encryptData(blob, testKey, aad);
 
@@ -158,7 +159,7 @@ describe("login-save", () => {
     });
 
     it("returns 'update' when password differs from existing entry", async () => {
-      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1);
+      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1, VAULT_TYPE.BLOB);
       const blob = JSON.stringify({ password: "old-password" });
       const encBlob = await encryptData(blob, testKey, aad);
 
@@ -214,14 +215,15 @@ describe("login-save", () => {
       expect(deps.invalidateCache).toHaveBeenCalled();
 
       // Verify encrypted blobs decrypt to correct content
-      const aad = buildPersonalEntryAAD("user-1", "new-uuid-1234");
-      const fullPlain = JSON.parse(await decryptData(callBody.encryptedBlob, testKey, aad));
+      const blobAad = buildPersonalEntryAAD("user-1", "new-uuid-1234", VAULT_TYPE.BLOB);
+      const overviewAad = buildPersonalEntryAAD("user-1", "new-uuid-1234", VAULT_TYPE.OVERVIEW);
+      const fullPlain = JSON.parse(await decryptData(callBody.encryptedBlob, testKey, blobAad));
       expect(fullPlain.username).toBe("alice");
       expect(fullPlain.password).toBe("password123");
       expect(fullPlain.title).toBe("example.com");
       expect(fullPlain.url).toBe("https://example.com/login");
 
-      const overviewPlain = JSON.parse(await decryptData(callBody.encryptedOverview, testKey, aad));
+      const overviewPlain = JSON.parse(await decryptData(callBody.encryptedOverview, testKey, overviewAad));
       expect(overviewPlain.title).toBe("example.com");
       expect(overviewPlain.username).toBe("alice");
       expect(overviewPlain.urlHost).toBe("example.com");
@@ -289,7 +291,8 @@ describe("login-save", () => {
 
   describe("handleUpdateLogin", () => {
     it("updates password while preserving other fields", async () => {
-      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1);
+      const blobAad = buildPersonalEntryAAD("user-1", TEST_UUID_1, VAULT_TYPE.BLOB);
+      const overviewAad = buildPersonalEntryAAD("user-1", TEST_UUID_1, VAULT_TYPE.OVERVIEW);
       const originalBlob = {
         title: "GitHub",
         username: "alice",
@@ -297,9 +300,9 @@ describe("login-save", () => {
         url: "https://github.com",
         notes: "my notes",
       };
-      const encBlob = await encryptData(JSON.stringify(originalBlob), testKey, aad);
+      const encBlob = await encryptData(JSON.stringify(originalBlob), testKey, blobAad);
       const overviewBlob = { title: "GitHub", username: "alice", urlHost: "github.com" };
-      const encOverview = await encryptData(JSON.stringify(overviewBlob), testKey, aad);
+      const encOverview = await encryptData(JSON.stringify(overviewBlob), testKey, overviewAad);
 
       const mockFetch = vi.fn()
         .mockResolvedValueOnce(
@@ -335,7 +338,7 @@ describe("login-save", () => {
 
       // Verify the updated blob preserves all original fields except password
       const putBody = JSON.parse(putCall[1].body);
-      const updatedBlobPlain = await decryptData(putBody.encryptedBlob, testKey, aad);
+      const updatedBlobPlain = await decryptData(putBody.encryptedBlob, testKey, blobAad);
       const updatedBlob = JSON.parse(updatedBlobPlain);
       expect(updatedBlob.password).toBe("new-password");
       expect(updatedBlob.title).toBe("GitHub");
@@ -379,11 +382,12 @@ describe("login-save", () => {
     });
 
     it("handles non-JSON error response from PUT", async () => {
-      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1);
+      const blobAad = buildPersonalEntryAAD("user-1", TEST_UUID_1, VAULT_TYPE.BLOB);
+      const overviewAad = buildPersonalEntryAAD("user-1", TEST_UUID_1, VAULT_TYPE.OVERVIEW);
       const blob = JSON.stringify({ password: "old" });
-      const encBlob = await encryptData(blob, testKey, aad);
+      const encBlob = await encryptData(blob, testKey, blobAad);
       const overviewBlob = JSON.stringify({ title: "GitHub", username: "alice", urlHost: "github.com" });
-      const encOverview = await encryptData(overviewBlob, testKey, aad);
+      const encOverview = await encryptData(overviewBlob, testKey, overviewAad);
 
       const mockFetch = vi.fn()
         .mockResolvedValueOnce(
@@ -417,7 +421,7 @@ describe("login-save", () => {
         { id: TEST_UUID_2, title: "GitHub (personal)", username: "alice", urlHost: "github.com", entryType: "LOGIN" },
       ];
 
-      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1);
+      const aad = buildPersonalEntryAAD("user-1", TEST_UUID_1, VAULT_TYPE.BLOB);
       const blob = JSON.stringify({ password: "old-password" });
       const encBlob = await encryptData(blob, testKey, aad);
 

--- a/extension/src/__tests__/background-login-save.test.ts
+++ b/extension/src/__tests__/background-login-save.test.ts
@@ -345,6 +345,16 @@ describe("login-save", () => {
       expect(updatedBlob.username).toBe("alice");
       expect(updatedBlob.url).toBe("https://github.com");
       expect(updatedBlob.notes).toBe("my notes");
+
+      // The re-encrypted overview must round-trip with the OVERVIEW AAD —
+      // guards against the blob/overview AADs being crossed on re-encrypt.
+      expect(putBody.encryptedOverview).toBeDefined();
+      const updatedOverview = JSON.parse(
+        await decryptData(putBody.encryptedOverview, testKey, overviewAad),
+      );
+      expect(updatedOverview.title).toBe("GitHub");
+      expect(updatedOverview.username).toBe("alice");
+      expect(updatedOverview.urlHost).toBe("github.com");
     });
 
     it("returns error when vault is locked", async () => {

--- a/extension/src/__tests__/background-passkey-provider.test.ts
+++ b/extension/src/__tests__/background-passkey-provider.test.ts
@@ -3,6 +3,7 @@ import type { DecryptedEntry } from "../types/messages";
 import {
   encryptData,
   buildPersonalEntryAAD,
+  VAULT_TYPE,
 } from "../lib/crypto";
 
 // Must stub chrome before importing passkey-provider
@@ -324,7 +325,7 @@ describe("passkey-provider", () => {
     });
 
     it("returns MISSING_KEY_MATERIAL when blob lacks privateKeyJwk", async () => {
-      const aad = buildPersonalEntryAAD(TEST_USER_ID, TEST_ENTRY_ID);
+      const aad = buildPersonalEntryAAD(TEST_USER_ID, TEST_ENTRY_ID, VAULT_TYPE.BLOB);
       const blob = JSON.stringify({ credentialId: TEST_CRED_ID, relyingPartyId: TEST_RP_ID });
       const encryptedBlob = await encryptData(blob, testKey, aad);
 
@@ -352,7 +353,7 @@ describe("passkey-provider", () => {
       // Build a real encrypted blob with a P-256 key pair
       const { generatePasskeyKeypair } = await import("../lib/webauthn-crypto");
       const { privateKeyJwk } = await generatePasskeyKeypair();
-      const aad = buildPersonalEntryAAD(TEST_USER_ID, TEST_ENTRY_ID);
+      const aad = buildPersonalEntryAAD(TEST_USER_ID, TEST_ENTRY_ID, VAULT_TYPE.BLOB);
       const blob = JSON.stringify({
         credentialId: TEST_CRED_ID,
         relyingPartyId: TEST_RP_ID,
@@ -404,7 +405,7 @@ describe("passkey-provider", () => {
     it("still returns ok:true with signature when counter-update PUT fails (non-fatal)", async () => {
       const { generatePasskeyKeypair } = await import("../lib/webauthn-crypto");
       const { privateKeyJwk } = await generatePasskeyKeypair();
-      const aad = buildPersonalEntryAAD(TEST_USER_ID, TEST_ENTRY_ID);
+      const aad = buildPersonalEntryAAD(TEST_USER_ID, TEST_ENTRY_ID, VAULT_TYPE.BLOB);
       const blob = JSON.stringify({
         credentialId: TEST_CRED_ID,
         relyingPartyId: TEST_RP_ID,
@@ -444,7 +445,7 @@ describe("passkey-provider", () => {
     it("returns SENDER_ORIGIN_MISMATCH when senderUrl hostname does not match stored rpId", async () => {
       const { generatePasskeyKeypair } = await import("../lib/webauthn-crypto");
       const { privateKeyJwk } = await generatePasskeyKeypair();
-      const aad = buildPersonalEntryAAD(TEST_USER_ID, TEST_ENTRY_ID);
+      const aad = buildPersonalEntryAAD(TEST_USER_ID, TEST_ENTRY_ID, VAULT_TYPE.BLOB);
       const blob = JSON.stringify({
         credentialId: TEST_CRED_ID,
         relyingPartyId: TEST_RP_ID, // example.com
@@ -853,7 +854,7 @@ describe("passkey-provider", () => {
         relyingPartyId: TEST_RP_ID,
         username: "alice@example.com",
       });
-      const replaceAad = buildPersonalEntryAAD(TEST_USER_ID, replaceId);
+      const replaceAad = buildPersonalEntryAAD(TEST_USER_ID, replaceId, VAULT_TYPE.BLOB);
       const encryptedReplaceBlob = await encryptData(replaceBlob, testKey, replaceAad);
 
       const swFetch = vi.fn()
@@ -894,7 +895,7 @@ describe("passkey-provider", () => {
         entryType: "LOGIN", // not PASSKEY
         relyingPartyId: TEST_RP_ID,
       });
-      const replaceAad = buildPersonalEntryAAD(TEST_USER_ID, replaceId);
+      const replaceAad = buildPersonalEntryAAD(TEST_USER_ID, replaceId, VAULT_TYPE.BLOB);
       const encryptedReplaceBlob = await encryptData(replaceBlob, testKey, replaceAad);
 
       const swFetch = vi.fn()
@@ -930,7 +931,7 @@ describe("passkey-provider", () => {
         entryType: "PASSKEY",
         relyingPartyId: "other.com", // different rpId
       });
-      const replaceAad = buildPersonalEntryAAD(TEST_USER_ID, replaceId);
+      const replaceAad = buildPersonalEntryAAD(TEST_USER_ID, replaceId, VAULT_TYPE.BLOB);
       const encryptedReplaceBlob = await encryptData(replaceBlob, testKey, replaceAad);
 
       const swFetch = vi.fn()
@@ -967,7 +968,7 @@ describe("passkey-provider", () => {
         relyingPartyId: TEST_RP_ID,
         username: "bob@example.com", // different userName
       });
-      const replaceAad = buildPersonalEntryAAD(TEST_USER_ID, replaceId);
+      const replaceAad = buildPersonalEntryAAD(TEST_USER_ID, replaceId, VAULT_TYPE.BLOB);
       const encryptedReplaceBlob = await encryptData(replaceBlob, testKey, replaceAad);
 
       const swFetch = vi.fn()

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -43,6 +43,7 @@ const cryptoMocks = vi.hoisted(() => ({
   ),
   buildPersonalEntryAAD: vi.fn().mockReturnValue(new Uint8Array([1, 2])),
   hexDecode: vi.fn().mockReturnValue(new Uint8Array([0, 1])),
+  VAULT_TYPE: { BLOB: "blob", OVERVIEW: "overview" },
 }));
 
 vi.mock("../lib/crypto", () => cryptoMocks);
@@ -487,7 +488,8 @@ describe("background message flow", () => {
     });
     expect(cryptoMocks.buildPersonalEntryAAD).toHaveBeenCalledWith(
       "user-1",
-      "pw-1"
+      "pw-1",
+      "overview"
     );
   });
 

--- a/extension/src/__tests__/background/team-entries.test.ts
+++ b/extension/src/__tests__/background/team-entries.test.ts
@@ -14,6 +14,7 @@ const cryptoMocks = vi.hoisted(() => ({
     ),
   buildPersonalEntryAAD: vi.fn().mockReturnValue(new Uint8Array([1, 2])),
   hexDecode: vi.fn().mockReturnValue(new Uint8Array([0, 1])),
+  VAULT_TYPE: { BLOB: "blob", OVERVIEW: "overview" },
 }));
 
 vi.mock("../../lib/crypto", () => cryptoMocks);

--- a/extension/src/__tests__/background/totp-handlers.test.ts
+++ b/extension/src/__tests__/background/totp-handlers.test.ts
@@ -22,6 +22,7 @@ const cryptoMocks = vi.hoisted(() => ({
   ),
   buildPersonalEntryAAD: vi.fn().mockReturnValue(new Uint8Array([1, 2])),
   hexDecode: vi.fn().mockReturnValue(new Uint8Array([0, 1])),
+  VAULT_TYPE: { BLOB: "blob", OVERVIEW: "overview" },
 }));
 
 vi.mock("../../lib/crypto", () => cryptoMocks);

--- a/extension/src/__tests__/crypto-encrypt.test.ts
+++ b/extension/src/__tests__/crypto-encrypt.test.ts
@@ -3,6 +3,7 @@ import {
   encryptData,
   decryptData,
   buildPersonalEntryAAD,
+  VAULT_TYPE,
 } from "../lib/crypto";
 
 // Web Crypto API is available in Node 20+ (vitest uses Node)
@@ -38,7 +39,7 @@ describe("encryptData / decryptData round-trip", () => {
   it("encrypts and decrypts with AAD", async () => {
     const key = await makeTestKey();
     const plaintext = JSON.stringify({ password: "s3cret", username: "alice" });
-    const aad = buildPersonalEntryAAD("user-123", "entry-456");
+    const aad = buildPersonalEntryAAD("user-123", "entry-456", VAULT_TYPE.BLOB);
 
     const encrypted = await encryptData(plaintext, key, aad);
     const decrypted = await decryptData(encrypted, key, aad);
@@ -48,8 +49,8 @@ describe("encryptData / decryptData round-trip", () => {
   it("fails to decrypt with wrong AAD", async () => {
     const key = await makeTestKey();
     const plaintext = "sensitive data";
-    const aad1 = buildPersonalEntryAAD("user-1", "entry-1");
-    const aad2 = buildPersonalEntryAAD("user-2", "entry-2");
+    const aad1 = buildPersonalEntryAAD("user-1", "entry-1", VAULT_TYPE.BLOB);
+    const aad2 = buildPersonalEntryAAD("user-2", "entry-2", VAULT_TYPE.BLOB);
 
     const encrypted = await encryptData(plaintext, key, aad1);
 
@@ -59,7 +60,7 @@ describe("encryptData / decryptData round-trip", () => {
   it("fails to decrypt with no AAD when encrypted with AAD", async () => {
     const key = await makeTestKey();
     const plaintext = "authenticated data";
-    const aad = buildPersonalEntryAAD("user-1", "entry-1");
+    const aad = buildPersonalEntryAAD("user-1", "entry-1", VAULT_TYPE.BLOB);
 
     const encrypted = await encryptData(plaintext, key, aad);
 
@@ -98,7 +99,7 @@ describe("encryptData / decryptData round-trip", () => {
 
   it("handles large JSON payload", async () => {
     const key = await makeTestKey();
-    const aad = buildPersonalEntryAAD("user-big", "entry-big");
+    const aad = buildPersonalEntryAAD("user-big", "entry-big", VAULT_TYPE.BLOB);
     const payload = JSON.stringify({
       title: "Example",
       username: "user@example.com",

--- a/extension/src/__tests__/lib/crypto.test.ts
+++ b/extension/src/__tests__/lib/crypto.test.ts
@@ -8,6 +8,7 @@ import {
   verifyKey,
   decryptData,
   buildPersonalEntryAAD,
+  VAULT_TYPE,
   type EncryptedData,
 } from "../../lib/crypto";
 
@@ -218,36 +219,67 @@ describe("verifyKey", () => {
 
 describe("buildPersonalEntryAAD", () => {
   it("produces deterministic output", () => {
-    const a = buildPersonalEntryAAD("user-1", "entry-1");
-    const b = buildPersonalEntryAAD("user-1", "entry-1");
+    const a = buildPersonalEntryAAD("user-1", "entry-1", VAULT_TYPE.BLOB);
+    const b = buildPersonalEntryAAD("user-1", "entry-1", VAULT_TYPE.BLOB);
     expect(hexEncode(a)).toBe(hexEncode(b));
   });
 
   it("differs for different userId", () => {
-    const a = buildPersonalEntryAAD("user-1", "entry-1");
-    const b = buildPersonalEntryAAD("user-2", "entry-1");
+    const a = buildPersonalEntryAAD("user-1", "entry-1", VAULT_TYPE.BLOB);
+    const b = buildPersonalEntryAAD("user-2", "entry-1", VAULT_TYPE.BLOB);
     expect(hexEncode(a)).not.toBe(hexEncode(b));
   });
 
   it("differs for different entryId", () => {
-    const a = buildPersonalEntryAAD("user-1", "entry-1");
-    const b = buildPersonalEntryAAD("user-1", "entry-2");
+    const a = buildPersonalEntryAAD("user-1", "entry-1", VAULT_TYPE.BLOB);
+    const b = buildPersonalEntryAAD("user-1", "entry-2", VAULT_TYPE.BLOB);
     expect(hexEncode(a)).not.toBe(hexEncode(b));
   });
 
   it("starts with scope 'PV' and version 1", () => {
-    const aad = buildPersonalEntryAAD("u", "e");
+    const aad = buildPersonalEntryAAD("u", "e", VAULT_TYPE.BLOB);
     expect(aad[0]).toBe("P".charCodeAt(0));
     expect(aad[1]).toBe("V".charCodeAt(0));
     expect(aad[2]).toBe(1); // version
-    expect(aad[3]).toBe(2); // field count
+    expect(aad[3]).toBe(3); // field count
   });
 
   it("can be used as AAD for encryption/decryption", async () => {
     const key = await makeTestKey();
-    const aad = buildPersonalEntryAAD("user-1", "entry-1");
+    const aad = buildPersonalEntryAAD("user-1", "entry-1", VAULT_TYPE.BLOB);
     const encrypted = await encrypt("secret-data", key, aad);
     const result = await decryptData(encrypted, key, aad);
     expect(result).toBe("secret-data");
+  });
+
+  // Recurrence guard (mirrors src/__tests__/aad-parity.test.ts and the iOS
+  // AADParityTests): pin the 3-field shape to the cross-implementation golden
+  // vectors so an extension-side AAD regression fails extension-ci.
+  it("matches the frozen 3-field golden vectors", () => {
+    // "PV"(5056) + version 01 + nFields 03 + len(1)"u" + len(1)"e" + len(N)vaultType
+    expect(hexEncode(buildPersonalEntryAAD("u", "e", VAULT_TYPE.BLOB))).toBe(
+      "505601030001750001650004626c6f62",
+    );
+    expect(hexEncode(buildPersonalEntryAAD("u", "e", VAULT_TYPE.OVERVIEW))).toBe(
+      "5056010300017500016500086f76657276696577",
+    );
+  });
+
+  it("binds the vaultType: BLOB and OVERVIEW AADs differ for the same entry", () => {
+    expect(hexEncode(buildPersonalEntryAAD("u", "e", VAULT_TYPE.BLOB))).not.toBe(
+      hexEncode(buildPersonalEntryAAD("u", "e", VAULT_TYPE.OVERVIEW)),
+    );
+  });
+
+  it("anti-vacuous: a BLOB-encrypted field cannot be decrypted with the OVERVIEW AAD", async () => {
+    const key = await makeTestKey();
+    const encrypted = await encrypt(
+      "secret-data",
+      key,
+      buildPersonalEntryAAD("user-1", "entry-1", VAULT_TYPE.BLOB),
+    );
+    await expect(
+      decryptData(encrypted, key, buildPersonalEntryAAD("user-1", "entry-1", VAULT_TYPE.OVERVIEW)),
+    ).rejects.toThrow();
   });
 });

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -6,6 +6,7 @@ import type {
 } from "../types/messages";
 import {
   buildPersonalEntryAAD,
+  VAULT_TYPE,
   decryptData,
   deriveEncryptionKey,
   deriveWrappingKey,
@@ -914,7 +915,7 @@ chrome.commands.onCommand.addListener(async (command) => {
 
         const aad =
           (data.aadVersion ?? 0) >= 1
-            ? buildPersonalEntryAAD(currentUserId!, data.id)
+            ? buildPersonalEntryAAD(currentUserId!, data.id, VAULT_TYPE.BLOB)
             : undefined;
         const plaintext = await decryptData(data.encryptedBlob, encryptionKey!, aad);
         blob = JSON.parse(plaintext) as typeof blob;
@@ -974,7 +975,7 @@ async function decryptOverviews(raw: RawEntry[]): Promise<DecryptedEntry[]> {
   for (const item of active) {
     const aad =
       (item.aadVersion ?? 0) >= 1
-        ? buildPersonalEntryAAD(currentUserId, item.id)
+        ? buildPersonalEntryAAD(currentUserId, item.id, VAULT_TYPE.OVERVIEW)
         : undefined;
     try {
       const plaintext = await decryptData(
@@ -1342,15 +1343,20 @@ async function performAutofillForEntry(
       entryType: string;
     };
 
-    const aad =
-      (data.aadVersion ?? 0) >= 1
-        ? buildPersonalEntryAAD(currentUserId, data.id)
-        : undefined;
-    blobPlain = await decryptData(data.encryptedBlob, encryptionKey, aad);
+    // Dual-field path: blob and overview each need their own AAD (BLOB vs
+    // OVERVIEW) — never share one, or the app-written overview won't decrypt.
+    const useAad = (data.aadVersion ?? 0) >= 1;
+    const blobAad = useAad
+      ? buildPersonalEntryAAD(currentUserId, data.id, VAULT_TYPE.BLOB)
+      : undefined;
+    const overviewAad = useAad
+      ? buildPersonalEntryAAD(currentUserId, data.id, VAULT_TYPE.OVERVIEW)
+      : undefined;
+    blobPlain = await decryptData(data.encryptedBlob, encryptionKey, blobAad);
     overviewPlain = await decryptData(
       data.encryptedOverview,
       encryptionKey,
-      aad,
+      overviewAad,
     );
     entryType = data.entryType;
   }
@@ -1942,7 +1948,7 @@ async function handleMessage(
 
           const aad =
             (data.aadVersion ?? 0) >= 1
-              ? buildPersonalEntryAAD(currentUserId, data.id)
+              ? buildPersonalEntryAAD(currentUserId, data.id, VAULT_TYPE.BLOB)
               : undefined;
           const plaintext = await decryptData(
             data.encryptedBlob,
@@ -2020,7 +2026,7 @@ async function handleMessage(
 
           const aad =
             (data.aadVersion ?? 0) >= 1
-              ? buildPersonalEntryAAD(currentUserId, data.id)
+              ? buildPersonalEntryAAD(currentUserId, data.id, VAULT_TYPE.BLOB)
               : undefined;
           const plaintext = await decryptData(
             data.encryptedBlob,

--- a/extension/src/background/login-save.ts
+++ b/extension/src/background/login-save.ts
@@ -6,6 +6,7 @@ import {
   encryptData,
   decryptData,
   buildPersonalEntryAAD,
+  VAULT_TYPE,
 } from "../lib/crypto";
 import { EXT_API_PATH, extApiPath } from "../lib/api-paths";
 import { readApiErrorBody } from "../lib/api-error-body";
@@ -89,7 +90,7 @@ export async function handleLoginDetected(
 
     const aad =
       (data.aadVersion ?? 0) >= 1
-        ? buildPersonalEntryAAD(userId, data.id)
+        ? buildPersonalEntryAAD(userId, data.id, VAULT_TYPE.BLOB)
         : undefined;
 
     const blobPlain = await decryptData(data.encryptedBlob, encKey, aad);
@@ -136,7 +137,8 @@ export async function handleSaveLogin(
 
   try {
     const entryId = crypto.randomUUID();
-    const aad = buildPersonalEntryAAD(userId, entryId);
+    const blobAad = buildPersonalEntryAAD(userId, entryId, VAULT_TYPE.BLOB);
+    const overviewAad = buildPersonalEntryAAD(userId, entryId, VAULT_TYPE.OVERVIEW);
 
     const fullBlob = JSON.stringify({
       title,
@@ -151,8 +153,8 @@ export async function handleSaveLogin(
       urlHost: host,
     });
 
-    const encryptedBlob = await encryptData(fullBlob, encKey, aad);
-    const encryptedOverview = await encryptData(overviewBlob, encKey, aad);
+    const encryptedBlob = await encryptData(fullBlob, encKey, blobAad);
+    const encryptedOverview = await encryptData(overviewBlob, encKey, overviewAad);
 
     const res = await deps.swFetch(EXT_API_PATH.PASSWORDS, {
       method: "POST",
@@ -210,21 +212,28 @@ export async function handleUpdateLogin(
       id: string;
     };
 
-    const aad =
-      (data.aadVersion ?? 0) >= 1
-        ? buildPersonalEntryAAD(userId, data.id)
-        : undefined;
+    // Per-field AADs: blob and overview must never share an AAD (cross-field
+    // replay protection — matches the app's BLOB/OVERVIEW split).
+    // `?? 1` promotes a null/absent aadVersion to 1; an explicit 0 stays 0
+    // (no-AAD legacy path) — `??` does not fire on 0.
+    const useAad = (data.aadVersion ?? 0) >= 1;
+    const blobAad = useAad
+      ? buildPersonalEntryAAD(userId, data.id, VAULT_TYPE.BLOB)
+      : undefined;
+    const overviewAad = useAad
+      ? buildPersonalEntryAAD(userId, data.id, VAULT_TYPE.OVERVIEW)
+      : undefined;
 
     // Decrypt full blob, update password, re-encrypt
-    const blobPlain = await decryptData(data.encryptedBlob, encKey, aad);
+    const blobPlain = await decryptData(data.encryptedBlob, encKey, blobAad);
     const blob = JSON.parse(blobPlain) as Record<string, unknown>;
     blob.password = newPassword;
 
     // Re-encrypt both blobs (overview stays the same content but needs re-encryption)
-    const overviewPlain = await decryptData(data.encryptedOverview, encKey, aad);
+    const overviewPlain = await decryptData(data.encryptedOverview, encKey, overviewAad);
 
-    const encryptedBlob = await encryptData(JSON.stringify(blob), encKey, aad);
-    const encryptedOverview = await encryptData(overviewPlain, encKey, aad);
+    const encryptedBlob = await encryptData(JSON.stringify(blob), encKey, blobAad);
+    const encryptedOverview = await encryptData(overviewPlain, encKey, overviewAad);
 
     const putRes = await deps.swFetch(extApiPath.passwordById(entryId), {
       method: "PUT",

--- a/extension/src/background/passkey-provider.ts
+++ b/extension/src/background/passkey-provider.ts
@@ -3,6 +3,7 @@ import {
   encryptData,
   decryptData,
   buildPersonalEntryAAD,
+  VAULT_TYPE,
 } from "../lib/crypto";
 import { EXT_API_PATH, extApiPath } from "../lib/api-paths";
 import { readApiErrorBody } from "../lib/api-error-body";
@@ -233,7 +234,9 @@ async function doSignAssertion(
     if ((data.aadVersion ?? 0) < 1) {
       return { ok: false, error: "INVALID_ENTRY" };
     }
-    const aad = buildPersonalEntryAAD(userId, data.id);
+    // Blob-only path: decrypt and re-encrypt the blob; the overview is never
+    // touched here (omitted from the PUT below), so only the BLOB AAD is used.
+    const aad = buildPersonalEntryAAD(userId, data.id, VAULT_TYPE.BLOB);
 
     const blobPlain = await decryptData(data.encryptedBlob, encKey, aad);
     const blob = JSON.parse(blobPlain) as Record<string, unknown>;
@@ -363,7 +366,8 @@ export async function handlePasskeyCreateCredential(
     const attestationObject = buildAttestationObject(authData);
 
     const entryId = crypto.randomUUID();
-    const aad = buildPersonalEntryAAD(currentUserId, entryId);
+    const blobAad = buildPersonalEntryAAD(currentUserId, entryId, VAULT_TYPE.BLOB);
+    const overviewAad = buildPersonalEntryAAD(currentUserId, entryId, VAULT_TYPE.OVERVIEW);
     const title = `${rpName} (${userName})`;
 
     const fullBlob = JSON.stringify({
@@ -393,8 +397,8 @@ export async function handlePasskeyCreateCredential(
       tags: [],
     });
 
-    const encryptedBlob = await encryptData(fullBlob, encKey, aad);
-    const encryptedOverview = await encryptData(overviewBlob, encKey, aad);
+    const encryptedBlob = await encryptData(fullBlob, encKey, blobAad);
+    const encryptedOverview = await encryptData(overviewBlob, encKey, overviewAad);
 
     const res = await deps.swFetch(EXT_API_PATH.PASSWORDS, {
       method: "POST",
@@ -424,7 +428,7 @@ export async function handlePasskeyCreateCredential(
         const targetData = await targetRes.json().catch(() => null) as { encryptedBlob?: EncryptedData; aadVersion?: number; id?: string } | null;
         if (targetData?.encryptedBlob && targetData.id) {
           const targetAad = (targetData.aadVersion ?? 0) >= 1
-            ? buildPersonalEntryAAD(currentUserId, targetData.id)
+            ? buildPersonalEntryAAD(currentUserId, targetData.id, VAULT_TYPE.BLOB)
             : undefined;
           const targetBlob = await decryptData(targetData.encryptedBlob, encKey, targetAad)
             .then((s) => JSON.parse(s) as Record<string, unknown>)

--- a/extension/src/lib/crypto.ts
+++ b/extension/src/lib/crypto.ts
@@ -252,9 +252,20 @@ function buildAADBytes(
   return bytes;
 }
 
+// Mirrors src/lib/crypto/crypto-aad.ts: personal-vault AAD binds
+// userId + entryId + vaultType ("blob" vs "overview") to prevent cross-field
+// ciphertext replay. Must stay byte-identical to the app builder — the
+// aad-parity tests pin this.
+export const VAULT_TYPE = {
+  BLOB: "blob",
+  OVERVIEW: "overview",
+} as const;
+export type VaultType = (typeof VAULT_TYPE)[keyof typeof VAULT_TYPE];
+
 export function buildPersonalEntryAAD(
   userId: string,
-  entryId: string
+  entryId: string,
+  vaultType: VaultType
 ): Uint8Array {
-  return buildAADBytes(SCOPE_PERSONAL, 2, [userId, entryId]);
+  return buildAADBytes(SCOPE_PERSONAL, 3, [userId, entryId, vaultType]);
 }

--- a/ios/PasswdSSOApp/Debug/DebugVaultLoader.swift
+++ b/ios/PasswdSSOApp/Debug/DebugVaultLoader.swift
@@ -160,7 +160,10 @@ public enum DebugVaultLoader {
     userId: String
   ) throws -> [CacheEntry] {
     try fixtureEntries.map { fixture in
-      let aad = try buildPersonalEntryAAD(userId: userId, entryId: fixture.id)
+      let blobAAD = try buildPersonalEntryAAD(
+        userId: userId, entryId: fixture.id, vaultType: VaultType.blob)
+      let overviewAAD = try buildPersonalEntryAAD(
+        userId: userId, entryId: fixture.id, vaultType: VaultType.overview)
 
       let summary = VaultEntrySummary(
         id: fixture.id,
@@ -185,10 +188,10 @@ public enum DebugVaultLoader {
       let detailData = try encoder.encode(detail)
 
       let overviewEncrypted = try encryptAESGCMEncoded(
-        plaintext: overviewData, key: vaultKey, aad: aad
+        plaintext: overviewData, key: vaultKey, aad: overviewAAD
       )
       let blobEncrypted = try encryptAESGCMEncoded(
-        plaintext: detailData, key: vaultKey, aad: aad
+        plaintext: detailData, key: vaultKey, aad: blobAAD
       )
 
       return CacheEntry(

--- a/ios/PasswdSSOApp/Debug/DebugVaultLoader.swift
+++ b/ios/PasswdSSOApp/Debug/DebugVaultLoader.swift
@@ -153,7 +153,7 @@ public enum DebugVaultLoader {
   // MARK: - Private helpers
 
   /// Build fixture CacheEntries with VaultEntrySummary/VaultEntryDetail JSON,
-  /// encrypted with vault_key + buildPersonalEntryAAD(userId, entryId).
+  /// encrypted with vault_key + per-field buildPersonalEntryAAD(userId, entryId, vaultType).
   /// Uses the same encryption format as CredentialResolver expects at decrypt time.
   private static func buildFixtureCacheEntries(
     vaultKey: SymmetricKey,

--- a/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
@@ -100,7 +100,7 @@ public enum VaultViewModelError: Error, Equatable {
       )
     }
     if entry.aadVersion >= 1 {
-      return try buildPersonalEntryAAD(userId: userId, entryId: entry.id)
+      return try buildPersonalEntryAAD(userId: userId, entryId: entry.id, vaultType: vaultType)
     }
     return nil  // legacy aadVersion == 0 entries have no AAD binding
   }
@@ -111,7 +111,7 @@ public enum VaultViewModelError: Error, Equatable {
     userId: String
   ) -> VaultEntrySummary? {
     do {
-      let aad = try buildEntryAAD(entry: entry, userId: userId, vaultType: "overview")
+      let aad = try buildEntryAAD(entry: entry, userId: userId, vaultType: VaultType.overview)
       let plaintext = try decryptAESGCMEncoded(
         encrypted: entry.encryptedOverview,
         key: vaultKey,
@@ -129,7 +129,7 @@ public enum VaultViewModelError: Error, Equatable {
     userId: String
   ) -> VaultEntryDetail? {
     do {
-      let aad = try buildEntryAAD(entry: entry, userId: userId, vaultType: "blob")
+      let aad = try buildEntryAAD(entry: entry, userId: userId, vaultType: VaultType.blob)
       let plaintext = try decryptAESGCMEncoded(
         encrypted: entry.encryptedBlob,
         key: vaultKey,

--- a/ios/PasswdSSOTests/AADParityTests.swift
+++ b/ios/PasswdSSOTests/AADParityTests.swift
@@ -7,27 +7,42 @@ final class AADParityTests: XCTestCase {
   // MARK: - Personal entry
 
   func testPersonalEntryAADByteIdentical() throws {
-    // scope="PV"(2) + version=1(1) + nFields=2(1) + len="u"(2) + "u"(1) + len="e"(2) + "e"(1) = 10
-    let result = try buildPersonalEntryAAD(userId: "u", entryId: "e")
-    let expected: [UInt8] = [
-      0x50, 0x56,       // "PV"
-      0x01,             // aadVersion = 1
-      0x02,             // nFields = 2
-      0x00, 0x01,       // len("u") = 1, big-endian
-      0x75,             // "u"
-      0x00, 0x01,       // len("e") = 1, big-endian
-      0x65,             // "e"
-    ]
-    XCTAssertEqual([UInt8](result), expected)
+    // 3-field shape (byte-identical to crypto-aad.ts since server PR #482):
+    // scope="PV"(2) + version=1(1) + nFields=3(1)
+    //   + len="u"(2)+"u"(1) + len="e"(2)+"e"(1) + len="blob"(2)+"blob"(4)
+    let blobResult = try buildPersonalEntryAAD(userId: "u", entryId: "e", vaultType: VaultType.blob)
+    XCTAssertEqual([UInt8](blobResult), [
+      0x50, 0x56,             // "PV"
+      0x01,                   // aadVersion = 1
+      0x03,                   // nFields = 3
+      0x00, 0x01, 0x75,       // len("u")=1, "u"
+      0x00, 0x01, 0x65,       // len("e")=1, "e"
+      0x00, 0x04, 0x62, 0x6c, 0x6f, 0x62,  // len("blob")=4, "blob"
+    ])
+
+    // overview differs only in the trailing vaultType field — proves the
+    // per-field discriminator is present (cross-field replay protection).
+    let overviewResult = try buildPersonalEntryAAD(
+      userId: "u", entryId: "e", vaultType: VaultType.overview)
+    XCTAssertEqual([UInt8](overviewResult), [
+      0x50, 0x56,
+      0x01,
+      0x03,
+      0x00, 0x01, 0x75,
+      0x00, 0x01, 0x65,
+      0x00, 0x08, 0x6f, 0x76, 0x65, 0x72, 0x76, 0x69, 0x65, 0x77,  // len("overview")=8, "overview"
+    ])
+    XCTAssertNotEqual([UInt8](blobResult), [UInt8](overviewResult))
   }
 
   func testPersonalEntryAADMultiByteFields() throws {
-    let result = try buildPersonalEntryAAD(userId: "user123", entryId: "entry456")
+    let result = try buildPersonalEntryAAD(
+      userId: "user123", entryId: "entry456", vaultType: VaultType.blob)
 
     XCTAssertEqual(result[0], UInt8(ascii: "P"))
     XCTAssertEqual(result[1], UInt8(ascii: "V"))
     XCTAssertEqual(result[2], 0x01)
-    XCTAssertEqual(result[3], 0x02)
+    XCTAssertEqual(result[3], 0x03)  // nFields = 3
     // field 1 length: big-endian 7
     XCTAssertEqual(result[4], 0x00)
     XCTAssertEqual(result[5], 0x07)
@@ -37,6 +52,10 @@ final class AADParityTests: XCTestCase {
     XCTAssertEqual(result[13], 0x00)
     XCTAssertEqual(result[14], 0x08)
     XCTAssertEqual([UInt8](result[15..<23]), Array("entry456".utf8))
+    // field 3 (vaultType): len("blob")=4, "blob"
+    XCTAssertEqual(result[23], 0x00)
+    XCTAssertEqual(result[24], 0x04)
+    XCTAssertEqual([UInt8](result[25..<29]), Array("blob".utf8))
   }
 
   // MARK: - Team entry
@@ -85,7 +104,7 @@ final class AADParityTests: XCTestCase {
   func testFieldLengthIsBigEndian() throws {
     // A field of length 256 should serialize as [0x01, 0x00], not [0x00, 0x01]
     let longField = String(repeating: "a", count: 256)
-    let result = try buildPersonalEntryAAD(userId: longField, entryId: "x")
+    let result = try buildPersonalEntryAAD(userId: longField, entryId: "x", vaultType: VaultType.blob)
 
     // After header (4 bytes), first field length at offset 4-5
     XCTAssertEqual(result[4], 0x01)  // high byte
@@ -95,7 +114,7 @@ final class AADParityTests: XCTestCase {
   // MARK: - Version and nFields in header
 
   func testHeaderVersionIsOne() throws {
-    let result = try buildPersonalEntryAAD(userId: "a", entryId: "b")
+    let result = try buildPersonalEntryAAD(userId: "a", entryId: "b", vaultType: VaultType.blob)
     XCTAssertEqual(result[2], 0x01)
   }
 }

--- a/ios/PasswdSSOTests/CredentialResolverTests.swift
+++ b/ios/PasswdSSOTests/CredentialResolverTests.swift
@@ -163,10 +163,10 @@ private func makePersonalCacheEntry(
   keyVersion: Int = 1
 ) throws -> CacheEntry {
   let overviewAAD: Data? = aadVersion >= 1
-    ? try buildPersonalEntryAAD(userId: userId, entryId: summary.id)
+    ? try buildPersonalEntryAAD(userId: userId, entryId: summary.id, vaultType: VaultType.overview)
     : nil
   let blobAAD: Data? = aadVersion >= 1
-    ? try buildPersonalEntryAAD(userId: userId, entryId: detail.id)
+    ? try buildPersonalEntryAAD(userId: userId, entryId: detail.id, vaultType: VaultType.blob)
     : nil
   return CacheEntry(
     id: summary.id,
@@ -190,10 +190,10 @@ private func makeTeamCacheEntry(
 ) throws -> CacheEntry {
   let entryId = summary.id
   let overviewAAD = try buildTeamEntryAAD(
-    teamId: teamId, entryId: entryId, vaultType: "overview", itemKeyVersion: itemKeyVersion
+    teamId: teamId, entryId: entryId, vaultType: VaultType.overview, itemKeyVersion: itemKeyVersion
   )
   let blobAAD = try buildTeamEntryAAD(
-    teamId: teamId, entryId: entryId, vaultType: "blob", itemKeyVersion: itemKeyVersion
+    teamId: teamId, entryId: entryId, vaultType: VaultType.blob, itemKeyVersion: itemKeyVersion
   )
 
   let (entryKey, encryptedItemKey): (SymmetricKey, EncryptedData?)
@@ -854,10 +854,10 @@ final class CredentialResolverTests: XCTestCase {
     )
     // itemKeyVersion=1 but encryptedItemKey=nil → resolver must filter this entry
     let overviewAAD = try buildTeamEntryAAD(
-      teamId: teamId, entryId: "te-missing", vaultType: "overview", itemKeyVersion: 1
+      teamId: teamId, entryId: "te-missing", vaultType: VaultType.overview, itemKeyVersion: 1
     )
     let blobAAD = try buildTeamEntryAAD(
-      teamId: teamId, entryId: "te-missing", vaultType: "blob", itemKeyVersion: 1
+      teamId: teamId, entryId: "te-missing", vaultType: VaultType.blob, itemKeyVersion: 1
     )
     let brokenEntry = CacheEntry(
       id: "te-missing",
@@ -910,10 +910,10 @@ final class CredentialResolverTests: XCTestCase {
     )
     // Encrypt overview with vaultType="blob" AAD (wrong — resolver will try "overview")
     let wrongAAD = try buildTeamEntryAAD(
-      teamId: teamId, entryId: "te-wrong-aad", vaultType: "blob", itemKeyVersion: 0
+      teamId: teamId, entryId: "te-wrong-aad", vaultType: VaultType.blob, itemKeyVersion: 0
     )
     let blobAAD = try buildTeamEntryAAD(
-      teamId: teamId, entryId: "te-wrong-aad", vaultType: "blob", itemKeyVersion: 0
+      teamId: teamId, entryId: "te-wrong-aad", vaultType: VaultType.blob, itemKeyVersion: 0
     )
     let wrongEntry = CacheEntry(
       id: "te-wrong-aad",

--- a/ios/PasswdSSOTests/CredentialResolverTests.swift
+++ b/ios/PasswdSSOTests/CredentialResolverTests.swift
@@ -153,7 +153,7 @@ private func encryptDetail(
 }
 
 /// Build a personal CacheEntry with AAD-bound ciphertext.
-/// aadVersion >= 1 → encrypt with buildPersonalEntryAAD(userId, entryId).
+/// aadVersion >= 1 → encrypt each field with buildPersonalEntryAAD(userId, entryId, vaultType).
 private func makePersonalCacheEntry(
   summary: VaultEntrySummary,
   detail: VaultEntryDetail,
@@ -162,11 +162,13 @@ private func makePersonalCacheEntry(
   aadVersion: Int,
   keyVersion: Int = 1
 ) throws -> CacheEntry {
+  // Both fields belong to the same entry — bind to one canonical entryId.
+  let entryId = summary.id
   let overviewAAD: Data? = aadVersion >= 1
-    ? try buildPersonalEntryAAD(userId: userId, entryId: summary.id, vaultType: VaultType.overview)
+    ? try buildPersonalEntryAAD(userId: userId, entryId: entryId, vaultType: VaultType.overview)
     : nil
   let blobAAD: Data? = aadVersion >= 1
-    ? try buildPersonalEntryAAD(userId: userId, entryId: detail.id, vaultType: VaultType.blob)
+    ? try buildPersonalEntryAAD(userId: userId, entryId: entryId, vaultType: VaultType.blob)
     : nil
   return CacheEntry(
     id: summary.id,

--- a/ios/PasswdSSOTests/EntryEncrypterTests.swift
+++ b/ios/PasswdSSOTests/EntryEncrypterTests.swift
@@ -79,6 +79,26 @@ final class EntryEncrypterTests: XCTestCase {
     )
   }
 
+  // MARK: - Cross-field AAD fails (anti-vacuous)
+
+  func testEncryptPersonalEntry_blobCannotDecryptWithOverviewAAD() throws {
+    let (blobEnc, _) = try encryptPersonalEntry(
+      entryId: entryId,
+      userId: userId,
+      vaultKey: vaultKey,
+      detail: sampleDetail,
+      overview: sampleOverview
+    )
+
+    // Same user + entry, wrong vaultType → must fail (cross-field replay guard).
+    let overviewAAD = try buildPersonalEntryAAD(
+      userId: userId, entryId: entryId, vaultType: VaultType.overview)
+
+    XCTAssertThrowsError(
+      try decryptAESGCMEncoded(encrypted: blobEnc, key: vaultKey, aad: overviewAAD)
+    )
+  }
+
   // MARK: - Independent IVs
 
   func testEncryptPersonalEntry_blobAndOverviewIndependentIVs() throws {

--- a/ios/PasswdSSOTests/EntryEncrypterTests.swift
+++ b/ios/PasswdSSOTests/EntryEncrypterTests.swift
@@ -42,10 +42,15 @@ final class EntryEncrypterTests: XCTestCase {
       overview: sampleOverview
     )
 
-    let aad = try buildPersonalEntryAAD(userId: userId, entryId: entryId)
+    // Per-field AADs — must match what encryptPersonalEntry used per field.
+    let blobAAD = try buildPersonalEntryAAD(
+      userId: userId, entryId: entryId, vaultType: VaultType.blob)
+    let overviewAAD = try buildPersonalEntryAAD(
+      userId: userId, entryId: entryId, vaultType: VaultType.overview)
 
-    let blobData = try decryptAESGCMEncoded(encrypted: blobEnc, key: vaultKey, aad: aad)
-    let overviewData = try decryptAESGCMEncoded(encrypted: overviewEnc, key: vaultKey, aad: aad)
+    let blobData = try decryptAESGCMEncoded(encrypted: blobEnc, key: vaultKey, aad: blobAAD)
+    let overviewData = try decryptAESGCMEncoded(
+      encrypted: overviewEnc, key: vaultKey, aad: overviewAAD)
 
     let decodedDetail = try JSONDecoder().decode(EntryPlaintext.self, from: blobData)
     let decodedOverview = try JSONDecoder().decode(OverviewPlaintext.self, from: overviewData)
@@ -66,7 +71,8 @@ final class EntryEncrypterTests: XCTestCase {
     )
 
     // Different userId → different AAD → should fail authentication
-    let wrongAAD = try buildPersonalEntryAAD(userId: "other-user", entryId: entryId)
+    let wrongAAD = try buildPersonalEntryAAD(
+      userId: "other-user", entryId: entryId, vaultType: VaultType.blob)
 
     XCTAssertThrowsError(
       try decryptAESGCMEncoded(encrypted: blobEnc, key: vaultKey, aad: wrongAAD)

--- a/ios/Shared/AutoFill/CredentialResolver.swift
+++ b/ios/Shared/AutoFill/CredentialResolver.swift
@@ -315,7 +315,7 @@ public actor CredentialResolver {
     key: SymmetricKey,
     userId: String
   ) -> VaultEntrySummary? {
-    let aad = buildEntryAAD(entry: entry, vaultType: "overview", userId: userId)
+    let aad = buildEntryAAD(entry: entry, vaultType: VaultType.overview, userId: userId)
     guard
       let ivData = try? hexDecode(entry.encryptedOverview.iv),
       let cipherData = try? hexDecode(entry.encryptedOverview.ciphertext),
@@ -339,7 +339,7 @@ public actor CredentialResolver {
     key: SymmetricKey,
     userId: String
   ) -> VaultEntryDetail? {
-    let aad = buildEntryAAD(entry: entry, vaultType: "blob", userId: userId)
+    let aad = buildEntryAAD(entry: entry, vaultType: VaultType.blob, userId: userId)
     guard
       let ivData = try? hexDecode(entry.encryptedBlob.iv),
       let cipherData = try? hexDecode(entry.encryptedBlob.ciphertext),
@@ -375,7 +375,7 @@ public actor CredentialResolver {
       )
     } else {
       guard entry.aadVersion >= 1 else { return nil }
-      return try? buildPersonalEntryAAD(userId: userId, entryId: entry.id)
+      return try? buildPersonalEntryAAD(userId: userId, entryId: entry.id, vaultType: vaultType)
     }
   }
 

--- a/ios/Shared/Crypto/AAD.swift
+++ b/ios/Shared/Crypto/AAD.swift
@@ -15,6 +15,13 @@ public enum AADScope: String {
   case itemKey = "IK"
 }
 
+/// Vault-field discriminators used in the AAD `vaultType` field, mirroring
+/// crypto-aad.ts `VAULT_TYPE`. Used by both personal and team entry AADs.
+public enum VaultType {
+  public static let blob = "blob"
+  public static let overview = "overview"
+}
+
 /// Build the length-prefixed binary AAD from scope + fields.
 /// All multi-byte integers are big-endian per plan §"Encrypted-entries cache integrity".
 public func buildAADBytes(scope: AADScope, fields: [String]) throws -> Data {
@@ -50,9 +57,18 @@ public func buildAADBytes(scope: AADScope, fields: [String]) throws -> Data {
   return data
 }
 
-/// Build AAD for a personal vault entry (userId, entryId).
-public func buildPersonalEntryAAD(userId: String, entryId: String) throws -> Data {
-  try buildAADBytes(scope: .personal, fields: [userId, entryId])
+/// Build AAD for a personal vault entry (userId, entryId, vaultType).
+/// vaultType ("blob" vs "overview") prevents cross-field ciphertext replay and
+/// is REQUIRED — it must match the field being encrypted/decrypted (3-field
+/// shape, byte-identical to crypto-aad.ts since server PR #482). String-typed
+/// to match buildTeamEntryAAD and the vaultType already threaded by
+/// CredentialResolver / VaultViewModel.
+public func buildPersonalEntryAAD(
+  userId: String,
+  entryId: String,
+  vaultType: String
+) throws -> Data {
+  try buildAADBytes(scope: .personal, fields: [userId, entryId, vaultType])
 }
 
 /// Build AAD for a team vault entry (teamId, entryId, vaultType, itemKeyVersion).
@@ -60,7 +76,7 @@ public func buildPersonalEntryAAD(userId: String, entryId: String) throws -> Dat
 public func buildTeamEntryAAD(
   teamId: String,
   entryId: String,
-  vaultType: String = "blob",
+  vaultType: String = VaultType.blob,
   itemKeyVersion: Int = 0
 ) throws -> Data {
   try buildAADBytes(scope: .team, fields: [teamId, entryId, vaultType, String(itemKeyVersion)])

--- a/ios/Shared/Vault/EntryEncrypter.swift
+++ b/ios/Shared/Vault/EntryEncrypter.swift
@@ -60,8 +60,9 @@ public enum EntryEncrypterError: Error, Equatable {
 
 // MARK: - Encrypt helper
 
-/// Encrypts both the full entry plaintext (blob) and the overview-summary plaintext
-/// with the personal-vault AAD `buildPersonalEntryAAD(userId, entryId)`.
+/// Encrypts the full entry plaintext (blob) and the overview-summary plaintext,
+/// each with its own personal-vault AAD (BLOB vs OVERVIEW) — they must never
+/// share an AAD (cross-field replay protection).
 public func encryptPersonalEntry(
   entryId: String,
   userId: String,
@@ -69,16 +70,19 @@ public func encryptPersonalEntry(
   detail: EntryPlaintext,
   overview: OverviewPlaintext
 ) throws -> (blob: EncryptedData, overview: EncryptedData) {
-  let aad = try buildPersonalEntryAAD(userId: userId, entryId: entryId)
+  let blobAAD = try buildPersonalEntryAAD(
+    userId: userId, entryId: entryId, vaultType: VaultType.blob)
+  let overviewAAD = try buildPersonalEntryAAD(
+    userId: userId, entryId: entryId, vaultType: VaultType.overview)
   let encoder = JSONEncoder()
 
   let detailData = try encoder.encode(detail)
   let overviewData = try encoder.encode(overview)
 
   do {
-    let blobEncrypted = try encryptAESGCMEncoded(plaintext: detailData, key: vaultKey, aad: aad)
+    let blobEncrypted = try encryptAESGCMEncoded(plaintext: detailData, key: vaultKey, aad: blobAAD)
     let overviewEncrypted = try encryptAESGCMEncoded(
-      plaintext: overviewData, key: vaultKey, aad: aad)
+      plaintext: overviewData, key: vaultKey, aad: overviewAAD)
     return (blob: blobEncrypted, overview: overviewEncrypted)
   } catch {
     throw EntryEncrypterError.encryptionFailed

--- a/src/__tests__/aad-parity.test.ts
+++ b/src/__tests__/aad-parity.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildPersonalEntryAAD as appBuildPersonalEntryAAD,
+  VAULT_TYPE as APP_VAULT_TYPE,
+} from "@/lib/crypto/crypto-aad";
+import { encryptData } from "@/lib/crypto/crypto-client";
+import {
+  buildPersonalEntryAAD as extBuildPersonalEntryAAD,
+  VAULT_TYPE as EXT_VAULT_TYPE,
+  decryptData as extDecryptData,
+} from "../../extension/src/lib/crypto";
+
+// Recurrence guard for the desync fixed in fix/ext-personal-aad-3field-sync:
+// the app moved the personal-vault AAD to a 3-field shape (#482) and the
+// extension was not updated, silently breaking decryption. This test fails
+// the moment the app personal AAD diverges from the extension's. The frozen
+// golden vectors additionally pin the absolute shape so a change that breaks
+// BOTH sides identically still fails. (iOS pins the same vectors in
+// ios/PasswdSSOTests/AADParityTests.swift; team/history AADs are out of scope.)
+
+const toHex = (b: Uint8Array) =>
+  Array.from(b)
+    .map((x) => x.toString(16).padStart(2, "0"))
+    .join("");
+
+// "PV"(5056) + version 01 + nFields 03 + len(1)"u" + len(1)"e" + len(N)vaultType
+const GOLDEN_BLOB = "505601030001750001650004626c6f62";
+const GOLDEN_OVERVIEW = "5056010300017500016500086f76657276696577";
+
+describe("personal-vault AAD parity (app ↔ extension)", () => {
+  const userId = "u";
+  const entryId = "e";
+
+  it("produces identical BLOB AAD bytes across app and extension", () => {
+    expect(toHex(extBuildPersonalEntryAAD(userId, entryId, EXT_VAULT_TYPE.BLOB))).toBe(
+      toHex(appBuildPersonalEntryAAD(userId, entryId, APP_VAULT_TYPE.BLOB)),
+    );
+  });
+
+  it("produces identical OVERVIEW AAD bytes across app and extension", () => {
+    expect(toHex(extBuildPersonalEntryAAD(userId, entryId, EXT_VAULT_TYPE.OVERVIEW))).toBe(
+      toHex(appBuildPersonalEntryAAD(userId, entryId, APP_VAULT_TYPE.OVERVIEW)),
+    );
+  });
+
+  it("matches the frozen 3-field golden vectors (both implementations)", () => {
+    expect(toHex(appBuildPersonalEntryAAD(userId, entryId, APP_VAULT_TYPE.BLOB))).toBe(GOLDEN_BLOB);
+    expect(toHex(extBuildPersonalEntryAAD(userId, entryId, EXT_VAULT_TYPE.BLOB))).toBe(GOLDEN_BLOB);
+    expect(toHex(appBuildPersonalEntryAAD(userId, entryId, APP_VAULT_TYPE.OVERVIEW))).toBe(
+      GOLDEN_OVERVIEW,
+    );
+    expect(toHex(extBuildPersonalEntryAAD(userId, entryId, EXT_VAULT_TYPE.OVERVIEW))).toBe(
+      GOLDEN_OVERVIEW,
+    );
+  });
+
+  it("uses the 3-field shape (nFields byte = 3), differing from the legacy 2-field AAD", () => {
+    expect(extBuildPersonalEntryAAD(userId, entryId, EXT_VAULT_TYPE.BLOB)[3]).toBe(3);
+  });
+
+  it("produces identical bytes for non-ASCII (UTF-8) identifiers", () => {
+    const u = "ユーザー";
+    const e = "エントリ";
+    expect(toHex(extBuildPersonalEntryAAD(u, e, EXT_VAULT_TYPE.OVERVIEW))).toBe(
+      toHex(appBuildPersonalEntryAAD(u, e, APP_VAULT_TYPE.OVERVIEW)),
+    );
+  });
+
+  it("cross-decrypt: app-encrypted overview decrypts in the extension with the matching OVERVIEW AAD", async () => {
+    const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, [
+      "encrypt",
+      "decrypt",
+    ]);
+    const payload = JSON.stringify({ title: "t", username: "user", urlHost: "example.com" });
+    const enc = await encryptData(
+      payload,
+      key,
+      appBuildPersonalEntryAAD(userId, entryId, APP_VAULT_TYPE.OVERVIEW),
+    );
+    const dec = await extDecryptData(
+      enc,
+      key,
+      extBuildPersonalEntryAAD(userId, entryId, EXT_VAULT_TYPE.OVERVIEW),
+    );
+    expect(dec).toBe(payload);
+  });
+
+  it("anti-vacuous: a BLOB-encrypted field fails to decrypt with the OVERVIEW AAD", async () => {
+    const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, [
+      "encrypt",
+      "decrypt",
+    ]);
+    const enc = await encryptData(
+      "secret",
+      key,
+      appBuildPersonalEntryAAD(userId, entryId, APP_VAULT_TYPE.BLOB),
+    );
+    await expect(
+      extDecryptData(enc, key, extBuildPersonalEntryAAD(userId, entryId, EXT_VAULT_TYPE.OVERVIEW)),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

The web app moved the personal-vault AAD (AES-256-GCM additional authenticated data) from a 2-field shape `(userId, entryId)` to a **3-field** shape `(userId, entryId, vaultType)` in `#482`. The browser extension and the iOS app were **not** updated and kept building the 2-field AAD, so neither could decrypt any personal entry (login, credit card, identity, passkey) written by the current app. The user-visible symptom was a newly-created credit card never appearing in the extension popup.

In both the extension and iOS, the **team** AAD had already been migrated to the vaultType-aware shape — only the **personal** AAD was left behind.

## Changes

**Extension** (`extension/`)
- `buildPersonalEntryAAD` now takes a required `vaultType` (`VAULT_TYPE.BLOB` / `VAULT_TYPE.OVERVIEW`) and emits the 3-field AAD.
- All 11 call sites updated. Dual-field paths (`performAutofillForEntry`, `handleSaveLogin`, `handleUpdateLogin`, passkey create) now use **distinct** blob/overview AADs — never one shared AAD — preserving cross-field replay protection. `aadVersion` gating is unchanged.

**iOS** (`ios/`)
- Same fix in `AAD.swift` + `EntryEncrypter` / `CredentialResolver` / `VaultViewModel` / `DebugVaultLoader`.
- Introduced a `VaultType` constant (`blob` / `overview`); no raw string literals remain in iOS AAD code.

**Recurrence prevention**
- New cross-implementation parity guards pin the exact AAD bytes so a one-sided change fails CI:
  - `src/__tests__/aad-parity.test.ts` — app ↔ extension byte equality + frozen golden vectors + a real cross-decrypt (app-encrypt → extension-decrypt) + an anti-vacuous cross-field-throw test (runs under `app-ci`).
  - `extension/src/__tests__/lib/crypto.test.ts` — extension-side golden guard (runs under `extension-ci`).
  - `ios/PasswdSSOTests/AADParityTests.swift` — iOS golden guard. Its pre-existing test had pinned the **wrong** 2-field golden, which is exactly why the `#482` drift went undetected; it now pins the correct 3-field bytes.

## Scope / notes

- **No data migration** (per request): entries written by the *old* extension/iOS under the 2-field AAD are not back-supported; the app already could not read pre-`#482` 2-field entries either.
- Out of scope: inline in-page credit-card autofill suggestions (the `cc-form-detector` is unwired and `GET_MATCHES_FOR_URL` is LOGIN-only) — a separate feature, to be handled in a follow-up PR. This PR fixes the popup list + manual fill path.

## Verification

- Root: `npx vitest run` → 10764 passed (incl. the new parity test).
- Extension: `npm test` → 694 passed; `npm run build` clean; **confirmed on a real credit-card checkout form** — the card now appears under "Other entries" and autofill works.
- iOS: `xcodebuild ... test` → **TEST SUCCEEDED** (incl. AADParity / EntryEncrypter / CredentialResolver tests).
- Three-round triangulate review (plan + code) with functionality / security / testing experts; all findings resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)