### PR TITLE
ci: publish CLI to npm via OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      id-token: write # OIDC for npm Trusted Publishing
     steps:
       - uses: actions/checkout@v6
 
@@ -38,6 +39,10 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
+
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 20 ships npm 10.
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest
 
       - name: Install and build CLI
         working-directory: cli
@@ -55,6 +60,4 @@ jobs:
 
       - name: Publish to npm
         working-directory: cli
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish # Auth via OIDC Trusted Publishing (no NODE_AUTH_TOKEN)


### PR DESCRIPTION
## Why

The long-lived `NPM_TOKEN` used by the release workflow expired after `0.4.50` (published 2026-05-17). Every subsequent release publish (`0.4.51`–`0.4.55`) failed with:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/passwd-sso-cli
```

(npm returns 404 rather than 401 when the publish token is invalid/expired.) Rotating the token is recurring manual toil with a hard expiry.

## What

Switch the CLI publish job to **npm Trusted Publishing (OIDC)**:

- Add `id-token: write` permission so GitHub issues a short-lived OIDC token.
- Remove `NODE_AUTH_TOKEN` / the stored `NPM_TOKEN` secret dependency — no stored secret, no expiry.
- Upgrade npm before publishing: Node 20 ships npm 10, but Trusted Publishing requires npm >= 11.5.1.
- Provenance attestation is emitted automatically under Trusted Publishing.

## Out-of-band setup (one-time, already configured on npm)

The `passwd-sso-cli` package's Trusted Publisher is registered on npmjs.com (repo `ngc-shj/passwd-sso`, workflow `release.yml`, publish action). This PR's workflow must be on `main` for the next release to authenticate via OIDC.

## Note on 0.4.55

The `0.4.55` release commit predates this workflow change, so it is published once manually from a local checkout. Subsequent releases (`0.4.56`+) publish automatically via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
