### PR TITLE
fix(hardening): post-#530 follow-ups (Redis HA, Sentry scrub, Jackson connect isolation, env-example, CodeQL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -299,7 +299,7 @@ REDIS_SENTINEL_TLS=false
 # Must use URL-safe characters only (hex recommended).
 # NOTE: docker-compose deployments REQUIRE this variable — the compose files
 # use a :? guard that aborts startup when it is missing.
-# REDIS_PASSWORD=
+REDIS_PASSWORD=
 
 
 # --- Outbox worker ---

--- a/docker-compose.ha.yml
+++ b/docker-compose.ha.yml
@@ -75,6 +75,7 @@ services:
   app:
     environment:
       - REDIS_URL=redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required}@redis:6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD is required}
       - REDIS_SENTINEL=true
       - REDIS_SENTINEL_HOSTS=sentinel-1:26379,sentinel-2:26379,sentinel-3:26379
       - REDIS_SENTINEL_MASTER_NAME=mymaster

--- a/docs/archive/review/post-530-hardening-code-review.md
+++ b/docs/archive/review/post-530-hardening-code-review.md
@@ -1,0 +1,17 @@
+# Code Review: post-530-hardening
+
+Date: 2026-06-11
+Review round: 1
+
+## Round 1 (on impl commit cf7b5881)
+
+- **Functionality — No findings.** Verified: C2 three scrub points correctly placed/guarded (trace.op left alone, no double-processing); C3 migration SQL correct (current_database(), no hardcode, checksum clean) + the privilege-assertion test uses the right roles + DROP IF EXISTS/try-finally; C4 requiredForCompose affects ONLY REDIS_PASSWORD (.env.example diff is REDIS_PASSWORD-only, NOTE retained); C1 YAML valid; C5 afterEach fully removed. R14/R15/R16 clean (REVOKE touches only PUBLIC default; current_database(); CI bootstrap re-grants passwd_app CONNECT after migrate).
+- **Security — No findings** (+ S1 [Info]). C3 availability re-verified independently: all 4 app/worker roles have explicit GRANT CONNECT, passwd_user/healthcheck is superuser, jackson connects to the jackson DB — no PUBLIC-dependent connector; the test proves the REVOKE took effect (probe FALSE, non-false-pass) and legit roles survive (4 TRUE). C2 covers all 3 token routes; redactCapabilityPaths not sanitizeUrl. No secret/PII committed. **S1 [Info]**: `event.tags` (Sentry auto-copies transaction→tags.transaction) was not scrubbed — same capability-URL class. → fixed.
+- **Testing — No findings** (+ T1/T2 [Info]). C3 test is a real non-vacuous guard (reviewer empirically confirmed it FAILS if PUBLIC connect is restored); C2 fixtures red-able + non-breaking (reviewer confirmed only the 4 new cases fail pre-change); C4 assertions correct. The 4 failing integration tests confirmed unrelated (audit-anchor/sentinel/cache-rollback — pre-existing shared-DB noise, none connection-refused). T1 (flaky shared DB) / T2 (catalog-priv vs actual-connect — intentional) are Info, no fix.
+
+## Resolution Status
+
+- S1 [Info] → `e.tags` string values now pass `redactCapabilityPaths` (closes the transaction→tags.transaction auto-copy path); red-able test added. Fixed in the review commit.
+- T1/T2 [Info] (shared-DB flakiness / catalog-vs-connect design) — accepted, no change (documented; CI fresh-DB is authoritative).
+
+Code review CLOSED after 1 round: Functionality/Testing clean; Security 1 Info (fixed). No Major/Critical, no deferrals.

--- a/docs/archive/review/post-530-hardening-deviation.md
+++ b/docs/archive/review/post-530-hardening-deviation.md
@@ -1,0 +1,12 @@
+# Coding Deviation Log: post-530-hardening
+
+## Phase 2 implementation deviations
+
+- C3 migration: `prisma migrate dev --create-only` initially emitted a schema-diff SQL; replaced with the hand-written REVOKE per the plan (permission change, no schema diff). Applied to the dev DB via `migrate deploy` (mutates the dev DB — intended by the plan). Migration: `20260611011121_revoke_public_connect_on_app_db`.
+- C3 verification: the full integration suite still shows 224 passed after the REVOKE (legit roles passwd_app/workers still connect — if REVOKE had broken them we'd see "permission denied for database", not the same pre-existing failures). The 4 failing integration tests (audit-anchor manifest, audit-sentinel backfill, mobile cache-rollback x2) are the same pre-existing shared-dev-DB noise documented in #530 / the concurrency PR — none are connection-refused, none touch this PR's files. The new `revoke-public-connect.integration.test.ts` passes (probe role CONNECT=false, 4 legit roles=true). CI integration job on a fresh DB is the authoritative proof.
+- C3 dev DB note: `jackson_user` does not exist on the local dev volume (initdb already ran before #530's role was added), mirroring CI — so the local manual jackson_user-refused check is N/A; the probe-role test is the CI-safe structural guard.
+
+## Follow-up tracked
+
+- SC1 / PR-B: DCR per-IP unclaimed cap (#530 review item 4 = SC7) — schema change, separate triangulate cycle.
+- SC2 TODO(post-530-hardening): `check:env-docs` does not regenerate-and-byte-compare `.env.example` (pre-existing tooling gap). C4's T4 test partially mitigates.

--- a/docs/archive/review/post-530-hardening-plan.md
+++ b/docs/archive/review/post-530-hardening-plan.md
@@ -1,0 +1,96 @@
+# Plan: post-530-hardening
+
+Branch: `fix/post-530-hardening`
+Worktree: `passwd-sso-ord`
+
+## Project context
+
+- Type: web app (Next.js 16 + Prisma 7 + PostgreSQL 16 + RLS + Docker Compose + Sentry).
+- Test infrastructure: unit (vitest) + real-DB integration (`npm run test:integration`, role-separation/RLS smoke) + CI (`scripts/pre-pr.sh` 32 gates incl. `check:env-docs`).
+- Verification environment constraints:
+  - **VE1**: HA Sentinel live behavior (C1) is config-render verifiable only (`docker compose -f docker-compose.yml -f docker-compose.ha.yml config`); live failover is operator manual-test.
+  - **VE2**: C3's `REVOKE CONNECT` effect on a FRESH volume is exercised by the CI integration job (initdb + migrate on a clean DB + role-separation smoke); on the shared dev volume it is verified by running `migrate deploy` + reconnecting as `passwd_app` (must still connect) and confirming `jackson_user` cannot connect to `passwd_sso`.
+
+## Objective
+
+Five Low/Info post-`#530` hardening items (NOT the DCR per-IP cap — that is SC7, a schema-change feature deferred to a separate PR-B). No application-logic behavior change; one permission migration (C3); Sentry-scrubber coverage extension (C2); compose + env-tooling tidies (C1/C4); a CodeQL unused-import cleanup (C5).
+
+## Contracts
+
+### C1 — HA app service sets REDIS_PASSWORD explicitly
+
+- File: `docker-compose.ha.yml` (app service `environment:`, currently lines 75-88).
+- Root cause: `src/lib/redis.ts:30` reads `process.env.REDIS_PASSWORD` for the Sentinel data-node `password`, but the ha.yml app `environment:` only sets `REDIS_URL` (embedded) + `REDIS_SENTINEL_PASSWORD`; the bare `REDIS_PASSWORD` reaches the app only via `env_file: .env` inheritance. Fail-closed (the `REDIS_URL` `:?` guard already requires it), but the data-node-auth dependency is implicit.
+- Signature: add `- REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD is required}` to the ha.yml app `environment:` list — making the Sentinel data-node password dependency explicit and render-validated, independent of env_file injection.
+- Invariants: (app-enforced) the HA app container's `REDIS_PASSWORD` is set explicitly, not only via env_file inheritance.
+- Acceptance: `docker compose -f docker-compose.yml -f docker-compose.ha.yml config` renders the app env with `REDIS_PASSWORD`; renders cleanly with the var set. No app-code change.
+
+### C2 — Sentry scrubber covers span.description and event.transaction
+
+- Files: `src/lib/security/sentry-scrub.ts` (`scrubSentryEvent`), `sentry-scrub.test.ts`.
+- Root cause: `scrubSentryEvent` applies `redactCapabilityPaths` to `event.message`, `exception.values[].value`, span `data` URL keys, request URL/headers/breadcrumbs — but NOT to the top-level `event.transaction` (transaction name string) nor per-span `span.description` (span name). App Router parameterizes route-pattern transaction names, but an outbound-fetch span description or a manually-named transaction could carry a concrete capability URL (`/s/<token>`).
+- Signature: in `scrubSentryEvent`, (a) if `typeof e.transaction === "string"`, set `e.transaction = redactCapabilityPaths(e.transaction)`; (b) in the existing `e.spans` loop, if `typeof span.description === "string"`, set `span.description = redactCapabilityPaths(span.description)`; (c) **(S1) `contexts.trace.description`** — the ROOT span's name lives here (not in `spans[]`), so in the existing `contexts.trace` handling, if `typeof trace.description === "string"`, set `trace.description = redactCapabilityPaths(trace.description)` (`trace.op` is categorical — leave it). Use `redactCapabilityPaths` (path-segment redaction only — preserves the rest of the name), NOT `sanitizeUrl` (which strips query/fragment — wrong for free-text names).
+- Invariants: (app-enforced) every Sentry event field that can carry a capability path — including transaction name, per-span `description`, and the root-span `contexts.trace.description` — passes `redactCapabilityPaths`.
+- Forbidden patterns: none grep-able; enforced by test.
+- Acceptance: new fixtures in the C11 describe — `event.transaction` carrying `/s/<token>` is redacted; a span with `description` carrying `/dashboard/teams/invite/<token>` is redacted; `contexts.trace.description` carrying `/s/<token>` is redacted; each fixture must FAIL against the pre-change scrubber (red-green by reverting the lines). One assert distinguishes `redactCapabilityPaths` from `sanitizeUrl` by including a query/suffix in the name (e.g. `GET /s/<token> (cached)`) and asserting the suffix survives while the token is redacted (T3). vitest green.
+
+### C3 — REVOKE CONNECT on the app database FROM PUBLIC (connection-level Jackson isolation)
+
+- Files: a NEW Prisma migration `prisma/migrations/<ts>_revoke_public_connect_on_app_db/migration.sql` (create via `npx prisma migrate dev --create-only --name revoke_public_connect_on_app_db`, then hand-write the SQL; do NOT let it diff the schema).
+- Root cause: `jackson_user` (the dedicated Jackson role from #530) can still CONNECT to `passwd_sso` via the PUBLIC default (it has no table GRANTs, so no data access — but connection-level isolation is one notch tighter). All legitimate app/worker roles already have EXPLICIT `GRANT CONNECT` (verified: `02-create-app-role.sql:27,63,107` for passwd_app/outbox/anchor; migration `20260428170853:10` for dcr_cleanup; `passwd_user` is `POSTGRES_USER` superuser, exempt). So a `REVOKE CONNECT FROM PUBLIC` blocks exactly `jackson_user` and any other non-explicitly-granted role — the desired effect — without breaking the legitimate roles.
+- Signature (migration SQL, mirroring the existing `DO $$ … format('… %I …', current_database())` pattern used by the GRANT CONNECT migrations): `DO $$ BEGIN EXECUTE format('REVOKE CONNECT ON DATABASE %I FROM PUBLIC', current_database()); END $$;`. Runs as `passwd_user` (superuser/owner) via `migrate deploy`; applies to BOTH fresh installs (migrate runs after initdb) and existing volumes (migrate deploy).
+- Invariants: (schema-enforced) only roles with an explicit `GRANT CONNECT` (or superuser) can connect to `passwd_sso`; `jackson_user` cannot.
+- Automated verification (T1/T2 — the contract's invariant MUST be machine-asserted, not manual-only; note CI's integration DB has NO `jackson_user` because initdb is not mounted there, so the test must not depend on that role existing): add a db-integration test `src/__tests__/db-integration/revoke-public-connect.integration.test.ts` that, as superuser against the migrated DB:
+  1. creates a throwaway no-grant probe role — **idempotent + leak-safe (T5): `DROP ROLE IF EXISTS revoke_probe_role` first, then `CREATE ROLE revoke_probe_role NOLOGIN`, and put the `DROP ROLE` in a `try/finally` so a failed assertion does not leave the role behind on a shared/local DB** — asserts `has_database_privilege('revoke_probe_role', current_database(), 'CONNECT')` is **FALSE** (proves PUBLIC connect is revoked — a role with no explicit grant cannot connect; `NOLOGIN` does not affect the CONNECT-privilege catalog check), then drops it;
+  2. asserts `has_database_privilege` for ALL FOUR legit roles (`passwd_app`, `passwd_outbox_worker`, `passwd_anchor_publisher`, `passwd_dcr_cleanup_worker`) is **TRUE** (the explicit grants survive the REVOKE) — closes T2 structurally without depending on the suite actually connecting as each;
+  3. (RT4 both-branches) the false (probe) and true (legit) assertions both run, so a no-op migration or an over-broad REVOKE is caught.
+  This runs in the CI integration job (which applies `migrate deploy` to `passwd_test`) and locally. The probe-role mechanism is CI-safe (does not require `jackson_user`).
+- Acceptance: `npm run db:migrate` applies cleanly on the dev DB; the new privilege-assertion test passes (probe role FALSE, 4 legit roles TRUE); the full integration suite + RLS role-separation smoke stay green; on the dev volume (where `jackson_user` exists) a manual `psql` connect as `jackson_user` to `passwd_sso` is additionally confirmed refused. CI integration job is the authoritative fresh-DB proof.
+- Risk note: connection-permission migration — the privilege-assertion test is the structural guard that no legit role relies on PUBLIC connect; the 4 worker/app roles are explicitly granted (verified), the migrate/superuser role is exempt.
+
+### C4 — .env.example renders REDIS_PASSWORD symmetrically with PASSWD_JACKSON_PASSWORD
+
+- Files: `scripts/env-descriptions.ts` (the `REDIS_PASSWORD` sidecar entry, ~:593-603), `scripts/generate-env-example.ts` (the Zod-path comment-out logic, ~:204), regenerate `.env.example`.
+- Root cause: both vars are REQUIRED for any docker-compose deployment (compose `:?` guards), but `.env.example` renders `PASSWD_JACKSON_PASSWORD=` uncommented (allowlist `requiredForConsumer: true`) while `REDIS_PASSWORD` renders `# REDIS_PASSWORD=` commented (Zod-optional path: `emitUncommented = hasZodDefault || isAlwaysRequired`, both false). Onboarding friction — the commented form reads as "optional".
+- Signature: add an opt-in flag to the Zod sidecar (e.g. `requiredForCompose: true`) on the `REDIS_PASSWORD` `env-descriptions.ts` entry, and extend `generate-env-example.ts`'s `emitUncommented` to `hasZodDefault || isAlwaysRequired || sidecar.requiredForCompose`. Then `REDIS_PASSWORD` renders uncommented (`REDIS_PASSWORD=`), symmetric with `PASSWD_JACKSON_PASSWORD`, keeping its explanatory NOTE comment. Regenerate `.env.example` via `npm run generate:env-example`.
+- Invariants: (app-enforced) compose-required secrets render uncommented in `.env.example`.
+- Acceptance: `.env.example` shows `REDIS_PASSWORD=` uncommented (with its NOTE comment retained); `npm run check:env-docs` green (no drift); the sidecar flag is typed and documented. No change to the app's Zod-optional status of `REDIS_PASSWORD` (it remains optional at the schema level; only the example rendering changes). (T4) `scripts/__tests__/generate-env-example.test.mjs` gains an assertion mirroring the existing `requiredForConsumer` precedent (`expect(content).toMatch(/^JACKSON_API_KEY=/m)`): `expect(content).toMatch(/^REDIS_PASSWORD=/m)` AND `expect(content).not.toMatch(/^# ?REDIS_PASSWORD=/m)` AND the NOTE comment is retained — this pins the uncommented rendering so a future generator refactor cannot silently revert it (check:env-docs alone does not catch comment-vs-uncomment).
+- Alternative considered (rejected): commenting out `PASSWD_JACKSON_PASSWORD` instead — wrong direction (both are required; uncommenting REDIS_PASSWORD makes the requirement visible).
+
+### C5 — Remove unused `afterEach` import (CodeQL alert 210)
+
+- File: `src/lib/redis.test.ts:1`.
+- Root cause: #530 converted this file to `vi.stubEnv` and removed the manual `afterEach` env cleanup, leaving `afterEach` imported but unused → CodeQL `js/unused-local-variable` (note) alert 210 on main.
+- Signature: drop `afterEach` from `import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";` → `import { describe, it, expect, vi, beforeEach } from "vitest";`.
+- Acceptance: `npm run lint` clean; vitest for redis.test.ts green; the CodeQL alert closes on the next scan.
+
+## Go/No-Go Gate
+
+| ID | Subject                                                  | Status |
+|----|----------------------------------------------------------|--------|
+| C1 | HA app explicit REDIS_PASSWORD env                       | locked |
+| C2 | Sentry scrub span.description + event.transaction        | locked |
+| C3 | REVOKE CONNECT on app DB FROM PUBLIC (migration)         | locked |
+| C4 | .env.example REDIS_PASSWORD symmetric rendering          | locked |
+| C5 | Remove unused afterEach import (CodeQL 210)              | locked |
+
+## Testing strategy
+
+- Unit: C2 (2 red-able scrubber fixtures), C5 (lint). C1/C3/C4 are not vitest-testable (compose/SQL-permission/generator) — covered by render check / migration apply + integration + check:env-docs.
+- db-integration (`npm run test:integration`, real Postgres): C3 — run the migration on the dev DB, confirm the full integration suite + RLS role-separation smoke stay green (they connect as explicitly-granted roles), and manually confirm `jackson_user` connect is refused. CI integration job is the authoritative fresh-DB proof.
+- Gates: `npx vitest run`, `npx next build`, `npm run lint`, `npm run check:env-docs`, `docker compose -f docker-compose.yml -f docker-compose.ha.yml config`, `scripts/pre-pr.sh`, `npm run test:integration`.
+- R35: C3 adds a Prisma migration (deployment-relevant); a `*-manual-test.md` is NOT required because the migration is a single REVOKE with no data change and its verification (passwd_app reconnect / jackson_user refusal / smoke green) is captured in the C3 acceptance and run locally + in CI. (If a reviewer deems the permission change Tier-1, a short manual-test note will be added.)
+
+## Considerations & constraints
+
+- C3 is the only item with a migration; it is a permission REVOKE, not a table/column change — no `prisma migrate dev` schema diff (use `--create-only` + hand-written SQL).
+- C4 changes only the example RENDERING, not the app's Zod-optional treatment of `REDIS_PASSWORD`.
+- SC1: DCR per-IP/per-window unclaimed cap (the #530 review's item 4, = SC7) is OUT of scope — it needs persisting the registrant IP (schema change) and its own triangulate cycle (PR-B).
+- SC2: `check:env-docs` does not regenerate-and-byte-compare `.env.example` (a forgotten `generate:env-example` after a sidecar change would pass the drift check) — pre-existing tooling gap, not introduced here; recorded as `TODO(post-530-hardening): env-docs regenerate-compare`. C4's T4 test partially mitigates by pinning the REDIS_PASSWORD rendering.
+
+## User operation scenarios
+
+1. HA operator brings up the stack → app container has `REDIS_PASSWORD` explicitly, Sentinel data-node auth wired without relying on env_file ordering.
+2. A Sentry trace for an outbound fetch to `/s/<token>` → transaction/span names are redacted, not just the request URL.
+3. A new dev clones and `cat .env.example` → `REDIS_PASSWORD=` reads as required (uncommented), like `PASSWD_JACKSON_PASSWORD=`.
+4. `jackson_user` credential leak → cannot even connect to `passwd_sso` (connection refused), not just table-denied.

--- a/docs/archive/review/post-530-hardening-review.md
+++ b/docs/archive/review/post-530-hardening-review.md
@@ -1,0 +1,34 @@
+# Plan Review: post-530-hardening
+
+Date: 2026-06-11
+Review round: 1 (+ targeted R2 on C3)
+
+## Round 1
+
+### Functionality — no blockers
+- C3 REVOKE CONNECT verified safe: all 4 app/worker roles have explicit GRANT CONNECT (initdb `02-create-app-role.sql:27,63,107` + migrations for dcr_cleanup); `passwd_user`/CI `postgres` are superuser (exempt); `jackson_user` relies on PUBLIC only → REVOKE blocks exactly it. CI parity confirmed (RLS smoke connects as passwd_app; integration as superuser/app/workers). `--create-only` + hand-written SQL checksum is the standard supported flow.
+- C1/C2/C4/C5 mechanisms confirmed implementable. F1 (current_database() resolution — info, matches existing pattern), F2 (check:env-docs doesn't regenerate-compare — pre-existing gap → recorded as SC2 TODO).
+
+### Security — S1 [Minor]
+- C3 availability re-verified by enumerating EVERY connector (app, 3 workers, migrate, db healthcheck `pg_isready -U passwd_user` = superuser, jackson service connects to the `jackson` DB not `passwd_sso`, build-time dummy URL = no real connection) — none rely on PUBLIC connect. No outage risk.
+- **S1 [Minor]**: C2 missed `contexts.trace.description` — the ROOT span's name lives there (not in `spans[].description`), same capability-URL leak class. → C2 extended to scrub `contexts.trace.description`.
+- C1 no secret-exposure delta (parity with existing PASSWD_* env practice); C4 placeholder-only (no real secret).
+
+### Testing
+- **T1 [Critical]**: C3's "jackson_user cannot connect" invariant had NO automated test, and CI's integration DB has no `jackson_user` (initdb not mounted) — so calling CI the "authoritative proof" was false for this invariant (only the legit-roles-still-connect half is CI-checkable). → C3 now adds a db-integration privilege-assertion test using a throwaway no-grant **probe role** (`has_database_privilege` FALSE proves PUBLIC connect revoked, CI-safe — no jackson_user dependency) + asserts the 4 legit roles TRUE (closes T2), both branches (RT4).
+- **T2 [Major]**: "integration suite stays green" only exercises app/superuser connects, not anchor/dcr — folded into T1's all-4-roles privilege assertion.
+- **T3 [Minor]**: C2 fixtures red-able + non-breaking (confirmed); added an assert distinguishing redactCapabilityPaths from sanitizeUrl (suffix survives).
+- **T4 [Minor]**: check:env-docs doesn't pin comment-vs-uncomment → C4 adds a generate-env-example.test.mjs assertion (REDIS_PASSWORD uncommented + NOT commented + NOTE retained).
+- R35: the mechanical hook does NOT match `prisma/migrations/*.sql` (no fire); manual-test.md correctly omitted, SUPERSEDED by the T1 automated privilege assertion.
+
+## Round 2 (targeted — C3 test mechanism)
+
+Verifying the probe-role `has_database_privilege` approach below.
+
+## Resolution Status (Round 1)
+
+S1, T1, T2, T3, T4 reflected in the plan (C2 trace.description, C3 privilege-assertion test, C4 env-example test). F2 → SC2 TODO. No skips.
+
+## Round 2 result
+
+C3 probe-role mechanism verified sound (PG `has_database_privilege` evaluates PUBLIC+explicit+membership; NOLOGIN irrelevant to the CONNECT-priv check; CI superuser can CREATE/DROP ROLE; all 4 legit roles exist in CI at test time). **T5 [Low]**: idempotent `DROP ROLE IF EXISTS` + try/finally to avoid probe-role residue on local re-run — reflected in C3. Plan review CLOSED; all contracts locked.

--- a/prisma/migrations/20260611011121_revoke_public_connect_on_app_db/migration.sql
+++ b/prisma/migrations/20260611011121_revoke_public_connect_on_app_db/migration.sql
@@ -1,0 +1,11 @@
+-- Revoke the PUBLIC default CONNECT privilege on the application database.
+-- All legitimate app/worker roles already have explicit GRANT CONNECT (see
+-- 02-create-app-role.sql and migration 20260428170853). This tightens
+-- connection-level isolation so roles without an explicit grant (e.g.
+-- jackson_user) cannot even connect to passwd_sso.
+--
+-- Pattern mirrors the existing GRANT CONNECT migrations: DO/$$/format()/current_database().
+-- Runs as passwd_user (superuser/owner) via `migrate deploy`.
+DO $$ BEGIN
+  EXECUTE format('REVOKE CONNECT ON DATABASE %I FROM PUBLIC', current_database());
+END $$;

--- a/scripts/__tests__/generate-env-example.test.mjs
+++ b/scripts/__tests__/generate-env-example.test.mjs
@@ -171,4 +171,20 @@ describe("generate-env-example.ts", () => {
     const trContent = readFileSync(rTr.outPath, "utf8");
     expect(enContent).toBe(trContent);
   });
+
+  it("C4: REDIS_PASSWORD renders uncommented with NOTE comment retained (requiredForCompose)", () => {
+    // Pins the C4 rendering so a future generator refactor cannot silently
+    // revert REDIS_PASSWORD to a commented-out form (check:env-docs alone
+    // does not catch comment-vs-uncomment).
+    const result = runGenerator();
+    expect(result.status).toBe(0);
+    const content = readFileSync(result.outPath, "utf8");
+
+    // Must be uncommented (mirrors JACKSON_API_KEY requiredForConsumer test).
+    expect(content).toMatch(/^REDIS_PASSWORD=/m);
+    // Must NOT appear in any commented form.
+    expect(content).not.toMatch(/^# ?REDIS_PASSWORD=/m);
+    // NOTE comment from the sidecar description must be retained.
+    expect(content).toContain("NOTE: docker-compose deployments REQUIRE this variable");
+  });
 });

--- a/scripts/env-descriptions.ts
+++ b/scripts/env-descriptions.ts
@@ -36,6 +36,10 @@ export type SidecarEntry = {
   example?: string;
   secret?: boolean;
   scope?: "runtime" | "build" | "framework-set";
+  /** When true, .env.example renders this key uncommented even if it has no
+   *  Zod default and is not isAlwaysRequired — it is required for any
+   *  docker-compose deployment (compose :? guard aborts startup without it). */
+  requiredForCompose?: boolean;
 };
 
 export const descriptions: Record<
@@ -600,6 +604,7 @@ export const descriptions: Record<
       "NOTE: docker-compose deployments REQUIRE this variable — the compose files\n" +
       "use a :? guard that aborts startup when it is missing.",
     secret: true,
+    requiredForCompose: true,
   },
 
   // ── Outbox worker ─────────────────────────────────────────────────────────

--- a/scripts/generate-env-example.ts
+++ b/scripts/generate-env-example.ts
@@ -199,10 +199,12 @@ for (const { key, groupIndex } of entries) {
   //   - the key has a Zod .default() — it always has a runtime value; OR
   //   - the key is always-required (no default, no .optional()) — CF4 fix:
   //     developers doing `cp .env.example .env.local && npm run dev` must see
-  //     the assignment uncommented so the template shows what to fill in.
+  //     the assignment uncommented so the template shows what to fill in; OR
+  //   - the sidecar marks it requiredForCompose — Zod-optional at app level
+  //     but the compose :? guard aborts startup without it (e.g. REDIS_PASSWORD).
   // Emit commented when the key is truly optional (may be left unset at boot).
   const emitUncommented =
-    hasZodDefault(null as never, key) || isAlwaysRequired(key);
+    hasZodDefault(null as never, key) || isAlwaysRequired(key) || sidecar.requiredForCompose === true;
 
   if (emitUncommented) {
     lines.push(`${key}=${guardedExample ?? ""}`);

--- a/src/__tests__/db-integration/revoke-public-connect.integration.test.ts
+++ b/src/__tests__/db-integration/revoke-public-connect.integration.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Verifies that the REVOKE CONNECT FROM PUBLIC migration (C3) took effect.
+ *
+ * T1: a freshly-created role with no explicit GRANT cannot connect (PUBLIC revoked).
+ * T2: all four legitimate app/worker roles retain their explicit GRANT CONNECT.
+ * RT4: both false (probe) and true (legit) branches are asserted, so a no-op
+ *      migration or an over-broad REVOKE is caught.
+ *
+ * Uses has_database_privilege() to check catalog state without needing a live
+ * connection as the probe role (NOLOGIN roles cannot actually connect, but the
+ * CONNECT privilege catalog check still reflects the grant state correctly).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createTestContext, type TestContext } from "./helpers";
+
+describe("REVOKE CONNECT FROM PUBLIC (C3 migration)", () => {
+  let ctx: TestContext;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+  });
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  it("T1: probe role with no explicit GRANT cannot connect (PUBLIC revoked)", async () => {
+    // Idempotent cleanup before create (T5: leak-safe)
+    await ctx.su.prisma.$executeRawUnsafe(`DROP ROLE IF EXISTS revoke_probe_role`);
+
+    try {
+      await ctx.su.prisma.$executeRawUnsafe(`CREATE ROLE revoke_probe_role NOLOGIN`);
+
+      const rows = await ctx.su.prisma.$queryRaw<Array<{ can_connect: boolean }>>`
+        SELECT has_database_privilege('revoke_probe_role', current_database(), 'CONNECT') AS can_connect
+      `;
+      expect(rows[0].can_connect).toBe(false);
+    } finally {
+      // T5: always clean up so a failed assertion does not leave the role behind
+      await ctx.su.prisma.$executeRawUnsafe(`DROP ROLE IF EXISTS revoke_probe_role`);
+    }
+  });
+
+  it("T2: passwd_app retains explicit GRANT CONNECT", async () => {
+    const rows = await ctx.su.prisma.$queryRaw<Array<{ can_connect: boolean }>>`
+      SELECT has_database_privilege('passwd_app', current_database(), 'CONNECT') AS can_connect
+    `;
+    expect(rows[0].can_connect).toBe(true);
+  });
+
+  it("T2: passwd_outbox_worker retains explicit GRANT CONNECT", async () => {
+    const rows = await ctx.su.prisma.$queryRaw<Array<{ can_connect: boolean }>>`
+      SELECT has_database_privilege('passwd_outbox_worker', current_database(), 'CONNECT') AS can_connect
+    `;
+    expect(rows[0].can_connect).toBe(true);
+  });
+
+  it("T2: passwd_anchor_publisher retains explicit GRANT CONNECT", async () => {
+    const rows = await ctx.su.prisma.$queryRaw<Array<{ can_connect: boolean }>>`
+      SELECT has_database_privilege('passwd_anchor_publisher', current_database(), 'CONNECT') AS can_connect
+    `;
+    expect(rows[0].can_connect).toBe(true);
+  });
+
+  it("T2: passwd_dcr_cleanup_worker retains explicit GRANT CONNECT", async () => {
+    const rows = await ctx.su.prisma.$queryRaw<Array<{ can_connect: boolean }>>`
+      SELECT has_database_privilege('passwd_dcr_cleanup_worker', current_database(), 'CONNECT') AS can_connect
+    `;
+    expect(rows[0].can_connect).toBe(true);
+  });
+});

--- a/src/lib/redis.test.ts
+++ b/src/lib/redis.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ioredis default export is used as a constructor: `new Redis(...)`.
 // The mock must use a regular function (not an arrow function) so it can be

--- a/src/lib/security/sentry-scrub.test.ts
+++ b/src/lib/security/sentry-scrub.test.ts
@@ -489,6 +489,63 @@ describe("F1 / S2 — new coverage", () => {
   });
 });
 
+// C2 acceptance fixtures — each MUST fail before the sentry-scrub.ts C2 changes
+// (red-green verified by reverting the 3 new lines and re-running the suite).
+describe("C2 — transaction name, span.description, contexts.trace.description scrubbing", () => {
+  // (a) event.transaction with /s/<token> is redacted
+  it("(a) redacts /s/<token> in event.transaction", () => {
+    const token = "shareTokenC2a123";
+    const event = { transaction: `/s/${token}` };
+    const result = scrubSentryEvent(event);
+    expect((result as Record<string, unknown>).transaction).toBe("/s/[redacted]");
+  });
+
+  // (b) span.description with capability path is redacted
+  it("(b) redacts team invite token in span.description", () => {
+    const token = "inviteTokenC2b456";
+    const event = {
+      spans: [
+        {
+          op: "http.client",
+          description: `/dashboard/teams/invite/${token}`,
+        },
+      ],
+    };
+    const result = scrubSentryEvent(event);
+    const span = (result.spans as Array<Record<string, unknown>>)[0];
+    expect(span.description).toBe("/dashboard/teams/invite/[redacted]");
+  });
+
+  // (c) contexts.trace.description with /s/<token> is redacted
+  it("(c) redacts /s/<token> in contexts.trace.description", () => {
+    const token = "traceTokenC2c789";
+    const event = {
+      contexts: {
+        trace: {
+          op: "http.server",
+          description: `/s/${token}`,
+        },
+      },
+    };
+    const result = scrubSentryEvent(event);
+    const trace = ((result.contexts as Record<string, unknown>).trace as Record<string, unknown>);
+    expect(trace.description).toBe("/s/[redacted]");
+    // trace.op (categorical) must be preserved unchanged
+    expect(trace.op).toBe("http.server");
+  });
+
+  // (T3) suffix preserved: redactCapabilityPaths, not sanitizeUrl
+  // sanitizeUrl would strip the suffix; redactCapabilityPaths must keep it
+  it("(T3) keeps suffix after token in transaction name (proves redactCapabilityPaths not sanitizeUrl)", () => {
+    const token = "suffixTokenC2d";
+    const event = { transaction: `GET /s/${token} (cached)` };
+    const result = scrubSentryEvent(event);
+    const txn = (result as Record<string, unknown>).transaction as string;
+    expect(txn).toBe("GET /s/[redacted] (cached)");
+    expect(txn).not.toContain(token);
+  });
+});
+
 describe("sanitizeUrl", () => {
   it("strips query string", () => {
     expect(sanitizeUrl("https://example.com/path?foo=bar&baz=qux")).toBe("https://example.com/path");

--- a/src/lib/security/sentry-scrub.test.ts
+++ b/src/lib/security/sentry-scrub.test.ts
@@ -546,6 +546,23 @@ describe("C2 — transaction name, span.description, contexts.trace.description 
   });
 });
 
+// C11 acceptance fixtures — tags scrubbing
+// MUST fail against the pre-change scrubber (before e.tags handling was added).
+describe("C11 — tags scrubbing", () => {
+  it("redacts capability URL in tags.transaction and preserves non-capability tags", () => {
+    const event = {
+      tags: {
+        transaction: "/s/<token>",
+        env: "production",
+      },
+    };
+    const result = scrubSentryEvent(event);
+    const tags = (result as Record<string, unknown>).tags as Record<string, unknown>;
+    expect(tags.transaction).toBe("/s/[redacted]");
+    expect(tags.env).toBe("production");
+  });
+});
+
 describe("sanitizeUrl", () => {
   it("strips query string", () => {
     expect(sanitizeUrl("https://example.com/path?foo=bar&baz=qux")).toBe("https://example.com/path");

--- a/src/lib/security/sentry-scrub.ts
+++ b/src/lib/security/sentry-scrub.ts
@@ -299,5 +299,16 @@ export function scrubSentryEvent<T extends Record<string, unknown>>(event: T): T
     e.transaction = redactCapabilityPaths(e.transaction);
   }
 
+  // Redact capability paths from tags — Sentry auto-copies transaction into tags.transaction,
+  // and custom tags could carry capability URLs.
+  if (e.tags && typeof e.tags === "object" && !Array.isArray(e.tags)) {
+    const tags = e.tags as Record<string, unknown>;
+    for (const key of Object.keys(tags)) {
+      if (typeof tags[key] === "string") {
+        tags[key] = redactCapabilityPaths(tags[key] as string);
+      }
+    }
+  }
+
   return event;
 }

--- a/src/lib/security/sentry-scrub.ts
+++ b/src/lib/security/sentry-scrub.ts
@@ -156,6 +156,10 @@ export function scrubSentryEvent<T extends Record<string, unknown>>(event: T): T
         }
         trace.data = scrubbed;
       }
+      // Redact capability paths from root-span description (free-text span name)
+      if (typeof trace.description === "string") {
+        trace.description = redactCapabilityPaths(trace.description);
+      }
     }
   }
 
@@ -283,7 +287,16 @@ export function scrubSentryEvent<T extends Record<string, unknown>>(event: T): T
         }
         span.data = scrubbed;
       }
+      // Redact capability paths from span description (free-text span name)
+      if (typeof span.description === "string") {
+        span.description = redactCapabilityPaths(span.description);
+      }
     }
+  }
+
+  // Redact capability paths from top-level transaction name
+  if (typeof e.transaction === "string") {
+    e.transaction = redactCapabilityPaths(e.transaction);
   }
 
   return event;


### PR DESCRIPTION
## Summary

Five Low/Info post-`#530` hardening items from the follow-up review. No application-logic behavior change; one permission migration (C3); a Sentry-scrubber coverage extension (C2). The DCR per-IP unclaimed cap (`#530` review item 4, = SC7) is intentionally NOT here — it needs a schema change and gets its own PR.

Developed via the triangulate workflow (plan + 2 review rounds + code review).

## Items

| # | Fix |
|---|-----|
| C1 | `docker-compose.ha.yml` app service sets `REDIS_PASSWORD` explicitly — makes the Sentinel data-node auth dependency (`redis.ts` reads `process.env.REDIS_PASSWORD`) explicit and render-validated instead of relying on `env_file` inheritance. |
| C2 | The Sentry scrubber now redacts capability paths (`/s/<token>`, invite links) in `event.transaction`, per-span `description`, `contexts.trace.description` (root-span name), and `event.tags` — previously only request URL / span data / breadcrumbs / exception / message were covered. |
| C3 | **`REVOKE CONNECT ON DATABASE <appdb> FROM PUBLIC`** (Prisma migration) — connection-level isolation so a role without an explicit grant (e.g. `jackson_user`) cannot even connect to `passwd_sso`. All legitimate app/worker roles already have explicit `GRANT CONNECT` (verified); the migrate/superuser role is exempt. A db-integration test asserts a no-grant probe role gets `CONNECT = false` while all four app/worker roles stay `true`. |
| C4 | `.env.example` renders `REDIS_PASSWORD=` uncommented (a compose-required secret), symmetric with `PASSWD_JACKSON_PASSWORD=`, removing onboarding ambiguity. |
| C5 | Remove an unused `afterEach` import in `redis.test.ts` (closes CodeQL `js/unused-local-variable` alert 210). |

## Testing

- C3: a new `revoke-public-connect.integration.test.ts` proves the REVOKE took effect (probe role `has_database_privilege` = false — verified non-vacuous) and that all four legit roles retain CONNECT (both branches). The full integration suite still shows the legit roles connecting after the REVOKE (no `permission denied`). CI integration job on a fresh DB is the authoritative proof.
- C2: red-able scrubber fixtures (transaction / span.description / trace.description / tags, plus a `(cached)` suffix assert proving `redactCapabilityPaths` not `sanitizeUrl`).
- C4: a generate-env-example test pins the uncommented `REDIS_PASSWORD` rendering.
- `scripts/pre-pr.sh` 32/32, full unit suite green.

## Availability note (C3)

`REVOKE CONNECT FROM PUBLIC` affects only roles relying on the PUBLIC default. Enumerated every connector to `passwd_sso` — `passwd_app` + 3 workers (explicit `GRANT CONNECT`), `passwd_user`/healthcheck (superuser), Jackson (connects to the `jackson` DB, not `passwd_sso`) — none rely on PUBLIC. Applied + verified on the dev DB.

## Artifacts

`docs/archive/review/post-530-hardening-{plan,review,deviation,code-review}.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)