### PR TITLE
fix(ext): recover popup from stuck "loading" when service worker is unreachable

### DIFF
--- a/docs/archive/review/extension-popup-stuck-loading-code-review.md
+++ b/docs/archive/review/extension-popup-stuck-loading-code-review.md
@@ -1,0 +1,99 @@
+# Code Review: extension-popup-stuck-loading
+
+Date: 2026-06-12
+Review rounds: 2 (terminated — all lenses "No findings" in Round 2)
+Branch: fix/extension-popup-stuck-loading
+
+## Summary
+
+Fix for the browser-extension popup occasionally getting stuck on the
+"読み込み中 / Loading" spinner with no lock/sign-out buttons.
+
+Root cause: `refreshStatus()` issued `sendMessage({ type: "GET_STATUS" })` with no
+`.catch()`. Under MV3, the service worker can be torn down (or hang while awaiting
+`hydrationPromise`), so `chrome.runtime.sendMessage` rejects ("message channel
+closed"). With no rejection handler, `setState` was never called and `state`
+stayed at its initial `"loading"`. The header lock/disconnect buttons render only
+in `logged_in`/`vault_unlocked`, so they were absent too.
+
+Fix: wrap GET_STATUS in a 3s timeout (`fetchStatus`), add `.catch()` with up to 2
+retries (250ms apart), and on persistent failure show a new `"error"` state with a
+Retry button — eliminating the permanent-spinner failure mode.
+
+## Changed files
+- `extension/src/popup/App.tsx`
+- `extension/src/messages/en.json`, `ja.json` (`popup.statusError`, `popup.retry`)
+- `extension/src/__tests__/popup/App.test.tsx` (4 new tests)
+
+## Round 1 Findings & Resolution
+
+Security expert: No findings (fail-closed confirmed; GET_STATUS idempotent;
+no information disclosure; R37 clean).
+
+### F2 [Major] Background refresh failure clobbers a working screen — RESOLVED
+- The `chrome.storage.onChanged` listener called bare `refreshStatus()`, so a
+  transient failure during a vault-lock event could flip a good `vault_unlocked`
+  view to the full-screen error pane.
+- Fix: added `allowError` param; the storage listener now calls
+  `refreshStatus(0, false)`. Only initial load and manual Retry surface `error`.
+- File: `extension/src/popup/App.tsx:52,92`
+
+### T2 [Major] Automatic-retry recovery path untested — RESOLVED
+- Added test "recovers automatically when an internal retry succeeds (no user
+  action)": first attempt rejects, scheduled retry resolves → MatchList renders,
+  no Retry button ever shown.
+- File: `extension/src/__tests__/popup/App.test.tsx:155`
+
+### F3 [Minor] Floating rejection after timeout wins the race — RESOLVED
+- Attached `status.catch(() => {})` to the underlying sendMessage promise so a
+  late rejection does not become an unhandledrejection. `Promise.race` still
+  observes the original rejection and retries fire (verified).
+- File: `extension/src/popup/App.tsx:20-23`
+
+### F5 [Minor] Unguarded handleLock/handleDisconnect (pre-existing, in scope) — RESOLVED
+- `handleLock`: try/catch, still sets `logged_in` (fail-secure — a torn-down SW
+  has already lost its in-memory key).
+- `handleDisconnect`: try/catch; on failure sets `error` and returns rather than
+  falsely claiming `not_logged_in` (CLEAR_TOKEN revokes server-side and may not
+  have run).
+- File: `extension/src/popup/App.tsx:99-120`
+
+### T3 [Minor] Timeout-hang path untested — RESOLVED
+- Added fake-timer test "shows the retry control when the status request hangs
+  past the timeout" (sendMessage never settles; advance 10s through all 3
+  timeouts + 2 retry delays).
+- File: `extension/src/__tests__/popup/App.test.tsx:177`
+
+### Accepted / informational (no action)
+- F1 (error state hides lock/disconnect): acceptable — a wedged SW also blocks
+  those messages, so Retry is the only meaningful action. Strict improvement over
+  the infinite spinner.
+- F4 (Retry interleaving with in-flight chain): low likelihood, benign outcome;
+  largely neutralized by the F2 fix. States are idempotent.
+- F6/F7 (retry effectiveness vs wedged hydration; worst-case ~9.5s to error):
+  informational. Follow-up candidate: add a timeout to `hydrateFromSession()` in
+  the service worker so GET_STATUS returns a degraded status instead of hanging.
+- T1/T4/T5/T6 (mock omits optional `tenantAutoLockMinutes`; timer leak; mockReset;
+  isolation): no-action — harmless / sound in current ordering.
+
+## Round 2 (incremental verification)
+
+Combined functionality / security (token-lifecycle) / testing review of the fix
+diff. **No findings** in any lens:
+- allowError threading verified (preserved through retries; background failure
+  leaves prior state untouched; initial load always reaches a terminal state).
+- handleDisconnect→error justified (fail-closed, two-step Retry recovery, no
+  lockout). handleLock fail-secure claim verified against the synchronous
+  LOCK_VAULT SW handler.
+- F3 catch does not consume the race's rejection (verified empirically).
+- Both new tests assert the intended paths; fake-timer test is deterministic.
+- R37 pass; R25 N/A; RS1-RS4 N/A; no stale closures.
+
+## Verification
+- `npx tsc --noEmit` — clean
+- `npx vitest run` (extension) — 748 passed / 50 files
+- `npm run build` (extension) — success
+
+## Follow-up (out of scope, not blocking)
+- Service-worker `hydrateFromSession()` lacks a timeout; a hung internal await
+  there keeps GET_STATUS blocked across retries. Tracked for a separate change.

--- a/extension/src/__tests__/popup/App.test.tsx
+++ b/extension/src/__tests__/popup/App.test.tsx
@@ -3,7 +3,7 @@
  */
 import "@testing-library/jest-dom/vitest";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, waitFor, screen, fireEvent } from "@testing-library/react";
+import { render, waitFor, screen, fireEvent, act } from "@testing-library/react";
 
 const mockSendMessage = vi.fn();
 const mockMatchList = vi.fn((_props: unknown) => null);
@@ -136,6 +136,86 @@ describe("App tab URL handling", () => {
 
     await waitFor(() => {
       expect(mockSendMessage).toHaveBeenCalledWith({ type: "CLEAR_TOKEN" });
+    });
+  });
+
+  it("shows a retry control instead of spinning forever when status cannot be fetched", async () => {
+    const chromeMock = (globalThis as unknown as { chrome: { tabs: { query: ReturnType<typeof vi.fn> } } }).chrome;
+    chromeMock.tabs.query.mockResolvedValue([{ url: "https://example.com" }]);
+    // GET_STATUS rejects on the initial attempt and every retry (e.g. the MV3
+    // service worker was torn down and the message channel closed).
+    mockSendMessage.mockRejectedValue(new Error("channel closed"));
+
+    render(<App />);
+
+    const retryButton = await screen.findByRole("button", { name: /retry/i }, { timeout: 2000 });
+    expect(retryButton).toBeInTheDocument();
+    expect(screen.queryByText(/loading/i)).toBeNull();
+  });
+
+  it("recovers automatically when an internal retry succeeds (no user action)", async () => {
+    const chromeMock = (globalThis as unknown as { chrome: { tabs: { query: ReturnType<typeof vi.fn> } } }).chrome;
+    chromeMock.tabs.query.mockResolvedValue([{ url: "https://example.com" }]);
+    // First attempt fails (SW waking up), the scheduled retry succeeds.
+    mockSendMessage
+      .mockRejectedValueOnce(new Error("channel closed"))
+      .mockResolvedValue({
+        type: "GET_STATUS",
+        hasToken: true,
+        vaultUnlocked: true,
+        expiresAt: Date.now() + 1000,
+      });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockMatchList).toHaveBeenCalled();
+    });
+    // The error pane must never have appeared — the retry self-healed.
+    expect(screen.queryByRole("button", { name: /retry/i })).toBeNull();
+  });
+
+  it("shows the retry control when the status request hangs past the timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const chromeMock = (globalThis as unknown as { chrome: { tabs: { query: ReturnType<typeof vi.fn> } } }).chrome;
+      chromeMock.tabs.query.mockResolvedValue([{ url: "https://example.com" }]);
+      // Never settles — exercises the fetchStatus timeout branch on every attempt.
+      mockSendMessage.mockReturnValue(new Promise(() => {}));
+
+      render(<App />);
+
+      // Drive all attempts: 3 timeouts (3s) + 2 retry delays (250ms).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10000);
+      });
+
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("recovers from the error state when retry succeeds", async () => {
+    const chromeMock = (globalThis as unknown as { chrome: { tabs: { query: ReturnType<typeof vi.fn> } } }).chrome;
+    chromeMock.tabs.query.mockResolvedValue([{ url: "https://example.com" }]);
+    mockSendMessage.mockRejectedValue(new Error("channel closed"));
+
+    render(<App />);
+
+    const retryButton = await screen.findByRole("button", { name: /retry/i }, { timeout: 2000 });
+
+    mockSendMessage.mockReset();
+    mockSendMessage.mockResolvedValue({
+      type: "GET_STATUS",
+      hasToken: true,
+      vaultUnlocked: true,
+      expiresAt: Date.now() + 1000,
+    });
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(mockMatchList).toHaveBeenCalled();
     });
   });
 

--- a/extension/src/messages/en.json
+++ b/extension/src/messages/en.json
@@ -3,6 +3,8 @@
     "title": "passwd-sso",
     "settings": "Settings",
     "loading": "Loading...",
+    "statusError": "Couldn't reach the extension. Please try again.",
+    "retry": "Retry",
     "signIn": "Allow the connection in passwd-sso to use the extension.",
     "openApp": "Connect",
     "unlockDescription": "Enter your passphrase to unlock the vault.",

--- a/extension/src/messages/ja.json
+++ b/extension/src/messages/ja.json
@@ -3,6 +3,8 @@
     "title": "passwd-sso",
     "settings": "設定",
     "loading": "読み込み中...",
+    "statusError": "拡張機能に接続できませんでした。もう一度お試しください。",
+    "retry": "再試行",
     "signIn": "拡張機能を使うには passwd-sso で接続を許可してください。",
     "openApp": "接続",
     "unlockDescription": "保管庫をアンロックするためにパスフレーズを入力してください。",

--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -6,7 +6,28 @@ import { LoginPrompt } from "./components/LoginPrompt";
 import { VaultUnlock } from "./components/VaultUnlock";
 import { MatchList } from "./components/MatchList";
 
-type AppState = "loading" | "not_logged_in" | "logged_in" | "vault_unlocked";
+type AppState = "loading" | "error" | "not_logged_in" | "logged_in" | "vault_unlocked";
+
+// MV3 service workers can be torn down between popup opens; the first
+// GET_STATUS may reject ("message channel closed") or hang while the SW wakes
+// and rehydrates. Guard with a timeout + a few retries so the popup never
+// strands on the loading spinner.
+const STATUS_TIMEOUT_MS = 3000;
+const MAX_STATUS_RETRIES = 2;
+const STATUS_RETRY_DELAY_MS = 250;
+
+function fetchStatus() {
+  const status = sendMessage({ type: "GET_STATUS" });
+  // If the timeout wins the race, the SW reply may still reject later
+  // ("message channel closed"). Attach a no-op handler so that late rejection
+  // does not surface as an unhandledrejection.
+  status.catch(() => {});
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("GET_STATUS timeout")), STATUS_TIMEOUT_MS);
+  });
+  return Promise.race([status, timeout]).finally(() => clearTimeout(timer));
+}
 
 async function notifyVaultStateChanged(): Promise<void> {
   try {
@@ -25,16 +46,28 @@ export function App() {
   const containerMinHeight =
     state === "vault_unlocked" ? "min-h-[480px]" : "min-h-[260px]";
 
-  const refreshStatus = useCallback(() => {
-    sendMessage({ type: "GET_STATUS" }).then((res) => {
-      if (!res.hasToken) {
-        setState("not_logged_in");
-      } else if (res.vaultUnlocked) {
-        setState("vault_unlocked");
-      } else {
-        setState("logged_in");
-      }
-    });
+  // allowError=false is used by background refreshes (storage events): a
+  // transient failure there must leave the current view intact rather than
+  // clobbering a working screen with the error pane.
+  const refreshStatus = useCallback((attempt = 0, allowError = true) => {
+    fetchStatus()
+      .then((res) => {
+        if (!res.hasToken) {
+          setState("not_logged_in");
+        } else if (res.vaultUnlocked) {
+          setState("vault_unlocked");
+        } else {
+          setState("logged_in");
+        }
+      })
+      .catch(() => {
+        if (attempt < MAX_STATUS_RETRIES) {
+          setTimeout(() => refreshStatus(attempt + 1, allowError), STATUS_RETRY_DELAY_MS);
+        } else if (allowError) {
+          // Surface a manual retry instead of spinning forever.
+          setState("error");
+        }
+      });
   }, []);
 
   useEffect(() => {
@@ -56,7 +89,7 @@ export function App() {
       areaName: string,
     ) => {
       if (areaName === "session" && SESSION_KEY in changes) {
-        refreshStatus();
+        refreshStatus(0, false);
       }
     };
     chrome.storage.onChanged.addListener(listener);
@@ -64,12 +97,25 @@ export function App() {
   }, [refreshStatus]);
 
   const handleLock = async () => {
-    await sendMessage({ type: "LOCK_VAULT" });
+    // Locking is fail-secure: a torn-down SW has already lost the in-memory
+    // key, so reflect the locked state locally even if the message rejects.
+    try {
+      await sendMessage({ type: "LOCK_VAULT" });
+    } catch {
+      // SW unreachable — treat as locked.
+    }
     setState("logged_in");
   };
 
   const handleDisconnect = async () => {
-    await sendMessage({ type: "CLEAR_TOKEN" });
+    // CLEAR_TOKEN revokes the token server-side; if it never reached the SW,
+    // do NOT claim "disconnected" — surface the error so the user can retry.
+    try {
+      await sendMessage({ type: "CLEAR_TOKEN" });
+    } catch {
+      setState("error");
+      return;
+    }
     setState("not_logged_in");
   };
 
@@ -113,6 +159,21 @@ export function App() {
         {state === "loading" && (
           <div className="flex items-center justify-center h-full">
             <p className="text-gray-500">{t("popup.loading")}</p>
+          </div>
+        )}
+        {state === "error" && (
+          <div className="flex flex-col items-center justify-center gap-3 h-full text-center">
+            <p className="text-sm text-gray-500">{t("popup.statusError")}</p>
+            <button
+              type="button"
+              onClick={() => {
+                setState("loading");
+                refreshStatus();
+              }}
+              className="px-3 py-1.5 text-sm rounded-md bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+            >
+              {t("popup.retry")}
+            </button>
           </div>
         )}
         {state === "not_logged_in" && <LoginPrompt />}


### PR DESCRIPTION
## Summary
The browser extension popup occasionally stayed stuck on the "Loading" spinner with no Lock / Sign-out buttons. This is a structural fix so the popup can never strand on the loading state.

## Root cause
`refreshStatus()` called `sendMessage({ type: "GET_STATUS" })` with no `.catch()`. Under MV3 the service worker can be torn down (or hang while awaiting session hydration), so `chrome.runtime.sendMessage` rejects ("message channel closed"). With no rejection handler, `setState` was never called and the popup stayed at its initial `loading` state. The header Lock / Disconnect buttons render only in `logged_in` / `vault_unlocked`, so they were absent too.

## Changes
- Wrap `GET_STATUS` in a 3s timeout (`fetchStatus`) and add `.catch()` with up to 2 bounded retries (250ms apart) to absorb service-worker wake-up latency.
- On persistent failure, transition to a new `error` state that shows a "Retry" control instead of spinning forever.
- Background refreshes (storage events) pass `allowError=false` so a transient failure leaves a working screen intact rather than flipping it to the error pane.
- Guard `handleLock` / `handleDisconnect` against `sendMessage` rejection (lock is fail-secure; disconnect surfaces the error rather than falsely claiming "disconnected").
- Swallow the late `sendMessage` rejection that loses the timeout race to avoid an unhandled rejection.
- Add i18n keys `popup.statusError` / `popup.retry` (en/ja).

## Tests
- 4 new tests in the popup App suite: Retry control appears on persistent failure, automatic-retry self-heals without user action, timeout (hang) path, and recovery via the Retry button.
- Verified: `npx vitest run` (extension) and `npm run build` (extension) pass.

## Review
Reviewed via triangulate (functionality / security / testing), 2 rounds, all findings resolved. See `docs/archive/review/extension-popup-stuck-loading-code-review.md`.

## Follow-up (out of scope)
The service worker `hydrateFromSession()` lacks a timeout; a hung internal await keeps `GET_STATUS` blocked across retries. Tracked for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)