### PR TITLE
test: remove dead code flagged by CodeQL (js/unused-local-variable)

### DIFF
--- a/cli/src/__tests__/unit/agent.test.ts
+++ b/cli/src/__tests__/unit/agent.test.ts
@@ -76,7 +76,6 @@ const { getEncryptionKey, getUserId, getSecretKeyBytes } = await import("../../l
 const { apiRequest } = await import("../../lib/api-client.js");
 const { decryptData } = await import("../../lib/crypto.js");
 const { loadKey } = await import("../../lib/ssh-key-agent.js");
-const { startAgent } = await import("../../lib/ssh-agent-socket.js");
 const output = await import("../../lib/output.js");
 
 const { agentCommand } = await import("../../commands/agent.js");


### PR DESCRIPTION
## Summary
Removes an unused destructured binding `startAgent` from a dynamic import in `cli/src/__tests__/unit/agent.test.ts`. The corresponding `vi.mock("../../lib/ssh-agent-socket.js", ...)` definition is untouched, so the module stays mocked for the code under test.

Resolves the open code-scanning alert (`js/unused-local-variable`, alert 209).

## Verification
- `npx vitest run src/__tests__/unit/agent.test.ts` → 9 passed
- `npx tsc --noEmit` (cli) → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)