### PR TITLE
test(mcp): remove unused insertUnclaimedDcrClient helper (CodeQL #211)

### DIFF
--- a/src/__tests__/db-integration/dcr-cleanup-worker-sweep.integration.test.ts
+++ b/src/__tests__/db-integration/dcr-cleanup-worker-sweep.integration.test.ts
@@ -288,23 +288,6 @@ describe("DCR register lazy cleanup (real DB)", () => {
     }
   });
 
-  async function insertUnclaimedDcrClient(expiresAt: string): Promise<string> {
-    const id = randomUUID();
-    const clientIdStr = `test-cl-${id.slice(0, 12)}`;
-    await ctx.su.prisma.$transaction(async (tx) => {
-      await setBypassRlsGucs(tx);
-      await tx.$executeRawUnsafe(
-        `INSERT INTO mcp_clients (id, client_id, client_secret_hash, name, redirect_uris, allowed_scopes, is_dcr, tenant_id, dcr_expires_at, created_at, updated_at)
-         VALUES ($1::uuid, $2, '', $3, '{}', 'credentials:list', true, NULL, ${expiresAt}, now(), now())`,
-        id,
-        clientIdStr,
-        `client-${id.slice(0, 8)}`,
-      );
-    });
-    seededClientIds.push(id);
-    return id;
-  }
-
   /**
    * Executes the same deleteMany-then-count transaction that register/route.ts
    * runs, using the production Prisma query shapes from that route.


### PR DESCRIPTION
## Summary

Removes the now-dead `insertUnclaimedDcrClient` helper in the DCR cleanup-worker-sweep integration test, resolving CodeQL `js/unused-local-variable` alert 211.

When `#538` refactored the cap-seed loops to a single bulk `INSERT` (to keep the 1000-row seed fast), this per-row helper lost all its callers. Per the dead-code rule, the fix is deletion at the root, not a suppression comment.

## Verification

- The helper had zero callers (grep-confirmed); `randomUUID` remains used by the bulk-insert loops (import retained).
- The 3 integration tests still pass; ESLint clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)