### PR TITLE
fix(ios): honest "Vault is Locked" AutoFill copy (no fake Open-app button)

### DIFF
--- a/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
+++ b/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
@@ -192,9 +192,6 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
   @MainActor
   private func presentLockedSheet() {
     let view = LockedFallbackView(
-      onOpen: { [weak self] in
-        self?.openHostApp()
-      },
       onDismiss: { [weak self] in
         self?.cancel(with: nil)
       }
@@ -234,18 +231,6 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
       } catch {
         cancel(with: error)
       }
-    }
-  }
-
-  // MARK: - Host-app deep link (iOS 17+)
-
-  private func openHostApp() {
-    if #available(iOS 17.0, *) {
-      // extensionContext.open is not available to credential provider extensions;
-      // dismiss so the user can switch to the host app manually.
-      cancel(with: nil)
-    } else {
-      cancel(with: nil)
     }
   }
 

--- a/ios/PasswdSSOAutofillExtension/Views/LockedFallbackView.swift
+++ b/ios/PasswdSSOAutofillExtension/Views/LockedFallbackView.swift
@@ -1,10 +1,10 @@
 import AuthenticationServices
 import SwiftUI
 
-/// Shown when the vault is locked (bridge_key not in Keychain).
-/// Prompts the user to open the host app to unlock.
+/// Shown when the vault is locked (bridge_key not in Keychain). Credential
+/// provider extensions have no supported API to launch the host app, so this
+/// only instructs the user to open passwd-sso manually, then dismisses.
 struct LockedFallbackView: View {
-  let onOpen: () -> Void
   let onDismiss: () -> Void
 
   var body: some View {
@@ -21,15 +21,15 @@ struct LockedFallbackView: View {
             .font(.title2)
             .fontWeight(.semibold)
 
-          Text("Open passwd-sso to unlock your vault, then return here to fill.")
+          Text("Open the passwd-sso app and unlock your vault, then come back here to fill.")
             .font(.subheadline)
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
             .padding(.horizontal)
         }
 
-        Button("Open passwd-sso") {
-          onOpen()
+        Button("OK") {
+          onDismiss()
         }
         .buttonStyle(.borderedProminent)
         .controlSize(.large)


### PR DESCRIPTION
## Why

When the vault is locked during AutoFill, the fallback sheet showed an **"Open passwd-sso"** button that only **dismissed the dialog** — it never opened the app. Credential provider extensions have **no supported API to launch the host app**:
- `NSExtensionContext.open(_:)` is supported only by Today/iMessage extensions (returns false here).
- `UIApplication.open` is unavailable under `APPLICATION_EXTENSION_API_ONLY = YES`.

The button label promised an action it couldn't perform — misleading UX (user reported "it just closes").

## What

Relabel to honest guidance and drop the dead path:
- Message → "Open the passwd-sso app and unlock your vault, then come back here to fill."
- Button → "OK" (dismisses), plus the existing toolbar Cancel.
- Removed `LockedFallbackView.onOpen` and the no-op `openHostApp()`.

No logic/security change — fill, biometric gate, and lock detection are untouched.

## Verification

- `build-for-testing` clean; **261 unit + 2 UI tests pass**.
- Too small for the full triangulate ceremony (text/button only, no logic/security surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)