### PR TITLE
fix(ci): add gitleaks secret-scan job and fix Dockerfile version compare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,34 @@ jobs:
           fi
           exit $FAIL
 
+  # ─── Secret Scan (gitleaks) ───────────────────────────────
+  # Scans the working tree with a checksum-pinned gitleaks binary. Allowlists for
+  # test fixtures / docs / known non-secret code markers live in .gitleaks.toml.
+  # Uses the binary directly (not gitleaks-action) to keep the supply chain
+  # pinned and avoid the action's license/telemetry surface. Always runs (not
+  # gated on `changes`) — the local pre-pr hook only scans the staged diff.
+  secret-scan:
+    name: "Secret scan (gitleaks)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install pinned gitleaks
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+        run: |
+          set -euo pipefail
+          curl -fsSL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar xzf gitleaks.tar.gz gitleaks
+          ./gitleaks version
+
+      - name: Scan working tree
+        run: ./gitleaks dir . --config .gitleaks.toml --no-banner --redact
+
   # ─── Static Security Check Guards ─────────────────────────
   # Runs the environment-independent static guards from scripts/pre-pr.sh via
   # PRE_PR_STATIC_ONLY — same definition as the local pre-PR hook, so the

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,35 @@
+# gitleaks config — extends the default ruleset with allowlists for this repo's
+# test fixtures, sample data, docs, and a few non-secret code markers. Production
+# source is still scanned. Used by the CI secret-scan job (.github/workflows/ci.yml)
+# and any local `gitleaks dir . --config .gitleaks.toml` run.
+#
+# When adding an allowlist entry, prefer the narrowest scope (a specific path or a
+# unique regex) over broad suppression, and explain why the match is not a secret.
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Test files, fixtures, sample export data, and docs hold non-secret test vectors / mock tokens (RFC 6238 TOTP vectors, SSH-key fixtures, example API tokens, sample CSV/JSON exports)."
+paths = [
+  '''.*\.test\.(ts|tsx|swift)$''',
+  '''.*\.spec\.(ts|tsx)$''',
+  '''(^|/)__tests__/''',
+  '''(^|/)test/fixtures/''',
+  '''^ios/.*Tests/.*''',
+  '''^docs/''',
+]
+
+[[allowlists]]
+description = "SSH-key format/parser source files: the only key-shaped strings are PEM header markers used for format detection, not real key material."
+paths = [
+  '''^cli/src/lib/openssh-key-parser\.ts$''',
+  '''^src/lib/format/ssh-key\.ts$''',
+]
+
+[[allowlists]]
+description = "Crypto KDF constant identifier, not a credential (generic-api-key false positive)."
+regexTarget = "match"
+regexes = [
+  '''VERIFIER_PBKDF2_BITS''',
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,8 +126,8 @@ RUN TAR_VER=7.5.11 && \
     rm -rf /root/.npm /tmp/* && \
     # Post-patch invariant assertion: fail the build if any expected version is missing.
     [ "$(npm -v)" = "${NPM_VER}" ] && \
-    node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tar/package.json').version;if(v<'${TAR_VER}'){console.error('tar still '+v);process.exit(1)}" && \
-    node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch/package.json').version;if(v<'${PICOMATCH_VER}'){console.error('picomatch still '+v);process.exit(1)}" && \
+    node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tar/package.json').version,c=v.split('.').map(Number),m='${TAR_VER}'.split('.').map(Number);for(let i=0;i<m.length;i++){const a=c[i]||0;if(a>m[i])break;if(a<m[i]){console.error('tar still '+v);process.exit(1)}}" && \
+    node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch/package.json').version,c=v.split('.').map(Number),m='${PICOMATCH_VER}'.split('.').map(Number);for(let i=0;i<m.length;i++){const a=c[i]||0;if(a>m[i])break;if(a<m[i]){console.error('picomatch still '+v);process.exit(1)}}" && \
     node -e "const v=require('/app/node_modules/prisma/package.json').version;if(v!=='${PRISMA_VER}'){console.error('prisma pin failed: got '+v+', expected ${PRISMA_VER}');process.exit(1)}"
 
 # Copy @prisma runtime adapters (overlay on top of prisma's @prisma packages)

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -388,7 +388,7 @@ run_step "Static: fetch basePath compliance" bash -c '
 '
 
 if [ "$STATIC_ONLY" = "1" ]; then
-  printf "${BOLD}▸ Secret scan${RESET}\n  (skipped — PRE_PR_STATIC_ONLY: the gitleaks --staged scan is a local pre-push check; nothing is staged in CI)\n\n"
+  printf "${BOLD}▸ Secret scan${RESET}\n  (skipped — PRE_PR_STATIC_ONLY: this is the local --staged scan; CI runs a full-tree gitleaks scan in the secret-scan job)\n\n"
 elif command -v gitleaks >/dev/null 2>&1; then
   run_step "Secret scan (gitleaks)" gitleaks detect --no-banner --redact --staged
 else


### PR DESCRIPTION
## Summary

Two follow-ups deferred from the supply-chain hardening PR (`#510`).

## Changes

### Secret-scanning CI gate (was: local-hook only)
- `pre-pr.sh` ran gitleaks only locally over the staged diff; CI had no
  secret-scanning job. Added a `secret-scan` CI job that scans the working tree
  with a **checksum-pinned** gitleaks binary (`v8.30.1`, sha256 verified). Always
  runs (not gated on `changes`).
- Uses the binary directly rather than `gitleaks-action` to keep the supply
  chain pinned (checksum, not just a tag) and avoid the action's
  license/telemetry surface — consistent with this repo's pinning posture.
- Added `.gitleaks.toml` allowlisting test fixtures, docs, sample export data,
  the two SSH-key parser files (PEM header *markers*, not key material), and the
  `VERIFIER_PBKDF2_BITS` constant. Verified: **0 findings** over the tracked-file
  set; the local pre-push hook auto-loads the same config.

### Fix lexicographic version compare in Dockerfile assertions
- The tar/picomatch build-time invariant assertions compared versions with JS
  string `<`, which is wrong for multi-digit segments (`'7.10.0' < '7.8.0'` is
  `true` → a newer patch would false-fail the build). Replaced with a
  left-to-right numeric compare. The prisma assertion already used exact `!==`.

## Verification
- `gitleaks dir . --config .gitleaks.toml` → no leaks (tested on a CI-shaped
  clone with `.git` present, no `node_modules`; gitleaks excludes `.git/`).
- Version-compare logic unit-checked: `7.10.0 >= 7.5.11` PASS, `7.5.10 >= 7.5.11`
  FAIL, `4.0.3 >= 4.0.4` FAIL, exact-equal PASS.
- `check-actions-sha-pinned.sh` passes (new job's `checkout` is SHA-pinned);
  `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` → 27 checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)