### PR TITLE
fix(ios): AutoFill credential list (iOS 17+ methods) + matched-only picker with search

### DIFF
--- a/docs/archive/review/ios-autofill-matching-plan.md
+++ b/docs/archive/review/ios-autofill-matching-plan.md
@@ -1,0 +1,190 @@
+# Plan: iOS AutoFill — fix blank list (iOS 17+ methods) + matched-only picker with search
+
+## Project context
+- Type: `mixed` — native iOS app; this change is in the AutoFill credential-provider extension and
+  the Shared framework (security-sensitive: it governs which decrypted credential summaries are
+  shown for filling).
+- Test infrastructure: `unit tests only` (PasswdSSOTests; logic-level incl. URLMatchingTests). The
+  `resolveCandidates` filtering/return-shape IS unit-testable with in-memory fakes; the iOS
+  credential-provider method routing is NOT unit-testable (UIKit/ASCredentialProvider internals) and
+  is verified on-device (already done — see Evidence).
+
+## Evidence (on-device, iOS 18/26, confirmed before this plan)
+- iOS calls **`prepareCredentialList(for:requestParameters:)`** (iOS 17+ variant), NOT the legacy
+  `prepareCredentialList(for:)`. The extension only overrode the legacy method → no prepare ran →
+  `viewDidLoad/viewWillAppear/viewDidAppear` fired but the picker was **blank** ("0 candidates").
+  This was misread as a host-matching bug; matching is correct.
+- With a delegating override added, the list populated: `allEntries=417 decryptedSummaries=417`,
+  page `serviceIdentifier raw=https://www.amazon.co.jp/ap/signin?...`, `tabHosts=[amazon.co.jp]`,
+  and the amazon entry `urlHost='www.amazon.co.jp' -> match=true`. Matching works.
+- `resolveCandidates` returns `matched + unmatched` = all 417 entries → the picker shows everything,
+  including empty-host and unrelated entries ("URL mismatch entries also appear").
+- Deployment target is iOS 17.0, so iOS ALWAYS calls the iOS 17+ method variants; the legacy
+  `ASPasswordCredentialIdentity`-based overrides are dead code on every supported device.
+
+## Objective
+1. (#2) Make the credential list actually appear by overriding the iOS 17+ method variants iOS
+   actually calls.
+2. (#3) Show only host-matched entries by default; provide a search field to reach any entry
+   (user-approved policy: matched-only + search; empty when no match, search browses all).
+3. Remove all temporary `AFDIAG` diagnostics and now-dead legacy overrides.
+
+## Requirements
+Functional:
+- Selecting passwd-sso as the AutoFill provider shows host-matched entries (not blank, not all).
+- A search field filters across ALL entries (title / username / urlHost, case-insensitive).
+- Single-credential fill and TOTP fill continue to work via the iOS 17+ methods.
+- No behavior change to crypto/decrypt; only which summaries are surfaced + which iOS methods are
+  implemented.
+
+Non-functional:
+- No `AFDIAG`/diagnostic logging or dead legacy overrides remain in the diff.
+- Matching logic (`isHostMatch`, `extractHost`, `normalizeHost`) is UNCHANGED — it is correct
+  (confirmed on-device). Do not touch URLMatcher.
+
+## Contracts
+
+### C1 — iOS 17+ credential-provider method overrides (locked)
+- `CredentialProviderViewController` overrides, as the real entry points:
+  - `prepareCredentialList(for serviceIdentifiers: [ASCredentialServiceIdentifier], requestParameters: ASPasskeyCredentialRequestParameters)` (iOS 17+) → delegates to the shared password-list presentation.
+  - `provideCredentialWithoutUserInteraction(for credentialRequest: any ASCredentialRequest)` (iOS 17+) → cancel with `userInteractionRequired` (per-fill biometric is mandatory).
+  - `prepareInterfaceToProvideCredential(for credentialRequest: any ASCredentialRequest)` (iOS 17+) → decrypt `credentialRequest.credentialIdentity.recordIdentifier` and complete.
+  - keep `prepareCredentialList(for serviceIdentifiers:)` as the shared implementation (entry point on any iOS that still calls it; called by the requestParameters override).
+  - keep `prepareOneTimeCodeCredentialList(for:)`.
+- Remove the legacy `provideCredentialWithoutUserInteraction(for: ASPasswordCredentialIdentity)` and
+  `prepareInterfaceToProvideCredential(for: ASPasswordCredentialIdentity)` overrides (dead on iOS
+  17.0+ deployment target).
+- Acceptance: on-device, selecting the provider shows the list (already verified with the delegating
+  override); single-credential + TOTP fill complete. Build clean.
+- Forbidden patterns:
+  - `pattern: AFDIAG` — reason: all diagnostic logging must be removed.
+  - `pattern: ASPasswordCredentialIdentity` — reason: the legacy identity-based method overrides are
+    removed; the iOS 17+ ASCredentialRequest path supersedes them (ASPasswordCredential — the fill
+    result type — is still allowed; this forbids the *Identity* override params).
+
+### C2 — resolveCandidates returns matched + all (locked)
+- `CredentialResolver.resolveCandidates(for:)` returns a `CandidateResult` value:
+  - `struct CandidateResult: Sendable { let matched: [VaultEntrySummary]; let all: [VaultEntrySummary] }`
+  - `matched` = host-matched summaries (current `matched` set). `all` = `matched + unmatched`
+    (matched-first ordering preserved, for search display).
+- The matching computation (`isHostMatch` over `tabHosts`) is unchanged; only the return shape and
+  the removal of the `matched + unmatched` flattening at the call boundary.
+- All `AFDIAG` logging in CredentialResolver is removed (and the `#if DEBUG import os` block).
+- **Consumer-flow walkthrough**:
+  - Consumer `CredentialProviderViewController.prepareCredentialList` reads `{ matched, all }` and
+    passes both to `CredentialPickerView` (matched for the default view, all for search).
+  - Consumer `CredentialProviderViewController.prepareOneTimeCodeCredentialList` reads `{ matched, all }`
+    and filters each by `hasTOTP` before passing to `OneTimeCodePickerView`.
+  - No consumer needs a field absent from `CandidateResult`.
+- Acceptance: unit test — given summaries where some host-match and some do not, `matched` contains
+  exactly the matched ones and `all` contains every decrypted summary with matched ones first.
+- Forbidden patterns:
+  - `pattern: return matched + unmatched` — reason: the all-entries flattening is what caused #3.
+
+### C3 — Picker shows matched-only + search across all (locked)
+- `CredentialPickerView`: props become `matched: [VaultEntrySummary]`, `all: [VaultEntrySummary]`
+  (plus existing serviceIdentifiers/onSelect/onCancel). `@State searchText`.
+  - searchText empty → display `matched`. Empty `matched` → empty state "No passwords for this site"
+    (with hint that search browses all).
+  - searchText non-empty → display `all` filtered by case-insensitive contains on title, username,
+    or urlHost. No results → "No matches".
+  - `.searchable(text: $searchText, prompt: "Search all entries")`.
+- `OneTimeCodePickerView`: same `matched`/`all` + search pattern (entries already TOTP-filtered by the
+  controller).
+- App-side confirmation sheet (bundle-ID requests) behavior is preserved.
+- Acceptance: build clean; on-device, default view shows only host matches, typing in search reaches
+  any entry. (Geometry/interaction is manual; the filter predicate is small enough to keep inline.)
+
+### C4 — No regression (locked)
+- `xcodegen generate` + `build-for-testing` + `test-without-building` pass; existing 233 unit + 2 UI
+  tests stay green, plus new CredentialResolver tests (C2). No new warnings (warnings-as-errors).
+
+## Testing strategy
+- Unit: new `CredentialResolverTests` (or extend existing) for C2 — the matched/all split using
+  in-memory `BridgeKeyStore`/`WrappedKeyStore` fakes and a synthesized cache, OR if full resolver
+  setup is too heavy, factor the pure matching/partition step into a testable free function and test
+  that directly (preferred — keeps the test at logic level). URLMatchingTests already cover
+  `isHostMatch`/`extractHost`/`normalizeHost` (unchanged).
+- Picker search predicate: if extracted to a pure function, unit-test it; otherwise manual.
+- On-device method routing (#2): already verified; not unit-testable. Manual re-confirm after cleanup.
+
+## Considerations & constraints
+- **QuickType inline bar still empty (separate gap, OUT of scope)**: no `ASCredentialIdentityStore`
+  registration exists, so the inline keyboard suggestion bar shows nothing — only the manual provider
+  picker is fixed here. Tracked as a follow-up (`TODO(ios-autofill-quicktype)`): register
+  `ASPasswordCredentialIdentity` entries on host-app sync. NOT included now to keep this PR focused on
+  the confirmed blank-list + over-matching fixes. (30-min rule N/A: identity registration is a
+  non-trivial host-app sync change with its own threat-model review.)
+- Removing legacy overrides: safe because deployment target is iOS 17.0 (the new variants are always
+  called). If the reviewer wants belt-and-suspenders, the legacy overrides may be kept as no-op
+  delegators, but default is removal (no dead code).
+- The picker now holds the full decrypted summary set in memory for search — this is unchanged from
+  today (it already received all 417); no new exposure.
+
+## User operation scenarios
+- amazon login field → select passwd-sso → see only the amazon entry (and other amazon matches).
+- A site with no stored entry → empty "No passwords for this site" → type in search → find any entry.
+- TOTP field → see only host-matched entries that have TOTP.
+
+## Round 1 Review Resolutions (triangulate — functionality/security/testing)
+
+- **T1/F1 (High/Major) → FIXED in spec**: changing `resolveCandidates` to return `CandidateResult`
+  source-breaks ~12 existing test call sites (CredentialResolverTests.swift: 459,773-775,806-809,
+  848-850,886-888,940-941,994-995; DebugVaultLoaderTests.swift: 65-67,78-80,130-135,145,151). C4's
+  "stay green" requires MIGRATING them, not leaving them. Decision:
+  1. Extract a **pure free function** `partitionCandidates(_ summaries: [VaultEntrySummary], tabHosts:
+     [String]) -> CandidateResult` in Shared (the matching loop is already pure given summaries +
+     tabHosts). `resolveCandidates` calls it and returns `CandidateResult`.
+  2. Migrate the ~12 existing callers: mechanical `candidates` → `result.all` (semantics identical:
+     `all == matched + unmatched` = old return). EXCEPT the host-filter integration test
+     `testResolveCandidates_filtersByURLHost` (CredentialResolverTests.swift:386-472) which is
+     **rewritten (not just redirected)** to assert BOTH `result.matched.map(\.id) == ["entry-1","entry-2"]`
+     AND `result.all.count == 3 && result.all.last?.id == "entry-3"` (T4).
+- **T2 → FIXED**: new C2 tests run against the pure `partitionCandidates` (no crypto fixtures). Five
+  cases: (1) matched non-empty + matched-first ordering; (2) matched empty → `all == summaries`;
+  (3) ordering stable with ≥2 matched + ≥2 unmatched; (4) empty-`urlHost` entry → matched-EXCLUDED
+  but present in `all` (asserts `isHostMatch("",…)` is not a wildcard); (5) empty `tabHosts` →
+  matched empty, `all == summaries`. One behavioral assertion per test.
+- **T3/F6 → FIXED**: extract a pure shared predicate `summaryMatchesSearch(_ summary:, query:) -> Bool`
+  (case-insensitive OR over title/username/urlHost), used by BOTH pickers (DRY), unit-tested
+  (~5 cases incl. case-insensitivity and urlHost match). Empty/whitespace query → caller shows
+  `matched` (the view branches before calling).
+- **F4 (Major) → FIXED in C3**: replace the single `candidates.isEmpty` branch with a computed
+  `displayed` list and THREE empty states: (a) search empty + matched empty → "No passwords for this
+  site" (+ hint search browses all); (b) search non-empty + filtered empty → "No matches"; (c) has
+  rows. Search-result selection MUST route through the existing `handleSelection` (app-side bundle-ID
+  confirmation-sheet gate) — not a new direct `onSelect`.
+- **F3 (Minor) → FIXED in C1**: `prepareInterfaceToProvideCredential(for: any ASCredentialRequest)`
+  guards request type — only handle password requests; cancel a passkey request explicitly (no
+  wrong-type completion). `credentialRequest.credentialIdentity.recordIdentifier` is valid on the
+  protocol (no force-unwrap; already nil-coalesced).
+- **F2 (Major) → RESOLVED by on-device evidence**: the list override param type
+  `ASPasskeyCredentialRequestParameters` is empirically the variant iOS 18/26 calls (the device log
+  showed `prepareCredentialList(requestParameters) invoked` and the list populated). Keep it; the body
+  ignores the params and delegates to `prepareCredentialList(for:)`. (Expert reasoned from API memory;
+  the device is authoritative.)
+- **F5/T5 (Major) → DOCUMENTED + mitigated**: `hasTOTP` comes from the overview blob and is
+  unreliable (DebugVaultLoaderTests.swift:147-156 documents it as always-false for legacy/fixture
+  overviews). With matched-only, the TOTP picker's matched set can be empty even when host-matched
+  TOTP entries exist. Mitigation: the TOTP picker's SEARCH path filters `all` WITHOUT the `hasTOTP`
+  gate (so a mis-flagged entry is still reachable; `completeTOTPFill` already guards on
+  `detail.totpSecret`). The matched DEFAULT keeps the `hasTOTP` gate (no regression vs today). Full
+  fix (write `hasTOTP` into the overview) is a named follow-up `TODO(ios-autofill-hastotp)`, NOT this
+  PR.
+- **S1 (Low) → FIXED**: remove ALL `AFDIAG` statements AND both `#if DEBUG import os`/`Logger(...)`
+  blocks. The forbidden-pattern grep MUST also cover the lifecycle diagnostics
+  (`viewDidLoad`/`viewWillAppear`/`viewDidAppear`/`prepareInterfaceForExtensionConfiguration`), not
+  only the credential-flow methods. Acceptance: zero `Logger`/`os_log`/`AFDIAG` in
+  `ios/Shared/AutoFill/` and `ios/PasswdSSOAutofillExtension/`. Biometric gate confirmed intact;
+  passwords/TOTP secrets never logged.
+- **Security follow-up note**: when the QuickType `ASCredentialIdentityStore` registration lands
+  (`TODO(ios-autofill-quicktype)`), identities MUST be cleared on vault lock / logout / travel-mode
+  (stale username/URL hints otherwise persist in the system store). Captured for that PR's threat model.
+
+## Go/No-Go Gate
+| ID  | Subject                                              | Status |
+|-----|------------------------------------------------------|--------|
+| C1  | iOS 17+ method overrides (fix blank list)            | locked |
+| C2  | resolveCandidates returns matched + all              | locked |
+| C3  | Picker matched-only + search                         | locked |
+| C4  | No build/test regression                             | locked |

--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		A457C9391F7E1E8164C97A46 /* AutoLockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C68DCFC79DBA6600F27E36 /* AutoLockService.swift */; };
 		A49DCEFF5ABDE722BF33C324 /* SPKIEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FBC66A0BFC38B393757852 /* SPKIEncoder.swift */; };
 		A5FA7118BBC2D9CE7C30901E /* MobileAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7D6EC824EE87139CFBABE4 /* MobileAPIClient.swift */; };
+		AECB0836C18828A74C015D24 /* AutoFillCandidateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C330CB177E3117289263E7F5 /* AutoFillCandidateTests.swift */; };
 		B083185D5D570CC65E2C2624 /* EntryFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B346160EEA436AAF564277 /* EntryFetcher.swift */; };
 		B0974C58F65B8B4CBE7FB084 /* EntryEditForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3E40BD15B72CC7D2465FA1 /* EntryEditForm.swift */; };
 		B324E00C768C3F3B498A0BCA /* AuthCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D844C1C788162BAC9B723269 /* AuthCoordinatorTests.swift */; };
@@ -243,6 +244,7 @@
 		C02778E2A8EE7B7A09B671C4 /* KDF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KDF.swift; sourceTree = "<group>"; };
 		C19D6A107E63BFA725F2C0F3 /* WrappedKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappedKeyStoreTests.swift; sourceTree = "<group>"; };
 		C1F6D6429583F4DF936E38A0 /* SharedFrameworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedFrameworkTests.swift; sourceTree = "<group>"; };
+		C330CB177E3117289263E7F5 /* AutoFillCandidateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFillCandidateTests.swift; sourceTree = "<group>"; };
 		C40C54B860C6D1B296674038 /* LockState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockState.swift; sourceTree = "<group>"; };
 		C579D0D8BCA69B900181743B /* VaultUnlocker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultUnlocker.swift; sourceTree = "<group>"; };
 		C9E896E2CA0264206A65A0B8 /* ServerTrustService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerTrustService.swift; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 				62893F31F539812D3B5BE334 /* AADParityTests.swift */,
 				2DAD672FE74D0EB78FA99F1C /* AESGCMTests.swift */,
 				D844C1C788162BAC9B723269 /* AuthCoordinatorTests.swift */,
+				C330CB177E3117289263E7F5 /* AutoFillCandidateTests.swift */,
 				3E865DC09076361C7278C2FC /* AutoLockServiceTests.swift */,
 				77C0E5B05F04FC285CE89519 /* BackgroundSyncCoordinatorTests.swift */,
 				B19DB7B9B5F953AC7FC8CE8E /* BridgeKeyStoreTests.swift */,
@@ -816,6 +819,7 @@
 				88F5B89748A0E904EFAE7515 /* AADParityTests.swift in Sources */,
 				5421D67E38D403D16E75A584 /* AESGCMTests.swift in Sources */,
 				B324E00C768C3F3B498A0BCA /* AuthCoordinatorTests.swift in Sources */,
+				AECB0836C18828A74C015D24 /* AutoFillCandidateTests.swift in Sources */,
 				8BE8F6E7C0F4C6C96943DC74 /* AutoLockServiceTests.swift in Sources */,
 				6C09DE06209A534D059F5B02 /* BackgroundSyncCoordinatorTests.swift in Sources */,
 				99EB5AFBB9A9C2E9C0818CF6 /* BridgeKeyStoreTests.swift in Sources */,

--- a/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
+++ b/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
@@ -27,8 +27,15 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
   }()
 
   // MARK: - Password fill (Step 8)
+  //
+  // Deployment target is iOS 17.0, so iOS always calls the iOS 17+ method
+  // variants below; the legacy ASPasswordCredentialIdentity-based overrides are
+  // never invoked and are intentionally absent. The requestParameters list
+  // variant is the one iOS 18/26 actually calls — without it the picker was
+  // presented blank (no prepare* ran). It delegates to the shared presentation.
 
-  override func prepareCredentialList(for serviceIdentifiers: [ASCredentialServiceIdentifier]) {
+  /// Shared password-list presentation, called by the iOS 17+ entry point.
+  private func presentCredentialList(for serviceIdentifiers: [ASCredentialServiceIdentifier]) {
     // Convert to Sendable ServiceIdentifier before the actor hop.
     let sendable = serviceIdentifiers.map { ServiceIdentifier(from: $0) }
     let originalIdents = serviceIdentifiers.map {
@@ -36,8 +43,12 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
     }
     Task { @MainActor in
       do {
-        let candidates = try await resolver.resolveCandidates(for: sendable)
-        presentPicker(with: candidates, serviceIdentifiers: originalIdents)
+        let result = try await resolver.resolveCandidates(for: sendable)
+        presentPicker(
+          matched: result.matched,
+          all: result.all,
+          serviceIdentifiers: originalIdents
+        )
       } catch CredentialResolver.Error.vaultLocked {
         presentLockedSheet()
       } catch {
@@ -46,9 +57,33 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
     }
   }
 
-  /// Per plan §"Per-fill biometric": per-fill biometric is required. Always require user interaction.
+  override func prepareCredentialList(for serviceIdentifiers: [ASCredentialServiceIdentifier]) {
+    presentCredentialList(for: serviceIdentifiers)
+  }
+
+  /// iOS 17+ passkey-aware list entry point — the variant iOS 18/26 actually
+  /// invokes. Passkeys are unsupported, so the request parameters are ignored
+  /// and we present the password list.
+  @available(iOS 17.0, *)
+  override func prepareCredentialList(
+    for serviceIdentifiers: [ASCredentialServiceIdentifier],
+    requestParameters: ASPasskeyCredentialRequestParameters
+  ) {
+    presentCredentialList(for: serviceIdentifiers)
+  }
+
+  override func prepareInterfaceForExtensionConfiguration() {
+    // Configuration UI — not needed for credential provider; no-op.
+  }
+
+  // MARK: - Single-credential fill (iOS 17+)
+
+  /// Per-fill biometric is mandatory: never fill silently. Always require user
+  /// interaction so the subsequent prepare-to-provide path runs the biometric
+  /// Keychain read.
+  @available(iOS 17.0, *)
   override func provideCredentialWithoutUserInteraction(
-    for credentialIdentity: ASPasswordCredentialIdentity
+    for credentialRequest: any ASCredentialRequest
   ) {
     extensionContext.cancelRequest(
       withError: NSError(
@@ -59,24 +94,26 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
   }
 
   /// Single-credential path: iOS already knows which credential to provide.
+  @available(iOS 17.0, *)
   override func prepareInterfaceToProvideCredential(
-    for credentialIdentity: ASPasswordCredentialIdentity
+    for credentialRequest: any ASCredentialRequest
   ) {
+    // Only password requests are supported; cancel passkey assertions rather
+    // than completing them with the wrong credential type.
+    guard credentialRequest.type == .password else {
+      cancel(with: nil)
+      return
+    }
+    let recordId = credentialRequest.credentialIdentity.recordIdentifier ?? ""
     Task { @MainActor in
       do {
-        let detail = try await resolver.decryptEntryDetail(
-          entryId: credentialIdentity.recordIdentifier ?? ""
-        )
+        let detail = try await resolver.decryptEntryDetail(entryId: recordId)
         let credential = ASPasswordCredential(user: detail.username, password: detail.password)
         extensionContext.completeRequest(withSelectedCredential: credential)
       } catch {
         cancel(with: error)
       }
     }
-  }
-
-  override func prepareInterfaceForExtensionConfiguration() {
-    // Configuration UI — not needed for credential provider; no-op.
   }
 
   // MARK: - TOTP fill (Step 9, iOS 17+)
@@ -91,9 +128,17 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
     }
     Task { @MainActor in
       do {
-        let candidates = try await resolver.resolveCandidates(for: sendable)
-        let withTOTP = candidates.filter { $0.hasTOTP }
-        presentOneTimeCodePicker(with: withTOTP, serviceIdentifiers: originalIdents)
+        let result = try await resolver.resolveCandidates(for: sendable)
+        // Default view = host-matched entries flagged as having TOTP. Search
+        // spans all entries WITHOUT the hasTOTP gate, because the overview-blob
+        // hasTOTP marker is unreliable for legacy entries (see
+        // TODO(ios-autofill-hastotp)); completeTOTPFill guards on the actual
+        // decrypted secret, so a non-TOTP pick is a safe no-op.
+        presentOneTimeCodePicker(
+          matched: result.matched.filter { $0.hasTOTP },
+          all: result.all,
+          serviceIdentifiers: originalIdents
+        )
       } catch CredentialResolver.Error.vaultLocked {
         presentLockedSheet()
       } catch {
@@ -106,11 +151,13 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
 
   @MainActor
   private func presentPicker(
-    with candidates: [VaultEntrySummary],
+    matched: [VaultEntrySummary],
+    all: [VaultEntrySummary],
     serviceIdentifiers: [ASCredentialServiceIdentifier]
   ) {
     let view = CredentialPickerView(
-      candidates: candidates,
+      matched: matched,
+      all: all,
       serviceIdentifiers: serviceIdentifiers,
       onSelect: { [weak self] summary in
         self?.completePasswordFill(for: summary)
@@ -124,11 +171,13 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
 
   @MainActor
   private func presentOneTimeCodePicker(
-    with candidates: [VaultEntrySummary],
+    matched: [VaultEntrySummary],
+    all: [VaultEntrySummary],
     serviceIdentifiers: [ASCredentialServiceIdentifier]
   ) {
     let view = OneTimeCodePickerView(
-      candidates: candidates,
+      matched: matched,
+      all: all,
       serviceIdentifiers: serviceIdentifiers,
       onSelect: { [weak self] summary in
         self?.completeTOTPFill(for: summary)

--- a/ios/PasswdSSOAutofillExtension/Views/CredentialPickerView.swift
+++ b/ios/PasswdSSOAutofillExtension/Views/CredentialPickerView.swift
@@ -7,12 +7,26 @@ import SwiftUI
 /// Per plan §"App-side AutoFill (resolves S24)": for app-bundle-ID requests (non-URL),
 /// the bundle ID is shown prominently and an extra confirmation tap is required.
 struct CredentialPickerView: View {
-  let candidates: [VaultEntrySummary]
+  /// Host-matched entries, shown by default.
+  let matched: [VaultEntrySummary]
+  /// Every entry (matched first), searched when the search field is non-empty.
+  let all: [VaultEntrySummary]
   let serviceIdentifiers: [ASCredentialServiceIdentifier]
   let onSelect: (VaultEntrySummary) -> Void
   let onCancel: () -> Void
 
   @State private var pendingAppSideSelection: VaultEntrySummary?
+  @State private var searchText: String = ""
+
+  private var isSearching: Bool {
+    !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  /// Default view shows `matched`; an active search filters across `all`.
+  private var displayed: [VaultEntrySummary] {
+    guard isSearching else { return matched }
+    return all.filter { summaryMatchesSearch($0, query: searchText) }
+  }
 
   // The `.app` IdentifierType is iOS 26+ only and isn't present in iOS 18 SDKs.
   // Reference its rawValue (1) instead of the symbol `.app` so this file
@@ -36,7 +50,7 @@ struct CredentialPickerView: View {
   var body: some View {
     NavigationStack {
       Group {
-        if candidates.isEmpty {
+        if displayed.isEmpty {
           emptyView
         } else {
           candidateList
@@ -44,6 +58,7 @@ struct CredentialPickerView: View {
       }
       .navigationTitle("passwd-sso")
       .navigationBarTitleDisplayMode(.inline)
+      .searchable(text: $searchText, prompt: "Search all entries")
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
           Button("Cancel", action: onCancel)
@@ -62,19 +77,24 @@ struct CredentialPickerView: View {
       Image(systemName: "key.slash")
         .font(.system(size: 44))
         .foregroundStyle(.secondary)
-      Text("No matching credentials")
-        .font(.headline)
-      Text("No passwords stored for this site.")
-        .font(.subheadline)
-        .foregroundStyle(.secondary)
-        .multilineTextAlignment(.center)
+      if isSearching {
+        Text("No matches")
+          .font(.headline)
+      } else {
+        Text("No passwords for this site")
+          .font(.headline)
+        Text("Search to browse all entries.")
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+          .multilineTextAlignment(.center)
+      }
     }
     .padding()
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 
   private var candidateList: some View {
-    List(candidates) { summary in
+    List(displayed) { summary in
       Button {
         handleSelection(summary)
       } label: {

--- a/ios/PasswdSSOAutofillExtension/Views/OneTimeCodePickerView.swift
+++ b/ios/PasswdSSOAutofillExtension/Views/OneTimeCodePickerView.swift
@@ -5,15 +5,31 @@ import SwiftUI
 /// Presents a list of vault entries that have TOTP secrets for the user to pick from.
 /// On selection, generates the current TOTP code and returns it via `onSelect`.
 struct OneTimeCodePickerView: View {
-  let candidates: [VaultEntrySummary]
+  /// Host-matched entries flagged with TOTP, shown by default.
+  let matched: [VaultEntrySummary]
+  /// Every entry (matched first); searched without a hasTOTP gate so a
+  /// mis-flagged TOTP entry stays reachable (completeTOTPFill guards on the
+  /// decrypted secret).
+  let all: [VaultEntrySummary]
   let serviceIdentifiers: [ASCredentialServiceIdentifier]
   let onSelect: (VaultEntrySummary) -> Void
   let onCancel: () -> Void
 
+  @State private var searchText: String = ""
+
+  private var isSearching: Bool {
+    !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  private var displayed: [VaultEntrySummary] {
+    guard isSearching else { return matched }
+    return all.filter { summaryMatchesSearch($0, query: searchText) }
+  }
+
   var body: some View {
     NavigationStack {
       Group {
-        if candidates.isEmpty {
+        if displayed.isEmpty {
           emptyView
         } else {
           candidateList
@@ -21,6 +37,7 @@ struct OneTimeCodePickerView: View {
       }
       .navigationTitle("passwd-sso")
       .navigationBarTitleDisplayMode(.inline)
+      .searchable(text: $searchText, prompt: "Search all entries")
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
           Button("Cancel", action: onCancel)
@@ -36,19 +53,24 @@ struct OneTimeCodePickerView: View {
       Image(systemName: "number.circle.fill")
         .font(.system(size: 44))
         .foregroundStyle(.secondary)
-      Text("No matching one-time codes")
-        .font(.headline)
-      Text("No TOTP entries stored for this site.")
-        .font(.subheadline)
-        .foregroundStyle(.secondary)
-        .multilineTextAlignment(.center)
+      if isSearching {
+        Text("No matches")
+          .font(.headline)
+      } else {
+        Text("No one-time codes for this site")
+          .font(.headline)
+        Text("Search to browse all entries.")
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+          .multilineTextAlignment(.center)
+      }
     }
     .padding()
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 
   private var candidateList: some View {
-    List(candidates) { summary in
+    List(displayed) { summary in
       Button {
         onSelect(summary)
       } label: {

--- a/ios/PasswdSSOTests/AutoFillCandidateTests.swift
+++ b/ios/PasswdSSOTests/AutoFillCandidateTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+
+@testable import Shared
+
+/// Unit tests for the pure AutoFill candidate helpers (no crypto/Keychain):
+/// `partitionCandidates` (matched/all split) and `summaryMatchesSearch`.
+final class AutoFillCandidateTests: XCTestCase {
+
+  private func summary(_ id: String, urlHost: String, title: String = "", username: String = "")
+    -> VaultEntrySummary
+  {
+    VaultEntrySummary(id: id, title: title, username: username, urlHost: urlHost)
+  }
+
+  // MARK: - partitionCandidates
+
+  func testPartition_matchedFirstWhenSomeMatch() {
+    let summaries = [
+      summary("a", urlHost: "amazon.co.jp"),
+      summary("b", urlHost: "github.com"),
+      summary("c", urlHost: "www.amazon.co.jp"),
+    ]
+    let result = partitionCandidates(summaries, tabHosts: ["amazon.co.jp"])
+
+    XCTAssertEqual(result.matched.map(\.id), ["a", "c"])
+    XCTAssertEqual(result.all.map(\.id), ["a", "c", "b"], "all is matched-first, unmatched after")
+  }
+
+  func testPartition_noMatchReturnsEmptyMatchedAndFullAll() {
+    let summaries = [summary("a", urlHost: "github.com"), summary("b", urlHost: "gitlab.com")]
+    let result = partitionCandidates(summaries, tabHosts: ["amazon.co.jp"])
+
+    XCTAssertTrue(result.matched.isEmpty)
+    XCTAssertEqual(result.all.map(\.id), ["a", "b"], "all preserves the full input set")
+  }
+
+  func testPartition_preservesRelativeOrderWithinMatchedAndUnmatched() {
+    let summaries = [
+      summary("m1", urlHost: "amazon.co.jp"),
+      summary("u1", urlHost: "github.com"),
+      summary("m2", urlHost: "amazon.co.jp"),
+      summary("u2", urlHost: "gitlab.com"),
+    ]
+    let result = partitionCandidates(summaries, tabHosts: ["amazon.co.jp"])
+
+    XCTAssertEqual(result.all.map(\.id), ["m1", "m2", "u1", "u2"])
+  }
+
+  func testPartition_emptyUrlHostNeverMatchesButStaysInAll() {
+    let summaries = [summary("empty", urlHost: ""), summary("amz", urlHost: "amazon.co.jp")]
+    let result = partitionCandidates(summaries, tabHosts: ["amazon.co.jp"])
+
+    XCTAssertEqual(result.matched.map(\.id), ["amz"], "empty urlHost is not a wildcard match")
+    XCTAssertTrue(result.all.contains { $0.id == "empty" }, "empty-host entry remains searchable")
+  }
+
+  func testPartition_emptyTabHostsMatchesNothing() {
+    let summaries = [summary("a", urlHost: "amazon.co.jp"), summary("b", urlHost: "github.com")]
+    let result = partitionCandidates(summaries, tabHosts: [])
+
+    XCTAssertTrue(result.matched.isEmpty)
+    XCTAssertEqual(result.all.map(\.id), ["a", "b"])
+  }
+
+  // MARK: - summaryMatchesSearch
+
+  func testSearch_matchesTitle() {
+    let s = summary("a", urlHost: "x.com", title: "Amazon", username: "u")
+    XCTAssertTrue(summaryMatchesSearch(s, query: "amaz"))
+  }
+
+  func testSearch_matchesUsername() {
+    let s = summary("a", urlHost: "x.com", title: "T", username: "alice@example.com")
+    XCTAssertTrue(summaryMatchesSearch(s, query: "alice"))
+  }
+
+  func testSearch_matchesUrlHost() {
+    let s = summary("a", urlHost: "amazon.co.jp", title: "T", username: "u")
+    XCTAssertTrue(summaryMatchesSearch(s, query: "amazon.co"))
+  }
+
+  func testSearch_isCaseInsensitive() {
+    let s = summary("a", urlHost: "amazon.co.jp", title: "T", username: "u")
+    XCTAssertTrue(summaryMatchesSearch(s, query: "AMAZON"))
+  }
+
+  func testSearch_emptyQueryReturnsFalse() {
+    let s = summary("a", urlHost: "amazon.co.jp", title: "Amazon", username: "u")
+    XCTAssertFalse(summaryMatchesSearch(s, query: "   "), "blank query → caller shows matched")
+  }
+}

--- a/ios/PasswdSSOTests/CredentialResolverTests.swift
+++ b/ios/PasswdSSOTests/CredentialResolverTests.swift
@@ -456,19 +456,16 @@ final class CredentialResolverTests: XCTestCase {
     )
 
     let ident = ServiceIdentifier(identifier: "https://mail.google.com", isURL: true)
-    let candidates = try await resolver.resolveCandidates(for: [ident])
+    let result = try await resolver.resolveCandidates(for: [ident])
 
-    XCTAssertEqual(candidates.count, 3, "Should return all entries")
-    // Matched entries (entry-1, entry-2) should come first
-    XCTAssertTrue(
-      candidates.prefix(2).map(\.id).contains("entry-1"),
-      "entry-1 (mail.google.com exact) should be in first 2"
+    // matched = host matches only (entry-1 exact, entry-2 subdomain); entry-3 excluded.
+    XCTAssertEqual(
+      Set(result.matched.map(\.id)), ["entry-1", "entry-2"],
+      "matched should be exactly the host-matching entries"
     )
-    XCTAssertTrue(
-      candidates.prefix(2).map(\.id).contains("entry-2"),
-      "entry-2 (google.com subdomain) should be in first 2"
-    )
-    XCTAssertEqual(candidates.last?.id, "entry-3", "Non-matching entry should be last")
+    // all = full set, matched first then unmatched.
+    XCTAssertEqual(result.all.count, 3, "all should contain every entry")
+    XCTAssertEqual(result.all.last?.id, "entry-3", "Non-matching entry should be last in all")
   }
 
   // MARK: - Stale team key filtering
@@ -770,7 +767,7 @@ final class CredentialResolverTests: XCTestCase {
     let resolver = CredentialResolver(
       bridgeKeyStore: bridgeKeyStore, wrappedKeyStore: mockWKS, cacheURL: cacheURL
     )
-    let candidates = try await resolver.resolveCandidates(for: [])
+    let candidates = try await resolver.resolveCandidates(for: []).all
     XCTAssertEqual(candidates.count, 1, "aadVersion=0 entry must decrypt cleanly")
     XCTAssertEqual(candidates[0].id, "p-0")
   }
@@ -803,7 +800,7 @@ final class CredentialResolverTests: XCTestCase {
     let resolver = CredentialResolver(
       bridgeKeyStore: bridgeKeyStore, wrappedKeyStore: mockWKS, cacheURL: cacheURL
     )
-    let candidates = try? await resolver.resolveCandidates(for: [])
+    let candidates = (try? await resolver.resolveCandidates(for: []))?.all
     // The entry is silently filtered (decrypt fails), so candidates is empty or nil
     XCTAssertTrue(
       candidates?.isEmpty != false,
@@ -845,7 +842,7 @@ final class CredentialResolverTests: XCTestCase {
     let resolver = CredentialResolver(
       bridgeKeyStore: bridgeKeyStore, wrappedKeyStore: mockWKS, cacheURL: cacheURL
     )
-    let candidates = try await resolver.resolveCandidates(for: [])
+    let candidates = try await resolver.resolveCandidates(for: []).all
     XCTAssertEqual(candidates.count, 1, "Team entry itemKeyVersion=0 must decrypt with teamKey")
     XCTAssertEqual(candidates[0].id, "te-0")
   }
@@ -883,7 +880,7 @@ final class CredentialResolverTests: XCTestCase {
     let resolver = CredentialResolver(
       bridgeKeyStore: bridgeKeyStore, wrappedKeyStore: mockWKS, cacheURL: cacheURL
     )
-    let candidates = try await resolver.resolveCandidates(for: [])
+    let candidates = try await resolver.resolveCandidates(for: []).all
     XCTAssertEqual(candidates.count, 1, "Team entry itemKeyVersion=1 must unwrap ItemKey")
     XCTAssertEqual(candidates[0].id, "te-1")
   }
@@ -937,7 +934,7 @@ final class CredentialResolverTests: XCTestCase {
     )
     // Entry must be silently filtered; noEntries thrown since cache is non-empty but all fail
     do {
-      let candidates = try await resolver.resolveCandidates(for: [])
+      let candidates = try await resolver.resolveCandidates(for: []).all
       XCTAssertTrue(candidates.isEmpty, "Missing ItemKey must cause entry to be filtered")
     } catch CredentialResolver.Error.noEntries {
       // Also acceptable: resolver surfaces noEntries when all entries are filtered
@@ -991,7 +988,7 @@ final class CredentialResolverTests: XCTestCase {
       bridgeKeyStore: bridgeKeyStore, wrappedKeyStore: mockWKS, cacheURL: cacheURL
     )
     do {
-      let candidates = try await resolver.resolveCandidates(for: [])
+      let candidates = try await resolver.resolveCandidates(for: []).all
       XCTAssertTrue(candidates.isEmpty, "Wrong AAD must cause entry to be filtered")
     } catch CredentialResolver.Error.noEntries {
       // Also acceptable

--- a/ios/PasswdSSOTests/DebugVaultLoaderTests.swift
+++ b/ios/PasswdSSOTests/DebugVaultLoaderTests.swift
@@ -62,7 +62,7 @@ final class DebugVaultLoaderTests: XCTestCase {
       identifier: "https://github.com/login",
       isURL: true
     )
-    let candidates = try await resolver.resolveCandidates(for: [ident])
+    let candidates = try await resolver.resolveCandidates(for: [ident]).all
 
     let githubEntry = candidates.first { $0.urlHost == "github.com" }
     XCTAssertNotNil(githubEntry, "Expected at least one entry with urlHost == 'github.com'")
@@ -75,7 +75,7 @@ final class DebugVaultLoaderTests: XCTestCase {
 
     let resolver = makeResolver()
     let ident = ServiceIdentifier(identifier: "https://github.com/login", isURL: true)
-    let candidates = try await resolver.resolveCandidates(for: [ident])
+    let candidates = try await resolver.resolveCandidates(for: [ident]).all
 
     guard let githubSummary = candidates.first(where: { $0.urlHost == "github.com" }) else {
       XCTFail("No github.com candidate found")
@@ -127,7 +127,7 @@ final class DebugVaultLoaderTests: XCTestCase {
 
     let resolver = makeResolver()
     // Resolve all with no filter
-    let all = try await resolver.resolveCandidates(for: [])
+    let all = try await resolver.resolveCandidates(for: []).all
     XCTAssertEqual(all.count, 3, "Expected exactly 3 fixture entries")
 
     let hosts = Set(all.map(\.urlHost))
@@ -142,7 +142,7 @@ final class DebugVaultLoaderTests: XCTestCase {
     _ = try await loadFixture()
 
     let resolver = makeResolver()
-    let all = try await resolver.resolveCandidates(for: [])
+    let all = try await resolver.resolveCandidates(for: []).all
 
     // The overview blob does not carry TOTP info, so hasTOTP is always false in the summary.
     // TOTP secret is only available after decryptEntryDetail (from the full blob).

--- a/ios/Shared/AutoFill/CredentialResolver.swift
+++ b/ios/Shared/AutoFill/CredentialResolver.swift
@@ -2,6 +2,54 @@ import AuthenticationServices
 import CryptoKit
 import Foundation
 
+// MARK: - Candidate result
+
+/// Result of resolving AutoFill candidates for a set of service identifiers.
+/// `matched` is host-matched entries only (the default picker view); `all` is
+/// every decrypted summary with matched ones first (for the picker's search).
+public struct CandidateResult: Sendable {
+  public let matched: [VaultEntrySummary]
+  public let all: [VaultEntrySummary]
+
+  public init(matched: [VaultEntrySummary], all: [VaultEntrySummary]) {
+    self.matched = matched
+    self.all = all
+  }
+}
+
+/// Partition decrypted summaries into host-matched vs. the full matched-first set.
+/// Pure (no crypto/Keychain) so it is unit-testable in isolation.
+public func partitionCandidates(
+  _ summaries: [VaultEntrySummary],
+  tabHosts: [String]
+) -> CandidateResult {
+  var matched: [VaultEntrySummary] = []
+  var unmatched: [VaultEntrySummary] = []
+  for summary in summaries {
+    let isMatch = tabHosts.contains { host in
+      (!summary.urlHost.isEmpty && isHostMatch(stored: summary.urlHost, current: host))
+        || summary.additionalUrlHosts.contains { isHostMatch(stored: $0, current: host) }
+    }
+    if isMatch {
+      matched.append(summary)
+    } else {
+      unmatched.append(summary)
+    }
+  }
+  return CandidateResult(matched: matched, all: matched + unmatched)
+}
+
+/// Case-insensitive search predicate for the picker search field: matches when
+/// the trimmed query is a substring of the entry's title, username, or urlHost.
+/// An empty/whitespace query returns false (the caller shows `matched` instead).
+public func summaryMatchesSearch(_ summary: VaultEntrySummary, query: String) -> Bool {
+  let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+  guard !q.isEmpty else { return false }
+  return summary.title.lowercased().contains(q)
+    || summary.username.lowercased().contains(q)
+    || summary.urlHost.lowercased().contains(q)
+}
+
 // MARK: - Sendable service identifier
 
 /// Sendable mirror of ASCredentialServiceIdentifier for crossing actor boundaries.
@@ -71,12 +119,12 @@ public actor CredentialResolver {
 
   // MARK: - Public API
 
-  /// Returns matching entry summaries (decrypted overviews) for a given set of service identifiers.
-  /// Performs a SINGLE bridge_key Keychain read (one biometric prompt) per call.
+  /// Returns matched + full entry summaries (decrypted overviews) for a given set of service
+  /// identifiers. Performs a SINGLE bridge_key Keychain read (one biometric prompt) per call.
   /// Vault_key derived from bridge_key is zeroed before this method returns.
   public func resolveCandidates(
     for serviceIdentifiers: [ServiceIdentifier]
-  ) async throws -> [VaultEntrySummary] {
+  ) async throws -> CandidateResult {
     currentBlob = nil
 
     // Single biometric Keychain read.
@@ -188,7 +236,7 @@ public actor CredentialResolver {
       throw Error.noEntries
     }
 
-    // Filter and sort by URL host match.
+    // Extract hosts (URL identifiers → normalized host; bundle IDs → as-is).
     let tabHosts = serviceIdentifiers.compactMap { ident -> String? in
       if ident.isURL {
         return extractHost(ident.identifier)
@@ -197,25 +245,10 @@ public actor CredentialResolver {
       }
     }
 
-    var matched: [VaultEntrySummary] = []
-    var unmatched: [VaultEntrySummary] = []
-
-    for summary in summaries {
-      let isMatch = tabHosts.contains { host in
-        isHostMatch(stored: summary.urlHost, current: host)
-        || summary.additionalUrlHosts.contains { isHostMatch(stored: $0, current: host) }
-      }
-      if isMatch {
-        matched.append(summary)
-      } else {
-        unmatched.append(summary)
-      }
-    }
-
     // Store blob so decryptEntryDetail can reuse it within the same fill without re-prompting.
     currentBlob = blob
 
-    return matched + unmatched
+    return partitionCandidates(summaries, tabHosts: tabHosts)
   }
 
   /// Decrypts one entry's full blob (used after the user picks from the list).


### PR DESCRIPTION
Fixes two device-confirmed AutoFill defects (the original "host matches but 0 candidates" and "URL-mismatch entries also appear").

## 1. Blank credential list (the real "0 candidates")

On an iOS 17.0 deployment target, iOS calls the **iOS 17+ method variants** — `prepareCredentialList(for:requestParameters:)` and the `ASCredentialRequest`-based provide/prepare methods. The extension only overrode the legacy `prepareCredentialList(for:)` / `ASPasswordCredentialIdentity` methods, so when the user selected passwd-sso, iOS presented the view (`viewDidLoad`→`viewDidAppear` all fired) but **never sent a credential request** → blank picker.

On-device logging (since removed) proved the matching was actually correct: page `serviceIdentifier=https://www.amazon.co.jp/...` → `tabHosts=[amazon.co.jp]`, and the amazon entry `urlHost='www.amazon.co.jp' → match=true`. The bug was the missing method override, not matching.

- Override the iOS 17+ variants; the `requestParameters` list delegates to a shared `presentCredentialList`.
- Remove the now-dead legacy `ASPasswordCredentialIdentity` overrides (never called on iOS 17.0+).
- Guard `prepareInterfaceToProvideCredential` to cancel passkey assertions instead of completing them with a password.

## 2. Over-matching (every entry shown)

`resolveCandidates` returned `matched + unmatched` (all ~400 entries). It now returns `CandidateResult { matched, all }` via a pure, unit-tested `partitionCandidates`. The picker shows **host-matched entries by default** and a **search field** (shared `summaryMatchesSearch` over title/username/urlHost) reaches any entry. Empty match → "No passwords for this site"; search browses all. Same for the TOTP picker (search ungated by `hasTOTP` so mis-flagged entries stay reachable).

## Security

Per-fill biometric preserved: `provideCredentialWithoutUserInteraction` still cancels with `userInteractionRequired`; fills go through the biometric-gated `decryptEntryDetail`. All temporary diagnostic logging removed (no urlHost/title/id/password ever logged). Summaries are overview-only — search introduces no new exposure (the full set was already passed to the picker before). Phase-3 security review: no findings.

## Out of scope (tracked)

- `TODO(ios-autofill-quicktype)`: register `ASCredentialIdentityStore` so the inline QuickType suggestion bar populates (must clear identities on lock/logout/travel-mode).
- `TODO(ios-autofill-hastotp)`: write `hasTOTP` into the overview blob (currently unreliable for legacy entries).

## Verification

- `build-for-testing` clean (warnings-as-errors); forbidden-pattern grep clean (no `AFDIAG`, no flat `return matched + unmatched`).
- **243 unit (+10 new `partitionCandidates`/`summaryMatchesSearch`) + 2 UI tests pass.**
- Blank-list fix confirmed on real device (iOS 18/26); the AS* method overrides aren't unit-testable, so #1 rests on that manual verification. Signed device re-confirm after cleanup is a manual follow-up.

Plan + triangulate review (plan + Phase 3): `docs/archive/review/ios-autofill-matching-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)