### PR TITLE
fix(dashboard): contain vault scroll inside detail pane when banner shown

### DIFF
--- a/src/app/[locale]/dashboard/teams/[teamId]/page.tsx
+++ b/src/app/[locale]/dashboard/teams/[teamId]/page.tsx
@@ -278,8 +278,8 @@ export default function TeamDashboardPage({
   return (
     <div
       className={[
-        "flex flex-col min-h-0 p-4 md:p-6",
-        isMasterDetail ? "h-full" : "flex-1",
+        "flex flex-col flex-1 p-4 md:p-6",
+        isMasterDetail ? "min-h-0" : "",
       ].join(" ")}
     >
       <div className={isMasterDetail ? "mx-auto w-full max-w-[1024px]" : "mx-auto max-w-4xl w-full"}>

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -18,7 +18,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
           <Header onMenuToggle={() => setSidebarOpen(true)} />
           <div className="flex min-h-0 flex-1 overflow-hidden">
             <Sidebar open={sidebarOpen} onOpenChange={setSidebarOpen} />
-            <main className="min-h-0 flex-1 overflow-auto">
+            <main className="flex min-h-0 flex-1 flex-col overflow-auto">
               <RecoveryKeyBanner />
               <DelegationRevokeBanner />
               {children}

--- a/src/components/passwords/detail/password-dashboard.tsx
+++ b/src/components/passwords/detail/password-dashboard.tsx
@@ -252,13 +252,14 @@ export function PasswordDashboard({ view, tagId, folderId, entryType }: Password
   }, []);
 
   return (
-    // master-detail: h-full fills the (block, overflow-auto) <main>'s definite flex height so
-    // the list/detail panes scroll independently (INV-C5.1) instead of <main> scrolling the
-    // whole view as one. accordion: flex-1 keeps the page-level scroll (<main> scrolls).
+    // <main> is a flex column (banner(s) + this view). master-detail: flex-1 min-h-0 takes the
+    // height remaining below any banner so the list/detail panes scroll independently (INV-C5.1)
+    // instead of <main> scrolling the whole view. accordion: flex-1 (no min-h-0) lets the view
+    // grow with its content so <main> provides the page-level scroll.
     <div
       className={[
-        "flex flex-col min-h-0 p-4 md:p-6",
-        layoutMode === "master-detail" ? "h-full" : "flex-1",
+        "flex flex-col flex-1 p-4 md:p-6",
+        layoutMode === "master-detail" ? "min-h-0" : "",
       ].join(" ")}
     >
       <div className={layoutMode === "master-detail" ? "mx-auto w-full max-w-[1024px]" : "mx-auto max-w-4xl w-full"}>


### PR DESCRIPTION
## Summary

When a notification banner (e.g. the recovery-key rotation warning) was shown at the top of the dashboard, a vertical scrollbar appeared on the outer `<main>` element and scrolled the whole view as one unit, instead of the detail pane scrolling independently inside the 3-pane master-detail layout.

## Root cause

In master-detail mode the vault view used `h-full` (100% of `<main>`'s height). The banners are rendered above the view inside the same `<main>`, so `banner height + 100% of <main>` exceeded `<main>` and forced the outer `overflow-auto` to scroll the entire view.

## Fix

- Make `<main>` a flex column (`dashboard-shell.tsx`) so the banners take their natural height and the view fills the remaining space.
- Switch the vault view from `h-full` to `flex-1 min-h-0` in master-detail mode so it occupies only the height left below any banner; the list/detail panes then scroll independently (INV-C5.1). Accordion mode keeps page-level scroll via `flex-1` (no `min-h-0`).
- Apply the identical change to the team vault page, which shared the same pre-fix pattern (triangulate review surfaced this as the only finding).

## Verification

- `npx vitest run`: 2824 tests pass
- `npx next build`: succeeds
- `scripts/pre-pr.sh`: 31/31 pass
- Manual visual check recommended at viewport ≥1024px with a banner shown, for both the personal and team vault (CSS overflow behavior is not resolvable in jsdom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)