### PR TITLE
fix(i18n): use distinct recovery-key warning when key already invalidated

### DIFF
--- a/docs/archive/review/recovery-key-regenerate-warning-code-review.md
+++ b/docs/archive/review/recovery-key-regenerate-warning-code-review.md
@@ -1,0 +1,69 @@
+# Code Review: recovery-key-regenerate-warning-wording
+
+Date: 2026-05-31
+Review round: 1 (standalone Phase 3)
+Branch: fix/recovery-key-regenerate-warning-wording
+
+## Changes from Previous Round
+
+Initial review. Scope: i18n wording fix — the recovery-key dialog reused the
+"generating a new one will invalidate the previous key" warning even when the
+key was *already* invalidated by a vault key rotation (the state the banner
+links from), contradicting the banner's "already invalidated" message.
+
+Diff (`git diff main...HEAD`):
+- `messages/en/Vault.json`, `messages/ja/Vault.json` — add key `recoveryKeyRegenerateInvalidatedWarning`.
+- `src/components/vault/recovery-key-dialog.tsx` — select the invalidated-state
+  message when `recoveryKeyInvalidated` is true, else the generic regenerate warning.
+- `src/components/vault/recovery-key-dialog.render.test.tsx` — new render test (3 cases).
+
+## Functionality Findings
+
+No findings.
+
+- Server makes the two flags mutually exclusive on rotation: `rotate-key-server.ts`
+  sets `recoveryKeySetAt: null` + `recoveryKeyInvalidatedAt: new Date()`;
+  `api/vault/status/route.ts:64,68` maps them to `hasRecoveryKey=false` /
+  `recoveryKeyInvalidated=true`. After rotation only the invalidated branch fires.
+  Ternary precedence (tests `recoveryKeyInvalidated` first) is correct even in a
+  hypothetical both-true state.
+- i18n completeness: only `en` and `ja` locales exist; both updated. Banner
+  (`recovery-key-banner.tsx:57-59`) uses the identical predicate, so dialog and
+  banner are now semantically aligned.
+- No other consumer renders the warning block; no parallel fix needed.
+
+## Security Findings
+
+No findings.
+
+- `recoveryKeyInvalidated` is server-sourced (`api/vault/status/route.ts:68`,
+  RLS-scoped behind `checkAuth`), consumed (never set) by the client
+  (`vault-context.tsx:197`). A forged client value would only swap which of two
+  warning strings shows — it cannot make an invalid key usable.
+- New message is truthful (past-tense invalidation) and strictly better than the
+  prior wording, which could have lulled the user into thinking a valid key remained.
+- No `dangerouslySetInnerHTML`; next-intl `t()` returns escaped text; new strings
+  are static literals with no interpolation; no secrets/identifiers.
+
+## Testing Findings
+
+No findings.
+
+- Regression guard present: the invalidated-state test asserts both the positive
+  (`getByText("recoveryKeyRegenerateInvalidatedWarning")`) AND the critical negative
+  (`queryByText("recoveryKeyRegenerateWarning")).toBeNull()`).
+- Test independence: `beforeEach` resets both flags + `vi.clearAllMocks()`.
+- Mock-reality consistency: the `useVault` mock provides exactly the 5 fields the
+  component destructures (`recovery-key-dialog.tsx:104`). Translation keys are not
+  substrings of each other, so exact-match `getByText` is unambiguous.
+- All three gate branches covered (invalidated / has-key / neither).
+- i18n key-parity test `src/i18n/messages-consistency.test.ts` exists and passes
+  with the new key present in both locales.
+
+## Resolution Status
+
+No findings to resolve. All three experts returned "No findings" in Round 1.
+Loop terminated.
+
+Verification: `npx eslint`, `npx vitest run` (10767 passed), `npx next build`
+all green on this diff (run during the test-gen pass; diff unchanged since).

--- a/messages/en/Vault.json
+++ b/messages/en/Vault.json
@@ -59,6 +59,7 @@
   "recoveryKeyClose": "Close",
   "recoveryKeyGenerating": "Generating Recovery Key...",
   "recoveryKeyRegenerateWarning": "You already have a Recovery Key. Generating a new one will invalidate the previous key.",
+  "recoveryKeyRegenerateInvalidatedWarning": "Your previous Recovery Key was already invalidated by a vault key rotation. Generate a new Recovery Key below.",
   "vaultMustBeUnlocked": "Vault must be unlocked.",
   "or": "or",
   "setupInviteContext": "To accept this invitation, you need to set up your vault first. Please set a passphrase below.",

--- a/messages/ja/Vault.json
+++ b/messages/ja/Vault.json
@@ -59,6 +59,7 @@
   "recoveryKeyClose": "閉じる",
   "recoveryKeyGenerating": "回復キーを生成中...",
   "recoveryKeyRegenerateWarning": "既に回復キーが設定されています。新しい鍵を生成すると、以前の鍵は無効になります。",
+  "recoveryKeyRegenerateInvalidatedWarning": "以前の回復キーは保管庫キーローテーションにより既に無効化されています。新しい回復キーを生成してください。",
   "vaultMustBeUnlocked": "保管庫のロックを解除してください。",
   "or": "または",
   "setupInviteContext": "招待を受け入れるには、まず保管庫のセットアップが必要です。以下でパスフレーズを設定してください。",

--- a/src/components/vault/recovery-key-dialog.render.test.tsx
+++ b/src/components/vault/recovery-key-dialog.render.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+/**
+ * RecoveryKeyDialog render tests
+ *
+ * Regression: the passphrase-step warning banner must reflect the actual
+ * vault state. When the recovery key is already invalidated, the dialog must
+ * NOT claim that generating a new key "will invalidate" the existing one.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const { vault } = vi.hoisted(() => ({
+  vault: {
+    hasRecoveryKey: false,
+    recoveryKeyInvalidated: false,
+    getSecretKey: vi.fn(),
+    getAccountSalt: vi.fn(),
+    setHasRecoveryKey: vi.fn(),
+  },
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => vault,
+}));
+
+vi.mock("@/lib/crypto/crypto-client", () => ({
+  computePassphraseVerifier: vi.fn(),
+}));
+
+vi.mock("@/lib/crypto/crypto-recovery", () => ({
+  generateRecoveryKey: vi.fn(),
+  formatRecoveryKey: vi.fn(),
+  wrapSecretKeyWithRecovery: vi.fn(),
+}));
+
+vi.mock("@/lib/http/api-error-codes", () => ({
+  apiErrorToI18nKey: (code: string) => `apiErr:${code}`,
+}));
+
+vi.mock("@/lib/http/read-api-error-body", () => ({
+  readApiErrorBody: vi.fn(),
+}));
+
+vi.mock("@/lib/ui/ime-guard", () => ({
+  preventIMESubmit: vi.fn(),
+}));
+
+vi.mock("@/lib/constants", () => ({
+  API_PATH: { VAULT_RECOVERY_KEY_GENERATE: "/api/vault/recovery-key/generate" },
+}));
+
+vi.mock("@/lib/url-helpers", () => ({
+  fetchApi: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn() },
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, disabled, onClick, type, ...rest }: React.ComponentProps<"button">) => (
+    <button type={type} disabled={disabled} onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: ({ id, value, onChange, type, ...rest }: React.ComponentProps<"input">) => (
+    <input id={id} value={value} onChange={onChange} type={type} {...rest} />
+  ),
+}));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, htmlFor }: React.ComponentProps<"label">) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
+}));
+
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({ id }: { id?: string }) => <input id={id} type="checkbox" />,
+}));
+
+import { RecoveryKeyDialog } from "./recovery-key-dialog";
+
+describe("RecoveryKeyDialog passphrase-step warning", () => {
+  beforeEach(() => {
+    vault.hasRecoveryKey = false;
+    vault.recoveryKeyInvalidated = false;
+    vi.clearAllMocks();
+  });
+
+  it("shows the invalidated warning (not the regenerate warning) when recovery key is invalidated", () => {
+    vault.recoveryKeyInvalidated = true;
+
+    render(<RecoveryKeyDialog open={true} onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText("recoveryKeyRegenerateInvalidatedWarning")).toBeInTheDocument();
+    expect(screen.queryByText("recoveryKeyRegenerateWarning")).toBeNull();
+  });
+
+  it("shows the regenerate warning when a recovery key already exists and is not invalidated", () => {
+    vault.hasRecoveryKey = true;
+
+    render(<RecoveryKeyDialog open={true} onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText("recoveryKeyRegenerateWarning")).toBeInTheDocument();
+  });
+
+  it("shows no warning when there is no recovery key and it is not invalidated", () => {
+    render(<RecoveryKeyDialog open={true} onOpenChange={vi.fn()} />);
+
+    expect(screen.queryByText("recoveryKeyRegenerateInvalidatedWarning")).toBeNull();
+    expect(screen.queryByText("recoveryKeyRegenerateWarning")).toBeNull();
+  });
+});

--- a/src/components/vault/recovery-key-dialog.tsx
+++ b/src/components/vault/recovery-key-dialog.tsx
@@ -188,7 +188,11 @@ export function RecoveryKeyDialog({
             {(hasRecoveryKey || recoveryKeyInvalidated) && (
               <div className="flex items-start gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3 text-sm text-yellow-700 dark:text-yellow-400">
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                <p>{t("recoveryKeyRegenerateWarning")}</p>
+                <p>
+                  {recoveryKeyInvalidated
+                    ? t("recoveryKeyRegenerateInvalidatedWarning")
+                    : t("recoveryKeyRegenerateWarning")}
+                </p>
               </div>
             )}
 


### PR DESCRIPTION
## Problem

The recovery-key banner reached via a vault key rotation tells the user their previous Recovery Key was **already invalidated**, yet clicking through opened a dialog that reused the generic regenerate warning — "generating a new one **will** invalidate the previous key" — contradicting the banner (the old key was already dead).

## Fix

Select an invalidated-state message when `recoveryKeyInvalidated` is set, keeping the existing warning for the normal "regenerate an active key" case.

New i18n key `recoveryKeyRegenerateInvalidatedWarning`:
- en: "Your previous Recovery Key was already invalidated by a vault key rotation. Generate a new Recovery Key below."
- ja: 「以前の回復キーは保管庫キーローテーションにより既に無効化されています。新しい回復キーを生成してください。」

The dialog and the banner ([recovery-key-banner.tsx](../blob/main/src/components/vault/recovery-key-banner.tsx)) now branch on the identical `recoveryKeyInvalidated` predicate, so the two surfaces stay semantically aligned. The flag is server-sourced (`/api/vault/status`); on rotation the server sets `recoveryKeySetAt: null` + `recoveryKeyInvalidatedAt`, making the two flags mutually exclusive.

## Tests

Added `recovery-key-dialog.render.test.tsx` (3 cases). The regression-guarding case asserts both the positive message and the **negative** — that the old "will invalidate" string does NOT render when already invalidated. The existing en/ja key-parity test covers the new key in both locales.

## Verification

`scripts/pre-pr.sh` — 29/29 checks passed (lint, full vitest suite, production build).

## Review

Triangulated across functionality / security / testing — all three returned "No findings" in round 1. Log: `docs/archive/review/recovery-key-regenerate-warning-code-review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)