### PR TITLE
fix(security): zeroize PRF output and unwrapped vault key on all paths

### DIFF
--- a/docs/archive/review/prf-handoff-zeroization-code-review.md
+++ b/docs/archive/review/prf-handoff-zeroization-code-review.md
@@ -1,0 +1,76 @@
+# Code Review: prf-handoff-zeroization
+Date: 2026-05-31
+Review round: 1 (resolved)
+
+## Changes from Previous Round
+Initial code review of the committed implementation (10b57884). Three expert
+agents reviewed `git diff main...HEAD`. Functionality and Security returned No
+findings; both mutation-tested the ownership-transfer model. Testing returned
+one Low (dead test scaffolding), now fixed.
+
+## Functionality Findings
+**No findings.** Verified: ownership transfer correct in both producers (every
+exit either stashes-then-nulls or wipes exactly once — no leak, no double-wipe);
+`result.responseJSON` read correctly after the destructure→`result` restructure;
+consumer `secretKey` zeroization on its own error paths not regressed; outer
+`finally` touches only `prfOutput`; `prfOutput` guaranteed non-null entering the
+try; `pending?.prfOutput.fill(0)` optional chaining safe; `hexEncode` removed
+from producers, `hexDecode` correctly retained in vault-context.
+
+## Security Findings
+**No findings.** The refactor strictly increases zeroization coverage and
+introduces no new residue path (the immutable un-wipeable hex string is
+eliminated; the single `Uint8Array` is the only mutable copy and is wiped on
+every path). `clearPrf`/`stashPrf` overwrite-wipe correct; `takePrf`
+deliberately does not wipe (ownership → consumer). Consumer throw-window safe
+(`const prfOutput = handoff.prfOutput` cannot throw, no await before the try).
+sessionStorage posture unchanged (only the non-secret `psso:webauthn-signin`
+flag remains). No Critical → no escalation.
+
+- **[Adjacent / pre-existing, NOT a regression]**: `secretKey` is not zeroized
+  if a throw occurs after its assignment in the consumer (e.g.
+  `deriveAuthKey`/`computeAuthHash` throwing, or the `VaultUnlockError` throw
+  paths). Identical on `main`, unchanged by this diff, outside this fix's scope
+  (PRF buffer). Recorded for visibility; not fixed here. See Resolution Status.
+
+## Testing Findings
+- **T1 (Low) — resolved**: dead write-only `prfSentinel` hoisted scaffolding in
+  both producer test files (`passkey-signin-button.test.tsx`,
+  `security-key-signin-form.test.tsx`) — assigned in `makePrfSentinel` but never
+  read (assertions use the returned `prfBytes` local). Removed.
+- The reviewer mutation-tested the new assertions: removing `prfOutput = null`
+  (producer) made the success test fail; removing the consumer `finally` made
+  both new early-return tests fail — confirming the assertions are non-vacuous.
+
+## Adjacent Findings
+- Security [Adjacent] pre-existing `secretKey` throw-path zeroization gap (see
+  Security Findings above).
+
+## Resolution Status
+
+### T1 [Low] Dead `prfSentinel` scaffolding — Fixed
+- Action: removed `prfSentinel` from the hoisted block and the `.current`
+  assignment from `makePrfSentinel` in both producer test files.
+- Modified: `src/components/auth/passkey-signin-button.test.tsx`,
+  `src/components/auth/security-key-signin-form.test.tsx`
+
+### Security [Adjacent] secretKey throw-path zeroization — Out of scope (pre-existing)
+- **Anti-Deferral check**: pre-existing in a changed file (`vault-context.tsx`).
+- **Justification**: The gap is identical on `main` and is unrelated to this
+  fix's contract (PRF output zeroization). It is narrow defense-in-depth
+  (secretKey is copied to `secretKeyRef` and wiped at line 751 on success; the
+  only uncovered window is an exception thrown after assignment). Worst case:
+  the live `secretKey` buffer lingers in heap until GC after an unlock that
+  throws post-derivation — likelihood low (derivation rarely throws), cost to
+  fix small but cross-cutting (would touch the whole unlock family for
+  consistency, not just this path). Per the user's filter on speculative
+  defensive scaffolding, surfaced to the user rather than silently expanded
+  into this PR's scope.
+- **Orchestrator sign-off**: routed to user decision (see final report); not
+  blocking this fix.
+
+## Tightening-only skip — Round 1
+Findings applied directly (no Round 2 review):
+- [T1] [Low] dead `prfSentinel` scaffolding — both producer test files — applied
+Justification: test-only change, scoped within the reviewed files, inline minor
+(dead-code removal), no security-boundary touch. 16 affected tests + lint pass.

--- a/docs/archive/review/prf-handoff-zeroization-code-review.md
+++ b/docs/archive/review/prf-handoff-zeroization-code-review.md
@@ -84,6 +84,23 @@ drops the module and the timer via GC regardless.
   takePrf-cancels-TTL, re-stash-resets-TTL. Mutation-verified (neutering the
   `setTimeout` fails the self-expiry test). Full suite 10775 passed.
 
+### TTL triangulate review (functionality / security / testing)
+Ran a focused Phase 3 round on the TTL delta (`88d35c49..HEAD`):
+- Functionality: No findings — timer lifecycle correct (`cancelTtl` on every
+  `pending` transition), `clearPrf` hoisting valid, SSR-safe (no module-top
+  `setTimeout`), 30s comfortably covers stash→`takePrf` with graceful
+  degradation to manual unlock on expiry.
+- Security: No findings — strictly reduces residency (abandoned handoff wiped at
+  ≤30s vs. unbounded-until-GC before), no new exposure, take-vs-timer race
+  foreclosed by single-threaded `cancelTtl` in `takePrf`.
+- Testing: two Low items. (a) "does NOT wipe before TTL" is a narrow boundary
+  guard — kept. (b) Coverage gap: `clearPrf`'s timer cancellation untested.
+  Analysis showed the expert's suggested wipe-based test would be vacuous (a
+  following `stashPrf` cancels the timer anyway; a phantom fire no-ops on null
+  `pending`) — `clearPrf`'s `cancelTtl` is a timer-hygiene contract. Added a
+  `vi.getTimerCount()` assertion test instead; mutation-verified (removing
+  `cancelTtl` from `clearPrf` fails it). `prf-handoff.test.ts` now 9 tests.
+
 ## Tightening-only skip — Round 1
 Findings applied directly (no Round 2 review):
 - [T1] [Low] dead `prfSentinel` scaffolding — both producer test files — applied

--- a/docs/archive/review/prf-handoff-zeroization-code-review.md
+++ b/docs/archive/review/prf-handoff-zeroization-code-review.md
@@ -71,6 +71,19 @@ flag remains). No Critical → no escalation.
   happens before the finally wipe; no use-after-zeroize; scope-isolated to
   `unlockWithStoredPrf`; null-safe optional chain; strictly increases coverage).
 
+## Post-review hardening — stashPrf TTL (follow-up)
+A secondary review of PR #505 suggested a TTL on `stashPrf` so an unconsumed
+handoff does not linger indefinitely. Applied: `PRF_HANDOFF_TTL_MS = 30_000`;
+`stashPrf` arms `setTimeout(clearPrf, …)`, cancelled by `takePrf` / `clearPrf` /
+overwrite via a managed `ttlTimer` (so a stale timer can never wipe a fresh
+handoff or a consumer-owned buffer). The module doc keeps the scope honest: the
+TTL only bounds the in-SPA-without-unlock residency window — a full page reload
+drops the module and the timer via GC regardless.
+- Modified: `src/lib/auth/prf-handoff.ts`.
+- Tests: `prf-handoff.test.ts` — TTL self-expiry, no-wipe-before-TTL,
+  takePrf-cancels-TTL, re-stash-resets-TTL. Mutation-verified (neutering the
+  `setTimeout` fails the self-expiry test). Full suite 10775 passed.
+
 ## Tightening-only skip — Round 1
 Findings applied directly (no Round 2 review):
 - [T1] [Low] dead `prfSentinel` scaffolding — both producer test files — applied

--- a/docs/archive/review/prf-handoff-zeroization-code-review.md
+++ b/docs/archive/review/prf-handoff-zeroization-code-review.md
@@ -54,20 +54,22 @@ flag remains). No Critical → no escalation.
 - Modified: `src/components/auth/passkey-signin-button.test.tsx`,
   `src/components/auth/security-key-signin-form.test.tsx`
 
-### Security [Adjacent] secretKey throw-path zeroization — Out of scope (pre-existing)
-- **Anti-Deferral check**: pre-existing in a changed file (`vault-context.tsx`).
-- **Justification**: The gap is identical on `main` and is unrelated to this
-  fix's contract (PRF output zeroization). It is narrow defense-in-depth
-  (secretKey is copied to `secretKeyRef` and wiped at line 751 on success; the
-  only uncovered window is an exception thrown after assignment). Worst case:
-  the live `secretKey` buffer lingers in heap until GC after an unlock that
-  throws post-derivation — likelihood low (derivation rarely throws), cost to
-  fix small but cross-cutting (would touch the whole unlock family for
-  consistency, not just this path). Per the user's filter on speculative
-  defensive scaffolding, surfaced to the user rather than silently expanded
-  into this PR's scope.
-- **Orchestrator sign-off**: routed to user decision (see final report); not
-  blocking this fix.
+### Security [Adjacent] secretKey throw-path zeroization — Fixed (user opted to include)
+- The user chose to include this in the PR. Applied the same consolidation as
+  C3: `secretKey` hoisted to an outer `let`, the three explicit `secretKey.fill(0)`
+  calls folded into the single outer `finally` (`secretKey?.fill(0)` next to
+  `prfOutput.fill(0)`), so the post-derivation throw paths (VaultUnlockError on
+  `/api/vault/unlock` body.error, crypto-derivation throws) now zeroize the
+  unwrapped vault secret key.
+- Modified: `src/lib/vault/vault-context.tsx` (`unlockWithStoredPrf`).
+- Test: `src/lib/vault/vault-context.test.tsx` — new "zeroizes the unwrapped
+  secret key when unlock throws AFTER the key is unwrapped" regression test;
+  captures the real unwrapped key via a pass-through spy on
+  `unwrapSecretKeyWithPrf` (real crypto preserved) and asserts it is zeroized.
+  Mutation-verified: removing `secretKey?.fill(0)` makes the test fail.
+- Focused functionality + security re-review of the delta: No findings (copy
+  happens before the finally wipe; no use-after-zeroize; scope-isolated to
+  `unlockWithStoredPrf`; null-safe optional chain; strictly increases coverage).
 
 ## Tightening-only skip — Round 1
 Findings applied directly (no Round 2 review):

--- a/docs/archive/review/prf-handoff-zeroization-plan.md
+++ b/docs/archive/review/prf-handoff-zeroization-plan.md
@@ -1,0 +1,307 @@
+# Plan: prf-handoff-zeroization
+
+## Project context
+
+- Type: web app (Next.js client component crypto path) + shared crypto lib
+- Test infrastructure: unit + integration (vitest); existing tests for all four touched files
+- Scope: client-side, browser-only PRF (WebAuthn) handoff. No server changes.
+
+## Objective
+
+Harden the in-memory PRF handoff (`src/lib/auth/prf-handoff.ts`, introduced in the
+pre-v1.0 XSS-hardening sweep that moved `psso:prf-output` / `psso:prf-data` off
+`sessionStorage`) so that the PRF output — a sensitive secret that unwraps the
+vault secret key — is zeroizable and is actually zeroized on every code path.
+
+Two residual defense-in-depth gaps remain after the sessionStorage removal:
+
+1. **Immutable-string residue**: `PrfHandoff.prfOutputHex` is a hex `string`.
+   JS strings are immutable, so the PRF output cannot be wiped — it lingers in
+   the JS heap until GC. The producer zeroizes its own `Uint8Array` but the hex
+   copy survives in the module-level `pending` variable and in the consumer's
+   local until GC.
+2. **Uncovered exit paths**: neither the producer nor the consumer zeroizes the
+   PRF `Uint8Array` on all exits.
+   - Producer (`passkey-signin-button.tsx`, `security-key-signin-form.tsx`):
+     `prfOutput` is declared via `const { responseJSON, prfOutput } = await
+     startPasskeyAuthentication(...)` inside `try`, so it is out of scope in
+     `catch`/`finally`. If `fetchApi`/`verifyRes.json()` throws, or if
+     `prfOutput` is truthy but `verifyData.prf` is falsy, the buffer is never
+     `fill(0)`-ed.
+   - Consumer (`vault-context.tsx unlockWithStoredPrf`): early `return false` on
+     `!dataRes.ok` (non-401) and on `!vaultData.accountSalt` skip zeroization;
+     only the narrow `try/finally` around `unwrapSecretKeyWithPrf` wipes it.
+
+Severity: low (defense-in-depth). The primary XSS threat — enumerable
+`sessionStorage` — is already closed. JS-heap buffers are not enumerable via web
+APIs. This change reduces the lifetime of an unwrapping secret in memory.
+
+## Requirements
+
+- Functional: vault auto-unlock after PRF passkey/security-key sign-in continues
+  to work unchanged (same success path, same graceful degradation to manual
+  unlock after a full reload).
+- Non-functional: the PRF output buffer is zeroized on every exit path of both
+  producer and consumer; no immutable-string copy of the PRF output is created.
+- No behavior change to the non-PRF sign-in path.
+
+## Technical approach
+
+Change `PrfHandoff` to carry the PRF output as a `Uint8Array` (ownership-transfer
+model) instead of a hex string. This removes the immutable-string residue (gap 1)
+and removes the `hexEncode`/`hexDecode` round-trip. Ownership semantics:
+
+- `stashPrf` takes ownership of the passed buffer. The producer MUST NOT zeroize
+  the buffer it stashed (that buffer now lives in the handoff). It zeroizes only
+  on paths where it did NOT stash.
+- `takePrf` transfers ownership to the consumer, which zeroizes after use.
+- `stashPrf` overwrite and `clearPrf` zeroize the buffer they drop, so an
+  abandoned handoff is wiped *when code runs*.
+
+**Residue floor / honest scoping** (security review S1 + Info): the
+zeroization here is best-effort heap-residency reduction, not a guarantee of
+zero residue:
+- `clearPrf()` currently has **no production caller** (tests only). Its
+  zeroize duty is therefore *latent* — the realistic abandonment scenario (user
+  signs in → PRF stashed → full page reload before reaching the dashboard) drops
+  the module via GC with no code running to wipe. `clearPrf` cannot help there.
+  The only path that actually wipes an abandoned buffer is the next sign-in's
+  `stashPrf` overwrite. This plan adds zeroization to `clearPrf` for correctness
+  and so a future caller benefits, but does NOT claim it closes the full-reload
+  residue — that residue is accepted/unavoidable.
+- The source `prfOutput` is itself `new Uint8Array(prfResults.first)`
+  (`webauthn-client.ts:380`); the browser-owned `prfResults.first` ArrayBuffer is
+  un-wipeable and out of reach. So "no un-wipeable copy exists" is not literally
+  true at the WebAuthn boundary — the residency floor is set by the browser, not
+  this code. The improvement is real but bounded.
+
+Producer is restructured so `prfOutput` lives in an outer `let` and is zeroized
+in `finally` on every path except the one where ownership was transferred to the
+handoff (set the local to `null` after a successful `stashPrf`).
+
+Consumer is restructured so a single `try/finally` around the whole post-`takePrf`
+body zeroizes the buffer once, covering all early returns and throws.
+
+## Contracts
+
+### C1 — `PrfHandoff` shape + lifecycle (`src/lib/auth/prf-handoff.ts`)
+
+Signature:
+```ts
+export interface PrfHandoff {
+  prfOutput: Uint8Array;              // was: prfOutputHex: string
+  prfData: { prfEncryptedSecretKey: string; prfSecretKeyIv: string; prfSecretKeyAuthTag: string };
+}
+export function stashPrf(handoff: PrfHandoff): void;  // zeroizes prior pending.prfOutput before overwrite
+export function hasPrf(): boolean;
+export function takePrf(): PrfHandoff | null;          // single-use; does NOT zeroize (consumer owns)
+export function clearPrf(): void;                      // zeroizes pending.prfOutput, then drops
+```
+
+Invariants:
+- `prfOutput` is a `Uint8Array` everywhere in the handoff; no hex string of the
+  PRF output is ever constructed.
+- `stashPrf` and `clearPrf` are the only places that may zeroize a *pending*
+  buffer (an overwritten/abandoned one). `takePrf` never zeroizes — it hands the
+  buffer to the consumer.
+
+Acceptance:
+- `stashPrf(a); stashPrf(b)` zeroizes `a.prfOutput` (all bytes 0) and leaves
+  `b.prfOutput` intact and returned by `takePrf`.
+- `clearPrf` after a stash zeroizes the dropped buffer; subsequent `takePrf`
+  returns `null`.
+- `takePrf` returns the same `Uint8Array` reference that was stashed (no copy).
+
+#### Consumer-flow walkthrough for C1
+
+Consumer A (`src/lib/vault/vault-context.tsx` `unlockWithStoredPrf`) reads
+`{ prfOutput, prfData }` and uses `prfOutput` as the second arg to
+`unwrapSecretKeyWithPrf(prfData-bundle, prfOutput)`, then zeroizes `prfOutput`
+once in a `finally` covering the whole function body. It uses `prfData`'s three
+fields to build the wrapped-key bundle. All fields the consumer reads
+(`prfOutput`, `prfData.prfEncryptedSecretKey`, `prfData.prfSecretKeyIv`,
+`prfData.prfSecretKeyAuthTag`) are present in the locked C1 shape.
+
+Producer A (`src/components/auth/passkey-signin-button.tsx`) and Producer B
+(`src/components/auth/security-key-signin-form.tsx`) WRITE the contract:
+`stashPrf({ prfOutput, prfData: verifyData.prf })`. `prfOutput` is the
+`Uint8Array | null` from `startPasskeyAuthentication`; the stash happens only
+inside `if (prfOutput && verifyData.prf)`, so the narrowed non-null `Uint8Array`
+is passed. `verifyData.prf` is the server-returned bundle with exactly the three
+`prfData` fields.
+
+### C2 — Producer zeroization (both sign-in components)
+
+Signature (structure, both files identical in shape):
+```ts
+let prfOutput: Uint8Array | null = null;
+try {
+  ...
+  const result = await startPasskeyAuthentication(options, prfSalt || undefined);
+  prfOutput = result.prfOutput;
+  // read result.responseJSON below (do NOT re-destructure into a new const —
+  // that would shadow the outer `let prfOutput` and defeat finally-zeroization)
+  ... JSON.stringify(result.responseJSON) ...
+  ...
+  if (prfOutput && verifyData.prf) {
+    stashPrf({ prfOutput, prfData: verifyData.prf });
+    prfOutput = null;   // ownership transferred — do not zeroize below
+  }
+  ...
+} catch (err) { ... } finally {
+  prfOutput?.fill(0);
+  setLoading(false);
+}
+```
+
+Invariants:
+- `prfOutput` is zeroized in `finally` on every path where it was NOT stashed
+  (error throw, `!verifyRes.ok`, `prfOutput && !verifyData.prf`, no-PRF where it
+  is already `null`).
+- The pre-existing inline `prfOutput?.fill(0)` in the `!verifyRes.ok` branch is
+  removed (now covered by `finally`); no double-wipe, no missed wipe.
+- The success destructuring must not shadow the outer `prfOutput` — read
+  `result.responseJSON` / `result.prfOutput` instead of re-destructuring into a
+  new `const`. `responseJSON` is load-bearing — it is consumed at
+  `JSON.stringify(result.responseJSON)` in the verify request body
+  (`passkey-signin-button.tsx:63`, `security-key-signin-form.tsx:75`); the
+  restructure MUST preserve that read.
+- The `hexEncode` import becomes unused in BOTH producers once
+  `hexEncode(prfOutput)` is removed (it has no other use in these two files —
+  `passkey-signin-button.tsx:8`, `security-key-signin-form.tsx:9-13`). Remove the
+  import. (`@typescript-eslint/no-unused-vars` is `warn`, so build still passes,
+  but the standing rule is to fix the warning.) Note: `vault-context.tsx` keeps
+  `hexDecode`/`hexEncode` — they are used elsewhere (accountSalt etc.); only the
+  line-666 `hexDecode(handoff.prfOutputHex)` use goes away there.
+
+Forbidden patterns:
+- pattern: `const { responseJSON, prfOutput }` — reason: re-destructuring shadows the outer `let`, defeating finally-zeroization
+- pattern: `prfOutputHex` — reason: hex-string residue removed in C1
+- pattern: `hexEncode(prfOutput)` — reason: no hex copy of PRF output
+
+Acceptance:
+- On `fetchApi` throw after `startPasskeyAuthentication`, the obtained buffer is
+  zeroized (test: mock fetch to reject, assert buffer all-zero).
+- On `verifyData.prf` absent, buffer is zeroized and `stashPrf` not called.
+- On success, `stashPrf` is called with the buffer and the buffer is NOT
+  zeroized by the producer.
+
+### C3 — Consumer single zeroization (`unlockWithStoredPrf`)
+
+Signature (structure):
+```ts
+const handoff = takePrf();
+if (!handoff) return false;
+const prfOutput = handoff.prfOutput;   // was: hexDecode(handoff.prfOutputHex)
+try {
+  ... all existing logic, early returns and throws unchanged ...
+} finally {
+  prfOutput.fill(0);
+}
+```
+
+Invariants:
+- One `finally` zeroizes `prfOutput` for the whole function body; the inner
+  `try/finally` that previously wrapped only `unwrapSecretKeyWithPrf` is removed
+  (its job folds into the outer finally).
+- `secretKey` zeroization on its own error paths is unchanged (out of scope for
+  this fix; do not regress it).
+
+Forbidden patterns:
+- pattern: `hexDecode(handoff.prfOutput` — reason: prfOutput is now a Uint8Array, not hex
+
+Acceptance:
+- On `!dataRes.ok` (non-401) early return, `prfOutput` is zeroized.
+- On `!vaultData.accountSalt` early return, `prfOutput` is zeroized.
+- On the happy path, `prfOutput` is zeroized after unwrap; vault unlock still
+  succeeds (existing test passes with Uint8Array handoff).
+
+### C4 — Test updates
+
+Assertion idiom: use bare `buf.every((b) => b === 0)` for "wiped" and
+`buf.some((b) => b !== 0)` for "intact" (matches the two edited files'
+convention; no `Array.from` wrapper needed for `Uint8Array`).
+
+- `src/lib/auth/prf-handoff.test.ts`: replace `prfOutputHex` sample with a
+  `Uint8Array`; assert `takePrf` returns the **same reference** (not a copy);
+  assert `stashPrf` overwrite zeroizes the dropped prior buffer; assert
+  `clearPrf` zeroizes the pending buffer.
+
+- `src/components/auth/passkey-signin-button.test.tsx` &
+  `security-key-signin-form.test.tsx`:
+  - **INVERT the existing success-path zeroization assertion** (currently
+    `expect(prfBytes.every((b) => b === 0)).toBe(true)` at
+    `passkey-signin-button.test.tsx:140-141` and the parallel block in the
+    security-key test). Under the ownership-transfer model the producer must NOT
+    wipe on success. Replace with BOTH:
+    - `expect(mockStashPrf).toHaveBeenCalledWith({ prfOutput: prfBytes, prfData })`
+      — the *same live reference* is stashed, and
+    - `expect(prfBytes.some((b) => b !== 0)).toBe(true)` — producer did NOT wipe
+      the transferred buffer.
+    This is the cross-component double-wipe regression guard. Leaving the old
+    `every(b===0)===true` would either fail the suite or, if "fixed to green" by
+    keeping the producer wipe, ship the double-wipe bug.
+  - **New: `fetchApi` rejects after `startPasskeyAuthentication`** — resolve
+    `startPasskeyAuthentication` with `prfBytes`, mock options `ok`, then mock
+    `/verify` to reject → assert `prfBytes.every((b) => b === 0)` (finally wiped).
+    No existing test covers this (today's reject tests reject *before* the buffer
+    exists).
+  - **New: `prfOutput && !verifyData.prf` branch** (user scenario 3, vault not
+    PRF-enrolled) — `/verify` returns `ok` with no `prf` field → assert
+    `mockStashPrf` NOT called AND `prfBytes.every((b) => b === 0)`.
+  - Keep the existing `sessionStorage.getItem("psso:prf-output") === null` and
+    `psso:webauthn-signin` assertions.
+  - Remove now-dead scaffolding: `expectedHex = "ab".repeat(32)` locals and the
+    `mockHexEncode` mock (no longer referenced once `prfOutputHex` is dropped).
+
+- `src/lib/vault/vault-context.test.tsx`:
+  - Stash a `Uint8Array` (drop `hexEncode(prfOutput)`); hold the reference so
+    the new assertions can inspect it (the Uint8Array handoff returns the same
+    ref via `takePrf`, which is exactly what makes these assertions possible —
+    the old `hexDecode` path created an internal buffer the test could not see).
+  - **New: `!dataRes.ok` (non-401) early return** — stash a buffer, make
+    `/api/vault/unlock/data` return `{ ok: false, status: 500 }` →
+    `unlockWithStoredPrf()` returns `false` AND stashed buffer
+    `every((b) => b === 0)`.
+  - **New: `!vaultData.accountSalt` early return** — `/unlock/data` returns
+    `ok:true` with `accountSalt` stripped → returns `false` AND buffer wiped.
+  - Preserve the existing end-to-end success test (`encryptionKey instanceof
+    CryptoKey`) — it guards the consumer side against a zeroed stashed buffer.
+
+Acceptance: `npx vitest run` green; `npx next build` green.
+
+## Testing strategy
+
+Unit tests per C4. The zeroization assertions follow the project's existing
+buffer-wipe test idiom (assert `Array.from(buf).every(b => b === 0)`). No new
+test framework. Build verification mandatory (client component + crypto path).
+
+## Considerations & constraints
+
+- Ownership-transfer is the subtle part: a double-zeroize (producer wipes the
+  stashed buffer) would corrupt the consumer's unwrap. C2's `prfOutput = null`
+  after `stashPrf` is the guard; C2 forbidden-pattern grep guards the shadowing
+  re-destructure that would reintroduce the bug.
+- Full page reload still drops the buffer un-zeroized (module GC) — unavoidable
+  and unchanged; graceful degradation to manual unlock is the existing behavior.
+- Out of scope: `secretKey` lifetime hardening in `unlockWithStoredPrf`
+  (separate buffer, separate finding if any) — must not be regressed.
+
+## User operation scenarios
+
+1. Discoverable passkey sign-in with PRF → dashboard auto-unlocks (no second
+   ceremony). Buffer zeroized after unlock.
+2. Email security-key sign-in with PRF → same.
+3. PRF passkey where server returns no `prf` bundle (vault not PRF-enrolled) →
+   no stash, buffer zeroized, manual unlock prompt.
+4. Network failure during verify → error shown, buffer zeroized.
+5. Full reload between sign-in and dashboard → handoff gone, manual unlock.
+
+## Go/No-Go Gate
+
+| ID | Subject                                            | Status |
+|----|----------------------------------------------------|--------|
+| C1 | PrfHandoff Uint8Array shape + lifecycle            | locked |
+| C2 | Producer finally-zeroization (2 components)        | locked |
+| C3 | Consumer single finally-zeroization                | locked |
+| C4 | Test updates (4 files)                             | locked |

--- a/docs/archive/review/prf-handoff-zeroization-review.md
+++ b/docs/archive/review/prf-handoff-zeroization-review.md
@@ -1,0 +1,55 @@
+# Plan Review: prf-handoff-zeroization
+Date: 2026-05-31
+Review round: 1 (resolved)
+
+## Changes from Previous Round
+Initial review. Three expert agents (functionality, security, testing) reviewed
+the plan against the live codebase. No Critical findings; ownership-transfer
+model verified sound by all three. All findings incorporated into the plan.
+
+## Functionality Findings
+- **F1 (Major) — resolved**: C4 omitted inverting the existing producer
+  success-path zeroization assertion (`passkey-signin-button.test.tsx:140-141`).
+  Under ownership transfer the producer must NOT wipe on success. → C4 now
+  explicitly inverts to `some(b!==0)` + same-reference `stashPrf` assertion.
+- **F2 (Major) — resolved**: `hexEncode` becomes an unused import in both
+  producers. → C2 now lists import removal; notes `vault-context.tsx` keeps it.
+- **F3 (Minor) — resolved**: C2 skeleton elided the load-bearing
+  `result.responseJSON` read. → C2 skeleton + invariant now show it.
+- Info: ownership model (`prfOutput = null` after stash) verified sufficient;
+  no double-wipe path; C3 consumer fold safe; `secretKey` not regressed.
+
+## Security Findings
+- **S1 (Minor) — resolved**: `clearPrf()` has no production caller; its zeroize
+  duty is latent and does not close the realistic full-reload abandonment leak.
+  → C1 now scopes this honestly (latent, overwrite-only protection; full-reload
+  residue accepted) and notes the browser-owned `prfResults.first` ArrayBuffer
+  as the un-wipeable residency floor (no overstatement of "zero residue").
+- Info: threat-model framing ("low severity defense-in-depth") accurate — this
+  does not close an XSS read primitive (in-realm XSS could call `takePrf()`); it
+  reduces post-use heap residency. No hidden copies (`toArrayBuffer` zero-copy,
+  `importKey` opaque, no postMessage/structuredClone/Worker path).
+- No Critical → no Opus escalation.
+
+## Testing Findings
+- **T1 (Minor) — resolved**: C4 omitted the two consumer early-return
+  zeroization tests (`!dataRes.ok`, `!vaultData.accountSalt`) — the exact bug
+  paths. → added to C4.
+- **T2 (Minor) — resolved**: producer `fetchApi`-reject case underspecified and
+  `prfOutput && !verifyData.prf` branch untested. → both added to C4.
+- **T3 (Critical-adjacent → resolved)**: same as F1 — the producer success
+  assertion inversion is the cross-component double-wipe guard;
+  `prf-handoff.test.ts`'s `.toEqual` cannot catch it. → C4 now mandates the
+  inverted producer-test assertion.
+- **T4/T5 (Minor) — resolved**: remove dead `expectedHex`/`mockHexEncode`
+  scaffolding; use bare `buf.every((b) => b === 0)` / `buf.some((b) => b !== 0)`
+  idiom. → noted in C4.
+
+## Adjacent Findings
+- [Adjacent functional, from security] producer reject test must hold the same
+  `Uint8Array` reference returned by the mocked `startPasskeyAuthentication` —
+  folded into C4.
+
+## Resolution Status
+All findings resolved in-plan. Contracts C1-C4 remain `locked`. Proceeding to
+Phase 2 (coding).

--- a/src/components/auth/passkey-signin-button.test.tsx
+++ b/src/components/auth/passkey-signin-button.test.tsx
@@ -7,7 +7,6 @@ import "@testing-library/jest-dom/vitest";
 const {
   mockStartPasskeyAuthentication,
   mockIsWebAuthnSupported,
-  mockHexEncode,
   mockRouterPush,
   mockFetch,
   mockStashPrf,
@@ -15,9 +14,6 @@ const {
 } = vi.hoisted(() => ({
   mockStartPasskeyAuthentication: vi.fn(),
   mockIsWebAuthnSupported: vi.fn(() => true),
-  mockHexEncode: vi.fn((b: Uint8Array) =>
-    Array.from(b, (x) => x.toString(16).padStart(2, "0")).join(""),
-  ),
   mockRouterPush: vi.fn(),
   mockFetch: vi.fn(),
   mockStashPrf: vi.fn(),
@@ -56,7 +52,6 @@ vi.mock("@/lib/auth/webauthn/webauthn-client", () => ({
   startPasskeyAuthentication: (
     ...args: unknown[]
   ) => mockStartPasskeyAuthentication(...args),
-  hexEncode: (b: Uint8Array) => mockHexEncode(b),
 }));
 
 import { PasskeySignInButton } from "./passkey-signin-button";
@@ -96,7 +91,7 @@ describe("PasskeySignInButton — §Sec-7 WebAuthn / PRF", () => {
     expect(screen.getByRole("button", { name: /signInWithPasskey/ })).not.toBeDisabled();
   });
 
-  it("(success) hands PRF material to the in-memory channel (NOT sessionStorage), then zeroizes prfOutput", async () => {
+  it("(success) hands the live PRF buffer to the in-memory channel (NOT sessionStorage) WITHOUT zeroizing it", async () => {
     const prfBytes = makePrfSentinel();
     mockStartPasskeyAuthentication.mockResolvedValueOnce({
       responseJSON: { id: "cred-1" },
@@ -119,12 +114,11 @@ describe("PasskeySignInButton — §Sec-7 WebAuthn / PRF", () => {
     render(<PasskeySignInButton />);
     fireEvent.click(screen.getByRole("button", { name: /signInWithPasskey/ }));
 
-    // Hex of 32 bytes of 0xAB
-    const expectedHex = "ab".repeat(32);
     await waitFor(() => {
-      // PRF material goes to the in-memory hand-off, never to XSS-readable storage.
+      // Ownership transfer: the SAME live Uint8Array reference is stashed (no
+      // hex copy), so the consumer can zeroize the real buffer after use.
       expect(mockStashPrf).toHaveBeenCalledWith({
-        prfOutputHex: expectedHex,
+        prfOutput: prfBytes,
         prfData: {
           prfEncryptedSecretKey: "ct",
           prfSecretKeyIv: "iv",
@@ -137,10 +131,55 @@ describe("PasskeySignInButton — §Sec-7 WebAuthn / PRF", () => {
       expect(sessionStorage.getItem("psso:prf-data")).toBeNull();
     });
 
-    // Zeroization invariant: source calls prfOutput.fill(0) after the hand-off.
-    expect(prfBytes.every((b) => b === 0)).toBe(true);
+    // Ownership transferred: the producer must NOT wipe the stashed buffer
+    // (doing so would corrupt the consumer's unwrap). Buffer stays intact.
+    expect(prfBytes.some((b) => b !== 0)).toBe(true);
 
     expect(mockRouterPush).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("(no PRF bundle) does NOT hand off and zeroizes the obtained buffer", async () => {
+    const prfBytes = makePrfSentinel();
+    mockStartPasskeyAuthentication.mockResolvedValueOnce({
+      responseJSON: { id: "cred-1" },
+      prfOutput: prfBytes,
+    });
+    mockFetch
+      .mockResolvedValueOnce(okJson({ options: {}, challengeId: "ch-1", prfSalt: "salt" }))
+      .mockResolvedValueOnce(okJson({ ok: true })); // /verify ok but no prf bundle
+
+    render(<PasskeySignInButton />);
+    fireEvent.click(screen.getByRole("button", { name: /signInWithPasskey/ }));
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith("/dashboard");
+    });
+
+    // Vault not PRF-enrolled: no hand-off, buffer zeroized by the finally.
+    expect(mockStashPrf).not.toHaveBeenCalled();
+    expect(prfBytes.every((b) => b === 0)).toBe(true);
+  });
+
+  it("(fetch throws after ceremony) zeroizes the obtained buffer in finally", async () => {
+    const prfBytes = makePrfSentinel();
+    mockStartPasskeyAuthentication.mockResolvedValueOnce({
+      responseJSON: { id: "cred-1" },
+      prfOutput: prfBytes,
+    });
+    mockFetch
+      .mockResolvedValueOnce(okJson({ options: {}, challengeId: "ch-1", prfSalt: "salt" }))
+      .mockRejectedValueOnce(new Error("network")); // /verify rejects
+
+    render(<PasskeySignInButton />);
+    fireEvent.click(screen.getByRole("button", { name: /signInWithPasskey/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("passkeySignInFailed")).toBeInTheDocument();
+    });
+
+    // The buffer obtained before the throw is still zeroized by the finally.
+    expect(prfBytes.every((b) => b === 0)).toBe(true);
+    expect(mockStashPrf).not.toHaveBeenCalled();
   });
 
   it("(verify-failure) zeroizes prfOutput AND writes NO PRF/webauthn-signin keys to sessionStorage", async () => {
@@ -161,7 +200,7 @@ describe("PasskeySignInButton — §Sec-7 WebAuthn / PRF", () => {
       expect(screen.getByText("passkeySignInFailed")).toBeInTheDocument();
     });
 
-    // Zeroization in failure path (source line 73 prfOutput?.fill(0))
+    // Zeroization in failure path (finally: prfOutput?.fill(0))
     expect(prfBytes.every((b) => b === 0)).toBe(true);
 
     // No PRF handed off and no session keys persisted

--- a/src/components/auth/passkey-signin-button.test.tsx
+++ b/src/components/auth/passkey-signin-button.test.tsx
@@ -10,15 +10,12 @@ const {
   mockRouterPush,
   mockFetch,
   mockStashPrf,
-  prfSentinel,
 } = vi.hoisted(() => ({
   mockStartPasskeyAuthentication: vi.fn(),
   mockIsWebAuthnSupported: vi.fn(() => true),
   mockRouterPush: vi.fn(),
   mockFetch: vi.fn(),
   mockStashPrf: vi.fn(),
-  // Sentinel: 0xAB repeated. Tests check zeroization by post-hoc inspection.
-  prfSentinel: { current: null as Uint8Array | null },
 }));
 
 vi.mock("@/lib/auth/prf-handoff", () => ({
@@ -57,9 +54,8 @@ vi.mock("@/lib/auth/webauthn/webauthn-client", () => ({
 import { PasskeySignInButton } from "./passkey-signin-button";
 
 function makePrfSentinel(): Uint8Array {
-  const bytes = new Uint8Array(32).fill(0xab);
-  prfSentinel.current = bytes;
-  return bytes;
+  // 0xAB repeated. Tests hold this reference to check zeroization post-hoc.
+  return new Uint8Array(32).fill(0xab);
 }
 
 function okJson(body: unknown): Response {

--- a/src/components/auth/passkey-signin-button.tsx
+++ b/src/components/auth/passkey-signin-button.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
 import { Loader2, Fingerprint } from "lucide-react";
-import { isWebAuthnSupported, startPasskeyAuthentication, hexEncode } from "@/lib/auth/webauthn/webauthn-client";
+import { isWebAuthnSupported, startPasskeyAuthentication } from "@/lib/auth/webauthn/webauthn-client";
 import { API_PATH } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
 import { useCallbackUrl } from "@/hooks/use-callback-url";
@@ -28,6 +28,9 @@ export function PasskeySignInButton() {
     setLoading(true);
     setError(null);
 
+    // Held in the outer scope so `finally` can zeroize it on every path where
+    // ownership was NOT transferred to the handoff (set to null after stashPrf).
+    let prfOutput: Uint8Array | null = null;
     try {
       // 1. Get discoverable credential options from server (includes prfSalt)
       const optionsRes = await fetchApi(
@@ -45,10 +48,11 @@ export function PasskeySignInButton() {
       // 2. Run WebAuthn authentication WITH PRF if salt is available.
       // This combines sign-in + PRF key derivation into a single ceremony
       // so users only need one authenticator interaction (e.g., one QR scan).
-      const { responseJSON, prfOutput } = await startPasskeyAuthentication(
+      const result = await startPasskeyAuthentication(
         options,
         prfSalt || undefined,
       );
+      prfOutput = result.prfOutput;
 
       // 3. Verify and create database session via custom route.
       // Auth.js Credentials provider only supports JWT sessions, which is
@@ -60,14 +64,13 @@ export function PasskeySignInButton() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            credentialResponse: JSON.stringify(responseJSON),
+            credentialResponse: JSON.stringify(result.responseJSON),
             challengeId,
           }),
         },
       );
 
       if (!verifyRes.ok) {
-        prfOutput?.fill(0);
         setError(t("passkeySignInFailed"));
         return;
       }
@@ -78,9 +81,11 @@ export function PasskeySignInButton() {
       // hand both to the dashboard in-memory (NOT sessionStorage, which XSS can
       // read) for vault auto-unlock without a second ceremony. Survives the
       // client-side router.push below; a full reload drops it → manual unlock.
+      // Ownership of the buffer transfers to the handoff: null it out so the
+      // finally below does not zeroize what the consumer must still read.
       if (prfOutput && verifyData.prf) {
-        stashPrf({ prfOutputHex: hexEncode(prfOutput), prfData: verifyData.prf });
-        prfOutput.fill(0);
+        stashPrf({ prfOutput, prfData: verifyData.prf });
+        prfOutput = null;
       }
 
       // 5. Set flag for vault auto-unlock after dashboard navigation
@@ -95,6 +100,9 @@ export function PasskeySignInButton() {
         setError(t("passkeySignInFailed"));
       }
     } finally {
+      // Zeroize on every path where the buffer was not handed off (error throw,
+      // verify failure, no PRF bundle). No-op after a successful stashPrf.
+      prfOutput?.fill(0);
       setLoading(false);
     }
   };

--- a/src/components/auth/security-key-signin-form.test.tsx
+++ b/src/components/auth/security-key-signin-form.test.tsx
@@ -6,7 +6,6 @@ import "@testing-library/jest-dom/vitest";
 const {
   mockStartPasskeyAuthentication,
   mockIsWebAuthnSupported,
-  mockHexEncode,
   mockRouterPush,
   mockFetch,
   mockStashPrf,
@@ -14,9 +13,6 @@ const {
 } = vi.hoisted(() => ({
   mockStartPasskeyAuthentication: vi.fn(),
   mockIsWebAuthnSupported: vi.fn(() => true),
-  mockHexEncode: vi.fn((b: Uint8Array) =>
-    Array.from(b, (x) => x.toString(16).padStart(2, "0")).join(""),
-  ),
   mockRouterPush: vi.fn(),
   mockFetch: vi.fn(),
   mockStashPrf: vi.fn(),
@@ -53,7 +49,6 @@ vi.mock("@/lib/auth/webauthn/webauthn-client", () => ({
   startPasskeyAuthentication: (
     ...args: unknown[]
   ) => mockStartPasskeyAuthentication(...args),
-  hexEncode: (b: Uint8Array) => mockHexEncode(b),
 }));
 
 import { SecurityKeySignInForm } from "./security-key-signin-form";
@@ -105,7 +100,7 @@ describe("SecurityKeySignInForm — §Sec-7 WebAuthn / PRF", () => {
     expect(mockStartPasskeyAuthentication).not.toHaveBeenCalled();
   });
 
-  it("(success) hands PRF material to the in-memory channel (NOT sessionStorage), then zeroizes prfOutput", async () => {
+  it("(success) hands the live PRF buffer to the in-memory channel (NOT sessionStorage) WITHOUT zeroizing it", async () => {
     const prfBytes = makePrfSentinel();
     mockStartPasskeyAuthentication.mockResolvedValueOnce({
       responseJSON: { id: "cred-1" },
@@ -131,11 +126,11 @@ describe("SecurityKeySignInForm — §Sec-7 WebAuthn / PRF", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /signInWithSecurityKey/ }));
 
-    const expectedHex = "ab".repeat(32);
     await waitFor(() => {
-      // PRF material goes to the in-memory hand-off, never to XSS-readable storage.
+      // Ownership transfer: the SAME live Uint8Array reference is stashed (no
+      // hex copy), so the consumer can zeroize the real buffer after use.
       expect(mockStashPrf).toHaveBeenCalledWith({
-        prfOutputHex: expectedHex,
+        prfOutput: prfBytes,
         prfData: {
           prfEncryptedSecretKey: "ct",
           prfSecretKeyIv: "iv",
@@ -147,8 +142,55 @@ describe("SecurityKeySignInForm — §Sec-7 WebAuthn / PRF", () => {
       expect(sessionStorage.getItem("psso:prf-output")).toBeNull();
       expect(sessionStorage.getItem("psso:prf-data")).toBeNull();
     });
-    expect(prfBytes.every((b) => b === 0)).toBe(true);
+    // Ownership transferred: producer must NOT wipe the stashed buffer.
+    expect(prfBytes.some((b) => b !== 0)).toBe(true);
     expect(mockRouterPush).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("(no PRF bundle) does NOT hand off and zeroizes the obtained buffer", async () => {
+    const prfBytes = makePrfSentinel();
+    mockStartPasskeyAuthentication.mockResolvedValueOnce({
+      responseJSON: { id: "cred-1" },
+      prfOutput: prfBytes,
+    });
+    mockFetch
+      .mockResolvedValueOnce(okJson({ options: {}, challengeId: "ch-1", prfSalt: "salt" }))
+      .mockResolvedValueOnce(okJson({ ok: true })); // /verify ok but no prf bundle
+
+    render(<SecurityKeySignInForm />);
+    fireEvent.change(screen.getByPlaceholderText("emailForSecurityKey"), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /signInWithSecurityKey/ }));
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith("/dashboard");
+    });
+    expect(mockStashPrf).not.toHaveBeenCalled();
+    expect(prfBytes.every((b) => b === 0)).toBe(true);
+  });
+
+  it("(fetch throws after ceremony) zeroizes the obtained buffer in finally", async () => {
+    const prfBytes = makePrfSentinel();
+    mockStartPasskeyAuthentication.mockResolvedValueOnce({
+      responseJSON: { id: "cred-1" },
+      prfOutput: prfBytes,
+    });
+    mockFetch
+      .mockResolvedValueOnce(okJson({ options: {}, challengeId: "ch-1", prfSalt: "salt" }))
+      .mockRejectedValueOnce(new Error("network")); // /verify rejects
+
+    render(<SecurityKeySignInForm />);
+    fireEvent.change(screen.getByPlaceholderText("emailForSecurityKey"), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /signInWithSecurityKey/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("securityKeySignInFailed")).toBeInTheDocument();
+    });
+    expect(prfBytes.every((b) => b === 0)).toBe(true);
+    expect(mockStashPrf).not.toHaveBeenCalled();
   });
 
   it("(verify-failure) zeroizes prfOutput AND hands off NO PRF / writes no webauthn-signin key", async () => {

--- a/src/components/auth/security-key-signin-form.test.tsx
+++ b/src/components/auth/security-key-signin-form.test.tsx
@@ -9,14 +9,12 @@ const {
   mockRouterPush,
   mockFetch,
   mockStashPrf,
-  prfSentinel,
 } = vi.hoisted(() => ({
   mockStartPasskeyAuthentication: vi.fn(),
   mockIsWebAuthnSupported: vi.fn(() => true),
   mockRouterPush: vi.fn(),
   mockFetch: vi.fn(),
   mockStashPrf: vi.fn(),
-  prfSentinel: { current: null as Uint8Array | null },
 }));
 
 vi.mock("@/lib/auth/prf-handoff", () => ({
@@ -54,9 +52,8 @@ vi.mock("@/lib/auth/webauthn/webauthn-client", () => ({
 import { SecurityKeySignInForm } from "./security-key-signin-form";
 
 function makePrfSentinel(): Uint8Array {
-  const bytes = new Uint8Array(32).fill(0xab);
-  prfSentinel.current = bytes;
-  return bytes;
+  // 0xAB repeated. Tests hold this reference to check zeroization post-hoc.
+  return new Uint8Array(32).fill(0xab);
 }
 
 function okJson(body: unknown): Response {

--- a/src/components/auth/security-key-signin-form.tsx
+++ b/src/components/auth/security-key-signin-form.tsx
@@ -9,7 +9,6 @@ import { Loader2, KeyRound } from "lucide-react";
 import {
   isWebAuthnSupported,
   startPasskeyAuthentication,
-  hexEncode,
 } from "@/lib/auth/webauthn/webauthn-client";
 import { API_PATH } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
@@ -41,6 +40,9 @@ export function SecurityKeySignInForm() {
     }
 
     setLoading(true);
+    // Held in the outer scope so `finally` can zeroize it on every path where
+    // ownership was NOT transferred to the handoff (set to null after stashPrf).
+    let prfOutput: Uint8Array | null = null;
     try {
       // 1. Get options with allowCredentials for this email
       const optionsRes = await fetchApi(
@@ -60,10 +62,11 @@ export function SecurityKeySignInForm() {
       const { options, challengeId, prfSalt } = await optionsRes.json();
 
       // 2. WebAuthn ceremony (browser matches security key to allowCredentials)
-      const { responseJSON, prfOutput } = await startPasskeyAuthentication(
+      const result = await startPasskeyAuthentication(
         options,
         prfSalt || undefined,
       );
+      prfOutput = result.prfOutput;
 
       // 3. Verify (reuses existing /api/auth/passkey/verify)
       const verifyRes = await fetchApi(
@@ -72,14 +75,13 @@ export function SecurityKeySignInForm() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            credentialResponse: JSON.stringify(responseJSON),
+            credentialResponse: JSON.stringify(result.responseJSON),
             challengeId,
           }),
         },
       );
 
       if (!verifyRes.ok) {
-        prfOutput?.fill(0);
         setError(t("securityKeySignInFailed"));
         return;
       }
@@ -88,10 +90,12 @@ export function SecurityKeySignInForm() {
 
       // 4. Hand PRF data to the dashboard in-memory (NOT sessionStorage, which
       // XSS can read) for vault auto-unlock. Survives the client-side router.push
-      // below; a full reload drops it → manual unlock.
+      // below; a full reload drops it → manual unlock. Ownership of the buffer
+      // transfers to the handoff: null it out so the finally below does not
+      // zeroize what the consumer must still read.
       if (prfOutput && verifyData.prf) {
-        stashPrf({ prfOutputHex: hexEncode(prfOutput), prfData: verifyData.prf });
-        prfOutput.fill(0);
+        stashPrf({ prfOutput, prfData: verifyData.prf });
+        prfOutput = null;
       }
 
       sessionStorage.setItem("psso:webauthn-signin", "1");
@@ -103,6 +107,9 @@ export function SecurityKeySignInForm() {
         setError(t("securityKeySignInFailed"));
       }
     } finally {
+      // Zeroize on every path where the buffer was not handed off (error throw,
+      // verify failure, no PRF bundle). No-op after a successful stashPrf.
+      prfOutput?.fill(0);
       setLoading(false);
     }
   };

--- a/src/lib/auth/prf-handoff.test.ts
+++ b/src/lib/auth/prf-handoff.test.ts
@@ -103,5 +103,15 @@ describe("prf-handoff", () => {
       expect(second.prfOutput.some((b) => b !== 0)).toBe(true);
       expect(takePrf()).toBe(second);
     });
+
+    it("clearPrf cancels the pending TTL timer (no dangling timer left armed)", () => {
+      // clearPrf's cancellation is timer hygiene, not a buffer-wipe effect (a
+      // phantom fire would hit null pending and no-op). Assert it directly via
+      // the fake-timer queue rather than an observable wipe.
+      stashPrf(makeSample());
+      expect(vi.getTimerCount()).toBe(1);
+      clearPrf();
+      expect(vi.getTimerCount()).toBe(0);
+    });
   });
 });

--- a/src/lib/auth/prf-handoff.test.ts
+++ b/src/lib/auth/prf-handoff.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { stashPrf, takePrf, clearPrf, type PrfHandoff } from "./prf-handoff";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  stashPrf,
+  takePrf,
+  clearPrf,
+  PRF_HANDOFF_TTL_MS,
+  type PrfHandoff,
+} from "./prf-handoff";
 
 // Fresh buffers per call — stash/clear zeroize in place, so sharing one buffer
 // across tests would leak mutations between them.
@@ -49,5 +55,53 @@ describe("prf-handoff", () => {
     expect(first.prfOutput.every((b) => b === 0)).toBe(true);
     expect(takePrf()).toBe(second);
     expect(second.prfOutput.some((b) => b !== 0)).toBe(true);
+  });
+
+  describe("TTL self-expiry", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("zeroizes and drops an unconsumed handoff after the TTL elapses", () => {
+      const sample = makeSample();
+      stashPrf(sample);
+      vi.advanceTimersByTime(PRF_HANDOFF_TTL_MS);
+      expect(sample.prfOutput.every((b) => b === 0)).toBe(true);
+      expect(takePrf()).toBeNull();
+    });
+
+    it("does NOT wipe before the TTL elapses", () => {
+      const sample = makeSample();
+      stashPrf(sample);
+      vi.advanceTimersByTime(PRF_HANDOFF_TTL_MS - 1);
+      expect(sample.prfOutput.some((b) => b !== 0)).toBe(true);
+      expect(takePrf()).toBe(sample);
+    });
+
+    it("takePrf cancels the TTL so the consumer-owned buffer is not wiped later", () => {
+      const sample = makeSample();
+      stashPrf(sample);
+      const taken = takePrf();
+      expect(taken).toBe(sample);
+      // After the consumer owns it, the expired timer must not reach back in.
+      vi.advanceTimersByTime(PRF_HANDOFF_TTL_MS);
+      expect(sample.prfOutput.some((b) => b !== 0)).toBe(true);
+    });
+
+    it("a re-stash resets the TTL and the prior timer cannot wipe the new buffer", () => {
+      const first = makeSample(0xab);
+      stashPrf(first);
+      // Just before the first TTL would fire, stash a fresh handoff.
+      vi.advanceTimersByTime(PRF_HANDOFF_TTL_MS - 1);
+      const second = makeSample(0xcd);
+      stashPrf(second);
+      // The original timer (now cancelled) would have fired here.
+      vi.advanceTimersByTime(1);
+      expect(second.prfOutput.some((b) => b !== 0)).toBe(true);
+      expect(takePrf()).toBe(second);
+    });
   });
 });

--- a/src/lib/auth/prf-handoff.test.ts
+++ b/src/lib/auth/prf-handoff.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { stashPrf, takePrf, clearPrf } from "./prf-handoff";
+import { stashPrf, takePrf, clearPrf, type PrfHandoff } from "./prf-handoff";
 
-const sample = {
-  prfOutputHex: "ab".repeat(32),
-  prfData: {
-    prfEncryptedSecretKey: "ct",
-    prfSecretKeyIv: "iv",
-    prfSecretKeyAuthTag: "tag",
-  },
-};
+// Fresh buffers per call — stash/clear zeroize in place, so sharing one buffer
+// across tests would leak mutations between them.
+function makeSample(byte = 0xab): PrfHandoff {
+  return {
+    prfOutput: new Uint8Array(32).fill(byte),
+    prfData: {
+      prfEncryptedSecretKey: "ct",
+      prfSecretKeyIv: "iv",
+      prfSecretKeyAuthTag: "tag",
+    },
+  };
+}
 
 describe("prf-handoff", () => {
   beforeEach(() => {
@@ -19,23 +23,31 @@ describe("prf-handoff", () => {
     expect(takePrf()).toBeNull();
   });
 
-  it("returns the stashed material once, then clears (single-use)", () => {
+  it("returns the same stashed reference once, then clears (single-use)", () => {
+    const sample = makeSample();
     stashPrf(sample);
-    expect(takePrf()).toEqual(sample);
-    // Second read is empty — material is not retained.
+    const taken = takePrf();
+    // Same reference — no copy, so the consumer can zeroize the real buffer.
+    expect(taken).toBe(sample);
     expect(takePrf()).toBeNull();
   });
 
-  it("clearPrf drops material without consuming it", () => {
+  it("clearPrf zeroizes the dropped buffer and consumes it", () => {
+    const sample = makeSample();
     stashPrf(sample);
     clearPrf();
+    expect(sample.prfOutput.every((b) => b === 0)).toBe(true);
     expect(takePrf()).toBeNull();
   });
 
-  it("stashPrf overwrites a prior pending value", () => {
-    stashPrf(sample);
-    const next = { ...sample, prfOutputHex: "cd".repeat(32) };
-    stashPrf(next);
-    expect(takePrf()).toEqual(next);
+  it("stashPrf overwrites a prior pending value and zeroizes the prior buffer", () => {
+    const first = makeSample(0xab);
+    const second = makeSample(0xcd);
+    stashPrf(first);
+    stashPrf(second);
+    // The overwritten buffer is wiped; the new one survives intact.
+    expect(first.prfOutput.every((b) => b === 0)).toBe(true);
+    expect(takePrf()).toBe(second);
+    expect(second.prfOutput.some((b) => b !== 0)).toBe(true);
   });
 });

--- a/src/lib/auth/prf-handoff.ts
+++ b/src/lib/auth/prf-handoff.ts
@@ -10,12 +10,22 @@
  * passkey takes). `takePrf()` clears on read so the material is held only for
  * the single sign-in→dashboard transition.
  *
+ * The PRF output is held as a `Uint8Array` (not a hex string) so it can be
+ * zeroized after use — JS strings are immutable and cannot be wiped. Ownership
+ * transfers along producer → handoff → consumer: the producer stops referencing
+ * the buffer after `stashPrf` (it must NOT zeroize the stashed buffer), the
+ * consumer zeroizes it after `takePrf` + use. `stashPrf` (on overwrite) and
+ * `clearPrf` zeroize the buffer they drop. Zeroization is best-effort
+ * heap-residency reduction: a full page reload before consume drops the module
+ * via GC with nothing running to wipe, and the source buffer originates from a
+ * browser-owned WebAuthn `ArrayBuffer` that is itself un-wipeable.
+ *
  * Client-only: imported solely by "use client" components.
  */
 
 export interface PrfHandoff {
-  /** PRF output as hex (consumer hex-decodes, uses, then zeroes the buffer). */
-  prfOutputHex: string;
+  /** PRF output bytes. Owned by the handoff; the consumer zeroizes after use. */
+  prfOutput: Uint8Array;
   /** Server-returned PRF-wrapped secret key bundle. */
   prfData: {
     prfEncryptedSecretKey: string;
@@ -28,6 +38,7 @@ let pending: PrfHandoff | null = null;
 
 /** Stash PRF material for the upcoming vault auto-unlock. Overwrites any prior. */
 export function stashPrf(handoff: PrfHandoff): void {
+  pending?.prfOutput.fill(0);
   pending = handoff;
 }
 
@@ -36,7 +47,10 @@ export function hasPrf(): boolean {
   return pending !== null;
 }
 
-/** Return the stashed PRF material and clear it (single-use). */
+/**
+ * Return the stashed PRF material and clear it (single-use). Does NOT zeroize —
+ * ownership transfers to the caller, which zeroizes `prfOutput` after use.
+ */
 export function takePrf(): PrfHandoff | null {
   const value = pending;
   pending = null;
@@ -45,5 +59,6 @@ export function takePrf(): PrfHandoff | null {
 
 /** Drop any stashed material without consuming it (e.g. on sign-in failure). */
 export function clearPrf(): void {
+  pending?.prfOutput.fill(0);
   pending = null;
 }

--- a/src/lib/auth/prf-handoff.ts
+++ b/src/lib/auth/prf-handoff.ts
@@ -20,8 +20,18 @@
  * via GC with nothing running to wipe, and the source buffer originates from a
  * browser-owned WebAuthn `ArrayBuffer` that is itself un-wipeable.
  *
+ * A stashed handoff also self-expires after `PRF_HANDOFF_TTL_MS`: if the
+ * dashboard never reaches auto-unlock while the SPA stays alive (e.g. an
+ * in-page navigation away before unlock), the buffer is wiped instead of
+ * lingering. A full page reload drops the module (and this timer) via GC, so
+ * the TTL only bounds the in-SPA-without-unlock case — the one residency window
+ * that is observable from JS.
+ *
  * Client-only: imported solely by "use client" components.
  */
+
+/** Grace window before an unconsumed handoff self-wipes. */
+export const PRF_HANDOFF_TTL_MS = 30_000;
 
 export interface PrfHandoff {
   /** PRF output bytes. Owned by the handoff; the consumer zeroizes after use. */
@@ -35,11 +45,23 @@ export interface PrfHandoff {
 }
 
 let pending: PrfHandoff | null = null;
+let ttlTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Cancel any pending self-expiry timer (on consume, overwrite, or clear). */
+function cancelTtl(): void {
+  if (ttlTimer !== null) {
+    clearTimeout(ttlTimer);
+    ttlTimer = null;
+  }
+}
 
 /** Stash PRF material for the upcoming vault auto-unlock. Overwrites any prior. */
 export function stashPrf(handoff: PrfHandoff): void {
   pending?.prfOutput.fill(0);
+  cancelTtl();
   pending = handoff;
+  // Self-expire if never consumed; cancelled by takePrf/clearPrf/overwrite.
+  ttlTimer = setTimeout(clearPrf, PRF_HANDOFF_TTL_MS);
 }
 
 /** Whether PRF material is stashed, without consuming it (gate before takePrf). */
@@ -52,6 +74,7 @@ export function hasPrf(): boolean {
  * ownership transfers to the caller, which zeroizes `prfOutput` after use.
  */
 export function takePrf(): PrfHandoff | null {
+  cancelTtl();
   const value = pending;
   pending = null;
   return value;
@@ -59,6 +82,7 @@ export function takePrf(): PrfHandoff | null {
 
 /** Drop any stashed material without consuming it (e.g. on sign-in failure). */
 export function clearPrf(): void {
+  cancelTtl();
   pending?.prfOutput.fill(0);
   pending = null;
 }

--- a/src/lib/vault/vault-context.test.tsx
+++ b/src/lib/vault/vault-context.test.tsx
@@ -22,6 +22,9 @@ import {
 } from "./vault-context";
 import { stashPrf, clearPrf } from "@/lib/auth/prf-handoff";
 import { wrapSecretKeyWithPrf } from "@/lib/auth/webauthn/webauthn-client";
+// Namespace import used ONLY to attach a pass-through spy that captures the
+// real unwrapped key for a zeroization assertion — crypto still runs for real.
+import * as webauthnClient from "@/lib/auth/webauthn/webauthn-client";
 
 const PASSPHRASE = "correct horse battery staple";
 
@@ -477,6 +480,79 @@ describe("VaultProvider — unlockWithStoredPrf (in-memory PRF hand-off)", () =>
     expect(ok).toBe(false);
     expect(prfOutput.every((b) => b === 0)).toBe(true);
   });
+
+  it(
+    "zeroizes the unwrapped secret key when unlock throws AFTER the key is unwrapped",
+    async () => {
+      // Regression guard for the secretKey throw-path gap: a VaultUnlockError
+      // thrown after unwrapSecretKeyWithPrf must still hit the single finally
+      // that wipes the unwrapped secretKey. We capture the real unwrapped key
+      // via a pass-through spy (crypto still runs for real) and assert it is
+      // zeroized after the throw.
+      let capturedSecretKey: Uint8Array | null = null;
+      const actualUnwrap = webauthnClient.unwrapSecretKeyWithPrf;
+      const unwrapSpy = vi
+        .spyOn(webauthnClient, "unwrapSecretKeyWithPrf")
+        .mockImplementation(async (wrapped, prf) => {
+          const sk = await actualUnwrap(wrapped, prf);
+          capturedSecretKey = sk;
+          return sk;
+        });
+
+      const { fetchMock, store } = makeFetchEnv(null);
+      // Wrap the env so /api/vault/unlock fails with a server error AFTER the
+      // real key unwrap + derivation has already happened.
+      const failingFetch = vi.fn(async (url: string, init?: RequestInit) => {
+        const path = typeof url === "string" ? url : "";
+        if (path === "/api/vault/unlock" && init?.method === "POST") {
+          return { ok: false, status: 423, json: async () => ({ error: "VAULT_LOCKED" }) };
+        }
+        return fetchMock(path, init);
+      }) as unknown as typeof fetch;
+      globalThis.fetch = failingFetch;
+
+      const { result } = renderHook(() => useVault(), { wrapper });
+      await act(async () => {
+        await result.current.setup(PASSPHRASE);
+      });
+      const secretKey = result.current.getSecretKey();
+      expect(secretKey).toBeInstanceOf(Uint8Array);
+      expect(store.vault).not.toBeNull();
+
+      // Stash a real PRF-wrapped key so the unwrap + derivation succeed and the
+      // throw happens at the /api/vault/unlock step.
+      const prfOutput = new Uint8Array(32).fill(0x5a);
+      const wrapped = await wrapSecretKeyWithPrf(secretKey!, prfOutput);
+      stashPrf({
+        prfOutput,
+        prfData: {
+          prfEncryptedSecretKey: wrapped.ciphertext,
+          prfSecretKeyIv: wrapped.iv,
+          prfSecretKeyAuthTag: wrapped.authTag,
+        },
+      });
+
+      act(() => {
+        result.current.lock();
+      });
+
+      await act(async () => {
+        await expect(result.current.unlockWithStoredPrf()).rejects.toBeInstanceOf(
+          VaultUnlockError,
+        );
+      });
+
+      // The spy ran (key was unwrapped) and the finally wiped the secret key
+      // on the post-unwrap throw path; prfOutput is wiped by the same finally.
+      expect(unwrapSpy).toHaveBeenCalledOnce();
+      expect(capturedSecretKey).not.toBeNull();
+      expect(capturedSecretKey!.every((b) => b === 0)).toBe(true);
+      expect(prfOutput.every((b) => b === 0)).toBe(true);
+
+      unwrapSpy.mockRestore();
+    },
+    60_000,
+  );
 });
 
 describe("VaultProvider — session-driven status", () => {

--- a/src/lib/vault/vault-context.test.tsx
+++ b/src/lib/vault/vault-context.test.tsx
@@ -21,7 +21,7 @@ import {
   VaultUnlockError,
 } from "./vault-context";
 import { stashPrf, clearPrf } from "@/lib/auth/prf-handoff";
-import { wrapSecretKeyWithPrf, hexEncode } from "@/lib/auth/webauthn/webauthn-client";
+import { wrapSecretKeyWithPrf } from "@/lib/auth/webauthn/webauthn-client";
 
 const PASSPHRASE = "correct horse battery staple";
 
@@ -382,7 +382,7 @@ describe("VaultProvider — unlockWithStoredPrf (in-memory PRF hand-off)", () =>
       const prfOutput = new Uint8Array(32).fill(0x5a);
       const wrapped = await wrapSecretKeyWithPrf(secretKey!, prfOutput);
       stashPrf({
-        prfOutputHex: hexEncode(prfOutput),
+        prfOutput,
         prfData: {
           prfEncryptedSecretKey: wrapped.ciphertext,
           prfSecretKeyIv: wrapped.iv,
@@ -417,6 +417,66 @@ describe("VaultProvider — unlockWithStoredPrf (in-memory PRF hand-off)", () =>
     },
     60_000,
   );
+
+  it("zeroizes the PRF buffer on the !dataRes.ok early return", async () => {
+    clearPrf();
+    // makeFetchEnv(null) → /api/vault/unlock/data returns { ok: false, 404 }.
+    const { fetchMock } = makeFetchEnv(null);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useVault(), { wrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const prfOutput = new Uint8Array(32).fill(0x5a);
+    stashPrf({
+      prfOutput,
+      prfData: { prfEncryptedSecretKey: "ct", prfSecretKeyIv: "iv", prfSecretKeyAuthTag: "tag" },
+    });
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.unlockWithStoredPrf();
+    });
+    expect(ok).toBe(false);
+    // The single outer finally wipes the buffer even on the early return.
+    expect(prfOutput.every((b) => b === 0)).toBe(true);
+  });
+
+  it("zeroizes the PRF buffer on the missing-accountSalt early return", async () => {
+    clearPrf();
+    // unlock/data returns ok:true but without accountSalt → early return false.
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = typeof url === "string" ? url : "";
+      if (path === "/api/vault/status") {
+        return { ok: true, json: async () => ({ setupRequired: false, hasRecoveryKey: false, vaultAutoLockMinutes: null, tenantMinPasswordLength: 0, tenantRequireUppercase: false, tenantRequireLowercase: false, tenantRequireNumbers: false, tenantRequireSymbols: false }) };
+      }
+      if (path === "/api/vault/unlock/data") {
+        return { ok: true, json: async () => ({ keyVersion: 1 }) }; // no accountSalt
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    const { result } = renderHook(() => useVault(), { wrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const prfOutput = new Uint8Array(32).fill(0x5a);
+    stashPrf({
+      prfOutput,
+      prfData: { prfEncryptedSecretKey: "ct", prfSecretKeyIv: "iv", prfSecretKeyAuthTag: "tag" },
+    });
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.unlockWithStoredPrf();
+    });
+    expect(ok).toBe(false);
+    expect(prfOutput.every((b) => b === 0)).toBe(true);
+  });
 });
 
 describe("VaultProvider — session-driven status", () => {

--- a/src/lib/vault/vault-context.tsx
+++ b/src/lib/vault/vault-context.tsx
@@ -662,9 +662,12 @@ export function VaultProvider({ children }: { children: ReactNode }) {
     const handoff = takePrf();
     if (!handoff) return false;
 
-    // Single finally zeroizes the PRF output on every exit (early returns and
-    // throws alike); ownership transferred to us by takePrf above.
+    // Single finally zeroizes both the PRF output and the unwrapped secret key
+    // on every exit (early returns and throws alike); the PRF buffer's
+    // ownership was transferred to us by takePrf above. secretKey is hoisted
+    // here so the finally covers the post-derivation throw paths too.
     const prfOutput = handoff.prfOutput;
+    let secretKey: Uint8Array | null = null;
     try {
       const prfData = handoff.prfData;
 
@@ -680,7 +683,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       if (!vaultData.accountSalt) return false;
 
       // Unwrap secretKey using PRF output (no WebAuthn ceremony needed)
-      const secretKey = await unwrapSecretKeyWithPrf(
+      secretKey = await unwrapSecretKeyWithPrf(
         {
           ciphertext: prfData.prfEncryptedSecretKey,
           iv: prfData.prfSecretKeyIv,
@@ -694,7 +697,6 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       if (vaultData.verificationArtifact) {
         const valid = await verifyKey(encKey, vaultData.verificationArtifact);
         if (!valid) {
-          secretKey.fill(0);
           return false;
         }
       }
@@ -714,7 +716,6 @@ export function VaultProvider({ children }: { children: ReactNode }) {
         if (body.error) {
           throw new VaultUnlockError(body.error, body.lockedUntil);
         }
-        secretKey.fill(0);
         return false;
       }
 
@@ -748,8 +749,6 @@ export function VaultProvider({ children }: { children: ReactNode }) {
         }
       }
 
-      secretKey.fill(0);
-
       // Auto-confirm pending emergency access grants
       const userId = session?.user?.id;
       if (userId && secretKeyRef.current) {
@@ -769,6 +768,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       return false;
     } finally {
       prfOutput.fill(0);
+      secretKey?.fill(0);
     }
   }, [session?.user?.id]);
 

--- a/src/lib/vault/vault-context.tsx
+++ b/src/lib/vault/vault-context.tsx
@@ -662,8 +662,10 @@ export function VaultProvider({ children }: { children: ReactNode }) {
     const handoff = takePrf();
     if (!handoff) return false;
 
+    // Single finally zeroizes the PRF output on every exit (early returns and
+    // throws alike); ownership transferred to us by takePrf above.
+    const prfOutput = handoff.prfOutput;
     try {
-      const prfOutput = hexDecode(handoff.prfOutputHex);
       const prfData = handoff.prfData;
 
       // Fetch vault data
@@ -678,19 +680,14 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       if (!vaultData.accountSalt) return false;
 
       // Unwrap secretKey using PRF output (no WebAuthn ceremony needed)
-      let secretKey: Uint8Array;
-      try {
-        secretKey = await unwrapSecretKeyWithPrf(
-          {
-            ciphertext: prfData.prfEncryptedSecretKey,
-            iv: prfData.prfSecretKeyIv,
-            authTag: prfData.prfSecretKeyAuthTag,
-          },
-          prfOutput,
-        );
-      } finally {
-        prfOutput.fill(0);
-      }
+      const secretKey = await unwrapSecretKeyWithPrf(
+        {
+          ciphertext: prfData.prfEncryptedSecretKey,
+          iv: prfData.prfSecretKeyIv,
+          authTag: prfData.prfSecretKeyAuthTag,
+        },
+        prfOutput,
+      );
 
       // Derive encryption key and verify with artifact
       const encKey = await deriveEncryptionKey(secretKey);
@@ -770,6 +767,8 @@ export function VaultProvider({ children }: { children: ReactNode }) {
     } catch (err) {
       if (err instanceof VaultUnlockError) throw err;
       return false;
+    } finally {
+      prfOutput.fill(0);
     }
   }, [session?.user?.id]);
 


### PR DESCRIPTION
## Summary

Hardens zeroization of two in-memory secrets in the passkey/security-key sign-in → vault auto-unlock flow. Both are pre-v1.0 defense-in-depth gaps that survived the earlier XSS-hardening sweep (which moved PRF material off `sessionStorage`).

### 1. PRF output — un-wipeable hex string + missing exit-path zeroization
- `PrfHandoff` carried the PRF output as a hex `string`. JS strings are immutable, so the secret could not be wiped — it lingered in the heap until GC. Changed to a `Uint8Array` with an ownership-transfer model (producer → handoff → consumer), removing the un-wipeable copy and the `hexEncode`/`hexDecode` round-trip.
- Neither producer (`passkey-signin-button.tsx`, `security-key-signin-form.tsx`) nor the consumer (`vault-context.tsx` `unlockWithStoredPrf`) zeroized the buffer on every exit. The producer's `prfOutput` was declared inside `try` (out of scope in `catch`/`finally`); the consumer's early returns skipped the wipe. Both now zeroize in a single `finally`. The producer transfers ownership on a successful stash (`prfOutput = null`) so the consumer's buffer is not double-wiped.

### 2. Unwrapped vault secret key — missing throw-path zeroization
- In `unlockWithStoredPrf`, `secretKey` was wiped only on explicit `return` paths; a throw after derivation (e.g. `VaultUnlockError` from `/api/vault/unlock`) skipped the wipe. Hoisted `secretKey` to the outer scope and folded the three explicit `secretKey.fill(0)` calls into the same `finally`, so all exits — including post-derivation throws — zeroize the key. A session-lifetime copy in `secretKeyRef.current` is made before the wipe, so behavior is unchanged.

## Scope note

This does not close an XSS read primitive (in-realm XSS could call `takePrf()` regardless); it reduces post-use heap residency of secrets. The residency floor is set by the browser-owned WebAuthn `ArrayBuffer`, which is un-wipeable.

## Tests

- `prf-handoff.test.ts` — same-reference handoff, overwrite/`clearPrf` zeroization.
- Producer tests — inverted success assertion (ownership transfer: buffer NOT wiped, same reference stashed); new no-PRF-bundle and fetch-throws cases assert zeroization.
- `vault-context.test.tsx` — new consumer early-return zeroization tests, plus a throw-after-unwrap test that captures the real unwrapped key via a pass-through spy and asserts it is zeroized.
- All new zeroization assertions were mutation-verified (removing the fix makes them fail).

Full suite: 10771 passed. `npx next build` and `scripts/pre-pr.sh` (29 checks) green.

## Review

Built and reviewed via the triangulate workflow (plan review + code review, functionality / security / testing experts). The ownership-transfer model and the secret-key delta were independently verified with no outstanding findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)