### PR TITLE
fix(extension): bound the service-worker hydration wait so GET_STATUS can't hang

### DIFF
--- a/docs/archive/review/extension-sw-hydration-timeout-code-review.md
+++ b/docs/archive/review/extension-sw-hydration-timeout-code-review.md
@@ -1,0 +1,66 @@
+# Code Review: extension-sw-hydration-timeout
+
+Date: 2026-06-12
+Review rounds: 2 (Round 2 clean — only non-blocking LOW observations)
+Branch: fix/extension-sw-hydration-timeout
+
+## Summary
+
+The MV3 service worker's `handleMessage` did `await hydrationPromise` (unbounded).
+If `hydrateFromSession()` wedges (IndexedDB/crypto), GET_STATUS hangs forever and
+the popup spins. The fix bounds the message-handler wait (`awaitHydrationBounded`,
+5s); the alarm path stays unbounded (a delayed token refresh is harmless, and
+proceeding early there could clear a token mid-hydration).
+
+## Changed files
+- `extension/src/background/index.ts`
+- `extension/src/__tests__/background.test.ts`
+
+## Round 1 findings & resolution
+
+Functionality: No blocking findings. Security PR-A side: No findings.
+
+### S1 [Major] Late-completing hydration resurrects state a message just mutated — RESOLVED
+- Bounding the message wait let a message (LOCK_VAULT, CLEAR_TOKEN) run before
+  hydration finished; the late-completing `hydrateFromSession()` then
+  unconditionally overwrote the mutation — e.g. re-deriving `encryptionKey` after
+  an explicit LOCK_VAULT (vault silently unlocked again), or restoring a token
+  after CLEAR_TOKEN. Fail-open relative to the user's security action.
+- Fix: a module-level `hydrationSuperseded` flag set by the authoritative mutators
+  (`applyToken`, `clearVault` — reached by clearToken and all lock/logout paths,
+  and the UNLOCK_VAULT success path). `hydrateFromSession()` checks it at every
+  resume-after-await point (after loadSession, getDpopThumbprint,
+  deriveEncryptionKey, unwrapEcdhPrivateKey) and bails rather than overwrite.
+  The flag is read only inside the single startup hydration, so the never-reset
+  design cannot block a later operation.
+- Regression test: LOCK_VAULT during a slow (parked-at-deriveEncryptionKey)
+  hydration → GET_STATUS reports vaultUnlocked:false. **Verified load-bearing**
+  (the test fails — vault key resurrected — when the encryptionKey guard is
+  disabled).
+
+### F2 [Minor] Bounded-wait safety rested on an undocumented invariant — RESOLVED
+- Addressed by the S1 fix plus the `hydrationSuperseded` doc comment that makes
+  the bounded/unbounded asymmetry and the "no-resurrect" invariant explicit.
+
+### T2 [Minor] Hydration-hang test used a loose matcher — RESOLVED
+- Added `expiresAt: null` to the GET_STATUS assertion to pin the not-hydrated
+  contract.
+
+## Round 2 (incremental verification of the S1 fix) — clean
+
+Security/functionality/testing review of the guard: all interleavings of an
+authoritative mutator vs the slow hydration confirmed to leave the mutator's
+state intact (no resurrection); no remaining un-guarded await-resume write; flag
+read only in the one-shot hydration; happy path unchanged; the regression test is
+correct, non-flaky, load-bearing, with clean teardown. Full suite 79/0.
+
+Non-blocking LOW observations (not fixed — out of scope / optional):
+- **F-b**: UNLOCK arriving during a >5s-slow hydration leaves the token without a
+  TTL/refresh alarm until the next SW restart (self-healing; lazy `Date.now() >=
+  tokenExpiresAt` expiry still applies). Not introduced by S1; follow-up candidate.
+- **T-c**: No dedicated CLEAR_TOKEN-resurrection test; the structurally identical
+  guard path is covered by the LOCK_VAULT test.
+
+## Verification
+- `npx vitest run` (extension) — 750 passed
+- `npm run build` (extension) — success

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -271,6 +271,31 @@ describe("background message flow", () => {
     );
   });
 
+  it("GET_STATUS responds even when session hydration hangs (bounded wait — popup never strands)", async () => {
+    // Reload the SW with a hydrate that never settles (e.g. a wedged IndexedDB
+    // read). Without the bounded wait, handleMessage would await forever and
+    // GET_STATUS never returns — the popup spins on its loading state.
+    vi.resetModules();
+    chromeMock = installChromeMock();
+    sessionStorageMocks.loadSession.mockReturnValue(new Promise(() => {}));
+    vi.useFakeTimers();
+    try {
+      await loadBackground();
+
+      const respPromise = sendMessage({ type: "GET_STATUS" });
+      // Drive past HYDRATION_TIMEOUT_MS so the bounded wait releases.
+      await vi.advanceTimersByTimeAsync(5_000);
+      const status = await respPromise;
+
+      expect(status).toEqual(
+        expect.objectContaining({ type: "GET_STATUS", hasToken: false, vaultUnlocked: false }),
+      );
+    } finally {
+      vi.useRealTimers();
+      sessionStorageMocks.loadSession.mockResolvedValue(null);
+    }
+  });
+
   it("sends stop-keepalive on LOCK_VAULT", async () => {
     applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -288,11 +288,63 @@ describe("background message flow", () => {
       const status = await respPromise;
 
       expect(status).toEqual(
-        expect.objectContaining({ type: "GET_STATUS", hasToken: false, vaultUnlocked: false }),
+        expect.objectContaining({
+          type: "GET_STATUS",
+          hasToken: false,
+          vaultUnlocked: false,
+          expiresAt: null,
+        }),
       );
     } finally {
       vi.useRealTimers();
       sessionStorageMocks.loadSession.mockResolvedValue(null);
+    }
+  });
+
+  it("does not resurrect the vault key when LOCK_VAULT runs during a slow hydration (S1 race)", async () => {
+    // Startup hydration restores a vault that WOULD derive encryptionKey, but
+    // it is slow (parked at deriveEncryptionKey). The bounded message wait lets
+    // LOCK_VAULT proceed and clear the vault; the late-completing hydration must
+    // NOT re-derive the key the user just locked.
+    vi.resetModules();
+    chromeMock = installChromeMock();
+    sessionStorageMocks.loadSession.mockResolvedValue({
+      token: "hydrated-tok",
+      expiresAt: 9_999_999_999_999,
+      userId: "user-1",
+      vaultSecretKey: "00",
+      tokenCnfJkt: STATIC_TEST_JKT,
+      tenantAutoLockMinutes: null,
+      personalKeyVersion: 1,
+    } as unknown as SessionState);
+    let releaseDerive!: (k: unknown) => void;
+    cryptoMocks.deriveEncryptionKey.mockReturnValue(
+      new Promise((r) => {
+        releaseDerive = r;
+      }),
+    );
+    vi.useFakeTimers();
+    try {
+      await loadBackground();
+      await vi.advanceTimersByTimeAsync(0); // park hydration at deriveEncryptionKey
+
+      // LOCK_VAULT proceeds after the 5s bounded wait, clearing the vault.
+      const lockResp = sendMessage({ type: "LOCK_VAULT" });
+      await vi.advanceTimersByTimeAsync(5_000);
+      await lockResp;
+
+      // Hydration's deriveEncryptionKey now resolves — the guard must bail.
+      releaseDerive("enc-key");
+      await vi.advanceTimersByTimeAsync(0);
+
+      const status = await sendMessage({ type: "GET_STATUS" });
+      expect(status).toEqual(
+        expect.objectContaining({ type: "GET_STATUS", vaultUnlocked: false }),
+      );
+    } finally {
+      vi.useRealTimers();
+      sessionStorageMocks.loadSession.mockResolvedValue(null);
+      cryptoMocks.deriveEncryptionKey.mockResolvedValue("enc-key");
     }
   });
 

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -100,6 +100,16 @@ let tenantAutoLockMinutes: number | null = null;
 // persisted through SW restart via session-storage.
 let personalKeyVersion: number | null = null;
 
+// Set true once any mutator (applyToken / clearToken→clearVault / clearVault /
+// vault unlock) establishes authoritative token/vault state. A slow
+// hydrateFromSession() that is still in flight when a message proceeds past
+// awaitHydrationBounded() must NOT clobber (resurrect) what the user/flow just
+// changed — e.g. re-deriving encryptionKey after an explicit LOCK_VAULT, or
+// restoring a token after CLEAR_TOKEN. hydrateFromSession() checks this at each
+// resume-after-await point and bails. Only meaningful during the single
+// startup hydration; never reset (hydration runs once per SW lifetime).
+let hydrationSuperseded = false;
+
 // ── Team key state ──────────────────────────────────────────────
 let ecdhPrivateKeyBytes: Uint8Array | null = null;
 /** Encrypted ECDH data for session persistence (re-unwrap on SW restart) */
@@ -285,6 +295,7 @@ export function applyToken(
   expiresAt: number,
   cnfJkt: string,
 ): void {
+  hydrationSuperseded = true;
   const tokenChanged = currentToken !== null && currentToken !== token;
   if (tokenChanged) {
     // A new token may represent a different auth session/user.
@@ -310,6 +321,7 @@ export function applyToken(
 }
 
 function clearVault(): void {
+  hydrationSuperseded = true;
   encryptionKey = null;
   currentUserId = null;
   currentVaultSecretKeyHex = null;
@@ -431,6 +443,11 @@ async function hydrateFromSession(): Promise<void> {
     return;
   }
 
+  // A mutator may have run during the bounded message wait (awaitHydrationBounded)
+  // while this slow hydration was still awaiting storage. It owns the authoritative
+  // state now — bail rather than overwrite it. Re-checked after each later await.
+  if (hydrationSuperseded) return;
+
   currentToken = state.token;
   tokenExpiresAt = state.expiresAt;
   currentUserId = state.userId ?? null;
@@ -445,6 +462,7 @@ async function hydrateFromSession(): Promise<void> {
   // Mismatch → the key was reset mid-session; clear state so the user reconnects.
   try {
     const idbJkt = await getDpopThumbprint();
+    if (hydrationSuperseded) return;
     if (state.tokenCnfJkt !== idbJkt) {
       await clearSession();
       return;
@@ -459,8 +477,12 @@ async function hydrateFromSession(): Promise<void> {
   if (currentVaultSecretKeyHex) {
     try {
       const secretKey = hexDecode(currentVaultSecretKeyHex);
-      encryptionKey = await deriveEncryptionKey(secretKey);
+      const derived = await deriveEncryptionKey(secretKey);
       secretKey.fill(0);
+      // An explicit LOCK_VAULT / CLEAR_TOKEN ran while we derived — do NOT
+      // resurrect the vault key the user just cleared.
+      if (hydrationSuperseded) return;
+      encryptionKey = derived;
     } catch {
       encryptionKey = null;
       currentVaultSecretKeyHex = null;
@@ -473,10 +495,12 @@ async function hydrateFromSession(): Promise<void> {
         const secretKeyForEcdh = hexDecode(currentVaultSecretKeyHex!);
         const ecdhWrappingKey = await deriveEcdhWrappingKey(secretKeyForEcdh);
         secretKeyForEcdh.fill(0);
-        ecdhPrivateKeyBytes = await unwrapEcdhPrivateKey(
+        const unwrapped = await unwrapEcdhPrivateKey(
           state.ecdhEncrypted,
           ecdhWrappingKey,
         );
+        if (hydrationSuperseded) return;
+        ecdhPrivateKeyBytes = unwrapped;
         ecdhEncryptedData = state.ecdhEncrypted;
       } catch {
         ecdhPrivateKeyBytes = null;
@@ -1942,6 +1966,9 @@ async function handleMessage(
           }
         }
 
+        // Authoritative unlock state — a slow startup hydration must not
+        // overwrite it (or relock by racing in its own null write).
+        hydrationSuperseded = true;
         encryptionKey = encKey;
         currentUserId = data.userId || null;
         personalKeyVersion = typeof data.keyVersion === "number" ? data.keyVersion : 1;

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -584,6 +584,24 @@ void configureSessionStorageAccess();
 // Hydrate on SW startup
 const hydrationPromise = hydrateFromSession().catch(() => {});
 
+// Upper bound a message handler's wait for hydration. hydrateFromSession()
+// reads IndexedDB + runs crypto; if any of that wedges, an unbounded
+// `await hydrationPromise` in handleMessage blocks GET_STATUS forever and the
+// popup spins on its loading state with no Lock/Sign-out buttons. Cap the wait
+// so handlers proceed (in a not-yet-hydrated state) rather than hang — the
+// popup retries and a later message re-checks once hydration settles. The
+// alarm path keeps the unbounded await (a delayed token refresh is harmless,
+// and proceeding early there could wrongly clear a token mid-hydration).
+const HYDRATION_TIMEOUT_MS = 5_000; // 5 seconds
+
+function awaitHydrationBounded(): Promise<void> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, HYDRATION_TIMEOUT_MS);
+  });
+  return Promise.race([hydrationPromise, timeout]).finally(() => clearTimeout(timer));
+}
+
 // Initialize setting caches on SW startup
 getSettings().then((s) => {
   const v = validateSettings(s);
@@ -1786,8 +1804,9 @@ async function handleMessage(
 ): Promise<void> {
   // Wait for session hydration to complete before processing any message.
   // This prevents race conditions where the SW restarts and messages arrive
-  // before in-memory state (token, encryptionKey) is restored.
-  await hydrationPromise;
+  // before in-memory state (token, encryptionKey) is restored. Bounded so a
+  // wedged hydrate can't hang GET_STATUS and strand the popup spinner.
+  await awaitHydrationBounded();
 
   switch (message.type) {
     case EXT_MSG.START_CONNECT: {


### PR DESCRIPTION
## Summary
The MV3 service worker's `handleMessage` did `await hydrationPromise` (unbounded). If `hydrateFromSession()` wedges (IndexedDB / crypto), `GET_STATUS` hangs forever and the popup spins on its loading state with no Lock/Sign-out buttons.

## Changes
- `awaitHydrationBounded()` caps the message-handler wait at 5s; `handleMessage` awaits that instead of the raw `hydrationPromise`. After the cap, handlers proceed in a not-yet-hydrated (fail-closed: locked/disconnected) state rather than hang; the popup retries and a later message re-checks once hydration settles.
- The alarm path keeps the unbounded await on purpose — a delayed token refresh is harmless, and proceeding early there could clear a token mid-hydration.

## S1 — race closed (found in review)
Bounding the message wait let a message run before hydration finished, so a slow-but-completing `hydrateFromSession()` could OVERWRITE state a mutation just set — re-deriving `encryptionKey` after an explicit LOCK_VAULT (vault silently unlocked again), or restoring a token after CLEAR_TOKEN. Fixed with a `hydrationSuperseded` flag set by the authoritative mutators (`applyToken` / `clearVault` / unlock); `hydrateFromSession()` bails at each resume-after-await point rather than clobber the user's action. The flag is read only inside the single startup hydration, so the never-reset design is safe.

## Tests
- `GET_STATUS` responds (does not hang) when hydration never settles, via bounded-wait timeout.
- LOCK_VAULT during a slow hydration does NOT resurrect the vault key (`vaultUnlocked:false`) — **verified load-bearing** (fails when the guard is disabled).
- Verified: extension `vitest` 750 passed, extension `build` ✓.

## Review
Reviewed via triangulate, 2 rounds. Round 1 surfaced S1 (Major); Round 2 confirmed the fix is complete and correct (all interleavings leave the mutator's state intact; no remaining un-guarded await-resume write). Two non-blocking LOW observations recorded as follow-ups. See `docs/archive/review/extension-sw-hydration-timeout-code-review.md`.

## Follow-up (out of scope)
UNLOCK arriving during a >5s-slow hydration leaves the token without a TTL/refresh alarm until the next SW restart (self-healing; lazy expiry still applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)