### PR TITLE
feat(ios): passkey (WebAuthn) provider — assertion-only AutoFill

### DIFF
--- a/docs/archive/review/ios-passkey-provider-code-review.md
+++ b/docs/archive/review/ios-passkey-provider-code-review.md
@@ -1,0 +1,83 @@
+# Code Review: ios-passkey-provider
+
+Date: 2026-06-12
+Review round: 1
+
+## Changes from Previous Round
+
+Initial code review of the committed implementation (`git diff ios-main...HEAD`,
+commit 378419e4) by three expert sub-agents. All findings Minor/Low — no
+Critical/Major. Build clean (warnings-as-errors); 335→351 unit tests pass after fixes.
+
+## Functionality Findings
+
+- **F1 (Minor)** — Missing T5 test: bare-JWK-object at `passkeyPrivateKeyJwk` → nil. Behavior correct but unproven.
+- **F2 (Minor)** — `buildPasskeyAssertion` did not guard an empty decoded `userHandle` before constructing `ASPasskeyAssertionCredential` (framework-crash risk for a residual/pre-migration identity).
+- **F3 (Minor, UX)** — `CredentialPickerView` showed "No passwords for this site" when reused for the passkey ceremony empty state.
+- **F4 (Minor)** — `presentPasskeyList` passes `all: matches` (intentional for passkey ceremony); wanted a clarifying comment.
+
+## Security Findings
+
+- **S1 (Low)** — `decodeP256PrivateKeyJWK` did not zero the intermediate raw 32-byte private `scalar: Data` after constructing the key (plan committed to zeroing). escalate: false.
+- All other security checks PASS: I1 (no network/writes from extension, structurally enforced by `APPLICATION_EXTENSION_API_ONLY`), S2 (rpId guard before crypto, OS rpId authoritative), I3 (JWK Data zeroed on success+catch; no secret logging; bare error enums), RS4 (single biometric read; vault_key zeroed), C8 (registration cancelled; no `ASPasskeyRegistrationCredential` except a doc comment), confused-deputy (team + non-passkey guards), signCount 0, entitlement scope (no webcredentials).
+
+## Testing Findings
+
+- **T1 (Low)** — No test for key_ops/ext extra-field tolerance in JWK decode (plan T13).
+- **T2 (Low)** — = F1 (bare-JWK-object → nil).
+- **T3 (Low)** — No test for empty-credentialID skip in `buildPasskeyIdentitySpecs` (symmetric to the empty-userHandle test).
+- **T4 (Info)** — Comment requested documenting the standalone (no-resolveCandidates) path.
+- All required coverage criteria otherwise PASS (rpIdMismatch, OS-rpId authData, signCount-0 two-call, empty credentialId, empty-userHandle skip, non-passkey/team → entryNotFound, filterPasskeyCandidates exact-match, back-compat replace, FakeIdentityStore migrated, single-biometric count==2). RT5: HostSyncService test asserts the production `toPersonalCacheEntry` mapping (D1), not the stub copy.
+
+## Adjacent Findings
+
+- (Functionality) UI-test pre-existing failures — already documented in deviation D2; not re-flagged.
+
+## Quality Warnings
+
+None.
+
+## Recurring Issue Check
+
+### Functionality expert
+R1 (reuse) clean — `toPersonalCacheEntry` SSOT removed duplication; all helpers reused. R3/R5 (actor/Sendable) correct. No `URLSession`/`signCount+1`/`ASPasskeyRegistrationCredential` in real code. R35 manual-test doc present.
+
+### Security expert
+RS1 (scalar zeroing gap → S1, now fixed), RS2 (no bypass; guards before crypto), RS3 (no network — grep + extension-API-only), RS4 (biometric per fill). R20 backward-compat (nil-default fields). R16 input validation (32-byte d).
+
+### Testing expert
+RT1 (mock-reality: pinned-d + byte-exact authData + double-encoded JWK fixture) PASS with T1/T2 pin-test gaps (now added). RT5 (production mapping) PASS via D1. No vacuous-pass / async-drop patterns.
+
+## Resolution Status
+
+### S1 [Low] Raw private scalar not zeroed
+- Action: `var scalar` + `defer { scalar.resetBytes(in:) }` after key construction.
+- Modified: ios/Shared/Crypto/PasskeyAssertion.swift (decodeP256PrivateKeyJWK)
+
+### F2 [Minor] Empty userHandle not guarded in assertion
+- Action: `buildPasskeyAssertion` now throws `PasskeyCryptoError.emptyUserHandle` when the decoded userHandle is empty; added `.emptyUserHandle` error case + test `testBuildPasskeyAssertion_emptyUserHandleThrows`.
+- Modified: ios/Shared/Crypto/PasskeyAssertion.swift, ios/PasswdSSOTests/PasskeyAssertionTests.swift
+
+### F3 [Minor] Passkey empty-state copy
+- Action: `CredentialPickerView.emptyStateText` param (default password copy); passkey list passes "No passkeys for this site"; added en+ja catalog entry.
+- Modified: ios/PasswdSSOAutofillExtension/Views/CredentialPickerView.swift, CredentialProviderViewController.swift, PasswdSSOAutofillExtension/Localizable.xcstrings
+
+### F4 [Minor] Clarify all==matches in passkey list
+- Action: added explanatory comment.
+- Modified: ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
+
+### F1/T2 [Minor/Low] bare-JWK-object → nil test
+- Action: added `testPasskeyMaterialReturnsNilWhenJWKIsBareObject`.
+- Modified: ios/PasswdSSOTests/EntryBlobDecoderTests.swift
+
+### T1 [Low] key_ops/ext tolerance test
+- Action: added `testDecodeJWK_toleratesExtraWebCryptoFields`.
+- Modified: ios/PasswdSSOTests/PasskeyAssertionTests.swift
+
+### T3 [Low] empty-credentialID skip test
+- Action: added `testBuildPasskeyIdentitySpecs_skipsEmptyCredentialId`.
+- Modified: ios/PasswdSSOTests/CredentialIdentityRegistrarTests.swift
+
+### T4 [Info] standalone-path comment
+- Action: added comment in `testDecryptPasskeyMaterial_returnsMaterial`.
+- Modified: ios/PasswdSSOTests/CredentialResolverTests.swift

--- a/docs/archive/review/ios-passkey-provider-code-review.md
+++ b/docs/archive/review/ios-passkey-provider-code-review.md
@@ -81,3 +81,26 @@ RT1 (mock-reality: pinned-d + byte-exact authData + double-encoded JWK fixture) 
 ### T4 [Info] standalone-path comment
 - Action: added comment in `testDecryptPasskeyMaterial_returnsMaterial`.
 - Modified: ios/PasswdSSOTests/CredentialResolverTests.swift
+
+---
+
+# Round 2 (incremental verification of round-1 fixes)
+
+Date: 2026-06-12
+
+## Changes from Previous Round
+Verified the round-1 fix commit (700aa800). Two reviewers (functionality+testing, security).
+
+## Result: No findings
+
+- **S1 fix sound**: `decodeP256PrivateKeyJWK` is fully synchronous; `defer { scalar.resetBytes }` fires at scope exit AFTER `P256.Signing.PrivateKey(rawRepresentation:)` has synchronously copied the bytes and after `return key` — no use-after-zero. On the malformed path the defer still zeroes. Verified.
+- **F2 fix fail-closed**: `.emptyUserHandle` guard prevents any outputs escaping with an invalid handle; bare error case carries no key bytes; caller maps to `ASExtensionError`. (Non-finding noted: signing runs before the guard — wasted ECDSA on a dead path; no security impact, left as-is to avoid churn.)
+- **F3**: two CredentialPickerView call sites only (password default + passkey override); catalog has en+ja "translated" → `testExtensionCatalogHasJapaneseForEveryKey` passes.
+- **New tests** non-vacuous and exercise the guarded paths.
+- Key-custody chain complete: privateKeyJWK Data zeroed (completePasskeyAssertion), raw scalar zeroed (S1), only the JSONDecoder-internal `d` String remains unzeroable (acknowledged Swift/Foundation limitation, documented in-code).
+
+## Recurring Issue Check (round-2 delta)
+- R1/RT1/RT5: no regression. RS1 (timing/secret handling): scalar zeroing now complete. No new findings across R1-R37 / RS1-RS4 / RT1-RT5 for the fix delta.
+
+Review loop terminated: all reviewers returned "No findings" at round 2.
+

--- a/docs/archive/review/ios-passkey-provider-deviation.md
+++ b/docs/archive/review/ios-passkey-provider-deviation.md
@@ -1,0 +1,18 @@
+# Coding Deviation Log: ios-passkey-provider
+
+## D1 — Extracted `EncryptedEntry.toPersonalCacheEntry()` (refactor beyond the plan's literal C4)
+
+- **What**: The plan's C4 said "HostSyncService populates entryType in its `personal.map { CacheEntry(...) }` block." During Phase 2 I instead extracted the mapping into a single source of truth `EncryptedEntry.toPersonalCacheEntry()` (in `EntryFetcher.swift`), used by both `HostSyncService.runSync` and the `StubHostSyncService` test double.
+- **Why**: The test stub (`HostSyncServiceTests.StubHostSyncService`) had its OWN copy of the EncryptedEntry→CacheEntry mapping. Asserting `entryType` propagation against the stub (RT5/RT1) would have tested the stub's copy, not production. Extracting one mapping lets the S6 test (`testPersonalCacheEntryPropagatesEntryType`) verify the production primitive directly, and removes the duplication (R1).
+- **Net**: stronger test fidelity + less duplication; no behavior change.
+
+## D2 — Pre-existing UI-test failures (NOT introduced by this branch)
+
+- `PasswdSSOUITests.testPrimaryButtonIsHittable` and `testAppLaunches` fail in the local simulator (launch-screen "passwd-sso" / primary button not found).
+- **Verified pre-existing**: the SAME two failures reproduce on a pristine `ios-main` worktree with no passkey changes (run 2026-06-12). Environment-specific (local simulator launch state), not a regression.
+- **Anti-Deferral check**: pre-existing in an UNCHANGED file (`PasswdSSOUITests.swift` is not in this diff). Worst case: local UI smoke test red; Likelihood: environmental (clean CI runners are expected to pass — CI on `ios-main` is the reference); Cost to fix: out of scope (launch-screen/simulator issue unrelated to passkeys). Routed as [Adjacent] to a separate UI-test-stability task.
+- **TODO(ios-uitest-launch)**: investigate launch-screen UI test stability separately.
+
+## D3 — `signCount` removed from `PasskeyAssertionMaterial`
+
+- Per C7 (emit 0 always), the stored counter is never read, so `PasskeyAssertionMaterial` does not carry `signCount` (as locked in the plan after round 1). Documented here because the round-1 plan draft briefly carried it.

--- a/docs/archive/review/ios-passkey-provider-manual-test.md
+++ b/docs/archive/review/ios-passkey-provider-manual-test.md
@@ -1,0 +1,56 @@
+# Manual Test Plan: ios-passkey-provider
+
+Auth-flow + deployment-surface change (project.yml `ProvidesPasskeys`, AutoFill
+credential-provider passkey assertion). Device testing required — the AutoFill
+passkey APIs cannot be exercised in unit tests or the simulator's AutoFill UI.
+
+## Pre-conditions
+
+- A real iPhone (iOS 17+) signed into a passwd-sso account, vault unlocked at least once.
+- passwd-sso enabled under Settings → General → AutoFill & Passwords (as a source).
+- At least one **passkey created via the browser extension** for a real RP (e.g.
+  `webauthn.io`) and synced to the account. Use placeholder/test accounts only — do
+  NOT record real personal emails/handles in this doc (RS4).
+- A second authenticator available (iCloud Keychain) for the fallthrough scenarios.
+
+## Steps (happy path — assertion)
+
+1. On the iPhone, open Safari → `https://webauthn.io` (or the RP where the passkey
+   was created). Choose "Authenticate" / sign in with a passkey.
+2. Expected: the system passkey sheet lists the passwd-sso passkey for that RP.
+3. Select it → Face ID prompt → the RP reports a successful sign-in.
+
+## Expected result
+
+- The passkey appears in the system passkey sheet (QuickType identity registered).
+- After Face ID, the assertion verifies at the RP and sign-in succeeds.
+- After locking the vault (or app background/launch), the passkey no longer appears
+  in the sheet (identities cleared on the same lifecycle as password QuickType).
+
+## Rollback
+
+- Revert the branch (no schema/migration changes; cache format is backward
+  compatible — old caches decode `entryType`/passkey fields as nil). Removing
+  `ProvidesPasskeys` from project.yml + regenerating the project restores the
+  prior password/TOTP-only provider behavior.
+
+## Adversarial scenarios (Tier-2: auth flow)
+
+1. **signCount monotonicity (C7 known limitation)**: sign in via the browser
+   extension first (RP counter becomes non-zero), then attempt iOS assertion.
+   Record whether the RP accepts (most do) or rejects (strict-monotonic RPs may,
+   because iOS emits 0). Confirm passwd-sso's own RP accepts. Document the result.
+2. **Team-entry routing**: ensure no crash/hang if a team entry id ever reaches the
+   passkey path — expected clean failure (team passkeys out of scope; `entryNotFound`).
+3. **Lock race**: lock the vault between opening the passkey sheet and tapping the
+   entry. Expected: the locked sheet / a clean cancel, no cryptic error.
+4. **Multi-provider**: have BOTH passwd-sso and iCloud Keychain hold a passkey for
+   the same RP. Expected: both listed distinctly; selecting passwd-sso's works; no
+   cross-contamination of credential IDs.
+5. **Registration fallthrough (C8)**: attempt to CREATE a new passkey on the iPhone
+   with passwd-sso selectable. Expected: passwd-sso does not produce a
+   stored-but-unsaveable credential and does not hang — the user can complete
+   creation with another provider (e.g. iCloud Keychain). passwd-sso must NEVER
+   return an ASPasskeyRegistrationCredential (would lock the user out).
+6. **Regression**: confirm password AutoFill and TOTP (one-time-code) fills still
+   work unchanged on a normal login form.

--- a/docs/archive/review/ios-passkey-provider-plan.md
+++ b/docs/archive/review/ios-passkey-provider-plan.md
@@ -1,0 +1,298 @@
+# Plan: ios-passkey-provider
+
+## Project context
+
+- **Type**: mixed — native iOS app (Swift / SwiftUI) + AutoFill credential-provider app extension, inside a larger Next.js monorepo. This branch touches the iOS targets only.
+- **Test infrastructure**: unit tests (XCTest under `ios/PasswdSSOTests`). No iOS CI for this branch locally; device/simulator testing is manual. Server side is untouched.
+- Deployment target: **iOS 17.0** (both host + extension), confirmed in `ios/project.yml`.
+- Branch: `feat/ios-passkey-provider`, cut from `ios-main` (= origin/main, includes #544).
+
+## Objective
+
+Reach feature parity with the browser extension's passkey (WebAuthn) provider — **on the USE (assertion) side**: let a user sign in to a third-party website/app on iOS, via native AutoFill, using a passkey that passwd-sso already holds (created by the browser extension and synced E2E). The passkey appears in the iOS system passkey sheet (QuickType) and, when chosen, passwd-sso produces a valid WebAuthn assertion (P-256 ECDSA signature) locally, offline, biometric-gated.
+
+**Explicitly deferred to a follow-up branch**: passkey *registration* (creating a new passkey from iOS) and signature-counter write-back. See "Considerations" for the rationale (the AutoFill extension is read-only / offline; a deferred-upload registration path risks account lockout).
+
+## Requirements
+
+### Functional
+
+1. The AutoFill extension declares passkey support so iOS routes WebAuthn assertion ceremonies to passwd-sso.
+2. Stored passkeys (personal `entryType=PASSKEY` entries) are registered as `ASPasskeyCredentialIdentity` in `ASCredentialIdentityStore` while the vault is unlocked, so they surface in the system passkey sheet — registered/cleared on the SAME lifecycle hooks as the existing password QuickType identities (unlock/foreground-sync → register; lock/logout/background/launch → clear).
+3. When iOS requests a passkey assertion (`prepareInterfaceToProvideCredential(for:)` with a `.passkeyAssertion` request, or selection from the extension's own list via `prepareCredentialList(for:requestParameters:)`), passwd-sso:
+   - resolves the chosen passkey entry by `recordIdentifier`,
+   - decrypts its full blob offline (existing biometric-gated unwrap path),
+   - builds `authenticatorData` and signs `authenticatorData ‖ clientDataHash` with the entry's P-256 private key,
+   - returns an `ASPasskeyAssertionCredential`.
+4. Personal entries only (team passkeys out of scope, matching the #537 QuickType precedent).
+5. Passkey *registration* requests (`prepareInterface(forPasskeyRegistration:)`) are **explicitly and cleanly cancelled** (not silently mishandled), so the OS falls through to another provider instead of producing a broken/unsaveable credential.
+
+### Non-functional
+
+- **No network and no writes from the AutoFill extension** — it has no bearer token and no `MobileAPIClient` (per-app keychain token, offline by design). All assertion work is local.
+- **Per-fill biometric preserved**: exactly one Keychain `readForFill` per fill (reuse `CredentialResolver`'s retained-blob pattern); never fill silently.
+- **signCount is emitted as 0** on every assertion (no counter state on iOS). See C7.
+- The private-key JWK is carried as `Data` (UTF-8 bytes), never logged, and zeroed via the existing `zeroData(&mutable)` pattern immediately after the `P256.Signing.PrivateKey` is constructed (S4). (Swift `String` cannot be reliably zeroed; `Data` matches the existing `mutableVaultKeyData` zeroing.)
+- **userVerification**: we always emit UV=true (UP=true) because every fill is biometric-gated (I2). `userVerificationPreference` is read but `.discouraged` is intentionally NOT honored — emitting UV=true is strictly stronger assurance than requested and carries no downgrade risk; documented as a deliberate, no-security-impact deviation (S10).
+- Backward compatible with existing caches and existing password/TOTP AutoFill (no regression).
+
+## Technical approach
+
+- Storage model is fixed by the server/extension (confirmed): a passkey is a `PasswordEntry` with `entryType=PASSKEY`; all material lives in the client-side E2E `encryptedBlob`. Relevant decrypted-blob fields:
+  - Overview blob: `title`, `username`, `relyingPartyId`, `credentialId`, `creationDate`, `tags`.
+  - Full blob: above **plus** `passkeyPrivateKeyJwk` (stringified P-256 EC JWK with `d`/`x`/`y`), `passkeyUserHandle` (base64url), `passkeySignCount` (Int), `passkeyAlgorithm` (-7), `passkeyPublicKeyCose`, `passkeyUserDisplayName`, `passkeyTransports`.
+- iOS signs with CryptoKit `P256.Signing.PrivateKey(rawRepresentation: d)` → `.signature(for:).derRepresentation`. **`ASPasskeyAssertionCredential.signature` is DER/ASN.1-encoded ECDSA, passed unchanged to the RP** — VERIFIED against Apple Developer Forums thread 710457 (a developer who debugged passkey-provider signature verification confirmed `sigdecode_der`) and consistent with the browser extension's own P1363→DER conversion (`extension/src/lib/webauthn-crypto.ts` `p1363ToDer`). So `.derRepresentation` is correct (NOT `.rawRepresentation`).
+- **iOS supplies `clientDataHash` directly** in the passkey request — the extension does NOT construct `clientDataJSON` and does NOT perform origin validation (the OS owns RP/origin binding; it generates `clientDataHash` from its own origin-validated `clientDataJSON`, so a caller cannot smuggle a cross-origin hash). This is the key simplification vs. the browser extension. Defense-in-depth: we still assert the chosen entry's stored rpId equals the request's rpId (C6/S2).
+- **entryType is NOT on the cache row** (`CacheEntry` has no `entryType`; it is dropped by `HostSyncService` today). To classify passkeys in the extension and to register passkey QuickType identities in the host, add an **optional** `entryType` to `CacheEntry` (nil-tolerant for old caches) AND extend the overview decode with `relyingPartyId`/`credentialId`. `userHandle` lives only in the full blob, so the host decrypts each passkey's full blob during sync to obtain it for `ASPasskeyCredentialIdentity`.
+
+## Contracts
+
+> Conventions: `EncryptedData` = existing hex `{ciphertext, iv, authTag}`. base64url decode = existing `base64URLDecode`. AAD uses existing `buildPersonalEntryAAD(userId, entryId, vaultType)`.
+
+### C1 — Extension passkey capability + entitlements
+
+- **Change**: in `ios/project.yml`, add `ProvidesPasskeys: true` to the extension's `NSExtensionAttributes.ASCredentialProviderExtensionCapabilities` (alongside `ProvidesPasswords`/`ProvidesOneTimeCodes`).
+- **Invariant**: the `com.apple.developer.authentication-services.autofill-credential-provider` entitlement is present on BOTH host and extension (already true — verify, do not remove). No `associated-domains` / `webcredentials` is added (assertion does not need it; that is an RP-side concern).
+- **Acceptance**: built extension's `Info.plist` shows all three `Provides*` keys true; iOS offers passwd-sso in the passkey sheet on a device that has a matching stored passkey.
+- **Forbidden**: `pattern: ProvidesPasskeys:\s*false` — reason: must be true or absent-then-added, never false.
+
+### C2 — Passkey assertion crypto (Shared, new file `ios/Shared/Crypto/PasskeyAssertion.swift`)
+
+Signatures (no bodies):
+
+```swift
+public enum PasskeyCryptoError: Error, Equatable {
+  case malformedJWK
+  case unsupportedKeyType    // kty != "EC" or crv != "P-256"
+  case malformedPrivateScalar // d absent or not exactly 32 bytes after base64url-decode
+  case rpIdMismatch           // stored rpId != request rpId (C6/S2)
+}
+
+/// Parse a stringified JWK ({kty:"EC", crv:"P-256", d, x, y}) into a P-256 signing key.
+/// `d` is base64url; MUST decode to exactly 32 bytes → rawRepresentation. Rejects
+/// non-EC / non-P-256 / wrong-length d.
+public func decodeP256PrivateKeyJWK(_ jwkJSON: Data) throws -> P256.Signing.PrivateKey
+
+/// authData = SHA256(rpId)(32) ‖ flags(1) ‖ signCount(4, big-endian).
+/// flags = (userPresent ? 0x01 : 0) | (userVerified ? 0x04 : 0). No attested-cred / extensions.
+/// signCount is a parameter for testability; the production assertion path always passes 0 (C7).
+public func buildAssertionAuthenticatorData(
+  rpId: String, userPresent: Bool, userVerified: Bool, signCount: UInt32
+) -> Data
+
+/// Sign authenticatorData ‖ clientDataHash with ECDSA-P256-SHA256; return the DER
+/// (ASN.1) signature — `.derRepresentation` (NOT raw r‖s). This is what
+/// ASPasskeyAssertionCredential.signature expects (VERIFIED, see Technical approach).
+public func signPasskeyAssertion(
+  privateKey: P256.Signing.PrivateKey, authenticatorData: Data, clientDataHash: Data
+) throws -> Data
+```
+
+- **Invariants**: pure crypto; no I/O, no logging of `d`. The function does not own counter state; `buildPasskeyAssertion` (C6) always passes signCount=0 (C7).
+- **Acceptance**: (a) a known P-256 JWK + fixed rpId + clientDataHash produces a `.derRepresentation` signature that verifies via `P256.Signing.PublicKey.isValidSignature(_:for:)` over `authData ‖ clientDataHash`; (b) authData layout byte-exact: 37 bytes, `SHA256(rpId)` at [0..31], byte[32]==flags, bytes[33..36]==signCount BE; (c) `buildAssertionAuthenticatorData(userPresent:true,userVerified:true,...)` → byte[32]==0x05; all-false → 0x00 (T11); (d) malformed `d` (≠32 bytes) / non-P-256 → throws (R16). Use a PINNED P-256 `d` scalar + expected public key, not only generate-then-verify (T1).
+- **Forbidden**: `pattern: signCount \+ 1|signCount\+1|signCount \+= ` in this file — reason: no counter increment on iOS (C7).
+
+### C3 — Passkey material decode (Shared, extend `EntryBlobDecoder`)
+
+```swift
+public struct PasskeyAssertionMaterial: Sendable, Equatable {
+  public let entryId: String
+  public let relyingPartyId: String
+  public let credentialId: String      // base64url, as stored
+  public let userHandle: String        // base64url, as stored (may be empty)
+  public let privateKeyJWK: Data        // raw UTF-8 bytes of the stringified JWK; zeroable (S4)
+}
+
+/// Decode a passkey's FULL blob into assertion material. Returns nil when the
+/// blob is not a passkey (no relyingPartyId / no passkeyPrivateKeyJwk).
+public static func passkeyMaterial(plaintext: Data, entryId: String) -> PasskeyAssertionMaterial?
+```
+
+- `signCount` is NOT carried in material — iOS always emits 0 (C7), so reading/clamping the stored counter is dead weight and is intentionally omitted (removes the overflow-edge surface T4 raised).
+- Add a private `PasskeyFullBlobPayload: Decodable` (or extend `FullBlobPayload`) decoding EXACTLY these keys from the full blob: `relyingPartyId: String?`, `credentialId: String?`, `passkeyPrivateKeyJwk: String?` (a JSON **string** that itself contains the JWK object — double-encoded, see Testing/T5), `passkeyUserHandle: String?`. `passkeyMaterial` returns nil unless `relyingPartyId`, `credentialId`, AND `passkeyPrivateKeyJwk` are ALL present (F17 — `credentialId` is required because `PasskeyAssertionOutputs.credentialID` is non-optional; gating here fails fast instead of letting an empty string reach `base64URLDecode` in `buildPasskeyAssertion`); `privateKeyJWK` = the UTF-8 bytes of the `passkeyPrivateKeyJwk` string (still double-encoded — `decodeP256PrivateKeyJWK` parses the inner JSON). The inner JWK may carry extra Web-Crypto fields (`key_ops`, `ext`) — `JSONDecoder` ignores unknown keys (T13).
+- Extend `OverviewBlobPayload` with `relyingPartyId: String?`, `credentialId: String?`; extend `VaultEntrySummary` with optional `relyingPartyId: String?`, `credentialId: String?` (default nil) and surface them in `EntryBlobDecoder.summary`. A summary is a passkey iff `relyingPartyId != nil`. (userHandle is NOT in the overview — see C5.)
+- **Invariant**: `VaultEntrySummary`'s new fields are additive with defaults so existing `init` call sites and Codable decode of old cached summaries still compile and decode.
+- **Acceptance**: a LOGIN overview decodes with `relyingPartyId == nil` (classified non-passkey); a passkey full blob with a **double-encoded** `passkeyPrivateKeyJwk` string decodes to non-nil material with the expected rpId/credentialId/userHandle/privateKeyJWK; the same JSON with a bare JWK *object* at that field → nil (T5).
+
+### C4 — Cache row carries entryType (Shared `CacheEntry`, host `HostSyncService`)
+
+- Add `public let entryType: String?` to `CacheEntry` (optional, default nil) and to its `init`. `HostSyncService` (`ios/PasswdSSOApp/Vault/HostSyncService.swift`, the `personal.map { … CacheEntry(…) }` block) currently DROPS `entryType` though `EncryptedEntry.entryType` is already decoded (`ios/PasswdSSOApp/Vault/EntryFetcher.swift`) — populate it there. Old caches (no field) decode to nil.
+- **Team caveat (F5)**: `TeamEncryptedEntry` does not carry `entryType` at all, so team rows have `entryType == nil` permanently. Acceptable — team passkeys are out of scope (I5); the `relyingPartyId != nil` fallback below covers/excludes them correctly.
+- **Consumer-flow walkthrough**:
+  - Consumer A (`CredentialResolver.decryptSummary/decryptDetail`, `ios/Shared/AutoFill/CredentialResolver.swift`) reads `{ entryType }` only as a fast pre-classifier; it MUST NOT rely on it for correctness — passkey classification still falls back to `relyingPartyId != nil` from the decrypted overview (C3), because old cache rows AND all team rows have `entryType == nil`. So `entryType` is an optimization, not the source of truth.
+  - Consumer B (host passkey-identity builder, C5) reads `{ entryType }` to select which personal entries to decrypt-full-blob for userHandle; for `entryType == nil` rows it falls back to decrypting overview and checking `relyingPartyId != nil`. Required fields all present.
+- **Invariant**: adding the field does not force a cache version bump that invalidates existing caches — it is decode-optional. CONFIRMED (F7): `EntryCacheFile`'s AES-GCM MAC covers the ciphertext wholesale, not the JSON key set; a missing `entryType` key decodes to `nil` without breaking authentication.
+- **Acceptance**: a cache written before this change still loads (no rejection); a freshly synced PASSKEY `EncryptedEntry` produces a `CacheEntry` with `entryType == "PASSKEY"` (HostSyncServiceTests, S6). Old-cache decode test uses a JSON literal lacking the key → `entryType == nil` (T7).
+
+### C5 — Passkey QuickType identity registration (host + Shared `CredentialIdentityRegistrar`)
+
+```swift
+public struct PasskeyIdentitySpec: Sendable, Equatable {
+  public let relyingPartyIdentifier: String
+  public let userName: String
+  public let credentialID: Data       // base64url-decoded
+  public let userHandle: Data         // base64url-decoded
+  public let recordIdentifier: String // vault entry id
+}
+```
+
+- Extend `CredentialIdentityStoring` so a single replace registers BOTH password and passkey identities in ONE atomic call. Use the iOS 17+ heterogeneous-array API: the ObjC selector is `replaceCredentialIdentityEntries:` but its **Swift name is `replaceCredentialIdentities(_:)`** (via `NS_SWIFT_NAME`), taking `[any ASCredentialIdentity]` — both `ASPasswordCredentialIdentity` and `ASPasskeyCredentialIdentity` conform (F13). The existing code already calls `ASCredentialIdentityStore.shared.replaceCredentialIdentities(identities)` with a homogeneous `[ASPasswordCredentialIdentity]`; passing a mixed `[any ASCredentialIdentity]` selects the heterogeneous overload — one atomic replace of the whole store.
+
+```swift
+public protocol CredentialIdentityStoring: Sendable {
+  func isEnabled() async -> Bool
+  // Back-compat (S5): default passkeys: [] so existing callers/tests using the
+  // password-only form keep compiling; one atomic replace covers both kinds.
+  func replace(passwords: [CredentialIdentitySpec], passkeys: [PasskeyIdentitySpec]) async
+  func removeAll() async
+}
+extension CredentialIdentityStoring {
+  func replace(with passwords: [CredentialIdentitySpec]) async {
+    await replace(passwords: passwords, passkeys: [])
+  }
+}
+```
+
+- **Where passkey specs are built and threaded (F14/F15)** — adopt the existing `decryptPersonalOverviews` pattern, NOT a `runSync`/`SyncReport` change. Add a Shared helper, sibling to `decryptPersonalOverviews` in `CredentialIdentityRegistrar.swift`:
+
+```swift
+/// Decrypt the FULL blobs of personal PASSKEY entries to build QuickType passkey
+/// identity specs. Mirrors decryptPersonalOverviews' signature/timing so the two
+/// call sites can invoke both from the same place (post-sync, vaultKey in scope).
+public func buildPasskeyIdentitySpecs(
+  from cacheData: CacheData, vaultKey: SymmetricKey, userId: String
+) -> [PasskeyIdentitySpec]
+```
+
+  For each personal entry classified as a passkey (`entryType=="PASSKEY"` OR overview `relyingPartyId != nil`), decrypt the FULL blob (AAD = `buildPersonalEntryAAD(userId, entryId, .blob)`), read `relyingPartyId`, `credentialId`, `passkeyUserHandle`, `userName`, base64url-decode credentialId/userHandle. SKIP entries whose credentialId fails to decode OR whose decoded `userHandle` is EMPTY (0 bytes) — `ASPasskeyCredentialIdentity` requires a non-empty userHandle; registering empty silently drops it (T9). Skips are debug-logged WITHOUT secret material.
+
+- Extend the registrar's higher-level method to thread passkeys: `CredentialIdentityRegistrar.replace(with summaries: [VaultEntrySummary], passkeys: [PasskeyIdentitySpec] = [])` → `store.replace(passwords: Self.specs(from: summaries), passkeys: passkeys)`. The default `[]` keeps the lock/clear paths and any password-only caller compiling.
+- **Update BOTH call sites** (`PasswdSSOApp/PasswdSSOAppApp.swift` ~line 59-62 foreground-sync; `PasswdSSOApp/Views/RootView.swift` — the `refreshCredentialIdentities(cacheData:vaultKey:userId:)` chokepoint at ~line 328-329, which already serves both `handleVaultUnlocked` and the DEBUG vault-loaded path): after `decryptPersonalOverviews(...)`, also call `buildPasskeyIdentitySpecs(from: cacheData, vaultKey:, userId:)` and pass both into `replace(with: summaries, passkeys: passkeySpecs)`. Without this, the atomic combined replace with `passkeys: []` would wipe passkey identities on every foreground sync (F14). Confirmed these are the only `replace(with:)` production call sites.
+- **Consumer-flow walkthrough** (`ASPasskeyCredentialIdentity(relyingPartyIdentifier:userName:credentialID:userHandle:recordIdentifier:)`): the OS reads all five fields; `credentialID`/`userHandle` must be the raw decoded bytes, `recordIdentifier` is our entry id used later to resolve the entry in the assertion path (C6). userHandle is NOT in the overview blob (confirmed F10), which is why C5 mandates a full-blob decrypt for passkey entries.
+- **Invariant**: lifecycle parity (I6) — passkey identities are registered and cleared at exactly the same call sites as the existing password QuickType identities (no new lifecycle). One atomic `replaceCredentialIdentityEntries` swaps the WHOLE set (passwords+passkeys) so a password-only refresh with `passkeys: []` also clears stale passkey identities. Provider-disabled → no-op (existing `isEnabled` gate); `removeAll()` clears both kinds.
+- **Acceptance**: after unlock+sync with one stored passkey, the system passkey sheet on a matching RP lists it; after lock/logout/background/launch the identity is gone (store cleared). Unit: `replace(passwords:[…],passkeys:[])` registers only password identities (no stale passkeys); empty-userHandle passkey spec is skipped.
+- **Forbidden**: `pattern: import .*MobileAPIClient|URLSession` under `PasswdSSOAutofillExtension/` (the host, not the extension, builds passkey identities — the extension never registers). Assertion-side construction of `ASPasskeyAssertionCredential` in the extension is expected and fine.
+
+### C6 — Assertion handling (extension `CredentialProviderViewController` + a Shared builder)
+
+Shared builder (so it is unit-testable without the extension host):
+
+```swift
+/// Inputs the OS gives us for a passkey assertion. clientDataHash is provided by iOS.
+public struct PasskeyAssertionRequest: Sendable {
+  public let relyingPartyId: String
+  public let clientDataHash: Data
+  public let userVerificationRequired: Bool
+}
+
+/// Build the assertion outputs from decrypted material + the OS request.
+/// FIRST asserts material.relyingPartyId == request.relyingPartyId (throws
+/// PasskeyCryptoError.rpIdMismatch otherwise — defense-in-depth, S2), then uses
+/// request.relyingPartyId (OS-provided, authoritative) for authData. Emits
+/// signCount = 0 (C7). UP=true; UV=true (we biometric-gate every fill, S10).
+/// Returns the fields needed to construct ASPasskeyAssertionCredential.
+public struct PasskeyAssertionOutputs: Sendable {
+  public let userHandle: Data
+  public let relyingParty: String
+  public let signature: Data            // DER (.derRepresentation)
+  public let authenticatorData: Data
+  public let credentialID: Data
+}
+public func buildPasskeyAssertion(
+  material: PasskeyAssertionMaterial, request: PasskeyAssertionRequest
+) throws -> PasskeyAssertionOutputs
+
+/// Pure, Shared, unit-testable: filter decrypted summaries to passkeys whose
+/// stored rpId EXACTLY equals the requested rpId (no eTLD+1 expansion — the OS
+/// already domain-filters before invoking the provider). Extracted out of the
+/// view controller so the list-path logic is testable (T6).
+public func filterPasskeyCandidates(_ summaries: [VaultEntrySummary], rpId: String) -> [VaultEntrySummary]
+```
+
+Extension wiring (thin coordinators only; all logic in Shared above):
+- `CredentialResolver` gains `decryptPasskeyMaterial(entryId:) async throws -> PasskeyAssertionMaterial` (parallels `decryptEntryDetail`; reuses retained blob → same single-biometric-read contract I2; applies the same `defer { zeroData(&mutableVaultKeyData) }` guard, S8; personal entries only — throws `entryNotFound` for team or non-passkey entries, T8). `PasskeyAssertionMaterial` is a short-lived local; the assertion handler zeroes `material.privateKeyJWK` (Data) on both the success path (after the `P256.Signing.PrivateKey` is built) and in the `catch` before re-throwing, so an `rpIdMismatch` throw does not leave `d` lingering (S11). For defense-in-depth, the handler MAY assert `material.relyingPartyId == request.relyingPartyId` before decrypt is even reached via `filterPasskeyCandidates` selection, but `buildPasskeyAssertion` remains the authoritative guard.
+- `prepareInterfaceToProvideCredential(for credentialRequest: any ASCredentialRequest)` (Swift 6 `any`, F9): branch on `credentialRequest.type == .passkeyAssertion` → downcast to `ASPasskeyCredentialRequest`, read `relyingPartyIdentifier`, `clientDataHash`, `userVerificationPreference`, and `recordIdentifier` (from `credentialIdentity`, type `String?` — if nil/empty, `cancel` with a descriptive error rather than letting `entryNotFound` propagate, F4) → `decryptPasskeyMaterial` → `buildPasskeyAssertion` → `await extensionContext.completeAssertionRequest(using: ASPasskeyAssertionCredential(...))` (the method is async — F2, mirrors the TOTP `await completeOneTimeCodeRequest`). The existing `.password` branch is unchanged; unknown types still `cancel(with: nil)`.
+- `prepareCredentialList(for:requestParameters:)`: when `requestParameters.relyingPartyIdentifier` is non-empty (passkey ceremony), present a picker of `filterPasskeyCandidates(all, rpId:)`. `ASPasskeyCredentialRequestParameters` is `Sendable`, so capture it directly in the picker's `onSelect` closure (no instance var needed, F16); on selection build `PasskeyAssertionRequest` from `requestParameters.clientDataHash`, `requestParameters.relyingPartyIdentifier`, and `requestParameters.userVerificationPreference`, then `buildPasskeyAssertion` → `await completeAssertionRequest`. Password-only ceremonies (empty rpId) keep today's behavior. A no-match passkey ceremony presents an empty/locked sheet and the user can cancel (graceful, F8).
+- `provideCredentialWithoutUserInteraction(for:)`: unchanged (always `userInteractionRequired`) — already correct for passkeys.
+- `ASPasskeyAssertionCredential` is constructed from `PasskeyAssertionOutputs` via the documented initializer `init(userHandle:relyingParty:signature:clientDataHash:authenticatorData:credentialID:)` (clientDataHash from the request). If the SDK variant that also takes `rawAttestationObject` is used, pass `nil` (assertion, not attestation).
+- **Acceptance**: end-to-end on device, selecting a stored passkey signs the user into the RP (signature verifies). Unit: rpId-mismatch material+request → `rpIdMismatch` thrown; non-passkey entry id → `entryNotFound`.
+- **Forbidden**: `pattern: import .*MobileAPIClient|URLSession` inside `PasswdSSOAutofillExtension/` — reason: extension stays offline/read-only.
+
+### C7 — signCount semantics: emit 0 unconditionally (no counter state on iOS)
+
+- iOS emits `signCount = 0` on EVERY assertion. It does not read, increment, or write back the stored counter. This is the established behavior for an authenticator that does not maintain a persistent signature counter — the WebAuthn spec's "Signature Counter Considerations" permit a constant 0 when the authenticator does not implement a counter, and Apple's own synced passkeys send 0. (Citation: WebAuthn Level 3 "Signature Counter Considerations" — section number unverified here; confirm before quoting in the PR body.)
+- **Why 0 (corrects an earlier "emit stored N" design — S1)**: the browser extension *increments* the counter and persists N+1 to both the blob and the RP. So after a browser sign-in the RP's stored counter is N+1 and our blob is N+1. An RP that strictly enforces monotonicity (`received > stored`) rejects ANY value ≤ N+1 — emitting stored N+1 fails (`N+1 ≤ N+1`), and emitting a decreased value fails too. Emitting stored-N is therefore NO better than 0 against strict RPs, while 0 is the standard "I don't track counters" signal (Apple/iCloud Keychain synced passkeys always send 0) that RP libraries special-case (e.g. SimpleWebAuthn skips the check when both received and stored are 0).
+- **Honest known limitation (documented, not hidden)**: a passkey that has already been used via the browser extension against an RP that *strictly* enforces signCount monotonicity may be rejected on iOS (the RP saw a non-zero counter; iOS sends 0). Most RPs do NOT strictly enforce this (it is a SHOULD, widely relaxed precisely because synced/multi-device authenticators break it). The complete fix is counter write-back via the host — deferred to the registration/write-back follow-up branch. This limitation is recorded in the manual-test doc and the PR body.
+- **Acceptance**: every iOS assertion presents signCount 0 (authData bytes[33..36]==0); two consecutive assertions are identical in that field; passwd-sso's own RP accepts; a never-browser-used passkey (RP counter 0) is accepted by a standards-conformant RP.
+
+### C8 — Registration explicitly out of scope but safely handled
+
+- `prepareInterface(forPasskeyRegistration registrationRequest: any ASCredentialRequest)` (iOS 17+, Swift 6 `any`) MUST be **explicitly overridden** and call `extensionContext.cancelRequest(withError: NSError(domain: ASExtensionErrorDomain, code: ASExtensionError.failed.rawValue))`. "Omit the override" is NOT an option (S3): with `ProvidesPasskeys: true`, iOS routes registration to us, and the base-class default for an un-overridden registration handler is undefined across iOS versions (may hang the ceremony). An explicit clean cancel makes iOS fall through to another provider.
+- **Invariant**: passwd-sso must NEVER return an `ASPasskeyRegistrationCredential` it cannot persist (that would hand the RP a credential whose private key we then lose → permanent account lockout). This is the core safety reason registration is deferred.
+- **Acceptance**: on a device, selecting passwd-sso for passkey *creation* does not produce a stored-but-unsaveable credential and does not hang — the user can complete creation with another provider (e.g. iCloud Keychain). The forbidden-pattern grep confirms no `ASPasskeyRegistrationCredential` / `completeRegistrationRequest` appears in the diff.
+
+## Invariants (cross-cutting)
+
+- I1: AutoFill extension performs no network I/O and no writes (C6 forbidden pattern enforces).
+- I2: One biometric Keychain read per fill (reuse `CredentialResolver` retained-blob).
+- I3: Private-key JWK never logged; cleared after signing.
+- I4: Additive model changes (`VaultEntrySummary`, `CacheEntry`) are backward compatible (optional/defaulted) — old caches load, password/TOTP AutoFill unaffected.
+- I5: Personal entries only; team passkeys skipped (parity with #537).
+- I6: Lifecycle parity for QuickType passkey identities (same register/clear hooks as passwords).
+
+## Forbidden patterns (diff-wide grep keys)
+
+These greps are run as a contract-conformance gate during Phase 2 (post-implementation) and Phase 3 (review) against `git diff ios-main...HEAD` — they are part of the automated/reviewer pre-PR checklist, not merely advisory (T16). The registration-cancel path (C8) is additionally verified by device manual test.
+
+- `pattern: import .*MobileAPIClient` in `PasswdSSOAutofillExtension/` — reason: extension must not gain network/write capability.
+- `pattern: URLSession` in `PasswdSSOAutofillExtension/` — reason: same.
+- `pattern: signCount \+ 1|signCount\+1|signCount \+= 1` anywhere — reason: no counter increment (C7).
+- `pattern: completeRegistrationRequest|ASPasskeyRegistrationCredential` — reason: registration is out of scope; returning one risks lockout (C8). (If present, it must be a deliberate, reviewed exception — default is absence.)
+- `pattern: os_log|Logger\.|print\(|NSLog` inside `PasskeyAssertion.swift` and `EntryBlobDecoder`'s passkey-decode methods — reason: no secret logging (I3); the narrow `os_log.*jwk` grep missed `os_log("parse error: \(err)")` where `err` wraps a JWK fragment (S12). Catch blocks MUST re-throw as `PasskeyCryptoError.malformedJWK`/`.malformedPrivateScalar` WITHOUT logging the caught decoder error.
+
+## Testing strategy
+
+- **Unit (XCTest, new files under `ios/PasswdSSOTests`)**:
+  - `PasskeyAssertionTests`:
+    - **PINNED vector** (T1/T11): a hardcoded P-256 `d` scalar (base64url) + known rpId (`"webauthn.io"`) + fixed `clientDataHash`. Assert authData is byte-exact (37 bytes; `SHA256(rpId)` at [0..31]; byte[32]==0x05 for UP+UV, 0x00 for all-false; bytes[33..36]==signCount BE) AND the `.derRepresentation` signature verifies via `P256.Signing.PublicKey(x,y).isValidSignature(_:for:)` over `authData ‖ clientDataHash`. NOT generate-then-verify alone (would pass even with a wrong shared layout).
+    - JWK decode: valid; wrong `kty`/`crv` → `unsupportedKeyType`; `d` ≠ 32 bytes → `malformedPrivateScalar`.
+    - `buildPasskeyAssertion` (explicit tests, T14): signature is DER (`.derRepresentation`); UV=true, UP=true; rpId-mismatch material/request → throws `rpIdMismatch`; matching rpIds → `outputs.relyingParty == request.relyingPartyId` (confirms the OS-provided rpId, not the material value, drives authData); signCount always 0 — call twice with the SAME material + DIFFERENT clientDataHash and assert both outputs' authData[33..36] are equal and == BE(0) (T3).
+  - `EntryBlobDecoderTests` additions: passkey full-blob (with **double-encoded** `passkeyPrivateKeyJwk` string, T5) → non-nil material; same JSON with a bare JWK *object* at that field → nil; LOGIN overview → `relyingPartyId == nil`; passkey overview → rpId/credentialId surfaced; empty `passkeyUserHandle` decodes (skip happens at registrar, C5).
+  - `CredentialIdentityRegistrarTests` (MIGRATION, T2/T12 — the `FakeIdentityStore` change MUST land in the SAME commit as the protocol change: add the required `replace(passwords:passkeys:)` method + a `replacedPasskeySpecs` capture (nil/[] when no passkeys passed) + keep `replacedPasswordSpecs`; the old `replace(with:)` is now a protocol-extension default, so the fake must implement only the new requirement, else "type does not conform"). Tests: `buildPasskeyIdentitySpecs` builds specs from a cache with a passkey full blob; ONE combined replace registers both kinds; empty-userHandle spec skipped (T9); credentialId decode failure skipped; dedup; provider-disabled → no-op; `removeAll` clears both; back-compat `replace(with: [pwd])` → `replacedPasswordSpecs` has the pwd AND `replacedPasskeySpecs` is empty (T15, guards against the wrapper passing a wrong array / stale passkeys).
+  - `CacheEntry` decode: an old JSON literal lacking `entryType` → `entryType == nil` (T7); new fixture → "PASSKEY".
+  - `HostSyncServiceTests`: a PASSKEY `EncryptedEntry` → `CacheEntry.entryType == "PASSKEY"` (S6).
+  - `CredentialResolverTests`: `decryptPasskeyMaterial` on a LOGIN entry id → `entryNotFound` (T8); on a team entry id → `entryNotFound` (I5); biometric-read invariant for `resolveCandidates` → `decryptPasskeyMaterial` mirrors the existing `testResolveCandidates_singleKeychainRead`, which asserts `copyMatchingCallCount == 2` (one biometric-gated bridge-key read + one no-ACL meta read) — assert `== 2`, NOT `== 1` (T17); per-test temp-dir isolation (RT5).
+  - `filterPasskeyCandidates` pure-function tests: exact rpId match only; no eTLD+1 expansion (T6).
+- **Manual / device** (`docs/archive/review/ios-passkey-provider-manual-test.md`, required by R35 — auth-flow + deployment-surface change; sections Pre-conditions / Steps / Expected / Rollback / Adversarial). Happy path: passkey created via the browser extension on an RP (e.g. webauthn.io), sync, sign in on iOS via the system passkey sheet. **Adversarial scenarios (T10)**: (1) RP that strictly enforces signCount monotonicity after a prior browser use → document accept/reject (the C7 known limitation); (2) team-entry id routed to the passkey path → no crash/hang, clean fail; (3) vault locks between `resolveCandidates` and the user tapping the sheet → locked sheet, no cryptic error; (4) both passwd-sso and iCloud Keychain hold a passkey for the same rpId → no cross-contamination; (5) C8 registration attempt → clean fallthrough, no stuck dialog. Also verify password/TOTP AutoFill unregressed. RS4: use placeholder identities, no real personal data in the doc.
+- Run the project's iOS test command (`xcodebuild … test` for the host scheme) and confirm green before completion.
+
+## User operation scenarios
+
+1. Desktop: user creates a passkey on `example.com` via the browser extension → syncs. iPhone: opens `example.com` in Safari, taps Sign in → system passkey sheet lists the passwd-sso passkey → Face ID → signed in.
+2. Vault locked on iPhone → passkey ceremony → passwd-sso shows the honest locked sheet / does not offer a broken credential.
+3. RP requests a passkey for an rpId with no stored match → passwd-sso contributes nothing; other providers still work.
+4. User tries to *create* a passkey on iPhone with passwd-sso selected → falls through to another provider (no lockout); registration is a later branch.
+5. Two sign-ins in a row on the same passkey → both accepted despite equal signCount.
+
+## Considerations & constraints
+
+- **Why assertion-only**: the AutoFill extension has no auth token (per-app keychain, no shared access group) and no networking layer; it is read-only/offline. Registration requires durable, synchronous persistence of a freshly generated private key — impossible from the extension, and a deferred "stage to App Group, host uploads later" path creates a window where the RP has the credential but passwd-sso has not persisted the private key → **account lockout** if the host app is never reopened. Shipping that is worse than not having registration. Registration gets its own branch with a correct persistence design.
+- **entryType not on cache row**: handled by C4 (optional field + rpId fallback), avoiding a breaking cache-format bump.
+- **userHandle only in full blob**: handled by C5 (host decrypts passkey full blobs at sync for identity registration).
+- **Out of scope**: passkey registration/creation; counter write-back; team passkeys; PRF/largeBlob extensions; `excludeCredentials` dedup; attestation (assertion only).
+- **External dependency**: relies on the browser extension's stored-passkey blob shape (`passkeyPrivateKeyJwk` etc.) — if that shape changes server-side, decode must follow. Pinned by the EntryBlobDecoder tests.
+
+## Go/No-Go Gate
+
+| ID  | Subject                                                    | Status |
+|-----|-----------------------------------------------------------|--------|
+| C1  | Extension passkey capability + entitlements               | locked |
+| C2  | Passkey assertion crypto (Shared)                         | locked |
+| C3  | Passkey material decode (EntryBlobDecoder + summary)      | locked |
+| C4  | Cache row carries entryType (optional, backward compat)   | locked |
+| C5  | Passkey QuickType identity registration                   | locked |
+| C6  | Assertion handling (extension + Shared builder)           | locked |
+| C7  | signCount semantics (emit 0, no write-back)               | locked |
+| C8  | Registration out of scope, safely handled                 | locked |
+
+All contracts `locked` after 3 plan-review rounds (round 3: READY TO LOCK — no blocking findings). Proceeding to Phase 2.

--- a/docs/archive/review/ios-passkey-provider-review.md
+++ b/docs/archive/review/ios-passkey-provider-review.md
@@ -1,0 +1,117 @@
+# Plan Review: ios-passkey-provider
+
+Date: 2026-06-12
+Review round: 1 (full) — resolutions applied
+
+## Changes from Previous Round
+
+Initial review by three expert sub-agents (functionality, security, testing) on the
+assertion-only passkey-provider plan. All Critical/Major/actionable-Minor findings
+resolved in the plan; rejections recorded with evidence below.
+
+## Functionality Findings (F#)
+
+- **F1 — Critical — REJECTED (verified false).** Claimed `ASPasskeyAssertionCredential.signature`
+  needs raw r‖s, not DER. VERIFIED the opposite via Apple Developer Forums thread 710457
+  (developer debugged passkey-provider verification → `sigdecode_der`) and the repo's own
+  browser extension (`webauthn-crypto.ts` `p1363ToDer` converts to DER for the RP). `.derRepresentation`
+  is correct. Plan §Technical approach / C2 annotated with the verification.
+  - **Anti-Deferral check**: not a deferral — finding refuted with primary-source evidence.
+  - **Orchestrator sign-off**: confirmed; agent's "evidence" was self-admittedly speculative.
+- F2 — Major — RESOLVED. `completeAssertionRequest(using:)` is async → C6 now mandates `await` (mirrors TOTP `await completeOneTimeCodeRequest`).
+- F3 — Major — RESOLVED. Mixed `[ASCredentialIdentity]` cannot use deprecated `replaceCredentialIdentities`; C5 migrated to iOS 17 `replaceCredentialIdentityEntries(_:)` (heterogeneous array, one atomic call). Verified via dotnet/macios binding + Microsoft Learn deprecation note.
+- F4 — Major — RESOLVED. `recordIdentifier` is `String?`; C6 adds nil/empty guard → descriptive cancel.
+- F5 — Major — RESOLVED. `entryType` dropped by HostSyncService though present on `EncryptedEntry`; C4 populates it + documents team-rows-always-nil.
+- F6 — Major — RESOLVED. C3 now explicitly lists the full-blob fields to decode (`PasskeyFullBlobPayload`).
+- F7 — Minor — CONFIRMED (no action). Cache MAC covers ciphertext, not JSON keys → optional field is backward compatible. Noted in C4.
+- F8 — Minor — RESOLVED. C6 specifies clientDataHash/UV source from `requestParameters` and exact rpId match (no eTLD+1).
+- F9 — Minor — RESOLVED. C6/C8 use `any ASCredentialRequest` (Swift 6 strict existential).
+- F10 — Minor — RESOLVED. C5 specifies full-blob decrypt happens inline in `runSync` using the in-scope `vaultKey`.
+- F11, F12 — Minor — CONFIRMED correct (authData layout; CryptoKit JWK feasibility). No action.
+
+## Security Findings (S#)
+
+- **S1 — High — RESOLVED (design change).** Emitting stored signCount N is rejected by strict RPs
+  (browser increments+persists N+1; received ≤ stored fails). C7 changed to emit **0 unconditionally**
+  (spec-standard non-tracking-authenticator signal) with an HONEST documented limitation (browser-used
+  passkeys may be rejected by strictly-monotonic RPs until the deferred write-back branch). signCount
+  removed from `PasskeyAssertionMaterial` (eliminates T4 overflow surface).
+- S2 — Medium — RESOLVED. `buildPasskeyAssertion` asserts `material.relyingPartyId == request.relyingPartyId` (`rpIdMismatch`) and uses the OS-provided rpId for authData (defense-in-depth).
+- S3 — Medium — RESOLVED. C8 now REQUIRES an explicit registration override that cancels cleanly; "omit the override" removed.
+- S4 — Low/Med — RESOLVED. `privateKeyJWK` changed `String` → `Data`; zeroed via existing `zeroData` pattern (I3).
+- S5 — Low — RESOLVED. Protocol keeps a back-compat default-arg `replace(with:)` extension wrapper; one atomic replace clears both kinds.
+- S6 — Low — RESOLVED. C4 adds a HostSyncService entryType-propagation test.
+- S7, S9 — Informational — CONFIRMED correct (HostTokenStore per-app isolation; OS owns origin binding). No action.
+- S8 — Informational — RESOLVED. C6 mandates `decryptPasskeyMaterial` applies the same `defer { zeroData }` guard.
+- S10 — Low — RESOLVED. C2/§Non-functional document UV=true always (deliberate, no downgrade risk).
+
+## Testing Findings (T#)
+
+- T1 — High — RESOLVED. Pinned P-256 vector + byte-exact authData assertion (not generate-then-verify only).
+- T2 — High — RESOLVED. Testing strategy calls out `FakeIdentityStore` MIGRATION to the new signature + passkey-spec capture.
+- T3 — Medium — RESOLVED. Two-call same-material assertion that authData[33..36]==BE(0).
+- T4 — Medium — OBVIATED. signCount removed from material (always 0) → no overflow path.
+- T5 — Medium — RESOLVED. C3 + tests pin the double-encoded `passkeyPrivateKeyJwk` string shape.
+- T6 — High — RESOLVED. Extracted `filterPasskeyCandidates` pure Shared function (testable); list-path logic thinned.
+- T7 — Low — RESOLVED. Old-cache decode test uses a JSON literal lacking the key.
+- T8 — Medium — RESOLVED. `decryptPasskeyMaterial` on LOGIN/team id → `entryNotFound` test.
+- T9 — Medium — RESOLVED. Empty-userHandle passkey spec skipped + tested.
+- T10 — Medium — RESOLVED. Manual-test doc gains 5 adversarial scenarios.
+- T11 — Medium — RESOLVED. Flag-byte 0x05 / 0x00 pinned assertions.
+
+## Adjacent Findings
+
+- F-R13/R16 (functionality, security-adjacent): `d` must be validated as exactly 32 bytes; routed to C2 (`malformedPrivateScalar`). RESOLVED.
+
+## Quality Warnings
+
+None flagged (no merge-findings quality gate run; manual dedup — Ollama not invoked this round).
+
+## Recurring Issue Check
+
+### Functionality expert
+R1–R37 returned by the sub-agent; salient: R20 (backward compat — additive, OK), R23/R36 (Swift 6 strict-concurrency/warnings-as-errors → F2/F9 would be build failures, now fixed), R24 (WebAuthn byte layout verified). Test-recommendation rules deferred to testing expert.
+
+### Security expert
+R1–R37 + RS1–RS4. Salient: RS3 (no network from extension — enforced by forbidden grep + HostTokenStore isolation), RS4 (biometric per fill — `touchIDAuthenticationAllowableReuseDuration=0`), R20/R21/R22/R23 mapped to S1/S2/S3/S4. No Critical.
+
+### Testing expert
+R1–R37 + RT1–RT5. Salient: RT1 (mock-reality — double-encoded JWK fixture, T5), RT2 (pinned vectors, T1/T11), RT3 (protocol-change propagation to FakeIdentityStore, T2), RT4 (single-Keychain-read mirror test), RT5 (per-test isolation).
+
+---
+
+# Round 2 (incremental) — resolutions applied
+
+## Changes from Previous Round
+Verified round-1 resolutions and surfaced threading/precision gaps. The one architecture-level
+finding (F14/F15) is resolved with a concrete pattern-matching design (a Shared
+`buildPasskeyIdentitySpecs` helper mirroring `decryptPersonalOverviews`, threaded through the
+registrar's `replace(with:passkeys:)` and both call sites — NO `SyncReport` change).
+
+## Functionality (F#)
+- F13 — Minor — RESOLVED. Swift name is `replaceCredentialIdentities(_:)` (NS_SWIFT_NAME of `replaceCredentialIdentityEntries:`); passing `[any ASCredentialIdentity]` selects the heterogeneous overload. C5 corrected.
+- F14 — Major — RESOLVED. Registrar's higher-level `replace(with summaries:)` + both call sites (`PasswdSSOAppApp.swift` ~59-62, `RootView.swift` ~328-329) updated to thread passkey specs; otherwise atomic `passkeys:[]` replace would wipe passkey identities every foreground sync.
+- F15 — Major — RESOLVED. Adopted `buildPasskeyIdentitySpecs(from:vaultKey:userId:)` Shared helper called at the same sites as `decryptPersonalOverviews` (no `SyncReport` change). Supersedes round-1 F10 "build inside runSync" guidance.
+- F16 — Minor — RESOLVED. C6 captures the `Sendable` `requestParameters` in the picker `onSelect` closure.
+- F17 — Minor — RESOLVED. C3 nil-gate now also requires `credentialId`.
+
+## Security (S#)
+- S11 — Low — RESOLVED. C6 zeroes `material.privateKeyJWK` (Data) on success and in `catch` before re-throw (rpIdMismatch).
+- S12 — Low — RESOLVED. Forbidden-logging grep broadened to `os_log|Logger\.|print\(|NSLog` in the passkey crypto/decode files; catch blocks re-throw without logging the decoder error.
+- S1 citation caveat — noted: WebAuthn "Signature Counter Considerations" section number marked unverified in-plan; MUST be confirmed before quoting in the PR body (R29).
+
+## Testing (T#)
+- T12 — High — RESOLVED. FakeIdentityStore migration mandated as a same-commit change with capture-property guidance.
+- T13 — Low — RESOLVED. JWK fixture note allows/encourages `key_ops`/`ext`; JSONDecoder ignores unknown keys.
+- T14 — Medium — RESOLVED. Explicit `buildPasskeyAssertion` rpIdMismatch + OS-rpId-in-authData tests added.
+- T15 — Medium — RESOLVED. Explicit back-compat `replace(with:[pwd])` → empty passkeys test added.
+- T16 — Low — RESOLVED. Forbidden-pattern greps declared as a Phase 2/3 conformance gate; registration-cancel via manual test.
+- T17 — Low — RESOLVED. Corrected the keychain-read invariant wording to `copyMatchingCallCount == 2` (one biometric + one no-ACL meta).
+
+## Anti-Deferral
+No findings deferred. All round-2 items applied in-plan. No "acceptable risk" / "pre-existing" skips taken.
+
+## Recurring Issue Check (round 2 delta)
+- R3 (propagation): F14/F15 — the additive identity-spec output is now threaded through ALL consumers (registrar method + 2 call sites). Confirmed.
+- RT3 (protocol-change propagation): T12 — FakeIdentityStore conformance update enforced same-commit.
+- R25 (persist/hydrate symmetry): N/A — QuickType identities are ephemeral (registered on unlock, cleared on lock/background/launch); not persisted across restart.

--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		347F2D6168FB578E0E7687EC /* ServerURLSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9710064A995CE5E0D639202D /* ServerURLSetupView.swift */; };
 		34E13CBD9ED4C6D8D72D6EFE /* AppGroupContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720107D734C7B5EBBBFCB91E /* AppGroupContainer.swift */; };
 		3582DA3CD5414790F589E168 /* HostTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C68B395A2ACE49D3F116CB /* HostTokenStore.swift */; };
+		3602BE17465AD01B73DA82AC /* PasskeyAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3000F818C09142AEC4837294 /* PasskeyAssertion.swift */; };
 		393E223C042BBEF961AB0EFA /* SecureEnclaveDPoPSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F706FEFB55F6B0111CDFF17B /* SecureEnclaveDPoPSigner.swift */; };
 		3D23FF146F64052F0EC31277 /* WrappedKeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19D6A107E63BFA725F2C0F3 /* WrappedKeyStoreTests.swift */; };
 		4372EB553FD8B0AE2BF33972 /* StaleBlobRecoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B088B96E6D37D767B517A837 /* StaleBlobRecoveryService.swift */; };
@@ -40,6 +41,7 @@
 		53BABB8B7A6B12FE9A269D87 /* EntryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A274ABCE6A2833F3A66EF5 /* EntryFetcherTests.swift */; };
 		5421D67E38D403D16E75A584 /* AESGCMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAD672FE74D0EB78FA99F1C /* AESGCMTests.swift */; };
 		542B8D1BD03A73706A98778B /* KDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02778E2A8EE7B7A09B671C4 /* KDF.swift */; };
+		56F8D2D70DF4C0539E6A7988 /* PasskeyAssertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493B2BB02D23F64F52EF0DAA /* PasskeyAssertionTests.swift */; };
 		5B65C54AB593A685DC452BA4 /* OneTimeCodePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57AF6A21C048387AB2FC0C5 /* OneTimeCodePickerView.swift */; };
 		60AD9C0835A9502C54C79E90 /* AESGCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86EB7DC9441141057919E49 /* AESGCM.swift */; };
 		60C6D1BB9FB84DB9FA966478 /* PasswdSSOAutofillExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 4F631B3CA954B4A2A4EC5714 /* PasswdSSOAutofillExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -204,6 +206,7 @@
 		2A3E40BD15B72CC7D2465FA1 /* EntryEditForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryEditForm.swift; sourceTree = "<group>"; };
 		2C025655D57D0A2807DB8625 /* PasswdSSOAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswdSSOAppApp.swift; sourceTree = "<group>"; };
 		2DAD672FE74D0EB78FA99F1C /* AESGCMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AESGCMTests.swift; sourceTree = "<group>"; };
+		3000F818C09142AEC4837294 /* PasskeyAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAssertion.swift; sourceTree = "<group>"; };
 		327A83D67306CD99E0CB3270 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		32E806A6C00D78F85B1ABC89 /* PersonalEntryBlobBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalEntryBlobBuilder.swift; sourceTree = "<group>"; };
 		345F9CF0FA1F40F81B8D6074 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -214,6 +217,7 @@
 		404B7404ADFE4D340E600931 /* PasswdSSOTests.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PasswdSSOTests.entitlements; sourceTree = "<group>"; };
 		430B7C32D3A606C25EDA8568 /* AppSettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStoreTests.swift; sourceTree = "<group>"; };
 		49247874A1D0207489D6F624 /* PasswdSSOApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = PasswdSSOApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		493B2BB02D23F64F52EF0DAA /* PasskeyAssertionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAssertionTests.swift; sourceTree = "<group>"; };
 		4A24C3EFD4C6BA4ACDA40380 /* KDFTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KDFTests.swift; sourceTree = "<group>"; };
 		4F631B3CA954B4A2A4EC5714 /* PasswdSSOAutofillExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = PasswdSSOAutofillExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		5008EABA0367B0BB5E55052F /* LockStateReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockStateReducer.swift; sourceTree = "<group>"; };
@@ -346,6 +350,7 @@
 				AB5881187BA33EA8F91B91B7 /* LocalizationCatalogTests.swift */,
 				7AFCE015CCAE07263B30B8B4 /* LockStateReducerTests.swift */,
 				DFF49A0C20D6BD5D36E24D92 /* MobileAPIClientTests.swift */,
+				493B2BB02D23F64F52EF0DAA /* PasskeyAssertionTests.swift */,
 				404B7404ADFE4D340E600931 /* PasswdSSOTests.entitlements */,
 				D1FBE5BA0C4B6D7DE1B50B32 /* PersonalEntryBlobBuilderTests.swift */,
 				DB996D498008FC6F399B7078 /* RollbackFlagDrainTests.swift */,
@@ -525,6 +530,7 @@
 				D86EB7DC9441141057919E49 /* AESGCM.swift */,
 				FC38F9BDA78209BF77E16CC7 /* CryptoUtils.swift */,
 				C02778E2A8EE7B7A09B671C4 /* KDF.swift */,
+				3000F818C09142AEC4837294 /* PasskeyAssertion.swift */,
 				120E0D108C572BDFE0A5E79E /* SecureEnclaveKey.swift */,
 				A3FBC66A0BFC38B393757852 /* SPKIEncoder.swift */,
 			);
@@ -881,6 +887,7 @@
 				86F214BA34DD5D5A4B64EB87 /* LocalizationCatalogTests.swift in Sources */,
 				C9B811D75D4CC8737741AF8E /* LockStateReducerTests.swift in Sources */,
 				4FB785329A7B8D8BDF40FC5E /* MobileAPIClientTests.swift in Sources */,
+				56F8D2D70DF4C0539E6A7988 /* PasskeyAssertionTests.swift in Sources */,
 				77BB29B71060E99C8B62A235 /* PersonalEntryBlobBuilderTests.swift in Sources */,
 				270E924C1DDE26ACB7454E34 /* RollbackFlagDrainTests.swift in Sources */,
 				DBFB20A7E48448D3D840FDE7 /* RollbackFlagWriterTests.swift in Sources */,
@@ -916,6 +923,7 @@
 				542B8D1BD03A73706A98778B /* KDF.swift in Sources */,
 				2F1B42C2B8566A94C6155FEE /* LockState.swift in Sources */,
 				6790FB758EF3FD2CB70EA152 /* LockStateReducer.swift in Sources */,
+				3602BE17465AD01B73DA82AC /* PasskeyAssertion.swift in Sources */,
 				0A26FC6678B43677C57CEB9D /* PersonalEntryBlobBuilder.swift in Sources */,
 				765B1E34A07F76D0203E28D3 /* RollbackFlagWriter.swift in Sources */,
 				A49DCEFF5ABDE722BF33C324 /* SPKIEncoder.swift in Sources */,

--- a/ios/PasswdSSOApp/PasswdSSOAppApp.swift
+++ b/ios/PasswdSSOApp/PasswdSSOAppApp.swift
@@ -68,7 +68,10 @@ struct PasswdSSOAppApp: App {
               let summaries = decryptPersonalOverviews(
                 from: cacheData, vaultKey: vaultKey, userId: userId
               )
-              await CredentialIdentityRegistrar().replace(with: summaries)
+              let passkeys = buildPasskeyIdentitySpecs(
+                from: cacheData, vaultKey: vaultKey, userId: userId
+              )
+              await CredentialIdentityRegistrar().replace(with: summaries, passkeys: passkeys)
             }
           }
         case .background:

--- a/ios/PasswdSSOApp/Vault/EntryFetcher.swift
+++ b/ios/PasswdSSOApp/Vault/EntryFetcher.swift
@@ -60,6 +60,24 @@ public struct EncryptedEntry: Sendable, Codable, Equatable {
     case folderId
     case requireReprompt
   }
+
+  /// Convert a personal entry to a CacheEntry for the App Group cache. Single
+  /// source of truth for the mapping (used by HostSyncService and tests) so the
+  /// entryType propagation can't silently diverge.
+  public func toPersonalCacheEntry() -> CacheEntry {
+    CacheEntry(
+      id: id,
+      teamId: nil,
+      aadVersion: aadVersion,
+      keyVersion: keyVersion,
+      teamKeyVersion: nil,
+      itemKeyVersion: nil,
+      encryptedItemKey: nil,
+      encryptedBlob: encryptedBlob,
+      encryptedOverview: encryptedOverview,
+      entryType: entryType
+    )
+  }
 }
 
 // MARK: - Team wire model (matches /api/teams/[teamId]/passwords flat response shape)

--- a/ios/PasswdSSOApp/Vault/HostSyncService.swift
+++ b/ios/PasswdSSOApp/Vault/HostSyncService.swift
@@ -55,20 +55,9 @@ public actor HostSyncService {
       teams = []
     }
 
-    // Convert personal entries to CacheEntry (with aadVersion/keyVersion propagated)
-    var allCacheEntries: [CacheEntry] = personal.map { entry in
-      CacheEntry(
-        id: entry.id,
-        teamId: nil,
-        aadVersion: entry.aadVersion,
-        keyVersion: entry.keyVersion,
-        teamKeyVersion: nil,
-        itemKeyVersion: nil,
-        encryptedItemKey: nil,
-        encryptedBlob: entry.encryptedBlob,
-        encryptedOverview: entry.encryptedOverview
-      )
-    }
+    // Convert personal entries to CacheEntry (aadVersion/keyVersion/entryType
+    // propagated via the single-source-of-truth mapping on EncryptedEntry).
+    var allCacheEntries: [CacheEntry] = personal.map { $0.toPersonalCacheEntry() }
 
     // Fetch team entries sequentially to avoid overwhelming the server
     for team in teams {

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -342,7 +342,8 @@ struct RootView: View {
     cacheData: CacheData, vaultKey: SymmetricKey, userId: String
   ) async {
     let summaries = decryptPersonalOverviews(from: cacheData, vaultKey: vaultKey, userId: userId)
-    await CredentialIdentityRegistrar().replace(with: summaries)
+    let passkeys = buildPasskeyIdentitySpecs(from: cacheData, vaultKey: vaultKey, userId: userId)
+    await CredentialIdentityRegistrar().replace(with: summaries, passkeys: passkeys)
   }
 
   private func makeFallbackSyncService(apiClient: MobileAPIClient) -> HostSyncService {

--- a/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
+++ b/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
@@ -62,14 +62,59 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
   }
 
   /// iOS 17+ passkey-aware list entry point — the variant iOS 18/26 actually
-  /// invokes. Passkeys are unsupported, so the request parameters are ignored
-  /// and we present the password list.
+  /// invokes. For a passkey ceremony (non-empty relyingPartyIdentifier) we
+  /// present a passkey picker filtered to the requested rpId; password-only
+  /// ceremonies keep presenting the password list.
   @available(iOS 17.0, *)
   override func prepareCredentialList(
     for serviceIdentifiers: [ASCredentialServiceIdentifier],
     requestParameters: ASPasskeyCredentialRequestParameters
   ) {
-    presentCredentialList(for: serviceIdentifiers)
+    let rpId = requestParameters.relyingPartyIdentifier
+    if rpId.isEmpty {
+      presentCredentialList(for: serviceIdentifiers)
+    } else {
+      presentPasskeyList(for: serviceIdentifiers, requestParameters: requestParameters)
+    }
+  }
+
+  /// Present a passkey picker for the requested rpId. On selection, build the
+  /// assertion from the OS-provided request parameters (clientDataHash etc.).
+  @available(iOS 17.0, *)
+  @MainActor
+  private func presentPasskeyList(
+    for serviceIdentifiers: [ASCredentialServiceIdentifier],
+    requestParameters: ASPasskeyCredentialRequestParameters
+  ) {
+    let sendable = serviceIdentifiers.map { ServiceIdentifier(from: $0) }
+    let originalIdents = serviceIdentifiers.map {
+      ASCredentialServiceIdentifier(identifier: $0.identifier, type: $0.type)
+    }
+    let request = PasskeyAssertionRequest(
+      relyingPartyId: requestParameters.relyingPartyIdentifier,
+      clientDataHash: requestParameters.clientDataHash,
+      userVerificationRequired: requestParameters.userVerificationPreference == .required
+    )
+    Task { @MainActor in
+      do {
+        let result = try await resolver.resolveCandidates(for: sendable)
+        let matches = filterPasskeyCandidates(result.all, rpId: request.relyingPartyId)
+        let view = CredentialPickerView(
+          matched: matches,
+          all: matches,
+          serviceIdentifiers: originalIdents,
+          onSelect: { [weak self] summary in
+            self?.completePasskeyAssertion(entryId: summary.id, request: request)
+          },
+          onCancel: { [weak self] in self?.cancel(with: nil) }
+        )
+        presentSwiftUI(view)
+      } catch CredentialResolver.Error.vaultLocked {
+        presentLockedSheet()
+      } catch {
+        cancel(with: error)
+      }
+    }
   }
 
   override func prepareInterfaceForExtensionConfiguration() {
@@ -98,22 +143,75 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
   override func prepareInterfaceToProvideCredential(
     for credentialRequest: any ASCredentialRequest
   ) {
-    // Only password requests are supported; cancel passkey assertions rather
-    // than completing them with the wrong credential type.
-    guard credentialRequest.type == .password else {
+    switch credentialRequest.type {
+    case .password:
+      let recordId = credentialRequest.credentialIdentity.recordIdentifier ?? ""
+      Task { @MainActor in
+        do {
+          let detail = try await resolver.decryptEntryDetail(entryId: recordId)
+          let credential = ASPasswordCredential(user: detail.username, password: detail.password)
+          extensionContext.completeRequest(withSelectedCredential: credential)
+        } catch {
+          cancel(with: error)
+        }
+      }
+    case .passkeyAssertion:
+      guard
+        let passkeyRequest = credentialRequest as? ASPasskeyCredentialRequest,
+        let identity = passkeyRequest.credentialIdentity as? ASPasskeyCredentialIdentity,
+        let recordId = identity.recordIdentifier, !recordId.isEmpty
+      else {
+        cancel(with: nil)
+        return
+      }
+      let request = PasskeyAssertionRequest(
+        relyingPartyId: identity.relyingPartyIdentifier,
+        clientDataHash: passkeyRequest.clientDataHash,
+        userVerificationRequired: passkeyRequest.userVerificationPreference == .required
+      )
+      completePasskeyAssertion(entryId: recordId, request: request)
+    default:
       cancel(with: nil)
-      return
     }
-    let recordId = credentialRequest.credentialIdentity.recordIdentifier ?? ""
+  }
+
+  /// Resolve the chosen passkey entry, build the assertion, and complete the
+  /// request. signCount is 0; UV/UP are true (every fill is biometric-gated).
+  @available(iOS 17.0, *)
+  private func completePasskeyAssertion(entryId: String, request: PasskeyAssertionRequest) {
     Task { @MainActor in
       do {
-        let detail = try await resolver.decryptEntryDetail(entryId: recordId)
-        let credential = ASPasswordCredential(user: detail.username, password: detail.password)
-        extensionContext.completeRequest(withSelectedCredential: credential)
+        var material = try await resolver.decryptPasskeyMaterial(entryId: entryId)
+        defer { material.zeroPrivateKey() }
+        let outputs = try buildPasskeyAssertion(material: material, request: request)
+        let credential = ASPasskeyAssertionCredential(
+          userHandle: outputs.userHandle,
+          relyingParty: outputs.relyingParty,
+          signature: outputs.signature,
+          clientDataHash: request.clientDataHash,
+          authenticatorData: outputs.authenticatorData,
+          credentialID: outputs.credentialID
+        )
+        await extensionContext.completeAssertionRequest(using: credential)
       } catch {
         cancel(with: error)
       }
     }
+  }
+
+  /// Passkey REGISTRATION is out of scope for this build: the AutoFill extension
+  /// is read-only/offline and cannot durably persist a freshly-generated private
+  /// key, so returning an ASPasskeyRegistrationCredential we cannot save would
+  /// lock the user out of that account. Cancel cleanly so iOS falls through to
+  /// another provider.
+  @available(iOS 17.0, *)
+  override func prepareInterface(forPasskeyRegistration registrationRequest: any ASCredentialRequest) {
+    extensionContext.cancelRequest(
+      withError: NSError(
+        domain: ASExtensionErrorDomain,
+        code: ASExtensionError.failed.rawValue
+      )
+    )
   }
 
   // MARK: - TOTP fill (Step 9, iOS 17+)

--- a/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
+++ b/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
@@ -101,12 +101,15 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
         let matches = filterPasskeyCandidates(result.all, rpId: request.relyingPartyId)
         let view = CredentialPickerView(
           matched: matches,
+          // Search stays within passkey candidates — offering a non-passkey
+          // entry in a passkey ceremony would be wrong, so `all` == `matches`.
           all: matches,
           serviceIdentifiers: originalIdents,
           onSelect: { [weak self] summary in
             self?.completePasskeyAssertion(entryId: summary.id, request: request)
           },
-          onCancel: { [weak self] in self?.cancel(with: nil) }
+          onCancel: { [weak self] in self?.cancel(with: nil) },
+          emptyStateText: "No passkeys for this site"
         )
         presentSwiftUI(view)
       } catch CredentialResolver.Error.vaultLocked {

--- a/ios/PasswdSSOAutofillExtension/Info.plist
+++ b/ios/PasswdSSOAutofillExtension/Info.plist
@@ -28,6 +28,8 @@
 			<dict>
 				<key>ProvidesOneTimeCodes</key>
 				<true/>
+				<key>ProvidesPasskeys</key>
+				<true/>
 				<key>ProvidesPasswords</key>
 				<true/>
 			</dict>

--- a/ios/PasswdSSOAutofillExtension/Localizable.xcstrings
+++ b/ios/PasswdSSOAutofillExtension/Localizable.xcstrings
@@ -117,6 +117,22 @@
         }
       }
     },
+    "No passkeys for this site" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No passkeys for this site"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このサイトのパスキーはありません"
+          }
+        }
+      }
+    },
     "No passwords for this site" : {
       "localizations" : {
         "en" : {

--- a/ios/PasswdSSOAutofillExtension/Views/CredentialPickerView.swift
+++ b/ios/PasswdSSOAutofillExtension/Views/CredentialPickerView.swift
@@ -14,6 +14,10 @@ struct CredentialPickerView: View {
   let serviceIdentifiers: [ASCredentialServiceIdentifier]
   let onSelect: (VaultEntrySummary) -> Void
   let onCancel: () -> Void
+  /// Empty-state headline. Defaults to the password copy; the passkey list
+  /// passes a passkey-specific string so a no-match passkey ceremony isn't
+  /// mislabelled as "No passwords".
+  var emptyStateText: LocalizedStringKey = "No passwords for this site"
 
   @State private var pendingAppSideSelection: VaultEntrySummary?
   @State private var searchText: String = ""
@@ -81,7 +85,7 @@ struct CredentialPickerView: View {
         Text("No matches")
           .font(.headline)
       } else {
-        Text("No passwords for this site")
+        Text(emptyStateText)
           .font(.headline)
         Text("Search to browse all entries.")
           .font(.subheadline)

--- a/ios/PasswdSSOTests/CredentialIdentityRegistrarTests.swift
+++ b/ios/PasswdSSOTests/CredentialIdentityRegistrarTests.swift
@@ -237,6 +237,21 @@ final class CredentialIdentityRegistrarTests: XCTestCase {
     XCTAssertTrue(specs.isEmpty, "empty userHandle must be skipped (ASPasskeyCredentialIdentity requires it)")
   }
 
+  func testBuildPasskeyIdentitySpecs_skipsEmptyCredentialId() throws {
+    let vaultKey = SymmetricKey(size: .bits256)
+    let userId = "user-1"
+    let entry = try passkeyEntry(
+      id: "pk1", rpId: "webauthn.io", username: "alice",
+      credentialID: Data(), userHandle: Data([5, 6, 7, 8]),  // empty credentialID → skip
+      userId: userId, vaultKey: vaultKey
+    )
+    let cache = try makeCache([entry], userId: userId)
+
+    let specs = buildPasskeyIdentitySpecs(from: cache, vaultKey: vaultKey, userId: userId)
+
+    XCTAssertTrue(specs.isEmpty, "empty credentialID must be skipped")
+  }
+
   func testBuildPasskeyIdentitySpecs_ignoresLoginEntries() throws {
     let vaultKey = SymmetricKey(size: .bits256)
     let userId = "user-1"

--- a/ios/PasswdSSOTests/CredentialIdentityRegistrarTests.swift
+++ b/ios/PasswdSSOTests/CredentialIdentityRegistrarTests.swift
@@ -97,8 +97,39 @@ final class CredentialIdentityRegistrarTests: XCTestCase {
     let registrar = CredentialIdentityRegistrar(store: store)
     await registrar.replace(with: [summary("e1", urlHost: "a.com", username: "u")])
 
-    let replaced = await store.replacedSpecs
+    let replaced = await store.replacedPasswordSpecs
     XCTAssertEqual(replaced, [CredentialIdentitySpec(host: "a.com", user: "u", recordIdentifier: "e1")])
+  }
+
+  func testReplace_passwordOnly_leavesNoStalePasskeyIdentities() async {
+    // Back-compat wrapper must pass an EMPTY passkeys array (one atomic replace
+    // clears any previously-registered passkey identities).
+    let store = FakeIdentityStore(enabled: true)
+    let registrar = CredentialIdentityRegistrar(store: store)
+    await registrar.replace(with: [summary("e1", urlHost: "a.com", username: "u")])
+
+    let passwords = await store.replacedPasswordSpecs
+    let passkeys = await store.replacedPasskeySpecs
+    XCTAssertEqual(passwords?.count, 1)
+    XCTAssertEqual(passkeys, [], "password-only replace must clear passkey identities")
+  }
+
+  func testReplace_withPasskeys_registersBothKinds() async {
+    let store = FakeIdentityStore(enabled: true)
+    let registrar = CredentialIdentityRegistrar(store: store)
+    let spec = PasskeyIdentitySpec(
+      relyingPartyIdentifier: "webauthn.io", userName: "alice",
+      credentialID: Data([1, 2, 3, 4]), userHandle: Data([5, 6, 7, 8]),
+      recordIdentifier: "pk1"
+    )
+    await registrar.replace(
+      with: [summary("e1", urlHost: "a.com", username: "u")], passkeys: [spec]
+    )
+
+    let passwords = await store.replacedPasswordSpecs
+    let passkeys = await store.replacedPasskeySpecs
+    XCTAssertEqual(passwords?.count, 1)
+    XCTAssertEqual(passkeys, [spec])
   }
 
   func testReplace_whenDisabled_isNoOp() async {
@@ -167,12 +198,108 @@ final class CredentialIdentityRegistrarTests: XCTestCase {
     XCTAssertTrue(summaries.isEmpty, "AAD-bound entry must not decrypt under the wrong userId")
   }
 
+  // MARK: - buildPasskeyIdentitySpecs
+
+  func testBuildPasskeyIdentitySpecs_buildsSpecFromPasskeyEntry() throws {
+    let vaultKey = SymmetricKey(size: .bits256)
+    let userId = "user-1"
+    let credentialID = Data([1, 2, 3, 4])
+    let userHandle = Data([9, 8, 7, 6])
+    let entry = try passkeyEntry(
+      id: "pk1", rpId: "webauthn.io", username: "alice",
+      credentialID: credentialID, userHandle: userHandle,
+      userId: userId, vaultKey: vaultKey
+    )
+    let cache = try makeCache([entry], userId: userId)
+
+    let specs = buildPasskeyIdentitySpecs(from: cache, vaultKey: vaultKey, userId: userId)
+
+    XCTAssertEqual(specs, [
+      PasskeyIdentitySpec(
+        relyingPartyIdentifier: "webauthn.io", userName: "alice",
+        credentialID: credentialID, userHandle: userHandle, recordIdentifier: "pk1"
+      )
+    ])
+  }
+
+  func testBuildPasskeyIdentitySpecs_skipsEmptyUserHandle() throws {
+    let vaultKey = SymmetricKey(size: .bits256)
+    let userId = "user-1"
+    let entry = try passkeyEntry(
+      id: "pk1", rpId: "webauthn.io", username: "alice",
+      credentialID: Data([1, 2, 3, 4]), userHandle: Data(),  // empty → skip
+      userId: userId, vaultKey: vaultKey
+    )
+    let cache = try makeCache([entry], userId: userId)
+
+    let specs = buildPasskeyIdentitySpecs(from: cache, vaultKey: vaultKey, userId: userId)
+
+    XCTAssertTrue(specs.isEmpty, "empty userHandle must be skipped (ASPasskeyCredentialIdentity requires it)")
+  }
+
+  func testBuildPasskeyIdentitySpecs_ignoresLoginEntries() throws {
+    let vaultKey = SymmetricKey(size: .bits256)
+    let userId = "user-1"
+    let login = try personalEntry(id: "p0", urlHost: "a.com", username: "u",
+                                  userId: userId, aadVersion: 1, vaultKey: vaultKey)
+    let cache = try makeCache([login], userId: userId)
+
+    let specs = buildPasskeyIdentitySpecs(from: cache, vaultKey: vaultKey, userId: userId)
+
+    XCTAssertTrue(specs.isEmpty, "LOGIN entries (no relyingPartyId) are not passkeys")
+  }
+
   // MARK: - Cache fixtures
 
   private struct TestOverviewBlob: Encodable {
     let title: String
     let username: String?
     let urlHost: String?
+  }
+
+  private struct TestPasskeyOverviewBlob: Encodable {
+    let title: String
+    let username: String?
+    let relyingPartyId: String
+    let credentialId: String
+  }
+
+  private struct TestPasskeyFullBlob: Encodable {
+    let title: String
+    let username: String?
+    let relyingPartyId: String
+    let credentialId: String
+    let passkeyPrivateKeyJwk: String  // double-encoded JWK string (content irrelevant here)
+    let passkeyUserHandle: String
+  }
+
+  private func passkeyEntry(
+    id: String, rpId: String, username: String,
+    credentialID: Data, userHandle: Data,
+    userId: String, vaultKey: SymmetricKey
+  ) throws -> CacheEntry {
+    let credIdB64 = base64URLEncode(credentialID)
+    let userHandleB64 = base64URLEncode(userHandle)
+    let overviewData = try JSONEncoder().encode(
+      TestPasskeyOverviewBlob(
+        title: "T", username: username, relyingPartyId: rpId, credentialId: credIdB64
+      )
+    )
+    let fullData = try JSONEncoder().encode(
+      TestPasskeyFullBlob(
+        title: "T", username: username, relyingPartyId: rpId, credentialId: credIdB64,
+        passkeyPrivateKeyJwk: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"d\":\"x\"}",
+        passkeyUserHandle: userHandleB64
+      )
+    )
+    let overviewAAD = try buildPersonalEntryAAD(userId: userId, entryId: id, vaultType: VaultType.overview)
+    let blobAAD = try buildPersonalEntryAAD(userId: userId, entryId: id, vaultType: VaultType.blob)
+    let overview = try encryptAESGCMEncoded(plaintext: overviewData, key: vaultKey, aad: overviewAAD)
+    let blob = try encryptAESGCMEncoded(plaintext: fullData, key: vaultKey, aad: blobAAD)
+    return CacheEntry(
+      id: id, teamId: nil, aadVersion: 1,
+      encryptedBlob: blob, encryptedOverview: overview, entryType: "PASSKEY"
+    )
   }
 
   private func personalEntry(
@@ -207,15 +334,17 @@ final class CredentialIdentityRegistrarTests: XCTestCase {
 /// ASCredentialIdentityStore which is entitlement/device-dependent).
 private actor FakeIdentityStore: CredentialIdentityStoring {
   private let enabled: Bool
-  private(set) var replacedSpecs: [CredentialIdentitySpec]?
+  private(set) var replacedPasswordSpecs: [CredentialIdentitySpec]?
+  private(set) var replacedPasskeySpecs: [PasskeyIdentitySpec]?
   private(set) var replaceCount = 0
   private(set) var removeAllCount = 0
 
   init(enabled: Bool) { self.enabled = enabled }
 
   func isEnabled() async -> Bool { enabled }
-  func replace(with specs: [CredentialIdentitySpec]) async {
-    replacedSpecs = specs
+  func replace(passwords: [CredentialIdentitySpec], passkeys: [PasskeyIdentitySpec]) async {
+    replacedPasswordSpecs = passwords
+    replacedPasskeySpecs = passkeys
     replaceCount += 1
   }
   func removeAll() async { removeAllCount += 1 }

--- a/ios/PasswdSSOTests/CredentialResolverTests.swift
+++ b/ios/PasswdSSOTests/CredentialResolverTests.swift
@@ -702,6 +702,7 @@ final class CredentialResolverTests: XCTestCase {
     )
     let (resolver, _) = try makePasskeyResolver(entries: [entry], vaultKey: vaultKey, userId: userId)
 
+    // No prior resolveCandidates — exercises the standalone readForFill path.
     let material = try await resolver.decryptPasskeyMaterial(entryId: "pk1")
 
     XCTAssertEqual(material.relyingPartyId, "github.com")

--- a/ios/PasswdSSOTests/CredentialResolverTests.swift
+++ b/ios/PasswdSSOTests/CredentialResolverTests.swift
@@ -108,6 +108,49 @@ private struct TestTotpBlob: Encodable {
   let secret: String
 }
 
+private struct PasskeyTestOverviewBlob: Encodable {
+  let title: String
+  let username: String?
+  let relyingPartyId: String
+  let credentialId: String
+}
+
+private struct PasskeyTestFullBlob: Encodable {
+  let title: String
+  let username: String?
+  let relyingPartyId: String
+  let credentialId: String
+  let passkeyPrivateKeyJwk: String
+  let passkeyUserHandle: String
+}
+
+/// Build a personal PASSKEY CacheEntry (overview + full blob) with AAD binding.
+private func makePasskeyCacheEntry(
+  id: String, rpId: String, credentialID: Data, userHandle: Data,
+  key: SymmetricKey, userId: String
+) throws -> CacheEntry {
+  let credIdB64 = base64URLEncode(credentialID)
+  let userHandleB64 = base64URLEncode(userHandle)
+  let overviewData = try JSONEncoder().encode(
+    PasskeyTestOverviewBlob(title: "T", username: "alice", relyingPartyId: rpId, credentialId: credIdB64)
+  )
+  let fullData = try JSONEncoder().encode(
+    PasskeyTestFullBlob(
+      title: "T", username: "alice", relyingPartyId: rpId, credentialId: credIdB64,
+      passkeyPrivateKeyJwk: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"d\":\"abc\"}",
+      passkeyUserHandle: userHandleB64
+    )
+  )
+  let overviewAAD = try buildPersonalEntryAAD(userId: userId, entryId: id, vaultType: VaultType.overview)
+  let blobAAD = try buildPersonalEntryAAD(userId: userId, entryId: id, vaultType: VaultType.blob)
+  return CacheEntry(
+    id: id, teamId: nil, aadVersion: 1, keyVersion: 1,
+    encryptedBlob: try encryptAESGCMEncoded(plaintext: fullData, key: key, aad: blobAAD),
+    encryptedOverview: try encryptAESGCMEncoded(plaintext: overviewData, key: key, aad: overviewAAD),
+    entryType: "PASSKEY"
+  )
+}
+
 // MARK: - Test helpers
 
 private func makeBridgeKeyBlob(
@@ -618,6 +661,111 @@ final class CredentialResolverTests: XCTestCase {
       counting.copyMatchingCallCount,
       2,
       "resolveCandidates must use exactly TWO Keychain reads (one biometric prompt + one no-ACL meta)"
+    )
+  }
+
+  // MARK: - decryptPasskeyMaterial (C6)
+
+  /// Build a resolver over a cache containing the given entries, with the bridge
+  /// blob + wrapped vault key wired up. Returns the resolver and the counting
+  /// keychain so the caller can assert read counts.
+  private func makePasskeyResolver(
+    entries: [CacheEntry], vaultKey: SymmetricKey, userId: String
+  ) throws -> (CredentialResolver, CountingKeychainAccessor) {
+    let counting = CountingKeychainAccessor()
+    let bridgeKeyStore = BridgeKeyStore(
+      accessGroup: "test.jp.jpng.passwd-sso.shared", keychain: counting
+    )
+    let blob = try bridgeKeyStore.create()
+    let cacheKey = try deriveCacheVaultKey(bridgeKey: blob.bridgeKey)
+    let mockWKS = MockWrappedKeyStore()
+    try wrapAndSaveVaultKey(vaultKey: vaultKey, cacheKey: cacheKey, store: mockWKS)
+    try buildCacheFile(
+      at: cacheURL, entries: entries, vaultKey: vaultKey,
+      hostInstallUUID: blob.hostInstallUUID, counter: blob.cacheVersionCounter, userId: userId
+    )
+    counting.copyMatchingCallCount = 0  // reset after create
+    let resolver = CredentialResolver(
+      bridgeKeyStore: bridgeKeyStore, wrappedKeyStore: mockWKS, cacheURL: cacheURL
+    )
+    return (resolver, counting)
+  }
+
+  func testDecryptPasskeyMaterial_returnsMaterial() async throws {
+    let vaultKey = SymmetricKey(size: .bits256)
+    let userId = "test-user-id"
+    let credentialID = Data([1, 2, 3, 4])
+    let userHandle = Data([9, 8, 7, 6])
+    let entry = try makePasskeyCacheEntry(
+      id: "pk1", rpId: "github.com", credentialID: credentialID, userHandle: userHandle,
+      key: vaultKey, userId: userId
+    )
+    let (resolver, _) = try makePasskeyResolver(entries: [entry], vaultKey: vaultKey, userId: userId)
+
+    let material = try await resolver.decryptPasskeyMaterial(entryId: "pk1")
+
+    XCTAssertEqual(material.relyingPartyId, "github.com")
+    XCTAssertEqual(material.credentialId, base64URLEncode(credentialID))
+    XCTAssertEqual(material.userHandle, base64URLEncode(userHandle))
+  }
+
+  func testDecryptPasskeyMaterial_loginEntry_throwsEntryNotFound() async throws {
+    let vaultKey = SymmetricKey(size: .bits256)
+    let userId = "test-user-id"
+    let login = try makePersonalCacheEntry(
+      summary: VaultEntrySummary(id: "p0", title: "T", username: "u", urlHost: "a.com"),
+      detail: VaultEntryDetail(id: "p0", title: "T", username: "u", urlHost: "", password: "pw", url: "a.com"),
+      key: vaultKey, userId: userId, aadVersion: 1
+    )
+    let (resolver, _) = try makePasskeyResolver(entries: [login], vaultKey: vaultKey, userId: userId)
+
+    do {
+      _ = try await resolver.decryptPasskeyMaterial(entryId: "p0")
+      XCTFail("Expected entryNotFound for a non-passkey entry")
+    } catch CredentialResolver.Error.entryNotFound {
+      // expected
+    }
+  }
+
+  func testDecryptPasskeyMaterial_teamEntry_throwsEntryNotFound() async throws {
+    // Team passkeys are out of scope (I5): the teamId guard fires before any
+    // team-key decryption, so a team entry id is rejected as entryNotFound.
+    let vaultKey = SymmetricKey(size: .bits256)
+    let userId = "test-user-id"
+    let dummy = try encryptAESGCMEncoded(plaintext: Data("{}".utf8), key: vaultKey, aad: nil)
+    let team = CacheEntry(
+      id: "t0", teamId: "team-1", aadVersion: 0,
+      encryptedBlob: dummy, encryptedOverview: dummy
+    )
+    let (resolver, _) = try makePasskeyResolver(entries: [team], vaultKey: vaultKey, userId: userId)
+
+    do {
+      _ = try await resolver.decryptPasskeyMaterial(entryId: "t0")
+      XCTFail("Expected entryNotFound for a team entry")
+    } catch CredentialResolver.Error.entryNotFound {
+      // expected
+    }
+  }
+
+  func testDecryptPasskeyMaterial_singleBiometricRead() async throws {
+    // resolveCandidates retains the bridge blob; decryptPasskeyMaterial reuses it,
+    // so the two-call (one biometric + one meta) invariant holds across both.
+    let vaultKey = SymmetricKey(size: .bits256)
+    let userId = "test-user-id"
+    let entry = try makePasskeyCacheEntry(
+      id: "pk1", rpId: "github.com", credentialID: Data([1, 2, 3, 4]),
+      userHandle: Data([9, 8, 7, 6]), key: vaultKey, userId: userId
+    )
+    let (resolver, counting) = try makePasskeyResolver(
+      entries: [entry], vaultKey: vaultKey, userId: userId
+    )
+
+    _ = try await resolver.resolveCandidates(for: [])
+    _ = try await resolver.decryptPasskeyMaterial(entryId: "pk1")
+
+    XCTAssertEqual(
+      counting.copyMatchingCallCount, 2,
+      "resolveCandidates + decryptPasskeyMaterial must share one biometric read (2 keychain reads total)"
     )
   }
 

--- a/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
+++ b/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
@@ -144,4 +144,78 @@ final class EntryBlobDecoderTests: XCTestCase {
       EntryBlobDecoder.detail(plaintext: data("not-json"), entryId: "e9", teamId: nil)
     )
   }
+
+  // MARK: - passkey overview / material (C3)
+
+  func testSummarySurfacesPasskeyOverviewFields() throws {
+    let json = #"{"title":"GitHub","username":"alice","relyingPartyId":"github.com","credentialId":"AQIDBA"}"#
+    let summary = try XCTUnwrap(
+      EntryBlobDecoder.summary(plaintext: data(json), entryId: "pk1", teamId: nil)
+    )
+    XCTAssertEqual(summary.relyingPartyId, "github.com")
+    XCTAssertEqual(summary.credentialId, "AQIDBA")
+  }
+
+  func testSummaryLoginEntryHasNilPasskeyFields() throws {
+    let json = #"{"title":"Acme","username":"u","urlHost":"acme.com","tags":[]}"#
+    let summary = try XCTUnwrap(
+      EntryBlobDecoder.summary(plaintext: data(json), entryId: "e1", teamId: nil)
+    )
+    XCTAssertNil(summary.relyingPartyId, "LOGIN entries are not passkeys")
+    XCTAssertNil(summary.credentialId)
+  }
+
+  func testPasskeyMaterialDecodesDoubleEncodedJWK() throws {
+    // passkeyPrivateKeyJwk is a JSON STRING containing the JWK object (double-encoded),
+    // matching the browser extension's JSON.stringify(privateKeyJwk).
+    let json = #"""
+    {"title":"GitHub","relyingPartyId":"github.com","credentialId":"AQIDBA",\#
+    "passkeyPrivateKeyJwk":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"d\":\"abc\",\"x\":\"xx\",\"y\":\"yy\"}",\#
+    "passkeyUserHandle":"BQYHCA"}
+    """#
+    let material = try XCTUnwrap(
+      EntryBlobDecoder.passkeyMaterial(plaintext: data(json), entryId: "pk1")
+    )
+    XCTAssertEqual(material.entryId, "pk1")
+    XCTAssertEqual(material.relyingPartyId, "github.com")
+    XCTAssertEqual(material.credentialId, "AQIDBA")
+    XCTAssertEqual(material.userHandle, "BQYHCA")
+    // The stored JWK is the inner object string; decodeP256PrivateKeyJWK parses it.
+    XCTAssertEqual(String(decoding: material.privateKeyJWK, as: UTF8.self),
+                   #"{"kty":"EC","crv":"P-256","d":"abc","x":"xx","y":"yy"}"#)
+  }
+
+  func testPasskeyMaterialReturnsNilWhenNotPasskey() {
+    // LOGIN blob: no relyingPartyId / no passkeyPrivateKeyJwk.
+    let json = #"{"title":"Acme","username":"u","password":"p","url":"acme.com"}"#
+    XCTAssertNil(EntryBlobDecoder.passkeyMaterial(plaintext: data(json), entryId: "e1"))
+  }
+
+  func testPasskeyMaterialReturnsNilWhenCredentialIdMissing() {
+    // rpId + jwk present but credentialId absent → fail fast (F17).
+    let json = #"{"relyingPartyId":"github.com","passkeyPrivateKeyJwk":"{}","passkeyUserHandle":"BQYHCA"}"#
+    XCTAssertNil(EntryBlobDecoder.passkeyMaterial(plaintext: data(json), entryId: "pk1"))
+  }
+
+  // MARK: - CacheEntry.entryType backward compat (C4)
+
+  func testCacheEntryDecodesNilEntryTypeFromLegacyJSON() throws {
+    let json = #"""
+    {"id":"e1","aadVersion":0,"keyVersion":0,\#
+    "encryptedBlob":{"ciphertext":"00","iv":"00","authTag":"00"},\#
+    "encryptedOverview":{"ciphertext":"00","iv":"00","authTag":"00"}}
+    """#
+    let entry = try JSONDecoder().decode(CacheEntry.self, from: data(json))
+    XCTAssertNil(entry.entryType, "legacy cache rows lack entryType → decode to nil")
+  }
+
+  func testCacheEntryDecodesPasskeyEntryType() throws {
+    let json = #"""
+    {"id":"pk1","aadVersion":1,"keyVersion":1,"entryType":"PASSKEY",\#
+    "encryptedBlob":{"ciphertext":"00","iv":"00","authTag":"00"},\#
+    "encryptedOverview":{"ciphertext":"00","iv":"00","authTag":"00"}}
+    """#
+    let entry = try JSONDecoder().decode(CacheEntry.self, from: data(json))
+    XCTAssertEqual(entry.entryType, "PASSKEY")
+  }
 }

--- a/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
+++ b/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
@@ -197,6 +197,17 @@ final class EntryBlobDecoderTests: XCTestCase {
     XCTAssertNil(EntryBlobDecoder.passkeyMaterial(plaintext: data(json), entryId: "pk1"))
   }
 
+  func testPasskeyMaterialReturnsNilWhenJWKIsBareObject() {
+    // passkeyPrivateKeyJwk MUST be a JSON string (double-encoded). A bare JWK
+    // object at that field is a type mismatch → decode fails → nil (T5 guard).
+    let json = #"""
+    {"relyingPartyId":"github.com","credentialId":"AQIDBA",\#
+    "passkeyPrivateKeyJwk":{"kty":"EC","crv":"P-256","d":"abc"},\#
+    "passkeyUserHandle":"BQYHCA"}
+    """#
+    XCTAssertNil(EntryBlobDecoder.passkeyMaterial(plaintext: data(json), entryId: "pk1"))
+  }
+
   // MARK: - CacheEntry.entryType backward compat (C4)
 
   func testCacheEntryDecodesNilEntryTypeFromLegacyJSON() throws {

--- a/ios/PasswdSSOTests/HostSyncServiceTests.swift
+++ b/ios/PasswdSSOTests/HostSyncServiceTests.swift
@@ -180,6 +180,17 @@ final class HostSyncServiceTests: XCTestCase {
     let blob = try bks.readDirect()
     XCTAssertEqual(blob.cacheVersionCounter, 6)
   }
+
+  func testPersonalCacheEntryPropagatesEntryType() {
+    let enc = EncryptedData(ciphertext: "00", iv: "00", authTag: "00")
+    let passkey = EncryptedEntry(
+      id: "pk1", encryptedOverview: enc, encryptedBlob: enc, entryType: "PASSKEY"
+    )
+    XCTAssertEqual(passkey.toPersonalCacheEntry().entryType, "PASSKEY")
+
+    let login = EncryptedEntry(id: "e1", encryptedOverview: enc, encryptedBlob: enc)
+    XCTAssertEqual(login.toPersonalCacheEntry().entryType, "LOGIN")
+  }
 }
 
 // MARK: - Stub that avoids network calls
@@ -214,17 +225,9 @@ private actor StubHostSyncService {
     let blob = try bridgeKeyStore.readDirect()
     let newCounter = blob.cacheVersionCounter &+ 1
 
-    // Convert EncryptedEntry → CacheEntry (personal, aadVersion from entry)
-    let cacheEntries: [CacheEntry] = entries.map { entry in
-      CacheEntry(
-        id: entry.id,
-        teamId: nil,
-        aadVersion: entry.aadVersion,
-        keyVersion: entry.keyVersion,
-        encryptedBlob: entry.encryptedBlob,
-        encryptedOverview: entry.encryptedOverview
-      )
-    }
+    // Convert EncryptedEntry → CacheEntry via the production mapping (same call
+    // HostSyncService.runSync uses).
+    let cacheEntries: [CacheEntry] = entries.map { $0.toPersonalCacheEntry() }
 
     let encoder = JSONEncoder()
     let entriesJSON = try encoder.encode(cacheEntries)

--- a/ios/PasswdSSOTests/PasskeyAssertionTests.swift
+++ b/ios/PasswdSSOTests/PasskeyAssertionTests.swift
@@ -1,0 +1,192 @@
+import CryptoKit
+import Foundation
+import XCTest
+
+@testable import Shared
+
+/// Tests for the passkey assertion crypto (C2) and the buildPasskeyAssertion
+/// builder (C6). Uses a PINNED P-256 private scalar so the JWK is deterministic,
+/// then verifies the DER signature with the derived public key AND asserts the
+/// authenticatorData bytes exactly (a generate-then-verify loop alone would pass
+/// even with a wrong shared layout).
+final class PasskeyAssertionTests: XCTestCase {
+
+  /// Deterministic, pinned 32-byte scalar (bytes 1...32; well below curve order).
+  private static let pinnedScalar = Data((1...32).map { UInt8($0) })
+
+  private func pinnedKey() -> P256.Signing.PrivateKey {
+    try! P256.Signing.PrivateKey(rawRepresentation: Self.pinnedScalar)
+  }
+
+  /// Build the double-encoded JWK string the extension stores, from a P-256 key.
+  private func jwkString(for key: P256.Signing.PrivateKey) -> String {
+    let d = base64URLEncode(key.rawRepresentation)
+    let pub = key.publicKey.x963Representation  // 0x04 ‖ x(32) ‖ y(32)
+    let x = base64URLEncode(pub.subdata(in: 1..<33))
+    let y = base64URLEncode(pub.subdata(in: 33..<65))
+    return "{\"kty\":\"EC\",\"crv\":\"P-256\",\"d\":\"\(d)\",\"x\":\"\(x)\",\"y\":\"\(y)\"}"
+  }
+
+  // MARK: - authenticatorData layout (T1/T11)
+
+  func testAuthenticatorData_layoutFlagsAndSignCount() {
+    let rpId = "webauthn.io"
+    let authData = buildAssertionAuthenticatorData(
+      rpId: rpId, userPresent: true, userVerified: true, signCount: 0
+    )
+    XCTAssertEqual(authData.count, 37)
+    let expectedHash = Data(SHA256.hash(data: Data(rpId.utf8)))
+    XCTAssertEqual(authData.subdata(in: 0..<32), expectedHash)
+    XCTAssertEqual(authData[32], 0x05, "UP|UV = 0x05")
+    XCTAssertEqual(Array(authData.subdata(in: 33..<37)), [0, 0, 0, 0])
+  }
+
+  func testAuthenticatorData_allFlagsFalseAndSignCountBigEndian() {
+    let authData = buildAssertionAuthenticatorData(
+      rpId: "example.com", userPresent: false, userVerified: false, signCount: 0x01020304
+    )
+    XCTAssertEqual(authData[32], 0x00)
+    XCTAssertEqual(Array(authData.subdata(in: 33..<37)), [0x01, 0x02, 0x03, 0x04])
+  }
+
+  // MARK: - JWK decode
+
+  func testDecodeJWK_validPinnedKey() throws {
+    let key = pinnedKey()
+    let decoded = try decodeP256PrivateKeyJWK(Data(jwkString(for: key).utf8))
+    XCTAssertEqual(decoded.rawRepresentation, key.rawRepresentation)
+  }
+
+  func testDecodeJWK_rejectsNonP256() {
+    let jwk = "{\"kty\":\"EC\",\"crv\":\"P-384\",\"d\":\"AQ\"}"
+    XCTAssertThrowsError(try decodeP256PrivateKeyJWK(Data(jwk.utf8))) { error in
+      XCTAssertEqual(error as? PasskeyCryptoError, .unsupportedKeyType)
+    }
+  }
+
+  func testDecodeJWK_rejectsWrongLengthScalar() {
+    // d decodes to 4 bytes, not 32.
+    let jwk = "{\"kty\":\"EC\",\"crv\":\"P-256\",\"d\":\"AQIDBA\"}"
+    XCTAssertThrowsError(try decodeP256PrivateKeyJWK(Data(jwk.utf8))) { error in
+      XCTAssertEqual(error as? PasskeyCryptoError, .malformedPrivateScalar)
+    }
+  }
+
+  func testDecodeJWK_rejectsMalformedJSON() {
+    XCTAssertThrowsError(try decodeP256PrivateKeyJWK(Data("not json".utf8))) { error in
+      XCTAssertEqual(error as? PasskeyCryptoError, .malformedJWK)
+    }
+  }
+
+  // MARK: - sign / verify round trip + DER
+
+  func testSignPasskeyAssertion_producesVerifiableDERSignature() throws {
+    let key = pinnedKey()
+    let authData = buildAssertionAuthenticatorData(
+      rpId: "webauthn.io", userPresent: true, userVerified: true, signCount: 0
+    )
+    let clientDataHash = Data(SHA256.hash(data: Data("client-data".utf8)))
+    let der = try signPasskeyAssertion(
+      privateKey: key, authenticatorData: authData, clientDataHash: clientDataHash
+    )
+    // The signature is DER (ASN.1) — parse via derRepresentation and verify.
+    let signature = try P256.Signing.ECDSASignature(derRepresentation: der)
+    var signed = authData
+    signed.append(clientDataHash)
+    XCTAssertTrue(key.publicKey.isValidSignature(signature, for: signed))
+  }
+
+  // MARK: - buildPasskeyAssertion (C6)
+
+  private func material(rpId: String, key: P256.Signing.PrivateKey,
+                        credentialId: String = "AQIDBA", userHandle: String = "BQYHCA")
+    -> PasskeyAssertionMaterial {
+    PasskeyAssertionMaterial(
+      entryId: "e1", relyingPartyId: rpId, credentialId: credentialId,
+      userHandle: userHandle, privateKeyJWK: Data(jwkString(for: key).utf8)
+    )
+  }
+
+  func testBuildPasskeyAssertion_rpIdMismatchThrows() {
+    let key = pinnedKey()
+    let mat = material(rpId: "stored.example", key: key)
+    let request = PasskeyAssertionRequest(
+      relyingPartyId: "attacker.example",
+      clientDataHash: Data(repeating: 0xAB, count: 32),
+      userVerificationRequired: true
+    )
+    XCTAssertThrowsError(try buildPasskeyAssertion(material: mat, request: request)) { error in
+      XCTAssertEqual(error as? PasskeyCryptoError, .rpIdMismatch)
+    }
+  }
+
+  func testBuildPasskeyAssertion_usesRequestRpIdForAuthDataAndVerifies() throws {
+    let key = pinnedKey()
+    let rpId = "webauthn.io"
+    let mat = material(rpId: rpId, key: key)
+    let clientDataHash = Data(repeating: 0x11, count: 32)
+    let request = PasskeyAssertionRequest(
+      relyingPartyId: rpId, clientDataHash: clientDataHash, userVerificationRequired: true
+    )
+    let outputs = try buildPasskeyAssertion(material: mat, request: request)
+
+    XCTAssertEqual(outputs.relyingParty, rpId)
+    // authData rpIdHash is from the OS-provided rpId.
+    XCTAssertEqual(outputs.authenticatorData.subdata(in: 0..<32),
+                   Data(SHA256.hash(data: Data(rpId.utf8))))
+    XCTAssertEqual(outputs.credentialID, try base64URLDecode("AQIDBA"))
+    XCTAssertEqual(outputs.userHandle, try base64URLDecode("BQYHCA"))
+    // Signature verifies under the stored key.
+    let signature = try P256.Signing.ECDSASignature(derRepresentation: outputs.signature)
+    var signed = outputs.authenticatorData
+    signed.append(clientDataHash)
+    XCTAssertTrue(key.publicKey.isValidSignature(signature, for: signed))
+  }
+
+  func testBuildPasskeyAssertion_signCountAlwaysZero() throws {
+    let key = pinnedKey()
+    let rpId = "webauthn.io"
+    let mat = material(rpId: rpId, key: key)
+    let out1 = try buildPasskeyAssertion(
+      material: mat,
+      request: PasskeyAssertionRequest(
+        relyingPartyId: rpId, clientDataHash: Data(repeating: 0x01, count: 32),
+        userVerificationRequired: true)
+    )
+    let out2 = try buildPasskeyAssertion(
+      material: mat,
+      request: PasskeyAssertionRequest(
+        relyingPartyId: rpId, clientDataHash: Data(repeating: 0x02, count: 32),
+        userVerificationRequired: true)
+    )
+    XCTAssertEqual(Array(out1.authenticatorData.subdata(in: 33..<37)), [0, 0, 0, 0])
+    XCTAssertEqual(out1.authenticatorData.subdata(in: 33..<37),
+                   out2.authenticatorData.subdata(in: 33..<37))
+  }
+
+  func testBuildPasskeyAssertion_emptyCredentialIdThrows() {
+    let key = pinnedKey()
+    let mat = material(rpId: "webauthn.io", key: key, credentialId: "")
+    let request = PasskeyAssertionRequest(
+      relyingPartyId: "webauthn.io", clientDataHash: Data(repeating: 0x11, count: 32),
+      userVerificationRequired: true
+    )
+    XCTAssertThrowsError(try buildPasskeyAssertion(material: mat, request: request)) { error in
+      XCTAssertEqual(error as? PasskeyCryptoError, .malformedCredentialId)
+    }
+  }
+
+  // MARK: - filterPasskeyCandidates (T6)
+
+  func testFilterPasskeyCandidates_exactMatchOnly() {
+    let summaries = [
+      VaultEntrySummary(id: "a", title: "A", username: "u", urlHost: "",
+                        relyingPartyId: "webauthn.io", credentialId: "c1"),
+      VaultEntrySummary(id: "b", title: "B", username: "u", urlHost: "",
+                        relyingPartyId: "sub.webauthn.io", credentialId: "c2"),
+      VaultEntrySummary(id: "c", title: "C", username: "u", urlHost: "login.com"),  // login, rpId nil
+    ]
+    let matches = filterPasskeyCandidates(summaries, rpId: "webauthn.io")
+    XCTAssertEqual(matches.map(\.id), ["a"], "exact rpId match only; no eTLD+1 expansion")
+  }
+}

--- a/ios/PasswdSSOTests/PasskeyAssertionTests.swift
+++ b/ios/PasswdSSOTests/PasskeyAssertionTests.swift
@@ -78,6 +78,20 @@ final class PasskeyAssertionTests: XCTestCase {
     }
   }
 
+  func testDecodeJWK_toleratesExtraWebCryptoFields() throws {
+    // Web Crypto exportKey("jwk") emits key_ops/ext; JSONDecoder must ignore them.
+    let key = pinnedKey()
+    let pub = key.publicKey.x963Representation
+    let jwk = """
+      {"kty":"EC","crv":"P-256","d":"\(base64URLEncode(key.rawRepresentation))",\
+      "x":"\(base64URLEncode(pub.subdata(in: 1..<33)))",\
+      "y":"\(base64URLEncode(pub.subdata(in: 33..<65)))",\
+      "key_ops":["sign"],"ext":true}
+      """
+    let decoded = try decodeP256PrivateKeyJWK(Data(jwk.utf8))
+    XCTAssertEqual(decoded.rawRepresentation, key.rawRepresentation)
+  }
+
   // MARK: - sign / verify round trip + DER
 
   func testSignPasskeyAssertion_producesVerifiableDERSignature() throws {
@@ -173,6 +187,20 @@ final class PasskeyAssertionTests: XCTestCase {
     )
     XCTAssertThrowsError(try buildPasskeyAssertion(material: mat, request: request)) { error in
       XCTAssertEqual(error as? PasskeyCryptoError, .malformedCredentialId)
+    }
+  }
+
+  func testBuildPasskeyAssertion_emptyUserHandleThrows() {
+    // A residual/pre-migration entry with empty userHandle must fail cleanly,
+    // not crash AuthenticationServices on an empty handle.
+    let key = pinnedKey()
+    let mat = material(rpId: "webauthn.io", key: key, userHandle: "")
+    let request = PasskeyAssertionRequest(
+      relyingPartyId: "webauthn.io", clientDataHash: Data(repeating: 0x11, count: 32),
+      userVerificationRequired: true
+    )
+    XCTAssertThrowsError(try buildPasskeyAssertion(material: mat, request: request)) { error in
+      XCTAssertEqual(error as? PasskeyCryptoError, .emptyUserHandle)
     }
   }
 

--- a/ios/Shared/AutoFill/CredentialIdentityRegistrar.swift
+++ b/ios/Shared/AutoFill/CredentialIdentityRegistrar.swift
@@ -37,6 +37,58 @@ public func decryptPersonalOverviews(
   return result
 }
 
+/// Build QuickType passkey identity specs from PERSONAL passkey entries. Mirrors
+/// `decryptPersonalOverviews`' signature/timing so the two call sites can invoke
+/// both from the same place (post-sync, vaultKey in scope). For each personal
+/// passkey (overview `relyingPartyId != nil`), additionally decrypt the FULL blob
+/// to recover the userHandle (which lives only in the full blob). Entries whose
+/// credentialId fails to decode OR whose userHandle is empty are skipped —
+/// `ASPasskeyCredentialIdentity` requires a non-empty userHandle.
+public func buildPasskeyIdentitySpecs(
+  from cacheData: CacheData,
+  vaultKey: SymmetricKey,
+  userId: String
+) -> [PasskeyIdentitySpec] {
+  guard let entries = try? JSONDecoder().decode([CacheEntry].self, from: cacheData.entries) else {
+    return []
+  }
+  var result: [PasskeyIdentitySpec] = []
+  for entry in entries where entry.teamId == nil {
+    let overviewAAD: Data? = entry.aadVersion >= 1
+      ? (try? buildPersonalEntryAAD(userId: userId, entryId: entry.id, vaultType: VaultType.overview))
+      : nil
+    guard
+      let overviewPlain = try? decryptAESGCMEncoded(
+        encrypted: entry.encryptedOverview, key: vaultKey, aad: overviewAAD
+      ),
+      let summary = EntryBlobDecoder.summary(plaintext: overviewPlain, entryId: entry.id, teamId: nil),
+      let rpId = summary.relyingPartyId,
+      let credentialIdStr = summary.credentialId
+    else { continue }
+    let blobAAD: Data? = entry.aadVersion >= 1
+      ? (try? buildPersonalEntryAAD(userId: userId, entryId: entry.id, vaultType: VaultType.blob))
+      : nil
+    guard
+      let blobPlain = try? decryptAESGCMEncoded(
+        encrypted: entry.encryptedBlob, key: vaultKey, aad: blobAAD
+      ),
+      let material = EntryBlobDecoder.passkeyMaterial(plaintext: blobPlain, entryId: entry.id),
+      let credentialID = try? base64URLDecode(credentialIdStr), !credentialID.isEmpty,
+      let userHandle = try? base64URLDecode(material.userHandle), !userHandle.isEmpty
+    else { continue }
+    result.append(
+      PasskeyIdentitySpec(
+        relyingPartyIdentifier: rpId,
+        userName: summary.username,
+        credentialID: credentialID,
+        userHandle: userHandle,
+        recordIdentifier: entry.id
+      )
+    )
+  }
+  return result
+}
+
 // MARK: - Sendable identity spec
 
 /// Sendable description of one QuickType credential identity: the site host,
@@ -56,19 +108,57 @@ public struct CredentialIdentitySpec: Sendable, Equatable {
   }
 }
 
+/// Sendable description of one QuickType PASSKEY identity. Carries the raw
+/// (base64url-decoded) credentialID + userHandle bytes the OS needs to render
+/// the passkey in the system passkey sheet. No private key here — the actual
+/// assertion (after the user picks) goes through the extension's biometric-gated
+/// decrypt by recordIdentifier.
+public struct PasskeyIdentitySpec: Sendable, Equatable {
+  public let relyingPartyIdentifier: String
+  public let userName: String
+  public let credentialID: Data
+  public let userHandle: Data
+  public let recordIdentifier: String
+
+  public init(
+    relyingPartyIdentifier: String,
+    userName: String,
+    credentialID: Data,
+    userHandle: Data,
+    recordIdentifier: String
+  ) {
+    self.relyingPartyIdentifier = relyingPartyIdentifier
+    self.userName = userName
+    self.credentialID = credentialID
+    self.userHandle = userHandle
+    self.recordIdentifier = recordIdentifier
+  }
+}
+
 // MARK: - Store seam (DI for tests)
 
 /// Thin seam over `ASCredentialIdentityStore` so the registration/clear wiring
 /// is unit-testable with a fake (matching the BridgeKeyStore/Clock DI pattern).
 public protocol CredentialIdentityStoring: Sendable {
   func isEnabled() async -> Bool
-  func replace(with specs: [CredentialIdentitySpec]) async
+  /// Atomically replace the WHOLE identity set (passwords + passkeys) in one
+  /// call, so a password-only refresh with `passkeys: []` also clears stale
+  /// passkey identities (lifecycle parity).
+  func replace(passwords: [CredentialIdentitySpec], passkeys: [PasskeyIdentitySpec]) async
   func removeAll() async
 }
 
+extension CredentialIdentityStoring {
+  /// Back-compat password-only wrapper for callers/tests that don't deal in passkeys.
+  public func replace(with passwords: [CredentialIdentitySpec]) async {
+    await replace(passwords: passwords, passkeys: [])
+  }
+}
+
 /// Production store: forwards to `ASCredentialIdentityStore.shared`. Builds the
-/// `ASPasswordCredentialIdentity` objects from the Sendable specs internally so
-/// no non-Sendable AuthenticationServices type crosses an actor boundary.
+/// `ASPasswordCredentialIdentity` / `ASPasskeyCredentialIdentity` objects from
+/// the Sendable specs internally so no non-Sendable AuthenticationServices type
+/// crosses an actor boundary.
 public struct SystemCredentialIdentityStore: CredentialIdentityStoring {
   public init() {}
 
@@ -80,14 +170,30 @@ public struct SystemCredentialIdentityStore: CredentialIdentityStoring {
     }
   }
 
-  public func replace(with specs: [CredentialIdentitySpec]) async {
-    let identities = specs.map { spec in
+  public func replace(
+    passwords: [CredentialIdentitySpec],
+    passkeys: [PasskeyIdentitySpec]
+  ) async {
+    var identities: [any ASCredentialIdentity] = passwords.map { spec in
       ASPasswordCredentialIdentity(
         serviceIdentifier: ASCredentialServiceIdentifier(identifier: spec.host, type: .domain),
         user: spec.user,
         recordIdentifier: spec.recordIdentifier
       )
     }
+    for spec in passkeys {
+      identities.append(
+        ASPasskeyCredentialIdentity(
+          relyingPartyIdentifier: spec.relyingPartyIdentifier,
+          userName: spec.userName,
+          credentialID: spec.credentialID,
+          userHandle: spec.userHandle,
+          recordIdentifier: spec.recordIdentifier
+        )
+      )
+    }
+    // iOS 17+ heterogeneous-array API (ObjC `replaceCredentialIdentityEntries:`,
+    // Swift name `replaceCredentialIdentities(_:)`) — one atomic replace of both kinds.
     try? await ASCredentialIdentityStore.shared.replaceCredentialIdentities(identities)
   }
 
@@ -136,11 +242,15 @@ public struct CredentialIdentityRegistrar: Sendable {
     return result
   }
 
-  /// Replace the registered identity set with the given summaries' specs.
+  /// Replace the registered identity set with the given summaries' password specs
+  /// plus the supplied passkey specs (one atomic replace covering both kinds).
   /// No-op when the AutoFill provider is disabled in Settings.
-  public func replace(with summaries: [VaultEntrySummary]) async {
+  public func replace(
+    with summaries: [VaultEntrySummary],
+    passkeys: [PasskeyIdentitySpec] = []
+  ) async {
     guard await store.isEnabled() else { return }
-    await store.replace(with: Self.specs(from: summaries))
+    await store.replace(passwords: Self.specs(from: summaries), passkeys: passkeys)
   }
 
   /// Remove all registered identities (always runs; removeAll is a no-op when

--- a/ios/Shared/AutoFill/CredentialResolver.swift
+++ b/ios/Shared/AutoFill/CredentialResolver.swift
@@ -341,6 +341,91 @@ public actor CredentialResolver {
     return detail
   }
 
+  /// Decrypts one PERSONAL passkey entry's full blob into assertion material.
+  /// Parallels `decryptEntryDetail`: reuses the bridge_key retained from the
+  /// preceding `resolveCandidates` (single biometric read), zeroes vault_key
+  /// before returning. Throws `entryNotFound` for team entries OR non-passkey
+  /// entries (no rpId / no private key in the blob).
+  public func decryptPasskeyMaterial(entryId: String) async throws -> PasskeyAssertionMaterial {
+    let blob: BridgeKeyStore.Blob
+    if let retained = currentBlob {
+      blob = retained
+    } else {
+      do {
+        blob = try bridgeKeyStore.readForFill(reason: "Fill credential from passwd-sso vault")
+      } catch {
+        throw Error.vaultLocked
+      }
+    }
+    currentBlob = nil  // consume after one use
+
+    let cacheKey = try deriveCacheVaultKey(bridgeKey: blob.bridgeKey)
+    guard let wrapped = try? wrappedKeyStore.loadVaultKey() else {
+      throw Error.vaultLocked
+    }
+    guard
+      let vaultKeyData = try? decryptAESGCM(
+        ciphertext: wrapped.ciphertext,
+        iv: wrapped.iv,
+        tag: wrapped.authTag,
+        key: cacheKey
+      )
+    else {
+      throw Error.vaultLocked
+    }
+    var mutableVaultKeyData = vaultKeyData
+    defer { zeroData(&mutableVaultKeyData) }
+    let vaultKey = SymmetricKey(data: vaultKeyData)
+
+    let cacheData: CacheData
+    do {
+      cacheData = try readCacheFile(
+        path: cacheURL,
+        vaultKey: vaultKey,
+        expectedHostInstallUUID: blob.hostInstallUUID,
+        expectedCounter: blob.cacheVersionCounter,
+        now: now()
+      )
+    } catch EntryCacheError.rejection(let kind) {
+      await writeRollbackFlag(kind: kind, blob: blob, vaultKey: vaultKey)
+      throw Error.cacheRejected(kind)
+    } catch {
+      throw Error.cacheUnavailable
+    }
+
+    let allEntries: [CacheEntry]
+    do {
+      allEntries = try JSONDecoder().decode([CacheEntry].self, from: cacheData.entries)
+    } catch {
+      throw Error.cacheUnavailable
+    }
+
+    guard let entry = allEntries.first(where: { $0.id == entryId }) else {
+      throw Error.entryNotFound
+    }
+    // Personal entries only (team passkeys out of scope).
+    guard entry.teamId == nil else { throw Error.entryNotFound }
+
+    let userId = cacheData.header.userId
+    let aad = buildEntryAAD(entry: entry, vaultType: VaultType.blob, userId: userId)
+    guard
+      let ivData = try? hexDecode(entry.encryptedBlob.iv),
+      let cipherData = try? hexDecode(entry.encryptedBlob.ciphertext),
+      let tagData = try? hexDecode(entry.encryptedBlob.authTag),
+      let plaintext = try? decryptAESGCM(
+        ciphertext: cipherData,
+        iv: ivData,
+        tag: tagData,
+        key: vaultKey,
+        aad: aad
+      ),
+      let material = EntryBlobDecoder.passkeyMaterial(plaintext: plaintext, entryId: entry.id)
+    else {
+      throw Error.entryNotFound
+    }
+    return material
+  }
+
   // Blob → model decode is shared with the host app via EntryBlobDecoder
   // (ios/Shared/Models/EntryBlobDecoder.swift) — do NOT reintroduce a local copy.
 
@@ -511,6 +596,11 @@ public struct CacheEntry: Codable, Sendable {
   public let encryptedItemKey: EncryptedData?
   public let encryptedBlob: EncryptedData
   public let encryptedOverview: EncryptedData
+  /// Server entry type (e.g. "LOGIN", "PASSKEY"). Optional/nil-tolerant: caches
+  /// written before this field existed, and all team rows, decode to nil. Used
+  /// only as a fast pre-classifier — passkey detection falls back to the
+  /// decrypted overview's relyingPartyId, so nil never causes a miss.
+  public let entryType: String?
 
   public init(
     id: String,
@@ -521,7 +611,8 @@ public struct CacheEntry: Codable, Sendable {
     itemKeyVersion: Int? = nil,
     encryptedItemKey: EncryptedData? = nil,
     encryptedBlob: EncryptedData,
-    encryptedOverview: EncryptedData
+    encryptedOverview: EncryptedData,
+    entryType: String? = nil
   ) {
     self.id = id
     self.teamId = teamId
@@ -532,5 +623,6 @@ public struct CacheEntry: Codable, Sendable {
     self.encryptedItemKey = encryptedItemKey
     self.encryptedBlob = encryptedBlob
     self.encryptedOverview = encryptedOverview
+    self.entryType = entryType
   }
 }

--- a/ios/Shared/Crypto/PasskeyAssertion.swift
+++ b/ios/Shared/Crypto/PasskeyAssertion.swift
@@ -1,0 +1,205 @@
+import CryptoKit
+import Foundation
+
+// MARK: - Errors
+
+public enum PasskeyCryptoError: Error, Equatable {
+  case malformedJWK
+  case unsupportedKeyType      // kty != "EC" or crv != "P-256"
+  case malformedPrivateScalar  // d absent or not exactly 32 bytes after base64url-decode
+  case rpIdMismatch            // stored rpId != request rpId (defense-in-depth)
+  case malformedCredentialId
+}
+
+// MARK: - Assertion material (decrypted from the full blob)
+
+/// Fields needed to produce a WebAuthn assertion. `privateKeyJWK` is the raw
+/// UTF-8 bytes of the stringified EC JWK (zeroable). The host never reaches this
+/// type — it is built inside the AutoFill extension after the biometric unwrap.
+public struct PasskeyAssertionMaterial: Sendable, Equatable {
+  public let entryId: String
+  public let relyingPartyId: String
+  public let credentialId: String   // base64url, as stored
+  public let userHandle: String     // base64url, as stored (may be empty)
+  public var privateKeyJWK: Data    // raw UTF-8 bytes of the stringified JWK
+
+  public init(
+    entryId: String,
+    relyingPartyId: String,
+    credentialId: String,
+    userHandle: String,
+    privateKeyJWK: Data
+  ) {
+    self.entryId = entryId
+    self.relyingPartyId = relyingPartyId
+    self.credentialId = credentialId
+    self.userHandle = userHandle
+    self.privateKeyJWK = privateKeyJWK
+  }
+
+  /// Best-effort overwrite of the JWK bytes after the signing key is built.
+  /// Note: Swift value semantics make this best-effort (the inner `d` String the
+  /// JSON decoder materialises cannot be zeroed); the material is otherwise a
+  /// short-lived local whose buffer is released at scope end.
+  public mutating func zeroPrivateKey() {
+    privateKeyJWK.resetBytes(in: 0..<privateKeyJWK.count)
+  }
+}
+
+// MARK: - JWK → P-256 key
+
+private struct ECPrivateKeyJWK: Decodable {
+  let kty: String
+  let crv: String
+  let d: String
+}
+
+/// Parse a stringified EC JWK into a P-256 signing key. `d` (base64url) MUST
+/// decode to exactly 32 bytes. Rejects non-EC / non-P-256 / wrong-length d.
+/// Does NOT log the caught decoder error (never echoes key material).
+public func decodeP256PrivateKeyJWK(_ jwkJSON: Data) throws -> P256.Signing.PrivateKey {
+  guard let jwk = try? JSONDecoder().decode(ECPrivateKeyJWK.self, from: jwkJSON) else {
+    throw PasskeyCryptoError.malformedJWK
+  }
+  guard jwk.kty == "EC", jwk.crv == "P-256" else {
+    throw PasskeyCryptoError.unsupportedKeyType
+  }
+  guard let scalar = try? base64URLDecode(jwk.d), scalar.count == 32 else {
+    throw PasskeyCryptoError.malformedPrivateScalar
+  }
+  guard let key = try? P256.Signing.PrivateKey(rawRepresentation: scalar) else {
+    throw PasskeyCryptoError.malformedPrivateScalar
+  }
+  return key
+}
+
+// MARK: - authenticatorData
+
+private let kFlagUserPresent: UInt8 = 0x01
+private let kFlagUserVerified: UInt8 = 0x04
+
+/// Build assertion authenticatorData: SHA256(rpId)(32) ‖ flags(1) ‖ signCount(4, BE).
+/// No attested-credential-data / extensions. signCount is a parameter for
+/// testability; the production path always passes 0 (non-tracking authenticator).
+public func buildAssertionAuthenticatorData(
+  rpId: String,
+  userPresent: Bool,
+  userVerified: Bool,
+  signCount: UInt32
+) -> Data {
+  var out = Data()
+  let rpIdHash = SHA256.hash(data: Data(rpId.utf8))
+  out.append(contentsOf: rpIdHash)
+  var flags: UInt8 = 0
+  if userPresent { flags |= kFlagUserPresent }
+  if userVerified { flags |= kFlagUserVerified }
+  out.append(flags)
+  out.append(UInt8((signCount >> 24) & 0xff))
+  out.append(UInt8((signCount >> 16) & 0xff))
+  out.append(UInt8((signCount >> 8) & 0xff))
+  out.append(UInt8(signCount & 0xff))
+  return out
+}
+
+/// Sign authenticatorData ‖ clientDataHash with ECDSA-P256-SHA256 and return the
+/// DER (ASN.1) signature — `.derRepresentation`, which is what
+/// ASPasskeyAssertionCredential.signature expects (passed unchanged to the RP).
+public func signPasskeyAssertion(
+  privateKey: P256.Signing.PrivateKey,
+  authenticatorData: Data,
+  clientDataHash: Data
+) throws -> Data {
+  var signed = authenticatorData
+  signed.append(clientDataHash)
+  let signature = try privateKey.signature(for: signed)
+  return signature.derRepresentation
+}
+
+// MARK: - Assertion request / outputs
+
+/// Inputs the OS gives us for a passkey assertion. clientDataHash is provided by
+/// iOS (it owns origin/RP binding); we never construct clientDataJSON.
+public struct PasskeyAssertionRequest: Sendable {
+  public let relyingPartyId: String
+  public let clientDataHash: Data
+  public let userVerificationRequired: Bool
+
+  public init(relyingPartyId: String, clientDataHash: Data, userVerificationRequired: Bool) {
+    self.relyingPartyId = relyingPartyId
+    self.clientDataHash = clientDataHash
+    self.userVerificationRequired = userVerificationRequired
+  }
+}
+
+/// The fields needed to construct ASPasskeyAssertionCredential.
+public struct PasskeyAssertionOutputs: Sendable, Equatable {
+  public let userHandle: Data
+  public let relyingParty: String
+  public let signature: Data            // DER (.derRepresentation)
+  public let authenticatorData: Data
+  public let credentialID: Data
+
+  public init(
+    userHandle: Data,
+    relyingParty: String,
+    signature: Data,
+    authenticatorData: Data,
+    credentialID: Data
+  ) {
+    self.userHandle = userHandle
+    self.relyingParty = relyingParty
+    self.signature = signature
+    self.authenticatorData = authenticatorData
+    self.credentialID = credentialID
+  }
+}
+
+/// Build the assertion outputs. FIRST asserts material.relyingPartyId ==
+/// request.relyingPartyId (defense-in-depth), then uses the OS-provided rpId
+/// (authoritative) for authData. Emits signCount = 0; UP=true; UV=true (every
+/// fill is biometric-gated). userVerificationRequired is accepted but not used
+/// to downgrade (always UV=true).
+public func buildPasskeyAssertion(
+  material: PasskeyAssertionMaterial,
+  request: PasskeyAssertionRequest
+) throws -> PasskeyAssertionOutputs {
+  guard material.relyingPartyId == request.relyingPartyId else {
+    throw PasskeyCryptoError.rpIdMismatch
+  }
+  guard let credentialID = try? base64URLDecode(material.credentialId), !credentialID.isEmpty else {
+    throw PasskeyCryptoError.malformedCredentialId
+  }
+  let privateKey = try decodeP256PrivateKeyJWK(material.privateKeyJWK)
+  let authData = buildAssertionAuthenticatorData(
+    rpId: request.relyingPartyId,
+    userPresent: true,
+    userVerified: true,
+    signCount: 0
+  )
+  let signature = try signPasskeyAssertion(
+    privateKey: privateKey,
+    authenticatorData: authData,
+    clientDataHash: request.clientDataHash
+  )
+  // userHandle may be empty (stored that way); base64url-decode best-effort.
+  let userHandle = (try? base64URLDecode(material.userHandle)) ?? Data()
+  return PasskeyAssertionOutputs(
+    userHandle: userHandle,
+    relyingParty: request.relyingPartyId,
+    signature: signature,
+    authenticatorData: authData,
+    credentialID: credentialID
+  )
+}
+
+// MARK: - Candidate filtering
+
+/// Filter decrypted summaries to passkeys whose stored rpId EXACTLY equals the
+/// requested rpId (no eTLD+1 expansion — the OS already domain-filters before
+/// invoking the provider). Pure + Shared so the list-path logic is unit-testable.
+public func filterPasskeyCandidates(
+  _ summaries: [VaultEntrySummary],
+  rpId: String
+) -> [VaultEntrySummary] {
+  summaries.filter { $0.relyingPartyId == rpId }
+}

--- a/ios/Shared/Crypto/PasskeyAssertion.swift
+++ b/ios/Shared/Crypto/PasskeyAssertion.swift
@@ -9,6 +9,7 @@ public enum PasskeyCryptoError: Error, Equatable {
   case malformedPrivateScalar  // d absent or not exactly 32 bytes after base64url-decode
   case rpIdMismatch            // stored rpId != request rpId (defense-in-depth)
   case malformedCredentialId
+  case emptyUserHandle         // ASPasskeyAssertionCredential requires a non-empty userHandle
 }
 
 // MARK: - Assertion material (decrypted from the full blob)
@@ -64,9 +65,12 @@ public func decodeP256PrivateKeyJWK(_ jwkJSON: Data) throws -> P256.Signing.Priv
   guard jwk.kty == "EC", jwk.crv == "P-256" else {
     throw PasskeyCryptoError.unsupportedKeyType
   }
-  guard let scalar = try? base64URLDecode(jwk.d), scalar.count == 32 else {
+  guard var scalar = try? base64URLDecode(jwk.d), scalar.count == 32 else {
     throw PasskeyCryptoError.malformedPrivateScalar
   }
+  // Zero the raw private scalar once the key is constructed (the inner JSON
+  // String the decoder materialised cannot be zeroed; this covers the Data).
+  defer { scalar.resetBytes(in: 0..<scalar.count) }
   guard let key = try? P256.Signing.PrivateKey(rawRepresentation: scalar) else {
     throw PasskeyCryptoError.malformedPrivateScalar
   }
@@ -181,8 +185,13 @@ public func buildPasskeyAssertion(
     authenticatorData: authData,
     clientDataHash: request.clientDataHash
   )
-  // userHandle may be empty (stored that way); base64url-decode best-effort.
-  let userHandle = (try? base64URLDecode(material.userHandle)) ?? Data()
+  // ASPasskeyAssertionCredential requires a non-empty userHandle. Registration
+  // already skips empty-userHandle entries (C5), but guard here too so a
+  // residual/pre-migration identity fails cleanly instead of crashing the
+  // AuthenticationServices framework on an empty handle.
+  guard let userHandle = try? base64URLDecode(material.userHandle), !userHandle.isEmpty else {
+    throw PasskeyCryptoError.emptyUserHandle
+  }
   return PasskeyAssertionOutputs(
     userHandle: userHandle,
     relyingParty: request.relyingPartyId,

--- a/ios/Shared/Models/EntryBlobDecoder.swift
+++ b/ios/Shared/Models/EntryBlobDecoder.swift
@@ -31,6 +31,10 @@ public enum EntryBlobDecoder {
     // dropping travelSafe would lose the entry's travel-mode visibility.
     let requireReprompt: Bool?
     let travelSafe: Bool?
+    // PASSKEY overview fields (present only for entryType==PASSKEY). Their
+    // presence classifies an entry as a passkey on iOS (rpId != nil).
+    let relyingPartyId: String?
+    let credentialId: String?
   }
 
   private struct FullBlobPayload: Decodable {
@@ -44,6 +48,16 @@ public enum EntryBlobDecoder {
     let notes: String?
     let tags: [TagPayload]?
     let totp: TotpPayload?
+  }
+
+  /// Full-blob fields needed to build a passkey assertion. Decoded separately
+  /// so the LOGIN detail path stays untouched. `passkeyPrivateKeyJwk` is itself
+  /// a JSON string (double-encoded) holding the EC JWK.
+  private struct PasskeyFullBlobPayload: Decodable {
+    let relyingPartyId: String?
+    let credentialId: String?
+    let passkeyPrivateKeyJwk: String?
+    let passkeyUserHandle: String?
   }
 
   private struct TagPayload: Decodable {
@@ -83,7 +97,37 @@ public enum EntryBlobDecoder {
       hasTOTP: p.hasTOTP ?? false,
       requireReprompt: p.requireReprompt ?? false,
       // Keep travelSafe three-state (nil = absent): preserved verbatim on edit.
-      travelSafe: p.travelSafe
+      travelSafe: p.travelSafe,
+      relyingPartyId: p.relyingPartyId,
+      credentialId: p.credentialId
+    )
+  }
+
+  /// Decode a passkey's FULL blob into assertion material. Returns nil unless
+  /// relyingPartyId, credentialId AND passkeyPrivateKeyJwk are all present (i.e.
+  /// the blob is a usable passkey). The inner JWK may carry extra Web-Crypto
+  /// fields (`key_ops`/`ext`) — JSONDecoder ignores unknown keys.
+  public static func passkeyMaterial(
+    plaintext: Data,
+    entryId: String
+  ) -> PasskeyAssertionMaterial? {
+    guard let p = try? JSONDecoder().decode(PasskeyFullBlobPayload.self, from: plaintext) else {
+      return nil
+    }
+    guard
+      let rpId = p.relyingPartyId,
+      let credentialId = p.credentialId,
+      let jwk = p.passkeyPrivateKeyJwk,
+      let jwkData = jwk.data(using: .utf8)
+    else {
+      return nil
+    }
+    return PasskeyAssertionMaterial(
+      entryId: entryId,
+      relyingPartyId: rpId,
+      credentialId: credentialId,
+      userHandle: p.passkeyUserHandle ?? "",
+      privateKeyJWK: jwkData
     )
   }
 

--- a/ios/Shared/Models/VaultEntrySummary.swift
+++ b/ios/Shared/Models/VaultEntrySummary.swift
@@ -22,6 +22,12 @@ public struct VaultEntrySummary: Codable, Sendable, Equatable, Identifiable {
   /// travel-unsafe entry back to travel-safe on the next web load.
   public let requireReprompt: Bool
   public let travelSafe: Bool?
+  /// Passkey overview fields (PASSKEY entries only; nil otherwise). A summary is
+  /// a passkey iff `relyingPartyId != nil`. credentialId/relyingPartyId come from
+  /// the overview blob; the user handle lives only in the full blob (see
+  /// buildPasskeyIdentitySpecs).
+  public let relyingPartyId: String?
+  public let credentialId: String?
 
   public init(
     id: String,
@@ -34,7 +40,9 @@ public struct VaultEntrySummary: Codable, Sendable, Equatable, Identifiable {
     lastAccessedAt: Date? = nil,
     hasTOTP: Bool = false,
     requireReprompt: Bool = false,
-    travelSafe: Bool? = nil
+    travelSafe: Bool? = nil,
+    relyingPartyId: String? = nil,
+    credentialId: String? = nil
   ) {
     self.id = id
     self.title = title
@@ -47,5 +55,7 @@ public struct VaultEntrySummary: Codable, Sendable, Equatable, Identifiable {
     self.hasTOTP = hasTOTP
     self.requireReprompt = requireReprompt
     self.travelSafe = travelSafe
+    self.relyingPartyId = relyingPartyId
+    self.credentialId = credentialId
   }
 }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -152,6 +152,9 @@ targets:
             ASCredentialProviderExtensionCapabilities:
               ProvidesPasswords: true
               ProvidesOneTimeCodes: true
+              # Passkey assertion (sign-in). Registration is explicitly cancelled
+              # in CredentialProviderViewController (read-only/offline extension).
+              ProvidesPasskeys: true
     entitlements:
       path: PasswdSSOAutofillExtension/PasswdSSOAutofillExtension.entitlements
       properties:


### PR DESCRIPTION
## Summary

iOS acts as a WebAuthn **authenticator** for sign-in: passkeys created via the browser extension (synced E2E) appear in the system passkey sheet and produce a P-256 ECDSA assertion **locally, biometric-gated, offline**. Assertion-only — credential creation/registration is deferred to a follow-up.

Roadmap item #3 (iOS ↔ extension passkey parity).

## What's included

- **PasskeyAssertion** (`Shared/Crypto`): JWK→P256 decode, authData builder, DER signing, `buildPasskeyAssertion` (rpId-mismatch guard, OS rpId authoritative, signCount 0)
- **EntryBlobDecoder**: passkey overview (rpId/credentialId) + full-blob material decode
- **CacheEntry.entryType** (optional, backward compatible) via single-source `EncryptedEntry.toPersonalCacheEntry()` — used by `HostSyncService` and both QuickType registration call sites
- **ASPasskeyCredentialIdentity QuickType registration** (one atomic `replace(with:passkeys:)`); `buildPasskeyIdentitySpecs` decrypts the full blob host-side for `userHandle`
- **CredentialProviderViewController** passkey assertion path (iOS 17+ `prepareCredentialList(for:requestParameters:)`) + `CredentialResolver.decryptPasskeyMaterial` (single biometric read)
- `signCount` always 0 (non-tracking authenticator; documented strict-RP limitation)
- Registration explicitly cancelled (extension is read-only/offline; an unsaveable credential would lock the user out)

## Testing

- **All passkey unit tests pass** (`PasskeyAssertionTests` 220 lines, `CredentialResolverTests`, `EntryBlobDecoderTests`, `CredentialIdentityRegistrarTests`, `HostSyncServiceTests` — full `PasswdSSOTests` suite green).
- Rebased cleanly onto `main` (#547); the `HostSyncService` overlap with #547's token-refresh change merged without conflict (separate regions).
- **Pre-existing UITest note**: `PasswdSSOUITests.testPrimaryButtonIsHittable` fails under headless `xcodebuild test` — verified to fail **identically on `origin/main`** (clean simulator, this PR's diff does not touch `PasswdSSOUITests.swift` or the launch-screen views). Not a regression; tracked separately. See `docs/archive/review/ios-passkey-provider-deviation.md` D2.

## Review

Plan + 2 rounds of code review completed before this PR (see `docs/archive/review/ios-passkey-provider-*.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
