### PR TITLE
feat: add dev.sh compose helper and systemd self-host unit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The following must NOT move into any `scripts/<subdir>/`:
 
 - **Runtime entrypoints**: `audit-outbox-worker.ts` (referenced by `Dockerfile:25`, `docker-compose.override.yml:35`)
 - **Operator / incident-response**: `purge-history.sh`, `purge-audit-logs.sh`, `rotate-master-key.sh`, `set-outbox-worker-password.sh`
-- **Other operational**: `deploy.sh`, `scim-smoke.sh`, `mcp-reauth.sh`, `generate-icons.sh`, `bump-version.sh`
+- **Other operational**: `deploy.sh`, `dev.sh`, `scim-smoke.sh`, `mcp-reauth.sh`, `generate-icons.sh`, `bump-version.sh`
 - **Data fixtures**: `rls-smoke-*.sql`, `tenant-team-*.sql`, `license-allowlist.json`
 - **Admin-only refactor tools** (CODEOWNERS-gated): `move-and-rewrite-imports.mjs`, `verify-move-only-diff.mjs`, `verify-allowlist-rename-only.mjs`, `refactor-phase-verify.mjs`, `check-codeowners-drift.mjs`, `check-blame-ignore-revs.mjs`
 - **CI orchestrator** (CODEOWNERS-gated): `pre-pr.sh`

--- a/docs/archive/review/dev-ops-tooling-manual-test.md
+++ b/docs/archive/review/dev-ops-tooling-manual-test.md
@@ -1,0 +1,50 @@
+# Manual Test: dev-ops-tooling (systemd + dev.sh)
+
+Covers the deployment artifacts in this PR that automated tests / CI cannot
+exercise (R35 Tier-1): `infra/systemd/passwd-sso.service` and
+`scripts/dev.sh`. Both require a real Docker host, so they are operator-run.
+
+## Pre-conditions
+
+- A Linux host with Docker Engine + Compose v2 (`docker compose version`).
+- Repo checked out (e.g. `/opt/passwd-sso`), `.env` populated and `chmod 0600`.
+- DB migrated once: `docker compose -f docker-compose.yml --profile migrate run --rm migrate`.
+
+## Part A — systemd unit
+
+### A1 — Boot
+- **Steps**:
+  1. `sudo cp infra/systemd/passwd-sso.service /etc/systemd/system/ && sudo systemctl daemon-reload`
+  2. `sudo systemctl enable --now passwd-sso`
+  3. `systemctl is-active passwd-sso` and `journalctl -u passwd-sso -n 50`
+- **Expected**: unit active; logs show `app`, `db`, `jackson`, `redis` starting; the app answers on its port. No `docker-compose.override.yml` is loaded (datastore ports NOT published — verify `ss -ltnp | grep -E ':5432|:6379|:5225'` shows nothing bound on the host).
+
+### A2 — Crash recovery (verifies F6 `--abort-on-container-exit`)
+- **Steps**:
+  1. `docker kill $(docker compose -f docker-compose.yml ps -q app)`
+  2. Watch `journalctl -u passwd-sso -f`
+- **Expected**: compose exits non-zero, systemd reports failure, and after `RestartSec=10` the whole stack restarts. The app becomes reachable again. (If the unit lacked `--abort-on-container-exit`, compose would keep running and no restart would fire — this step is the reason that flag exists.)
+
+### A3 — Stop
+- **Steps**: `sudo systemctl stop passwd-sso`
+- **Expected**: `ExecStop` runs `docker compose down`; all containers removed within `TimeoutStopSec=90`; no orphaned containers (`docker compose -f docker-compose.yml ps` empty).
+
+### A4 — Secret hygiene
+- **Steps**: `stat -c '%a %U:%G' /opt/passwd-sso/.env`
+- **Expected**: `600 root:root` (or the dedicated service user). The unit has no inline secrets and no `EnvironmentFile=`, so this file mode is the sole protection (S3).
+
+### Rollback
+- `sudo systemctl disable --now passwd-sso && sudo rm /etc/systemd/system/passwd-sso.service && sudo systemctl daemon-reload`. Stack can still be run manually via `scripts/dev.sh` / `npm run docker:up`.
+
+## Part B — dev.sh (local dev)
+
+### B1 — init
+- **Steps**: from a fresh clone, `scripts/dev.sh init`
+- **Expected**: generates `.env` if absent (interactive), builds images, starts `db`/`redis`/`jackson`, applies migrations via the `migrate` profile, prints the "Start the full stack" hint. Idempotent on re-run (skips `.env`/`npm install`).
+
+### B2 — lifecycle
+- **Steps**: `scripts/dev.sh start` → `scripts/dev.sh status` → `scripts/dev.sh logs app` → `scripts/dev.sh restart` → `scripts/dev.sh stop`
+- **Expected**: stack comes up detached on the dev override (app :3000, mailpit :8025); `logs app` follows; `restart` recreates; `stop` removes containers. Named volumes (`postgres_data`, `redis_data`) survive `stop` (no `down -v`).
+
+### Rollback
+- `scripts/dev.sh stop`. No persistent changes beyond the dev DB volume, which is untouched by this tooling.

--- a/docs/archive/review/dev-ops-tooling-plan.md
+++ b/docs/archive/review/dev-ops-tooling-plan.md
@@ -1,0 +1,177 @@
+# Plan: dev-ops-tooling
+
+> **Revision (post Phase-1 review)**: The `scripts/` reorganization (contracts
+> C3/C3a/C3b/C3c) is **dropped**. Phase-1 review surfaced that the top-level
+> `scripts/` layout is governed by an intentional, documented Directory Policy
+> (`CONTRIBUTING.md` §"Root-of-`scripts/` fixed" + per-path `CODEOWNERS` gates;
+> the check-* consolidation already happened in a prior "PR 2"). The proposed
+> move map conflicted with that policy on nearly every entry and would have
+> dropped the SEC-4 `env-allowlist.ts` CODEOWNERS gate (review finding S1,
+> Critical). Net value did not justify overturning a load-bearing policy in
+> this PR. **Final scope: C1 (`dev.sh`) + C2 (systemd) only.** C3 and its
+> review findings (F1–F5, S1–S2, T1–T7) are resolved by elimination. The
+> systemd findings F6/F8/S3/R32/R35 are folded into C2 below.
+
+## Project context
+
+- **Type**: `mixed` — CLI/shell tooling (`scripts/`) + deployment artifacts (systemd, Docker Compose) + a file-move refactor across a Next.js web app.
+- **Test infrastructure**: `unit + integration + E2E + CI/CD`. `scripts/__tests__/` holds vitest specs that import the very scripts being moved; `pre-pr.sh` and `.github/workflows/*` invoke many scripts by path.
+- **Verification environment constraints**:
+  - VC1 — systemd units cannot be `systemctl start`-verified in this dev environment (no systemd-managed Docker host here). Verification is limited to `systemd-analyze verify` (static unit-file lint) + manual-test instructions for the operator. Classified `blocked-deferred` for the live-boot path; `verifiable-local` for static lint.
+  - VC2 — `dev.sh` end-to-end (`init`→`start`) requires a working Docker daemon + the full secret set in `.env`; the no-arg/`help` path and `bash -n`/shellcheck are `verifiable-local`, the Docker-touching subcommands are `blocked-deferred` (operator runs them).
+  - VC3 — the production image build (`docker build`) that would prove the worker-path move in the Dockerfile is heavy; classified `verifiable-CI` (CI builds the image) with a local `grep`-level path-consistency check as the cheap gate.
+
+## Objective
+
+Three cohesive deliverables for self-host / local-dev operability, plus a structural tidy of `scripts/`:
+
+1. **`dev.sh`** — a local-dev Docker Compose helper (`start`/`stop`/`restart`/`logs`/`init`/…). *(already drafted; this plan locks its surface)*
+2. **systemd units** — run the production Docker Compose stack (`docker-compose.yml`) as a managed service on a self-hosted VM.
+3. **`scripts/` reorganization** — move the ~30 scattered top-level scripts into purpose-named subdirectories, updating every **live** reference (package.json, CI, `pre-pr.sh`, deploy artifacts, live docs, test imports). Archived review docs are left untouched as historical record.
+
+## Requirements
+
+### Functional
+- `dev.sh` wraps the same compose-file pair as `npm run docker:up` (base + override) and adds first-run bootstrap.
+- systemd unit(s) start/stop the **base** `docker-compose.yml` stack (NOT the dev override — no host port exposure in prod) and restart on failure.
+- After reorg, every `npm run` script, CI job, `pre-pr.sh` check, worker container command, and live doc command that references a moved script resolves to the new path.
+
+### Non-functional
+- No behavior change to any moved script (pure relocation + import-path rewrite).
+- `pre-pr.sh` and `vitest` stay green. `next build` is **out of scope** to gate on (no app/`src` code changes — per the project rule that build cannot catch script-only issues); it remains runnable but is not a required gate for this PR.
+- Deployment-artifact changes (systemd, Dockerfile worker path, compose `command`) carry a manual-test artifact (R35 Tier-1).
+
+## Technical approach
+
+- **systemd**: a `Type=oneshot`/`RemainAfterExit` style unit is wrong for a long-lived stack; use `docker compose up` with `Restart=on-failure` is also wrong (compose `up` without `-d` blocks; with `-d` it exits). Correct pattern: a single service that runs `docker compose up` in the **foreground** (no `-d`) so systemd tracks it, with `ExecStop=docker compose down`. Place under `infra/systemd/`.
+- **scripts move**: use `git mv` per file (preserves history), then rewrite relative imports for the env cluster, then sweep references. Workers use `@/` alias imports → no intra-script import rewrite needed, only path references in build/deploy/docs.
+- **Risk tiering** — implement and commit in three independently-verifiable batches, low→high blast radius (see Contracts C3a/C3b/C3c).
+
+## Contracts
+
+### C1 — `scripts/ops/dev.sh` command surface *(locked; already implemented)*
+- **Signature**: `dev.sh <init|start|stop|restart|logs|status|build|migrate|seed|shell> [args]`, plus `help`/`-h`/`--help`/`""`.
+- **Invariants** (app-enforced):
+  - Resolves repo root via `BASH_SOURCE` and `cd`s there → runnable from any CWD.
+  - Uses exactly `docker compose -f docker-compose.yml -f docker-compose.override.yml` (same pair as `npm run docker:up`).
+  - `init` is idempotent: skips `.env` generation if `.env` exists, skips `npm install` if `node_modules` exists.
+  - `migrate` runs the profile-gated one-shot via `--profile migrate run --rm migrate`.
+  - Every Docker-touching command guards on `.env` presence (`require_env`) except `stop`/`status`/`build`.
+- **Forbidden patterns**:
+  - `pattern: docker compose down -v` — reason: never destroy named volumes (postgres_data/redis_data) from a dev helper.
+  - `pattern: set -x` — reason: no command tracing that could echo secrets.
+- **Acceptance**: `bash -n` clean; `dev.sh help` prints the usage block; `shellcheck` clean if installed.
+- **Location**: `scripts/dev.sh` — pinned at `scripts/` root alongside `deploy.sh` per `CONTRIBUTING.md` §"Root-of-`scripts/` fixed" → "Other operational" (this PR adds `dev.sh` to that list). The earlier `scripts/ops/dev.sh` idea is void with C3 dropped.
+
+### C2 — systemd unit(s) under `infra/systemd/`
+- **Files**:
+  - `infra/systemd/passwd-sso.service` — manages the base compose stack.
+  - `infra/systemd/README.md` — install/enable instructions + the `EnvironmentFile`/`WorkingDirectory` placeholders the operator must set.
+- **`passwd-sso.service` contract**:
+  - `[Unit]`: `After=docker.service network-online.target`, `Requires=docker.service`, `Wants=network-online.target`.
+  - `[Service]`: `Type=simple`, `WorkingDirectory=/opt/passwd-sso` (documented placeholder), `ExecStartPre=-/usr/bin/docker compose -f docker-compose.yml pull` (best-effort; `-` prefix to not fail boot), `ExecStart=/usr/bin/docker compose -f docker-compose.yml up --abort-on-container-exit`, `ExecStop=/usr/bin/docker compose -f docker-compose.yml down`, `Restart=on-failure`, `RestartSec=10`, `KillMode=mixed`, `TimeoutStopSec=90`.
+  - **`--abort-on-container-exit` is mandatory** (review F6): foreground `compose up` does NOT exit when a single container dies, so without it `Restart=on-failure` never fires and a crashed `app`/`redis` leaves systemd believing the service is healthy. With the flag, compose exits non-zero on any container exit → restart triggers.
+  - `KillMode=mixed` + `TimeoutStopSec=90` (review F8): SIGTERM the compose process, let `ExecStop` do the orderly teardown, bounded stop time.
+  - Runs the **base** file only (no `docker-compose.override.yml`) — prod must not expose db/redis/jackson ports.
+  - Migrations: documented as a separate operator step (`docker compose --profile migrate run --rm migrate`) in the README, NOT auto-run by the unit (matches the existing one-shot `migrate` profile design).
+- **Invariants**:
+  - No hardcoded secrets; secrets come from the repo-root `.env` that compose auto-loads (the unit relies on `WorkingDirectory` + compose's native `.env` load, so no `EnvironmentFile=` is strictly required — README states this).
+  - **`.env` file mode is the sole secret protection** (review S3): with no `EnvironmentFile=`, the README MUST instruct `install -m 0600 -o root -g root` for `/opt/passwd-sso/.env`. On a multi-user host a world-readable `.env` leaks every secret (DB passwords, `AUTH_SECRET`, `JACKSON_API_KEY`, `SHARE_MASTER_KEY`).
+  - `docker compose` invoked with an absolute binary path (systemd has a minimal `PATH`).
+- **Forbidden patterns**:
+  - `pattern: docker-compose.override.yml` inside `passwd-sso.service` — reason: prod must not load the dev override.
+  - `pattern: (?i)password|secret\s*=` literal assignment in the unit — reason: no inline secrets.
+- **Acceptance**: `systemd-analyze verify infra/systemd/passwd-sso.service` reports no errors (VC1 static path); README documents enable/start/journalctl and the `0600` `.env` step; `docs/archive/review/dev-ops-tooling-manual-test.md` covers boot + crash-recovery + secret-mode (R35 Tier-1).
+
+### C3 — `scripts/` target layout (move map) — **DROPPED** (see top-of-file Revision)
+The move map below is retained for the record only; it is NOT implemented in
+this PR. It conflicts with `CONTRIBUTING.md` §"Root-of-`scripts/` fixed" and the
+per-path `CODEOWNERS` gates. Any future reorg must first amend that policy as
+its own decision.
+
+Target tree (existing subdirs `checks/`, `lib/`, `__tests__/`, `__fixtures__/`, `manual-tests/` retained; `pre-pr.sh` stays at `scripts/pre-pr.sh` as the entry point):
+
+```
+scripts/
+  workers/      audit-outbox-worker.ts  dcr-cleanup-worker.ts
+                audit-chain-verify-worker.ts  audit-anchor-publisher.ts
+  env/          init-env.ts  generate-env-example.ts  check-env-docs.ts
+                env-allowlist.ts  env-descriptions.ts
+  rls/          rls-cross-tenant-{coverage,seed,verify}.sql
+                rls-cross-tenant-negative-test.sh  rls-cross-tenant-tables.manifest
+                rls-smoke-{seed,verify}.sql  tenant-team-phase2-validate.sql
+                tenant-team-phase5-rls.sql
+  migrations/   migrate-account-tokens-to-encrypted.ts
+                migrate-prf-per-credential-salt.sh  migrate-webhook-secrets-v1-to-v2.ts
+  ops/          dev.sh  deploy.sh  bump-version.sh  mcp-reauth.sh  scim-smoke.sh
+                purge-audit-logs.sh  purge-history.sh  rotate-master-key.sh
+                set-{outbox-worker,dcr-cleanup-worker,audit-anchor-publisher}-password.sh
+                generate-{icons,audit-anchor-signing-key,audit-anchor-tag-secret}.sh
+  checks/       (existing) + check-blame-ignore-revs.mjs  check-codeowners-drift.mjs
+                check-state-mutation-centralization.{sh,ts}  coverage-diff.mjs
+                refactor-phase-verify.mjs  move-and-rewrite-imports.mjs
+                verify-allowlist-rename-only.mjs  verify-move-only-diff.mjs
+                license-allowlist.json
+  __tests__/ __fixtures__/ lib/ manual-tests/  (unchanged location)
+  pre-pr.sh   (unchanged — entry point)
+```
+
+`regenerate-account-token-legacy-fixture.ts` → `scripts/__tests__/` (it regenerates a test fixture).
+
+Implemented as three batches:
+
+#### C3a — checks consolidation (LOW blast radius, CI-only)
+- Move the scattered `check-*`/`verify-*`/`coverage-diff`/`refactor-phase-verify`/`move-and-rewrite-imports`/`license-allowlist.json` into `checks/`.
+- **Reference surfaces to update**: `pre-pr.sh`, `.github/workflows/*`, `scripts/__tests__/*` import paths, any check that reads `license-allowlist.json` by relative path, cross-references between the moved `.mjs` and `checks/` siblings.
+- **Invariant**: no runtime/deploy artifact references these (verified — they are CI/lint only).
+
+#### C3b — rls / migrations / ops grouping (MEDIUM, no import rewrites)
+- `git mv` the `.sql`/`.sh`/`.manifest`/`.ts` into `rls/`, `migrations/`, `ops/`.
+- **Reference surfaces**: `.github/workflows/*` (rls suite paths, `rls-cross-tenant-tables.manifest`), `pre-pr.sh` (manifest + verify SQL), `package.json` (`migrate:account-tokens`, `bump-version`/`version:bump`), `CLAUDE.md` admin-script command block, live docs under `docs/operations/`, `docs/setup/`.
+- `migrate-account-tokens` relative imports: verify none to siblings (uses `@/`).
+
+#### C3c — workers / env (HIGH blast radius)
+- `git mv` workers → `workers/`, env cluster → `env/`.
+- **env import rewrites** (relative): inside `env/`, `./env-allowlist` and `./env-descriptions` stay valid (same dir); `./lib/*` → `../lib/*` in `init-env.ts` and `generate-env-example.ts`. Update `scripts/__tests__/*` imports (`../init-env.ts` → `../env/init-env.ts`, etc.).
+- **worker reference surfaces** (NO import rewrite — `@/` alias): `package.json` (`worker:*`), `Dockerfile`, `docker-compose.override.yml` (`command:`), live docs `docs/setup/{aws,azure,gcp,vercel}/en.md`, `docs/operations/alerts.md`, `docs/security/audit-preparation-checklist.md`.
+- **env reference surfaces**: `package.json` (`init:env`, `generate:env-example`, `check:env-docs`), `.github/workflows/*`, `pre-pr.sh`, `CLAUDE.md`.
+
+### C4 — reference-update completeness invariant
+- **Invariant (app-enforced via grep gate)**: after each batch, `grep -rn` for the OLD path of every moved file across **live** surfaces (`package.json`, `.github/`, `pre-pr.sh`, `Dockerfile`, `docker-compose*.yml`, `infra/`, `docs/` **excluding `docs/archive/`**, `scripts/` **excluding `scripts/__tests__/fixtures/`**) returns **zero** hits. Archive docs (`docs/archive/**`) and `.next/` cache are explicitly excluded.
+- **Forbidden pattern (per batch)**: the moved file's old `scripts/<name>` path appearing in any live surface after the batch commit.
+
+## Testing strategy
+- Per batch: run the specific affected gate first (targeted), then the full `pre-pr.sh` before the final commit.
+  - C3a: `npx vitest run scripts/__tests__` + the moved checks invoked directly + `bash scripts/pre-pr.sh` (or the relevant check subset).
+  - C3b: re-run any `.github/workflows` RLS step locally if a DB is available (else grep-gate + manual note); `npx vitest run`.
+  - C3c: `npx vitest run scripts/__tests__`; `npm run worker:audit-outbox -- --help`-style boot smoke for each worker (R32 — confirm the process resolves its new path and loads env; declare ready signal); `grep` Dockerfile/compose path consistency (VC3).
+- Full suite gate before PR: `npx vitest run` green + `bash scripts/pre-pr.sh` green.
+
+## Considerations & constraints
+
+### Scope contract
+- **SC1** — `docs/archive/review/**` path references to moved scripts are **NOT** rewritten. They are historical records of past plans/reviews; rewriting them falsifies the archive. Owner: permanent policy (this plan).
+- **SC2** — Native (non-Docker) systemd units for individual workers (`tsx` processes) are out of scope; the chosen systemd model manages the whole compose stack (per user decision). Owner: future PR if a worker-only host is needed.
+- **SC3** — `next build` is not a required gate (no `src/` changes). Owner: project rule "skip build for test/script-only changes".
+- **SC4** — `.env`-dependent live runs of `dev.sh`/systemd are operator-side (VC1/VC2); CI/static verification only in this PR.
+
+### Risks
+- R-A: a missed live reference after a move → CI/pre-pr/worker-boot failure. Mitigated by C4 grep gate per batch.
+- R-B: Dockerfile worker-path drift → broken production image (caught by CI image build, VC3 grep gate locally).
+- R-C: systemd unit `PATH`/foreground-vs-detached mistake → service flaps. Mitigated by `systemd-analyze verify` + explicit foreground `up` pattern + README.
+
+## User operation scenarios
+1. New developer clones repo → `scripts/ops/dev.sh init` → `dev.sh start` → app on :3000, mailpit on :8025.
+2. Operator on a VM → copies `infra/systemd/passwd-sso.service` to `/etc/systemd/system/`, edits `WorkingDirectory`, `systemctl enable --now passwd-sso` → stack runs, `journalctl -u passwd-sso -f` shows logs.
+3. CI runs `pre-pr.sh` → all moved-script paths resolve; RLS suite + env-docs drift check + license check pass from their new `checks/`/`rls/`/`env/` homes.
+
+## Go/No-Go Gate
+| ID   | Subject                                                        | Status |
+|------|---------------------------------------------------------------|--------|
+| C1   | `dev.sh` command surface (stays at `scripts/dev.sh`)          | locked  |
+| C2   | systemd `passwd-sso.service` + README + manual-test           | locked  |
+| C3   | `scripts/` reorganization (move map)                          | dropped |
+| C3a  | checks consolidation batch                                    | dropped |
+| C3b  | rls/migrations/ops grouping batch                             | dropped |
+| C3c  | workers/env batch (+ import rewrites)                         | dropped |
+| C4   | reference-update completeness grep gate                       | dropped |

--- a/docs/archive/review/dev-ops-tooling-review.md
+++ b/docs/archive/review/dev-ops-tooling-review.md
@@ -1,0 +1,121 @@
+# Plan Review: dev-ops-tooling
+
+Date: 2026-06-07
+Review round: 1 (single round — outcome collapsed scope; see Resolution)
+
+## Changes from Previous Round
+Initial review of the plan covering `dev.sh`, systemd units, and a `scripts/`
+reorganization.
+
+## Functionality Findings
+- **F1 [Major]** — C4 grep gate omitted `CLAUDE.md`, `README.md`, `README.ja.md`,
+  `CONTRIBUTING.md`, `messages/` (e.g. `messages/{en,ja}/OperatorToken.json:36`
+  embeds `scripts/purge-history.sh` in a user-visible `usageHint`).
+- **F2 [Major]** — `CONTRIBUTING.md:17-27` "Root-of-`scripts/` fixed" explicitly
+  pins (with reasons) every file the reorg would move. The reorg contradicts a
+  documented, must-respect policy.
+- **F3 [Major]** — C3b reference list missed `scim:smoke`, `generate:icons`,
+  `generate:audit-anchor-signing-key`, `generate:audit-anchor-tag-secret` in
+  `package.json`.
+- **F4 [Major]** — `scripts/__tests__/*` build paths via `resolve(ROOT,"scripts",...)`
+  (not ES imports); C3a/C3b reference lists didn't cover them.
+- **F5 [Major]** — `scripts/check-env-docs.ts` `SCRIPT_DIR` uses `"../.."` (repo
+  root from `scripts/`); moving to `scripts/env/` shifts it to `"../../.."`, plus
+  five hardcoded `resolve(root,"scripts/env-*.ts")` strings need rewriting.
+- **F6 [Major]** — systemd `Restart=on-failure` is ineffective with a plain
+  foreground `docker compose up`; needs `--abort-on-container-exit`.
+- **F7 [Minor]** — `dev.sh` self-referential help strings hardcode `scripts/dev.sh`
+  (moot once the file stays at `scripts/dev.sh`).
+- **F8 [Minor]** — `ExecStop` races with SIGTERM; add `KillMode=mixed` /
+  `TimeoutStopSec`.
+
+## Security Findings
+- **S1 [Critical, escalate:true]** — `CODEOWNERS:35` `/scripts/env-allowlist.ts`
+  (SEC-4 allowlist governance gate) would be silently dropped on move to
+  `scripts/env/`; no `/scripts/env/**` rule exists. Ungated changes to the
+  env-validation-bypass allowlist.
+- **S2 [Major]** — `CODEOWNERS:5-10` per-path rules for the six admin refactor
+  tools become dead on move; policy comment says "stay at scripts/ root".
+- **S3 [Major]** — systemd `.env` is the sole secrets carrier with no
+  `EnvironmentFile=`; plan/README didn't mandate `0600 root:root`. World-readable
+  `.env` on a multi-user host leaks all secrets.
+- **S4 [Minor]** — `docker-compose.override.yml` `minioadmin/minioadmin` dev
+  default lacks a documented gitleaks allowlist note (dev-only, not in prod base
+  stack).
+- **S5 [Minor]** — `ci.yml:228 check-state-mutation-centralization.sh` covered by
+  the `.github/workflows/*` surface but not named explicitly in C3a.
+
+## Testing Findings
+- **T1-T3 [Major]** — eight `scripts/__tests__/*` subprocess `resolve()` paths
+  (set-*-password, check-state-mutation, worker-env, env-tool tests) break on
+  move; per-batch checklists named only the one ES import in `init-env.test.mjs`.
+- **T4 [Major]** — no test exercises `npm run check:env-docs` without `--root`,
+  so the `SCRIPT_DIR` depth break (F5) is invisible to vitest.
+- **T5 [Minor]** — boot-smoke flag is `--validate-env-only` not `--help`;
+  `audit-chain-verify-worker` lacks the flag and a `package.json` script.
+- **T6 [Minor]** — `ci.yml` `paths-filter` env entries would go stale (silent
+  CI-trigger gap), not just the `run:` commands.
+- **T7 [Minor]** — `check-licenses.mjs:65-66` says `license-allowlist.json` stays
+  at `scripts/`; moving it breaks `resolve(__dirname,"..","license-allowlist.json")`
+  and C4's literal grep would not catch it.
+
+## Adjacent Findings
+- S4 noted minio is absent from the production base compose (override-only).
+
+## Resolution Status
+
+### Scope decision — `scripts/` reorganization (C3/C3a/C3b/C3c/C4) — Dropped
+- **Anti-Deferral check**: "out of scope (different feature)" — superseded by an
+  explicit user scope decision after the policy conflict was surfaced.
+- **Justification**: F2 + S1 + S2 establish that the top-level `scripts/` layout
+  is an intentional, documented Directory Policy (`CONTRIBUTING.md` §"Root-of-
+  `scripts/` fixed", per-path `CODEOWNERS` gates, prior "PR 2" check-*
+  consolidation). The move map conflicted with that policy on nearly every entry
+  and would have dropped the SEC-4 CODEOWNERS gate (S1, Critical). Overturning a
+  load-bearing policy is its own decision, not a side effect of a tidy-up PR.
+- **Effect on findings**: F1, F3, F4, F5, F7, S1, S2, S5, T1-T7 are resolved by
+  elimination (the moves that would trigger them are not performed). Tracked here
+  so they are auditable if a future reorg PR revisits the move map.
+- **Orchestrator sign-off**: confirmed — user chose "drop the reorg"; the only
+  retained scripts/ change is adding `dev.sh` to the `CONTRIBUTING.md`
+  operational pin list (keeps the policy in sync with the new file).
+
+### Retained findings — folded into C2 (systemd) / C1 (dev.sh)
+- **F6 — Fixed**: `ExecStart=... up --abort-on-container-exit` in
+  `infra/systemd/passwd-sso.service`.
+- **F8 — Fixed**: `KillMode=mixed` + `TimeoutStopSec=90` added.
+- **S3 — Fixed**: `infra/systemd/README.md` mandates
+  `install -m 0600 -o root -g root .env`; plan C2 invariant updated.
+- **R32 / R35 — Fixed**: `docs/archive/review/dev-ops-tooling-manual-test.md`
+  adds the operator boot + crash-recovery (A2 exercises F6) + secret-mode (A4)
+  test plan; README links it.
+- **F7 — Moot**: `dev.sh` stays at `scripts/dev.sh`, so its self-referential
+  help strings are already correct.
+- **S4 — Skipped (Minor)**: dev-only default credential in an override file that
+  the systemd unit never loads (prod base stack has no minio). Worst case: CI
+  secret-scan noise; Likelihood: low (low-entropy literal, current ruleset does
+  not flag); Cost to fix: low but orthogonal to this PR's intent. Tracked as a
+  pre-existing dev-hygiene item, not introduced here.
+
+## Recurring Issue Check
+### Functionality expert
+- R1 (reimplementation): N/A — `dev.sh` is a thin wrapper over the same compose
+  pair, with unique subcommands.
+- R3 (incomplete propagation): was the central reorg risk; eliminated by dropping C3.
+- R15 (hardcoded env-specific values): clean — systemd unit uses a documented
+  `WorkingDirectory` placeholder, secrets via compose `.env`.
+- R32 (long-running artifact boot test): addressed via manual-test A1/A2.
+- R35 (deployment artifact manual-test): addressed via `dev-ops-tooling-manual-test.md`.
+
+### Security expert
+- R15: no finding. R18 (allowlist sync): S1/S2 — resolved by not moving the gated
+  files. R31 (destructive ops): clean — `dev.sh` forbids `down -v`. R33 (CI
+  security-gate path drift): resolved by dropping the moves. R35: present (manual
+  test). RS4 (personal data in artifacts): clean — no personal emails/handles in
+  any new doc.
+
+### Testing expert
+- R7 (path breakage in tests): eliminated (no moves). R16 (dev/CI RLS parity):
+  N/A (rls files not moved). R19 (mock/fixture alignment): clean. R32 (boot smoke
+  + ready signal): manual-test A1/A2; static `systemd-analyze verify` is the CI-
+  side gate. RT1 (mock-reality divergence): N/A.

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -1,0 +1,84 @@
+# systemd unit for self-hosted passwd-sso
+
+`passwd-sso.service` runs the **production** Docker Compose stack
+(`docker-compose.yml` — the base file only, no dev override) as a
+systemd-managed service on a single Linux host.
+
+It is intended for self-hosted VM deployments. The AWS ECS / Kubernetes paths
+(`infra/terraform/`, `infra/k8s/`) are the managed-platform alternatives and do
+not use this unit.
+
+## Why the base compose file only
+
+The unit deliberately omits `docker-compose.override.yml`. The override is a
+**development** file: it publishes `db` (5432), `redis` (6379), and `jackson`
+(5225) to the host and adds `mailpit` / `minio`. Loading it in production would
+expose internal datastores. The base `docker-compose.yml` keeps those services
+on the internal Docker network only.
+
+## Prerequisites
+
+- Docker Engine with the Compose v2 plugin (`docker compose`, not
+  `docker-compose`). The unit calls `/usr/bin/docker` — adjust the path if your
+  install differs (`command -v docker`).
+- The repository checked out at the host (e.g. `/opt/passwd-sso`).
+- A populated `.env` in that directory (see below).
+
+## Install
+
+```bash
+# 1. Place the repo where the unit expects it (or edit WorkingDirectory).
+sudo git clone <repo-url> /opt/passwd-sso
+cd /opt/passwd-sso
+
+# 2. Create .env (interactive generator writes the canonical .env).
+sudo npm run init:env -- --profile=production
+
+# 3. Lock down .env — it holds every secret (DB passwords, AUTH_SECRET,
+#    JACKSON_API_KEY, SHARE_MASTER_KEY, ...). Compose auto-loads it from the
+#    WorkingDirectory; there is no EnvironmentFile= in the unit, so the file
+#    mode is the only thing protecting these secrets on a multi-user host.
+sudo install -m 0600 -o root -g root .env .env   # ensure 0600 root:root
+
+# 4. Apply database migrations once (the one-shot 'migrate' profile).
+sudo docker compose -f docker-compose.yml --profile migrate run --rm migrate
+
+# 5. Install and enable the unit.
+sudo cp infra/systemd/passwd-sso.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now passwd-sso
+```
+
+If you cloned somewhere other than `/opt/passwd-sso`, edit `WorkingDirectory=`
+in the unit before `daemon-reload`.
+
+## Operate
+
+```bash
+systemctl status passwd-sso
+journalctl -u passwd-sso -f          # follow logs
+sudo systemctl restart passwd-sso
+sudo systemctl stop passwd-sso
+```
+
+Database migrations on upgrade are an explicit operator step (the unit never
+runs them automatically — matching the profile-gated `migrate` service):
+
+```bash
+cd /opt/passwd-sso && git pull
+sudo docker compose -f docker-compose.yml --profile migrate run --rm migrate
+sudo systemctl restart passwd-sso
+```
+
+## Restart semantics
+
+`ExecStart` runs `docker compose up --abort-on-container-exit` in the
+foreground. When any container exits unexpectedly, compose exits non-zero and
+`Restart=on-failure` brings the whole stack back after `RestartSec=10`. On
+`systemctl stop`, `ExecStop` runs `docker compose down` for an orderly teardown.
+
+## Verification
+
+This unit cannot be boot-tested in CI (no systemd-managed Docker host). See
+[`docs/archive/review/dev-ops-tooling-manual-test.md`](../../docs/archive/review/dev-ops-tooling-manual-test.md)
+for the operator boot + crash-recovery test plan.

--- a/infra/systemd/passwd-sso.service
+++ b/infra/systemd/passwd-sso.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=passwd-sso (Docker Compose stack)
+Documentation=https://github.com/ngc-shj/passwd-sso/blob/main/infra/systemd/README.md
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Edit to the directory holding docker-compose.yml and the .env file.
+WorkingDirectory=/opt/passwd-sso
+# Best-effort image refresh on (re)start. The leading '-' keeps a registry
+# hiccup from blocking the boot.
+ExecStartPre=-/usr/bin/docker compose -f docker-compose.yml pull
+# Foreground (no -d) so systemd supervises the process. --abort-on-container-exit
+# makes compose exit non-zero when any container dies, which is what trips
+# Restart=on-failure — without it a crashed app/redis would leave compose
+# running and systemd would believe the service is healthy.
+ExecStart=/usr/bin/docker compose -f docker-compose.yml up --abort-on-container-exit
+ExecStop=/usr/bin/docker compose -f docker-compose.yml down
+Restart=on-failure
+RestartSec=10
+# SIGTERM the compose process only; ExecStop performs the orderly teardown.
+KillMode=mixed
+TimeoutStopSec=90
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dev environment helper for the local Docker Compose stack.
+#
+# Wraps `docker compose` with the base + dev override files (same pair as
+# `npm run docker:up`) and adds first-run bootstrap. Run from anywhere.
+#
+# Usage: scripts/dev.sh <command> [args]
+#
+#   init                First-run setup: create .env, build images, run migrations
+#   start [svc...]      Start the stack detached (docker compose up -d)
+#   stop                Stop and remove containers (docker compose down)
+#   restart [svc...]    Recreate and restart (down → up -d)
+#   logs [svc...]       Follow logs (all services, or only the named ones)
+#   status              Show container status (docker compose ps)
+#   build [svc...]      (Re)build images
+#   migrate             Apply DB migrations via the one-shot migrate service
+#   seed                Run prisma seed against the dev DB (host-side)
+#   shell <svc>         Open an interactive shell inside a running service
+#
+# Examples:
+#   scripts/dev.sh init
+#   scripts/dev.sh start
+#   scripts/dev.sh logs app
+#   scripts/dev.sh restart audit-outbox-worker
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.override.yml)
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+require_docker() {
+  command -v docker &>/dev/null || die "docker is required but not installed."
+  docker compose version &>/dev/null || die "docker compose v2 is required."
+}
+
+require_env() {
+  [[ -f .env ]] || die ".env not found. Run 'scripts/dev.sh init' first."
+}
+
+cmd_init() {
+  require_docker
+
+  if [[ ! -f .env ]]; then
+    echo "==> .env not found — launching interactive generator (npm run init:env)"
+    npm run init:env
+  else
+    echo "==> .env already present — skipping generation"
+  fi
+
+  if [[ ! -d node_modules ]]; then
+    echo "==> Installing host dependencies (npm install)"
+    npm install
+  fi
+
+  echo "==> Building images"
+  "${COMPOSE[@]}" build
+
+  echo "==> Starting datastores (db, redis, jackson)"
+  "${COMPOSE[@]}" up -d db redis jackson
+
+  echo "==> Applying database migrations"
+  cmd_migrate
+
+  echo ""
+  echo "Init complete. Start the full stack with:  scripts/dev.sh start"
+}
+
+cmd_start() {
+  require_docker
+  require_env
+  "${COMPOSE[@]}" up -d "$@"
+  "${COMPOSE[@]}" ps
+}
+
+cmd_stop() {
+  require_docker
+  "${COMPOSE[@]}" down
+}
+
+cmd_restart() {
+  require_docker
+  require_env
+  "${COMPOSE[@]}" down
+  "${COMPOSE[@]}" up -d "$@"
+  "${COMPOSE[@]}" ps
+}
+
+cmd_logs() {
+  require_docker
+  "${COMPOSE[@]}" logs -f --tail=100 "$@"
+}
+
+cmd_status() {
+  require_docker
+  "${COMPOSE[@]}" ps
+}
+
+cmd_build() {
+  require_docker
+  "${COMPOSE[@]}" build "$@"
+}
+
+cmd_migrate() {
+  require_docker
+  require_env
+  # migrate is profile-gated in docker-compose.yml; run it as a one-shot.
+  "${COMPOSE[@]}" --profile migrate run --rm migrate
+}
+
+cmd_seed() {
+  require_env
+  echo "==> Seeding dev DB (npm run db:seed)"
+  npm run db:seed
+}
+
+cmd_shell() {
+  require_docker
+  local svc="${1:-}"
+  [[ -n "$svc" ]] || die "Usage: scripts/dev.sh shell <service>"
+  "${COMPOSE[@]}" exec "$svc" sh
+}
+
+main() {
+  local cmd="${1:-}"
+  [[ $# -gt 0 ]] && shift || true
+  case "$cmd" in
+    init)    cmd_init "$@" ;;
+    start|up)   cmd_start "$@" ;;
+    stop|down)  cmd_stop "$@" ;;
+    restart) cmd_restart "$@" ;;
+    logs)    cmd_logs "$@" ;;
+    status|ps)  cmd_status "$@" ;;
+    build)   cmd_build "$@" ;;
+    migrate) cmd_migrate "$@" ;;
+    seed)    cmd_seed "$@" ;;
+    shell)   cmd_shell "$@" ;;
+    ""|-h|--help|help)
+      sed -n '4,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      ;;
+    *)
+      die "Unknown command: $cmd (run 'scripts/dev.sh help')"
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Adds two operability tools and intentionally leaves `scripts/` layout untouched.

- **`scripts/dev.sh`** — local Docker Compose lifecycle helper wrapping the base + dev-override pair (same as `npm run docker:up`): `init` (first-run bootstrap: `.env` → build → datastores → migrate), `start`/`stop`/`restart`/`logs`/`status`/`build`/`migrate`/`seed`/`shell`. Pinned at `scripts/` root next to `deploy.sh`.
- **`infra/systemd/passwd-sso.service` + README** — runs the **production** `docker-compose.yml` stack (base only — no dev port exposure) as a systemd service, for self-hosted VM deployments alongside the existing ECS/K8s paths.

## Notable design points (from triangulate review)
- The unit runs `up --abort-on-container-exit` so `Restart=on-failure` actually fires on a container crash (plain foreground `up` would leave systemd believing the service is healthy).
- `KillMode=mixed` + `TimeoutStopSec=90` for an orderly `ExecStop` teardown.
- No `EnvironmentFile=`; the README mandates `install -m 0600 -o root -g root .env` since that file is the sole secret carrier on a self-hosted host.
- R35 manual-test plan (boot / crash-recovery / secret-mode) under `docs/archive/review/`.

## Scope decision: scripts/ reorganization dropped
An initial plan included reorganizing the ~30 top-level `scripts/` files into subdirectories. Review found the layout is governed by an intentional, documented Directory Policy (`CONTRIBUTING.md` §"Root-of-`scripts/` fixed" + per-path `CODEOWNERS` gates; check-* were already consolidated in a prior PR). The move map conflicted with that policy and would have silently dropped the SEC-4 `env-allowlist.ts` CODEOWNERS gate, so it was dropped. The only retained `scripts/`-policy change is adding `dev.sh` to the operational pin list. Full rationale: `docs/archive/review/dev-ops-tooling-review.md`.

## Verification
- `bash -n scripts/dev.sh` ✓, `systemd-analyze verify` ✓ (no errors)
- `scripts/pre-pr.sh` ✓ (31 checks incl. production build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)