### PR TITLE
fix(extension): route expired-session reauth to full sign-in; add verifying label + cancel

### DIFF
--- a/docs/archive/review/extension-reauth-401-routing-code-review.md
+++ b/docs/archive/review/extension-reauth-401-routing-code-review.md
@@ -1,0 +1,60 @@
+# Code Review: extension-reauth-401-routing
+
+Date: 2026-06-12
+Review rounds: 1 (no code changes required from review — findings accepted)
+Branch: fix/extension-reauth-401-routing
+
+## Summary
+
+Two fixes to the extension-connect passkey reauth flow in
+`auto-extension-connect.tsx`:
+1. When the web session fully expires, the reauth options endpoint returns 401
+   ("UNAUTHORIZED") and the old code looped on the passkey prompt forever (it can
+   never succeed without a session). New code routes the UNAUTHORIZED result to a
+   full sign-in via a `redirectToFullSignIn` helper (extracted from the existing
+   recent-session path).
+2. UX: relabel the in-flight button "Verifying with passkey..." (was the generic
+   "Connecting..."), and add a Cancel control that aborts the ceremony via
+   `abortInFlightCeremony()`.
+
+## Round 1 findings & disposition
+
+Functionality: No blocking findings (redirectToFullSignIn extraction verified
+behavior-equivalent; UNAUTHORIZED branch ordering correct; label/cancel gating
+correct — recent-session path keeps "Connecting" + Go-to-dashboard).
+
+Security: **No findings.** Open-redirect safe — `callbackUrl` is built from
+same-origin `window.location` and validated on the sign-in side by
+`resolveCallbackUrl` (rejects protocol-relative / cross-origin / dangerous
+schemes, fails closed to /dashboard). The 401→signOut path is fail-closed (never
+connects the extension). Cancel→abort yields AUTHENTICATION_CANCELLED (a failure,
+never a pass) — cannot bypass step-up. R37: `connectReauthVerifying` /
+`connectReauthCancel` use user-domain language.
+
+### F1 [Minor] Cancel is a no-op during the options-fetch window — ACCEPTED
+- **Anti-Deferral check**: acceptable risk (quantified).
+- `abortInFlightCeremony()` only acts after `startPasskeyAuthentication`'s
+  `navigator.credentials.get()` registers the in-flight controller, i.e. after
+  the brief `fetchApi(reauth/options)` POST. A Cancel click during that sub-second
+  window does nothing.
+- **Worst case**: the user clicks Cancel during the options POST and the button
+  stays "Verifying..." until the native passkey dialog appears (which the user can
+  then dismiss). **Likelihood**: low — the options POST is sub-second; the actual
+  long wait the Cancel targets is the `get()` ceremony (up to 60-120s), which IS
+  cancelable. **Cost to fix**: medium — making `reauthenticateWithPasskey`
+  abortable end-to-end means threading an AbortSignal through the shared
+  passkey-reauth-client (also used by inline-reauth / operator-token), a broader
+  change. Deferred as a follow-up; the native dialog + 120s backstop remain escape
+  hatches.
+
+### T3 [Minor] Cancel test doesn't assert post-abort recovery — ACCEPTED
+- **Anti-Deferral check**: covered elsewhere.
+- The new test asserts the click→`abortInFlightCeremony` wiring (load-bearing).
+  The post-abort path (ceremony → AUTHENTICATION_CANCELLED → connectReauthCancelled
+  prompt) is already covered by the existing "shows cancellation feedback when
+  reauth is cancelled" test. No new test needed.
+
+## Verification
+- `npx vitest run src/components/extension/auto-extension-connect.test.tsx` — 28 passed
+- `npx vitest run` (full) — exit 0
+- `npx next build` — ✓ Compiled successfully

--- a/messages/en/Extension.json
+++ b/messages/en/Extension.json
@@ -15,6 +15,8 @@
   "connectReauthTitle": "Browser reauthentication required",
   "connectReauthDescription": "Your web session is still signed in, but it is not fresh enough to connect the extension. Reauthenticate in the browser, then try again.",
   "connectReauthAction": "Reauthenticate with passkey",
+  "connectReauthVerifying": "Verifying with passkey...",
+  "connectReauthCancel": "Cancel",
   "connectReauthCancelled": "Reauthentication was cancelled. Please try again.",
   "connectReauthFailed": "Reauthentication failed. Please try again.",
   "connectReauthStillRequired": "The extension still requires reauthentication after retrying. Please try again.",

--- a/messages/ja/Extension.json
+++ b/messages/ja/Extension.json
@@ -15,6 +15,8 @@
   "connectReauthTitle": "ブラウザでの再認証が必要です",
   "connectReauthDescription": "Web セッションは有効ですが、拡張機能を接続するには再認証が必要です。ブラウザで本人確認を行ってから、もう一度お試しください。",
   "connectReauthAction": "Passkey で再認証",
+  "connectReauthVerifying": "Passkey で確認中...",
+  "connectReauthCancel": "キャンセル",
   "connectReauthCancelled": "再認証がキャンセルされました。もう一度お試しください。",
   "connectReauthFailed": "再認証に失敗しました。もう一度お試しください。",
   "connectReauthStillRequired": "再認証後も接続を継続できませんでした。もう一度お試しください。",

--- a/src/components/extension/auto-extension-connect.test.tsx
+++ b/src/components/extension/auto-extension-connect.test.tsx
@@ -20,11 +20,13 @@ const {
   mockReauthenticateWithPasskey,
   mockSignOut,
   mockCanUsePasskeyRecovery,
+  mockAbortInFlightCeremony,
 } = vi.hoisted(() => ({
   mockRequestExtensionConnect: vi.fn() as ReturnType<typeof vi.fn>,
   mockReauthenticateWithPasskey: vi.fn(),
   mockSignOut: vi.fn(),
   mockCanUsePasskeyRecovery: vi.fn(),
+  mockAbortInFlightCeremony: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
@@ -47,6 +49,9 @@ vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
 }));
 vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
   canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+vi.mock("@/lib/auth/webauthn/webauthn-client", () => ({
+  abortInFlightCeremony: mockAbortInFlightCeremony,
 }));
 vi.mock("@/lib/url-helpers", async (importOriginal) => ({
   ...((await importOriginal()) as Record<string, unknown>),
@@ -286,6 +291,54 @@ describe("AutoExtensionConnect", () => {
     await waitFor(() => {
       expect(screen.getByText("connectReauthCancelled")).toBeInTheDocument();
     });
+  });
+
+  it("routes an expired session (reauth 401) to a full sign-in instead of looping on the passkey prompt", async () => {
+    setSearchParams("?ext_connect=1");
+    mockRequestExtensionConnect.mockResolvedValue({
+      ok: false,
+      errorCode: "SESSION_STEP_UP_REQUIRED",
+    });
+    mockCanUsePasskeyRecovery.mockResolvedValue(true);
+    // The web session expired between connect and reauth: reauth options 401'd.
+    mockReauthenticateWithPasskey.mockResolvedValue({
+      ok: false,
+      error: "UNAUTHORIZED",
+    });
+    await renderAndClickAllow();
+    await waitFor(() => {
+      expect(screen.getByText("connectReauthTitle")).toBeInTheDocument();
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByText("connectReauthAction"));
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledTimes(1);
+    });
+    // Must NOT fall into the generic retry-the-passkey loop.
+    expect(screen.queryByText("connectReauthFailed")).not.toBeInTheDocument();
+  });
+
+  it("shows a passkey-verifying label and a cancel control that aborts the in-flight ceremony", async () => {
+    setSearchParams("?ext_connect=1");
+    mockRequestExtensionConnect.mockResolvedValue({
+      ok: false,
+      errorCode: "SESSION_STEP_UP_REQUIRED",
+    });
+    mockCanUsePasskeyRecovery.mockResolvedValue(true);
+    // Keep the ceremony pending so the verifying/cancel UI stays visible.
+    mockReauthenticateWithPasskey.mockReturnValue(new Promise(() => {}));
+    await renderAndClickAllow();
+    await waitFor(() => {
+      expect(screen.getByText("connectReauthTitle")).toBeInTheDocument();
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByText("connectReauthAction"));
+    // Label reflects passkey verification, not a generic "connecting".
+    await waitFor(() => {
+      expect(screen.getByText("connectReauthVerifying")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("connectReauthCancel"));
+    expect(mockAbortInFlightCeremony).toHaveBeenCalledTimes(1);
   });
 
   it("redirects to sign-in when stale session for a non-passkey user", async () => {

--- a/src/components/extension/auto-extension-connect.tsx
+++ b/src/components/extension/auto-extension-connect.tsx
@@ -18,6 +18,7 @@ import { CheckCircle2, XCircle, Loader2, KeyRound } from "lucide-react";
 import { withBasePath } from "@/lib/url-helpers";
 import { reauthenticateWithPasskey } from "@/lib/auth/webauthn/passkey-reauth-client";
 import { canUsePasskeyRecovery } from "@/lib/auth/webauthn/can-use-passkey-recovery";
+import { abortInFlightCeremony } from "@/lib/auth/webauthn/webauthn-client";
 import { signOut } from "next-auth/react";
 
 /**
@@ -115,17 +116,32 @@ export function AutoExtensionConnect() {
     await connect();
   }, [connect]);
 
+  // Sign out and bounce to the full sign-in page, preserving ext_connect so the
+  // extension connection resumes after a fresh sign-in. Used both when the user
+  // has no passkey (recent-session path) and when the web session has fully
+  // expired (reauth options returns 401) — passkey reauth can never succeed
+  // without a session, so looping on the prompt would strand the user.
+  const redirectToFullSignIn = useCallback(async () => {
+    const currentUrl = new URL(window.location.href);
+    currentUrl.searchParams.set(EXT_CONNECT_PARAM, "1");
+    const callbackUrl = `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`;
+    const signInPath = `${withBasePath(`/${locale}/auth/signin`)}?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+    await signOut({ callbackUrl: signInPath });
+  }, [locale]);
+
+  // Abort the in-flight passkey ceremony so the user can escape a stuck
+  // "verifying" state. reauthenticateWithPasskey then resolves to
+  // AUTHENTICATION_CANCELLED, which handleRetry surfaces as a retry prompt.
+  const handleCancelReauth = () => {
+    abortInFlightCeremony();
+  };
+
   const handleRetry = async () => {
     if (!requiresReauth) {
       if (requiresRecentSession) {
         setReauthenticating(true);
         try {
-          const currentUrl = new URL(window.location.href);
-          currentUrl.searchParams.set(EXT_CONNECT_PARAM, "1");
-          const callbackUrl =
-            `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`;
-          const signInPath = `${withBasePath(`/${locale}/auth/signin`)}?callbackUrl=${encodeURIComponent(callbackUrl)}`;
-          await signOut({ callbackUrl: signInPath });
+          await redirectToFullSignIn();
         } finally {
           setReauthenticating(false);
         }
@@ -140,6 +156,13 @@ export function AutoExtensionConnect() {
     try {
       const result = await reauthenticateWithPasskey();
       if (!result.ok) {
+        // Session fully expired (not merely stale): reauth options 401'd, so a
+        // passkey ceremony can never complete. Route to a full sign-in instead
+        // of leaving the user clicking the passkey button forever.
+        if (result.error === "UNAUTHORIZED") {
+          await redirectToFullSignIn();
+          return;
+        }
         setReauthError(
           result.error === "AUTHENTICATION_CANCELLED"
             ? t("connectReauthCancelled")
@@ -292,7 +315,7 @@ export function AutoExtensionConnect() {
                   {reauthenticating ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      {t("connecting")}
+                      {requiresReauth ? t("connectReauthVerifying") : t("connecting")}
                     </>
                   ) : requiresReauth ? (
                     t("connectReauthAction")
@@ -303,13 +326,23 @@ export function AutoExtensionConnect() {
                   )}
                 </Button>
               )}
-              <Button
-                variant="ghost"
-                onClick={() => setStatus(CONNECT_STATUS.IDLE)}
-                className="w-full"
-              >
-                {t("goToDashboard")}
-              </Button>
+              {reauthenticating && requiresReauth ? (
+                <Button
+                  variant="ghost"
+                  onClick={handleCancelReauth}
+                  className="w-full"
+                >
+                  {t("connectReauthCancel")}
+                </Button>
+              ) : (
+                <Button
+                  variant="ghost"
+                  onClick={() => setStatus(CONNECT_STATUS.IDLE)}
+                  className="w-full"
+                >
+                  {t("goToDashboard")}
+                </Button>
+              )}
             </div>
           )}
         </CardContent>


### PR DESCRIPTION
## Summary
Two fixes to the extension-connect passkey reauth flow.

## Problem 1 — infinite passkey loop on an expired session
When the web session expired between the connect attempt and the passkey reauth, the reauth options endpoint returned 401 (`UNAUTHORIZED`) and the UI looped on the passkey prompt forever — passkey reauth can never succeed without a session.

## Problem 2 — confusing in-flight UX
The in-flight button showed the generic "Connecting..." during the passkey ceremony, and there was no way to cancel a long wait.

## Changes
- Route the `UNAUTHORIZED` reauth result to a full sign-in (signOut + redirect to `/auth/signin`, preserving `ext_connect` in `callbackUrl`) via a new `redirectToFullSignIn` helper extracted from the existing recent-session path.
- Relabel the in-flight button "Verifying with passkey..." (`connectReauthVerifying`) instead of "Connecting...".
- Add a Cancel control (shown during a passkey reauth) that aborts the ceremony via `abortInFlightCeremony`.
- i18n: `connectReauthVerifying` / `connectReauthCancel` (en/ja).

## Tests
- New tests: `UNAUTHORIZED` routes to a full sign-in (not the failure loop); the verifying label appears and Cancel aborts the ceremony.
- Verified: full `vitest` exit 0, `next build` compiles.

## Review
Reviewed via triangulate (functionality / security / testing). Functionality and security clean — open-redirect safe (callbackUrl built from same-origin `window.location` and validated by `resolveCallbackUrl`; fail-closed), and Cancel can only deny, never grant. Two Minor findings accepted with documented justification. See `docs/archive/review/extension-reauth-401-routing-code-review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)