### PR TITLE
fix(webauthn): abort stale in-flight ceremony so the passkey prompt always surfaces

### DIFF
--- a/docs/archive/review/webauthn-ceremony-singleton-abort-code-review.md
+++ b/docs/archive/review/webauthn-ceremony-singleton-abort-code-review.md
@@ -1,0 +1,62 @@
+# Code Review: webauthn-ceremony-singleton-abort
+
+Date: 2026-06-12
+Review rounds: 1 (Round 2 skipped — tightening-only, test-only fixes within Round 1 scope, no security boundary)
+Branch: fix/webauthn-ceremony-singleton-abort
+
+## Summary
+
+The browser passkey sign-in (and the extension reauth flow) intermittently showed
+NO OS passkey dialog and timed out after ~60s ("接続中..." / cancelled).
+
+Root cause (confirmed by the user reproducing it): Chrome services only ONE
+WebAuthn ceremony — `navigator.credentials.get()` or `.create()` — per document at
+a time. A stale ceremony left pending after an SPA navigation or a quick retry
+silently blocks the next modal request: no OS prompt appears and the call hangs
+until the stale request's 120s safety timer fires.
+
+Fix: a module-level singleton in `src/lib/auth/webauthn/webauthn-client.ts` aborts
+any prior in-flight ceremony before starting a new one, and releases a ceremony
+stranded by navigation via an exported `abortInFlightCeremony()` wired to the
+unmount cleanup of the two sign-in components.
+
+## Changed files
+- `src/lib/auth/webauthn/webauthn-client.ts` — `beginCeremony`/`endCeremony`/`abortInFlightCeremony`; both `startPasskeyRegistration` (create) and `startPasskeyAuthentication` (get) route through the guard.
+- `src/components/auth/passkey-signin-button.tsx`, `security-key-signin-form.tsx` — unmount cleanup `return abortInFlightCeremony`.
+- `src/lib/auth/webauthn/webauthn-client.test.ts` — 3 guard tests.
+- `src/components/auth/{passkey-signin-button,security-key-signin-form}.test.tsx` — mock alignment + unmount-cleanup tests.
+
+## Round 1 Findings & Resolution
+
+Functionality expert: **No findings** (traced all interleavings — `===` guard
+correct, no timer leak, success-path unmount is a no-op, double-cleanup safe,
+StrictMode safe, shared register/auth guard intended, no harmed callers).
+
+Security expert: **No findings** (PRF buffer constructed only after a successful
+ceremony → nothing to leak on abort; no challenge/credential mixing — each call
+has its own options/signal; abort can only deny, never grant; module-global state
+is client-only same-document; RS1-RS4 N/A; R37 N/A — no user-facing strings).
+
+### T2 [Minor] Unmount-cleanup wiring untested at component layer — RESOLVED
+- The `return abortInFlightCeremony` cleanup was not asserted; the component mocks
+  used a no-op rather than a spy.
+- Fix: mock `abortInFlightCeremony` as a hoisted `vi.fn()` spy in both component
+  test files; added a render→unmount test asserting it is called once.
+
+### T1 [Minor] Guard tests stalled 10s on regression instead of failing fast — RESOLVED
+- The "hanging" ceremony only rejects on abort; if the abort-prior logic were
+  removed, the awaited stale promise hangs until vitest's 10s testTimeout.
+- Fix: added a `within(promise, ms)` helper that races the stale promise against a
+  ~500ms sentinel, so a guard regression fails fast with a clear assertion.
+
+## Verification
+- `npx vitest run` (3 affected suites) — 48 passed
+- `npx vitest run` (full) — exit 0 / all pass
+- `npx next build` — ✓ Compiled successfully
+
+## Scope notes
+- Not included (separate concerns / branches): extension-connect reauth 401 → full
+  sign-in routing; "接続中..." → "verifying with passkey" label + cancel affordance.
+- Cross-tab concurrency is handled by the browser itself (the singleton is
+  per-document); the existing `OperationError → AUTHENTICATION_PENDING` mapping
+  covers it.

--- a/src/components/auth/passkey-signin-button.test.tsx
+++ b/src/components/auth/passkey-signin-button.test.tsx
@@ -7,6 +7,7 @@ import "@testing-library/jest-dom/vitest";
 const {
   mockStartPasskeyAuthentication,
   mockIsWebAuthnSupported,
+  mockAbortInFlightCeremony,
   mockRouterPush,
   mockFetch,
   mockStashPrf,
@@ -14,6 +15,7 @@ const {
 } = vi.hoisted(() => ({
   mockStartPasskeyAuthentication: vi.fn(),
   mockIsWebAuthnSupported: vi.fn(() => true),
+  mockAbortInFlightCeremony: vi.fn(),
   mockRouterPush: vi.fn(),
   mockFetch: vi.fn(),
   mockStashPrf: vi.fn(),
@@ -52,6 +54,7 @@ vi.mock("@/lib/auth/webauthn/webauthn-client", () => ({
   startPasskeyAuthentication: (
     ...args: unknown[]
   ) => mockStartPasskeyAuthentication(...args),
+  abortInFlightCeremony: () => mockAbortInFlightCeremony(),
 }));
 
 import { PasskeySignInButton } from "./passkey-signin-button";
@@ -89,6 +92,13 @@ describe("PasskeySignInButton — §Sec-7 WebAuthn / PRF", () => {
   it("renders the sign-in-with-passkey button when supported (R26: enabled by default)", () => {
     render(<PasskeySignInButton />);
     expect(screen.getByRole("button", { name: /signInWithPasskey/ })).not.toBeDisabled();
+  });
+
+  it("aborts any in-flight ceremony on unmount (releases a ceremony stranded by navigation)", () => {
+    const { unmount } = render(<PasskeySignInButton />);
+    expect(mockAbortInFlightCeremony).not.toHaveBeenCalled();
+    unmount();
+    expect(mockAbortInFlightCeremony).toHaveBeenCalledTimes(1);
   });
 
   it("(success) hands the live PRF buffer to the in-memory channel (NOT sessionStorage) WITHOUT zeroizing it", async () => {

--- a/src/components/auth/passkey-signin-button.tsx
+++ b/src/components/auth/passkey-signin-button.tsx
@@ -5,7 +5,11 @@ import { useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
 import { Loader2, Fingerprint } from "lucide-react";
-import { isWebAuthnSupported, startPasskeyAuthentication } from "@/lib/auth/webauthn/webauthn-client";
+import {
+  isWebAuthnSupported,
+  startPasskeyAuthentication,
+  abortInFlightCeremony,
+} from "@/lib/auth/webauthn/webauthn-client";
 import { API_PATH } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
 import { useCallbackUrl } from "@/hooks/use-callback-url";
@@ -22,6 +26,9 @@ export function PasskeySignInButton() {
 
   useEffect(() => {
     setSupported(isWebAuthnSupported());
+    // Release any ceremony left pending if the user navigates away mid-prompt,
+    // so it can't silently block the next passkey attempt.
+    return abortInFlightCeremony;
   }, []);
 
   const handlePasskeySignIn = async () => {

--- a/src/components/auth/security-key-signin-form.test.tsx
+++ b/src/components/auth/security-key-signin-form.test.tsx
@@ -6,6 +6,7 @@ import "@testing-library/jest-dom/vitest";
 const {
   mockStartPasskeyAuthentication,
   mockIsWebAuthnSupported,
+  mockAbortInFlightCeremony,
   mockRouterPush,
   mockFetch,
   mockStashPrf,
@@ -13,6 +14,7 @@ const {
 } = vi.hoisted(() => ({
   mockStartPasskeyAuthentication: vi.fn(),
   mockIsWebAuthnSupported: vi.fn(() => true),
+  mockAbortInFlightCeremony: vi.fn(),
   mockRouterPush: vi.fn(),
   mockFetch: vi.fn(),
   mockStashPrf: vi.fn(),
@@ -50,6 +52,7 @@ vi.mock("@/lib/auth/webauthn/webauthn-client", () => ({
   startPasskeyAuthentication: (
     ...args: unknown[]
   ) => mockStartPasskeyAuthentication(...args),
+  abortInFlightCeremony: () => mockAbortInFlightCeremony(),
 }));
 
 import { SecurityKeySignInForm } from "./security-key-signin-form";
@@ -79,6 +82,13 @@ describe("SecurityKeySignInForm — §Sec-7 WebAuthn / PRF", () => {
     mockIsWebAuthnSupported.mockReturnValue(false);
     const { container } = render(<SecurityKeySignInForm />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it("aborts any in-flight ceremony on unmount (releases a ceremony stranded by navigation)", () => {
+    const { unmount } = render(<SecurityKeySignInForm />);
+    expect(mockAbortInFlightCeremony).not.toHaveBeenCalled();
+    unmount();
+    expect(mockAbortInFlightCeremony).toHaveBeenCalledTimes(1);
   });
 
   it("disables the submit button until an email is entered (R26 disabled cue)", () => {

--- a/src/components/auth/security-key-signin-form.tsx
+++ b/src/components/auth/security-key-signin-form.tsx
@@ -9,6 +9,7 @@ import { Loader2, KeyRound } from "lucide-react";
 import {
   isWebAuthnSupported,
   startPasskeyAuthentication,
+  abortInFlightCeremony,
 } from "@/lib/auth/webauthn/webauthn-client";
 import { API_PATH } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
@@ -27,6 +28,9 @@ export function SecurityKeySignInForm() {
 
   useEffect(() => {
     setSupported(isWebAuthnSupported());
+    // Release any ceremony left pending if the user navigates away mid-prompt,
+    // so it can't silently block the next passkey attempt.
+    return abortInFlightCeremony;
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/src/lib/auth/webauthn/webauthn-client.test.ts
+++ b/src/lib/auth/webauthn/webauthn-client.test.ts
@@ -242,6 +242,136 @@ describe("startPasskeyAuthentication PRF extension wiring", () => {
   });
 });
 
+// In-flight ceremony guard: Chrome services only one WebAuthn ceremony at a
+// time and silently drops a concurrent modal request. The guard must abort a
+// stale pending ceremony so a new one (or a retry) can surface its prompt.
+describe("startPasskeyAuthentication in-flight ceremony guard", () => {
+  const AUTH_OPTIONS: Record<string, unknown> = {
+    challenge: "Y2hhbGxlbmdl",
+    rpId: "localhost",
+    allowCredentials: [],
+  };
+
+  function credentialResult() {
+    return {
+      id: "cred-id",
+      rawId: new Uint8Array(8).buffer,
+      type: "public-key",
+      response: {
+        clientDataJSON: new Uint8Array(8).buffer,
+        authenticatorData: new Uint8Array(8).buffer,
+        signature: new Uint8Array(8).buffer,
+        userHandle: null,
+      },
+      getClientExtensionResults: () => ({}),
+    };
+  }
+
+  // A get()/create() that never settles on its own — only the abort signal
+  // can reject it, mirroring a real ceremony waiting for an OS prompt.
+  function hangingUntilAbort() {
+    return ({ signal }: { signal: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () =>
+          reject(new DOMException("aborted", "AbortError")),
+        );
+      });
+  }
+
+  // Resolve to the promise's value or a TIMED_OUT sentinel if it does not
+  // settle within `ms`. Keeps a regression (guard removed → stale ceremony
+  // never aborted) failing fast with a clear assertion instead of stalling on
+  // vitest's 10s testTimeout.
+  const TIMED_OUT = Symbol("timed-out");
+  function within<T>(p: Promise<T>, ms = 500): Promise<T | typeof TIMED_OUT> {
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<typeof TIMED_OUT>((resolve) => {
+      timer = setTimeout(() => resolve(TIMED_OUT), ms);
+    });
+    return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
+  }
+
+  beforeEach(async () => {
+    const { abortInFlightCeremony } = await import("./webauthn-client");
+    abortInFlightCeremony();
+  });
+
+  it("aborts a stale pending ceremony when a new one starts; the new one resolves", async () => {
+    const get = vi
+      .fn()
+      .mockImplementationOnce(hangingUntilAbort())
+      .mockImplementationOnce(async () => credentialResult());
+    vi.stubGlobal("navigator", { ...globalThis.navigator, credentials: { get } });
+
+    const { startPasskeyAuthentication } = await import("./webauthn-client");
+
+    const first = startPasskeyAuthentication(AUTH_OPTIONS);
+    const firstSettled = first.then(
+      () => "resolved",
+      (e: unknown) => e,
+    );
+
+    const second = await startPasskeyAuthentication(AUTH_OPTIONS);
+
+    const firstOutcome = await within(firstSettled);
+    expect(firstOutcome).toBeInstanceOf(Error);
+    expect((firstOutcome as Error).message).toBe("AUTHENTICATION_CANCELLED");
+    expect(second.responseJSON).toBeTruthy();
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it("abortInFlightCeremony() cancels the in-flight ceremony", async () => {
+    const get = vi.fn(hangingUntilAbort());
+    vi.stubGlobal("navigator", { ...globalThis.navigator, credentials: { get } });
+
+    const { startPasskeyAuthentication, abortInFlightCeremony } = await import(
+      "./webauthn-client"
+    );
+
+    const pending = startPasskeyAuthentication(AUTH_OPTIONS);
+    const settled = pending.then(
+      () => "resolved",
+      (e: unknown) => e,
+    );
+
+    abortInFlightCeremony();
+
+    const outcome = await within(settled);
+    expect(outcome).toBeInstanceOf(Error);
+    expect((outcome as Error).message).toBe("AUTHENTICATION_CANCELLED");
+  });
+
+  it("a new authentication aborts a stale pending registration (shared create/get guard)", async () => {
+    const create = vi.fn(hangingUntilAbort());
+    const get = vi.fn(async () => credentialResult());
+    vi.stubGlobal("navigator", {
+      ...globalThis.navigator,
+      credentials: { create, get },
+    });
+
+    const { startPasskeyRegistration, startPasskeyAuthentication } = await import(
+      "./webauthn-client"
+    );
+
+    const reg = startPasskeyRegistration({
+      rp: { id: "localhost", name: "x" },
+      user: { id: "dXNlcg", name: "u", displayName: "U" },
+      challenge: "Y2hhbGxlbmdl",
+      pubKeyCredParams: [],
+    });
+    const regSettled = reg.then(
+      () => "resolved",
+      (e: unknown) => e,
+    );
+
+    await startPasskeyAuthentication(AUTH_OPTIONS);
+
+    const regOutcome = await within(regSettled);
+    expect(regOutcome).toBeInstanceOf(Error);
+    expect((regOutcome as Error).message).toBe("REGISTRATION_CANCELLED");
+  });
+});
+
 describe("isWebAuthnSupported", () => {
   it("returns true when window.PublicKeyCredential is defined", () => {
     // jsdom does not ship PublicKeyCredential; stub it for this test.

--- a/src/lib/auth/webauthn/webauthn-client.ts
+++ b/src/lib/auth/webauthn/webauthn-client.ts
@@ -216,6 +216,52 @@ export async function unwrapSecretKeyWithPrf(
   return new Uint8Array(decrypted);
 }
 
+// ─── In-flight ceremony guard ──────────────────────────────
+//
+// Chrome (and other browsers) service only ONE WebAuthn ceremony — create()
+// OR get() — at a time. A second modal request issued while a prior one is
+// still pending is silently dropped: no OS prompt appears and the call hangs
+// until the stale request resolves or its 120s abort fires. This strands the
+// user on a spinner with no dialog. It happens when a ceremony is left pending
+// after the user navigates away (SPA route change) or retries before the first
+// request settled.
+//
+// Track the active controller so a new ceremony aborts a stale one, and expose
+// `abortInFlightCeremony` for component unmount cleanup.
+let inFlightCeremonyAbort: AbortController | null = null;
+
+const CEREMONY_TIMEOUT_MS = 120_000;
+
+/**
+ * Start a WebAuthn ceremony: abort any prior in-flight request, then register
+ * and return a fresh AbortController with an auto-abort safety timer. Always
+ * pair with {@link endCeremony} (in both the success and error paths) so the
+ * timer is cleared and the registration is released.
+ */
+function beginCeremony(): { abort: AbortController; timer: ReturnType<typeof setTimeout> } {
+  // Cancel a stale ceremony so this one can surface its prompt.
+  inFlightCeremonyAbort?.abort();
+  const abort = new AbortController();
+  inFlightCeremonyAbort = abort;
+  const timer = setTimeout(() => abort.abort(), CEREMONY_TIMEOUT_MS);
+  return { abort, timer };
+}
+
+function endCeremony(abort: AbortController, timer: ReturnType<typeof setTimeout>): void {
+  clearTimeout(timer);
+  if (inFlightCeremonyAbort === abort) inFlightCeremonyAbort = null;
+}
+
+/**
+ * Abort any in-flight passkey ceremony. Call from component unmount cleanup so
+ * a request left pending after navigation cannot silently block the next
+ * modal prompt.
+ */
+export function abortInFlightCeremony(): void {
+  inFlightCeremonyAbort?.abort();
+  inFlightCeremonyAbort = null;
+}
+
 // ─── Registration ──────────────────────────────────────────
 
 export interface PasskeyRegistrationResult {
@@ -237,8 +283,7 @@ export async function startPasskeyRegistration(
     };
   }
 
-  const abort = new AbortController();
-  const timer = setTimeout(() => abort.abort(), 120_000);
+  const { abort, timer } = beginCeremony();
 
   let credential: PublicKeyCredential | null;
   try {
@@ -247,7 +292,7 @@ export async function startPasskeyRegistration(
       signal: abort.signal,
     })) as PublicKeyCredential | null;
   } catch (err) {
-    clearTimeout(timer);
+    endCeremony(abort, timer);
     if (
       err instanceof DOMException &&
       (err.name === "AbortError" || err.name === "NotAllowedError")
@@ -262,7 +307,7 @@ export async function startPasskeyRegistration(
     }
     throw err;
   }
-  clearTimeout(timer);
+  endCeremony(abort, timer);
 
   if (!credential) throw new Error("REGISTRATION_CANCELLED");
 
@@ -348,8 +393,7 @@ export async function startPasskeyAuthentication(
     (publicKeyOptions as any).extensions = extensions;
   }
 
-  const abort = new AbortController();
-  const timer = setTimeout(() => abort.abort(), 120_000);
+  const { abort, timer } = beginCeremony();
 
   let credential: PublicKeyCredential | null;
   try {
@@ -358,7 +402,7 @@ export async function startPasskeyAuthentication(
       signal: abort.signal,
     })) as PublicKeyCredential | null;
   } catch (err) {
-    clearTimeout(timer);
+    endCeremony(abort, timer);
     if (
       err instanceof DOMException &&
       (err.name === "AbortError" || err.name === "NotAllowedError")
@@ -370,7 +414,7 @@ export async function startPasskeyAuthentication(
     }
     throw err;
   }
-  clearTimeout(timer);
+  endCeremony(abort, timer);
 
   if (!credential) throw new Error("AUTHENTICATION_CANCELLED");
 


### PR DESCRIPTION
## Summary
Browser passkey sign-in (and the extension reauth flow) intermittently showed NO OS passkey dialog and timed out after ~60s. This makes the WebAuthn ceremony robust so a stale request can never silently block the next prompt.

## Root cause
Browsers service only ONE WebAuthn ceremony — `navigator.credentials.get()` or `.create()` — per document at a time. A ceremony left pending after an SPA navigation or a quick retry silently blocks the next modal request: no OS prompt appears and the call hangs until the stale request's 120s safety timer fires (surfacing as a 60s "connecting" spinner → cancelled).

## Changes
- Add a module-level singleton in `webauthn-client.ts` (`beginCeremony` / `endCeremony` / exported `abortInFlightCeremony`). A new ceremony aborts any prior in-flight one before issuing its request, so the new prompt can surface. Both `startPasskeyRegistration` (create) and `startPasskeyAuthentication` (get) route through the guard (browsers serialize create+get together).
- Wire `abortInFlightCeremony()` to the unmount cleanup of `PasskeySignInButton` and `SecurityKeySignInForm` so a ceremony stranded by navigation is released immediately rather than blocking the next attempt for up to 120s.

## Why this is safe
- PRF/vault-key buffers are constructed only after a successful ceremony, so an aborted ceremony has nothing to zeroize/leak.
- Each call computes its own options + challenge + AbortController before `beginCeremony`; aborting only ever rejects the stale promise — it never resolves a credential against the wrong challenge, and can only deny, never grant.
- The singleton is client-only, per-document state. Cross-tab concurrency is handled by the browser itself (existing `OperationError → AUTHENTICATION_PENDING` mapping).

## Tests
- 3 guard tests in `webauthn-client.test.ts`: a new ceremony aborts a stale pending one (new one resolves); `abortInFlightCeremony()` cancels the in-flight one; a new authentication aborts a stale pending registration (shared create/get guard). Each is fail-fast (`within()` helper) so a guard regression fails in ~500ms, not a 10s timeout.
- Component tests: unmount calls `abortInFlightCeremony` (spy), plus mock alignment for the new export.
- Verified: `npx vitest run` (full) exit 0, `npx next build` compiles.

## Review
Reviewed via triangulate (functionality / security / testing): functionality and security clean, two Minor testing findings fixed. See `docs/archive/review/webauthn-ceremony-singleton-abort-code-review.md`.

## Out of scope (separate follow-ups)
- Extension-connect reauth: route a `401 UNAUTHORIZED` (expired session) to a full sign-in instead of looping on passkey reauth.
- Reauth UX: clearer "verifying with passkey" label + a cancel affordance during the wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)