### PR TITLE
fix(ci): pin GitHub Actions to SHAs, gate static checks in CI, pin Dockerfile prisma

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -95,9 +95,9 @@ jobs:
       PASSWD_ANCHOR_PUBLISHER_PASSWORD: passwd_anchor_publisher_pass
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       env: ${{ steps.filter.outputs.env }}
       ios: ${{ steps.filter.outputs.ios }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - id: filter
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             app:
@@ -80,8 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Verify version consistency
         working-directory: ${{ github.workspace }}
@@ -117,6 +117,43 @@ jobs:
             FAIL=1
           fi
           exit $FAIL
+
+  # ─── Static Security Check Guards ─────────────────────────
+  # Runs the environment-independent static guards from scripts/pre-pr.sh via
+  # PRE_PR_STATIC_ONLY — same definition as the local pre-PR hook, so the
+  # checks cannot drift between local and CI (R33). Always runs (not gated on
+  # `changes`) so workflow-pinning and security guards are never skipped.
+  static-checks:
+    name: "Static: security check guards"
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # diff-based guards (prf-salt-immutable, R35 gate) need `main`
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - run: npm ci
+
+      # actions/checkout with fetch-depth: 0 fetches full history of the PR ref
+      # but does NOT create a local `main` branch. The static guards compare
+      # against main (`git diff main...HEAD`); without this they fail open
+      # (empty diff → vacuous pass). Same pattern as refactor-phase-verify.yml.
+      - name: Ensure main ref is available
+        run: |
+          set -euo pipefail
+          if ! git rev-parse --verify main >/dev/null 2>&1; then
+            git fetch origin main:main
+          fi
+
+      # No `prisma generate` step: every static guard is a pure source/schema
+      # grep (none import the generated client), so the client is not needed.
+      - name: Run static check guards (PRE_PR_STATIC_ONLY)
+        run: PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh
 
   # ─── Main App: Lint → Test → Build ────────────────────────
   app-ci:
@@ -142,9 +179,9 @@ jobs:
       VERIFIER_PEPPER_KEY: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       REDIS_URL: "redis://localhost:6379"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -200,9 +237,9 @@ jobs:
       run:
         working-directory: extension
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -229,7 +266,7 @@ jobs:
     if: needs.changes.outputs.ios == 'true' || needs.changes.outputs.ci == 'true'
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Select latest stable Xcode
         run: |
@@ -307,9 +344,9 @@ jobs:
       run:
         working-directory: cli
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -379,9 +416,9 @@ jobs:
       AUDIT_ANCHOR_TAG_SECRET: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
       AUDIT_ANCHOR_DESTINATION_FS_PATH: "/tmp/ci-anchors"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -403,7 +440,7 @@ jobs:
       - name: Run E2E tests
         run: npm run test:e2e
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: playwright-report
@@ -443,9 +480,9 @@ jobs:
       PASSWD_APP_PASSWORD: passwd_app_pass
       DATABASE_URL: "postgresql://passwd_user:passwd_pass@localhost:5432/passwd_sso"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -510,13 +547,13 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build Docker image
         run: docker build --build-arg DATABASE_URL=postgresql://dummy:dummy@localhost:5432/dummy -t passwd-sso:scan .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: "passwd-sso:scan"
           scan-type: image
@@ -532,9 +569,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -553,9 +590,9 @@ jobs:
       run:
         working-directory: extension
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -575,9 +612,9 @@ jobs:
       run:
         working-directory: cli
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -598,9 +635,9 @@ jobs:
       needs.changes.outputs.cli == 'true' ||
       needs.changes.outputs.ci == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,19 +20,19 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: javascript-typescript
           queries: security-and-quality
           config-file: .github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0

--- a/.github/workflows/refactor-phase-verify.yml
+++ b/.github/workflows/refactor-phase-verify.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # fetch-depth: 0 is required because refactor-phase-verify.mjs and its
           # downstream scripts (verify-move-only-diff, verify-allowlist-rename-only,
@@ -35,7 +35,7 @@ jobs:
           # `git diff main...HEAD` and `git show main:<path>`.
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,16 +33,18 @@ jobs:
       contents: read
       id-token: write # OIDC for npm Trusted Publishing
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
       # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 20 ships npm 10.
+      # Pin the version (matches Dockerfile NPM_VER) — this job holds id-token:write,
+      # so an unpinned npm@latest is a supply-chain path to the OIDC publish token.
       - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.12.1
 
       - name: Install and build CLI
         working-directory: cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,11 +81,16 @@ COPY --from=builder /app/node_modules/dotenv ./node_modules/dotenv
 # `--ignore-scripts` on the global npm upgrade limits root-execution blast
 # radius if the registry is compromised. Cache is cleared at the end to avoid
 # shipping the downloaded tarballs in the final layer.
+# PRISMA_VER is pinned to the package-lock.json `prisma` version (the CLI the
+# `migrate` compose service runs); a floating `latest` here breaks build
+# reproducibility and risks CLI/generated-client skew. Kept in lockstep with the
+# lockfile by scripts/checks/check-dockerfile-prisma-pin.sh.
 RUN TAR_VER=7.5.11 && \
     PICOMATCH_VER=4.0.4 && \
     NPM_VER=11.12.1 && \
+    PRISMA_VER=7.8.0 && \
     npm install -g "npm@${NPM_VER}" --loglevel=error --ignore-scripts && \
-    npm install prisma --no-save --ignore-scripts && \
+    npm install "prisma@${PRISMA_VER}" --no-save --ignore-scripts && \
     TAR_DIR=/usr/local/lib/node_modules/npm/node_modules/tar && \
     if [ -d "$TAR_DIR" ]; then \
       CURRENT=$(node -p "require('${TAR_DIR}/package.json').version") && \
@@ -122,7 +127,8 @@ RUN TAR_VER=7.5.11 && \
     # Post-patch invariant assertion: fail the build if any expected version is missing.
     [ "$(npm -v)" = "${NPM_VER}" ] && \
     node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tar/package.json').version;if(v<'${TAR_VER}'){console.error('tar still '+v);process.exit(1)}" && \
-    node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch/package.json').version;if(v<'${PICOMATCH_VER}'){console.error('picomatch still '+v);process.exit(1)}"
+    node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch/package.json').version;if(v<'${PICOMATCH_VER}'){console.error('picomatch still '+v);process.exit(1)}" && \
+    node -e "const v=require('/app/node_modules/prisma/package.json').version;if(v!=='${PRISMA_VER}'){console.error('prisma pin failed: got '+v+', expected ${PRISMA_VER}');process.exit(1)}"
 
 # Copy @prisma runtime adapters (overlay on top of prisma's @prisma packages)
 COPY --from=builder /app/node_modules/@prisma/adapter-pg ./node_modules/@prisma/adapter-pg

--- a/docs/archive/review/supply-chain-passkey-audit-code-review.md
+++ b/docs/archive/review/supply-chain-passkey-audit-code-review.md
@@ -1,0 +1,173 @@
+# Code Review: supply-chain-passkey-audit
+
+Date: 2026-06-01
+Review round: 1 (triangulation of a manual security audit — no code changed; review of current `main`)
+
+## Changes from Previous Round
+
+Initial review. Three pre-existing findings from a manual audit were triangulated by three
+expert sub-agents (functionality / security / testing). All three findings reproduce; two had
+their severity and fix refined, one was substantially reframed (downgraded + partly refuted).
+
+## Consolidated Findings (deduplicated across experts)
+
+### S1/F1/T1 — GitHub Actions floating tags + ungated pin-check script — **Major** (was: High)
+- **File:** all workflows under `.github/workflows/` (`ci.yml`, `ci-integration.yml`, `codeql.yml`,
+  `release.yml`, `refactor-phase-verify.yml`); detector `scripts/checks/check-actions-sha-pinned.sh`.
+- **Evidence:** `check-actions-sha-pinned.sh` exits 1 (38 floating refs). `release.yml:21`
+  `googleapis/release-please-action@45996ed…` is the *only* SHA-pinned ref. `grep` confirms the check
+  script has **zero callers** in CI or `pre-pr.sh` — it is dead code.
+- **Problem / Impact:**
+  - Mutable tags (`@v6`, `@v4`, `@v0.36.0` — a Git tag is movable) let a compromised action publisher
+    retarget the tag to a malicious commit.
+  - **Highest blast radius:** `release.yml` publish job holds `id-token: write` (npm Trusted Publishing).
+    A poisoned `checkout`/`setup-node` runs inside a job with a live OIDC token → can push a backdoored
+    `passwd-sso` CLI to npm. (Mitigated: `id-token: write` is scoped to the publish job, and
+    release-please itself is pinned.)
+  - **Security-control poisoning:** `codeql.yml github/codeql-action/*@v4` and `ci.yml:519
+    aquasecurity/trivy-action@v0.36.0` are *security scanners* — unpinned, a poisoned version can
+    suppress findings / exfiltrate source = false assurance (R33).
+  - Also a reproducibility defect: a re-tag silently changes CI behavior for the same commit.
+- **Fix (ordering matters — R33):**
+  1. **First** backfill all refs to `owner/action@<40-hex-sha> # vX.Y.Z` (one mechanical pass).
+  2. **Then** wire `check-actions-sha-pinned.sh` into a CI job and `pre-pr.sh`.
+  - Reversing the order hard-fails the build. `dependabot.yml` is already present with grouped weekly
+    `github-actions` bumps, so ongoing SHA patching is handled after the one-time backfill.
+
+### S1/T2/T3 — Systemic: pre-pr static checks are local-only; multiple security check scripts ungated in CI — **Major** (new, expands F1)
+- **File:** `.github/workflows/ci.yml` vs `scripts/pre-pr.sh`.
+- **Evidence:** CI never invokes `pre-pr.sh`; it re-runs only a subset (`check:bypass-rls`,
+  `check:team-auth-rls`, `check:crypto-domains`, `check:migration-drift`, licenses, test, build).
+  Ungated-in-CI security/regression checks include: `check-actions-sha-pinned.sh`,
+  `check-fail-closed-routes-have-test.sh`, master-key-rotation CAS guards, `check-vitest-coverage-include.mjs`
+  (runs only on `refactor/` branches), `check-e2e-selectors.sh`, `check-security-doc-exists.sh`, etc.
+- **Impact:** A contributor who skips the local hook bypasses ~15 static guards with a green CI; CI is not
+  the authoritative gate the project assumes.
+- **Fix:** Run `pre-pr.sh` (static-only mode) in the `app` CI job, or mirror each local static check as a
+  CI step. Wire `check-vitest-coverage-include.mjs` unconditionally (not only on `refactor/`).
+
+### S2/F2/T4 — Dockerfile unpinned `prisma` install, redundant with builder — **Major** (was: High)
+- **File:** `Dockerfile:88` `npm install prisma --no-save --ignore-scripts`.
+- **Evidence:** Surrounding block pins `NPM_VER`/`TAR_VER`/`PICOMATCH_VER` with fail-closed checks, but
+  `prisma` resolves to registry `latest`. `package.json` pins `prisma ^7.6.0` (lockfile → 7.8.0); the
+  builder stage already has the lockfile-pinned `prisma` in `node_modules` and the runner already
+  `COPY --from=builder` overlays `@prisma/client`/`.prisma` (`Dockerfile:128-129`).
+- **Problem / Impact:**
+  - `--ignore-scripts` only blocks install-time lifecycle scripts; a malicious/regressed `prisma` version
+    still ships poisoned JS + query engine that loads at runtime with `DATABASE_URL` (data path).
+  - Functional: CLI/client version skew — `migrate` service reuses this image for `prisma migrate deploy`;
+    a newer floating CLI against the 7.8.0-generated client risks engine/schema incompatibility.
+  - `--ignore-scripts` also skips prisma's postinstall engine fetch, so the fresh CLI relies on engines
+    from the copied client dirs — another reason the copy-from-builder fix is the consistent one.
+  - trivy (`ci.yml:519`, `ignore-unfixed:true`) catches published CVEs only — not the pinning defect.
+- **Fix (preferred = match existing idiom):** `COPY --from=builder /app/node_modules/prisma ./node_modules/prisma`
+  (+ `@prisma/engines`, `@prisma/get-platform` as needed) — mirrors line 128-129, lockfile-exact, zero
+  network. Minimum fallback: `npm install prisma@<lockfile-version> --no-save --ignore-scripts` + a drift
+  tripwire mirroring the tar/picomatch assertions.
+
+### S3/F3/T(refuted) — Passkey assertion returns ok on counter-persist failure — **Minor / correctness** (was: Medium security)
+- **File:** `extension/src/background/passkey-provider.ts:261,278-305` (comment `:290-292`).
+- **Reframed by triangulation — three independent corrections to the original finding:**
+  1. **Security (scope):** This extension is a *software passkey manager* synthesizing assertions for
+     **arbitrary external RPs** (`blob.relyingPartyId`), not passwd-sso's own login. passwd-sso's server
+     **does** enforce counter regression (`src/lib/auth/webauthn/webauthn-authorize.ts:174-187` CAS
+     `UPDATE … WHERE counter=storedCounter`, + `@simplewebauthn` throws on non-increment). So clone-detection
+     risk is **theoretical for this app**, real only for *external* counter-enforcing RPs.
+  2. **Functionality (mechanism):** No "permanent stuck counter" — `signCount` is **re-hydrated from the
+     server blob every assertion** (`:249`), so a failed PUT self-heals next sign-in. Real residual: the
+     *same* counter value is presented twice across two sign-ins → a strict RP (`>` not `>=`) may reject the
+     *next* legit sign-in intermittently. Also: a **network** failure is correctly caught (returns
+     `{ok:false}` via the `catch`); only an **HTTP 4xx/5xx** PUT swallows to `ok:true`.
+  3. **Testing:** The behavior **is tested** — `extension/src/__tests__/background-passkey-provider.test.ts:450-488`
+     mocks counter-PUT→500 and asserts `ok:true` + `invalidateCache` not called. Not untested.
+- **Net:** Not a security vuln in this app's threat model; behavior is intentional and gated by a test. The
+  remaining issue is that the **comment is misleading** — it justifies the in-flight assertion but omits the
+  cross-session duplicate-counter consequence.
+- **Fix (optional, Minor):** Correct the comment to state the next-sign-in duplicate-counter consequence;
+  optionally add a dirty-flag so the failed persist is retried before the next assertion reads the blob.
+
+## Recurring Issue Check (merged)
+- **R31 (supply-chain pinning):** Findings S1, S2.
+- **R33 (CI security-control gating):** Findings S1, T2, T3, T4 — systemic under-wiring of authored checks.
+- **R25 (persist/hydrate symmetry):** F3 — symmetry holds (server-hydrated), which is why the failed persist
+  self-corrects rather than deadlocking.
+- **R3 (error propagation):** F3 — both PUT failure paths traced; swallow is deliberate, not a silent bug.
+- **R34 (adjacent):** F2 — `--ignore-scripts` skips engine fetch; copy-from-builder keeps CLI/engine consistent.
+- **RS1-RS4 / RT1-RT6:** checked, no additional findings beyond the above.
+
+## Resolution Status
+
+Branch: `chore/pin-actions-and-wire-ci-checks`. User chose the comprehensive scope (full supply-chain +
+CI wiring). Fixes applied:
+
+### S1/F1/T1 — Actions floating tags — RESOLVED
+- Pinned every `uses:` ref to a 40-char SHA + version comment across all 5 workflows (SHAs resolved via
+  `gh api repos/<a>/commits/<tag>`): `actions/checkout@de0fac2…# v6.0.2`, `actions/setup-node@48b55a0…# v6.4.0`,
+  `actions/upload-artifact@043fb46…# v7.0.1`, `dorny/paths-filter@fbd0ab8…# v4.0.1`,
+  `aquasecurity/trivy-action@ed142fd…# v0.36.0`, `github/codeql-action/{init,autobuild,analyze}@7211b7c…# v4.36.0`.
+- `release.yml`: also pinned the previously-floating `npm install -g npm@latest` → `npm@11.12.1` (this job
+  holds `id-token: write`, so an unpinned npm was a path to the OIDC publish token) — R34 adjacent.
+- Verified: `scripts/checks/check-actions-sha-pinned.sh` now passes.
+
+### S1/T2/T3 — Ungated checks / pre-pr-not-in-CI — RESOLVED (SSoT, no new drift)
+- Added `PRE_PR_STATIC_ONLY=1` mode to `scripts/pre-pr.sh` (skips Lint/Test/Build/integration/secret-scan,
+  runs all static guards).
+- Added a `static-checks` CI job (`ci.yml`) that runs `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` with
+  `fetch-depth: 0`. CI and the local hook now share one definition — the gap cannot reopen.
+- Wired `check-actions-sha-pinned.sh` into the pre-pr static block (was dead code).
+
+### S2/F2/T4 — Dockerfile unpinned prisma — RESOLVED
+- Pinned `Dockerfile:88` install to the lockfile version: `PRISMA_VER=7.8.0` + a build-time fail-closed
+  assertion mirroring the tar/picomatch tripwires. Kept `--no-save --ignore-scripts` (behavior-preserving;
+  copy-from-builder rejected — it would drop the CLI's transitive `@prisma/engines` etc.).
+- Added `scripts/checks/check-dockerfile-prisma-pin.sh` asserting `PRISMA_VER` == lockfile prisma version,
+  wired into pre-pr static block (+ CI via static-checks) so it cannot drift.
+
+### S3/F3 — Passkey counter soft-fail — RESOLVED (comment only)
+- Behavior kept (intentional, tested by `background-passkey-provider.test.ts:450`). Rewrote the misleading
+  comment in `passkey-provider.ts` to state accurately: network failure already returns `{ok:false}`; only
+  HTTP errors reach the soft-fail; the cross-session duplicate-counter consequence; that it self-heals; and
+  that passwd-sso's own RP tolerates it while external RPs vary.
+
+### Verification (Round 1)
+- `check-actions-sha-pinned.sh` → PASS; `check-dockerfile-prisma-pin.sh` → PASS.
+- `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` → 27 checks pass, heavy steps correctly skipped.
+- All 5 workflow YAMLs parse. `extension` passkey-provider test suite → 54 pass / 0 fail.
+
+## Round 2 — triangulation of the implementation
+
+Three experts reviewed the staged diff. Most of the implementation was confirmed correct & complete
+(SHA-pin completeness, pre-pr STATIC_ONLY gating + exit-code propagation, Dockerfile pin scope/path,
+prisma-pin check, passkey comment accuracy, OIDC scoping, no fork-secret exposure on the `pull_request`
+trigger). Three actionable findings, all fixed:
+
+### F1 — Major (incomplete fix): static-checks job missing `main` ref → diff-vs-main guards fail open — FIXED
+- `actions/checkout` with `fetch-depth: 0` fetches history but does NOT create a local `main` branch, so
+  `git diff main...HEAD` errored and the diff-based guards (prf-salt-immutable, R35 manual-test gate,
+  test-hygiene, e2e-selectors, settings-card-layout) silently passed vacuously in CI.
+- Fix: added the `Ensure main ref is available` step (`git fetch origin main:main`) — the exact pattern
+  already proven in `refactor-phase-verify.yml`. (`ci.yml`)
+
+### T3 — Minor: redundant `npx prisma generate` in static-checks — FIXED
+- Verified every static guard is a pure source/schema grep (e.g. `check-bypass-rls.mjs` imports only
+  `node:fs`/`node:path`); none import the generated client, and there is no `postinstall`. Removed the step.
+
+### T6 — Major (adjacent): misleading secret-scan comment — FIXED
+- The skip message claimed "CI scans the full history elsewhere," but no secret-scan CI job exists. Reworded
+  to state accurately that the gitleaks `--staged` scan is a local pre-push check (nothing is staged in CI).
+- NOTE (deferred, user decision): CI has **no** secret-scanning job. This is pre-existing (gitleaks was only
+  ever in the local hook). Adding one (gitleaks-action full-history, or relying on GitHub push protection)
+  is an optional follow-up, out of this PR's agreed scope.
+
+### S2 — Informational (deferred, pre-existing in changed file): tar/picomatch assertions use JS `<`
+- The pre-existing tar/picomatch build-time assertions (`Dockerfile`, not introduced here) compare versions
+  with lexicographic `node -e "... v < VER"`. **Anti-Deferral:** Worst case = a future newer version
+  false-fails the build (fail-CLOSED, never fail-open → no security risk); Likelihood = low (pinned
+  versions); Cost-to-fix = low but orthogonal to this PR's CVE-patch logic. The new prisma assertion
+  correctly uses exact `!==`. Deferred as `TODO(dockerfile-version-cmp): use semver-correct compare in
+  tar/picomatch assertions`.
+
+### Verification (Round 2)
+- `ci.yml` parses; `static-checks` steps = checkout → setup-node → npm ci → Ensure main ref → static guards.
+- `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` → 27 pass; both new guards pass.
+- Round 2 converged — no new findings beyond the three fixed (all within Round-1 fix scope). NOT committed.

--- a/extension/src/background/passkey-provider.ts
+++ b/extension/src/background/passkey-provider.ts
@@ -287,9 +287,15 @@ async function doSignAssertion(
     if (putRes.ok) {
       deps.invalidateCache();
     }
-    // Assertion succeeds even if counter-update PUT fails: the signed authenticatorData
-    // already contains the incremented counter and the RP validates it independently.
-    // A transient server failure should not block the user from signing in.
+    // Soft-fail on counter-persist failure: a network error already returned
+    // {ok:false} via the catch below, so this point is only reached on an HTTP
+    // error response. This assertion still ships signCount=N+1, so the *current*
+    // sign-in succeeds (we do not block the user on a transient server fault).
+    // Trade-off: because the blob was NOT persisted, the next sign-in re-hydrates
+    // the stale N and re-signs N+1 — presenting the same counter twice. An RP that
+    // strictly enforces counter monotonicity (> not >=) may reject that next
+    // assertion as a possible clone. This self-heals as soon as one PUT succeeds.
+    // passwd-sso's own RP tolerates this; external RPs vary.
 
     return {
       ok: true,

--- a/scripts/checks/check-dockerfile-prisma-pin.sh
+++ b/scripts/checks/check-dockerfile-prisma-pin.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Assert the Dockerfile runner stage pins `prisma` to the exact version
+# resolved in package-lock.json. A floating `latest` (or a drifted pin) breaks
+# build reproducibility and risks prisma-CLI / generated-client version skew in
+# the production image and the `migrate` compose service. Mirrors the tar /
+# picomatch fail-closed tripwires already in the Dockerfile.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "$0")/../.." && pwd))"
+
+DOCKERFILE="Dockerfile"
+LOCKFILE="package-lock.json"
+
+[ -f "$DOCKERFILE" ] || { echo "OK ($DOCKERFILE not present)"; exit 0; }
+[ -f "$LOCKFILE" ] || { echo "ERROR: $LOCKFILE not found"; exit 1; }
+
+lock_ver=$(node -p "require('./package-lock.json').packages['node_modules/prisma'].version")
+docker_ver=$(grep -oE 'PRISMA_VER=[0-9]+\.[0-9]+\.[0-9]+' "$DOCKERFILE" | head -1 | cut -d= -f2)
+
+if [ -z "$docker_ver" ]; then
+  echo "ERROR: no pinned 'PRISMA_VER=X.Y.Z' found in $DOCKERFILE — prisma must be version-pinned, not floating"
+  exit 1
+fi
+
+if [ "$docker_ver" != "$lock_ver" ]; then
+  echo "ERROR: Dockerfile PRISMA_VER=$docker_ver does not match package-lock.json prisma $lock_ver"
+  echo "Update PRISMA_VER in $DOCKERFILE (and the build-time assertion) to $lock_ver."
+  exit 1
+fi
+
+echo "OK (Dockerfile PRISMA_VER=$docker_ver matches lockfile)"

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -8,6 +8,13 @@ GREEN='\033[0;32m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
+# PRE_PR_STATIC_ONLY=1 runs only the environment-independent static checks
+# (grep/script guards) and skips Lint, Test, Build, integration, and the
+# staged-diff secret scan. CI's static-checks job sets this so the security
+# static guards run in CI from the same definition as the local hook — there
+# is no second copy to drift (R33).
+STATIC_ONLY="${PRE_PR_STATIC_ONLY:-0}"
+
 passed=0
 failed=0
 failures=()
@@ -123,7 +130,11 @@ run_step "Static: settings-card-layout"  bash scripts/checks/check-settings-card
 run_step "Static: api-error-codes" bash scripts/checks/check-api-error-codes.sh
 run_step "Static: api-error-body-drift" bash scripts/checks/check-api-error-body-drift.sh
 run_step "Static: fail-closed-routes-have-test" bash scripts/checks/check-fail-closed-routes-have-test.sh
-run_step "Lint"                   npx eslint .
+run_step "Static: actions-sha-pinned" bash scripts/checks/check-actions-sha-pinned.sh
+run_step "Static: dockerfile-prisma-pin" bash scripts/checks/check-dockerfile-prisma-pin.sh
+if [ "$STATIC_ONLY" != "1" ]; then
+  run_step "Lint"                   npx eslint .
+fi
 run_step "Static: env drift check"  npm run check:env-docs
 run_step "Static: team-auth-rls"  node scripts/checks/check-team-auth-rls.mjs
 run_step "Static: bypass-rls"     node scripts/checks/check-bypass-rls.mjs
@@ -376,7 +387,9 @@ run_step "Static: fetch basePath compliance" bash -c '
   fi
 '
 
-if command -v gitleaks >/dev/null 2>&1; then
+if [ "$STATIC_ONLY" = "1" ]; then
+  printf "${BOLD}▸ Secret scan${RESET}\n  (skipped — PRE_PR_STATIC_ONLY: the gitleaks --staged scan is a local pre-push check; nothing is staged in CI)\n\n"
+elif command -v gitleaks >/dev/null 2>&1; then
   run_step "Secret scan (gitleaks)" gitleaks detect --no-banner --redact --staged
 else
   # S19/S27 safe fallback: use node (already available — package.json runtime).
@@ -412,15 +425,18 @@ if git diff --name-only main...HEAD | grep -q '^src/app/\[locale\]/admin/'; then
     passed=$((passed + 1))
   fi
 fi
-# Clear vitest cache to match CI's clean environment
-rm -rf node_modules/.vitest extension/node_modules/.vitest 2>/dev/null || true
-run_step "Test"                   npx vitest run
+if [ "$STATIC_ONLY" != "1" ]; then
+  # Clear vitest cache to match CI's clean environment
+  rm -rf node_modules/.vitest extension/node_modules/.vitest 2>/dev/null || true
+  run_step "Test"                   npx vitest run
+fi
 
 # Integration tests on refactor branches touching auth/DB modules.
 # Round 4: T10 (regex covers pre- and post-PR-5 paths), T13 (DB reachability + 3s timeout),
 # T22 (CI via ci-integration.yml is authoritative; this local run is a preview).
 # Set PREPR_SKIP_INTEGRATION=1 to defer to CI.
-if git rev-parse --abbrev-ref HEAD | grep -q "^refactor/" && \
+if [ "$STATIC_ONLY" != "1" ] && \
+   git rev-parse --abbrev-ref HEAD | grep -q "^refactor/" && \
    git diff --name-only main...HEAD | \
      grep -E '^src/lib/(prisma|redis|tenant-(context|rls)|auth/.+-token)\.ts$|^src/lib/(prisma|tenant|auth)/' \
      > /dev/null; then
@@ -435,7 +451,9 @@ if git rev-parse --abbrev-ref HEAD | grep -q "^refactor/" && \
   fi
 fi
 
-run_step "Build"                  npx next build
+if [ "$STATIC_ONLY" != "1" ]; then
+  run_step "Build"                  npx next build
+fi
 
 echo ""
 printf "${BOLD}═══ Results ═══${RESET}\n"


### PR DESCRIPTION
## Summary

Supply-chain hardening surfaced by a triangulated security review
(functionality / security / testing). Fixes three audit findings plus the
systemic CI-gating gap behind them.

## Changes

### Pin GitHub Actions to SHAs (was: floating tags)
- Every `uses:` across all 5 workflows is pinned to a 40-char commit SHA with a
  `# vX.Y.Z` comment (`checkout`, `setup-node`, `upload-artifact`,
  `paths-filter`, `trivy-action`, `codeql-action/*`).
- `release.yml` holds `id-token: write` for npm Trusted Publishing — a poisoned
  `checkout`/`setup-node` there could mint a publish token. Also pinned its
  `npm install -g npm@latest` to `npm@11.12.1`.

### Gate static checks in CI (single source of truth)
- `scripts/checks/check-actions-sha-pinned.sh` existed but was never run, and
  `pre-pr.sh` static guards had no CI mirror — violations could merge green.
- Added a `PRE_PR_STATIC_ONLY=1` mode to `pre-pr.sh` and a `static-checks` CI
  job that calls it, so CI and the local hook share one definition and cannot
  drift. Wired the actions-pin and Dockerfile-prisma-pin checks into it.

### Pin the Dockerfile prisma install
- `npm install prisma` was unpinned (`latest`) while every neighbouring dep was
  pinned. Pinned to the lockfile version (`7.8.0`) with a fail-closed build-time
  assertion + `check-dockerfile-prisma-pin.sh` keeping it in lockstep.

### Passkey comment correction
- Rewrote a misleading comment in `passkey-provider.ts`: a network PUT failure
  already returns `{ok:false}`; only an HTTP error reaches the soft-fail. The
  cross-session duplicate-counter trade-off is now documented accurately. No
  behaviour change (covered by `background-passkey-provider.test.ts`).

## Verification
- `check-actions-sha-pinned.sh` + `check-dockerfile-prisma-pin.sh` pass.
- `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` -> 27 checks pass, heavy steps skipped.
- All 5 workflow YAMLs parse; extension passkey-provider suite 54/0.

## Notes (deferred)
- No secret-scanning CI job today (gitleaks is local-hook only) — optional follow-up.
- Pre-existing tar/picomatch assertions use lexicographic version compare
  (fail-closed, no security risk); tracked as `TODO(dockerfile-version-cmp)`.

Review log: `docs/archive/review/supply-chain-passkey-audit-code-review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)