### PR TITLE
feat(ext): inline in-page autofill suggestions for credit cards and identities

### DIFF
--- a/docs/archive/review/ext-inline-cc-identity-autofill-plan.md
+++ b/docs/archive/review/ext-inline-cc-identity-autofill-plan.md
@@ -1,0 +1,158 @@
+# Plan: Inline in-page autofill suggestions for CREDIT_CARD and IDENTITY
+
+Date: 2026-05-31
+Intended branch: `feature/ext-inline-cc-identity-autofill` (to be cut from **main after #503 merges** — needs the 3-field AAD fix so CC/IDENTITY entries decrypt at all)
+Status: PLAN ONLY — implementation deferred until #503 is merged.
+
+## Project context
+
+- **Type**: browser extension (`extension/`) feature addition. Touches content scripts, background service worker, dropdown UI, i18n, manifest web-accessible resources (already present), and tests.
+- **Test infrastructure**: unit + integration (Vitest, `cd extension && npm test`). Parallel `.js` (production content scripts) + `-lib.ts` (testable logic) files — see project memory [[project_extension_parallel_impl]].
+- **Depends on**: `#503` (3-field AAD) merged — without it CC/IDENTITY overviews don't decrypt, so there is nothing to suggest.
+
+## Objective
+
+Credit-card and identity entries currently appear only in the extension **popup** ("Other entries") and fill via the manual popup button. There is **no in-page inline suggestion**: focusing a `cc-number` (or address/name) field on a web form shows nothing. Wire the existing-but-unused CC/IDENTITY detection + fill infrastructure into the same inline pipeline that LOGIN already uses, so focusing a card/identity field shows a suggestion dropdown and selecting an entry fills the form.
+
+### What already exists (do NOT rebuild)
+- Detection libs: `cc-form-detector-lib.ts` (`detectCreditCardFields`), `identity-form-detector-lib.ts` (`detectIdentityFields`).
+- Fill libs + content listeners: `autofill-cc.js` (`AUTOFILL_CC_FILL` → `performCreditCardAutofill`), `autofill-identity.js` (`AUTOFILL_IDENTITY_FILL` → `performIdentityAutofill`); both are web-accessible resources already injected on demand by `performAutofillForEntry` (`background/index.ts`).
+- The fill dispatch: `performAutofillForEntry` already branches on `entryType` and sends `AUTOFILL_CC_FILL` / `AUTOFILL_IDENTITY_FILL` (injecting the right content script first). **So the select→fill half is done.**
+- Dropdown UI: `content/ui/suggestion-dropdown.ts` (`showDropdown`), currently LOGIN-specific (icons + header label).
+- Popup already lists CC/IDENTITY and fills them — confirms decryption + `AUTOFILL_FROM_CONTENT` dispatch work end-to-end.
+
+### What is missing (the wiring)
+1. No `initCreditCardDetector()` / `initIdentityDetector()` — nothing registers focus listeners on card/identity fields.
+2. `form-detector.ts` entry point only inits LOGIN.
+3. Background `GET_MATCHES_FOR_URL` (`index.ts:~2140`) returns LOGIN-only.
+4. Dropdown UI is hard-coded to LOGIN (icons, header).
+
+## Requirements
+
+### Functional
+1. Focusing a field that `detectCreditCardFields` identifies as part of a CC form shows an inline dropdown listing the user's CREDIT_CARD entries; selecting one fills the card fields via the existing `AUTOFILL_CC_FILL` path.
+2. Same for IDENTITY via `detectIdentityFields` → `AUTOFILL_IDENTITY_FILL`.
+3. CC/IDENTITY matches are **URL-independent** (cards/identities are not site-specific — they have no `urlHost`). Unlike LOGIN, they are NOT host-filtered: all of the user's CC (resp. IDENTITY) entries are offered on any page presenting a matching form. This mirrors native browser autofill and the popup's "Other entries" behavior.
+4. The same gates as LOGIN apply: only when inline suggestions are enabled (`cachedEnableInlineSuggestions`), the vault is unlocked, and the page is not the passwd-sso app's own page; disconnected/locked states surface the same dropdown messages.
+5. The LOGIN inline path is unchanged (no regression).
+
+### Non-functional
+6. No duplication of the background match/gate logic — LOGIN, CC, IDENTITY share one helper that differs only by entry-type filter + whether host-matching applies.
+7. New user-facing strings added to BOTH `messages/en.json` and `messages/ja.json` (content-script header labels). Japanese per existing content-script tone; no internal jargon ([[feedback_no_internal_jargon_in_user_strings]]).
+
+## Technical approach
+
+- Add `initCreditCardDetector()` / `initIdentityDetector()` to the respective `-lib.ts` files, mirroring `initFormDetector()` (focus listener + suppression window + dropdown). The focus trigger fires when the focused input is one of the fields returned by `detectCreditCardFields(document)` / `detectIdentityFields(document)`.
+- `form-detector.ts` initializes all three detectors and tears them down together on context-invalidation.
+- Background: extract the existing `GET_MATCHES_FOR_URL` body into a shared `resolveInlineMatches(kind, effectiveUrl)` helper; LOGIN keeps host-matching, CC/IDENTITY return all entries of that type. Add `GET_CC_MATCHES_FOR_URL` / `GET_IDENTITY_MATCHES_FOR_URL` message handlers that call the helper (the URL is still needed for the own-app/disconnected gates).
+- Dropdown: parametrize `showDropdown` with an `entryType` (drives icon + header label); the per-entry display uses `title` (+ `username`/cardholder) from the already-decrypted overview. Card numbers are NOT in the overview, so nothing sensitive beyond what the popup shows is rendered.
+- Select → reuse existing `AUTOFILL_FROM_CONTENT` (it dispatches by entryType). No new fill path.
+
+## Contracts
+
+### C1 — Message constants
+- **File**: `extension/src/lib/constants.ts` — add to `EXT_MSG`: `GET_CC_MATCHES_FOR_URL`, `GET_IDENTITY_MATCHES_FOR_URL`. Also promote the currently-hardcoded `"AUTOFILL_CC_FILL"` / `"AUTOFILL_IDENTITY_FILL"` strings to `EXT_MSG` constants and reference them from both background and the `.js`/`-lib.ts` listeners (R2: stop hardcoding the literal in 2+ places).
+- **Acceptance**: no new bare message-string literals; all via `EXT_MSG`.
+
+### C2 — Background shared match helper + new handlers
+- **File**: `extension/src/background/index.ts`
+- Extract `GET_MATCHES_FOR_URL`'s gate+filter body into `async function resolveInlineMatches(kind: "login" | "credit_card" | "identity", effectiveUrl, senderTabId?)` returning the same response shape `{ entries, vaultLocked, suppressInline, disconnected? }`. LOGIN branch keeps `entryType === LOGIN` + host match; CC/IDENTITY branches filter `entryType === CREDIT_CARD`/`IDENTITY` with **no** host match.
+- `GET_MATCHES_FOR_URL` delegates to `resolveInlineMatches("login", …)` (behavior identical to today — verify byte-for-byte in tests). New `GET_CC_MATCHES_FOR_URL` / `GET_IDENTITY_MATCHES_FOR_URL` delegate with their kind.
+- **Invariant**: all gates (`cachedEnableInlineSuggestions`, `isOwnAppPage`, `!currentToken` → disconnected, `!encryptionKey` → vaultLocked) are applied identically across all three kinds. The badge-update side effect and the in-process cache population stay on the LOGIN path only (badge counts logins).
+- **F4 — `!tabHost` guard is LOGIN-only**: the current handler early-returns empty when `extractHost(effectiveUrl)` is null (e.g. `file://`). For LOGIN that's fine (no host = no match). For CC/IDENTITY (no host matching at all) the helper MUST skip that guard and still return all type-matching entries.
+- **F5 — SW error-fallback**: the catch/error path that currently emits a graceful empty response for `GET_MATCHES_FOR_URL` must add equivalent cases for `GET_CC_MATCHES_FOR_URL` / `GET_IDENTITY_MATCHES_FOR_URL`, so the content script always gets a response (no dangling `lastError`).
+- **Consumer-flow walkthrough**: the content dropdown reads `{ entries: DecryptedEntry[], vaultLocked, disconnected, suppressInline }`; each entry needs `{ id, title, username, teamId? }` for display and `id`/`teamId` for the subsequent `AUTOFILL_FROM_CONTENT`. `decryptOverviews` (`index.ts:~1003`) populates `username = overview.username ?? cardholderName ?? fullName ?? ""` — so CC shows the cardholder, IDENTITY the full name. ✅
+- **Acceptance**: LOGIN response byte-identical to today (locked by the T1 regression test); CC/IDENTITY return all type-matching entries regardless of host incl. on hostless pages; gates identical; error path covers the new types.
+
+### C3 — CC detector init (mirrors LOGIN, with the gotchas made explicit)
+- **File**: `extension/src/content/cc-form-detector-lib.ts` — `export function initCreditCardDetector(): { destroy: () => void }`. Required behaviors (NOT just "mirror initFormDetector" — these are the parts that bite):
+  - **S2 cross-origin guard (mandatory)**: if `window.top !== window.self` and `window.top.location` is inaccessible (cross-origin subframe), return a no-op `{ destroy: () => {} }` immediately — same as `initFormDetector`. Prevents a malicious iframe rendering a deceptive card dropdown.
+  - **F2 field-membership via WeakSet (mandatory, not per-focus DOM scan)**: maintain a `WeakSet<HTMLElement>` of detected CC fields, (re)built by a `MutationObserver` + initial scan using `detectCreditCardFields` — reuse the LOGIN `scanInputs`/`trackInput`/observer pattern. The `focusin` handler does an O(1) `ccFields.has(target)` check, NOT `detectCreditCardFields(document)` per event.
+  - **F1 own suppression state**: the post-fill suppression window (`autofillSuppressUntil`) is a **detector-local** variable, not shared with the LOGIN module's globals. A CC fill must not suppress the LOGIN dropdown and vice-versa.
+  - **F7 vault-state re-trigger**: register a runtime-message handler for `PSSO_VAULT_STATE_CHANGED` / `PSSO_TRIGGER_INLINE_SUGGESTIONS` that re-evaluates the active element against `ccFields` (so a focused CC field gets a dropdown right after unlock).
+  - **R17/R22 helper reuse**: import `isUsableInput` / visibility helpers from `form-detector-lib.ts` rather than re-defining `isElementVisible`/`isUsableField` (no 3rd copy).
+  - Flow: focus a CC field → send `GET_CC_MATCHES_FOR_URL {url, topUrl}` → `showDropdown({entryType: "CREDIT_CARD", …})` → onSelect sends `AUTOFILL_FROM_CONTENT {entryId, teamId}`.
+- **Acceptance**: focusing a `cc-number`/expiry/cvv field triggers exactly one match request (O(1) per focus); non-CC fields do not; cross-origin subframe = no-op; CC fill does not suppress LOGIN; post-unlock refresh works.
+
+### C4 — IDENTITY detector init
+- **File**: `extension/src/content/identity-form-detector-lib.ts` — `export function initIdentityDetector(): { destroy: () => void }`. Identical shape and **all** the C3 mandatory behaviors (cross-origin guard, WeakSet via `detectIdentityFields`, detector-local suppression, vault-state handler, helper reuse), via `GET_IDENTITY_MATCHES_FOR_URL` → dropdown (entryType IDENTITY).
+- **Acceptance**: focusing an identity field (name/address/postal/phone/email) triggers one match request; all C3 acceptance points hold.
+
+### C5 — Entry-point wiring
+- **File**: `extension/src/content/form-detector.ts` — call `initCreditCardDetector()` and `initIdentityDetector()` alongside the existing inits; collect all `destroy()` fns and call them together in the context-invalidation `error` handler. Keep the single-injection guard.
+- **F6 shadow-host ownership**: each detector's `destroy()` only removes its own listeners + `hideDropdown()`; the shared `removeShadowHost()` is called **once** by the entry-point teardown (not per-detector), so tearing down one detector doesn't destroy the shared dropdown DOM for the others.
+- **Acceptance**: all three detectors active on page load; all torn down once on extension reload without double-removing the shadow host.
+
+### C6 — Dropdown UI parametrization + inline error mapping
+- **File**: `extension/src/content/ui/suggestion-dropdown.ts` — add **optional** `entryType?: "LOGIN" | "CREDIT_CARD" | "IDENTITY"` to `DropdownOptions`, **defaulting to `"LOGIN"`** (T4: keeps every existing `showDropdown`/`makeOptions` caller and test compiling unchanged). The type selects icon + `headerLabel`. CC shows title + cardholder; IDENTITY shows title + name. No card number / no secret rendered.
+- **F3 inline error mapping**: the content-side `onSelect` error handler (in `form-detector-lib.ts` / the new detectors) currently maps `NO_PASSWORD`; add mappings for `NO_CARD_NUMBER` (CC) and the identity-equivalent error so a failed CC/identity fill shows a meaningful message, not the generic fallback.
+- **Acceptance**: LOGIN dropdown + existing tests unchanged (no required-field break); CC/IDENTITY render their own header + icon; CC fill failure shows a CC-specific message.
+
+### C7 — i18n
+- **Files**: `messages/en.json`, `messages/ja.json` — add `contentScript.creditCards` and `contentScript.identities` header labels (and any "no matches" variants if the existing one is login-worded). ja uses content-script tone, no internal tokens.
+- **Acceptance**: both locales have the keys; `npm run` i18n/key-coverage check (if any) passes.
+
+### C8 — Frame-targeted fill (security hardening, S6/S7)
+- **File**: `extension/src/background/index.ts` (`AUTOFILL_FROM_CONTENT` handler + `performAutofillForEntry`)
+- Today the CC/IDENTITY fill does `chrome.tabs.sendMessage(tabId, AUTOFILL_CC_FILL, …)` with **no `frameId`**, broadcasting card data to every frame in the tab. Add an optional `frameId?: number` param to `performAutofillForEntry`. The `AUTOFILL_FROM_CONTENT` handler captures `_sender.frameId` and passes it; the SW then targets `chrome.tabs.sendMessage(tabId, msg, { frameId })` (and `executeScript` `target: { tabId, frameIds: [frameId] }`).
+- **F8/T12 popup fallback (do NOT regress)**: the popup / context-menu callers have no originating frame (`frameId` undefined). In that case keep the **current** behavior — omit `frameIds`/`frameId` entirely (tab-wide), do **not** substitute `0`, which would break popup fills on same-origin subframe forms. So: frameId known (inline) → target that frame; frameId undefined (popup) → unchanged. The security win (no tab-wide card broadcast) applies to the inline path, which is the one this PR introduces.
+- **Frame-detached edge case**: if the target frame is gone before the fill, `executeScript`/`sendMessage` throws "No frame with id N"; the existing catch returns `AUTOFILL_INJECT_FAILED` — keep that graceful path.
+- **Invariant**: on the inline path, card/identity plaintext is delivered only to the frame that requested the fill, never broadcast tab-wide.
+- **Acceptance**: an inline CC fill reaches only the originating `frameId`; popup-initiated fill behaves exactly as today (no frameId narrowing).
+
+### C9 — Validate content-supplied identifiers (RS3, S8)
+- **File**: `extension/src/background/index.ts` (`AUTOFILL_FROM_CONTENT` and the `GET_*_MATCHES_FOR_URL` handlers)
+- `entryId`/`teamId` arrive from a content-script message as `unknown` at runtime and flow into an authenticated API path. Add a guard for BOTH ids: `typeof === "string"` + a charset/length bound `/^[A-Za-z0-9_-]{1,64}$/`; reject otherwise. Applies equally to the existing LOGIN `AUTOFILL_FROM_CONTENT` path (pre-existing gap in a touched file → fix here).
+- **Do NOT use a UUIDv4-strict regex** (a Round-2 suggestion): `PasswordEntry` ids in this repo are **mixed CUID v1 and UUIDv4** (see [[project_cuid_uuid_inconsistency]]), so a UUIDv4-only guard would reject legacy CUID entries and break real fills. This guard is defense-in-depth against oversized/injection input (the id is also URL-encoded into the API path), not a format authority — a permissive-but-bounded charset is the correct choice and covers both id shapes.
+- **Acceptance**: malformed/oversized `entryId` AND `teamId` are rejected before any `swFetch`, on both the inline and LOGIN paths; a legitimate CUID-shaped id is accepted.
+
+### Forbidden patterns
+- pattern: `"AUTOFILL_CC_FILL"` / `"AUTOFILL_IDENTITY_FILL"` as bare string literals OUTSIDE `constants.ts` — reason: C1 centralizes them.
+- pattern: a CC/IDENTITY match path that calls `isHostMatch` — reason: cards/identities are URL-independent (R: don't blindly copy the LOGIN host filter).
+- pattern: duplicated gate logic (`cachedEnableInlineSuggestions` / `isOwnAppPage`) in the new handlers instead of the shared `resolveInlineMatches` helper.
+
+## Testing strategy
+
+All new content-script tests MUST carry the file-level `// @vitest-environment jsdom` docblock (T3 — the extension's default env is `node`; `environmentMatchGlobs` is a per-file whitelist, not a directory glob).
+
+- **T1 (Critical) — LOGIN host-filter regression lock (write BEFORE the C2 refactor)**: send `GET_MATCHES_FOR_URL` for an external URL with the fetch mock returning a LOGIN entry whose `urlHost` matches → assert it's returned; a non-matching host → assert empty. This is the test that catches the refactor accidentally dropping `isHostMatch` / the `entryType===LOGIN` guard (currently no test locks this).
+- **T2 (Critical) — non-vacuous CC host test**: extend the background fetch mock to include a CC entry (mock currently returns only LOGIN). The CC entry's `urlHost` MUST be set to a value **deliberately different** from the test page URL (T9 — otherwise the test passes under both a host-filtered and non-filtered implementation and is vacuous); assert `GET_CC_MATCHES_FOR_URL` returns it despite the mismatch. Same for IDENTITY.
+- **Background gates**: `resolveInlineMatches` respects every gate (disabled / own-app / disconnected / locked) for all three kinds; CC/IDENTITY handlers return the right type; error-fallback path responds for the new message types (F5); hostless (`file://`) page still returns CC entries (F4).
+- **T6 — overview field mapping**: assert `decryptOverviews` yields `username = cardholderName` (CC) / `fullName` (IDENTITY) so the dropdown shows a usable label.
+- **C3/C4 detector tests** (jsdom): focusing a detected field issues exactly one match request; an unrelated field issues none; `destroy()` removes listeners (T8); WeakSet membership updates when the observer sees a new CC form. **T10 — the cross-origin-subframe no-op (S2) is NOT naturally reproducible in jsdom** (`window.top === window.self` always; no cross-origin frame model): test it by monkey-patching `window.top` with a `location` getter that throws (document this in the test), or verify by inspection — flag as a mock-only/limited test, not a clean jsdom case.
+- **T5 — select→fill path**: simulate selecting a CC dropdown item → assert `chrome.runtime.sendMessage` called with `{ type: AUTOFILL_FROM_CONTENT, entryId }`.
+- **C8 — frame targeting**: assert the inline fill `sendMessage`/`executeScript` carry the originating `frameId`; assert the popup path sends with **no** `frameId` (unchanged behavior, T12) — not `frameIds: [0]`.
+- **C9 — validation**: malformed/oversized `entryId` AND `teamId` are rejected before `swFetch`, on both the inline AND the LOGIN `AUTOFILL_FROM_CONTENT` paths (T11); a CUID-shaped id is accepted (guards against an over-strict regex).
+- **Dropdown**: renders CC/IDENTITY header + icon; LOGIN unchanged; `entryType` optional default keeps existing `makeOptions` callers compiling (T4).
+- **T7 — both-forms-on-one-page**: login field → `GET_MATCHES_FOR_URL`; CC field → `GET_CC_MATCHES_FOR_URL`; no cross-trigger. Plus an entry-point error-handler teardown test.
+- **R19** — update `autofill-cc.test.ts` (and identity) to use `EXT_MSG.AUTOFILL_CC_FILL` after C1 centralizes the constant.
+- Both suites + extension build green; manual: load built extension, focus the Apple checkout `cc-number` field, confirm the card dropdown appears and fills only that frame.
+
+## Considerations & constraints
+
+- **Security/privacy — URL-independent suggestions (Major design point for review)**: CC/IDENTITY dropdowns appear on *any* site's matching form, not host-bound like LOGIN, because cards/identities are not tied to a domain. This matches native browser autofill, Bitwarden, and the existing popup. The dropdown renders only non-secret overview fields (title, cardholder/name) — the card number/CVV are revealed only on explicit user selection. A malicious/phishing form could solicit a card the same way it could today via the popup; inline does not increase the trust surface beyond explicit user action. Document this; do not host-gate CC (would break the feature). **Two hard requirements keep the inline surface no worse than the popup**: (a) the cross-origin-subframe no-op guard (C3/C4, S2) so an embedded attacker frame can't render a deceptive dropdown; (b) frame-targeted fill (C8, S6) so decrypted card data is delivered only to the originating frame, never broadcast tab-wide. Fill always requires an explicit, `isTrusted` user selection — no fill on focus.
+- **Autofill suppression**: reuse the LOGIN post-fill suppression window so the dropdown doesn't re-open from fill-induced focus events.
+- iOS / app: out of scope (extension-only feature).
+- Inline suggestion master toggle (`cachedEnableInlineSuggestions`) governs all three kinds uniformly.
+
+## User operation scenarios
+
+1. Apple checkout (`secure9.store.apple.com`): focus "クレジット / デビットカード番号" (`autocomplete="cc-number"`) → dropdown lists "オリコ Mastercard" → select → number/expiry/cvv filled by `autofill-cc.js`.
+2. A shipping-address form: focus a name/address field → identity dropdown → select → fields filled.
+3. Vault locked: focusing a CC field shows the "unlock" dropdown message (same as LOGIN).
+4. Inline suggestions disabled in settings: no dropdown for any type.
+5. A page with both a login form and a CC form: login fields show login suggestions (host-matched), CC fields show card suggestions (all cards) — no cross-contamination.
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | Message constants (+ centralize CC/IDENTITY fill message strings) | locked |
+| C2 | Background shared `resolveInlineMatches` + CC/IDENTITY handlers (no host filter) | locked |
+| C3 | `initCreditCardDetector` | locked |
+| C4 | `initIdentityDetector` | locked |
+| C5 | `form-detector.ts` entry-point wiring + teardown | locked |
+| C6 | Dropdown UI parametrized by entryType (optional, default LOGIN) + inline error mapping | locked |
+| C7 | i18n header labels (en + ja) | locked |
+| C8 | Frame-targeted fill (no tab-wide card broadcast; fixes popup path too) | locked |
+| C9 | Validate content-supplied entryId/teamId before authed fetch | locked |

--- a/docs/archive/review/ext-inline-cc-identity-autofill-review.md
+++ b/docs/archive/review/ext-inline-cc-identity-autofill-review.md
@@ -1,0 +1,45 @@
+# Plan Review: ext-inline-cc-identity-autofill
+
+Date: 2026-05-31
+Review round: 1
+
+## Functionality (adopted)
+- **F1 [Major]** — `form-detector-lib.ts` keeps `autofillSuppressUntil`/`currentContext` at module scope. CC/IDENTITY detectors must own their **own** suppression state, not share LOGIN's, or a CC fill suppresses the LOGIN dropdown. → C3/C4 specify per-detector state.
+- **F2 [Major]** — calling `detectCreditCardFields(document)` on every `focusin` is O(N) DOM scan + wrong for multi-form pages. → C3 prescribes a `WeakSet` of detected fields built/refreshed by a MutationObserver (reuse the LOGIN `scanInputs`/`trackInput` pattern); focus handler does `WeakSet.has(target)`.
+- **F4 [Major]** — `GET_MATCHES_FOR_URL` early-returns empty when `extractHost` is null (`file://`). For CC/IDENTITY (no host match) that wrongly returns zero. → C2: the `!tabHost` guard is LOGIN-only.
+- **F3 [Minor]** — inline error handler maps `NO_PASSWORD` only; CC returns `NO_CARD_NUMBER`. → C6 adds CC/identity error mapping.
+- **F5 [Minor]** — SW error-fallback switch needs cases for the two new message types. → C2.
+- **F6 [Minor]** — `destroy()` calling `removeShadowHost()` tears down the shared dropdown for all detectors. → C5: entry point owns `removeShadowHost` once; detectors only `hideDropdown` + remove their own listeners.
+- **F7 [Minor]** — `PSSO_VAULT_STATE_CHANGED`/`PSSO_TRIGGER_INLINE_SUGGESTIONS` handler is LOGIN-only; after unlock a focused CC field won't refresh. → C3/C4 add per-detector handlers.
+- **R17/R22 [Adjacent]** — cc/identity detector libs duplicate `isElementVisible`/`isUsableField`; import the shared ones from `form-detector-lib` instead of adding a 3rd copy.
+
+## Security (adopted)
+- **S2 [Major]** — LOGIN bails out in cross-origin subframes (`isCrossOriginSubframe`). C3/C4 MUST replicate this explicitly (else a malicious iframe renders a deceptive CC dropdown). → explicit acceptance criterion.
+- **S6 [Major]** — `chrome.tabs.sendMessage(tabId, AUTOFILL_CC_FILL, …)` has no `frameId` → broadcasts card data to all frames in the tab. The inline path makes the triggering frame deterministic (`_sender.frameId`). → new **C8**: capture `_sender.frameId`, target executeScript + sendMessage to that frame (also fixes the existing popup path).
+- **S8 [Minor, RS3]** — `entryId`/`teamId` from `AUTOFILL_FROM_CONTENT` reach an authed API path unvalidated. → new **C9**: runtime format guard.
+- **S1/S3/S4 [Clean]** — no secret in overview/dropdown; no fill without explicit trusted gesture (`isTrusted` + explicit select); gates uniform. **S5** (content-supplied `topUrl` for own-app gate) pre-existing, not a security boundary.
+- **URL-independent design**: confirmed sound (matches popup + native autofill); the dropdown shows only non-secret fields; not host-gating CC is intentional. Documented.
+
+## Testing (adopted)
+- **T1 [Critical]** — no existing test locks LOGIN host-filtering; the C2 refactor could silently drop it. → add a regression test (matching host → entry returned; non-matching → empty) BEFORE refactor.
+- **T2 [Critical]** — the "non-vacuous CC host" test needs the background fetch mock to include a CC entry (mock currently returns only LOGIN). → adjust harness so the test proves the host filter is actually absent for CC.
+- **T3 [Major]** — new content tests need the file-level `// @vitest-environment jsdom` docblock (env default is `node`; `environmentMatchGlobs` is a whitelist). → note in plan.
+- **T4 [Major, R19]** — making `entryType` a **required** `DropdownOptions` field breaks every existing `makeOptions()` caller. → C6 makes it **optional, default `"LOGIN"`** (keeps LOGIN call sites + tests unchanged).
+- **T5 [Major]** — select→`AUTOFILL_FROM_CONTENT` path needs a test for CC/IDENTITY.
+- **T6 [Major]** — assert `decryptOverviews` populates `username` from `cardholderName`/`fullName` for CC/IDENTITY on the inline path.
+- **T7/T8 [Minor]** — both-forms-on-one-page; `destroy()` removes listeners. Plus an error-handler-teardown test ([Adjacent]).
+- **R19** — `autofill-cc.test.ts` uses bare `"AUTOFILL_CC_FILL"`; update to `EXT_MSG.AUTOFILL_CC_FILL` after C1.
+
+## Disposition (round 1)
+All adopted into the plan revision (round 2). New contracts C8 (frame-targeted fill) and C9 (message-param validation) added. C6 `entryType` made optional. Testing strategy expanded with the regression-lock + non-vacuous + select-path + jsdom-docblock items.
+
+## Round 2
+
+All round-1 Critical/Major confirmed RESOLVED. New findings — all Minor refinements, incorporated:
+- **F8/T12** — C8 popup fallback would silently narrow popup fills to frame 0 (regressing same-origin-subframe popup fills). Resolved: popup path (frameId undefined) keeps **current** behavior (no frameId), only the inline path targets `_sender.frameId`.
+- **S9** — Round-2 suggested a strict UUIDv4 regex for C9. **OVERRIDDEN**: entry IDs in this repo are mixed CUID v1 + UUIDv4 ([[project_cuid_uuid_inconsistency]]); a UUIDv4-only guard would reject legacy CUID entries. C9 uses a bounded charset guard `/^[A-Za-z0-9_-]{1,64}$/` (defense-in-depth, not a format authority) covering both shapes — and a test asserts a CUID-shaped id is accepted.
+- **T9** — T2 must set the CC mock entry's `urlHost` deliberately ≠ page URL (else vacuous). Specified.
+- **T10** — S2 cross-origin no-op isn't naturally reproducible in jsdom; flagged as mock-only/limited (monkey-patch `window.top`).
+- **T11** — C9 tests must cover `teamId` + the LOGIN path, not just `entryId`. Specified.
+
+**Convergence**: round-1 Critical/Major resolved; round-2 only Minor refinements, all incorporated. All 9 contracts locked. Plan is final and ready for implementation **once #503 merges** (branch to be cut from updated main). Implementation deferred per the user's "one step before branching" instruction.

--- a/extension/src/__tests__/background/inline-matches.test.ts
+++ b/extension/src/__tests__/background/inline-matches.test.ts
@@ -513,3 +513,48 @@ describe("AUTOFILL_FROM_CONTENT frame targeting + id validation", () => {
     expect(res.ok).toBe(true);
   });
 });
+
+// ── M3: disabled-inline gate for CC and IDENTITY ──────────────────────────────
+
+describe("M3: resolveInlineMatches suppresses inline when enableInlineSuggestions=false", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    const mock = installChromeMock();
+    // Override storage to return enableInlineSuggestions=false.
+    mock.storage.local.get.mockResolvedValue({
+      serverUrl: "https://localhost:3000",
+      autoLockMinutes: 15,
+      enableInlineSuggestions: false,
+    });
+    mockEntries([], []);
+    await loadBackground();
+    // Flush the getSettings().then(...) microtask so cachedEnableInlineSuggestions
+    // is set before any message arrives.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    // Unlock the vault so the gate is reached with a valid token+key.
+    applyToken("t", Date.now() + 60_000, "");
+    await sendMessage({ type: EXT_MSG.UNLOCK_VAULT, passphrase: "pw" });
+  });
+
+  it("GET_CC_MATCHES_FOR_URL returns suppressInline=true and empty entries", async () => {
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_CC_MATCHES_FOR_URL,
+      url: "https://store.example.com/checkout",
+    })) as { suppressInline: boolean; entries: unknown[] };
+
+    expect(res.suppressInline).toBe(true);
+    expect(res.entries).toEqual([]);
+  });
+
+  it("GET_IDENTITY_MATCHES_FOR_URL returns suppressInline=true and empty entries", async () => {
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL,
+      url: "https://shop.example.com/address",
+    })) as { suppressInline: boolean; entries: unknown[] };
+
+    expect(res.suppressInline).toBe(true);
+    expect(res.entries).toEqual([]);
+  });
+});

--- a/extension/src/__tests__/background/inline-matches.test.ts
+++ b/extension/src/__tests__/background/inline-matches.test.ts
@@ -1,0 +1,515 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EXT_ENTRY_TYPE, EXT_MSG } from "../../lib/constants";
+import { EXT_API_PATH, extApiPath } from "../../lib/api-paths";
+
+const PASSWORD_BY_ID_PREFIX = extApiPath.passwordById("");
+
+// ── Module mocks (mirror background.test.ts) ──
+
+const sessionStorageMocks = vi.hoisted(() => ({
+  persistSession: vi.fn().mockResolvedValue(undefined),
+  loadSession: vi.fn().mockResolvedValue(null),
+  clearSession: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../lib/session-storage", () => sessionStorageMocks);
+
+const dpopKeyMocks = vi.hoisted(() => ({
+  getDpopThumbprint: vi.fn().mockResolvedValue("abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG"),
+  signDpopProof: vi.fn().mockResolvedValue("fake.dpop.proof"),
+  getOrGenerateDpopKeyPair: vi.fn().mockResolvedValue({
+    publicJwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
+    sign: vi.fn().mockResolvedValue(new ArrayBuffer(64)),
+  }),
+  resetInMemoryKeyCache: vi.fn(),
+}));
+vi.mock("../../lib/dpop-key", () => dpopKeyMocks);
+
+const cryptoMocks = vi.hoisted(() => ({
+  deriveWrappingKey: vi.fn().mockResolvedValue("wrap-key"),
+  unwrapSecretKey: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+  deriveEncryptionKey: vi.fn().mockResolvedValue("enc-key"),
+  verifyKey: vi.fn().mockResolvedValue(true),
+  decryptData: vi.fn().mockResolvedValue(
+    JSON.stringify({ title: "Example", username: "alice", urlHost: "example.com" }),
+  ),
+  buildPersonalEntryAAD: vi.fn().mockReturnValue(new Uint8Array([1, 2])),
+  hexDecode: vi.fn().mockReturnValue(new Uint8Array([0, 1])),
+  VAULT_TYPE: { BLOB: "blob", OVERVIEW: "overview" },
+}));
+vi.mock("../../lib/crypto", () => cryptoMocks);
+
+type MessageHandler = (
+  message: unknown,
+  sender: unknown,
+  sendResponse: (resp: unknown) => void,
+) => boolean | void;
+
+let messageHandlers: MessageHandler[] = [];
+let chromeMock: ReturnType<typeof installChromeMock> | null = null;
+
+function installChromeMock() {
+  messageHandlers = [];
+  const chromeMock = {
+    runtime: {
+      onMessage: { addListener: (fn: MessageHandler) => messageHandlers.push(fn) },
+      onInstalled: { addListener: vi.fn() },
+      onStartup: { addListener: vi.fn() },
+      sendMessage: vi.fn().mockResolvedValue({ ok: true }),
+      getContexts: vi.fn().mockResolvedValue([]),
+    },
+    offscreen: {
+      createDocument: vi.fn().mockResolvedValue(undefined),
+      hasDocument: vi.fn().mockResolvedValue(false),
+      Reason: { CLIPBOARD: "CLIPBOARD" },
+    },
+    alarms: {
+      onAlarm: { addListener: vi.fn() },
+      create: vi.fn(),
+      clear: vi.fn(),
+    },
+    scripting: {
+      executeScript: vi.fn().mockResolvedValue([]),
+      registerContentScripts: vi.fn().mockResolvedValue(undefined),
+      unregisterContentScripts: vi.fn().mockResolvedValue(undefined),
+    },
+    tabs: {
+      sendMessage: vi.fn().mockResolvedValue({}),
+      get: vi.fn().mockResolvedValue({ id: 1, url: "https://example.com" }),
+      query: vi.fn().mockResolvedValue([{ id: 1, url: "https://example.com" }]),
+      onActivated: { addListener: vi.fn() },
+      onUpdated: { addListener: vi.fn() },
+      onRemoved: { addListener: vi.fn() },
+    },
+    action: {
+      setBadgeText: vi.fn().mockResolvedValue(undefined),
+      setBadgeBackgroundColor: vi.fn().mockResolvedValue(undefined),
+    },
+    contextMenus: {
+      create: vi.fn(),
+      removeAll: vi.fn((cb?: () => void) => cb?.()),
+      onClicked: { addListener: vi.fn() },
+    },
+    permissions: { contains: vi.fn().mockResolvedValue(true) },
+    storage: {
+      local: {
+        get: vi.fn().mockResolvedValue({ serverUrl: "https://localhost:3000", autoLockMinutes: 15 }),
+      },
+      session: {
+        get: vi.fn().mockResolvedValue({}),
+        set: vi.fn().mockResolvedValue(undefined),
+        remove: vi.fn().mockResolvedValue(undefined),
+        setAccessLevel: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: { addListener: vi.fn() },
+    },
+    commands: { onCommand: { addListener: vi.fn() } },
+  };
+  vi.stubGlobal("chrome", chromeMock);
+  return chromeMock;
+}
+
+let bgModule: typeof import("../../background/index") | null = null;
+async function loadBackground() {
+  bgModule = await import("../../background/index");
+}
+function applyToken(token: string, expiresAt: number, cnfJkt: string): void {
+  if (!bgModule) throw new Error("loadBackground() must run first");
+  bgModule.applyToken(token, expiresAt, cnfJkt);
+}
+function sendMessage(message: unknown, sender: unknown = {}): Promise<unknown> {
+  return new Promise((resolve) => {
+    messageHandlers[0](message, sender, (resp) => resolve(resp));
+  });
+}
+
+/** Build the PASSWORDS list fetch + per-entry overview decryption. */
+function mockEntries(
+  entries: Array<{ id: string; entryType: string }>,
+  overviews: Array<Record<string, unknown>>,
+): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      if (url.includes(EXT_API_PATH.EXTENSION_TOKEN_REFRESH)) {
+        return {
+          ok: true,
+          json: async () => ({
+            token: "refreshed-tok",
+            expiresAt: new Date(Date.now() + 900_000).toISOString(),
+            scope: ["passwords:read", "vault:unlock-data"],
+          }),
+        };
+      }
+      if (url.includes(EXT_API_PATH.VAULT_UNLOCK_DATA)) {
+        return {
+          ok: true,
+          json: async () => ({
+            userId: "user-1",
+            accountSalt: "00",
+            encryptedSecretKey: "aa",
+            secretKeyIv: "bb",
+            secretKeyAuthTag: "cc",
+            verificationArtifact: { ciphertext: "11", iv: "22", authTag: "33" },
+          }),
+        };
+      }
+      if (url.includes(EXT_API_PATH.PASSWORDS)) {
+        return {
+          ok: true,
+          json: async () =>
+            entries.map((e) => ({
+              id: e.id,
+              encryptedOverview: { ciphertext: "11", iv: "22", authTag: "33" },
+              entryType: e.entryType,
+              aadVersion: 1,
+            })),
+        };
+      }
+      return { ok: false, json: async () => ({}) };
+    }),
+  );
+  // decryptOverviews decrypts each entry's overview in list order.
+  cryptoMocks.decryptData.mockReset();
+  for (const ov of overviews) {
+    cryptoMocks.decryptData.mockResolvedValueOnce(JSON.stringify(ov));
+  }
+}
+
+describe("resolveInlineMatches (LOGIN / CC / IDENTITY)", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    chromeMock = installChromeMock();
+    mockEntries([], []);
+    await loadBackground();
+  });
+
+  async function unlock() {
+    applyToken("t", Date.now() + 60_000, "");
+    await sendMessage({ type: EXT_MSG.UNLOCK_VAULT, passphrase: "pw" });
+  }
+
+  // ── T1: LOGIN host-filter regression lock ──
+
+  it("LOGIN returns an entry whose urlHost matches the page host", async () => {
+    mockEntries(
+      [{ id: "login-1", entryType: EXT_ENTRY_TYPE.LOGIN }],
+      [{ title: "GitHub", username: "alice", urlHost: "github.com" }],
+    );
+    await unlock();
+
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_MATCHES_FOR_URL,
+      url: "https://github.com/login",
+    })) as { entries: Array<{ id: string }> };
+
+    expect(res.entries.map((e) => e.id)).toEqual(["login-1"]);
+  });
+
+  it("LOGIN returns no entry when urlHost does not match the page host", async () => {
+    mockEntries(
+      [{ id: "login-1", entryType: EXT_ENTRY_TYPE.LOGIN }],
+      [{ title: "GitHub", username: "alice", urlHost: "github.com" }],
+    );
+    await unlock();
+
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_MATCHES_FOR_URL,
+      url: "https://gitlab.com/login",
+    })) as { entries: unknown[] };
+
+    expect(res.entries).toEqual([]);
+  });
+
+  // ── T2: non-vacuous CC host test (urlHost deliberately ≠ page host) ──
+
+  it("CC returns the card even though its urlHost differs from the page host", async () => {
+    mockEntries(
+      [{ id: "cc-1", entryType: EXT_ENTRY_TYPE.CREDIT_CARD }],
+      // urlHost deliberately set to a value that does NOT match the page —
+      // proves CC is not host-filtered (would be empty under a host filter).
+      [{ title: "Orico Mastercard", cardholderName: "Alice", urlHost: "elsewhere.example" }],
+    );
+    await unlock();
+
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_CC_MATCHES_FOR_URL,
+      url: "https://store.apple.com/checkout",
+    })) as { type: string; entries: Array<{ id: string; username: string }> };
+
+    expect(res.type).toBe(EXT_MSG.GET_CC_MATCHES_FOR_URL);
+    expect(res.entries.map((e) => e.id)).toEqual(["cc-1"]);
+    // T6: cardholderName surfaces as username for the dropdown label.
+    expect(res.entries[0].username).toBe("Alice");
+  });
+
+  it("IDENTITY returns the identity regardless of host, mapping fullName → username", async () => {
+    mockEntries(
+      [{ id: "id-1", entryType: EXT_ENTRY_TYPE.IDENTITY }],
+      [{ title: "Home", fullName: "Alice Smith", urlHost: "elsewhere.example" }],
+    );
+    await unlock();
+
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL,
+      url: "https://shop.example/address",
+    })) as { entries: Array<{ id: string; username: string }> };
+
+    expect(res.entries.map((e) => e.id)).toEqual(["id-1"]);
+    expect(res.entries[0].username).toBe("Alice Smith");
+  });
+
+  it("CC does not return LOGIN entries (filters strictly by entry type)", async () => {
+    mockEntries(
+      [
+        { id: "login-1", entryType: EXT_ENTRY_TYPE.LOGIN },
+        { id: "cc-1", entryType: EXT_ENTRY_TYPE.CREDIT_CARD },
+      ],
+      [
+        { title: "GitHub", username: "alice", urlHost: "github.com" },
+        { title: "Card", cardholderName: "Alice", urlHost: "x.example" },
+      ],
+    );
+    await unlock();
+
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_CC_MATCHES_FOR_URL,
+      url: "https://github.com/anything",
+    })) as { entries: Array<{ id: string }> };
+
+    expect(res.entries.map((e) => e.id)).toEqual(["cc-1"]);
+  });
+
+  // ── F4: hostless (file://) page still returns CC entries ──
+
+  it("CC returns entries on a hostless (file://) page", async () => {
+    mockEntries(
+      [{ id: "cc-1", entryType: EXT_ENTRY_TYPE.CREDIT_CARD }],
+      [{ title: "Card", cardholderName: "Alice", urlHost: "" }],
+    );
+    await unlock();
+
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_CC_MATCHES_FOR_URL,
+      url: "file:///home/user/form.html",
+    })) as { entries: Array<{ id: string }> };
+
+    expect(res.entries.map((e) => e.id)).toEqual(["cc-1"]);
+  });
+
+  it("LOGIN returns empty on a hostless (file://) page", async () => {
+    mockEntries(
+      [{ id: "login-1", entryType: EXT_ENTRY_TYPE.LOGIN }],
+      [{ title: "GitHub", username: "alice", urlHost: "github.com" }],
+    );
+    await unlock();
+
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_MATCHES_FOR_URL,
+      url: "file:///home/user/form.html",
+    })) as { entries: unknown[] };
+
+    expect(res.entries).toEqual([]);
+  });
+
+  // ── Gates apply uniformly across all three kinds ──
+
+  it("CC reports disconnected when there is no token", async () => {
+    // No unlock() → no token.
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_CC_MATCHES_FOR_URL,
+      url: "https://store.apple.com/checkout",
+    })) as { disconnected?: boolean; entries: unknown[] };
+
+    expect(res.disconnected).toBe(true);
+    expect(res.entries).toEqual([]);
+  });
+
+  it("CC reports vaultLocked when connected but locked", async () => {
+    applyToken("t", Date.now() + 60_000, "");
+    // token applied but vault never unlocked → encryptionKey null
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_CC_MATCHES_FOR_URL,
+      url: "https://store.apple.com/checkout",
+    })) as { vaultLocked: boolean; entries: unknown[] };
+
+    expect(res.vaultLocked).toBe(true);
+    expect(res.entries).toEqual([]);
+  });
+
+  it("CC suppresses inline on the passwd-sso own-app origin", async () => {
+    await unlock();
+    const res = (await sendMessage({
+      type: EXT_MSG.GET_CC_MATCHES_FOR_URL,
+      url: "https://localhost:3000/ja/passwords/new",
+    })) as { suppressInline: boolean; entries: unknown[] };
+
+    expect(res.suppressInline).toBe(true);
+    expect(res.entries).toEqual([]);
+  });
+});
+
+// ── C8 (frame-targeted fill) + C9 (id validation) via AUTOFILL_FROM_CONTENT ──
+
+/** Stub fetch so a personal CC entry decrypts to a fillable card blob. */
+function mockCcFillFetch(): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      if (url.includes(EXT_API_PATH.EXTENSION_TOKEN_REFRESH)) {
+        return {
+          ok: true,
+          json: async () => ({
+            token: "refreshed-tok",
+            expiresAt: new Date(Date.now() + 900_000).toISOString(),
+            scope: ["passwords:read", "vault:unlock-data"],
+          }),
+        };
+      }
+      if (url.includes(EXT_API_PATH.VAULT_UNLOCK_DATA)) {
+        return {
+          ok: true,
+          json: async () => ({
+            userId: "user-1",
+            accountSalt: "00",
+            encryptedSecretKey: "aa",
+            secretKeyIv: "bb",
+            secretKeyAuthTag: "cc",
+            verificationArtifact: { ciphertext: "11", iv: "22", authTag: "33" },
+          }),
+        };
+      }
+      // passwordById prefix must be checked before the PASSWORDS list path.
+      if (url.includes(PASSWORD_BY_ID_PREFIX) && !url.endsWith(EXT_API_PATH.PASSWORDS)) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: "cc-1",
+            encryptedBlob: { ciphertext: "aa", iv: "bb", authTag: "cc" },
+            encryptedOverview: { ciphertext: "11", iv: "22", authTag: "33" },
+            entryType: EXT_ENTRY_TYPE.CREDIT_CARD,
+            aadVersion: 1,
+          }),
+        };
+      }
+      return { ok: false, json: async () => ({}) };
+    }),
+  );
+  // blob (with cardNumber) then overview, per performAutofillForEntry.
+  cryptoMocks.decryptData.mockReset();
+  cryptoMocks.decryptData
+    .mockResolvedValueOnce(
+      JSON.stringify({ cardNumber: "4111111111111111", cardholderName: "Alice" }),
+    )
+    .mockResolvedValueOnce(JSON.stringify({ username: "Alice" }));
+}
+
+describe("AUTOFILL_FROM_CONTENT frame targeting + id validation", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    chromeMock = installChromeMock();
+    await loadBackground();
+  });
+
+  async function unlock() {
+    mockCcFillFetch();
+    applyToken("t", Date.now() + 60_000, "");
+    await sendMessage({ type: EXT_MSG.UNLOCK_VAULT, passphrase: "pw" });
+    mockCcFillFetch();
+  }
+
+  it("C8: inline fill targets the originating frame (sendMessage + executeScript)", async () => {
+    await unlock();
+
+    const res = (await sendMessage(
+      { type: EXT_MSG.AUTOFILL_FROM_CONTENT, entryId: "cc-1" },
+      { tab: { id: 7 }, frameId: 42 },
+    )) as { ok: boolean };
+
+    expect(res.ok).toBe(true);
+    expect(chromeMock?.scripting.executeScript).toHaveBeenCalledWith(
+      expect.objectContaining({ target: { tabId: 7, frameIds: [42] } }),
+    );
+    expect(chromeMock?.tabs.sendMessage).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({ type: EXT_MSG.AUTOFILL_CC_FILL }),
+      { frameId: 42 },
+    );
+  });
+
+  it("C8: popup fill (no frameId) stays tab-wide — no frameIds / no frameId option", async () => {
+    await unlock();
+
+    // Popup/context-menu sender has a tab but no frameId.
+    const res = (await sendMessage(
+      { type: EXT_MSG.AUTOFILL_FROM_CONTENT, entryId: "cc-1" },
+      { tab: { id: 7 } },
+    )) as { ok: boolean };
+
+    expect(res.ok).toBe(true);
+    expect(chromeMock?.scripting.executeScript).toHaveBeenCalledWith(
+      expect.objectContaining({ target: { tabId: 7 } }),
+    );
+    // Two-arg form (no options) — must NOT narrow to frame 0.
+    expect(chromeMock?.tabs.sendMessage).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({ type: EXT_MSG.AUTOFILL_CC_FILL }),
+    );
+  });
+
+  it("C9: rejects an oversized entryId before any fetch", async () => {
+    await unlock();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockClear();
+
+    const res = (await sendMessage(
+      { type: EXT_MSG.AUTOFILL_FROM_CONTENT, entryId: "a".repeat(65) },
+      { tab: { id: 7 }, frameId: 1 },
+    )) as { ok: boolean; error?: string };
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("INVALID_ID");
+    expect(globalThis.fetch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("C9: rejects an entryId with illegal characters", async () => {
+    await unlock();
+    const res = (await sendMessage(
+      { type: EXT_MSG.AUTOFILL_FROM_CONTENT, entryId: "../../etc/passwd" },
+      { tab: { id: 7 }, frameId: 1 },
+    )) as { ok: boolean; error?: string };
+
+    expect(res.error).toBe("INVALID_ID");
+  });
+
+  it("C9: rejects a malformed teamId even when entryId is valid", async () => {
+    await unlock();
+    const res = (await sendMessage(
+      { type: EXT_MSG.AUTOFILL_FROM_CONTENT, entryId: "cc-1", teamId: "bad/id" },
+      { tab: { id: 7 }, frameId: 1 },
+    )) as { ok: boolean; error?: string };
+
+    expect(res.error).toBe("INVALID_ID");
+  });
+
+  it("C9: accepts a CUID-shaped id (not over-strict UUIDv4)", async () => {
+    await unlock();
+    // Override the by-id fetch to recognize the CUID-shaped entryId.
+    cryptoMocks.decryptData.mockReset();
+    cryptoMocks.decryptData
+      .mockResolvedValueOnce(
+        JSON.stringify({ cardNumber: "4111111111111111", cardholderName: "Alice" }),
+      )
+      .mockResolvedValueOnce(JSON.stringify({ username: "Alice" }));
+
+    const cuid = "cjld2cjxh0000qzrmn831i7rn"; // CUID v1 shape
+    const res = (await sendMessage(
+      { type: EXT_MSG.AUTOFILL_FROM_CONTENT, entryId: cuid },
+      { tab: { id: 7 }, frameId: 1 },
+    )) as { ok: boolean; error?: string };
+
+    // Not rejected by the id guard (would be INVALID_ID otherwise).
+    expect(res.error).not.toBe("INVALID_ID");
+    expect(res.ok).toBe(true);
+  });
+});

--- a/extension/src/__tests__/content/autofill-cc.test.ts
+++ b/extension/src/__tests__/content/autofill-cc.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { performCreditCardAutofill } from "../../content/autofill-cc-lib";
+import { EXT_MSG } from "../../lib/constants";
 
 beforeEach(() => {
   Object.defineProperty(navigator, "language", {
@@ -26,7 +27,7 @@ describe("performCreditCardAutofill", () => {
     `);
 
     performCreditCardAutofill({
-      type: "AUTOFILL_CC_FILL",
+      type: EXT_MSG.AUTOFILL_CC_FILL,
       cardholderName: "John Doe",
       cardNumber: "4111111111111111",
       expiryMonth: "12",
@@ -50,7 +51,7 @@ describe("performCreditCardAutofill", () => {
     `);
 
     performCreditCardAutofill({
-      type: "AUTOFILL_CC_FILL",
+      type: EXT_MSG.AUTOFILL_CC_FILL,
       cardholderName: "",
       cardNumber: "4111111111111111",
       expiryMonth: "3",
@@ -80,7 +81,7 @@ describe("performCreditCardAutofill", () => {
     `);
 
     performCreditCardAutofill({
-      type: "AUTOFILL_CC_FILL",
+      type: EXT_MSG.AUTOFILL_CC_FILL,
       cardholderName: "",
       cardNumber: "4111111111111111",
       expiryMonth: "12",
@@ -106,7 +107,7 @@ describe("performCreditCardAutofill", () => {
     `);
 
     performCreditCardAutofill({
-      type: "AUTOFILL_CC_FILL",
+      type: EXT_MSG.AUTOFILL_CC_FILL,
       cardholderName: "",
       cardNumber: "4111111111111111",
       expiryMonth: "01",
@@ -125,7 +126,7 @@ describe("performCreditCardAutofill", () => {
     `);
 
     performCreditCardAutofill({
-      type: "AUTOFILL_CC_FILL",
+      type: EXT_MSG.AUTOFILL_CC_FILL,
       cardholderName: "Test",
       cardNumber: "4111111111111111",
       expiryMonth: "12",
@@ -146,7 +147,7 @@ describe("performCreditCardAutofill", () => {
     `);
 
     performCreditCardAutofill({
-      type: "AUTOFILL_CC_FILL",
+      type: EXT_MSG.AUTOFILL_CC_FILL,
       cardholderName: "Hidden Name",
       cardNumber: "4111111111111111",
       expiryMonth: "",
@@ -168,7 +169,7 @@ describe("performCreditCardAutofill", () => {
     `);
 
     performCreditCardAutofill({
-      type: "AUTOFILL_CC_FILL",
+      type: EXT_MSG.AUTOFILL_CC_FILL,
       cardholderName: "",
       cardNumber: "4111111111111111",
       expiryMonth: "01",
@@ -187,7 +188,7 @@ describe("performCreditCardAutofill", () => {
     `);
 
     const payload = {
-      type: "AUTOFILL_CC_FILL" as const,
+      type: EXT_MSG.AUTOFILL_CC_FILL,
       cardholderName: "",
       cardNumber: "4111111111111111",
       expiryMonth: "",
@@ -209,7 +210,7 @@ describe("performCreditCardAutofill", () => {
     `);
 
     performCreditCardAutofill({
-      type: "AUTOFILL_CC_FILL",
+      type: EXT_MSG.AUTOFILL_CC_FILL,
       cardholderName: "",
       cardNumber: "4111111111111111",
       expiryMonth: "",

--- a/extension/src/__tests__/content/autofill-identity.test.ts
+++ b/extension/src/__tests__/content/autofill-identity.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { performIdentityAutofill } from "../../content/autofill-identity-lib";
+import { EXT_MSG } from "../../lib/constants";
 
 beforeEach(() => {
   Object.defineProperty(navigator, "language", {
@@ -25,7 +26,7 @@ describe("performIdentityAutofill", () => {
     `);
 
     performIdentityAutofill({
-      type: "AUTOFILL_IDENTITY_FILL",
+      type: EXT_MSG.AUTOFILL_IDENTITY_FILL,
       fullName: "Jane Doe",
       address: "123 Main St",
       phone: "555-1234",
@@ -54,7 +55,7 @@ describe("performIdentityAutofill", () => {
     `);
 
     performIdentityAutofill({
-      type: "AUTOFILL_IDENTITY_FILL",
+      type: EXT_MSG.AUTOFILL_IDENTITY_FILL,
       fullName: "Jane Doe",
       address: "",
       phone: "555-1234",
@@ -75,7 +76,7 @@ describe("performIdentityAutofill", () => {
     `);
 
     performIdentityAutofill({
-      type: "AUTOFILL_IDENTITY_FILL",
+      type: EXT_MSG.AUTOFILL_IDENTITY_FILL,
       fullName: "Jane Doe",
       address: "",
       phone: "",
@@ -95,7 +96,7 @@ describe("performIdentityAutofill", () => {
     `);
 
     performIdentityAutofill({
-      type: "AUTOFILL_IDENTITY_FILL",
+      type: EXT_MSG.AUTOFILL_IDENTITY_FILL,
       fullName: "Jane Doe",
       address: "123 Main St",
       phone: "555-1234",
@@ -117,7 +118,7 @@ describe("performIdentityAutofill", () => {
     `);
 
     performIdentityAutofill({
-      type: "AUTOFILL_IDENTITY_FILL",
+      type: EXT_MSG.AUTOFILL_IDENTITY_FILL,
       fullName: "Jane Doe",
       address: "",
       phone: "555-1234",
@@ -139,7 +140,7 @@ describe("performIdentityAutofill", () => {
     `);
 
     performIdentityAutofill({
-      type: "AUTOFILL_IDENTITY_FILL",
+      type: EXT_MSG.AUTOFILL_IDENTITY_FILL,
       fullName: "Jane Doe",
       address: "",
       phone: "555-1234",
@@ -163,7 +164,7 @@ describe("performIdentityAutofill", () => {
     `);
 
     performIdentityAutofill({
-      type: "AUTOFILL_IDENTITY_FILL",
+      type: EXT_MSG.AUTOFILL_IDENTITY_FILL,
       fullName: "Jane Doe",
       address: "",
       phone: "555-1234",
@@ -190,7 +191,7 @@ describe("performIdentityAutofill", () => {
     `);
 
     performIdentityAutofill({
-      type: "AUTOFILL_IDENTITY_FILL",
+      type: EXT_MSG.AUTOFILL_IDENTITY_FILL,
       fullName: "山田太郎",
       address: "東京都渋谷区1-2-3",
       phone: "03-1234-5678",

--- a/extension/src/__tests__/content/cc-identity-detector.test.ts
+++ b/extension/src/__tests__/content/cc-identity-detector.test.ts
@@ -17,6 +17,18 @@ vi.mock("../../content/ui/suggestion-dropdown", () => ({
 
 vi.mock("../../lib/i18n", () => ({ t: (key: string) => key }));
 
+// M6: spy on showInlineNotice; stub the guard helpers with jsdom-safe defaults
+// (no layout in jsdom → hit-test always passes, elements always visible).
+const showInlineNoticeMock = vi.hoisted(() => vi.fn());
+vi.mock("../../content/form-detector-lib", () => ({
+  showInlineNotice: showInlineNoticeMock,
+  isUsableInput: (el: HTMLInputElement) => !el.disabled && !el.readOnly,
+  isElementVisuallySafe: () => true,
+  isPageVisuallySafe: () => true,
+  isInputHitTestSafe: () => true,
+  hasVisiblePopoverOverlayNear: () => false,
+}));
+
 // jsdom lacks layout — make visibility/hit-test helpers pass.
 if (typeof globalThis.CSS === "undefined") {
   (globalThis as Record<string, unknown>).CSS = { escape: (s: string) => s };
@@ -48,6 +60,7 @@ function matchRequests(type: string) {
 beforeEach(() => {
   showDropdownMock.mockReset();
   hideDropdownMock.mockReset();
+  showInlineNoticeMock.mockReset();
   document.body.innerHTML = "";
 });
 
@@ -121,6 +134,35 @@ describe("initCreditCardDetector", () => {
     destroy();
   });
 
+  it("M6: onSelect with NO_CARD_NUMBER response calls showInlineNotice with noCardNumber key", async () => {
+    document.body.innerHTML = `<input id="ccnum" autocomplete="cc-number" />`;
+    installChrome({
+      [EXT_MSG.GET_CC_MATCHES_FOR_URL]: {
+        type: EXT_MSG.GET_CC_MATCHES_FOR_URL,
+        entries: [{ id: "cc-1", title: "Card", username: "Alice", urlHost: "", entryType: "CREDIT_CARD" }],
+        vaultLocked: false,
+        suppressInline: false,
+      },
+      [EXT_MSG.AUTOFILL_FROM_CONTENT]: { ok: false, error: "NO_CARD_NUMBER" },
+    });
+    const { initCreditCardDetector } = await import("../../content/cc-form-detector-lib");
+    const { destroy } = initCreditCardDetector();
+
+    const input = document.getElementById("ccnum") as HTMLInputElement;
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    // Drive onSelect with the captured dropdown options.
+    const opts = showDropdownMock.mock.calls[0][0] as {
+      onSelect: (id: string, teamId?: string) => void;
+    };
+    opts.onSelect("cc-1");
+
+    // showInlineNotice must have been called with the noCardNumber i18n key.
+    expect(showInlineNoticeMock).toHaveBeenCalledOnce();
+    expect(showInlineNoticeMock).toHaveBeenCalledWith(input, "errors.noCardNumber");
+    destroy();
+  });
+
   it("T8: destroy() removes the focus listener (no further requests)", async () => {
     document.body.innerHTML = `<input id="ccnum" autocomplete="cc-number" />`;
     installChrome({
@@ -165,6 +207,36 @@ describe("initCreditCardDetector", () => {
 });
 
 describe("initIdentityDetector", () => {
+  it("M1 (mock-only): no-op in a cross-origin subframe", async () => {
+    document.body.innerHTML = `
+      <form>
+        <input id="name" autocomplete="name" />
+        <input id="addr" autocomplete="address-line1" />
+      </form>
+    `;
+    installChrome({});
+    // Simulate a cross-origin subframe: window.top !== window.self AND
+    // accessing window.top.location throws (SecurityError). jsdom cannot model
+    // a real cross-origin frame, so we monkey-patch window.top for this test.
+    const realTop = window.top;
+    const crossOriginTop = {
+      get location(): Location {
+        throw new Error("cross-origin");
+      },
+    };
+    Object.defineProperty(window, "top", { value: crossOriginTop, configurable: true });
+    try {
+      const { initIdentityDetector } = await import("../../content/identity-form-detector-lib");
+      const { destroy } = initIdentityDetector();
+      const input = document.getElementById("name") as HTMLInputElement;
+      input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+      expect(matchRequests(EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL)).toHaveLength(0);
+      destroy();
+    } finally {
+      Object.defineProperty(window, "top", { value: realTop, configurable: true });
+    }
+  });
+
   it("issues one GET_IDENTITY_MATCHES request when a detected identity field is focused", async () => {
     document.body.innerHTML = `
       <form>

--- a/extension/src/__tests__/content/cc-identity-detector.test.ts
+++ b/extension/src/__tests__/content/cc-identity-detector.test.ts
@@ -1,0 +1,231 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { EXT_MSG } from "../../lib/constants";
+
+// Capture showDropdown options so we can drive onSelect.
+const showDropdownMock = vi.fn();
+const hideDropdownMock = vi.fn();
+
+vi.mock("../../content/ui/suggestion-dropdown", () => ({
+  showDropdown: (opts: unknown) => showDropdownMock(opts),
+  hideDropdown: (...a: unknown[]) => hideDropdownMock(...a),
+  isDropdownVisible: () => false,
+  handleDropdownKeydown: () => false,
+}));
+
+vi.mock("../../lib/i18n", () => ({ t: (key: string) => key }));
+
+// jsdom lacks layout — make visibility/hit-test helpers pass.
+if (typeof globalThis.CSS === "undefined") {
+  (globalThis as Record<string, unknown>).CSS = { escape: (s: string) => s };
+}
+
+let sentMessages: Array<{ msg: { type?: string }; cb?: (r: unknown) => void }> = [];
+
+function installChrome(responses: Record<string, unknown>) {
+  sentMessages = [];
+  vi.stubGlobal("chrome", {
+    runtime: {
+      id: "ext-test-id",
+      onMessage: { addListener: vi.fn(), removeListener: vi.fn() },
+      sendMessage: vi.fn((msg: { type?: string }, cb?: (r: unknown) => void) => {
+        sentMessages.push({ msg, cb });
+        const resp = responses[msg.type ?? ""];
+        if (resp !== undefined && cb) cb(resp);
+      }),
+      lastError: null,
+    },
+    i18n: { getUILanguage: () => "en" },
+  });
+}
+
+function matchRequests(type: string) {
+  return sentMessages.filter((m) => m.msg.type === type);
+}
+
+beforeEach(() => {
+  showDropdownMock.mockReset();
+  hideDropdownMock.mockReset();
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("initCreditCardDetector", () => {
+  it("issues exactly one GET_CC_MATCHES request when a detected CC field is focused", async () => {
+    document.body.innerHTML = `<input id="ccnum" autocomplete="cc-number" />`;
+    installChrome({
+      [EXT_MSG.GET_CC_MATCHES_FOR_URL]: {
+        type: EXT_MSG.GET_CC_MATCHES_FOR_URL,
+        entries: [{ id: "cc-1", title: "Card", username: "Alice", urlHost: "", entryType: "CREDIT_CARD" }],
+        vaultLocked: false,
+        suppressInline: false,
+      },
+    });
+    const { initCreditCardDetector } = await import("../../content/cc-form-detector-lib");
+    const { destroy } = initCreditCardDetector();
+
+    const input = document.getElementById("ccnum") as HTMLInputElement;
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    expect(matchRequests(EXT_MSG.GET_CC_MATCHES_FOR_URL)).toHaveLength(1);
+    expect(showDropdownMock).toHaveBeenCalledTimes(1);
+    expect(showDropdownMock.mock.calls[0][0].entryType).toBe("CREDIT_CARD");
+    destroy();
+  });
+
+  it("does not request matches when an unrelated field is focused", async () => {
+    document.body.innerHTML = `
+      <input id="ccnum" autocomplete="cc-number" />
+      <input id="search" type="text" name="search" />
+    `;
+    installChrome({});
+    const { initCreditCardDetector } = await import("../../content/cc-form-detector-lib");
+    const { destroy } = initCreditCardDetector();
+
+    const search = document.getElementById("search") as HTMLInputElement;
+    search.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    expect(matchRequests(EXT_MSG.GET_CC_MATCHES_FOR_URL)).toHaveLength(0);
+    destroy();
+  });
+
+  it("T5: selecting an entry sends AUTOFILL_FROM_CONTENT with the entryId", async () => {
+    document.body.innerHTML = `<input id="ccnum" autocomplete="cc-number" />`;
+    installChrome({
+      [EXT_MSG.GET_CC_MATCHES_FOR_URL]: {
+        type: EXT_MSG.GET_CC_MATCHES_FOR_URL,
+        entries: [{ id: "cc-1", title: "Card", username: "Alice", urlHost: "", entryType: "CREDIT_CARD" }],
+        vaultLocked: false,
+        suppressInline: false,
+      },
+    });
+    const { initCreditCardDetector } = await import("../../content/cc-form-detector-lib");
+    const { destroy } = initCreditCardDetector();
+
+    const input = document.getElementById("ccnum") as HTMLInputElement;
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    const opts = showDropdownMock.mock.calls[0][0] as {
+      onSelect: (id: string, teamId?: string) => void;
+    };
+    opts.onSelect("cc-1");
+
+    const fills = matchRequests(EXT_MSG.AUTOFILL_FROM_CONTENT);
+    expect(fills).toHaveLength(1);
+    expect((fills[0].msg as { entryId?: string }).entryId).toBe("cc-1");
+    destroy();
+  });
+
+  it("T8: destroy() removes the focus listener (no further requests)", async () => {
+    document.body.innerHTML = `<input id="ccnum" autocomplete="cc-number" />`;
+    installChrome({
+      [EXT_MSG.GET_CC_MATCHES_FOR_URL]: {
+        type: EXT_MSG.GET_CC_MATCHES_FOR_URL, entries: [], vaultLocked: false, suppressInline: false,
+      },
+    });
+    const { initCreditCardDetector } = await import("../../content/cc-form-detector-lib");
+    const { destroy } = initCreditCardDetector();
+    destroy();
+
+    const input = document.getElementById("ccnum") as HTMLInputElement;
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    expect(matchRequests(EXT_MSG.GET_CC_MATCHES_FOR_URL)).toHaveLength(0);
+  });
+
+  it("T10 (mock-only): no-op in a cross-origin subframe", async () => {
+    document.body.innerHTML = `<input id="ccnum" autocomplete="cc-number" />`;
+    installChrome({});
+    // Simulate a cross-origin subframe: window.top !== window.self AND
+    // accessing window.top.location throws (SecurityError). jsdom cannot model
+    // a real cross-origin frame, so we monkey-patch window.top for this test.
+    const realTop = window.top;
+    const crossOriginTop = {
+      get location(): Location {
+        throw new Error("cross-origin");
+      },
+    };
+    Object.defineProperty(window, "top", { value: crossOriginTop, configurable: true });
+    try {
+      const { initCreditCardDetector } = await import("../../content/cc-form-detector-lib");
+      const { destroy } = initCreditCardDetector();
+      const input = document.getElementById("ccnum") as HTMLInputElement;
+      input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+      expect(matchRequests(EXT_MSG.GET_CC_MATCHES_FOR_URL)).toHaveLength(0);
+      destroy();
+    } finally {
+      Object.defineProperty(window, "top", { value: realTop, configurable: true });
+    }
+  });
+});
+
+describe("initIdentityDetector", () => {
+  it("issues one GET_IDENTITY_MATCHES request when a detected identity field is focused", async () => {
+    document.body.innerHTML = `
+      <form>
+        <input id="name" autocomplete="name" />
+        <input id="addr" autocomplete="address-line1" />
+      </form>
+    `;
+    installChrome({
+      [EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL]: {
+        type: EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL,
+        entries: [{ id: "id-1", title: "Home", username: "Alice Smith", urlHost: "", entryType: "IDENTITY" }],
+        vaultLocked: false,
+        suppressInline: false,
+      },
+    });
+    const { initIdentityDetector } = await import("../../content/identity-form-detector-lib");
+    const { destroy } = initIdentityDetector();
+
+    const input = document.getElementById("name") as HTMLInputElement;
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    expect(matchRequests(EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL)).toHaveLength(1);
+    expect(showDropdownMock.mock.calls[0][0].entryType).toBe("IDENTITY");
+    destroy();
+  });
+});
+
+describe("T7: both forms on one page do not cross-trigger", () => {
+  it("CC field → GET_CC only; identity field → GET_IDENTITY only", async () => {
+    document.body.innerHTML = `
+      <form id="payment">
+        <input id="ccnum" autocomplete="cc-number" />
+      </form>
+      <form id="shipping">
+        <input id="name" autocomplete="name" />
+        <input id="addr" autocomplete="address-line1" />
+      </form>
+    `;
+    installChrome({
+      [EXT_MSG.GET_CC_MATCHES_FOR_URL]: {
+        type: EXT_MSG.GET_CC_MATCHES_FOR_URL, entries: [], vaultLocked: false, suppressInline: false,
+      },
+      [EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL]: {
+        type: EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL, entries: [], vaultLocked: false, suppressInline: false,
+      },
+    });
+    const { initCreditCardDetector } = await import("../../content/cc-form-detector-lib");
+    const { initIdentityDetector } = await import("../../content/identity-form-detector-lib");
+    const cc = initCreditCardDetector();
+    const id = initIdentityDetector();
+
+    (document.getElementById("ccnum") as HTMLInputElement).dispatchEvent(
+      new FocusEvent("focusin", { bubbles: true }),
+    );
+    (document.getElementById("name") as HTMLInputElement).dispatchEvent(
+      new FocusEvent("focusin", { bubbles: true }),
+    );
+
+    expect(matchRequests(EXT_MSG.GET_CC_MATCHES_FOR_URL)).toHaveLength(1);
+    expect(matchRequests(EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL)).toHaveLength(1);
+    cc.destroy();
+    id.destroy();
+  });
+});

--- a/extension/src/__tests__/content/form-detector-entry.test.ts
+++ b/extension/src/__tests__/content/form-detector-entry.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * M5 — entry-point teardown (form-detector.ts, F6 invariant)
+ *
+ * The entry point runs module-level code on import (the guard-key pattern).
+ * vi.resetModules() + deleting the window guard key lets us re-import cleanly.
+ *
+ * We mock the four init-lib modules so each returns a destroy spy, and mock
+ * removeShadowHost from ./ui/shadow-host so we can count its invocations.
+ * After import (which registers the error handler), dispatching a window error
+ * with "Extension context invalidated" must call every destroy spy exactly once
+ * and removeShadowHost exactly once — not once per detector.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+// Spies declared with vi.hoisted so they are available inside vi.mock factories.
+const destroyCC = vi.hoisted(() => vi.fn());
+const destroyIdentity = vi.hoisted(() => vi.fn());
+const destroyForm = vi.hoisted(() => vi.fn());
+const destroyLogin = vi.hoisted(() => vi.fn());
+const removeShadowHostMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../content/cc-form-detector-lib", () => ({
+  initCreditCardDetector: () => ({ destroy: destroyCC }),
+}));
+
+vi.mock("../../content/identity-form-detector-lib", () => ({
+  initIdentityDetector: () => ({ destroy: destroyIdentity }),
+}));
+
+vi.mock("../../content/form-detector-lib", () => ({
+  initFormDetector: () => ({ destroy: destroyForm }),
+}));
+
+vi.mock("../../content/login-detector-lib", () => ({
+  initLoginDetector: () => ({ destroy: destroyLogin }),
+}));
+
+vi.mock("../../content/ui/shadow-host", () => ({
+  removeShadowHost: removeShadowHostMock,
+  getShadowHost: vi.fn(),
+}));
+
+// Side-effect-only imports — empty mocks prevent chrome API calls.
+vi.mock("../../content/autofill-lib", () => ({}));
+vi.mock("../../content/webauthn-bridge", () => ({}));
+
+const GUARD_KEY = "__passwdSsoFormDetector";
+
+beforeEach(() => {
+  destroyCC.mockReset();
+  destroyIdentity.mockReset();
+  destroyForm.mockReset();
+  destroyLogin.mockReset();
+  removeShadowHostMock.mockReset();
+
+  // Clear the double-injection guard so the entry point re-runs on import.
+  delete (window as unknown as Record<string, unknown>)[GUARD_KEY];
+
+  vi.resetModules();
+
+  vi.stubGlobal("chrome", {
+    runtime: {
+      id: "ext-test-id",
+      onMessage: { addListener: vi.fn(), removeListener: vi.fn() },
+      lastError: null,
+    },
+    storage: {
+      local: { get: vi.fn() },
+      session: { setAccessLevel: vi.fn() },
+    },
+  });
+});
+
+afterEach(() => {
+  delete (window as unknown as Record<string, unknown>)[GUARD_KEY];
+});
+
+describe("M5: entry-point error-handler teardown (F6 invariant)", () => {
+  it("dispatching 'Extension context invalidated' calls every destroy once and removeShadowHost once", async () => {
+    // Import the entry point — module-level code runs, registers cleanups + error handler.
+    await import("../../content/form-detector");
+
+    // Dispatch the error that orphaned content scripts produce.
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "Extension context invalidated" }),
+    );
+
+    // Each detector's destroy must have been called exactly once.
+    expect(destroyForm).toHaveBeenCalledOnce();
+    expect(destroyLogin).toHaveBeenCalledOnce();
+    expect(destroyCC).toHaveBeenCalledOnce();
+    expect(destroyIdentity).toHaveBeenCalledOnce();
+
+    // F6: the shared shadow host is removed once, not once per detector.
+    expect(removeShadowHostMock).toHaveBeenCalledOnce();
+  });
+
+  it("double-injection guard prevents a second init when the entry point is imported again", async () => {
+    // First import triggers init.
+    await import("../../content/form-detector");
+    const callsAfterFirst = destroyForm.mock.calls.length;
+
+    // Simulate a second import WITHOUT resetting the guard or modules —
+    // the guard key is set, so no second init should run.
+    await import("../../content/form-detector");
+
+    // destroyForm should not have been called a second time (no second init).
+    expect(destroyForm.mock.calls.length).toBe(callsAfterFirst);
+  });
+});

--- a/extension/src/__tests__/content/ui/suggestion-dropdown-entrytype.test.ts
+++ b/extension/src/__tests__/content/ui/suggestion-dropdown-entrytype.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Use an OPEN shadow root we control so the test can read the rendered DOM
+// (the production host uses a closed root that tests cannot inspect).
+const hostState: { host: HTMLDivElement | null; root: ShadowRoot | null } = {
+  host: null,
+  root: null,
+};
+
+vi.mock("../../../content/ui/shadow-host", () => ({
+  getShadowHost: () => {
+    if (!hostState.host || !document.body.contains(hostState.host)) {
+      const host = document.createElement("div");
+      host.setAttribute("data-passwd-sso-shadow-host", "test");
+      const root = host.attachShadow({ mode: "open" });
+      document.body.appendChild(host);
+      hostState.host = host;
+      hostState.root = root;
+    }
+    return { host: hostState.host, root: hostState.root };
+  },
+  removeShadowHost: () => {
+    hostState.host?.remove();
+    hostState.host = null;
+    hostState.root = null;
+  },
+}));
+
+import {
+  showDropdown,
+  hideDropdown,
+  type DropdownOptions,
+  type DropdownEntryType,
+} from "../../../content/ui/suggestion-dropdown";
+import { EXT_ENTRY_TYPE } from "../../../lib/constants";
+
+// jsdom re-serializes inline SVG (self-closing → explicit close tags), so the
+// raw icon strings won't match verbatim. Assert on a stable path-data fragment
+// unique to each icon instead.
+const CARD_PATH = "M1 4a2 2 0";
+const ID_PATH = "M2 3.5A1.5";
+const KEY_PATH = "M11.5 1a3.5";
+
+function itemIconHtml(): string {
+  return hostState.root?.querySelector(".psso-item-icon")?.innerHTML ?? "";
+}
+
+function makeAnchorRect(): DOMRect {
+  return {
+    top: 100, left: 50, bottom: 130, right: 250,
+    width: 200, height: 30, x: 50, y: 100, toJSON: () => ({}),
+  };
+}
+
+function makeOptions(overrides?: Partial<DropdownOptions>): DropdownOptions {
+  return {
+    anchorRect: makeAnchorRect(),
+    entries: [
+      { id: "1", title: "Card", username: "Alice", urlHost: "", entryType: EXT_ENTRY_TYPE.CREDIT_CARD },
+    ],
+    vaultLocked: false,
+    onSelect: vi.fn(),
+    onDismiss: vi.fn(),
+    lockedMessage: "locked",
+    noMatchesMessage: "none",
+    headerLabel: "Cards",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+afterEach(() => {
+  hideDropdown();
+});
+
+describe("showDropdown entryType parametrization", () => {
+  it("renders the card icon and Cards header for CREDIT_CARD", () => {
+    showDropdown(makeOptions({ entryType: "CREDIT_CARD", headerLabel: "Cards" }));
+    expect(itemIconHtml()).toContain(CARD_PATH);
+    expect(itemIconHtml()).not.toContain(KEY_PATH);
+    expect(hostState.root?.querySelector(".psso-dropdown-header")?.textContent).toBe("Cards");
+  });
+
+  it("renders the identity icon and Identities header for IDENTITY", () => {
+    showDropdown(makeOptions({ entryType: "IDENTITY", headerLabel: "Identities" }));
+    expect(itemIconHtml()).toContain(ID_PATH);
+    expect(hostState.root?.querySelector(".psso-dropdown-header")?.textContent).toBe("Identities");
+  });
+
+  it("defaults to the LOGIN key icon when entryType is omitted (T4)", () => {
+    const opts = makeOptions({ headerLabel: "Logins" });
+    delete (opts as Partial<DropdownOptions>).entryType;
+    showDropdown(opts);
+    expect(itemIconHtml()).toContain(KEY_PATH);
+  });
+
+  it("accepts the optional entryType type", () => {
+    const t: DropdownEntryType = "IDENTITY";
+    expect(t).toBe("IDENTITY");
+  });
+});

--- a/extension/src/__tests__/content/ui/suggestion-dropdown.test.ts
+++ b/extension/src/__tests__/content/ui/suggestion-dropdown.test.ts
@@ -131,14 +131,36 @@ describe("handleDropdownKeydown", () => {
     expect(isDropdownVisible()).toBe(false);
   });
 
+  // jsdom sets Event.isTrusted as a non-configurable own property (false by default).
+  // Object.defineProperty cannot override it, so use a Proxy to intercept isTrusted reads.
+  const trustedKeydown = (key: string): KeyboardEvent => {
+    const e = new KeyboardEvent("keydown", { key, cancelable: true });
+    return new Proxy(e, {
+      get(target, prop, receiver) {
+        if (prop === "isTrusted") return true;
+        const val = Reflect.get(target, prop, receiver);
+        return typeof val === "function" ? (val as (...a: unknown[]) => unknown).bind(target) : val;
+      },
+    }) as KeyboardEvent;
+  };
+
   it("selects active item with Enter", () => {
     const opts = makeOptions();
     showDropdown(opts);
     handleDropdownKeydown(new KeyboardEvent("keydown", { key: "ArrowDown", cancelable: true }));
-    const handled = handleDropdownKeydown(
-      new KeyboardEvent("keydown", { key: "Enter", cancelable: true }),
-    );
+    const handled = handleDropdownKeydown(trustedKeydown("Enter"));
     expect(handled).toBe(true);
     expect(opts.onSelect).toHaveBeenCalledWith("1", undefined);
+  });
+
+  it("does NOT select on a synthetic (untrusted) Enter — blocks scripted exfiltration", () => {
+    const opts = makeOptions();
+    showDropdown(opts);
+    handleDropdownKeydown(new KeyboardEvent("keydown", { key: "ArrowDown", cancelable: true }));
+    const handled = handleDropdownKeydown(
+      new KeyboardEvent("keydown", { key: "Enter", cancelable: true }), // isTrusted=false
+    );
+    expect(handled).toBe(false);
+    expect(opts.onSelect).not.toHaveBeenCalled();
   });
 });

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1312,10 +1312,26 @@ async function performAutofillForEntry(
   tabId: number,
   targetHint?: AutofillTargetHint,
   teamId?: string,
+  frameId?: number,
 ): Promise<{ ok: boolean; error?: string }> {
   if (!encryptionKey || !currentUserId) {
     return { ok: false, error: "VAULT_LOCKED" };
   }
+
+  // Inline path supplies the originating frame so card/identity plaintext is
+  // delivered only to that frame. Popup/context-menu callers pass no frameId —
+  // keep tab-wide behavior (do NOT substitute frame 0, which would break
+  // same-origin-subframe popup fills).
+  const hasFrameTarget = typeof frameId === "number";
+  const executeTarget = hasFrameTarget
+    ? { tabId, frameIds: [frameId] }
+    : { tabId };
+  // chrome.tabs.sendMessage's options overload rejects `undefined`; only pass
+  // frame-targeting options when an originating frame is known.
+  const sendFillMessage = (payload: unknown): Promise<unknown> =>
+    hasFrameTarget
+      ? chrome.tabs.sendMessage(tabId, payload, { frameId })
+      : chrome.tabs.sendMessage(tabId, payload);
 
   let blobPlain: string;
   let overviewPlain: string;
@@ -1394,11 +1410,11 @@ async function performAutofillForEntry(
     }
     try {
       await chrome.scripting.executeScript({
-        target: { tabId },
+        target: executeTarget,
         files: ["src/content/autofill-cc.js"],
       });
-      await chrome.tabs.sendMessage(tabId, {
-        type: "AUTOFILL_CC_FILL",
+      await sendFillMessage({
+        type: EXT_MSG.AUTOFILL_CC_FILL,
         cardholderName: blob.cardholderName ?? "",
         cardNumber,
         expiryMonth: blob.expiryMonth ?? "",
@@ -1416,11 +1432,11 @@ async function performAutofillForEntry(
   if (entryType === EXT_ENTRY_TYPE.IDENTITY) {
     try {
       await chrome.scripting.executeScript({
-        target: { tabId },
+        target: executeTarget,
         files: ["src/content/autofill-identity.js"],
       });
-      await chrome.tabs.sendMessage(tabId, {
-        type: "AUTOFILL_IDENTITY_FILL",
+      await sendFillMessage({
+        type: EXT_MSG.AUTOFILL_IDENTITY_FILL,
         fullName: blob.fullName ?? "",
         address: blob.address ?? "",
         postalCode: blob.postalCode ?? "",
@@ -1659,6 +1675,75 @@ async function performAutofillForEntry(
   }
 
   return { ok: true };
+}
+
+// ── Inline match resolution (shared by LOGIN / CC / IDENTITY) ────
+
+type InlineMatchKind = "login" | "credit_card" | "identity";
+
+interface InlineMatchResult {
+  entries: DecryptedEntry[];
+  vaultLocked: boolean;
+  suppressInline: boolean;
+  disconnected?: boolean;
+}
+
+/**
+ * Content-supplied identifiers reach an authenticated API path; bound their
+ * charset/length as defense-in-depth (the id is also URL-encoded into the path).
+ * NOT a UUIDv4-strict guard — entry ids in this repo are mixed CUID v1 + UUIDv4,
+ * so a UUIDv4-only regex would reject legitimate legacy CUID entries.
+ */
+const CONTENT_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+function isValidContentId(value: unknown): value is string {
+  return typeof value === "string" && CONTENT_ID_RE.test(value);
+}
+
+/**
+ * Shared gate + filter for inline suggestion requests. LOGIN keeps the host
+ * match (and the `!tabHost` early-return); CC/IDENTITY filter purely by entry
+ * type with no host match and MUST still return entries on hostless pages.
+ * Badge update + cache population side effects stay LOGIN-only (caller's job).
+ */
+async function resolveInlineMatches(
+  kind: InlineMatchKind,
+  effectiveUrl: string,
+): Promise<InlineMatchResult> {
+  if (!cachedEnableInlineSuggestions) {
+    return { entries: [], vaultLocked: false, suppressInline: true };
+  }
+  if (await isOwnAppPage(effectiveUrl)) {
+    return { entries: [], vaultLocked: false, suppressInline: true };
+  }
+  if (!currentToken) {
+    return { entries: [], vaultLocked: false, disconnected: true, suppressInline: false };
+  }
+  if (!encryptionKey || !currentUserId) {
+    return { entries: [], vaultLocked: true, suppressInline: false };
+  }
+
+  if (kind === "login") {
+    const tabHost = extractHost(effectiveUrl);
+    // LOGIN-only: no host means no possible host match.
+    if (!tabHost) {
+      return { entries: [], vaultLocked: false, suppressInline: false };
+    }
+    const entries = await getCachedEntries();
+    const matches = entries.filter((e) => {
+      if (e.entryType !== EXT_ENTRY_TYPE.LOGIN) return false;
+      if (e.urlHost && isHostMatch(e.urlHost, tabHost)) return true;
+      return (e.additionalUrlHosts ?? []).some((h) => isHostMatch(h, tabHost));
+    });
+    return { entries: matches, vaultLocked: false, suppressInline: false };
+  }
+
+  // CC / IDENTITY: URL-independent — no host match, no `!tabHost` early-return.
+  const targetType =
+    kind === "credit_card" ? EXT_ENTRY_TYPE.CREDIT_CARD : EXT_ENTRY_TYPE.IDENTITY;
+  const entries = await getCachedEntries();
+  const matches = entries.filter((e) => e.entryType === targetType);
+  return { entries: matches, vaultLocked: false, suppressInline: false };
 }
 
 // ── Message handler ──────────────────────────────────────────
@@ -2144,75 +2229,58 @@ async function handleMessage(
     }
 
     case EXT_MSG.GET_MATCHES_FOR_URL: {
-      if (!cachedEnableInlineSuggestions) {
-        sendResponse({
-          type: EXT_MSG.GET_MATCHES_FOR_URL,
-          entries: [],
-          vaultLocked: false,
-          suppressInline: true,
-        });
-        return;
-      }
       const effectiveUrl = message.topUrl ?? message.url;
-      if (await isOwnAppPage(effectiveUrl)) {
-        sendResponse({
-          type: EXT_MSG.GET_MATCHES_FOR_URL,
-          entries: [],
-          vaultLocked: false,
-          suppressInline: true,
-        });
-        return;
-      }
-      if (!currentToken) {
-        sendResponse({
-          type: EXT_MSG.GET_MATCHES_FOR_URL,
-          entries: [],
-          vaultLocked: false,
-          disconnected: true,
-          suppressInline: false,
-        });
-        return;
-      }
-      if (!encryptionKey || !currentUserId) {
-        sendResponse({
-          type: EXT_MSG.GET_MATCHES_FOR_URL,
-          entries: [],
-          vaultLocked: true,
-          suppressInline: false,
-        });
-        return;
-      }
-
       try {
-        const tabHost = extractHost(effectiveUrl);
-        if (!tabHost) {
-          sendResponse({
-            type: EXT_MSG.GET_MATCHES_FOR_URL,
-            entries: [],
-            vaultLocked: false,
-            suppressInline: false,
-          });
-          return;
-        }
-        const entries = await getCachedEntries();
-        const matches = entries.filter((e) => {
-          if (e.entryType !== EXT_ENTRY_TYPE.LOGIN) return false;
-          if (e.urlHost && isHostMatch(e.urlHost, tabHost)) return true;
-          return (e.additionalUrlHosts ?? []).some((h) => isHostMatch(h, tabHost));
-        });
-        sendResponse({
-          type: EXT_MSG.GET_MATCHES_FOR_URL,
-          entries: matches,
-          vaultLocked: false,
-          suppressInline: false,
-        });
-        // Cache was just populated — update badge for sender tab
-        if (_sender.tab?.id) {
+        const result = await resolveInlineMatches("login", effectiveUrl);
+        sendResponse({ type: EXT_MSG.GET_MATCHES_FOR_URL, ...result });
+        // LOGIN-only side effect (success path only): badge counts host-matched
+        // logins. Mirror the original exactly — fired only after a successful
+        // host-matched filter (gates passed AND a non-null host), never on the
+        // suppressed / disconnected / locked / hostless branches.
+        if (
+          !result.disconnected &&
+          !result.suppressInline &&
+          !result.vaultLocked &&
+          extractHost(effectiveUrl) &&
+          _sender.tab?.id
+        ) {
           void updateBadgeForTab(_sender.tab.id, effectiveUrl);
         }
       } catch {
         sendResponse({
           type: EXT_MSG.GET_MATCHES_FOR_URL,
+          entries: [],
+          vaultLocked: false,
+          suppressInline: false,
+        });
+      }
+      return;
+    }
+
+    case EXT_MSG.GET_CC_MATCHES_FOR_URL: {
+      const effectiveUrl = message.topUrl ?? message.url;
+      try {
+        const result = await resolveInlineMatches("credit_card", effectiveUrl);
+        sendResponse({ type: EXT_MSG.GET_CC_MATCHES_FOR_URL, ...result });
+      } catch {
+        sendResponse({
+          type: EXT_MSG.GET_CC_MATCHES_FOR_URL,
+          entries: [],
+          vaultLocked: false,
+          suppressInline: false,
+        });
+      }
+      return;
+    }
+
+    case EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL: {
+      const effectiveUrl = message.topUrl ?? message.url;
+      try {
+        const result = await resolveInlineMatches("identity", effectiveUrl);
+        sendResponse({ type: EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL, ...result });
+      } catch {
+        sendResponse({
+          type: EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL,
           entries: [],
           vaultLocked: false,
           suppressInline: false,
@@ -2231,6 +2299,20 @@ async function handleMessage(
         return;
       }
 
+      // C9: bound content-supplied identifiers before they reach the authed
+      // fetch path. teamId is optional — reject only when present-and-invalid.
+      if (
+        !isValidContentId(message.entryId) ||
+        (message.teamId !== undefined && !isValidContentId(message.teamId))
+      ) {
+        sendResponse({
+          type: EXT_MSG.AUTOFILL_FROM_CONTENT,
+          ok: false,
+          error: "INVALID_ID",
+        });
+        return;
+      }
+
       try {
         const tabId = _sender.tab?.id;
         if (!tabId) {
@@ -2241,11 +2323,14 @@ async function handleMessage(
           });
           return;
         }
+        // C8: deliver card/identity plaintext only to the originating frame.
+        const frameId = _sender.frameId;
         const result = await performAutofillForEntry(
           message.entryId,
           tabId,
           message.targetHint,
           message.teamId,
+          frameId,
         );
         sendResponse({
           type: EXT_MSG.AUTOFILL_FROM_CONTENT,
@@ -2518,6 +2603,12 @@ chrome.runtime.onMessage.addListener(
             break;
           case EXT_MSG.GET_MATCHES_FOR_URL:
             sendResponse({ type: EXT_MSG.GET_MATCHES_FOR_URL, entries: [], vaultLocked: !!currentToken && !encryptionKey, disconnected: !currentToken, suppressInline: false } as ExtensionResponse);
+            break;
+          case EXT_MSG.GET_CC_MATCHES_FOR_URL:
+            sendResponse({ type: EXT_MSG.GET_CC_MATCHES_FOR_URL, entries: [], vaultLocked: !!currentToken && !encryptionKey, disconnected: !currentToken, suppressInline: false } as ExtensionResponse);
+            break;
+          case EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL:
+            sendResponse({ type: EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL, entries: [], vaultLocked: !!currentToken && !encryptionKey, disconnected: !currentToken, suppressInline: false } as ExtensionResponse);
             break;
           case EXT_MSG.FETCH_PASSWORDS:
             sendResponse({ type: EXT_MSG.FETCH_PASSWORDS, entries: null, error: "INTERNAL_ERROR" } as ExtensionResponse);

--- a/extension/src/content/autofill-cc.js
+++ b/extension/src/content/autofill-cc.js
@@ -241,7 +241,9 @@ if (
 ) {
   window[CC_AUTOFILL_GUARD] = true;
   chrome.runtime.onMessage.addListener(function (message, sender) {
-    // Only accept messages from our own extension — reject external senders
+    // Only accept messages from our own extension — reject external senders.
+    // Literal must equal EXT_MSG.AUTOFILL_CC_FILL in src/lib/constants.ts —
+    // this plain-JS web-accessible resource cannot import the module.
     if (message && message.type === "AUTOFILL_CC_FILL" && sender.id === chrome.runtime.id) {
       performCreditCardAutofill(message);
     }

--- a/extension/src/content/autofill-identity.js
+++ b/extension/src/content/autofill-identity.js
@@ -185,7 +185,9 @@ if (
 ) {
   window[IDENTITY_AUTOFILL_GUARD] = true;
   chrome.runtime.onMessage.addListener(function (message, sender) {
-    // Only accept messages from our own extension — reject external senders
+    // Only accept messages from our own extension — reject external senders.
+    // Literal must equal EXT_MSG.AUTOFILL_IDENTITY_FILL in src/lib/constants.ts —
+    // this plain-JS web-accessible resource cannot import the module.
     if (message && message.type === "AUTOFILL_IDENTITY_FILL" && sender.id === chrome.runtime.id) {
       performIdentityAutofill(message);
     }

--- a/extension/src/content/cc-form-detector-lib.ts
+++ b/extension/src/content/cc-form-detector-lib.ts
@@ -1,5 +1,24 @@
 // Pure logic module for credit card form detection (exported, testable).
-// Side-effect-free — no global event registration here.
+// detectCreditCardFields is side-effect-free; initCreditCardDetector wires the
+// inline-suggestion lifecycle (focus → match request → dropdown → fill).
+
+import type { DecryptedEntry } from "../types/messages";
+import { t } from "../lib/i18n";
+import { EXT_MSG } from "../lib/constants";
+import {
+  isUsableInput,
+  isElementVisuallySafe,
+  isPageVisuallySafe,
+  isInputHitTestSafe,
+  hasVisiblePopoverOverlayNear,
+  showInlineNotice,
+} from "./form-detector-lib";
+import {
+  showDropdown,
+  hideDropdown,
+  isDropdownVisible,
+  handleDropdownKeydown,
+} from "./ui/suggestion-dropdown";
 
 // ── Types ──
 
@@ -209,4 +228,268 @@ export function detectCreditCardFields(root: ParentNode): CreditCardFormFields |
     cvv,
     expiryFormat: hasCombined ? "combined" : "split",
   };
+}
+
+// ── Inline detector ─────────────────────────────────────────
+
+declare const navigation: EventTarget | undefined;
+
+export interface CreditCardDetectorCleanup {
+  destroy: () => void;
+}
+
+function isContextValid(): boolean {
+  try {
+    return !!chrome.runtime?.id;
+  } catch {
+    return false;
+  }
+}
+
+/** Collect the detected CC field elements into a membership set for O(1) focus lookup. */
+function collectCcFields(fields: CreditCardFormFields, into: WeakSet<HTMLElement>): void {
+  const candidates = [
+    fields.cardholderName,
+    fields.cardNumber,
+    fields.expiryMonth,
+    fields.expiryYear,
+    fields.expiryCombined,
+    fields.cvv,
+  ];
+  for (const el of candidates) {
+    if (el) into.add(el);
+  }
+}
+
+/**
+ * Initialize the inline credit-card suggestion detector. Mirrors the LOGIN
+ * detector but with detector-LOCAL suppression state and a CC-field WeakSet,
+ * so it neither scans the DOM per focus nor cross-suppresses the LOGIN dropdown.
+ */
+export function initCreditCardDetector(): CreditCardDetectorCleanup {
+  let destroyed = false;
+
+  // S2: a malicious cross-origin subframe must not render a deceptive dropdown.
+  const isCrossOriginSubframe = (() => {
+    if (window.top === window.self) return false;
+    try {
+      void window.top?.location.href;
+      return false;
+    } catch {
+      return true;
+    }
+  })();
+  if (isCrossOriginSubframe) {
+    return { destroy: () => {} };
+  }
+
+  // F2: membership set rebuilt by scan + MutationObserver, not per-focus scan.
+  let ccFields = new WeakSet<HTMLElement>();
+  // F1: detector-local suppression — never shared with the LOGIN module.
+  let autofillSuppressUntil = 0;
+  let activeInput: HTMLInputElement | null = null;
+
+  const rescan = () => {
+    if (destroyed) return;
+    const next = new WeakSet<HTMLElement>();
+    const fields = detectCreditCardFields(document);
+    if (fields) collectCcFields(fields, next);
+    ccFields = next;
+  };
+
+  const requestMatches = (input: HTMLInputElement) => {
+    if (!isContextValid()) {
+      destroy();
+      return;
+    }
+    if (
+      !isPageVisuallySafe() ||
+      !isElementVisuallySafe(input) ||
+      !isInputHitTestSafe(input) ||
+      hasVisiblePopoverOverlayNear(input)
+    ) {
+      hideDropdown();
+      activeInput = null;
+      return;
+    }
+    const url = window.location.href;
+    let topUrl: string | undefined;
+    try {
+      topUrl = window.top?.location?.href;
+    } catch {
+      topUrl = undefined;
+    }
+    try {
+      chrome.runtime.sendMessage(
+        { type: EXT_MSG.GET_CC_MATCHES_FOR_URL, url, topUrl },
+        (response) => {
+          if (destroyed) return;
+          if (!isContextValid()) { destroy(); return; }
+          if (chrome.runtime.lastError) return;
+          if (!response) return;
+          showForInput(
+            input,
+            response.entries ?? [],
+            response.vaultLocked ?? false,
+            response.suppressInline ?? false,
+            response.disconnected ?? false,
+          );
+        },
+      );
+    } catch {
+      destroy();
+    }
+  };
+
+  const showForInput = (
+    input: HTMLInputElement,
+    entries: DecryptedEntry[],
+    vaultLocked: boolean,
+    suppressInline: boolean,
+    disconnected: boolean,
+  ) => {
+    if (suppressInline) {
+      hideDropdown();
+      activeInput = null;
+      return;
+    }
+    activeInput = input;
+    showDropdown({
+      anchorRect: input.getBoundingClientRect(),
+      entries,
+      vaultLocked,
+      disconnected,
+      entryType: "CREDIT_CARD",
+      onSelect: (entryId, teamId) => {
+        if (!isContextValid()) return;
+        autofillSuppressUntil = Date.now() + 1500;
+        chrome.runtime.sendMessage(
+          { type: EXT_MSG.AUTOFILL_FROM_CONTENT, entryId, ...(teamId ? { teamId } : {}) },
+          (resp?: { ok?: boolean; error?: string }) => {
+            if (!isContextValid()) return;
+            if (chrome.runtime.lastError) {
+              showInlineNotice(input, t("errors.autofillFailed"));
+              return;
+            }
+            if (!resp?.ok) {
+              if (resp?.error === "VAULT_LOCKED") {
+                showInlineNotice(input, t("contentScript.vaultLocked"));
+              } else if (resp?.error === "NO_CARD_NUMBER") {
+                showInlineNotice(input, t("errors.noCardNumber"));
+              } else {
+                showInlineNotice(input, t("errors.autofillFailed"));
+              }
+              return;
+            }
+            hideDropdown();
+          },
+        );
+      },
+      onDismiss: () => {
+        activeInput = null;
+      },
+      lockedMessage: t("contentScript.vaultLocked"),
+      disconnectedMessage: t("contentScript.disconnected"),
+      noMatchesMessage: t("contentScript.noCreditCards"),
+      headerLabel: t("contentScript.creditCards"),
+    });
+  };
+
+  const focusHandler = (e: FocusEvent) => {
+    if (destroyed) return;
+    if (Date.now() < autofillSuppressUntil) return;
+    const input = e.target;
+    if (!(input instanceof HTMLInputElement)) return;
+    if (!isUsableInput(input)) return;
+    if (!ccFields.has(input)) return;
+    requestMatches(input);
+  };
+
+  const blurHandler = (e: FocusEvent) => {
+    if (destroyed) return;
+    if (activeInput && e.target === activeInput) {
+      setTimeout(() => {
+        if (activeInput && activeInput !== document.activeElement) {
+          hideDropdown();
+        }
+      }, 150);
+    }
+  };
+
+  const keydownHandler = (e: KeyboardEvent) => {
+    if (destroyed) return;
+    if (isDropdownVisible()) {
+      handleDropdownKeydown(e);
+    }
+  };
+
+  const observer = new MutationObserver((mutations) => {
+    if (destroyed) return;
+    if (mutations.some((m) => m.addedNodes.length > 0)) rescan();
+  });
+
+  // F7: re-evaluate the active element after vault unlock / explicit trigger.
+  const runtimeMessageHandler = (message: { type?: string }) => {
+    if (destroyed) return;
+    if (
+      message?.type !== "PSSO_VAULT_STATE_CHANGED" &&
+      message?.type !== "PSSO_TRIGGER_INLINE_SUGGESTIONS"
+    ) {
+      return;
+    }
+    rescan();
+    const active = document.activeElement;
+    if (active instanceof HTMLInputElement && ccFields.has(active) && isUsableInput(active)) {
+      requestMatches(active);
+    }
+  };
+
+  try {
+    chrome.runtime.onMessage?.addListener(runtimeMessageHandler);
+  } catch {
+    // Extension context invalidated — skip listener registration.
+  }
+
+  document.addEventListener("focusin", focusHandler, true);
+  document.addEventListener("focusout", blurHandler, true);
+  document.addEventListener("keydown", keydownHandler, true);
+  rescan();
+  if (document.body) {
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  const navigationHandler = () => {
+    if (destroyed) return;
+    hideDropdown();
+    setTimeout(rescan, 100);
+  };
+  if (typeof navigation !== "undefined") {
+    navigation.addEventListener("navigate", navigationHandler);
+  }
+  window.addEventListener("popstate", navigationHandler);
+  window.addEventListener("hashchange", navigationHandler);
+
+  function destroy(): void {
+    if (destroyed) return;
+    destroyed = true;
+    try {
+      chrome.runtime.onMessage?.removeListener(runtimeMessageHandler);
+    } catch {
+      // Extension context invalidated.
+    }
+    document.removeEventListener("focusin", focusHandler, true);
+    document.removeEventListener("focusout", blurHandler, true);
+    document.removeEventListener("keydown", keydownHandler, true);
+    observer.disconnect();
+    if (typeof navigation !== "undefined") {
+      navigation.removeEventListener("navigate", navigationHandler);
+    }
+    window.removeEventListener("popstate", navigationHandler);
+    window.removeEventListener("hashchange", navigationHandler);
+    // F6: detectors only hide the dropdown; the shared shadow host is removed
+    // once by the entry-point teardown, not per-detector.
+    hideDropdown();
+  }
+
+  return { destroy };
 }

--- a/extension/src/content/form-detector-lib.ts
+++ b/extension/src/content/form-detector-lib.ts
@@ -13,7 +13,7 @@ import {
   isDropdownVisible,
   handleDropdownKeydown,
 } from "./ui/suggestion-dropdown";
-import { getShadowHost, removeShadowHost } from "./ui/shadow-host";
+import { getShadowHost } from "./ui/shadow-host";
 
 /** Returns false when the extension has been reloaded/updated and this content script is orphaned. */
 function isContextValid(): boolean {
@@ -339,7 +339,7 @@ function showForInput(
   });
 }
 
-function showInlineNotice(input: HTMLInputElement, message: string): void {
+export function showInlineNotice(input: HTMLInputElement, message: string): void {
   const { root } = getShadowHost();
   const existing = root.querySelector(".psso-inline-notice");
   if (existing) existing.remove();
@@ -577,7 +577,9 @@ export function initFormDetector(): FormDetectorCleanup {
     document.removeEventListener("keydown", keydownHandler, true);
     observer.disconnect();
     hideDropdown();
-    removeShadowHost();
+    // F6: the shared shadow host is removed once by the entry-point teardown,
+    // not per-detector — tearing down LOGIN must not destroy the shared dropdown
+    // DOM that the CC/IDENTITY detectors also use.
     if (typeof navigation !== "undefined") {
       navigation.removeEventListener("navigate", navigationHandler);
     }

--- a/extension/src/content/form-detector.ts
+++ b/extension/src/content/form-detector.ts
@@ -4,6 +4,9 @@
 
 import { initFormDetector } from "./form-detector-lib";
 import { initLoginDetector } from "./login-detector-lib";
+import { initCreditCardDetector } from "./cc-form-detector-lib";
+import { initIdentityDetector } from "./identity-form-detector-lib";
+import { removeShadowHost } from "./ui/shadow-host";
 // Register AUTOFILL_FILL listener so autofill works without chrome.scripting.executeScript
 // (which requires host permissions or activeTab that may not be available).
 import "./autofill-lib";
@@ -17,8 +20,14 @@ const GUARD_KEY = "__passwdSsoFormDetector";
 if (!(window as unknown as Record<string, boolean>)[GUARD_KEY]) {
   (window as unknown as Record<string, boolean>)[GUARD_KEY] = true;
 
-  const { destroy } = initFormDetector();
-  const { destroy: destroyLoginDetector } = initLoginDetector();
+  // Collect every detector's teardown. Each detector only removes its own
+  // listeners + hides the dropdown; the shared shadow host is removed once here.
+  const cleanups = [
+    initFormDetector(),
+    initLoginDetector(),
+    initCreditCardDetector(),
+    initIdentityDetector(),
+  ];
 
   // Self-destruct when extension context is invalidated (extension reload/update).
   // Orphaned content scripts can no longer communicate with the service worker,
@@ -32,8 +41,9 @@ if (!(window as unknown as Record<string, boolean>)[GUARD_KEY]) {
       (msg.includes("Cannot read properties of undefined") && msg.includes("runtime"))
     ) {
       event.preventDefault();
-      destroy();
-      destroyLoginDetector();
+      for (const { destroy } of cleanups) destroy();
+      // F6: remove the shared shadow host once, after all detectors tore down.
+      removeShadowHost();
     }
   });
 }

--- a/extension/src/content/identity-form-detector-lib.ts
+++ b/extension/src/content/identity-form-detector-lib.ts
@@ -1,5 +1,24 @@
 // Pure logic module for identity/address form detection (exported, testable).
-// Side-effect-free — no global event registration here.
+// detectIdentityFields is side-effect-free; initIdentityDetector wires the
+// inline-suggestion lifecycle (focus → match request → dropdown → fill).
+
+import type { DecryptedEntry } from "../types/messages";
+import { t } from "../lib/i18n";
+import { EXT_MSG } from "../lib/constants";
+import {
+  isUsableInput,
+  isElementVisuallySafe,
+  isPageVisuallySafe,
+  isInputHitTestSafe,
+  hasVisiblePopoverOverlayNear,
+  showInlineNotice,
+} from "./form-detector-lib";
+import {
+  showDropdown,
+  hideDropdown,
+  isDropdownVisible,
+  handleDropdownKeydown,
+} from "./ui/suggestion-dropdown";
 
 // ── Types ──
 
@@ -172,4 +191,262 @@ export function detectIdentityFields(root: ParentNode): IdentityFormFields | nul
     dateOfBirth,
     region,
   };
+}
+
+// ── Inline detector ─────────────────────────────────────────
+
+declare const navigation: EventTarget | undefined;
+
+export interface IdentityDetectorCleanup {
+  destroy: () => void;
+}
+
+function isContextValid(): boolean {
+  try {
+    return !!chrome.runtime?.id;
+  } catch {
+    return false;
+  }
+}
+
+/** Collect the detected identity field elements into a membership set for O(1) focus lookup. */
+function collectIdentityFields(fields: IdentityFormFields, into: WeakSet<HTMLElement>): void {
+  const candidates = [
+    fields.fullName,
+    fields.address,
+    fields.postalCode,
+    fields.phone,
+    fields.email,
+    fields.dateOfBirth,
+    fields.region,
+  ];
+  for (const el of candidates) {
+    if (el) into.add(el);
+  }
+}
+
+/**
+ * Initialize the inline identity suggestion detector. Mirrors the LOGIN detector
+ * but with detector-LOCAL suppression state and an identity-field WeakSet.
+ */
+export function initIdentityDetector(): IdentityDetectorCleanup {
+  let destroyed = false;
+
+  // S2: cross-origin subframe must not render a deceptive dropdown.
+  const isCrossOriginSubframe = (() => {
+    if (window.top === window.self) return false;
+    try {
+      void window.top?.location.href;
+      return false;
+    } catch {
+      return true;
+    }
+  })();
+  if (isCrossOriginSubframe) {
+    return { destroy: () => {} };
+  }
+
+  let identityFields = new WeakSet<HTMLElement>();
+  let autofillSuppressUntil = 0;
+  let activeInput: HTMLInputElement | null = null;
+
+  const rescan = () => {
+    if (destroyed) return;
+    const next = new WeakSet<HTMLElement>();
+    const fields = detectIdentityFields(document);
+    if (fields) collectIdentityFields(fields, next);
+    identityFields = next;
+  };
+
+  const requestMatches = (input: HTMLInputElement) => {
+    if (!isContextValid()) {
+      destroy();
+      return;
+    }
+    if (
+      !isPageVisuallySafe() ||
+      !isElementVisuallySafe(input) ||
+      !isInputHitTestSafe(input) ||
+      hasVisiblePopoverOverlayNear(input)
+    ) {
+      hideDropdown();
+      activeInput = null;
+      return;
+    }
+    const url = window.location.href;
+    let topUrl: string | undefined;
+    try {
+      topUrl = window.top?.location?.href;
+    } catch {
+      topUrl = undefined;
+    }
+    try {
+      chrome.runtime.sendMessage(
+        { type: EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL, url, topUrl },
+        (response) => {
+          if (destroyed) return;
+          if (!isContextValid()) { destroy(); return; }
+          if (chrome.runtime.lastError) return;
+          if (!response) return;
+          showForInput(
+            input,
+            response.entries ?? [],
+            response.vaultLocked ?? false,
+            response.suppressInline ?? false,
+            response.disconnected ?? false,
+          );
+        },
+      );
+    } catch {
+      destroy();
+    }
+  };
+
+  const showForInput = (
+    input: HTMLInputElement,
+    entries: DecryptedEntry[],
+    vaultLocked: boolean,
+    suppressInline: boolean,
+    disconnected: boolean,
+  ) => {
+    if (suppressInline) {
+      hideDropdown();
+      activeInput = null;
+      return;
+    }
+    activeInput = input;
+    showDropdown({
+      anchorRect: input.getBoundingClientRect(),
+      entries,
+      vaultLocked,
+      disconnected,
+      entryType: "IDENTITY",
+      onSelect: (entryId, teamId) => {
+        if (!isContextValid()) return;
+        autofillSuppressUntil = Date.now() + 1500;
+        chrome.runtime.sendMessage(
+          { type: EXT_MSG.AUTOFILL_FROM_CONTENT, entryId, ...(teamId ? { teamId } : {}) },
+          (resp?: { ok?: boolean; error?: string }) => {
+            if (!isContextValid()) return;
+            if (chrome.runtime.lastError) {
+              showInlineNotice(input, t("errors.autofillFailed"));
+              return;
+            }
+            if (!resp?.ok) {
+              if (resp?.error === "VAULT_LOCKED") {
+                showInlineNotice(input, t("contentScript.vaultLocked"));
+              } else {
+                showInlineNotice(input, t("errors.autofillFailed"));
+              }
+              return;
+            }
+            hideDropdown();
+          },
+        );
+      },
+      onDismiss: () => {
+        activeInput = null;
+      },
+      lockedMessage: t("contentScript.vaultLocked"),
+      disconnectedMessage: t("contentScript.disconnected"),
+      noMatchesMessage: t("contentScript.noIdentities"),
+      headerLabel: t("contentScript.identities"),
+    });
+  };
+
+  const focusHandler = (e: FocusEvent) => {
+    if (destroyed) return;
+    if (Date.now() < autofillSuppressUntil) return;
+    const input = e.target;
+    if (!(input instanceof HTMLInputElement)) return;
+    if (!isUsableInput(input)) return;
+    if (!identityFields.has(input)) return;
+    requestMatches(input);
+  };
+
+  const blurHandler = (e: FocusEvent) => {
+    if (destroyed) return;
+    if (activeInput && e.target === activeInput) {
+      setTimeout(() => {
+        if (activeInput && activeInput !== document.activeElement) {
+          hideDropdown();
+        }
+      }, 150);
+    }
+  };
+
+  const keydownHandler = (e: KeyboardEvent) => {
+    if (destroyed) return;
+    if (isDropdownVisible()) {
+      handleDropdownKeydown(e);
+    }
+  };
+
+  const observer = new MutationObserver((mutations) => {
+    if (destroyed) return;
+    if (mutations.some((m) => m.addedNodes.length > 0)) rescan();
+  });
+
+  const runtimeMessageHandler = (message: { type?: string }) => {
+    if (destroyed) return;
+    if (
+      message?.type !== "PSSO_VAULT_STATE_CHANGED" &&
+      message?.type !== "PSSO_TRIGGER_INLINE_SUGGESTIONS"
+    ) {
+      return;
+    }
+    rescan();
+    const active = document.activeElement;
+    if (active instanceof HTMLInputElement && identityFields.has(active) && isUsableInput(active)) {
+      requestMatches(active);
+    }
+  };
+
+  try {
+    chrome.runtime.onMessage?.addListener(runtimeMessageHandler);
+  } catch {
+    // Extension context invalidated — skip listener registration.
+  }
+
+  document.addEventListener("focusin", focusHandler, true);
+  document.addEventListener("focusout", blurHandler, true);
+  document.addEventListener("keydown", keydownHandler, true);
+  rescan();
+  if (document.body) {
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  const navigationHandler = () => {
+    if (destroyed) return;
+    hideDropdown();
+    setTimeout(rescan, 100);
+  };
+  if (typeof navigation !== "undefined") {
+    navigation.addEventListener("navigate", navigationHandler);
+  }
+  window.addEventListener("popstate", navigationHandler);
+  window.addEventListener("hashchange", navigationHandler);
+
+  function destroy(): void {
+    if (destroyed) return;
+    destroyed = true;
+    try {
+      chrome.runtime.onMessage?.removeListener(runtimeMessageHandler);
+    } catch {
+      // Extension context invalidated.
+    }
+    document.removeEventListener("focusin", focusHandler, true);
+    document.removeEventListener("focusout", blurHandler, true);
+    document.removeEventListener("keydown", keydownHandler, true);
+    observer.disconnect();
+    if (typeof navigation !== "undefined") {
+      navigation.removeEventListener("navigate", navigationHandler);
+    }
+    window.removeEventListener("popstate", navigationHandler);
+    window.removeEventListener("hashchange", navigationHandler);
+    // F6: shared shadow host removed once by entry-point teardown.
+    hideDropdown();
+  }
+
+  return { destroy };
 }

--- a/extension/src/content/ui/icons.ts
+++ b/extension/src/content/ui/icons.ts
@@ -8,3 +8,7 @@ export const KEY_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16
 export const USER_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="12" height="12"><path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM12.74 13c.14 0 .26-.11.24-.25A5.002 5.002 0 0 0 3.02 12.75c-.02.14.1.25.24.25h9.48Z"/></svg>`;
 
 export const DISCONNECT_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M1.22 1.22a.75.75 0 0 1 1.06 0l12.5 12.5a.75.75 0 0 1-1.06 1.06L1.22 2.28a.75.75 0 0 1 0-1.06Z"/><path d="M6.5 2a3.5 3.5 0 0 1 3.47 3.05l-1.54 1.54A2 2 0 0 0 6.5 4H5.25a.75.75 0 0 1 0-1.5H6.5ZM10.75 13.5H9.5a3.5 3.5 0 0 1-3.47-3.05l1.54-1.54A2 2 0 0 0 9.5 11.5h1.25a.75.75 0 0 1 0 1.5V13.5Z"/></svg>`;
+
+export const CARD_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="14" height="14"><path d="M1 4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v.5H1V4Zm14 2.5V12a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V6.5h14ZM3.5 10a.75.75 0 0 0 0 1.5h3a.75.75 0 0 0 0-1.5h-3Z"/></svg>`;
+
+export const ID_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="14" height="14"><path fill-rule="evenodd" d="M2 3.5A1.5 1.5 0 0 1 3.5 2h9A1.5 1.5 0 0 1 14 3.5v9a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 12.5v-9Zm3.5 1a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3ZM4 10.5c0-.83 1-1.5 1.5-1.5s1.5.67 1.5 1.5V11H4v-.5ZM9 5.25a.75.75 0 0 0 0 1.5h2.5a.75.75 0 0 0 0-1.5H9Zm0 3a.75.75 0 0 0 0 1.5h2.5a.75.75 0 0 0 0-1.5H9Z" clip-rule="evenodd"/></svg>`;

--- a/extension/src/content/ui/suggestion-dropdown.ts
+++ b/extension/src/content/ui/suggestion-dropdown.ts
@@ -4,7 +4,9 @@
 import type { DecryptedEntry } from "../../types/messages";
 import { getShadowHost } from "./shadow-host";
 import { DROPDOWN_STYLES } from "./styles";
-import { KEY_ICON, LOCK_ICON, USER_ICON, DISCONNECT_ICON } from "./icons";
+import { KEY_ICON, LOCK_ICON, USER_ICON, DISCONNECT_ICON, CARD_ICON, ID_ICON } from "./icons";
+
+export type DropdownEntryType = "LOGIN" | "CREDIT_CARD" | "IDENTITY";
 
 export interface DropdownOptions {
   anchorRect: DOMRect;
@@ -17,6 +19,20 @@ export interface DropdownOptions {
   disconnectedMessage?: string;
   noMatchesMessage: string;
   headerLabel: string;
+  // Drives the per-item icon. Optional, defaults to "LOGIN" so existing callers
+  // keep compiling unchanged.
+  entryType?: DropdownEntryType;
+}
+
+function itemIconFor(entryType: DropdownEntryType): string {
+  switch (entryType) {
+    case "CREDIT_CARD":
+      return CARD_ICON;
+    case "IDENTITY":
+      return ID_ICON;
+    default:
+      return KEY_ICON;
+  }
 }
 
 let currentDropdown: HTMLDivElement | null = null;
@@ -72,6 +88,8 @@ export function showDropdown(opts: DropdownOptions): void {
     itemElements = [];
     activeIndex = -1;
 
+    const itemIcon = itemIconFor(opts.entryType ?? "LOGIN");
+
     for (const entry of opts.entries) {
       const item = document.createElement("div");
       item.className = "psso-item";
@@ -80,7 +98,7 @@ export function showDropdown(opts: DropdownOptions): void {
       if (entry.teamId) item.setAttribute("data-team-id", entry.teamId);
 
       item.innerHTML = `
-        <div class="psso-item-icon">${KEY_ICON}</div>
+        <div class="psso-item-icon">${itemIcon}</div>
         <div class="psso-item-text">
           <div class="psso-item-title">${escapeHtml(entry.title || entry.urlHost)}</div>
           <div class="psso-item-username">${USER_ICON}<span>${escapeHtml(entry.username)}</span></div>

--- a/extension/src/content/ui/suggestion-dropdown.ts
+++ b/extension/src/content/ui/suggestion-dropdown.ts
@@ -185,6 +185,11 @@ export function handleDropdownKeydown(e: KeyboardEvent): boolean {
       return true;
     }
     case "Enter": {
+      // A fill is a credential disclosure — only a trusted (real) keypress may
+      // trigger it. Blocks a page script dispatching synthetic ArrowDown+Enter
+      // to auto-select and exfiltrate the entry (mirrors isSafeSelectClick on
+      // the mouse path). Navigation keys above are cosmetic and need no guard.
+      if (!e.isTrusted) return false;
       if (activeIndex >= 0 && activeIndex < itemElements.length) {
         e.preventDefault();
         const activeItem = itemElements[activeIndex];

--- a/extension/src/lib/constants.ts
+++ b/extension/src/lib/constants.ts
@@ -69,6 +69,8 @@ export const EXT_MSG = {
   COPY_PASSWORD: "COPY_PASSWORD",
   AUTOFILL: "AUTOFILL",
   GET_MATCHES_FOR_URL: "GET_MATCHES_FOR_URL",
+  GET_CC_MATCHES_FOR_URL: "GET_CC_MATCHES_FOR_URL",
+  GET_IDENTITY_MATCHES_FOR_URL: "GET_IDENTITY_MATCHES_FOR_URL",
   COPY_TOTP: "COPY_TOTP",
   AUTOFILL_FROM_CONTENT: "AUTOFILL_FROM_CONTENT",
   LOGIN_DETECTED: "LOGIN_DETECTED",
@@ -78,6 +80,11 @@ export const EXT_MSG = {
   CHECK_PENDING_SAVE: "CHECK_PENDING_SAVE",
   AUTOFILL_CREDIT_CARD: "AUTOFILL_CREDIT_CARD",
   AUTOFILL_IDENTITY: "AUTOFILL_IDENTITY",
+  // Fill payloads sent SW → injected web-accessible content scripts (autofill-cc.js
+  // / autofill-identity.js). Those plain-JS files cannot import this module, so they
+  // declare matching local literals — keep both in sync (mirrors the WebAuthn note).
+  AUTOFILL_CC_FILL: "AUTOFILL_CC_FILL",
+  AUTOFILL_IDENTITY_FILL: "AUTOFILL_IDENTITY_FILL",
   KEEPALIVE_PING: "KEEPALIVE_PING",
   // Options → SW: invalidate the SW's in-memory DPoP key cache after the
   // Options page deleted the IDB record. Without this the SW keeps signing

--- a/extension/src/messages/en.json
+++ b/extension/src/messages/en.json
@@ -92,7 +92,11 @@
     "vaultLocked": "Vault is locked",
     "disconnected": "Not connected to server",
     "noMatches": "No matches for this site",
-    "logins": "Logins"
+    "noCreditCards": "No saved cards",
+    "noIdentities": "No saved identities",
+    "logins": "Logins",
+    "creditCards": "Cards",
+    "identities": "Identities"
   },
   "contextMenu": {
     "title": "passwd-sso",
@@ -143,6 +147,7 @@
     "vaultLocked": "Vault is locked.",
     "fetchFailed": "Failed to load entries.",
     "noPassword": "No password available for this entry.",
+    "noCardNumber": "No card number available for this entry.",
     "permissionDenied": "Host permission was denied.",
     "clipboardFailed": "Clipboard write failed.",
     "copyFailed": "Copy failed.",

--- a/extension/src/messages/ja.json
+++ b/extension/src/messages/ja.json
@@ -92,7 +92,11 @@
     "vaultLocked": "保管庫がロックされています",
     "disconnected": "サーバーに接続されていません",
     "noMatches": "一致するエントリがありません",
-    "logins": "ログイン候補"
+    "noCreditCards": "保存済みのカードがありません",
+    "noIdentities": "保存済みの個人情報がありません",
+    "logins": "ログイン候補",
+    "creditCards": "カード候補",
+    "identities": "個人情報候補"
   },
   "contextMenu": {
     "title": "passwd-sso",
@@ -143,6 +147,7 @@
     "vaultLocked": "保管庫がロックされています。",
     "fetchFailed": "エントリの取得に失敗しました。",
     "noPassword": "このエントリにパスワードがありません。",
+    "noCardNumber": "このエントリにカード番号がありません。",
     "permissionDenied": "ホスト権限が拒否されました。",
     "clipboardFailed": "クリップボードに書き込めませんでした。",
     "copyFailed": "コピーに失敗しました。",

--- a/extension/src/types/messages.ts
+++ b/extension/src/types/messages.ts
@@ -13,6 +13,8 @@ export type ExtensionMessage =
   | { type: typeof EXT_MSG.COPY_PASSWORD; entryId: string; teamId?: string }
   | { type: typeof EXT_MSG.AUTOFILL; entryId: string; tabId: number; teamId?: string }
   | { type: typeof EXT_MSG.GET_MATCHES_FOR_URL; url: string; topUrl?: string }
+  | { type: typeof EXT_MSG.GET_CC_MATCHES_FOR_URL; url: string; topUrl?: string }
+  | { type: typeof EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL; url: string; topUrl?: string }
   | { type: typeof EXT_MSG.COPY_TOTP; entryId: string; teamId?: string }
   | {
       type: typeof EXT_MSG.AUTOFILL_FROM_CONTENT;
@@ -117,6 +119,20 @@ export type ExtensionResponse =
       disconnected?: boolean;
       suppressInline?: boolean;
     }
+  | {
+      type: typeof EXT_MSG.GET_CC_MATCHES_FOR_URL;
+      entries: DecryptedEntry[];
+      vaultLocked: boolean;
+      disconnected?: boolean;
+      suppressInline?: boolean;
+    }
+  | {
+      type: typeof EXT_MSG.GET_IDENTITY_MATCHES_FOR_URL;
+      entries: DecryptedEntry[];
+      vaultLocked: boolean;
+      disconnected?: boolean;
+      suppressInline?: boolean;
+    }
   | { type: typeof EXT_MSG.COPY_TOTP; code: string | null; error?: string }
   | { type: typeof EXT_MSG.AUTOFILL_FROM_CONTENT; ok: boolean; error?: string }
   | { type: typeof EXT_MSG.LOGIN_DETECTED; action: "save" | "update" | "none"; existingEntryId?: string; existingTitle?: string }
@@ -180,7 +196,7 @@ export interface AutofillTargetHint {
 // ── Credit Card autofill payload ──
 
 export interface CreditCardAutofillPayload {
-  type: "AUTOFILL_CC_FILL";
+  type: typeof EXT_MSG.AUTOFILL_CC_FILL;
   cardholderName: string;
   cardNumber: string;
   expiryMonth: string;
@@ -191,7 +207,7 @@ export interface CreditCardAutofillPayload {
 // ── Identity autofill payload ──
 
 export interface IdentityAutofillPayload {
-  type: "AUTOFILL_IDENTITY_FILL";
+  type: typeof EXT_MSG.AUTOFILL_IDENTITY_FILL;
   fullName: string;
   address: string;
   postalCode: string;


### PR DESCRIPTION
## Summary

Credit-card and identity entries previously appeared only in the extension **popup** ("Other entries") and filled via the manual popup button — focusing a `cc-number` or address field on a web page showed nothing. This wires CREDIT_CARD and IDENTITY into the **same inline suggestion pipeline LOGIN already uses**: focusing a card/identity field now shows a dropdown, and selecting an entry fills the form via the existing `AUTOFILL_CC_FILL` / `AUTOFILL_IDENTITY_FILL` path.

Builds on `#503` (the 3-field AAD fix) — without it CC/IDENTITY overviews don't decrypt, so this would have nothing to suggest.

## Changes

- **Background** — extracted a shared `resolveInlineMatches(kind)`: LOGIN stays host-matched; CC/IDENTITY are **URL-independent** (no host filter — cards/identities aren't site-specific, matching native browser autofill and the popup). All gates (inline-enabled / own-app / disconnected / vault-locked) apply uniformly. New `GET_CC_MATCHES_FOR_URL` / `GET_IDENTITY_MATCHES_FOR_URL` handlers + error-fallbacks.
- **Detectors** — `initCreditCardDetector` / `initIdentityDetector` mirroring the LOGIN detector: cross-origin-subframe no-op guard, field membership via a `WeakSet` rebuilt by a `MutationObserver` (not a per-focus DOM scan), detector-local suppression window, per-detector vault-state re-trigger.
- **Dropdown** — `entryType` parametrization (optional, default `LOGIN` so existing callers are unchanged) drives icon + header label.
- **i18n** — card/identity header + `noCardNumber` strings in both locales.

### Security

- **Frame-targeted fill** — on the inline path, decrypted card/identity plaintext is delivered only to the originating frame (`_sender.frameId`), never broadcast tab-wide; popup path keeps its current behavior.
- **Trusted-gesture guard** — a fill (Enter → select) only fires on a trusted keypress, blocking a page script from dispatching synthetic ArrowDown+Enter to auto-select and exfiltrate an entry (mirrors the mouse path; also hardens LOGIN).
- **Input validation** — content-supplied `entryId`/`teamId` are bounded before the authenticated fetch (charset/length guard, not UUIDv4-strict since entry ids are mixed CUID/UUID).
- No secret is rendered pre-selection — the dropdown shows only overview fields (title, cardholder/name); the card number/CVV live in the blob and fill only on explicit selection.

## Out of scope

LOGIN behavior is unchanged (locked by a regression test). The select→fill dispatch already existed; this PR adds the detection + match-request + dropdown wiring.

## Verification

- Extension: `npm test` → 728 passed; `npm run build` clean.
- Root: `scripts/pre-pr.sh` → all 29 checks pass.
- Plan + 2-round triangulate plan review and a 3-round code review (functionality / security / testing); all findings resolved. Plan/review artifacts under `docs/archive/review/ext-inline-cc-identity-autofill-*`.
- Manual check recommended: focus the Apple checkout `cc-number` field with the vault unlocked → card dropdown appears and fills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)