### PR TITLE
fix(passwords): lost-update-safe history snapshot + v1/api-key consistency

### DIFF
--- a/docs/archive/review/passwords-concurrency-v1-consistency-code-review.md
+++ b/docs/archive/review/passwords-concurrency-v1-consistency-code-review.md
@@ -1,0 +1,28 @@
+# Code Review: passwords-concurrency-v1-consistency
+
+Date: 2026-06-11
+Review round: 2 (cumulative)
+
+## Round 1 (on impl commit d78c8bf7)
+
+- **Functionality F1 [Minor]** the FOR UPDATE snapshot read can return 0 rows if the entry is deleted between the early `existing`/`existingEntry` read and the lock → `cur` undefined → unhandled 500. (No regression — pre-fix the same race hit P2025/500 — but a 500→404 improvement worth making.) → fixed.
+- **Security — No findings.** Verified: `${id}/${passwordId}/${teamId}::uuid` are bound params (no SQLi, no $queryRawUnsafe); the raw SELECT...FOR UPDATE runs under RLS (tenant GUC + FORCE ROW LEVEL SECURITY + all-command policy) so it cannot lock/read another tenant's row; team adds the `team_id` predicate; no lock-wait existence oracle (early 404 gate precedes the lock); snapshot-from-`cur` changes no authz decision (early `existing` stays authoritative for ownership/404); C2 actually enforces tenant IP restriction on the SA path and actorType=SERVICE_ACCOUNT does not bypass enforcement; C2 is correctly scoped to vault/status (v1 passwords routes reject SA tokens outright); C3 Set cannot smuggle an unowned tag; C4 throttle never touches the validity decision and lastUsedAt is display-only.
+- **Testing T1 [Minor / RT3]** api-key.test hardcoded the throttle constant. → fixed. Verified the C1 integration race is real (50 iters, both outcomes observed, content guard {v0,firstWriter}/firstWriter!=v0 by blob value, exactly-2-rows, runs in ~1.3s — not vacuous); unit field-level + SQL-text guards genuine; R19 sibling mocks added without weakening; pre-existing 5 integration failures confirmed unrelated (different files, no causal path).
+
+## Round 2 (on fix commit 44eeaf42)
+
+- **Functionality — No findings.** F1 resolved: `if (!updated) return notFound()` fires ONLY on the blob-path delete-race (metadata path always resolves a truthy row or throws P2025, never falsy); team's `TeamPasswordServiceError(NOT_FOUND,404)` maps to 404 at the route catch; the v1 `beforeEach` mockQueryRaw reset is necessary (restores the default cleared by clearAllMocks call-history) and masks nothing.
+- **Testing — No findings.** T1 resolved (constant imported, no residual hardcode). F1 tests red-able (removing the guard → all 3 fail with the TypeError, never reaching 404). Full suite green (905 files / 11214 tests). Minor note (not a finding): the v1 beforeEach commit comment slightly misstates why the reset is needed, but the line is correct and necessary.
+
+## Resolution Status
+
+### Round 1 — F1, T1 fixed in `44eeaf42` (no skips)
+- F1 [Minor] → 404 not-found guard in all 3 handlers (`if (!cur) return null` + post-check 404 for personal/v1; throw NOT_FOUND/404 for team) + a delete-race unit test per handler (red-verified).
+- T1 [Minor] → `import API_KEY_LAST_USED_THROTTLE_MS` in api-key.test.
+- Security: No findings (Round 1); Round 2 changes are local correctness/test only, no security boundary touched → no re-review needed.
+
+Code review CLOSED after 2 rounds: Round 1 — 1 Functionality + 1 Testing finding (both Minor); Round 2 — all clean. No deferrals.
+
+## Environment Verification Report
+- VE1 (concurrency lock proof, real Postgres): **verified-local** — the lost-update race test ran on the dev Postgres, 50 iterations, both outcomes + content guard held (`npm run test:integration` targeted run, 2/2 pass). Authoritative repeat is the CI integration job on a fresh DB.
+- Other acceptance: verified-local (vitest 11214 green, pre-pr 32/32). The 5 unrelated integration failures are pre-existing shared-dev-DB noise (documented in the deviation log; same set as #530, reproduce on origin/main baseline).

--- a/docs/archive/review/passwords-concurrency-v1-consistency-deviation.md
+++ b/docs/archive/review/passwords-concurrency-v1-consistency-deviation.md
@@ -1,0 +1,13 @@
+# Coding Deviation Log: passwords-concurrency-v1-consistency
+
+## Phase 2 implementation deviations
+
+- C1 implementation agent was interrupted mid-run (user pause); on resume the 3 primary unit files (personal/v1/team) + production + the lost-update integration test were already complete and green (114 unit + 2 integration). The interruption left two SIBLING test files broken by R19 mock-propagation (they exercise the same handlers but their mocks lacked the new `$queryRaw`): `src/app/api/teams/[teamId]/passwords/[id]/route.test.ts` (3) and `src/__tests__/api/passwords/write-scope.test.ts` (2). Fixed by adding `$queryRaw` mocks (R19) — no assertion weakened.
+- C1 db-integration: the lock-semantics proof races `updateTeamPassword` (the only raceable service of the three) per the locked plan; personal/v1 inline-handler SQL is covered by the column-validity check + unit SQL-text guard. Recorded as the plan's deliberate representative choice (avoids over-scoped service extraction for a Low fix).
+- Full `npm run test:integration` shows 5 pre-existing failures (audit-anchor manifest count, audit-sentinel backfill actor, mobile cache-rollback 401s, dcr-cleanup-worker-sweep audit-row count) — identical to the set documented in the #530 deviation log, all reproduce on an origin/main baseline against the same shared dev DB (stale-data / parallel contention), none are this PR's files. Authoritative gate: CI integration job on a fresh DB. This PR's two new integration tests pass in isolation.
+- C3: inlined `[...new Set(tagIds)]` at all 4 personal/v1 sites rather than extracting a shared helper (heterogeneous db-handle + error mapping) — accepted DRY exception per plan SC2.
+- C4: dedicated `API_KEY_LAST_USED_THROTTLE_MS` (not reusing the SA constant); both derive from `MS_PER_MINUTE`.
+
+## Follow-up tracked (NOT this PR)
+
+- Post-#530 hardening review produced 5 items (Redis HA app `REDIS_PASSWORD` explicit env, Sentry span.description/event.transaction scrub, Jackson `REVOKE CONNECT FROM PUBLIC`, DCR per-IP unclaimed cap = SC7, `.env.example` asymmetry). User directed: handle ALL of them in a SEPARATE follow-up PR after this concurrency PR merges.

--- a/docs/archive/review/passwords-concurrency-v1-consistency-plan.md
+++ b/docs/archive/review/passwords-concurrency-v1-consistency-plan.md
@@ -1,0 +1,115 @@
+# Plan: passwords-concurrency-v1-consistency
+
+Branch: `fix/passwords-concurrency-v1-consistency`
+Worktree: `passwd-sso-ord`
+
+## Project context
+
+- Type: web app (Next.js 16 + Prisma 7 + PostgreSQL 16 + RLS).
+- Test infrastructure: unit (vitest, co-located `route.test.ts`, `vi.mock` + `$transaction` mock convention) + real-DB integration (`npm run test:integration`, has a `raceTwoClients` concurrency helper at `src/__tests__/db-integration/helpers.ts:297`) + E2E + CI/CD (`scripts/pre-pr.sh`).
+- Verification environment constraints:
+  - **VE1**: the C1 lost-update guarantee is only observable under genuine concurrency against a real Postgres (mocked `$transaction` cannot exercise row-lock serialization). The authoritative test is a `raceTwoClients` db-integration test; unit tests cover only the call-shape (FOR UPDATE issued, snapshot sourced from the in-tx read).
+
+## Objective
+
+Remediate the 4 follow-up findings from the post-`#530` security review — all **Low** severity, none merge-blocking, all pre-existing (not introduced by `#530`). No Prisma schema migration (C1 uses row-level locking, not a new `version` column; C4's column already exists). No client-facing contract change.
+
+## Requirements
+
+Functional: no change to request/response shapes. C1 makes the password-entry history snapshot + update atomic and lost-update-safe for concurrent PUTs to the same entry. C2 applies the tenant access restriction to the SA-token path of `/api/v1/vault/status`. C3 stops rejecting valid `tagIds` that merely contain duplicates. C4 throttles the API-key `lastUsedAt` write.
+
+Non-functional: C1 must not regress single-PUT latency materially (one extra `SELECT … FOR UPDATE` on a PK row inside an already-open tx); must hold the lock for the minimal span (read → snapshot → update within one tenant-scoped tx).
+
+## Technical approach
+
+No schema change, no migration. C1 consolidates the per-handler transaction boundaries and adds a PK-row `FOR UPDATE` lock as the snapshot source. C2/C3/C4 are localized edits reusing existing helpers/constants/patterns (`enforceAccessRestriction`, team's `Set` dedupe precedent, SA-token throttle precedent).
+
+## Contracts
+
+### C1 — Password-entry history snapshot is atomic and lost-update-safe (personal + v1 + team)
+
+- Files: `src/app/api/passwords/[id]/route.ts` (personal PUT, currently 3 separate `withUserTenantRls` calls at :94 read, :146-172 snapshot, :203-209 update), `src/app/api/v1/passwords/[id]/route.ts` (v1 PUT, existing read at :117-130 separate from the snapshot+update tx at :198-228), `src/lib/services/team-password-service.ts` (`updateTeamPassword`, snapshot+update in one tx at :508-540 but sourcing the snapshot from the caller-supplied `input.existingEntry` read OUTSIDE the tx) + the three corresponding test files + one new db-integration test (personal is sufficient as the representative concurrency proof; team/v1 share the identical mechanism).
+- Root cause (verified, R3 — same class in all THREE handlers): the history snapshot writes blob/IV/authTag/keyVersion/aadVersion read OUTSIDE the snapshot/update transaction (`existing.*` in personal/v1, `input.existingEntry.*` in team). Two concurrent PUTs both read the same committed state, both snapshot the same old blob, last-writer-wins → the intermediate version is absent from history. Personal additionally has a single-thread window (snapshot and update are two distinct transactions).
+- Signature / mechanism — for ALL THREE handlers, when the blob is changing (`encryptedBlob` present / `isFullUpdate`), perform snapshot + update inside ONE tenant-scoped transaction (`withUserTenantRls`/`withTenantRls` already open a tx; team's `prisma.$transaction` is already one — do NOT nest a second `$transaction`):
+  1. Lock + re-read the current row as the snapshot source, using a **parameterized `$queryRaw` tagged template** (NOT `$queryRawUnsafe`; `id`/`passwordId` is an already-validated uuid route param, bound as a parameter — no injection surface):
+     - personal/v1: `` const [cur] = await tx.$queryRaw<Row[]>`SELECT encrypted_blob, blob_iv, blob_auth_tag, key_version, aad_version FROM password_entries WHERE id = ${id}::uuid FOR UPDATE` ``
+     - team: the analogous `SELECT ... FROM team_password_entries WHERE id = ${passwordId}::uuid AND team_id = ${teamId}::uuid FOR UPDATE` (the `team_id` predicate mirrors the existing `update where: { id, teamId }` — defense-in-depth symmetry, F3/S-info) covering team's snapshot columns (encrypted_blob, blob_iv, blob_auth_tag, aad_version, team_key_version, item_key_version, encrypted_item_key, item_key_iv, item_key_auth_tag).
+     - The PK row lock serializes concurrent PUTs to the same entry; the second waits until the first commits, then reads the first's committed blob as ITS snapshot source. RLS GUC is already set by the tenant wrapper; the `id` filter + RLS scope the row. `cur` is the authoritative pre-update state — the early `existing`/`existingEntry` read is retained ONLY for 404/ownership/version-validation, never as the snapshot source.
+  2. `…History.create({ data: { entryId, tenantId, changedById, encryptedBlob: cur.encrypted_blob, … } })` — the CRYPTO-METADATA fields (blob/iv/authTag/keyVersion/aadVersion and team's item-key columns) come from `cur`; the NON-past-state fields stay as before: `tenantId` from `existing`/`existingEntry` (tenant is invariant for an entry), and team's `changedById` = the CURRENT updater `userId` (it records who created this version, not a past actor). Do NOT source `tenantId`/`changedById` from `cur`.
+  3. existing trim-to-20 logic, unchanged, in the same tx.
+  4. `…passwordEntry.update({ where: { id }, data: updateData, … })` — in the same tx; the held lock guarantees no interleaved writer.
+  - The metadata-only path (no blob change) keeps its current single `update` (no snapshot, no lock needed) — unchanged.
+  - Snapshot row-shape parity: each `$queryRaw` SELECT column list MUST cover every PAST-STATE crypto-metadata field that handler's `…History.create` writes — and ONLY those (NOT `tenant_id`/`changed_by_id`, per step 2); map snake_case columns to the create's camelCase fields explicitly (a missing crypto column → a null/undefined snapshot field is a silent data bug).
+- Invariants:
+  - (app-enforced) for any entry (personal/v1/team), a blob-changing PUT records the immediately-preceding committed blob in history, even under concurrent PUTs — no snapshot is lost.
+  - (app-enforced) snapshot and update are atomic (same tx): a crash between them cannot leave a snapshot without its update or vice-versa.
+- Forbidden patterns:
+  - pattern: `encryptedBlob: existing.encryptedBlob` and `encryptedBlob: existingEntry.encryptedBlob` (snapshot sourced from the outside-tx read) — reason: the lost-update root cause.
+  - pattern: `\$queryRawUnsafe` in these handlers — reason: use parameterized tagged templates for the FOR UPDATE read.
+- Acceptance:
+  - Unit (3 test files — personal/v1/team): the tx/prisma mock additionally exposes `$queryRaw` returning the current row (v1's `vi.mock("@/lib/prisma")` factory and personal's `txMock` literal must gain a `$queryRaw` key — they lack it today). Assert: (primary, FIELD-LEVEL per F4) EVERY crypto-metadata field the snapshot writes (blob, iv, authTag, keyVersion, aadVersion, and team's item-key columns) comes from the `$queryRaw` result, by giving the `$queryRaw` mock row values DISTINCT PER FIELD from the early `existing`/`existingEntry` fixture — a payload-level "sourced from $queryRaw" check would miss a regression that leaves only SOME fields as `existing.*`; assert each field individually equals its `cur` value; (SQL-text guard, RT1) capture the `$queryRaw` tagged-template SQL fragments (first arg = `TemplateStringsArray`, precedent `purge-audit-logs/route.test.ts:186`) and assert they contain `FOR UPDATE` and the correct table + crypto column names — mocks cannot validate SQL otherwise; (secondary) `$queryRaw` is invoked before `…History.create`; (negative) metadata-only PUT issues neither `$queryRaw` nor snapshot. Existing snapshot/trim tests stay green.
+  - db-integration — **lock semantics (RT5 primary): race `updateTeamPassword`** (the ONLY one of the three that is a raceable service; personal/v1 snapshot+update are inline in their route handlers and `raceTwoClients` races service/direct-DB callbacks, not HTTP handlers — verified). Structure (per-entry to avoid the trim-to-20 conflict, T5): loop ≥50 iterations; EACH iteration seeds a FRESH team entry with an initial blob `v0`, then `raceTwoClients` runs two concurrent blob-changing `updateTeamPassword(E_i, blob=vA)` and `(E_i, blob=vB)`. After each race assert, for THAT entry (its history has at most 2 rows — far below the 20-row trim, so the trim never fires and "cumulative 2*N" is NOT used): (a) **exactly 2 history rows**; (b) **content guard — the two snapshot blobs are exactly `{v0, firstWriter}`** where `firstWriter ∈ {vA,vB}` and `firstWriter != v0` (this is the direct lost-update detector: if the lock were absent both writers snapshot `v0`, giving history `{v0, v0}` — the `firstWriter != v0` assertion fails); (c) final entry blob = the other of {vA,vB}. ALSO assert across iterations that both "A-wins" and "B-wins" occur (RT4 both-outcomes). Race-setup precondition (T6): both `updateTeamPassword` calls must be PURE blob changes with `teamKeyVersion`/`aadVersion`/`itemKeyVersion` held constant at the seeded entry's values — `updateTeamPassword` rejects a `teamKeyVersion` mismatch with 409 (`:476`) and gates version changes on the (outside-tx) `existingEntry` (`:427-431`); a version bump on either writer would 409 instead of racing. Identify `v0` vs `firstWriter` by BLOB VALUE (not `changedAt`, which is ms-precision and can tie on simultaneous writes). The identical SQL mechanism in personal/v1 (R3) is covered by the unit field-level + SQL-text guards PLUS the column-validity check below.
+  - db-integration — **SQL validity for the inline handlers (closes T2/RT1 for personal+v1)**: a small test that executes the exact personal AND v1 `$queryRaw … FOR UPDATE` SELECT statements against a seeded real `password_entries` row via `createPrismaForRole` + GUC, asserting they run and return the expected columns (catches column-name/`::uuid`-cast typos that the unit mock cannot).
+- Rationale for team as the lock-semantics representative: extracting personal's inline update into a service purely to make it raceable is a larger refactor than this Low-severity fix warrants; team's pre-existing `updateTeamPassword` service exercises the identical FOR-UPDATE-then-snapshot primitive, so it is the authoritative lock proof, while personal/v1's real SQL is validated by the column-validity test and their wiring by the unit SQL-text guard.
+- Consumer-flow walkthrough: the client (web/extension/CLI) reads `{ ..., updatedAt }` from the PUT response and the history list from `GET /history`; no field changes — consumers see the same shapes, only with complete history under contention.
+
+### C2 — v1 vault/status applies tenant access restriction to SA tokens
+
+- Files: `src/app/api/v1/vault/status/route.ts` (+ `route.test.ts`).
+- Signature: replace the `if (userId) { enforceAccessRestriction(req, userId, tenantId) }` gate with an `else` that calls `enforceAccessRestriction(req, SYSTEM_ACTOR_ID, tenantId, ACTOR_TYPE.SERVICE_ACCOUNT)` — exactly the form `src/app/api/tenant/access-requests/route.ts:150-156` uses. Imports: `SYSTEM_ACTOR_ID` from `@/lib/constants/app`, `ACTOR_TYPE` from `@/lib/constants/audit/audit`. (`enforceAccessRestriction`'s 4-arg signature `(req, userId, tenantIdOverride?, actorType?)` already supports this; its sentinel guard at access-restriction.ts:243 fails closed when `tenantIdOverride` is absent — we always pass `tenantId`, so it evaluates the tenant policy, not the fail-closed branch.)
+- Invariants: (app-enforced) every authenticated path of `/api/v1/vault/status` — human and SA — is subject to the tenant's IP/network access restriction; no token type is exempt.
+- Forbidden patterns: none grep-able; enforced by test.
+- Acceptance: unit test — SA token (`userId` null) under a denying `enforceAccessRestriction` mock returns the denial response (not `{ initialized: false }`); SA token under an allowing mock still returns `{ initialized: false, keyVersion: null }`; the human path is unchanged. Assert `enforceAccessRestriction` is called with `SYSTEM_ACTOR_ID` + `ACTOR_TYPE.SERVICE_ACCOUNT` on the SA path.
+
+### C3 — tagIds ownership check dedupes before length comparison
+
+- Files (4 sites, all using `prisma.tag`/`tx.tag` + `userId`): `src/app/api/passwords/[id]/route.ts:134-141`, `src/lib/services/personal-password-service.ts:56-59`, `src/app/api/v1/passwords/route.ts:143-146`, `src/app/api/v1/passwords/[id]/route.ts:152-158` (+ their tests).
+- Signature: in each site, `const uniqueTagIds = [...new Set(tagIds)]`, query `where: { id: { in: uniqueTagIds }, userId }`, compare `ownedCount !== uniqueTagIds.length`. Mirror the team precedent comment at `team-password-service.ts:120-122`. (DRY note: a shared helper is tempting at 4 sites, but they diverge on db-handle — `prisma` vs `tx` vs the service's `db` param — and error mapping — `validationError` vs `{ ok:false, reason }` vs `{ error }`. The 2-line Set normalization is inlined per site to avoid coupling heterogeneous callers; recorded as an accepted DRY exception. If a reviewer prefers extraction, a `dedupeTagIds(tagIds): string[]` pure util is the minimal shared piece.)
+- Invariants: (app-enforced) a PUT/POST with duplicate but owned `tagIds` succeeds; a PUT/POST referencing any non-owned tag still fails. Behavior matches team entries.
+- Forbidden patterns:
+  - pattern: `ownedCount !== tagIds.length` / `count !== tagIds.length` in the 4 personal/v1 sites — reason: raw-length comparison is the false-reject bug.
+- Acceptance: per-site unit test — `tagIds: ["t1","t1"]` where `t1` is owned → success (no `Invalid tagIds`/`INVALID_TAGS`/`TAGS_NOT_OWNED`); `tagIds: ["t1","t2-unowned"]` → still rejected.
+
+### C4 — API-key lastUsedAt write is throttled
+
+- Files: `src/lib/auth/tokens/api-key.ts` (validateApiKey, select at :81-91 + update at :116-122), `src/lib/constants/auth/api-key.ts` (new throttle constant) (+ `api-key.test.ts`).
+- Signature:
+  - `src/lib/constants/auth/api-key.ts`: `export const API_KEY_LAST_USED_THROTTLE_MS = 5 * MS_PER_MINUTE;` (import `MS_PER_MINUTE` from `../time`, mirroring `service-account.ts:1,46`). A dedicated constant — NOT a reuse of `SA_TOKEN_LAST_USED_THROTTLE_MS` — because the two are independent per-token-class policies that may diverge; both derive from `MS_PER_MINUTE` so there is no magic-number duplication (R2 satisfied).
+  - validateApiKey: add `lastUsedAt: true` to the findUnique `select`; wrap the best-effort update in the same throttle the SA token uses (`service-account-token.ts:114-125`): `const shouldUpdate = !key.lastUsedAt || Date.now() - key.lastUsedAt.getTime() > API_KEY_LAST_USED_THROTTLE_MS; if (shouldUpdate) { void withBypassRls(...).catch(()=>{}) }`. Uses `Date.now()` to match the SA-token precedent verbatim (the validator has no injected clock); the unit test drives it with `vi.useFakeTimers`/an injected `lastUsedAt` fixture rather than a time provider.
+- Invariants: (app-enforced) `lastUsedAt` is written at most once per `API_KEY_LAST_USED_THROTTLE_MS` per key; high-frequency v1 API calls do not amplify DB writes. Parity with SA tokens.
+- Forbidden patterns: none grep-able; enforced by test.
+- Acceptance: unit test — recent `lastUsedAt` (within throttle) ⇒ no `apiKey.update`; null or stale `lastUsedAt` ⇒ update issued. Use fake timers or an injected `lastUsedAt` fixture; assert via the `withBypassRls`/update mock call count. (R19: the existing `api-key.test.ts` `findUnique` mocks return rows WITHOUT `lastUsedAt`; once `lastUsedAt` is added to the production `select`, those fixtures must include `lastUsedAt` — a missing value reads as "stale ⇒ always update", silently masking the throttle. Update every `validateApiKey` fixture.)
+
+## Go/No-Go Gate
+
+| ID  | Subject                                                    | Status  |
+|-----|------------------------------------------------------------|---------|
+| C1  | Atomic + lost-update-safe history snapshot (row lock)      | locked  |
+| C2  | v1 vault/status SA-token tenant access restriction         | locked  |
+| C3  | tagIds dedupe before ownership length check (4 sites)      | locked  |
+| C4  | API-key lastUsedAt throttle (parity with SA tokens)        | locked  |
+
+## Testing strategy
+
+- Unit: C1 (both route tests, $queryRaw mock + ordering + source-distinctness), C2 (SA path denial/allow), C3 (4 sites, dup-owned success + unowned reject), C4 (throttle skip/perform).
+- db-integration (`npm run test:integration`, real Postgres): C1 `raceTwoClients` lost-update test (≥50 iters, both-outcomes guard, zero-lost-snapshot assertion). `ci-integration.yml` triggers on `src/app/api/**` + `src/lib/auth/**` — run locally before push.
+- Gates: `npx vitest run`, `npx next build`, `npm run lint`, `scripts/pre-pr.sh` (32 checks), `npm run test:integration`.
+- No `*-manual-test.md` (R35): the diff touches no deployment artifact (no Dockerfile/compose/IaC/auth-flow-config change) — this is application route/lib logic only.
+
+## Considerations & constraints
+
+- No schema migration (C1 row-lock, no `version` column; C4 column pre-exists). `npm run db:migrate` N/A.
+- C1 deliberately avoids a client-supplied optimistic-version contract change (would break extension/CLI/web). Row-level locking achieves lost-update safety server-side with no client change. Trade-off: a `FOR UPDATE` serializes concurrent PUTs to the SAME entry (correct + rare for a personal vault); cross-entry PUTs are unaffected.
+- C3 inlines Set normalization rather than extracting a helper (heterogeneous callers) — recorded DRY exception; reviewers may request a `dedupeTagIds` util.
+
+### Scope contract
+
+- SC1: optimistic concurrency control exposed to clients (sending a base `updatedAt`/ETag and returning 409 on conflict) is OUT of scope — a separate API-contract design PR if ever wanted. C1 solves the data-integrity bug without it.
+- SC2: a shared cross-vault (personal+team) tag-ownership helper unifying `prisma.tag`/`prisma.teamTag` paths is OUT of scope (C3 only fixes the dedupe bug in place).
+
+## User operation scenarios
+
+1. Two browser tabs (or web + extension) save edits to the same entry near-simultaneously → both succeed, history shows both the original and the first-saved version, final state is the last save. (Pre-fix: the first save vanishes from history.)
+2. An off-network SA token hits `/api/v1/vault/status` under a tenant IP restriction → denied (pre-fix: returned `{ initialized: false }`, acting as a validity oracle).
+3. A v1 client sends `tagIds: ["work","work"]` (both owned) → entry saved with the tag (pre-fix: 400 Invalid tagIds).
+4. A high-throughput v1 integration polls entries → API-key `lastUsedAt` updates at most every 5 min instead of every request.

--- a/docs/archive/review/passwords-concurrency-v1-consistency-review.md
+++ b/docs/archive/review/passwords-concurrency-v1-consistency-review.md
@@ -1,0 +1,40 @@
+# Plan Review: passwords-concurrency-v1-consistency
+
+Date: 2026-06-11
+Review round: 2 (cumulative)
+
+## Round 1
+
+Local LLM pre-screen findings dispositioned: team-race ADOPTED (C1 extended to team), SA-throttle-constant-reuse rejected, $queryRaw injection addressed, mock-ordering addressed, Date.now-vs-now() rejected.
+
+### Functionality (F1-F3)
+- **F1/F2 [Minor]** column-parity wording implied `$queryRaw` must cover EVERY `History.create` field, but `tenantId` (invariant) and team's `changedById` (= current updater) are NOT past-state and must NOT come from `cur`. → C1 step-2 + parity note rewritten to source only crypto-metadata from `cur`.
+- **F3 [Minor]** team `FOR UPDATE` should carry `AND team_id` for symmetry with the update where. → added.
+- **R19 [Adjacent→Testing]** existing api-key.test.ts findUnique mocks need `lastUsedAt`. → recorded in C4.
+- Verified-clean by functionality: READ COMMITTED + FOR UPDATE prevents the lost snapshot (second writer re-reads first's committed value after lock release — EvalPlanQual), tenant→tenant tx nesting folds GUC, RLS covers raw SELECT (id+GUC suffices), C2 4-arg form + sentinel guard correct, C3 all 4 sites enumerated + complete, C4 throttle off the auth path.
+
+### Security — No findings
+Confirmed: $queryRaw `${id}::uuid` is a bound param; RLS (`FORCE ROW LEVEL SECURITY` + all-command policy + GUC) covers the raw FOR UPDATE — no explicit tenant predicate needed (cross-tenant rows invisible/unlockable); no lock-wait existence oracle (early 404 gate precedes the lock); C2's `actorType` does NOT branch IP enforcement (audit-field only) so SA gets the same enforcement as humans; sentinel guard doesn't misfire with tenantId passed; C4 throttle never touches the validity decision and `lastUsedAt` is display-only (no anomaly signal); C3 dedupe has no authz angle (Set preserves the unowned tag). S-info: optional team `teamId` predicate on FOR UPDATE (= F3, adopted).
+
+### Testing (T1-T4)
+- **T1 [Critical]** `raceTwoClients` races service/direct-DB callbacks, NOT route handlers; personal's snapshot+update is inline in `handlePUT` (no service) so the personal lock can't be exercised by the race helper — only team's `updateTeamPassword` is a raceable service. → C1 db-integration representative switched to TEAM; personal/v1 real SQL covered by a column-validity integration test + unit SQL-text guard. (Service-extraction for personal rejected as over-scoped for a Low fix.)
+- **T2 [Major]** `$queryRaw` mock can't validate real SQL (RT1); v1's prisma mock lacks `$queryRaw`. → unit tests assert the captured tagged-template SQL text (FOR UPDATE + table + columns); add `$queryRaw` to v1/personal mocks; db-integration column-validity test added; RT5 note that integration is the SQL guard.
+- **T3 [Major]** RT4 guard "both-outcomes + lost-snapshot=0" can pass if contentions never overlap. → strengthened to assert EXACTLY 2 new history rows per iteration (cumulative 2*N) — the necessary condition that the lock serialized the writers.
+- **T4 [Minor]** db-integration should use team as representative. → folded into T1.
+
+## Round 2 (incremental)
+
+Functionality F1/F2/F3 confirmed resolved (column carve-out matches team's actual payload exactly; team FOR UPDATE teamId symmetric). Testing T1/T2/T4 confirmed resolved. New:
+- **F4 [Minor]** unit source-distinctness was payload-level — could miss a partial regression (only some crypto fields left as `existing.*`). → C1 unit assertion strengthened to FIELD-LEVEL (each crypto field individually distinct from `existing`, sourced from `cur`).
+- **T5 [Major]** the "cumulative 2*N history rows" RT4 guard conflicts with trim-to-20 (breaks at iteration 21 once an entry exceeds 20 history rows). → restructured: per-iteration FRESH entry, assert exactly 2 history rows for THAT entry (below trim), PLUS a content guard (the two snapshots = `{v0, firstWriter}`, `firstWriter != v0`) — the direct lost-update detector that a count-only guard misses. Both-outcomes retained.
+- Verified-clean R2: racing team is a valid representative (item-key/key-version logic widens the snapshot payload but does not touch the FOR-UPDATE serialization primitive); `$queryRaw` first-arg is `TemplateStringsArray` so SQL-text assertion is implementable (precedent purge-audit-logs test); column-validity integration feasible via `createPrismaForRole` + GUC.
+
+## Resolution Status (Round 2)
+
+F4, T5 reflected in C1 acceptance (field-level unit assertion + per-entry content-guard race). No skips.
+
+## Round 3 — verification round below.
+
+## Resolution Status (Round 1)
+
+All findings reflected in the plan this round (no skips). Dedup: F3=S-info; R19 routed to C4. Plan sections rewritten: C1 (mechanism step-2, parity note, team FOR UPDATE teamId, acceptance/testing fully reworked for T1-T4), C4 (R19 fixture note).

--- a/src/__tests__/api/passwords/write-scope.test.ts
+++ b/src/__tests__/api/passwords/write-scope.test.ts
@@ -167,16 +167,7 @@ describe("passwords:write scope", () => {
         keyVersion: 1,
         aadVersion: 1,
       });
-      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
-        await fn({
-          passwordEntryHistory: {
-            create: mockHistoryCreate.mockResolvedValue({}),
-            findMany: mockHistoryFindMany.mockResolvedValue([]),
-            deleteMany: mockHistoryDeleteMany.mockResolvedValue({}),
-          },
-        });
-      });
-      mockUpdate.mockResolvedValue({
+      const mockTxUpdate = vi.fn().mockResolvedValue({
         id: "p1",
         encryptedOverview: "1122",
         overviewIv: "3344",
@@ -189,6 +180,25 @@ describe("passwords:write scope", () => {
         tags: [],
         createdAt: new Date(),
         updatedAt: new Date(),
+      });
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+        return fn({
+          $queryRaw: vi.fn().mockResolvedValue([{
+            encrypted_blob: "old",
+            blob_iv: "old",
+            blob_auth_tag: "old",
+            key_version: 1,
+            aad_version: 1,
+          }]),
+          passwordEntryHistory: {
+            create: mockHistoryCreate.mockResolvedValue({}),
+            findMany: mockHistoryFindMany.mockResolvedValue([]),
+            deleteMany: mockHistoryDeleteMany.mockResolvedValue({}),
+          },
+          passwordEntry: {
+            update: mockTxUpdate,
+          },
+        });
       });
 
       const req = createRequest("PUT", "http://localhost/api/passwords/p1", { body: updateBody });
@@ -235,16 +245,7 @@ describe("passwords:write scope", () => {
         keyVersion: 1,
         aadVersion: 1,
       });
-      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
-        await fn({
-          passwordEntryHistory: {
-            create: mockHistoryCreate.mockResolvedValue({}),
-            findMany: mockHistoryFindMany.mockResolvedValue([]),
-            deleteMany: mockHistoryDeleteMany.mockResolvedValue({}),
-          },
-        });
-      });
-      mockUpdate.mockResolvedValue({
+      const mockTxUpdate2 = vi.fn().mockResolvedValue({
         id: "p1",
         encryptedOverview: "1122",
         overviewIv: "3344",
@@ -257,6 +258,25 @@ describe("passwords:write scope", () => {
         tags: [],
         createdAt: new Date(),
         updatedAt: new Date(),
+      });
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+        return fn({
+          $queryRaw: vi.fn().mockResolvedValue([{
+            encrypted_blob: "old",
+            blob_iv: "old",
+            blob_auth_tag: "old",
+            key_version: 1,
+            aad_version: 1,
+          }]),
+          passwordEntryHistory: {
+            create: mockHistoryCreate.mockResolvedValue({}),
+            findMany: mockHistoryFindMany.mockResolvedValue([]),
+            deleteMany: mockHistoryDeleteMany.mockResolvedValue({}),
+          },
+          passwordEntry: {
+            update: mockTxUpdate2,
+          },
+        });
       });
 
       const req = createRequest("PUT", "http://localhost/api/passwords/p1", {

--- a/src/__tests__/db-integration/passwords-history-lost-update.integration.test.ts
+++ b/src/__tests__/db-integration/passwords-history-lost-update.integration.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Integration tests (real DB): C1 — password-entry history snapshot is atomic
+ * and lost-update-safe.
+ *
+ * RT5 (primary): race two updateTeamPassword() calls against the same entry.
+ *   - Each iteration seeds a fresh entry with blob v0, races writers A(vA) and
+ *     B(vB).  After the race asserts:
+ *     (a) exactly 2 history rows for that entry
+ *     (b) the two snapshot blobs are {v0, firstWriter} where firstWriter ∈ {vA,vB}
+ *         and firstWriter != v0 — this is the direct lost-update detector
+ *         (without the lock both writers snapshot v0 → history {v0,v0} and
+ *         the "firstWriter != v0" assertion fails)
+ *     (c) final entry blob = the other writer's blob
+ *   - Across ≥50 iterations asserts both A-wins and B-wins occur (RT4).
+ *
+ * SQL column validity (T2/RT1 for personal + v1 inline handlers):
+ *   - Executes the exact personal / v1 SELECT … FOR UPDATE SQL against a seeded
+ *     password_entries row and asserts the 5 expected columns are returned.
+ *     Catches column-name / ::uuid-cast typos that unit mocks cannot.
+ *
+ * Run: docker compose up -d db && npm run test:integration -- passwords-history-lost-update
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { randomUUID, randomBytes } from "node:crypto";
+import {
+  createTestContext,
+  setBypassRlsGucs,
+  createPrismaForRole,
+  type TestContext,
+} from "./helpers";
+import { updateTeamPassword } from "@/lib/services/team-password-service";
+import { withTeamTenantRls } from "@/lib/tenant-context";
+
+// ─── Skip guard ──────────────────────────────────────────────────────────────
+const SKIP = !process.env.DATABASE_URL;
+
+// ─── Test context ─────────────────────────────────────────────────────────────
+
+describe("C1: password-entry history lost-update safety — integration", () => {
+  let ctx: TestContext;
+  let tenantId: string;
+  let userId: string;
+  let teamId: string;
+
+  beforeAll(async () => {
+    if (SKIP) return;
+    ctx = await createTestContext();
+  });
+
+  afterAll(async () => {
+    if (SKIP) return;
+    await ctx.cleanup();
+  });
+
+  beforeEach(async () => {
+    if (SKIP) return;
+    tenantId = await ctx.createTenant();
+    userId = await ctx.createUser(tenantId);
+    // Create a team with team_key_version=1 (schema default)
+    teamId = randomUUID();
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO teams (id, tenant_id, name, slug, team_key_version, created_at, updated_at)
+         VALUES ($1::uuid, $2::uuid, $3, $4, 1, now(), now())`,
+        teamId,
+        tenantId,
+        `test-team-${teamId.slice(0, 8)}`,
+        `team-${teamId.slice(0, 8)}`,
+      );
+    });
+    // Add the user as a team member so RLS passes the team membership check
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO team_members (id, team_id, tenant_id, user_id, role, created_at, updated_at)
+         VALUES ($1::uuid, $2::uuid, $3::uuid, $4::uuid, 'ADMIN', now(), now())`,
+        randomUUID(),
+        teamId,
+        tenantId,
+        userId,
+      );
+    });
+  });
+
+  afterEach(async () => {
+    if (SKIP) return;
+    await ctx.deleteTestData(tenantId);
+  });
+
+  // ─── Seed helper ─────────────────────────────────────────────────────────────
+
+  async function seedTeamEntry(blob: string): Promise<string> {
+    const id = randomUUID();
+    const iv = randomBytes(12).toString("hex");
+    const tag = randomBytes(16).toString("hex");
+    const placeholder = "placeholder";
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO team_password_entries (
+           id, team_id, tenant_id, created_by_id, updated_by_id,
+           encrypted_blob, blob_iv, blob_auth_tag,
+           encrypted_overview, overview_iv, overview_auth_tag,
+           team_key_version, aad_version, item_key_version, entry_type,
+           created_at, updated_at
+         ) VALUES (
+           $1::uuid, $2::uuid, $3::uuid, $4::uuid, $4::uuid,
+           $5, $6, $7,
+           $8, $9, $10,
+           1, 1, 0, 'LOGIN'::"EntryType", now(), now()
+         )`,
+        id, teamId, tenantId, userId,
+        blob, iv, tag,
+        placeholder, iv, tag,
+      );
+    });
+    return id;
+  }
+
+  // Fetch history rows for a team entry (order by changedAt asc)
+  async function fetchHistory(entryId: string): Promise<{ encrypted_blob: string }[]> {
+    const rows = await ctx.su.pool.query<{ encrypted_blob: string }>(
+      `SELECT encrypted_blob FROM team_password_entry_histories
+       WHERE entry_id = $1::uuid
+       ORDER BY changed_at ASC`,
+      [entryId],
+    );
+    return rows.rows;
+  }
+
+  // Fetch the current blob of a team entry
+  async function fetchEntryBlob(entryId: string): Promise<string> {
+    const row = await ctx.su.pool.query<{ encrypted_blob: string }>(
+      `SELECT encrypted_blob FROM team_password_entries WHERE id = $1::uuid`,
+      [entryId],
+    );
+    return row.rows[0].encrypted_blob;
+  }
+
+  // Wrap updateTeamPassword in the required withTeamTenantRls context
+  function callUpdateTeamPassword(
+    entryId: string,
+    blob: string,
+    existingBlobSnapshot: string,
+  ) {
+    const iv = randomBytes(12).toString("hex");
+    const tag = randomBytes(16).toString("hex");
+    return withTeamTenantRls(teamId, () =>
+      updateTeamPassword(teamId, entryId, {
+        encryptedBlob: { ciphertext: blob, iv, authTag: tag },
+        encryptedOverview: { ciphertext: "overview", iv, authTag: tag },
+        aadVersion: 1,
+        teamKeyVersion: 1,
+        itemKeyVersion: 0,
+        userId,
+        existingEntry: {
+          tenantId,
+          encryptedBlob: existingBlobSnapshot,
+          blobIv: "placeholder",
+          blobAuthTag: "placeholder",
+          aadVersion: 1,
+          teamKeyVersion: 1,
+          itemKeyVersion: 0,
+          encryptedItemKey: null,
+          itemKeyIv: null,
+          itemKeyAuthTag: null,
+        },
+      }),
+    );
+  }
+
+  // ─── RT5: lock semantics race ─────────────────────────────────────────────
+
+  it.skipIf(SKIP)(
+    "RT5: race updateTeamPassword × 50 iters — no snapshot is lost; both-outcomes occur",
+    async () => {
+      const ITERS = 50;
+      let aWins = 0;
+      let bWins = 0;
+
+      // Pre-warm the global prisma pool with two simultaneous connections so
+      // subsequent races do not pay connection-setup latency (mirrors raceTwoClients).
+      const { prisma: warmPrisma, pool: warmPool } = createPrismaForRole("app");
+      try {
+        await Promise.all([
+          warmPrisma.$executeRaw`SELECT 1`,
+          warmPrisma.$executeRaw`SELECT 1`,
+        ]);
+      } finally {
+        await warmPrisma.$disconnect().then(() => warmPool.end());
+      }
+
+      for (let i = 0; i < ITERS; i++) {
+        // Per-iter unique blobs so cross-iter ambiguity is impossible
+        const v0 = `v0-iter${i}-${randomBytes(4).toString("hex")}`;
+        const vA = `vA-iter${i}-${randomBytes(4).toString("hex")}`;
+        const vB = `vB-iter${i}-${randomBytes(4).toString("hex")}`;
+
+        const entryId = await seedTeamEntry(v0);
+
+        // Race A and B concurrently against the same entry.
+        // updateTeamPassword uses the global prisma pool; two concurrent calls
+        // acquire different connections and serialise at the FOR UPDATE row lock.
+        await Promise.all([
+          callUpdateTeamPassword(entryId, vA, v0),
+          callUpdateTeamPassword(entryId, vB, v0),
+        ]);
+
+        // (a) exactly 2 history rows
+        const hist = await fetchHistory(entryId);
+        expect(hist).toHaveLength(2);
+
+        // (b) content guard: snapshot blobs must be {v0, firstWriter}
+        const blobs = new Set(hist.map((r) => r.encrypted_blob));
+        expect(blobs.has(v0)).toBe(true);
+        const firstWriter = hist.find((r) => r.encrypted_blob !== v0)?.encrypted_blob;
+        expect(firstWriter).toBeDefined();
+        expect(firstWriter).not.toBe(v0);
+        expect([vA, vB]).toContain(firstWriter);
+
+        // (c) final entry blob = the other writer
+        const finalBlob = await fetchEntryBlob(entryId);
+        const other = firstWriter === vA ? vB : vA;
+        expect(finalBlob).toBe(other);
+
+        // Track winner for RT4 both-outcomes check
+        if (firstWriter === vA) bWins++;
+        else aWins++;
+      }
+
+      // RT4: both outcomes must occur across 50 iters
+      expect(aWins).toBeGreaterThan(0);
+      expect(bWins).toBeGreaterThan(0);
+    },
+    // Generous timeout: 50 iters × real DB round-trips
+    60_000,
+  );
+
+  // ─── SQL column validity (T2/RT1 for personal + v1 inline handlers) ────────
+
+  it.skipIf(SKIP)(
+    "SQL validity: personal/v1 SELECT … FOR UPDATE returns the 5 expected columns",
+    async () => {
+      // Seed a real password_entries row (personal vault)
+      const entryId = randomUUID();
+      const expectedBlob = `col-check-blob-${randomBytes(4).toString("hex")}`;
+      const iv = randomBytes(12).toString("hex");
+      const tag = randomBytes(16).toString("hex");
+
+      await ctx.su.prisma.$transaction(async (tx) => {
+        await setBypassRlsGucs(tx);
+        await tx.$executeRawUnsafe(
+          `INSERT INTO password_entries (
+             id, user_id, tenant_id,
+             encrypted_blob, blob_iv, blob_auth_tag,
+             encrypted_overview, overview_iv, overview_auth_tag,
+             key_version, aad_version,
+             created_at, updated_at
+           ) VALUES (
+             $1::uuid, $2::uuid, $3::uuid,
+             $4, $5, $6,
+             $7, $8, $9,
+             3, 2, now(), now()
+           )`,
+          entryId, userId, tenantId,
+          expectedBlob, iv, tag,
+          "overview-placeholder", iv, tag,
+        );
+      });
+
+      // Run the exact personal / v1 FOR UPDATE query using the app role with RLS GUC set.
+      // This validates column names and ::uuid cast — typos that unit mocks cannot catch.
+      const { prisma: appPrisma, pool: appPool } = createPrismaForRole("app");
+      try {
+        type PersonalBlobRow = {
+          encrypted_blob: string;
+          blob_iv: string;
+          blob_auth_tag: string;
+          key_version: number;
+          aad_version: number;
+        };
+
+        const rows = await appPrisma.$transaction(async (tx) => {
+          await tx.$executeRaw`SELECT set_config('app.tenant_id', ${tenantId}, true)`;
+          return tx.$queryRaw<PersonalBlobRow[]>`
+            SELECT encrypted_blob, blob_iv, blob_auth_tag, key_version, aad_version
+            FROM password_entries
+            WHERE id = ${entryId}::uuid
+            FOR UPDATE
+          `;
+        });
+
+        expect(rows).toHaveLength(1);
+        const row = rows[0];
+        // Verify all 5 columns are present with correct values
+        expect(row.encrypted_blob).toBe(expectedBlob);
+        expect(row.blob_iv).toBe(iv);
+        expect(row.blob_auth_tag).toBe(tag);
+        expect(row.key_version).toBe(3);
+        expect(row.aad_version).toBe(2);
+      } finally {
+        await appPrisma.$disconnect().then(() => appPool.end());
+      }
+    },
+  );
+});

--- a/src/app/api/passwords/[id]/route.test.ts
+++ b/src/app/api/passwords/[id]/route.test.ts
@@ -268,11 +268,25 @@ describe("GET /api/passwords/[id]", () => {
 });
 
 describe("PUT /api/passwords/[id]", () => {
+  // cur row returned by $queryRaw FOR UPDATE — values are DISTINCT from ownedEntry
+  // so field-level assertions can detect if the handler reads from `existing` instead.
+  const curRow = {
+    encrypted_blob: "cur-blob-cipher",
+    blob_iv: "cur-blob-iv",
+    blob_auth_tag: "cur-blob-tag",
+    key_version: 2,
+    aad_version: 3,
+  };
+
   const txMock = {
+    $queryRaw: vi.fn().mockResolvedValue([curRow]),
     passwordEntryHistory: {
       create: vi.fn().mockResolvedValue({}),
       findMany: vi.fn().mockResolvedValue([]),
       deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    passwordEntry: {
+      update: vi.fn(),
     },
   };
 
@@ -284,6 +298,21 @@ describe("PUT /api/passwords/[id]", () => {
     mockPrismaFolder.findFirst.mockResolvedValue({ id: "folder-1" });
     mockPrismaTag.count.mockResolvedValue(1);
     mockAuditCreate.mockResolvedValue({});
+    txMock.$queryRaw.mockResolvedValue([curRow]);
+    txMock.passwordEntryHistory.create.mockResolvedValue({});
+    txMock.passwordEntryHistory.findMany.mockResolvedValue([]);
+    txMock.passwordEntryHistory.deleteMany.mockResolvedValue({ count: 0 });
+    txMock.passwordEntry.update.mockResolvedValue({
+      id: PW_ID,
+      encryptedOverview: "new-over",
+      overviewIv: "c".repeat(24),
+      overviewAuthTag: "d".repeat(32),
+      keyVersion: 1,
+      aadVersion: 0,
+      tags: [],
+      createdAt: now,
+      updatedAt: now,
+    });
     mockPrismaTransaction.mockImplementation(async (fn: (tx: typeof txMock) => Promise<unknown>) => fn(txMock));
   });
 
@@ -331,16 +360,7 @@ describe("PUT /api/passwords/[id]", () => {
 
   it("updates password entry successfully", async () => {
     mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
-    mockPrismaPasswordEntry.update.mockResolvedValue({
-      id: PW_ID,
-      encryptedOverview: "new-over",
-      overviewIv: "c".repeat(24),
-      overviewAuthTag: "d".repeat(32),
-      keyVersion: 1,
-      tags: [],
-      createdAt: now,
-      updatedAt: now,
-    });
+    // blob-changing path: result comes from txMock.passwordEntry.update (already configured in beforeEach)
 
     const res = await PUT(
       createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, { body: updateBody }),
@@ -396,9 +416,52 @@ describe("PUT /api/passwords/[id]", () => {
     expect(res.status).toBe(400);
   });
 
+  it("C3: succeeds when tagIds contain duplicates but are all owned (count mock returns 1 for [t1,t1])", async () => {
+    // tag.count returns distinct row count; t1 is owned once → count=1.
+    // Before the fix, ownedCount(1) !== tagIds.length(2) → 400.
+    // After the fix, ownedCount(1) !== uniqueTagIds.length(1) → success.
+    const ownedTagId = "00000000-0000-4000-a000-000000000001";
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+    mockPrismaTag.count.mockResolvedValue(1);
+    // metadata-only path (no blob): update goes through mockPrismaPasswordEntry.update
+    mockPrismaPasswordEntry.update.mockResolvedValue({
+      id: PW_ID,
+      encryptedOverview: "overview-cipher",
+      overviewIv: "overview-iv",
+      overviewAuthTag: "overview-tag",
+      keyVersion: 1,
+      tags: [{ id: ownedTagId }],
+      createdAt: now,
+      updatedAt: now,
+    });
+    const res = await PUT(
+      createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, {
+        body: { tagIds: [ownedTagId, ownedTagId] },
+      }),
+      createParams({ id: PW_ID }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("C3: still rejects when tagIds reference an unowned tag", async () => {
+    // t1 owned, t2-unowned → count=1 but uniqueTagIds.length=2 → 400
+    const ownedTagId = "00000000-0000-4000-a000-000000000001";
+    const unownedTagId = "00000000-0000-4000-a000-000000000002";
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+    mockPrismaTag.count.mockResolvedValue(1);
+    const res = await PUT(
+      createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, {
+        body: { tagIds: [ownedTagId, unownedTagId] },
+      }),
+      createParams({ id: PW_ID }),
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("stores aadVersion when provided in update body", async () => {
     mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
-    mockPrismaPasswordEntry.update.mockResolvedValue({
+    // blob-changing path: update goes through txMock.passwordEntry.update
+    txMock.passwordEntry.update.mockResolvedValue({
       id: PW_ID,
       encryptedOverview: "new-over",
       overviewIv: "c".repeat(24),
@@ -419,7 +482,7 @@ describe("PUT /api/passwords/[id]", () => {
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.aadVersion).toBe(1);
-    expect(mockPrismaPasswordEntry.update).toHaveBeenCalledWith(
+    expect(txMock.passwordEntry.update).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ aadVersion: 1 }),
       }),
@@ -539,16 +602,6 @@ describe("PUT /api/passwords/[id]", () => {
 
   it("creates history snapshot when encryptedBlob is updated", async () => {
     mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
-    mockPrismaPasswordEntry.update.mockResolvedValue({
-      id: PW_ID,
-      encryptedOverview: "new-over",
-      overviewIv: "c".repeat(24),
-      overviewAuthTag: "d".repeat(32),
-      keyVersion: 1,
-      tags: [],
-      createdAt: now,
-      updatedAt: now,
-    });
 
     const updateBodyWithBlob = {
       encryptedBlob: { ciphertext: "new-blob", iv: "a".repeat(24), authTag: "b".repeat(32) },
@@ -561,14 +614,18 @@ describe("PUT /api/passwords/[id]", () => {
       createParams({ id: PW_ID }),
     );
 
-    // Should have called $transaction to create history snapshot
+    // $transaction and $queryRaw FOR UPDATE must be called
     expect(mockPrismaTransaction).toHaveBeenCalled();
+    expect(txMock.$queryRaw).toHaveBeenCalled();
+    // Snapshot fields must come from curRow (the FOR UPDATE result), NOT from ownedEntry
     expect(txMock.passwordEntryHistory.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         entryId: PW_ID,
-        encryptedBlob: ownedEntry.encryptedBlob,
-        blobIv: ownedEntry.blobIv,
-        blobAuthTag: ownedEntry.blobAuthTag,
+        encryptedBlob: curRow.encrypted_blob,
+        blobIv: curRow.blob_iv,
+        blobAuthTag: curRow.blob_auth_tag,
+        keyVersion: curRow.key_version,
+        aadVersion: curRow.aad_version,
       }),
     });
   });
@@ -578,16 +635,7 @@ describe("PUT /api/passwords/[id]", () => {
     txMock.passwordEntryHistory.findMany.mockResolvedValue(
       Array.from({ length: 21 }, (_, index) => ({ id: `hist-${index}` })),
     );
-    mockPrismaPasswordEntry.update.mockResolvedValue({
-      id: PW_ID,
-      encryptedOverview: "new-over",
-      overviewIv: "c".repeat(24),
-      overviewAuthTag: "d".repeat(32),
-      keyVersion: 1,
-      tags: [],
-      createdAt: now,
-      updatedAt: now,
-    });
+    // blob-changing path: update goes through txMock.passwordEntry.update
 
     await PUT(
       createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, { body: updateBody }),
@@ -603,6 +651,7 @@ describe("PUT /api/passwords/[id]", () => {
     mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
     mockPrismaTag.count.mockResolvedValue(2);
     const tagIds = ["00000000-0000-4000-a000-000000000001", "00000000-0000-4000-a000-000000000002"];
+    // metadata-only path (no encryptedBlob): update goes through mockPrismaPasswordEntry.update
     mockPrismaPasswordEntry.update.mockResolvedValue({
       id: PW_ID,
       encryptedOverview: "overview-cipher",
@@ -709,6 +758,95 @@ describe("PUT /api/passwords/[id]", () => {
       createParams({ id: PW_ID }),
     );
     expect(res.status).toBe(200);
+  });
+
+  // C1: FOR UPDATE snapshot source and SQL text guard
+  it("C1: $queryRaw is called before History.create on blob-changing PUT", async () => {
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+    const callOrder: string[] = [];
+    txMock.$queryRaw.mockImplementation(() => {
+      callOrder.push("$queryRaw");
+      return Promise.resolve([curRow]);
+    });
+    txMock.passwordEntryHistory.create.mockImplementation(() => {
+      callOrder.push("historyCreate");
+      return Promise.resolve({});
+    });
+
+    await PUT(
+      createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, { body: updateBody }),
+      createParams({ id: PW_ID }),
+    );
+
+    expect(callOrder.indexOf("$queryRaw")).toBeLessThan(callOrder.indexOf("historyCreate"));
+  });
+
+  it("C1: FOR UPDATE SQL contains table name and required crypto columns", async () => {
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+
+    await PUT(
+      createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, { body: updateBody }),
+      createParams({ id: PW_ID }),
+    );
+
+    expect(txMock.$queryRaw).toHaveBeenCalled();
+    // Extract the TemplateStringsArray (first arg) and join its static parts
+    const [tpl] = txMock.$queryRaw.mock.calls[0] as [TemplateStringsArray, ...unknown[]];
+    const sql = tpl.join("?");
+    expect(sql).toMatch(/FOR UPDATE/i);
+    expect(sql).toMatch(/password_entries/i);
+    expect(sql).toMatch(/encrypted_blob/i);
+    expect(sql).toMatch(/blob_iv/i);
+    expect(sql).toMatch(/blob_auth_tag/i);
+    expect(sql).toMatch(/key_version/i);
+    expect(sql).toMatch(/aad_version/i);
+  });
+
+  it("C1: all 5 crypto fields in History.create come from $queryRaw result, not from existing", async () => {
+    // curRow values are intentionally distinct from ownedEntry values
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+
+    await PUT(
+      createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, { body: updateBody }),
+      createParams({ id: PW_ID }),
+    );
+
+    const histData = txMock.passwordEntryHistory.create.mock.calls[0][0].data;
+    // Each field must equal curRow value (not ownedEntry value)
+    expect(histData.encryptedBlob).toBe(curRow.encrypted_blob);
+    expect(histData.blobIv).toBe(curRow.blob_iv);
+    expect(histData.blobAuthTag).toBe(curRow.blob_auth_tag);
+    expect(histData.keyVersion).toBe(curRow.key_version);
+    expect(histData.aadVersion).toBe(curRow.aad_version);
+    // Distinct-from-ownedEntry sanity check
+    expect(histData.encryptedBlob).not.toBe(ownedEntry.encryptedBlob);
+    expect(histData.blobIv).not.toBe(ownedEntry.blobIv);
+    expect(histData.keyVersion).not.toBe(ownedEntry.keyVersion);
+  });
+
+  it("C1: metadata-only PUT issues no $queryRaw and no History.create", async () => {
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+    mockPrismaPasswordEntry.update.mockResolvedValue({
+      id: PW_ID,
+      encryptedOverview: "overview-cipher",
+      overviewIv: "overview-iv",
+      overviewAuthTag: "overview-tag",
+      keyVersion: 1,
+      tags: [],
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await PUT(
+      createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, {
+        body: { isFavorite: true },
+      }),
+      createParams({ id: PW_ID }),
+    );
+
+    expect(txMock.$queryRaw).not.toHaveBeenCalled();
+    expect(txMock.passwordEntryHistory.create).not.toHaveBeenCalled();
+    expect(mockPrismaTransaction).not.toHaveBeenCalled();
   });
 });
 

--- a/src/app/api/passwords/[id]/route.test.ts
+++ b/src/app/api/passwords/[id]/route.test.ts
@@ -824,6 +824,21 @@ describe("PUT /api/passwords/[id]", () => {
     expect(histData.keyVersion).not.toBe(ownedEntry.keyVersion);
   });
 
+  // F1: race — entry deleted between early read and FOR UPDATE lock
+  it("F1: returns 404 when $queryRaw FOR UPDATE returns empty (concurrent delete)", async () => {
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+    txMock.$queryRaw.mockResolvedValue([]); // row gone by the time the lock fires
+
+    const res = await PUT(
+      createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, { body: updateBody }),
+      createParams({ id: PW_ID }),
+    );
+
+    expect(res.status).toBe(404);
+    // update must NOT have been called — the handler must abort before writing
+    expect(txMock.passwordEntry.update).not.toHaveBeenCalled();
+  });
+
   it("C1: metadata-only PUT issues no $queryRaw and no History.create", async () => {
     mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
     mockPrismaPasswordEntry.update.mockResolvedValue({

--- a/src/app/api/passwords/[id]/route.ts
+++ b/src/app/api/passwords/[id]/route.ts
@@ -198,6 +198,8 @@ async function handlePUT(
             WHERE id = ${id}::uuid
             FOR UPDATE
           `;
+          // Entry may be concurrently deleted between the early read and this lock.
+          if (!cur) return null;
           // Snapshot the current committed blob into history
           await tx.passwordEntryHistory.create({
             data: {
@@ -235,6 +237,10 @@ async function handlePUT(
           include: { tags: { select: { id: true } } },
         }),
       ));
+
+  // Null sentinel: the blob-tx path returns null when the entry was concurrently
+  // deleted between the early findUnique and the FOR UPDATE lock.
+  if (!updated) return notFound();
 
   await logAuditAsync({
     ...personalAuditBase(req, userId),

--- a/src/app/api/passwords/[id]/route.ts
+++ b/src/app/api/passwords/[id]/route.ts
@@ -130,47 +130,23 @@ async function handlePUT(
     }
   }
 
-  // Verify tag ownership
+  // Verify tag ownership. Normalize duplicates first: a caller-supplied
+  // duplicate (e.g. ["t1","t1"]) should not count as a missing tag —
+  // tag.count returns distinct row count, so compare against the deduped
+  // input length, not the raw array length. Mirrors team-password-service.ts.
   if (tagIds?.length) {
+    const uniqueTagIds = [...new Set(tagIds)];
     const ownedCount = await withUserTenantRls(userId, async () =>
-      prisma.tag.count({ where: { id: { in: tagIds }, userId } }),
+      prisma.tag.count({ where: { id: { in: uniqueTagIds }, userId } }),
     );
-    if (ownedCount !== tagIds.length) {
+    if (ownedCount !== uniqueTagIds.length) {
       return validationError({ message: "Invalid tagIds" });
     }
   }
 
   const updateData: Record<string, unknown> = {};
 
-  // If encryptedBlob is changing, snapshot the current version to history
   if (encryptedBlob) {
-    await withUserTenantRls(userId, async () =>
-      prisma.$transaction(async (tx) => {
-      await tx.passwordEntryHistory.create({
-        data: {
-          entryId: id,
-          tenantId: existing.tenantId,
-          encryptedBlob: existing.encryptedBlob,
-          blobIv: existing.blobIv,
-          blobAuthTag: existing.blobAuthTag,
-          keyVersion: existing.keyVersion,
-          aadVersion: existing.aadVersion,
-        },
-      });
-      // Trim to max 20 entries (stable sort: changedAt asc, id asc)
-      const all = await tx.passwordEntryHistory.findMany({
-        where: { entryId: id },
-        orderBy: [{ changedAt: "asc" }, { id: "asc" }],
-        select: { id: true },
-      });
-      if (all.length > 20) {
-        await tx.passwordEntryHistory.deleteMany({
-          where: { id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
-        });
-      }
-      }),
-    );
-
     updateData.encryptedBlob = encryptedBlob.ciphertext;
     updateData.blobIv = encryptedBlob.iv;
     updateData.blobAuthTag = encryptedBlob.authTag;
@@ -200,13 +176,65 @@ async function handlePUT(
     updateData.tags = { set: tagIds.map((tid) => ({ id: tid })) };
   }
 
-  const updated = await withUserTenantRls(userId, async () =>
-    prisma.passwordEntry.update({
-      where: { id },
-      data: updateData,
-      include: { tags: { select: { id: true } } },
-    }),
-  );
+  // Row type for the FOR UPDATE snapshot read (personal password_entries).
+  type PersonalBlobRow = {
+    encrypted_blob: string;
+    blob_iv: string;
+    blob_auth_tag: string;
+    key_version: number;
+    aad_version: number;
+  };
+
+  // If the blob is changing, snapshot + update must be atomic and lost-update-safe:
+  // acquire a PK row lock inside the same tenant-scoped transaction so concurrent
+  // PUTs serialise here and each writer snapshots the immediately-preceding committed
+  // blob (not the outside-tx `existing` read, which may be stale under contention).
+  const updated = await (encryptedBlob
+    ? withUserTenantRls(userId, async () =>
+        prisma.$transaction(async (tx) => {
+          const [cur] = await tx.$queryRaw<PersonalBlobRow[]>`
+            SELECT encrypted_blob, blob_iv, blob_auth_tag, key_version, aad_version
+            FROM password_entries
+            WHERE id = ${id}::uuid
+            FOR UPDATE
+          `;
+          // Snapshot the current committed blob into history
+          await tx.passwordEntryHistory.create({
+            data: {
+              entryId: id,
+              tenantId: existing.tenantId,
+              encryptedBlob: cur.encrypted_blob,
+              blobIv: cur.blob_iv,
+              blobAuthTag: cur.blob_auth_tag,
+              keyVersion: cur.key_version,
+              aadVersion: cur.aad_version,
+            },
+          });
+          // Trim to max 20 entries (stable sort: changedAt asc, id asc)
+          const all = await tx.passwordEntryHistory.findMany({
+            where: { entryId: id },
+            orderBy: [{ changedAt: "asc" }, { id: "asc" }],
+            select: { id: true },
+          });
+          if (all.length > 20) {
+            await tx.passwordEntryHistory.deleteMany({
+              where: { id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
+            });
+          }
+          return tx.passwordEntry.update({
+            where: { id },
+            data: updateData,
+            include: { tags: { select: { id: true } } },
+          });
+        }),
+      )
+    : withUserTenantRls(userId, async () =>
+        prisma.passwordEntry.update({
+          where: { id },
+          data: updateData,
+          include: { tags: { select: { id: true } } },
+        }),
+      ));
 
   await logAuditAsync({
     ...personalAuditBase(req, userId),

--- a/src/app/api/teams/[teamId]/passwords/[id]/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/route.test.ts
@@ -229,8 +229,24 @@ describe("GET /api/teams/[teamId]/passwords/[id]", () => {
   });
 });
 
+// curRow for the C1 FOR UPDATE re-read — values DISTINCT from makeEntryForPUT()
+// so that field-level assertions can detect if the snapshot was sourced from
+// existingEntry instead of the in-tx $queryRaw result.
+const teamCurRow = {
+  encrypted_blob: "cur-team-blob",
+  blob_iv: "cur-team-iv",
+  blob_auth_tag: "cur-team-tag",
+  aad_version: 11,
+  team_key_version: 5,
+  item_key_version: 2,
+  encrypted_item_key: "cur-ik-cipher",
+  item_key_iv: "cur-ik-iv",
+  item_key_auth_tag: "cur-ik-tag",
+};
+
 describe("PUT /api/teams/[teamId]/passwords/[id]", () => {
   const txMock = {
+    $queryRaw: vi.fn().mockResolvedValue([teamCurRow]),
     teamPasswordEntryHistory: {
       create: vi.fn().mockResolvedValue({}),
       findMany: vi.fn().mockResolvedValue([]),
@@ -248,6 +264,7 @@ describe("PUT /api/teams/[teamId]/passwords/[id]", () => {
     mockHasTeamPermission.mockReturnValue(true);
     mockAuditLogCreate.mockResolvedValue({});
     mockPrismaTeam.findUnique.mockResolvedValue({ teamKeyVersion: 1 });
+    txMock.$queryRaw.mockResolvedValue([teamCurRow]);
     txMock.teamPasswordEntryHistory.create.mockResolvedValue({});
     txMock.teamPasswordEntryHistory.findMany.mockResolvedValue([]);
     txMock.teamPasswordEntryHistory.deleteMany.mockResolvedValue({ count: 0 });
@@ -412,16 +429,17 @@ describe("PUT /api/teams/[teamId]/passwords/[id]", () => {
     expect(json.id).toBe(PW_ID);
     expect(json.entryType).toBe(ENTRY_TYPE.LOGIN);
 
-    // Verify old blob saved to history (inside transaction)
+    // Verify blob saved to history comes from $queryRaw FOR UPDATE result (C1),
+    // not from the outside-tx existingEntry read (which would be makeEntryForPUT() values).
     expect(txMock.teamPasswordEntryHistory.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           entryId: PW_ID,
-          encryptedBlob: "old-blob",
-          blobIv: "e".repeat(24),
-          blobAuthTag: "f".repeat(32),
-          aadVersion: 1,
-          teamKeyVersion: 1,
+          encryptedBlob: teamCurRow.encrypted_blob,
+          blobIv: teamCurRow.blob_iv,
+          blobAuthTag: teamCurRow.blob_auth_tag,
+          aadVersion: teamCurRow.aad_version,
+          teamKeyVersion: teamCurRow.team_key_version,
         }),
       }),
     );

--- a/src/app/api/v1/passwords/[id]/route.test.ts
+++ b/src/app/api/v1/passwords/[id]/route.test.ts
@@ -223,6 +223,8 @@ describe("PUT /api/v1/passwords/[id]", () => {
     mockHistoryFindMany.mockResolvedValue([]);
     mockHistoryDeleteMany.mockResolvedValue({ count: 0 });
     mockEntryUpdate.mockResolvedValue(updatedEntry);
+    // Restore default FOR UPDATE result (clearAllMocks clears it each run)
+    mockQueryRaw.mockResolvedValue([V1_CUR_ROW]);
   });
 
   it("returns 401 when API key is missing or invalid", async () => {
@@ -398,6 +400,21 @@ describe("PUT /api/v1/passwords/[id]", () => {
     // Distinct-from-ownedEntry sanity check
     expect(histData.encryptedBlob).not.toBe(ownedEntry.encryptedBlob);
     expect(histData.keyVersion).not.toBe(ownedEntry.keyVersion);
+  });
+
+  // F1: race — entry deleted between early read and FOR UPDATE lock
+  it("F1: returns 404 when $queryRaw FOR UPDATE returns empty (concurrent delete)", async () => {
+    mockQueryRaw.mockResolvedValue([]); // row gone by the time the lock fires
+
+    const res = await PUT(
+      createRequest("PUT", `http://localhost/api/v1/passwords/${PW_ID}`, { body: updateBody }),
+      createParams({ id: PW_ID }),
+    );
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(404);
+    // update must NOT have been called — the handler must abort before writing
+    expect(mockEntryUpdate).not.toHaveBeenCalled();
   });
 
   it("C1: metadata-only PUT issues no $queryRaw and no History.create", async () => {

--- a/src/app/api/v1/passwords/[id]/route.test.ts
+++ b/src/app/api/v1/passwords/[id]/route.test.ts
@@ -13,23 +13,47 @@ const {
   mockHistoryDeleteMany,
   mockFolderFindFirst,
   mockTagCount,
+  mockQueryRaw,
   mockLogAudit,
   mockWithTenantRls,
-} = vi.hoisted(() => ({
-  mockValidateApiKeyOnly: vi.fn(),
-  mockEnforceAccessRestriction: vi.fn().mockResolvedValue(null),
-  mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
-  mockEntryFindUnique: vi.fn(),
-  mockEntryUpdate: vi.fn(),
-  mockEntryDelete: vi.fn(),
-  mockHistoryCreate: vi.fn(),
-  mockHistoryFindMany: vi.fn().mockResolvedValue([]),
-  mockHistoryDeleteMany: vi.fn(),
-  mockFolderFindFirst: vi.fn(),
-  mockTagCount: vi.fn(),
-  mockLogAudit: vi.fn(),
-  mockWithTenantRls: vi.fn(async (prisma: unknown, _tenantId: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
-}));
+} = vi.hoisted(() => {
+  // curRow returned by $queryRaw FOR UPDATE — values are DISTINCT from ownedEntry
+  // so field-level assertions can detect if the handler reads from `existing` instead.
+  const curRow = {
+    encrypted_blob: "cur-v1-blob",
+    blob_iv: "cur-v1-iv",
+    blob_auth_tag: "cur-v1-tag",
+    key_version: 9,
+    aad_version: 7,
+  };
+  const mockQueryRaw = vi.fn().mockResolvedValue([curRow]);
+
+  return {
+    mockValidateApiKeyOnly: vi.fn(),
+    mockEnforceAccessRestriction: vi.fn().mockResolvedValue(null),
+    mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
+    mockEntryFindUnique: vi.fn(),
+    mockEntryUpdate: vi.fn(),
+    mockEntryDelete: vi.fn(),
+    mockHistoryCreate: vi.fn(),
+    mockHistoryFindMany: vi.fn().mockResolvedValue([]),
+    mockHistoryDeleteMany: vi.fn(),
+    mockFolderFindFirst: vi.fn(),
+    mockTagCount: vi.fn(),
+    mockQueryRaw,
+    mockLogAudit: vi.fn(),
+    mockWithTenantRls: vi.fn(async (prisma: unknown, _tenantId: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
+  };
+});
+
+// curRow values accessible in test assertions (must match the vi.hoisted values)
+const V1_CUR_ROW = {
+  encrypted_blob: "cur-v1-blob",
+  blob_iv: "cur-v1-iv",
+  blob_auth_tag: "cur-v1-tag",
+  key_version: 9,
+  aad_version: 7,
+};
 
 vi.mock("@/lib/auth/tokens/api-key", () => ({ validateApiKeyOnly: mockValidateApiKeyOnly }));
 vi.mock("@/lib/auth/policy/access-restriction", () => ({ enforceAccessRestriction: mockEnforceAccessRestriction }));
@@ -46,6 +70,7 @@ vi.mock("@/lib/prisma", () => ({
     },
     folder: { findFirst: mockFolderFindFirst },
     tag: { count: mockTagCount },
+    $queryRaw: mockQueryRaw,
   },
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>, withTenantRls: mockWithTenantRls }));
@@ -231,13 +256,16 @@ describe("PUT /api/v1/passwords/[id]", () => {
     expect(json.id).toBe(PW_ID);
     expect(json.keyVersion).toBe(2);
 
+    // C1: snapshot fields come from the FOR UPDATE re-read (V1_CUR_ROW), not from existing
     expect(mockHistoryCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           entryId: PW_ID,
-          encryptedBlob: ownedEntry.encryptedBlob,
-          blobIv: ownedEntry.blobIv,
-          blobAuthTag: ownedEntry.blobAuthTag,
+          encryptedBlob: V1_CUR_ROW.encrypted_blob,
+          blobIv: V1_CUR_ROW.blob_iv,
+          blobAuthTag: V1_CUR_ROW.blob_auth_tag,
+          keyVersion: V1_CUR_ROW.key_version,
+          aadVersion: V1_CUR_ROW.aad_version,
         }),
       }),
     );
@@ -313,7 +341,75 @@ describe("PUT /api/v1/passwords/[id]", () => {
     );
     const { status } = await parseResponse(res);
     expect(status).toBe(200);
+    // blob-changing path: update goes through mockEntryUpdate (tx is the prisma mock)
     expect(mockEntryUpdate).toHaveBeenCalled();
+  });
+
+  // C1: FOR UPDATE snapshot source and SQL text guard
+  it("C1: $queryRaw FOR UPDATE is issued before History.create on blob-changing PUT", async () => {
+    const callOrder: string[] = [];
+    mockQueryRaw.mockImplementation(() => {
+      callOrder.push("$queryRaw");
+      return Promise.resolve([V1_CUR_ROW]);
+    });
+    mockHistoryCreate.mockImplementation(() => {
+      callOrder.push("historyCreate");
+      return Promise.resolve({});
+    });
+
+    await PUT(
+      createRequest("PUT", `http://localhost/api/v1/passwords/${PW_ID}`, { body: updateBody }),
+      createParams({ id: PW_ID }),
+    );
+
+    expect(callOrder.indexOf("$queryRaw")).toBeLessThan(callOrder.indexOf("historyCreate"));
+  });
+
+  it("C1: FOR UPDATE SQL contains table name and required crypto columns", async () => {
+    await PUT(
+      createRequest("PUT", `http://localhost/api/v1/passwords/${PW_ID}`, { body: updateBody }),
+      createParams({ id: PW_ID }),
+    );
+
+    expect(mockQueryRaw).toHaveBeenCalled();
+    const [tpl] = mockQueryRaw.mock.calls[0] as [TemplateStringsArray, ...unknown[]];
+    const sql = tpl.join("?");
+    expect(sql).toMatch(/FOR UPDATE/i);
+    expect(sql).toMatch(/password_entries/i);
+    expect(sql).toMatch(/encrypted_blob/i);
+    expect(sql).toMatch(/blob_iv/i);
+    expect(sql).toMatch(/blob_auth_tag/i);
+    expect(sql).toMatch(/key_version/i);
+    expect(sql).toMatch(/aad_version/i);
+  });
+
+  it("C1: all 5 crypto fields in History.create come from $queryRaw result, not from existing", async () => {
+    await PUT(
+      createRequest("PUT", `http://localhost/api/v1/passwords/${PW_ID}`, { body: updateBody }),
+      createParams({ id: PW_ID }),
+    );
+
+    const histData = mockHistoryCreate.mock.calls[0][0].data;
+    expect(histData.encryptedBlob).toBe(V1_CUR_ROW.encrypted_blob);
+    expect(histData.blobIv).toBe(V1_CUR_ROW.blob_iv);
+    expect(histData.blobAuthTag).toBe(V1_CUR_ROW.blob_auth_tag);
+    expect(histData.keyVersion).toBe(V1_CUR_ROW.key_version);
+    expect(histData.aadVersion).toBe(V1_CUR_ROW.aad_version);
+    // Distinct-from-ownedEntry sanity check
+    expect(histData.encryptedBlob).not.toBe(ownedEntry.encryptedBlob);
+    expect(histData.keyVersion).not.toBe(ownedEntry.keyVersion);
+  });
+
+  it("C1: metadata-only PUT issues no $queryRaw and no History.create", async () => {
+    await PUT(
+      createRequest("PUT", `http://localhost/api/v1/passwords/${PW_ID}`, {
+        body: { isFavorite: true },
+      }),
+      createParams({ id: PW_ID }),
+    );
+
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+    expect(mockHistoryCreate).not.toHaveBeenCalled();
   });
 
   it("returns 400 when folderId is not owned by the user", async () => {
@@ -335,6 +431,39 @@ describe("PUT /api/v1/passwords/[id]", () => {
     const res = await PUT(
       createRequest("PUT", `http://localhost/api/v1/passwords/${PW_ID}`, {
         body: { tagIds: ["tag-x", "tag-y"] },
+      }),
+      createParams({ id: PW_ID }),
+    );
+    const { status, json } = await parseResponse(res);
+    expect(status).toBe(400);
+    expect(json.error).toBe("VALIDATION_ERROR");
+    expect(mockEntryUpdate).not.toHaveBeenCalled();
+  });
+
+  it("C3: succeeds when tagIds contain duplicates but are all owned (count mock returns 1 for [t1,t1])", async () => {
+    // tag.count returns distinct row count; t1 is owned once → count=1.
+    // Before the fix, ownedCount(1) !== tagIds.length(2) → 400.
+    // After the fix, ownedCount(1) !== uniqueTagIds.length(1) → success.
+    const ownedTagId = "00000000-0000-4000-a000-000000000001";
+    mockTagCount.mockResolvedValue(1);
+    const res = await PUT(
+      createRequest("PUT", `http://localhost/api/v1/passwords/${PW_ID}`, {
+        body: { tagIds: [ownedTagId, ownedTagId] },
+      }),
+      createParams({ id: PW_ID }),
+    );
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+  });
+
+  it("C3: still rejects when tagIds reference an unowned tag", async () => {
+    // t1 owned, t2-unowned → count=1 but uniqueTagIds.length=2 → 400
+    const ownedTagId = "00000000-0000-4000-a000-000000000001";
+    const unownedTagId = "00000000-0000-4000-a000-000000000002";
+    mockTagCount.mockResolvedValue(1);
+    const res = await PUT(
+      createRequest("PUT", `http://localhost/api/v1/passwords/${PW_ID}`, {
+        body: { tagIds: [ownedTagId, unownedTagId] },
       }),
       createParams({ id: PW_ID }),
     );

--- a/src/app/api/v1/passwords/[id]/route.ts
+++ b/src/app/api/v1/passwords/[id]/route.ts
@@ -148,12 +148,16 @@ async function handlePUT(
     }
   }
 
-  // Verify tag ownership
+  // Verify tag ownership. Normalize duplicates: a caller-supplied duplicate
+  // (e.g. ["t1","t1"]) should not count as a missing tag — tag.count returns
+  // distinct row count, so compare against the deduped input length, not the
+  // raw array length. Mirrors team-password-service.ts.
   if (tagIds?.length) {
+    const uniqueTagIds = [...new Set(tagIds)];
     const ownedCount = await withTenantRls(prisma, tenantId, async (tx) =>
-      tx.tag.count({ where: { id: { in: tagIds }, userId } }),
+      tx.tag.count({ where: { id: { in: uniqueTagIds }, userId } }),
     );
-    if (ownedCount !== tagIds.length) {
+    if (ownedCount !== uniqueTagIds.length) {
       return validationError({ message: "Invalid tagIds" });
     }
   }
@@ -192,20 +196,38 @@ async function handlePUT(
     updateData.tags = { set: tagIds.map((tid) => ({ id: tid })) };
   }
 
-  // Snapshot history and update entry. withTenantRls already runs the callback
+  // Row type for the FOR UPDATE snapshot read (personal password_entries).
+  type PersonalBlobRow = {
+    encrypted_blob: string;
+    blob_iv: string;
+    blob_auth_tag: string;
+    key_version: number;
+    aad_version: number;
+  };
+
+  // Snapshot history and update entry.  withTenantRls already runs the callback
   // inside a tenant-scoped transaction, so tx IS the transaction client — no
   // nested $transaction is needed (it would only fold back into the same tx).
+  // When the blob changes, acquire a PK row lock first: concurrent PUTs serialise
+  // here, so each writer snapshots the immediately-preceding committed blob
+  // (not the stale outside-tx `existing` read).
   const updated = await withTenantRls(prisma, tenantId, async (tx) => {
     if (encryptedBlob) {
+      const [cur] = await tx.$queryRaw<PersonalBlobRow[]>`
+        SELECT encrypted_blob, blob_iv, blob_auth_tag, key_version, aad_version
+        FROM password_entries
+        WHERE id = ${id}::uuid
+        FOR UPDATE
+      `;
       await tx.passwordEntryHistory.create({
         data: {
           entryId: id,
           tenantId: existing.tenantId,
-          encryptedBlob: existing.encryptedBlob,
-          blobIv: existing.blobIv,
-          blobAuthTag: existing.blobAuthTag,
-          keyVersion: existing.keyVersion,
-          aadVersion: existing.aadVersion,
+          encryptedBlob: cur.encrypted_blob,
+          blobIv: cur.blob_iv,
+          blobAuthTag: cur.blob_auth_tag,
+          keyVersion: cur.key_version,
+          aadVersion: cur.aad_version,
         },
       });
       // Trim to max 20 history entries (stable sort: changedAt asc, id asc)

--- a/src/app/api/v1/passwords/[id]/route.ts
+++ b/src/app/api/v1/passwords/[id]/route.ts
@@ -219,6 +219,8 @@ async function handlePUT(
         WHERE id = ${id}::uuid
         FOR UPDATE
       `;
+      // Entry may be concurrently deleted between the early read and this lock.
+      if (!cur) return null;
       await tx.passwordEntryHistory.create({
         data: {
           entryId: id,
@@ -248,6 +250,10 @@ async function handlePUT(
       include: { tags: { select: { id: true } } },
     });
   });
+
+  // Null sentinel: the blob-tx path returns null when the entry was concurrently
+  // deleted between the early findUnique and the FOR UPDATE lock.
+  if (!updated) return notFound();
 
   await logAuditAsync({
     ...personalAuditBase(req, userId),

--- a/src/app/api/v1/passwords/route.test.ts
+++ b/src/app/api/v1/passwords/route.test.ts
@@ -380,6 +380,35 @@ describe("POST /api/v1/passwords", () => {
     expect(status).toBe(400);
   });
 
+  it("C3: succeeds when tagIds contain duplicates but are all owned (count mock returns 1 for [t1,t1])", async () => {
+    // tag.count returns distinct row count; t1 is owned once → count=1.
+    // Before the fix, ownedCount(1) !== tagIds.length(2) → 400.
+    // After the fix, ownedCount(1) !== uniqueTagIds.length(1) → success.
+    const ownedTagId = "00000000-0000-4000-a000-000000000001";
+    mockTagCount.mockResolvedValue(1);
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/v1/passwords", {
+        body: { ...validBody, tagIds: [ownedTagId, ownedTagId] },
+      }),
+    );
+    const { status } = await parseResponse(res);
+    expect(status).toBe(201);
+  });
+
+  it("C3: still rejects when tagIds reference an unowned tag", async () => {
+    // t1 owned, t2-unowned → count=1 but uniqueTagIds.length=2 → 400
+    const ownedTagId = "00000000-0000-4000-a000-000000000001";
+    const unownedTagId = "00000000-0000-4000-a000-000000000002";
+    mockTagCount.mockResolvedValue(1);
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/v1/passwords", {
+        body: { ...validBody, tagIds: [ownedTagId, unownedTagId] },
+      }),
+    );
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
   it("creates entry and returns 201 with correct shape", async () => {
     const res = await POST(
       createRequest("POST", "http://localhost/api/v1/passwords", { body: validBody }),

--- a/src/app/api/v1/passwords/route.ts
+++ b/src/app/api/v1/passwords/route.ts
@@ -140,9 +140,14 @@ async function handlePOST(req: NextRequest) {
       if (!folder) return { error: "INVALID_FOLDER" as const };
     }
 
+    // Normalize duplicates: a caller-supplied duplicate (e.g. ["t1","t1"])
+    // should not count as a missing tag — tag.count returns distinct row count,
+    // so compare against the deduped input length, not the raw array length.
+    // Mirrors team-password-service.ts.
     if (tagIds?.length) {
-      const ownedCount = await tx.tag.count({ where: { id: { in: tagIds }, userId } });
-      if (ownedCount !== tagIds.length) return { error: "INVALID_TAGS" as const };
+      const uniqueTagIds = [...new Set(tagIds)];
+      const ownedCount = await tx.tag.count({ where: { id: { in: uniqueTagIds }, userId } });
+      if (ownedCount !== uniqueTagIds.length) return { error: "INVALID_TAGS" as const };
     }
 
     const entry = await tx.passwordEntry.create({

--- a/src/app/api/v1/vault/status/route.test.ts
+++ b/src/app/api/v1/vault/status/route.test.ts
@@ -37,12 +37,16 @@ vi.mock("@/lib/logger", () => {
 });
 
 import { GET } from "./route";
+import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
+import { ACTOR_TYPE } from "@/lib/constants/audit/audit";
 
 const USER_ID = "user-1";
 const TENANT_ID = "tenant-1";
 const API_KEY_ID = "key-1";
 
 const validApiKey = { userId: USER_ID, tenantId: TENANT_ID, apiKeyId: API_KEY_ID };
+// SA tokens have userId=null; rateLimitKey is the serviceAccountId
+const saApiKey = { userId: null, tenantId: TENANT_ID, rateLimitKey: "sa-1", apiKeyId: "sa-1" };
 
 describe("GET /api/v1/vault/status", () => {
   beforeEach(() => {
@@ -145,6 +149,72 @@ describe("GET /api/v1/vault/status", () => {
       expect.anything(),
       TENANT_ID,
       expect.any(Function),
+    );
+  });
+});
+
+describe("GET /api/v1/vault/status — SA token path (C2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKeyOnly.mockResolvedValue({ ok: true, data: saApiKey });
+    mockCheck.mockResolvedValue({ allowed: true });
+    mockEnforceAccessRestriction.mockResolvedValue(null);
+  });
+
+  it("returns the denial response when enforceAccessRestriction denies an SA token", async () => {
+    const { NextResponse } = await import("next/server");
+    const denial = NextResponse.json({ error: "ACCESS_RESTRICTED" }, { status: 403 });
+    mockEnforceAccessRestriction.mockResolvedValue(denial);
+
+    const res = await GET(createRequest("GET", "http://localhost/api/v1/vault/status"));
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("ACCESS_RESTRICTED");
+    // Must NOT fall through to the { initialized: false } response
+    expect(json.initialized).toBeUndefined();
+  });
+
+  it("calls enforceAccessRestriction with SYSTEM_ACTOR_ID and SERVICE_ACCOUNT actor type for SA tokens", async () => {
+    await GET(createRequest("GET", "http://localhost/api/v1/vault/status"));
+
+    expect(mockEnforceAccessRestriction).toHaveBeenCalledWith(
+      expect.anything(),
+      SYSTEM_ACTOR_ID,
+      TENANT_ID,
+      ACTOR_TYPE.SERVICE_ACCOUNT,
+    );
+  });
+
+  it("returns { initialized: false, keyVersion: null } when SA token is allowed", async () => {
+    const res = await GET(createRequest("GET", "http://localhost/api/v1/vault/status"));
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(200);
+    expect(json.initialized).toBe(false);
+    expect(json.keyVersion).toBeNull();
+    // SA tokens skip the user vault query
+    expect(mockWithTenantRls).not.toHaveBeenCalled();
+  });
+
+  it("does not call enforceAccessRestriction with SYSTEM_ACTOR_ID on the human path", async () => {
+    // Reset to human token
+    mockValidateApiKeyOnly.mockResolvedValue({ ok: true, data: validApiKey });
+    mockUserFindUnique.mockResolvedValue({ encryptedSecretKey: "enc-key", keyVersion: 1 });
+
+    await GET(createRequest("GET", "http://localhost/api/v1/vault/status"));
+
+    // Human path calls enforceAccessRestriction with userId, not SYSTEM_ACTOR_ID
+    expect(mockEnforceAccessRestriction).toHaveBeenCalledWith(
+      expect.anything(),
+      USER_ID,
+      TENANT_ID,
+    );
+    expect(mockEnforceAccessRestriction).not.toHaveBeenCalledWith(
+      expect.anything(),
+      SYSTEM_ACTOR_ID,
+      expect.anything(),
+      expect.anything(),
     );
   });
 });

--- a/src/app/api/v1/vault/status/route.ts
+++ b/src/app/api/v1/vault/status/route.ts
@@ -8,6 +8,8 @@ import { v1ApiKeyLimiter } from "@/lib/security/rate-limiters";
 import { API_KEY_SCOPE } from "@/lib/constants/auth/api-key";
 import { enforceAccessRestriction } from "@/lib/auth/policy/access-restriction";
 import { errorResponse, rateLimited, unauthorized } from "@/lib/http/api-response";
+import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
+import { ACTOR_TYPE } from "@/lib/constants/audit/audit";
 
 
 // GET /api/v1/vault/status — Check vault initialization status (API key or SA token)
@@ -22,9 +24,15 @@ async function handleGET(req: NextRequest) {
 
   const { userId, tenantId, rateLimitKey } = authResult.data;
 
-  // SA tokens have no userId — skip user-specific access restriction and vault query
+  // Enforce tenant network-boundary policy for all token types.
+  // SA tokens carry no userId; pass SYSTEM_ACTOR_ID with SERVICE_ACCOUNT actor
+  // type so the denial audit records the correct actor class (mirrors the
+  // pattern in src/app/api/tenant/access-requests/route.ts:150-156).
   if (userId) {
     const denied = await enforceAccessRestriction(req, userId, tenantId);
+    if (denied) return denied;
+  } else {
+    const denied = await enforceAccessRestriction(req, SYSTEM_ACTOR_ID, tenantId, ACTOR_TYPE.SERVICE_ACCOUNT);
     if (denied) return denied;
   }
 

--- a/src/lib/auth/tokens/api-key.test.ts
+++ b/src/lib/auth/tokens/api-key.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ─── Hoisted mocks ───────────────────────────────────────────
 
@@ -97,6 +97,9 @@ const VALID_KEY_ROW = {
   scope: "passwords:read",
   expiresAt: new Date(Date.now() + 3_600_000),
   revokedAt: null,
+  // R19: lastUsedAt must be present so the throttle guard evaluates correctly.
+  // Without it, the field reads as undefined (stale) → always-update, masking throttle.
+  lastUsedAt: null,
 };
 
 function makeReq(token = VALID_KEY) {
@@ -153,5 +156,75 @@ describe("validateApiKey — deactivated-user (C13)", () => {
 
     const result = await validateApiKey(makeReq());
     expect(result).toEqual({ ok: false, error: "API_KEY_INVALID" });
+  });
+});
+
+// ─── validateApiKey — lastUsedAt throttle (C4) ───────────────
+
+describe("validateApiKey — lastUsedAt throttle (C4)", () => {
+  const ACTIVE_MEMBER = { deactivatedAt: null };
+  // 5 minutes in ms (matches API_KEY_LAST_USED_THROTTLE_MS)
+  const THROTTLE_MS = 5 * 60 * 1_000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockTenantMemberFindUnique.mockResolvedValue(ACTIVE_MEMBER);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("null lastUsedAt ⇒ update is issued", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    mockApiKeyFindUnique.mockResolvedValue({
+      ...VALID_KEY_ROW,
+      expiresAt: new Date("2027-01-01T00:00:00Z"),
+      lastUsedAt: null,
+    });
+
+    await validateApiKey(makeReq());
+
+    expect(mockApiKeyUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("stale lastUsedAt (>5 min ago) ⇒ update is issued", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:10:00Z")); // now = T+10min
+    mockApiKeyFindUnique.mockResolvedValue({
+      ...VALID_KEY_ROW,
+      expiresAt: new Date("2027-01-01T00:00:00Z"),
+      lastUsedAt: new Date("2026-01-01T00:00:00Z"), // 10 min ago (> threshold)
+    });
+
+    await validateApiKey(makeReq());
+
+    expect(mockApiKeyUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("recent lastUsedAt (within 5 min) ⇒ update is NOT issued", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:04:00Z")); // now = T+4min
+    mockApiKeyFindUnique.mockResolvedValue({
+      ...VALID_KEY_ROW,
+      expiresAt: new Date("2027-01-01T00:00:00Z"),
+      lastUsedAt: new Date("2026-01-01T00:00:00Z"), // 4 min ago (within threshold)
+    });
+
+    await validateApiKey(makeReq());
+
+    expect(mockApiKeyUpdate).not.toHaveBeenCalled();
+  });
+
+  it("lastUsedAt exactly at threshold boundary ⇒ update is NOT issued", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z").getTime() + THROTTLE_MS);
+    mockApiKeyFindUnique.mockResolvedValue({
+      ...VALID_KEY_ROW,
+      expiresAt: new Date("2027-01-01T00:00:00Z"),
+      lastUsedAt: new Date("2026-01-01T00:00:00Z"), // exactly THROTTLE_MS ago (not >)
+    });
+
+    await validateApiKey(makeReq());
+
+    expect(mockApiKeyUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/auth/tokens/api-key.test.ts
+++ b/src/lib/auth/tokens/api-key.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/lib/crypto/crypto-server", () => ({
 
 import { createRequest } from "@/__tests__/helpers/request-builder";
 import { parseApiKeyScopes, hasApiKeyScope, validateApiKey } from "./api-key";
+import { API_KEY_LAST_USED_THROTTLE_MS } from "@/lib/constants/auth/api-key";
 
 // ─── parseApiKeyScopes ───────────────────────────────────────
 
@@ -163,8 +164,7 @@ describe("validateApiKey — deactivated-user (C13)", () => {
 
 describe("validateApiKey — lastUsedAt throttle (C4)", () => {
   const ACTIVE_MEMBER = { deactivatedAt: null };
-  // 5 minutes in ms (matches API_KEY_LAST_USED_THROTTLE_MS)
-  const THROTTLE_MS = 5 * 60 * 1_000;
+  const THROTTLE_MS = API_KEY_LAST_USED_THROTTLE_MS;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/lib/auth/tokens/api-key.ts
+++ b/src/lib/auth/tokens/api-key.ts
@@ -5,6 +5,7 @@ import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import {
   API_KEY_PREFIX,
   API_KEY_SCOPE,
+  API_KEY_LAST_USED_THROTTLE_MS,
   type ApiKeyScope,
 } from "@/lib/constants/auth/api-key";
 
@@ -87,6 +88,7 @@ export async function validateApiKey(
         scope: true,
         expiresAt: true,
         revokedAt: true,
+        lastUsedAt: true,
       },
     }),
   BYPASS_PURPOSE.TOKEN_LIFECYCLE);
@@ -113,13 +115,18 @@ export async function validateApiKey(
     return { ok: false, error: "API_KEY_INVALID" };
   }
 
-  // Best-effort lastUsedAt update (non-blocking)
-  void withBypassRls(prisma, async (tx) =>
-    tx.apiKey.update({
-      where: { id: key.id },
-      data: { lastUsedAt: new Date() },
-    }),
-  BYPASS_PURPOSE.TOKEN_LIFECYCLE).catch(() => {});
+  // Throttled lastUsedAt update (non-blocking) — parity with SA token
+  const shouldUpdate =
+    !key.lastUsedAt ||
+    Date.now() - key.lastUsedAt.getTime() > API_KEY_LAST_USED_THROTTLE_MS;
+  if (shouldUpdate) {
+    void withBypassRls(prisma, async (tx) =>
+      tx.apiKey.update({
+        where: { id: key.id },
+        data: { lastUsedAt: new Date() },
+      }),
+    BYPASS_PURPOSE.TOKEN_LIFECYCLE).catch(() => {});
+  }
 
   return {
     ok: true,

--- a/src/lib/constants/auth/api-key.ts
+++ b/src/lib/constants/auth/api-key.ts
@@ -1,4 +1,9 @@
+import { MS_PER_MINUTE } from "../time";
+
 export const API_KEY_PREFIX = "api_";
+
+/** Throttle interval for lastUsedAt writes — parity with SA_TOKEN_LAST_USED_THROTTLE_MS */
+export const API_KEY_LAST_USED_THROTTLE_MS = 5 * MS_PER_MINUTE;
 
 export const API_KEY_SCOPE = {
   PASSWORDS_READ: "passwords:read",

--- a/src/lib/services/personal-password-service.test.ts
+++ b/src/lib/services/personal-password-service.test.ts
@@ -118,4 +118,34 @@ describe("createPersonalPasswordEntry", () => {
       connect: [{ id: "tag-1" }, { id: "tag-2" }],
     });
   });
+
+  it("C3: succeeds when tagIds contain duplicates but are all owned (count mock returns 1 for [t1,t1])", async () => {
+    // tag.count returns distinct row count; t1 is owned once → count=1.
+    // Before the fix, ownedCount(1) !== tagIds.length(2) → TAGS_NOT_OWNED.
+    // After the fix, ownedCount(1) !== uniqueTagIds.length(1) → success.
+    mockTagCount.mockResolvedValue(1);
+
+    const result = await createPersonalPasswordEntry(
+      db,
+      USER_ID,
+      TENANT_ID,
+      baseInput({ tagIds: ["t1", "t1"] }),
+    );
+
+    expect(result).toEqual({ ok: true, entry: expect.anything() });
+  });
+
+  it("C3: still rejects when tagIds reference an unowned tag", async () => {
+    // t1 owned, t2-unowned → count=1 but uniqueTagIds.length=2 → TAGS_NOT_OWNED
+    mockTagCount.mockResolvedValue(1);
+
+    const result = await createPersonalPasswordEntry(
+      db,
+      USER_ID,
+      TENANT_ID,
+      baseInput({ tagIds: ["t1", "t2-unowned"] }),
+    );
+
+    expect(result).toEqual({ ok: false, reason: "TAGS_NOT_OWNED" });
+  });
 });

--- a/src/lib/services/personal-password-service.ts
+++ b/src/lib/services/personal-password-service.ts
@@ -53,9 +53,14 @@ export async function createPersonalPasswordEntry(
     if (!folder) return { ok: false, reason: "FOLDER_NOT_FOUND" };
   }
 
+  // Normalize duplicates: a caller-supplied duplicate (e.g. ["t1","t1"])
+  // should not count as a missing tag — tag.count returns distinct row count,
+  // so compare against the deduped input length, not the raw array length.
+  // Mirrors team-password-service.ts.
   if (tagIds?.length) {
-    const ownedCount = await db.tag.count({ where: { id: { in: tagIds }, userId } });
-    if (ownedCount !== tagIds.length) return { ok: false, reason: "TAGS_NOT_OWNED" };
+    const uniqueTagIds = [...new Set(tagIds)];
+    const ownedCount = await db.tag.count({ where: { id: { in: uniqueTagIds }, userId } });
+    if (ownedCount !== uniqueTagIds.length) return { ok: false, reason: "TAGS_NOT_OWNED" };
   }
 
   const entry = await db.passwordEntry.create({

--- a/src/lib/services/team-password-service.test.ts
+++ b/src/lib/services/team-password-service.test.ts
@@ -907,4 +907,27 @@ describe("updateTeamPassword", () => {
     expect(mockTxQueryRaw).not.toHaveBeenCalled();
     expect(mockTeamPasswordEntryHistoryCreate).not.toHaveBeenCalled();
   });
+
+  // F1: race — entry deleted between caller's read and FOR UPDATE lock
+  it("F1: throws TeamPasswordServiceError (NOT_FOUND, 404) when $queryRaw FOR UPDATE returns empty (concurrent delete)", async () => {
+    mockTeamFindUnique.mockResolvedValue({ teamKeyVersion: 3 });
+    mockTxQueryRaw.mockResolvedValue([]); // row gone by the time the lock fires
+
+    const input: UpdateTeamPasswordInput = {
+      encryptedBlob: ENCRYPTED_BLOB,
+      encryptedOverview: ENCRYPTED_OVERVIEW,
+      aadVersion: 1,
+      teamKeyVersion: 3,
+      itemKeyVersion: 0,
+      userId: USER_ID,
+      existingEntry: BASE_EXISTING_ENTRY,
+    };
+
+    const err = await updateTeamPassword(TEAM_ID, PASSWORD_ID, input).catch((e) => e);
+    expect(err).toBeInstanceOf(TeamPasswordServiceError);
+    expect(err.code).toBe(API_ERROR.NOT_FOUND);
+    expect(err.statusHint).toBe(404);
+    // update must NOT have been called — the handler must abort before writing
+    expect(mockTeamPasswordEntryUpdate).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/services/team-password-service.test.ts
+++ b/src/lib/services/team-password-service.test.ts
@@ -9,6 +9,7 @@ const {
   mockTeamPasswordEntryHistoryCreate,
   mockTeamPasswordEntryHistoryFindMany,
   mockTeamPasswordEntryHistoryDeleteMany,
+  mockTxQueryRaw,
   mockTransaction,
 } = vi.hoisted(() => {
   const mockTeamFindUnique = vi.fn();
@@ -20,7 +21,23 @@ const {
   const mockTeamPasswordEntryHistoryFindMany = vi.fn();
   const mockTeamPasswordEntryHistoryDeleteMany = vi.fn();
 
+  // curRow for the FOR UPDATE re-read — values DISTINCT from BASE_EXISTING_ENTRY
+  // so field-level assertions detect if the snapshot was sourced from existingEntry instead.
+  const teamCurRow = {
+    encrypted_blob: "cur-team-blob",
+    blob_iv: "cur-team-iv",
+    blob_auth_tag: "cur-team-tag",
+    aad_version: 11,
+    team_key_version: 5,
+    item_key_version: 2,
+    encrypted_item_key: "cur-ik-cipher",
+    item_key_iv: "cur-ik-iv",
+    item_key_auth_tag: "cur-ik-tag",
+  };
+  const mockTxQueryRaw = vi.fn().mockResolvedValue([teamCurRow]);
+
   const txClient = {
+    $queryRaw: mockTxQueryRaw,
     teamPasswordEntryHistory: {
       create: mockTeamPasswordEntryHistoryCreate,
       findMany: mockTeamPasswordEntryHistoryFindMany,
@@ -44,6 +61,7 @@ const {
     mockTeamPasswordEntryHistoryCreate,
     mockTeamPasswordEntryHistoryFindMany,
     mockTeamPasswordEntryHistoryDeleteMany,
+    mockTxQueryRaw,
     mockTransaction,
   };
 });
@@ -331,12 +349,27 @@ describe("createTeamPassword", () => {
 // updateTeamPassword
 // ---------------------------------------------------------------------------
 
+// curRow values accessible in test assertions (must match the vi.hoisted values)
+const TEAM_CUR_ROW = {
+  encrypted_blob: "cur-team-blob",
+  blob_iv: "cur-team-iv",
+  blob_auth_tag: "cur-team-tag",
+  aad_version: 11,
+  team_key_version: 5,
+  item_key_version: 2,
+  encrypted_item_key: "cur-ik-cipher",
+  item_key_iv: "cur-ik-iv",
+  item_key_auth_tag: "cur-ik-tag",
+};
+
 describe("updateTeamPassword", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    // Re-apply the transaction implementation after reset
+    // Re-apply $queryRaw and transaction implementation after reset
+    mockTxQueryRaw.mockResolvedValue([TEAM_CUR_ROW]);
     mockTransaction.mockImplementation(async (fn) =>
       fn({
+        $queryRaw: mockTxQueryRaw,
         teamPasswordEntryHistory: {
           create: mockTeamPasswordEntryHistoryCreate,
           findMany: mockTeamPasswordEntryHistoryFindMany,
@@ -486,7 +519,9 @@ describe("updateTeamPassword", () => {
     expect(mockTeamPasswordEntryHistoryCreate).toHaveBeenCalledOnce();
     const historyData = mockTeamPasswordEntryHistoryCreate.mock.calls[0][0].data;
     expect(historyData.entryId).toBe(PASSWORD_ID);
-    expect(historyData.encryptedBlob).toBe(BASE_EXISTING_ENTRY.encryptedBlob);
+    // C1: snapshot blob fields must come from TEAM_CUR_ROW (FOR UPDATE re-read)
+    expect(historyData.encryptedBlob).toBe(TEAM_CUR_ROW.encrypted_blob);
+    // changedById stays as the current userId (NOT from cur)
     expect(historyData.changedById).toBe(USER_ID);
   });
 
@@ -754,5 +789,122 @@ describe("updateTeamPassword", () => {
     // Should not throw — same version is a no-op, not a change
     const result = await updateTeamPassword(TEAM_ID, PASSWORD_ID, input);
     expect(result).toEqual({ id: PASSWORD_ID, tags: [] });
+  });
+
+  // C1: FOR UPDATE snapshot source and SQL text guard
+  it("C1: $queryRaw is called before History.create on full (blob-changing) update", async () => {
+    mockTeamFindUnique.mockResolvedValue({ teamKeyVersion: 3 });
+    mockTeamPasswordEntryHistoryFindMany.mockResolvedValue([]);
+    mockTeamPasswordEntryUpdate.mockResolvedValue({ id: PASSWORD_ID, tags: [] });
+
+    const callOrder: string[] = [];
+    mockTxQueryRaw.mockImplementation(() => {
+      callOrder.push("$queryRaw");
+      return Promise.resolve([TEAM_CUR_ROW]);
+    });
+    mockTeamPasswordEntryHistoryCreate.mockImplementation(() => {
+      callOrder.push("historyCreate");
+      return Promise.resolve({});
+    });
+
+    const input: UpdateTeamPasswordInput = {
+      encryptedBlob: ENCRYPTED_BLOB,
+      encryptedOverview: ENCRYPTED_OVERVIEW,
+      aadVersion: 1,
+      teamKeyVersion: 3,
+      itemKeyVersion: 0,
+      userId: USER_ID,
+      existingEntry: BASE_EXISTING_ENTRY,
+    };
+
+    await updateTeamPassword(TEAM_ID, PASSWORD_ID, input);
+
+    expect(callOrder.indexOf("$queryRaw")).toBeLessThan(callOrder.indexOf("historyCreate"));
+  });
+
+  it("C1: FOR UPDATE SQL contains table name, team_id predicate, and required crypto columns", async () => {
+    mockTeamFindUnique.mockResolvedValue({ teamKeyVersion: 3 });
+    mockTeamPasswordEntryHistoryCreate.mockResolvedValue({});
+    mockTeamPasswordEntryHistoryFindMany.mockResolvedValue([]);
+    mockTeamPasswordEntryUpdate.mockResolvedValue({ id: PASSWORD_ID, tags: [] });
+
+    const input: UpdateTeamPasswordInput = {
+      encryptedBlob: ENCRYPTED_BLOB,
+      encryptedOverview: ENCRYPTED_OVERVIEW,
+      aadVersion: 1,
+      teamKeyVersion: 3,
+      itemKeyVersion: 0,
+      userId: USER_ID,
+      existingEntry: BASE_EXISTING_ENTRY,
+    };
+
+    await updateTeamPassword(TEAM_ID, PASSWORD_ID, input);
+
+    expect(mockTxQueryRaw).toHaveBeenCalled();
+    const [tpl] = mockTxQueryRaw.mock.calls[0] as [TemplateStringsArray, ...unknown[]];
+    const sql = tpl.join("?");
+    expect(sql).toMatch(/FOR UPDATE/i);
+    expect(sql).toMatch(/team_password_entries/i);
+    expect(sql).toMatch(/team_id/i);
+    expect(sql).toMatch(/encrypted_blob/i);
+    expect(sql).toMatch(/blob_iv/i);
+    expect(sql).toMatch(/blob_auth_tag/i);
+    expect(sql).toMatch(/aad_version/i);
+    expect(sql).toMatch(/team_key_version/i);
+    expect(sql).toMatch(/item_key_version/i);
+    expect(sql).toMatch(/encrypted_item_key/i);
+    expect(sql).toMatch(/item_key_iv/i);
+    expect(sql).toMatch(/item_key_auth_tag/i);
+  });
+
+  it("C1: all 9 crypto fields in History.create come from $queryRaw result, not from existingEntry", async () => {
+    mockTeamFindUnique.mockResolvedValue({ teamKeyVersion: 3 });
+    mockTeamPasswordEntryHistoryCreate.mockResolvedValue({});
+    mockTeamPasswordEntryHistoryFindMany.mockResolvedValue([]);
+    mockTeamPasswordEntryUpdate.mockResolvedValue({ id: PASSWORD_ID, tags: [] });
+
+    const input: UpdateTeamPasswordInput = {
+      encryptedBlob: ENCRYPTED_BLOB,
+      encryptedOverview: ENCRYPTED_OVERVIEW,
+      aadVersion: 1,
+      teamKeyVersion: 3,
+      itemKeyVersion: 0,
+      userId: USER_ID,
+      existingEntry: BASE_EXISTING_ENTRY,
+    };
+
+    await updateTeamPassword(TEAM_ID, PASSWORD_ID, input);
+
+    const histData = mockTeamPasswordEntryHistoryCreate.mock.calls[0][0].data;
+    // All 9 crypto fields must come from TEAM_CUR_ROW (not BASE_EXISTING_ENTRY)
+    expect(histData.encryptedBlob).toBe(TEAM_CUR_ROW.encrypted_blob);
+    expect(histData.blobIv).toBe(TEAM_CUR_ROW.blob_iv);
+    expect(histData.blobAuthTag).toBe(TEAM_CUR_ROW.blob_auth_tag);
+    expect(histData.aadVersion).toBe(TEAM_CUR_ROW.aad_version);
+    expect(histData.teamKeyVersion).toBe(TEAM_CUR_ROW.team_key_version);
+    expect(histData.itemKeyVersion).toBe(TEAM_CUR_ROW.item_key_version);
+    expect(histData.encryptedItemKey).toBe(TEAM_CUR_ROW.encrypted_item_key);
+    expect(histData.itemKeyIv).toBe(TEAM_CUR_ROW.item_key_iv);
+    expect(histData.itemKeyAuthTag).toBe(TEAM_CUR_ROW.item_key_auth_tag);
+    // Distinct-from-existingEntry sanity check
+    expect(histData.encryptedBlob).not.toBe(BASE_EXISTING_ENTRY.encryptedBlob);
+    expect(histData.aadVersion).not.toBe(BASE_EXISTING_ENTRY.aadVersion);
+    // changedById must be the current userId, NOT from cur
+    expect(histData.changedById).toBe(USER_ID);
+  });
+
+  it("C1: metadata-only update issues no $queryRaw and no History.create", async () => {
+    mockTeamPasswordEntryUpdate.mockResolvedValue({ id: PASSWORD_ID, tags: [] });
+
+    const input: UpdateTeamPasswordInput = {
+      isArchived: true,
+      userId: USER_ID,
+      existingEntry: BASE_EXISTING_ENTRY,
+    };
+
+    await updateTeamPassword(TEAM_ID, PASSWORD_ID, input);
+
+    expect(mockTxQueryRaw).not.toHaveBeenCalled();
+    expect(mockTeamPasswordEntryHistoryCreate).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/services/team-password-service.ts
+++ b/src/lib/services/team-password-service.ts
@@ -505,22 +505,48 @@ export async function updateTeamPassword(
     updateData.tags = { set: tagIds.map((tid) => ({ id: tid })) };
   }
 
-  // Snapshot + update in a single transaction for atomicity (F-9)
+  // Row type for the FOR UPDATE snapshot read (team_password_entries).
+  // item_key_* columns are nullable.
+  type TeamBlobRow = {
+    encrypted_blob: string;
+    blob_iv: string;
+    blob_auth_tag: string;
+    aad_version: number;
+    team_key_version: number;
+    item_key_version: number;
+    encrypted_item_key: string | null;
+    item_key_iv: string | null;
+    item_key_auth_tag: string | null;
+  };
+
+  // Snapshot + update in a single transaction for atomicity (F-9).
+  // When the blob is changing, acquire a PK + team_id row lock first so
+  // concurrent PUTs serialise here and each writer snapshots the immediately-
+  // preceding committed blob (not the caller-supplied `existingEntry` read
+  // from outside the transaction, which may be stale under contention).
   return prisma.$transaction(async (tx) => {
     if (isFullUpdate) {
+      const [cur] = await tx.$queryRaw<TeamBlobRow[]>`
+        SELECT encrypted_blob, blob_iv, blob_auth_tag,
+               aad_version, team_key_version, item_key_version,
+               encrypted_item_key, item_key_iv, item_key_auth_tag
+        FROM team_password_entries
+        WHERE id = ${passwordId}::uuid AND team_id = ${teamId}::uuid
+        FOR UPDATE
+      `;
       await tx.teamPasswordEntryHistory.create({
         data: {
           entryId: passwordId,
           tenantId: existingEntry.tenantId,
-          encryptedBlob: existingEntry.encryptedBlob,
-          blobIv: existingEntry.blobIv,
-          blobAuthTag: existingEntry.blobAuthTag,
-          aadVersion: existingEntry.aadVersion,
-          teamKeyVersion: existingEntry.teamKeyVersion,
-          itemKeyVersion: existingEntry.itemKeyVersion,
-          encryptedItemKey: existingEntry.encryptedItemKey,
-          itemKeyIv: existingEntry.itemKeyIv,
-          itemKeyAuthTag: existingEntry.itemKeyAuthTag,
+          encryptedBlob: cur.encrypted_blob,
+          blobIv: cur.blob_iv,
+          blobAuthTag: cur.blob_auth_tag,
+          aadVersion: cur.aad_version,
+          teamKeyVersion: cur.team_key_version,
+          itemKeyVersion: cur.item_key_version,
+          encryptedItemKey: cur.encrypted_item_key,
+          itemKeyIv: cur.item_key_iv,
+          itemKeyAuthTag: cur.item_key_auth_tag,
           changedById: userId,
         },
       });

--- a/src/lib/services/team-password-service.ts
+++ b/src/lib/services/team-password-service.ts
@@ -534,6 +534,8 @@ export async function updateTeamPassword(
         WHERE id = ${passwordId}::uuid AND team_id = ${teamId}::uuid
         FOR UPDATE
       `;
+      // Entry may be concurrently deleted between the caller's read and this lock.
+      if (!cur) throw new TeamPasswordServiceError(API_ERROR.NOT_FOUND, 404);
       await tx.teamPasswordEntryHistory.create({
         data: {
           entryId: passwordId,


### PR DESCRIPTION
## Summary

Remediates the 4 **Low**-severity follow-up findings from the post-`#530` security review. All pre-existing (not introduced by `#530`), none merge-blocking. No Prisma schema migration, no client-facing contract change.

Developed via the triangulate workflow: 3 plan-review rounds + 2 code-review rounds (3 expert agents each).

## Findings fixed

| # | Severity | Fix |
|---|----------|-----|
| C1 | Low (integrity) | **History snapshot lost-update**: the snapshot was sourced from an entry read OUTSIDE the snapshot/update transaction, so concurrent PUTs to the same entry both snapshot the same old blob and the intermediate version vanishes from history (personal also had snapshot/update in two separate transactions). Now the snapshot is sourced from a `SELECT … FOR UPDATE` re-read inside the SAME tenant-scoped transaction as the update, in all three handlers (personal / v1 / team). The PK row lock serializes concurrent PUTs so the second writer snapshots the first's committed blob — no version is lost. |
| C2 | Low | `/api/v1/vault/status` now applies the tenant access restriction to the **SA-token path** (previously only the human path), closing an off-network token-validity oracle. |
| C3 | Low (correctness) | tagIds ownership check now dedupes (`new Set`) before the length comparison — a duplicate but owned tag no longer produces a spurious `Invalid tagIds` (4 personal/v1 sites; matches the existing team behavior). |
| C4 | Low (availability) | API-key `lastUsedAt` write is now throttled (5 min, parity with SA tokens) instead of writing on every validation. |

Review-round hardening: the FOR UPDATE snapshot read now returns 404 (not an unhandled 500) if the entry is deleted in the early-read→lock window.

## Testing

- Unit (field-level snapshot-source assertions + captured-SQL-text guards across personal/v1/team; C2/C3/C4 per-contract): full suite green (11,214 tests), `scripts/pre-pr.sh` 32/32.
- db-integration (real Postgres): a `raceTwoClients` lost-update proof on `updateTeamPassword` — per-iteration fresh entry, 50 iterations, asserts exactly 2 history rows, a content guard (`{v0, firstWriter}`, `firstWriter != v0` by blob value) that directly detects a lost snapshot, both win-orders observed; plus a column-validity check for the personal/v1 raw SQL.
- The lock semantics are proven on `updateTeamPassword` (the only one of the three that is a raceable service); the identical inline SQL in personal/v1 is covered by the column-validity check + unit SQL-text guards.

## Notes

- No schema migration (C1 uses row-level locking, not a new version column; C4's column pre-exists).
- A separate follow-up PR will address the post-`#530` infra-hardening items (Redis HA env explicitness, Sentry span/transaction scrub, Jackson REVOKE CONNECT, DCR per-IP cap, `.env.example` symmetry, a CodeQL unused-import note).

## Artifacts

`docs/archive/review/passwords-concurrency-v1-consistency-{plan,review,deviation,code-review}.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)