### PR TITLE
feat(extension): search all vault entries from the popup search box

### DIFF
--- a/docs/archive/review/extension-search-all-vault-code-review.md
+++ b/docs/archive/review/extension-search-all-vault-code-review.md
@@ -1,0 +1,92 @@
+# Code Review: extension-search-all-vault
+
+Date: 2026-06-13
+Review round: 2 — COMPLETE (all experts: No findings)
+
+## Round 2 (fix verification — final)
+
+Changes from previous round: review(1) commit — JSX reorder (header above no-results message) + three tightening assertions (A8 DOM order via compareDocumentPosition, A1 header on results-bearing path, A9b "Other entries" suppression).
+
+- Functionality: render order verified header → message → list; non-search branches untouched; no regression. No findings.
+- Security: pure sibling reorder inside the `isSearching` branch; guards intact; button structure/canFill/handleFill untouched; no new egress. No findings.
+- Testing: compareDocumentPosition direction verified correct AND non-vacuous (reverting the order yields PRECEDING=2 → bitmask 0 → fail); jsdom provides Node.DOCUMENT_POSITION_FOLLOWING; A1 addition exercises the results-bearing path; A9b suppression assertion non-vacuous (fixture's CREDIT_CARD would populate "Other entries" in idle mode). No findings.
+
+All Recurring Issue Check statuses carried forward clean. Verification after fixes: extension 759/759, extension build OK.
+
+---
+
+# Round 1
+
+## Changes from Previous Round
+
+Initial review (incremental on top of the Phase 2 self-R-check baseline, which was clean).
+
+## Functionality Findings
+
+- **F1 [Minor]**: no-results message rendered ABOVE the "Search results" header (MatchList.tsx:278-286), violating I7's "message appears beneath the header". A8 asserted presence only, not order, so tests stayed green.
+- Deviation evaluations: **D1 verified correct and complete** (PASSKEY excluded from both matched and unmatched; no non-search path renders a passkey). **D2 verified behavior-equivalent** across all entryType × canFill combinations (case-by-case proof in expert output).
+- Implementation Checklist ↔ diff cross-check: all 4 files present. Cross-cutting: no other popup component renders entries/Fill; background and content scripts untouched; badge and header styles consistent with existing patterns; I10 shadow rename confirmed.
+
+## Security Findings
+
+- **No findings.** Verified: (a) `handleFill` has exactly one call site, gated by `canFill(e)`; no keyboard/aria path bypasses it; (b) no new data egress (no new console/fetch/sendMessage in diff); (c) background/content scripts not in diff. I8 equivalence proof re-verified for non-search mode; search-mode gates (cross-domain LOGIN, null tabHost, PASSKEY) each covered by a test.
+
+## Testing Findings
+
+- **T1 [Minor]**: "Search results" header not asserted on the non-empty-results path (A8 covered only the zero-results sub-case) — a regression restricting the header to empty results would pass all tests.
+- **T2 [Minor]**: "Other entries" header suppression during search had no assertion (A9b had the right fixture but didn't check it).
+- **T3 [Minor, awareness]**: pre-existing `"SECURE_NOTE"` string literals (test lines 205/369).
+- Acceptance mapping A1-A9b: all mapped to real assertions (table in expert output). Mock hygiene clean (resets in beforeEach, no vacuous assertions, all findBy* awaited, fixtures match DecryptedEntry).
+
+## Adjacent Findings
+
+- Security expert noted the pre-screen's urlHost concern as [Adjacent] type-trust note only — no new attack surface (same call pattern pre-existed in the matched filter).
+
+## Quality Warnings
+
+None.
+
+## Seed Finding Disposition (preserved per expert)
+
+- Functionality: seed 1 (matched filter null-deref) **Rejected** — `matched` is computed inside `tabHost ? ... : []`; does not reproduce. Seed 2 (urlHost undefined) **Rejected** — `DecryptedEntry.urlHost` is required `string` (messages.ts:65); `isHostMatch("")` safely returns false. Pre-screen Critical likewise refuted.
+- Security: seed 1 (cross-domain card fill) **Rejected** — pre-existing accepted behavior of the "Other entries" section, reproduced exactly by `canFill`; seed's proposed "fix" was a no-op ternary. Seed 2 (PASSKEY username visibility) **Rejected** — re-litigation of accepted S4 (quantified).
+- Testing: seed 1 (header untested) **Verified — adopted as T1** (imprecise but real gap). Seed 2 (no-results untested) **Rejected** — covered by A8 + retained pre-existing test. Seed 3 (badge/title collision) **Rejected** — fixture title is "My Passkey Account" per the C4 constraint. Seed 4 (`within` unused) **Rejected** — used at lines 881/908.
+
+## Recurring Issue Check
+
+### Functionality expert
+- I7 DOM-order gap surfaced as F1 (Phase 2 self-check missed ordering).
+- All other R1-R37: carried forward clean from Phase 2 self-check.
+
+### Security expert
+- R37: re-verified clean for the new badge/header strings.
+- All other R1-R37 + RS1-RS4: carried forward clean from Phase 2 self-check.
+
+### Testing expert
+- All R1-R37 + RT1-RT6: carried forward clean from Phase 2 self-check.
+
+## Environment Verification Report
+
+- Unit/build gates: `verified-local` — `npm test` in `extension/` (759/759), root `npx vitest run` (11,228 passed / 1 pre-existing skip), `npx next build` (via scripts/pre-pr.sh, 32/32 checks), `npm run build` in `extension/`.
+- VE1 (real-browser popup smoke): `blocked-deferred` per the Phase 1 constraint entry VE1 (Chrome unpacked-extension manual check; declared non-gating in the plan's Testing strategy — all search/fill logic is unit-covered). Listed as the operator's post-merge smoke item; no Anti-Deferral cost entry required because the plan pre-classified it as non-gating manual verification.
+
+## Resolution Status
+
+### F1 [Minor] no-results message above header — Fixed
+- Action: swapped JSX order so the "Search results" header renders first, message beneath (I7). Added a `compareDocumentPosition` order assertion to A8 as a regression guard.
+- Modified: extension/src/popup/components/MatchList.tsx (header/message block), extension/src/__tests__/popup/MatchList.test.tsx (A8).
+
+### T1 [Minor] header unasserted on non-empty results — Fixed
+- Action: A1 now also asserts `getByText("Search results")` on a results-bearing search.
+- Modified: extension/src/__tests__/popup/MatchList.test.tsx (A1).
+
+### T2 [Minor] "Other entries" suppression untested — Fixed
+- Action: A9b now asserts `queryByText("Other entries")` is null while searching (fixture already provided a non-empty unmatched precondition).
+- Modified: extension/src/__tests__/popup/MatchList.test.tsx (A9b).
+
+### T3 [Minor] pre-existing "SECURE_NOTE" literals — Accepted
+- **Anti-Deferral check**: acceptable risk (pre-existing in changed file, but conversion is impossible-by-design, not deferred work).
+- **Justification**: `EXT_ENTRY_TYPE` deliberately has no SECURE_NOTE member — those tests model a server-known entry type the extension does NOT handle, so a string literal outside the enum is the correct representation; importing a nonexistent constant cannot be done, and adding SECURE_NOTE to the extension enum would falsely signal popup support. Worst case: if the server retires SECURE_NOTE the tests keep passing vacuously (they assert absence of buttons, which stays true). Likelihood: low. Cost to "fix": would require a production enum change that misrepresents capability.
+- **Orchestrator sign-off**: accepted — the literal is intentional, not debt.
+
+Fix commit: review(1) on feature/extension-search-all-vault. Verification after fixes: extension suite 759/759, extension build OK.

--- a/docs/archive/review/extension-search-all-vault-deviation.md
+++ b/docs/archive/review/extension-search-all-vault-deviation.md
@@ -1,0 +1,15 @@
+# Coding Deviation Log: extension-search-all-vault
+
+## D1 — PASSKEY excluded from the `matched` list (resolves A3b ↔ I2 conflict)
+
+- **Where**: `extension/src/popup/components/MatchList.tsx` — `matched` filter gained `if (e.entryType === EXT_ENTRY_TYPE.PASSKEY) return false;`
+- **Plan says**: I2 — empty-query rendering "identical to the pre-change component". A3b — a PASSKEY entry "remains absent from the default (empty-query) view".
+- **Conflict discovered during implementation**: pre-change code excluded PASSKEY only from the `unmatched` list; a PASSKEY whose `urlHost` matches the tab WOULD render in the `matched` list (as a bare row with no buttons). A3b and I2 cannot both hold for that edge case.
+- **Resolution**: A3b treated as authoritative (matches the existing code comment "PASSKEY entries are excluded: they are handled by the WebAuthn interceptor, not by popup autofill", and FR7's search-only discoverability intent). The `matched` filter now excludes PASSKEY, symmetrizing with the pre-existing `unmatched` exclusion. PASSKEY entries are visible ONLY in search mode.
+- **Impact**: behavior change only for the edge case "passkey entry whose host matches the current tab" — previously a button-less row in the matched list, now hidden unless searching. Plan's Background consequence 3 ("PASSKEY entries are never visible in the popup") was over-broad for this edge; the implementation makes it true.
+- **Status**: to be verified by Phase 3 reviewers (functionality + security perspectives).
+
+## D2 — Orchestrator refactor of `renderEntryRow` button block (quality, not contract)
+
+- **Where**: same file — the sub-agent's first version duplicated the Copy/TOTP button block across `canFill(e) && (...)` and `!canFill(e) && LOGIN && (...)` branches (~24 duplicated lines inside the dedup helper).
+- **Resolution**: orchestrator restructured to a single group `{(canFill(e) || e.entryType === LOGIN) && (... {canFill(e) && <Fill/>} {LOGIN && <TOTP/><Copy/>} ...)}`. Behavior-equivalent (verified by the full extension suite re-run: 759/759 pass). No contract affected.

--- a/docs/archive/review/extension-search-all-vault-plan.md
+++ b/docs/archive/review/extension-search-all-vault-plan.md
@@ -6,7 +6,7 @@ Branch: `feature/extension-search-all-vault`
 ## Project context
 
 - Type: web app + browser extension (this change: **extension popup only**)
-- Test infrastructure: unit tests (Vitest, jsdom + @testing-library/react for popup components) + integration tests + CI/CD
+- Test infrastructure: unit tests (Vitest, jsdom + `@testing-library/react` for popup components) + integration tests + CI/CD
   - Extension tests are a SEPARATE Vitest project: run via `npm test` inside `extension/` (root `npx vitest run` does NOT include them). CI: `extension-ci` job is path-gated on `extension/**` and picks up new tests automatically.
 - Verification environment constraints:
   - **VE1** (`verifiable-local`, manual): real-browser behavior of the popup (Chrome extension loaded unpacked) cannot be exercised by Vitest. All search/filter logic is pure client-side React state and IS unit-testable; only the visual smoke check is manual.
@@ -138,7 +138,7 @@ Not affected (verified): `extension/src/background/index.ts` (fetch/cache/decryp
 - Location: `extension/src/__tests__/popup/MatchList.test.tsx` (existing file, existing harness/mocks; `@vitest-environment jsdom` docblock already present).
 - Test inventory (one behavioral assertion per test):
   - A1, A2 written first as regression tests — confirmed to FAIL against the pre-change component before implementing.
-  - A3a, A3b, A4, A5, A8, A9a, A9b as specified in C1/C2 (A9a/A9b use `within()` from @testing-library/react for row-scoped button assertions).
+  - A3a, A3b, A4, A5, A8, A9a, A9b as specified in C1/C2 (A9a/A9b use `within()` from `@testing-library/react` for row-scoped button assertions).
   - Existing tests `filters entries by search query` and `shows no results message when search yields no entries` remain; their semantics stay valid under search-all (verified in round-1 review).
 - Test-quality constraints:
   - Fixtures use `EXT_ENTRY_TYPE.*` constants, never string literals (RT3; do not replicate the pre-existing `"SECURE_NOTE"` literals at lines 207/370).
@@ -182,6 +182,22 @@ Not affected (verified): `extension/src/background/index.ts` (fetch/cache/decryp
 | SC4 | Web-app search behavior | Already full-vault; untouched |
 | SC5 | Host-match enforcement inside `performAutofillForEntry` AND sender validation on the raw `AUTOFILL` message handler (the handler does not distinguish popup vs content-script senders — pre-existing, verified in round-2 review; not widened by this PR) | `TODO(extension-search-all-vault): SW-layer host check + AUTOFILL sender validation` — follow-up; render-time gating preserves the existing security model in this PR, and the SW change touches the shared autofill path used by inline suggestions (separate risk surface requiring its own review) |
 | SC6 | `normalizeHost` strips `www.` unconditionally ([url-matching.ts:13-15](../../../extension/src/lib/url-matching.ts#L13-L15)) — an entry stored with `urlHost = "www.<tld>"` would suffix-match any host under that TLD. Pre-existing, in an UNCHANGED file; theoretical (no legitimate credential stores a bare TLD host). Worst case: credential fill offered across a TLD for a pathological stored host. Likelihood: very low. Cost to fix here: touches host-matching semantics shared by all autofill paths — needs its own review | `TODO(extension-search-all-vault): normalizeHost TLD guard` — follow-up |
+
+## Implementation Checklist (Phase 2-1)
+
+Files to modify (verified complete; no parallel implementations — popup files have no `.js`/`-lib.ts` pair):
+- [ ] `extension/src/popup/components/MatchList.tsx` — `isSearching`/`searchResults`/`entryMatchesTab`/`canFill`, header logic (I7), no-results condition, `renderEntryRow(e, variant)` extraction (delete both duplicated `<li>` blocks), PASSKEY badge case, `displayHost` inner-shadow rename (I10)
+- [ ] `extension/src/messages/en.json` — `popup.searchResults` ("Search results"), `popup.badgePasskey` ("Passkey")
+- [ ] `extension/src/messages/ja.json` — `popup.searchResults` (検索結果), `popup.badgePasskey` (パスキー)
+- [ ] `extension/src/__tests__/popup/MatchList.test.tsx` — A1/A2 (fail-first), A3a/A3b, A4, A5, A8, A9a/A9b; duplicate test-name rename (lines 176/684); `within` import
+
+Shared assets that MUST be reused (no reimplementation — R1):
+- `sortByUrlMatch`, `isHostMatch`, `extractHost` — `extension/src/lib/url-matching.ts`
+- `EXT_ENTRY_TYPE` — `extension/src/lib/constants.ts` (PASSKEY at line 50; use constants in fixtures, RT3)
+- `t()` — `extension/src/lib/i18n.ts`; existing `filterEntries` stays in-component
+- Existing styles: section-header className `text-xs font-medium text-gray-500 dark:text-gray-400`; badge span pattern from `entryTypeBadge`; row `key` scheme `` `${e.teamId ?? "personal"}-${e.id}` ``
+
+CI gate parity (Phase 2-1 step 7): root CI gates (lint, RLS/crypto/env checks) are covered by `scripts/pre-pr.sh`; the `extension-ci` job (`npm ci && npm test && npm run build` in `extension/`) is NOT in pre-pr.sh — run both commands manually in Phase 2-4 (also listed in Testing strategy). Selected en title strings for test selectors: Fill="Fill", Copy="Copy", TOTP button title=`copyTotp` ("TOTP").
 
 ## User operation scenarios
 

--- a/docs/archive/review/extension-search-all-vault-plan.md
+++ b/docs/archive/review/extension-search-all-vault-plan.md
@@ -1,0 +1,193 @@
+# Plan: extension-search-all-vault
+
+Date: 2026-06-12 (rev 2: 2026-06-13, post round-1 review)
+Branch: `feature/extension-search-all-vault`
+
+## Project context
+
+- Type: web app + browser extension (this change: **extension popup only**)
+- Test infrastructure: unit tests (Vitest, jsdom + @testing-library/react for popup components) + integration tests + CI/CD
+  - Extension tests are a SEPARATE Vitest project: run via `npm test` inside `extension/` (root `npx vitest run` does NOT include them). CI: `extension-ci` job is path-gated on `extension/**` and picks up new tests automatically.
+- Verification environment constraints:
+  - **VE1** (`verifiable-local`, manual): real-browser behavior of the popup (Chrome extension loaded unpacked) cannot be exercised by Vitest. All search/filter logic is pure client-side React state and IS unit-testable; only the visual smoke check is manual.
+  - No deployment artifacts (Dockerfile, compose, IaC, auth config) are touched → R35 does not fire; no manual-test artifact required. The manual smoke check is listed under Testing strategy for completeness.
+
+## Objective
+
+Make the extension popup's search box search **all vault entries** (every decrypted entry fetched at popup open: personal + team, all entry types), instead of only filtering the entries currently displayed for the active tab — without opening a cross-domain credential-fill path (see C1 `canFill`).
+
+## Background / root cause
+
+The popup already fetches and decrypts ALL entries (`FETCH_PASSWORDS` → `entries` state in `MatchList`). The display pipeline then narrows them:
+
+- `matched` = entries whose `urlHost`/`additionalUrlHosts` match the current tab host ([MatchList.tsx:132-137](../../../extension/src/popup/components/MatchList.tsx#L132-L137))
+- `unmatched` = when a tab host exists, only non-LOGIN, non-PASSKEY entries (cards, identities) ([MatchList.tsx:143-147](../../../extension/src/popup/components/MatchList.tsx#L143-L147)); when the page has no host (chrome:// etc.), an empty list
+- The search query is applied via `filterEntries()` **to these two display lists only** ([MatchList.tsx:169-170](../../../extension/src/popup/components/MatchList.tsx#L169-L170))
+
+Consequences (the user-reported problem):
+1. A LOGIN entry for a different site can never be found by search while on a web page.
+2. On non-web pages (chrome://, extension pages) nothing is searchable at all.
+3. PASSKEY entries are never visible/searchable in the popup.
+
+No API, service-worker, or crypto change is needed — the data is already in popup memory.
+
+Security constraint discovered in round-1 review (S1): `performAutofillForEntry` ([background/index.ts:1363-1751](../../../extension/src/background/index.ts#L1363-L1751)) performs **no host-match check** — today the popup's display suppression is the only gate preventing a LOGIN credential from being filled into a non-matching page. Search mode must therefore not render Fill for cross-domain LOGIN entries.
+
+## Requirements
+
+Functional:
+- FR1: When the search query is non-empty, search across ALL entries in `entries` state — no domain-match exclusion, no entryType exclusion.
+- FR2: When the query is empty, rendering is byte-for-byte identical to current behavior (domain-matched section + "Other entries" section with the existing type exclusions).
+- FR3: Search-mode results are ordered with current-tab domain matches first (reuse `sortByUrlMatch`).
+- FR4: Search matches the same fields as today: `title`, `username`, `urlHost`, `additionalUrlHosts` (case-insensitive substring).
+- FR5: Per-row actions in search mode:
+  - Fill: rendered only when `canFill(e)` (C1) — autofillable type AND a web-page tab host exists AND (entry is non-LOGIN OR the LOGIN entry's hosts match the tab). Cross-domain LOGIN results are **Copy-only** (S1); on `tabHost === null` no Fill buttons at all (S2).
+  - Copy/TOTP: LOGIN entries always (unchanged).
+  - PASSKEY and other non-actionable types: display-only rows.
+- FR6: Search mode shows a "Search results" section header (same className as existing section headers) and **suppresses** the site-context header (`matchesFor`/`noMatchesFor`/`noMatchesForPage`) and the "Other entries" header while searching.
+- FR7: PASSKEY entries get a type badge ("Passkey" / 「パスキー」) so a display-only passkey row is distinguishable from a broken entry.
+
+Non-functional:
+- NFR1: No new API calls, no message-protocol change, no change to `DecryptedEntry` shape.
+- NFR2: No regression of the 1-minute service-worker entry cache or inline-suggestion path (`GET_MATCHES_FOR_URL`) — untouched.
+- NFR3: en/ja message files stay key-parity-complete (guarded by existing parity test [i18n.test.ts:55-58](../../../extension/src/__tests__/lib/i18n.test.ts#L55-L58)).
+
+## Technical approach
+
+Single-component change in `extension/src/popup/components/MatchList.tsx`, plus i18n keys and tests.
+
+- Derive `isSearching = query !== ""` (same truthiness semantics as the current `if (!q)` / `query &&` checks; `trim()` was considered and rejected to preserve exact behavior parity for whitespace queries).
+- Search mode: `searchResults = filterEntries(sorted, query)` where `sorted = sortByUrlMatch(entries, tabHost)` (already computed). This is the full entry set.
+- Non-search mode: render `matched` / `unmatched` directly. The `filterEntries(matched, query)` / `filterEntries(unmatched, query)` calls and the `filteredMatched` / `filteredUnmatched` variables are deleted; ALL their JSX reference sites (currently lines 204, 211, 218, 220, 273, 277, 279) switch to `matched` / `unmatched` (non-search branch) or `searchResults` (search branch). TypeScript build verifies no stale references remain.
+- No-results condition becomes `isSearching && searchResults.length === 0`.
+- Header logic: when `isSearching`, render only the "Search results" header (suppress the `hasTabUrl` site-context block and the "Other entries" header).
+- Extract the duplicated `<li>` row JSX (currently duplicated verbatim at [MatchList.tsx:220-269](../../../extension/src/popup/components/MatchList.tsx#L220-L269) and [MatchList.tsx:279-328](../../../extension/src/popup/components/MatchList.tsx#L279-L328), differing only in the `li` className) into one render helper used by all three lists (matched, other, search results). With the third consumer this hits the DRY third-duplication threshold.
+  - The helper is a plain function inside the `MatchList` component body returning JSX (called as `{list.map((e) => renderEntryRow(e, variant))}`), NOT a nested component — a component defined inside the render function would remount on every render and drop DOM state.
+  - `variant: "matched" | "plain"` selects the existing className; search results use `"plain"`.
+  - The Fill button render condition inside the helper changes from `isAutofillable(e.entryType)` to `canFill(e)` (C1). In non-search mode this is behavior-preserving (proof in C1 I8).
+
+### Files to update (complete list)
+
+| File | Change |
+|------|--------|
+| `extension/src/popup/components/MatchList.tsx` | search-mode branch, `canFill` gating, row render helper, header logic, PASSKEY badge |
+| `extension/src/messages/en.json` | add `popup.searchResults`, `popup.badgePasskey` |
+| `extension/src/messages/ja.json` | add `popup.searchResults` (検索結果), `popup.badgePasskey` (パスキー) |
+| `extension/src/__tests__/popup/MatchList.test.tsx` | regression + new behavior tests; rename one of the duplicate test names at lines 176/684 |
+
+Not affected (verified): `extension/src/background/index.ts` (fetch/cache/decrypt/autofill unchanged — the cross-domain gate is enforced at render time, matching the existing display-suppression security model), `extension/src/lib/url-matching.ts` (reused as-is), content scripts (no parallel `.js`/`-lib.ts` pair involved — popup files do not use that pattern), web app, iOS, API routes.
+
+## Contracts
+
+### C1 — Search scope: full entry set, fill-gated
+
+- Signature (derived state/helpers inside `MatchList`, no exported API change):
+  - `isSearching: boolean` — `query !== ""`
+  - `searchResults: DecryptedEntry[]` — `filterEntries(sortByUrlMatch(entries, tabHost), query)`
+  - `filterEntries(list: DecryptedEntry[], q: string): DecryptedEntry[]` — unchanged implementation (fields per FR4)
+  - `entryMatchesTab(e: DecryptedEntry): boolean` — `tabHost !== null && (isHostMatch(e.urlHost, tabHost) || (e.additionalUrlHosts ?? []).some((h) => isHostMatch(h, tabHost)))`
+  - `canFill(e: DecryptedEntry): boolean` — `isAutofillable(e.entryType) && tabHost !== null && (e.entryType !== EXT_ENTRY_TYPE.LOGIN || entryMatchesTab(e))`
+- Invariants (all app-enforced; this is pure client-side view logic, no storage layer can express them):
+  - I1: `isSearching === true` ⇒ the rendered result list is derived from the FULL `entries` state — never from `matched`, `unmatched`, or any entryType-excluded subset.
+  - I2: `isSearching === false` ⇒ rendered output is identical to the pre-change component (sections, headers, exclusions, ordering, buttons).
+  - I3: `entries` state and the service-worker message protocol are not modified.
+  - I7: `isSearching === true` ⇒ the site-context header block (`matchesFor`/`noMatchesFor`/`noMatchesForPage`) and the "Other entries" header are NOT rendered; the "Search results" header IS rendered whenever `isSearching`, regardless of whether `searchResults` is empty (the no-results message appears beneath it); the no-results condition is exactly `isSearching && searchResults.length === 0`.
+  - I8 (security, S1/S2): a Fill button is rendered for an entry iff `canFill(e)`. Proof of I2-compatibility: in non-search mode, matched-list entries satisfy `entryMatchesTab` by construction; the unmatched list contains only non-LOGIN types and exists only when `tabHost !== null`; when `tabHost === null` no entries render — so `canFill` reproduces current Fill visibility exactly. In search mode it newly suppresses Fill for cross-domain LOGIN entries and for all entries on non-web pages. The fill REQUEST path (`handleFill` → `AUTOFILL` message) is unchanged; render-time gating matches the existing display-suppression security model.
+- Forbidden patterns (diff of `MatchList.tsx`):
+  - pattern: `filterEntries(matched` — reason: query filtering of the domain-scoped list is the bug being removed
+  - pattern: `filterEntries(unmatched` — reason: query filtering of the type-excluded list is the bug being removed
+  - pattern: `filteredMatched.length === 0 && filteredUnmatched.length === 0` — reason: stale no-results condition; must be `isSearching && searchResults.length === 0`
+- Acceptance criteria:
+  - A1 (regression, discriminating per T2): With a tab host present and a query matching a LOGIN entry whose hosts do NOT match the tab, the entry's row IS rendered AND the `popup.noResults` message is NOT rendered. (Fails on current code; also fails on an implementation that keeps the stale no-results condition.)
+  - A2 (regression): With `tabUrl = null`, a non-empty query renders matching entries; none of them has a Fill button (I8); Copy is available for LOGIN entries. (Fails on current code, where nothing renders.)
+  - A3a: A PASSKEY entry matching the query appears in search results as a display-only row — Passkey badge shown, no Fill/Copy/TOTP buttons.
+  - A3b: With an empty query, a PASSKEY entry is absent from the rendered output (default view unchanged).
+  - A4: Empty query renders the site-context header ("Matches for {host}") and matched/"Other entries" sections exactly as before; the "Search results" header is absent; cross-host LOGIN entries are absent.
+  - A5: With two entries both matching the query — one whose host matches the tab, one not — the tab-matching entry's row precedes the other in DOM order (asserted via `getAllBy*` ordering).
+  - A8: With a non-empty query, the "Search results" header is rendered and the site-context header is not (I7); the header remains rendered when `searchResults` is empty, with the no-results message beneath it (the retained existing test `shows no results message when search yields no entries` covers the message itself).
+  - A9a: A cross-domain LOGIN search result's row — asserted with `within(<row li>)` scoping — contains Copy and TOTP buttons but NO Fill button (I8).
+  - A9b: A CREDIT_CARD search result's row on a web page — asserted with `within(<row li>)` scoping — contains its Fill button (I8). (Separate test from A9a; screen-scope `queryByRole("button", { name: "Fill" })` cannot discriminate which row owns the button when both entries are in one fixture.)
+- Consumer-flow walkthrough: the only consumer of `searchResults`/`canFill` is `MatchList`'s own JSX (rows read `{ id, title, username, urlHost, additionalUrlHosts, entryType, teamId, teamName }` to render and to dispatch `handleFill`/`handleCopy`/`handleCopyTotp`, which need `{ id, entryType, teamId }`; `canFill`/`entryMatchesTab` need `{ entryType, urlHost, additionalUrlHosts }` — all present in `DecryptedEntry`). No code outside the component reads the new state; no API/persisted/message shape is defined. No other consumer exists.
+
+### C2 — Row render helper (de-duplication)
+
+- Signature: `renderEntryRow(e: DecryptedEntry, variant: "matched" | "plain"): JSX.Element` — plain function declared inside the `MatchList` body (closure over handlers/`filling`/`displayHost`/`canFill`), not a component.
+- Invariants (app-enforced):
+  - I4: All three lists (matched, other, search results) render rows through this single helper; the two existing verbatim-duplicated `<li>` blocks are deleted.
+  - I5: Rendered DOM for the matched and other lists is unchanged vs. current code (same classNames, same button set per I8, same `key` scheme `` `${e.teamId ?? "personal"}-${e.id}` ``). The "Search results" header uses the existing section-header className (`text-xs font-medium text-gray-500 dark:text-gray-400`).
+  - I9: `entryTypeBadge()` gains a PASSKEY case rendering `t("popup.badgePasskey")` (style consistent with the existing Card/Identity badges).
+  - I10 (pre-existing cleanup, file in scope): the inner `const matched` inside `displayHost` ([MatchList.tsx:152](../../../extension/src/popup/components/MatchList.tsx#L152)) shadows the outer `matched` list — rename it (e.g., `additionalMatch`) while extracting the helper; behavior unchanged.
+- Forbidden patterns:
+  - pattern: `const EntryRow` — reason: nested component declaration inside `MatchList` would remount per render; the contract is a render function, and a module-level component is out of scope churn
+- Acceptance criteria:
+  - A6: Existing rendering/action tests (fill, copy, TOTP, badges) pass without weakening assertions.
+
+### C3 — i18n keys
+
+- Shape: added to both `extension/src/messages/en.json` and `extension/src/messages/ja.json`:
+  - `popup.searchResults` — "Search results" / "検索結果"
+  - `popup.badgePasskey` — "Passkey" / "パスキー"
+- Invariants (app-enforced): I6: en.json and ja.json key sets remain identical — enforced by the existing parity test (`keeps key sets aligned between locales`, [i18n.test.ts:55-58](../../../extension/src/__tests__/lib/i18n.test.ts#L55-L58)).
+- Forbidden patterns:
+  - pattern: `ボルト` — reason: ja translations must use 保管庫, never katakana (project convention)
+- Acceptance criteria:
+  - A7: Both locale files contain both keys; no internal jargon in either string (R37); parity test passes. Note: the parity test enforces en↔ja SYMMETRY only (both-missing passes it); key PRESENCE is enforced by the A3a/A8 functional assertions, which fail if `t()` returns the key path instead of the real string.
+
+### C4 — Tests
+
+- Location: `extension/src/__tests__/popup/MatchList.test.tsx` (existing file, existing harness/mocks; `@vitest-environment jsdom` docblock already present).
+- Test inventory (one behavioral assertion per test):
+  - A1, A2 written first as regression tests — confirmed to FAIL against the pre-change component before implementing.
+  - A3a, A3b, A4, A5, A8, A9a, A9b as specified in C1/C2 (A9a/A9b use `within()` from @testing-library/react for row-scoped button assertions).
+  - Existing tests `filters entries by search query` and `shows no results message when search yields no entries` remain; their semantics stay valid under search-all (verified in round-1 review).
+- Test-quality constraints:
+  - Fixtures use `EXT_ENTRY_TYPE.*` constants, never string literals (RT3; do not replicate the pre-existing `"SECURE_NOTE"` literals at lines 207/370).
+  - PASSKEY fixture uses the minimal `DecryptedEntry` shape (`id`, `title`, `username`, `urlHost`, `entryType`) — the row renders only title/username/host today. The fixture `title` must NOT equal the badge text ("Passkey") to avoid `getByText` ambiguity between badge and title.
+  - Header assertions use exact text (or role-scoped queries), never `/search/i`-style regexes — the "Search..." input placeholder would phantom-match (R7).
+  - i18n keys (C3) are added in the same change-set as (or before) the tests so `t()` resolves real strings, not key paths (T5).
+  - Rename one of the two duplicate `it("shows no entries when tabUrl is null (non-web page)")` blocks (lines 176/684) to a unique description (F4-A; pre-existing, file in scope).
+- Acceptance criteria: all tests above implemented and passing; A1/A2 demonstrated failing pre-change.
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | Search scope: full entry set, fill-gated (`canFill`) | locked |
+| C2 | Row render helper + PASSKEY badge + shadow rename | locked |
+| C3 | i18n keys (en/ja `popup.searchResults`, `popup.badgePasskey`) | locked |
+| C4 | Tests (A1-A9b inventory + quality constraints) | locked |
+
+## Testing strategy
+
+- Unit (Vitest, existing harness in `MatchList.test.tsx` with mocked `sendMessage`): the C4 inventory. A1/A2 written first to confirm they fail on current code.
+- Extension suite: `npm test` in `extension/` (root `npx vitest run` does NOT include extension tests).
+- Full root suite: `npx vitest run` (mandatory check).
+- Build: `npx next build` (mandatory check) + extension build (`npm run build` in `extension/`) since the change is extension code and the root Next build does not compile the extension.
+- Manual smoke (VE1, non-gating): load unpacked extension; on a site with one matched entry, search a different site's LOGIN entry → appears Copy-only (no Fill); on `chrome://extensions` search returns results with no Fill buttons; empty query view unchanged.
+
+## Considerations & constraints
+
+- Search fields stay at the 4 overview fields; the extension's `DecryptedEntry` carries no more searchable data (unlike the web app's 15+ fields, which come from a richer overview shape).
+- Entries snapshot is what was fetched at popup open (existing behavior; unchanged).
+- Performance: linear filter over all entries per keystroke, same complexity class as today (the full set is already in memory and already sorted once per render). No memoization added (the component currently filters inline without `useMemo`; matching existing style, list sizes are popup-scale).
+- Accepted risk (S4, quantified in review round 1): PASSKEY titles/usernames (often emails) become shoulder-surfable via search in an unlocked popup — same exposure class as existing matched-list rendering; masking them would cripple the feature.
+
+### Scope contract
+
+| ID | Deferred item | Owner / tracking |
+|----|---------------|------------------|
+| SC1 | Searching additional fields (notes snippet, card brand, etc.) — requires enriching the extension overview payload shape across app+extension(+iOS AAD parity) | Future feature; not tracked by an issue yet — out of this PR by design |
+| SC2 | Inline-suggestion matching (`GET_MATCHES_FOR_URL` / content-script dropdown) — remains domain-scoped by design (an in-page dropdown must stay site-relevant) | Intentionally unchanged behavior |
+| SC3 | Server-side search / pagination for very large vaults | Not needed — full fetch already exists; revisit only if fetch strategy changes |
+| SC4 | Web-app search behavior | Already full-vault; untouched |
+| SC5 | Host-match enforcement inside `performAutofillForEntry` AND sender validation on the raw `AUTOFILL` message handler (the handler does not distinguish popup vs content-script senders — pre-existing, verified in round-2 review; not widened by this PR) | `TODO(extension-search-all-vault): SW-layer host check + AUTOFILL sender validation` — follow-up; render-time gating preserves the existing security model in this PR, and the SW change touches the shared autofill path used by inline suggestions (separate risk surface requiring its own review) |
+| SC6 | `normalizeHost` strips `www.` unconditionally ([url-matching.ts:13-15](../../../extension/src/lib/url-matching.ts#L13-L15)) — an entry stored with `urlHost = "www.<tld>"` would suffix-match any host under that TLD. Pre-existing, in an UNCHANGED file; theoretical (no legitimate credential stores a bare TLD host). Worst case: credential fill offered across a TLD for a pathological stored host. Likelihood: very low. Cost to fix here: touches host-matching semantics shared by all autofill paths — needs its own review | `TODO(extension-search-all-vault): normalizeHost TLD guard` — follow-up |
+
+## User operation scenarios
+
+1. **Cross-site lookup while on a site**: User is on `github.com`; popup shows the GitHub entry under "Matches for github.com". They type "aws" → the AWS LOGIN entry (different host) appears under "Search results" with Copy/TOTP but no Fill; Copy password works. (Currently: no results.)
+2. **Search from a non-web page**: User opens the popup on `chrome://extensions` and types "bank" → matching entries appear, Copy-only. (Currently: the popup shows nothing and search is dead.)
+3. **No behavior change without a query**: User on `github.com` opens the popup and types nothing → GitHub matches on top, cards/identities under "Other entries", other sites' logins hidden — exactly as today.
+4. **Passkey discoverability**: User types the name of a passkey-only entry → it appears as a display-only row with a "Passkey" badge (no Fill/Copy), confirming the credential exists; actual passkey use still goes through the WebAuthn interceptor.
+5. **Query matching both scopes**: On `github.com`, query "git" → the matched GitHub entry sorts first (with Fill), followed by e.g. a "GitLab" entry for another host (Copy-only), in one "Search results" list.
+6. **Anti-phishing guard**: User is lured to `accounts-google.com.evil.example` and searches "google" → the real Google entry appears but offers no Fill button; the user cannot one-click-inject credentials into the lookalike page.

--- a/docs/archive/review/extension-search-all-vault-review.md
+++ b/docs/archive/review/extension-search-all-vault-review.md
@@ -1,0 +1,261 @@
+# Plan Review: extension-search-all-vault
+
+Date: 2026-06-12 (round 1) / 2026-06-13 (rounds 2-3)
+Review round: 3 — COMPLETE (all experts: No findings)
+
+---
+
+# Round 3 (verification — final)
+
+## Changes from Previous Round
+
+Round-2 fixes applied: I7 header-rendering rule for empty results (F11), I10 shadow rename (F5), A9 split into A9a/A9b with `within()` scoping (T7), A7 enforcement-mapping clarification (T8), PASSKEY fixture title constraint (T9), SC5 extended with AUTOFILL sender validation, SC6 added (normalizeHost TLD guard).
+
+## Results
+
+- **Functionality**: F11/F5 fixes verified correct and consistent with I2/A4/I5; no new findings. One marginal note (A8 could also assert the no-results message when results are empty) — folded into A8 wording; the retained existing test covers the message.
+- **Security**: SC5/SC6 deferrals verified against code — both pre-existing, not widened by this PR, quantified, grep-able TODO markers, routed for follow-up review. A9a/A9b fully discriminate the I8 property (A9a catches Fill-shown-for-cross-domain-LOGIN; A9b catches Fill-suppressed-for-legitimate-types). No findings.
+- **Testing**: T7/T8/T9 fixes verified; full A1-A9b inventory mapped to concrete non-vacuous mechanisms; button selectors unambiguous (en titles: "Fill"/"Copy"/"TOTP" — no substring collision); `within` import requirement noted. No findings.
+
+All Recurring Issue Check statuses carried forward unchanged from round 2.
+
+## Go/No-Go
+
+All contracts C1-C4 **locked**. Phase 1 complete after 3 rounds.
+
+---
+
+---
+
+# Round 2
+
+## Changes from Previous Round
+
+All 14 round-1 findings reflected in the plan: search-mode header suppression (I7), explicit no-results condition, `canFill` fill-gating predicate (S1/S2), PASSKEY badge (FR7), rename cascade enumeration, concretized test inventory (A1-A9), extension test command, SC5 scope-out.
+
+## Functionality Findings (round 2)
+
+- **F5 [Minor] (new in round 2)**: pre-existing variable shadow — `displayHost`'s inner `const matched` (MatchList.tsx:152) shadows the outer `matched` list. No runtime impact; file in scope → renamed during helper extraction (plan C2 I10).
+- **F11 [Major] (new in round 2)**: plan did not specify whether the "Search results" header renders when `searchResults.length === 0` — A8 had no determinate assertion target. Fixed: I7 now states the header renders whenever `isSearching`, with the no-results message beneath.
+- F6 retracted by the expert (urlHost is typed non-nullable); F7-F10, F12 self-resolved during analysis (no bugs: empty-vault search path unreachable by existing design; `sortByUrlMatch(entries, null)` returns fetch order — acceptable; canFill formula already namespaced; shadow covered by F5).
+- Verified: I8's behavior-preservation proof confirmed against MatchList.tsx:131-147/218-330 incl. additionalUrlHosts matches, `about:blank` (extractHost → null → nothing renders, canFill false), CREDIT_CARD/IDENTITY in matched list.
+
+## Security Findings (round 2)
+
+- **S1 re-verified CLOSED**: `isHostMatch` (url-matching.ts:17-22) suffix-matches in the safe direction only (`tabHost.endsWith("." + entryHost)`); entry `example.com` vs tab `example.com.evil.net` → false. `canFill` correctly gates.
+- **S2 re-verified CLOSED**: `tabHost !== null` short-circuit.
+- **SC5 deferral assessed ACCEPTABLE**: the raw `AUTOFILL` handler (background/index.ts:2240) lacks sender validation (popup vs content script) — pre-existing, NOT widened by this PR (content scripts use `AUTOFILL_FROM_CONTENT`, which validates sender; render-time gate preserves the existing model). SC5 extended to include sender validation in the TODO.
+- **Cross-domain Copy assessed ACCEPTABLE (no finding)**: user-initiated, clipboard not readable by the page without explicit permission grant, equivalent surface to the web app dashboard.
+- **S5 [Minor, Adjacent] (new in round 2)**: `normalizeHost` strips `www.` unconditionally — pathological stored host `www.<tld>` would suffix-match the whole TLD. Pre-existing in an unchanged file; theoretical. → SC6 with TODO marker.
+
+## Testing Findings (round 2)
+
+- **T7 [Critical] (new in round 2)**: A9 as a single two-entry test is a false-positive — screen-scope `queryByRole("button", { name: "Fill" })` matches the CREDIT_CARD's Fill, so "LOGIN row has no Fill" is unverifiable. Fixed: split into A9a/A9b with `within()` row scoping.
+- **T8 [Minor] (new in round 2)**: A7's "parity test passes" is necessary but not sufficient (both-keys-missing passes parity). Fixed: A7 now documents that key presence is enforced by A3a/A8 functional assertions.
+- **T9 [Minor] (new in round 2)**: PASSKEY fixture title could collide with badge text "Passkey", making `getByText` ambiguous. Fixed: C4 constraint added.
+- T1-T5, F4-A resolutions verified correct and complete.
+
+## Resolution Status (Round 2 → plan updates)
+
+| ID | Severity | Resolution |
+|----|----------|-----------|
+| F5 | Minor | **Fixed in plan** — C2 I10 (rename inner shadow during extraction) |
+| F11 | Major | **Fixed in plan** — I7 specifies header renders whenever `isSearching`; A8 updated |
+| S5 | Minor | **Skipped (pre-existing, unchanged file)** — Anti-Deferral check: out of scope with [Adjacent] routing + TODO. Worst case: fill offered across a TLD for a pathological stored host `www.<tld>`. Likelihood: very low (no legitimate credential stores a bare TLD). Cost to fix now: changes host-match semantics shared by ALL autofill paths — security carve-out demands its own impact analysis/review. Tracked: SC6 `TODO(extension-search-all-vault): normalizeHost TLD guard`. Orchestrator sign-off: exception satisfied. |
+| T7 | Critical | **Fixed in plan** — A9 split into A9a/A9b with `within()` scoping |
+| T8 | Minor | **Fixed in plan** — A7 mapping clarified |
+| T9 | Minor | **Fixed in plan** — fixture title constraint added |
+
+---
+
+# Round 1
+
+Date: 2026-06-12
+Review round: 1
+
+## Changes from Previous Round
+
+Initial review.
+
+## Functionality Findings
+
+- **F1 [Major]: Site-context header not suppressed in search mode** — `MatchList.tsx:208-214`: the `{hasTabUrl && ...}` matchesFor/noMatchesFor header renders regardless of search mode; plan must gate it with `!isSearching` (new invariant I7), otherwise "No matches for X" and "Search results" render simultaneously.
+- **F2 [Major]: `noResults` empty-state condition not updated for search mode** — `MatchList.tsx:204`: plan removes `filteredMatched`/`filteredUnmatched` without specifying the replacement condition `isSearching && searchResults.length === 0`.
+- **F3 [Minor]: PASSKEY rows have no type badge** — `MatchList.tsx:111-119`: `entryTypeBadge()` covers only CREDIT_CARD/IDENTITY; a PASSKEY search result looks like a broken entry. Add `popup.badgePasskey` ("Passkey" / "パスキー") to both locales and the badge function.
+- **F4 [Minor]: filteredMatched/filteredUnmatched rename cascade not enumerated** — 10 reference sites; plan must state non-search JSX uses `matched`/`unmatched` directly (TypeScript catches misses at build, so Minor).
+- **F4-A [Adjacent → Testing]: duplicate test name** — `MatchList.test.tsx:176,684`: two `it("shows no entries when tabUrl is null (non-web page)")` blocks; pre-existing, file in scope → rename one in this PR (R34).
+- R8 note: the "Search results" header must reuse the existing section-header className (`text-xs font-medium text-gray-500 dark:text-gray-400`).
+
+## Security Findings
+
+- **S1 [Major]: Cross-domain LOGIN Fill — NEW exploitation path** — `background/index.ts:1363-1751` (`performAutofillForEntry` has zero host-match check; display suppression is the only gate today), `MatchList.tsx:82-108,126-129`. Post-plan, search mode would render Fill for LOGIN entries of ANY domain: a user on a lookalike domain could search the real entry and inject the real password into the phishing page. Fix adopted: in search mode, suppress Fill for LOGIN entries whose hosts (urlHost + additionalUrlHosts via `isHostMatch`) do not match the current tab — Copy-only row. escalate: false.
+- **S2 [Minor]: Fill on chrome:// context silently fails (newly reachable)** — with `tabHost === null` there is no fillable page; suppress Fill for all rows in that state (Copy-only).
+- **S3: No finding** — query interpolation in `t("popup.noResults", { query })` is React text-node rendering; escaped by default.
+- **S4 [Minor]: PASSKEY username (often an email) visible via search** — pre-existing overview-data exposure class (same as titles/usernames in matched list); vault unlock is a precondition. Accepted (see Resolution Status).
+
+## Testing Findings
+
+- **T1 [Major]: A4 (empty-query unchanged) has no direct test** — add explicit test: empty query → "Matches for {host}" present, "Search results" absent, cross-host LOGIN absent.
+- **T2 [Critical]: no-results test is a false-positive guard** — `MatchList.test.tsx:322-340`: fixture makes old and new conditions both true; a stale old condition would still pass. Fix: the A1 regression test must assert the cross-host LOGIN row IS rendered AND the noResults message is NOT rendered (discriminates stale-condition implementations).
+- **T3 [Major]: A5 ordering test underspecified** — specify fixture (one tab-matching + one non-matching entry, both matching the query) and DOM-order assertion; otherwise `filterEntries(entries, query)` without `sortByUrlMatch` passes all tests.
+- **T4 [Minor]: split A3 into A3a/A3b** — search-mode display-only row vs absent-from-default-view are separate tests.
+- **T5 [Minor]: t() key-ordering note** — add i18n keys with/before the tests; missing key makes `t()` return the key path and header assertions fail confusingly.
+- **T6-A [Adjacent → Functionality]: PASSKEY fixture shape** — row renders only title/username/host today; minimal fixture is adequate (see Resolution Status for the "future-proof all optional fields" variant).
+- Verified facts: extension tests run via `npm test` in `extension/` (root `npx vitest run` does NOT include them — plan must list this explicitly); extension-ci picks up new tests automatically; i18n parity test exists (`i18n.test.ts:55-58`); `EXT_ENTRY_TYPE.PASSKEY` exists (`constants.ts:50`); RT3 — PASSKEY fixture must use the constant, not a string literal; R7 — header assertions must not use `/search/i` (phantom-matches the "Search..." placeholder).
+
+## Adjacent Findings
+
+- F4-A → Testing (duplicate test name; fix in this PR).
+- T6-A → Functionality (PASSKEY fixture shape; resolved — minimal shape is correct for current rendering).
+
+## Quality Warnings
+
+None detected by merge-findings.
+
+## Resolution Status (Round 1 → plan updates)
+
+| ID | Severity | Resolution |
+|----|----------|-----------|
+| F1 | Major | **Fixed in plan** — invariant I7 + implementation note added (C1) |
+| F2 | Major | **Fixed in plan** — explicit condition `isSearching && searchResults.length === 0` + forbidden pattern (C1) |
+| F3 | Minor | **Fixed in plan** — `popup.badgePasskey` added to C3; badge rendering added to C2 |
+| F4 | Minor | **Fixed in plan** — rename strategy enumerated (C1) |
+| F4-A | Minor | **Fixed in plan** — test rename added to C4 |
+| S1 | Major | **Fixed in plan** — `canFill` predicate added (C1/C2): Fill suppressed in search mode for LOGIN entries not matching the tab host |
+| S2 | Minor | **Fixed in plan** — `canFill` requires `tabHost !== null`, covering chrome:// context |
+| S4 | Minor | **Accepted** — Anti-Deferral check: acceptable risk. Worst case: shoulder-surfer reads a passkey entry's title/username (often an email) from an unlocked popup the user is actively searching in. Likelihood: low — requires physical proximity, unlocked vault, and an active search by the user. Cost to fix: high relative to benefit (masking usernames in search results cripples the feature's purpose; the same data class is already shown for all other entry types in the matched list). Orchestrator sign-off: acceptable-risk exception satisfied with quantification. |
+| T1 | Major | **Fixed in plan** — explicit A4 test specified (C4) |
+| T2 | Critical | **Fixed in plan** — A1 test now asserts row rendered AND noResults absent (C4) |
+| T3 | Major | **Fixed in plan** — A5 fixture + DOM-order assertion specified (C4) |
+| T4 | Minor | **Fixed in plan** — A3 split into A3a/A3b (C4) |
+| T5 | Minor | **Fixed in plan** — key-before-test note added (C4) |
+| T6-A (future-proof fixture variant) | Minor | **Skipped** — Anti-Deferral check: out of scope (speculative). The row renders only title/username/host; adding unused optional fields to fixtures asserts nothing today (decorative test data). Worst case: a future change renders `relyingPartyId` untested — that change's own review adds the fixture then. Likelihood: low. Cost now: pure speculation with no failing condition. Orchestrator sign-off: acceptable-risk exception satisfied. |
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1: Checked — no issue (sortByUrlMatch / filterEntries reused, no reimplementation)
+- R2: Checked — no issue (popup.searchResults is an i18n key, not hardcoded literal)
+- R3: Checked — no issue (inline-suggestion path correctly scoped out as SC2)
+- R4: N/A — no event dispatch
+- R5: N/A — no DB writes
+- R6: N/A — no data model changes
+- R7: Checked — no issue (header is a plain i18n string; existing tests don't query section headers by text)
+- R8: Checked — minor gap: plan should specify the "Search results" header uses the same className as existing section headers (text-xs font-medium text-gray-500 dark:text-gray-400)
+- R9: N/A — no async tx
+- R10: Checked — no issue (no new imports)
+- R11: Checked — no issue (search section replaces both sections, not parallel)
+- R12: Finding F3 (EXT_ENTRY_TYPE has 4 values; entryTypeBadge covers only 2; PASSKEY now surfaced without badge)
+- R13: N/A
+- R14: N/A
+- R15: N/A
+- R16: Checked — no issue (plan mandates vitest + extension build)
+- R17: Checked — no issue
+- R18: N/A
+- R19: Checked — no issue (existing harness/mocks; no shape drift)
+- R20: N/A
+- R21: N/A — plan review itself
+- R22: Checked — no issue
+- R23: Checked — no issue (no clamping/validation-on-keystroke; onChange sets query directly)
+- R24: N/A
+- R25: N/A — query is ephemeral component state
+- R26: Checked — no issue
+- R27: N/A — no numeric interpolation in new keys
+- R28: N/A — header, not toggle
+- R29: Checked — no spec citations in plan
+- R30: N/A
+- R31: N/A
+- R32: N/A
+- R33: Checked — no issue
+- R34: Finding F4-A (duplicate test name, pre-existing, file in scope)
+- R35: Checked — no issue (correctly N/A, VE1 documented)
+- R36: Checked — no issue (renderEntryRow as plain function avoids nested-component lint issue)
+- R37: Checked — no issue ("Search results" / "検索結果" clean)
+
+### Security expert
+- R1: Checked — no issue (filterEntries/sortByUrlMatch/isHostMatch reused)
+- R2: Checked — no issue
+- R3: Checked — no issue (render helper contained to MatchList.tsx)
+- R4: N/A — no event dispatch
+- R5: N/A — no DB writes
+- R6: N/A
+- R7: Checked — no issue
+- R8: Checked — no issue (plan reuses existing row classNames via helper)
+- R9: N/A
+- R10: Checked — no issue
+- R11: N/A
+- R12: Checked — no issue (EXT_ENTRY_TYPE reused; isAutofillable unchanged)
+- R13: N/A
+- R14: N/A
+- R15: N/A
+- R16: Checked — no issue
+- R17: Checked — no issue
+- R18: N/A — no route allowlists changed
+- R19: Checked — existing sendMessage mock harness; no new SW messages
+- R20: N/A
+- R21: N/A
+- R22: Checked — attacker perspective considered (S1)
+- R23: Checked — no issue
+- R24: N/A
+- R25: Checked — query is React state only, never persisted to sessionStorage/localStorage/chrome.storage
+- R26: Checked — no issue
+- R27: N/A
+- R28: N/A
+- R29: Checked — no spec citations
+- R30: Checked — no bare autolink tokens in plan
+- R31: N/A
+- R32: N/A
+- R33: Checked — no issue
+- R34: Finding S1 — pre-existing fill-path gap (no host check in performAutofillForEntry) flagged because the plan materially expands its exploitability (security carve-out: must be addressed in-plan, not deferred)
+- R35: Checked — correctly N/A (no deployment artifacts)
+- R36: Checked — no suppressions
+- R37: Checked — no jargon in new strings
+- RS1: N/A — no new credential/token comparisons
+- RS2: N/A — no new API endpoints (NFR1)
+- RS3: Checked — query used only client-side for substring filtering; nothing reaches the server
+- RS4: Checked — plan file contains no emails/handles/internal hostnames
+
+### Testing expert
+- R1: Checked — no issue
+- R2: Checked — see RT3 note (constant vs literal in fixtures)
+- R3: N/A — isolated component change
+- R4: N/A
+- R5: N/A
+- R6: N/A
+- R7: Checked — phantom-match risk noted: header assertions must not use /search/i regex (matches "Search..." placeholder); use exact text or getByRole
+- R8: N/A — out of testing scope
+- R9: N/A
+- R10: N/A
+- R11: N/A
+- R12: Checked — EXT_ENTRY_TYPE 4 values; A3 adds PASSKEY coverage
+- R13: N/A
+- R14: N/A
+- R15: N/A
+- R16: Checked — root vitest does NOT run extension tests; extension-ci runs `npm test` in extension/; plan must list extension test run explicitly
+- R17: N/A
+- R18: N/A
+- R19: Checked (RT1) — mock shapes match ExtensionResponse/DecryptedEntry
+- R20: N/A
+- R21: N/A
+- R22: N/A
+- R23: N/A
+- R24: N/A
+- R25: N/A
+- R26: N/A
+- R27: N/A
+- R28: N/A
+- R29: N/A
+- R30: N/A
+- R31: N/A
+- R32: N/A
+- R33: Checked — extension-ci path-gated on extension/**; new tests picked up automatically
+- R34: Checked — duplicate test name flagged by Functionality (F4-A); agree it should be fixed in this PR
+- R35: N/A — no deployment artifacts
+- R36: N/A
+- R37: Checked — parity test guards both locales; strings clean
+- RT1: Checked — no issue
+- RT2: Checked — all planned tests expressible in existing harness
+- RT3: Note — PASSKEY fixture must use EXT_ENTRY_TYPE.PASSKEY constant (existing "SECURE_NOTE" literals at 207/370 are a pre-existing inconsistency)
+- RT4: N/A — no concurrency tests
+- RT5: Checked — planned tests exercise MatchList itself (production filter/sort path)
+- RT6: Checked — renderEntryRow is not exported; covered transitively by existing row tests

--- a/extension/src/__tests__/popup/MatchList.test.tsx
+++ b/extension/src/__tests__/popup/MatchList.test.tsx
@@ -852,9 +852,13 @@ describe("MatchList", () => {
     const input = await screen.findByPlaceholderText("Search...");
     fireEvent.change(input, { target: { value: "zzznomatch" } });
 
-    expect(await screen.findByText("Search results")).toBeInTheDocument();
+    const header = await screen.findByText("Search results");
     expect(screen.queryByText(/Matches for/)).toBeNull();
-    expect(screen.getByText(/no results for/i)).toBeInTheDocument();
+    const noResults = screen.getByText(/no results for/i);
+    // I7: the no-results message appears beneath the header
+    expect(
+      header.compareDocumentPosition(noResults) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   // A9a: Cross-domain LOGIN search result has Copy and TOTP but no Fill (row-scoped)
@@ -907,6 +911,8 @@ describe("MatchList", () => {
     const row = title.closest("li") as HTMLElement;
     const rowScope = within(row);
     expect(rowScope.getByRole("button", { name: "Fill" })).toBeInTheDocument();
+    // I7: the "Other entries" header is suppressed while searching
+    expect(screen.queryByText("Other entries")).toBeNull();
   });
 
   // A1: cross-site LOGIN entry appears in search results and no-results is suppressed
@@ -937,6 +943,7 @@ describe("MatchList", () => {
 
     expect(await screen.findByText("AWS Console")).toBeInTheDocument();
     expect(screen.queryByText(/no results for/i)).toBeNull();
+    expect(screen.getByText("Search results")).toBeInTheDocument();
   });
 
   // A2: tabUrl=null with query renders matching entries; no Fill buttons; Copy available for LOGIN

--- a/extension/src/__tests__/popup/MatchList.test.tsx
+++ b/extension/src/__tests__/popup/MatchList.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { EXT_ENTRY_TYPE } from "../../lib/constants";
 
 const mockSendMessage = vi.fn();
@@ -681,7 +681,7 @@ describe("MatchList", () => {
     expect(screen.queryByText("Other Login")).toBeNull();
   });
 
-  it("shows no entries when tabUrl is null (non-web page)", async () => {
+  it("shows no entries when tabUrl is null (non-web page) — all types hidden without query", async () => {
     mockSendMessage.mockResolvedValueOnce({
       type: "FETCH_PASSWORDS",
       entries: [
@@ -707,5 +707,259 @@ describe("MatchList", () => {
     await screen.findByPlaceholderText("Search...");
     expect(screen.queryByText("Login Entry")).toBeNull();
     expect(screen.queryByText("Card Entry")).toBeNull();
+  });
+
+  // A3a: PASSKEY entry appears in search results as display-only (badge shown, no Fill/Copy/TOTP)
+  it("A3a: PASSKEY entry appears in search results as a display-only row with badge", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      type: "FETCH_PASSWORDS",
+      entries: [
+        {
+          id: "pk-1",
+          title: "My Passkey Account",
+          username: "alice@example.com",
+          urlHost: "example.com",
+          entryType: EXT_ENTRY_TYPE.PASSKEY,
+        },
+      ],
+    });
+
+    render(<MatchList tabUrl="https://example.com" />);
+    const input = await screen.findByPlaceholderText("Search...");
+    fireEvent.change(input, { target: { value: "passkey account" } });
+
+    expect(await screen.findByText("My Passkey Account")).toBeInTheDocument();
+    expect(screen.getByText("Passkey")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Fill" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Copy" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "TOTP" })).toBeNull();
+  });
+
+  // A3b: With empty query, PASSKEY entry is absent from the rendered output
+  it("A3b: PASSKEY entry is absent from default view (empty query)", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      type: "FETCH_PASSWORDS",
+      entries: [
+        {
+          id: "login-1",
+          title: "Regular Login",
+          username: "alice",
+          urlHost: "example.com",
+          entryType: EXT_ENTRY_TYPE.LOGIN,
+        },
+        {
+          id: "pk-1",
+          title: "My Passkey Account",
+          username: "alice@example.com",
+          urlHost: "example.com",
+          entryType: EXT_ENTRY_TYPE.PASSKEY,
+        },
+      ],
+    });
+
+    render(<MatchList tabUrl="https://example.com" />);
+    await screen.findByText("Regular Login");
+    expect(screen.queryByText("My Passkey Account")).toBeNull();
+  });
+
+  // A4: Empty query renders site-context header, matched/other sections; no search results header
+  it("A4: empty query renders site-context header and hides search results header", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      type: "FETCH_PASSWORDS",
+      entries: [
+        {
+          id: "login-1",
+          title: "Example Login",
+          username: "alice",
+          urlHost: "example.com",
+          entryType: EXT_ENTRY_TYPE.LOGIN,
+        },
+        {
+          id: "card-1",
+          title: "My Card",
+          username: "",
+          urlHost: "",
+          entryType: EXT_ENTRY_TYPE.CREDIT_CARD,
+        },
+        {
+          id: "other-login",
+          title: "Other Site Login",
+          username: "bob",
+          urlHost: "other.com",
+          entryType: EXT_ENTRY_TYPE.LOGIN,
+        },
+      ],
+    });
+
+    render(<MatchList tabUrl="https://example.com" />);
+    await screen.findByText("Example Login");
+
+    expect(screen.getByText("Matches for example.com")).toBeInTheDocument();
+    expect(screen.getByText("Other entries")).toBeInTheDocument();
+    expect(screen.queryByText("Search results")).toBeNull();
+    expect(screen.queryByText("Other Site Login")).toBeNull();
+  });
+
+  // A5: Tab-matching entry precedes non-matching entry in DOM order during search
+  it("A5: tab-matching entry precedes cross-domain entry in search results", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      type: "FETCH_PASSWORDS",
+      entries: [
+        {
+          id: "other-1",
+          title: "GitLab",
+          username: "bob",
+          urlHost: "gitlab.com",
+          entryType: EXT_ENTRY_TYPE.LOGIN,
+        },
+        {
+          id: "match-1",
+          title: "GitHub",
+          username: "alice",
+          urlHost: "github.com",
+          entryType: EXT_ENTRY_TYPE.LOGIN,
+        },
+      ],
+    });
+
+    render(<MatchList tabUrl="https://github.com" />);
+    const input = await screen.findByPlaceholderText("Search...");
+    fireEvent.change(input, { target: { value: "git" } });
+
+    await screen.findByText("GitHub");
+    const titles = screen.getAllByRole("listitem").map((li) => li.textContent);
+    const githubIdx = titles.findIndex((t) => t?.includes("GitHub"));
+    const gitlabIdx = titles.findIndex((t) => t?.includes("GitLab"));
+    expect(githubIdx).toBeLessThan(gitlabIdx);
+  });
+
+  // A8: Non-empty query renders search results header; site-context header absent; header present even when empty
+  it("A8: search results header renders when searching; site-context header suppressed", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      type: "FETCH_PASSWORDS",
+      entries: [
+        {
+          id: "login-1",
+          title: "Example",
+          username: "alice",
+          urlHost: "example.com",
+          entryType: EXT_ENTRY_TYPE.LOGIN,
+        },
+      ],
+    });
+
+    render(<MatchList tabUrl="https://example.com" />);
+    const input = await screen.findByPlaceholderText("Search...");
+    fireEvent.change(input, { target: { value: "zzznomatch" } });
+
+    expect(await screen.findByText("Search results")).toBeInTheDocument();
+    expect(screen.queryByText(/Matches for/)).toBeNull();
+    expect(screen.getByText(/no results for/i)).toBeInTheDocument();
+  });
+
+  // A9a: Cross-domain LOGIN search result has Copy and TOTP but no Fill (row-scoped)
+  it("A9a: cross-domain LOGIN search result has Copy and TOTP but no Fill", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      type: "FETCH_PASSWORDS",
+      entries: [
+        {
+          id: "aws-1",
+          title: "AWS Console",
+          username: "alice",
+          urlHost: "aws.amazon.com",
+          entryType: EXT_ENTRY_TYPE.LOGIN,
+        },
+      ],
+    });
+
+    render(<MatchList tabUrl="https://github.com" />);
+    const input = await screen.findByPlaceholderText("Search...");
+    fireEvent.change(input, { target: { value: "aws" } });
+
+    const title = await screen.findByText("AWS Console");
+    const row = title.closest("li") as HTMLElement;
+    const rowScope = within(row);
+    expect(rowScope.queryByRole("button", { name: "Fill" })).toBeNull();
+    expect(rowScope.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+    expect(rowScope.getByRole("button", { name: "TOTP" })).toBeInTheDocument();
+  });
+
+  // A9b: CREDIT_CARD search result on a web page has Fill button (row-scoped)
+  it("A9b: CREDIT_CARD search result on a web page has Fill button", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      type: "FETCH_PASSWORDS",
+      entries: [
+        {
+          id: "card-1",
+          title: "Visa Card",
+          username: "",
+          urlHost: "",
+          entryType: EXT_ENTRY_TYPE.CREDIT_CARD,
+        },
+      ],
+    });
+
+    render(<MatchList tabUrl="https://shop.example.com" />);
+    const input = await screen.findByPlaceholderText("Search...");
+    fireEvent.change(input, { target: { value: "visa" } });
+
+    const title = await screen.findByText("Visa Card");
+    const row = title.closest("li") as HTMLElement;
+    const rowScope = within(row);
+    expect(rowScope.getByRole("button", { name: "Fill" })).toBeInTheDocument();
+  });
+
+  // A1: cross-site LOGIN entry appears in search results and no-results is suppressed
+  it("A1: cross-site LOGIN entry appears when searching from a different tab host", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      type: "FETCH_PASSWORDS",
+      entries: [
+        {
+          id: "gh-1",
+          title: "GitHub",
+          username: "alice",
+          urlHost: "github.com",
+          entryType: EXT_ENTRY_TYPE.LOGIN,
+        },
+        {
+          id: "aws-1",
+          title: "AWS Console",
+          username: "bob",
+          urlHost: "aws.amazon.com",
+          entryType: EXT_ENTRY_TYPE.LOGIN,
+        },
+      ],
+    });
+
+    render(<MatchList tabUrl="https://github.com" />);
+    const input = await screen.findByPlaceholderText("Search...");
+    fireEvent.change(input, { target: { value: "aws" } });
+
+    expect(await screen.findByText("AWS Console")).toBeInTheDocument();
+    expect(screen.queryByText(/no results for/i)).toBeNull();
+  });
+
+  // A2: tabUrl=null with query renders matching entries; no Fill buttons; Copy available for LOGIN
+  it("A2: search with tabUrl=null renders matching entries without Fill buttons", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      type: "FETCH_PASSWORDS",
+      entries: [
+        {
+          id: "bank-1",
+          title: "Bank Login",
+          username: "alice",
+          urlHost: "bank.example.com",
+          entryType: EXT_ENTRY_TYPE.LOGIN,
+        },
+      ],
+    });
+
+    render(<MatchList tabUrl={null} />);
+    const input = await screen.findByPlaceholderText("Search...");
+    fireEvent.change(input, { target: { value: "bank" } });
+
+    expect(await screen.findByText("Bank Login")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Fill" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
   });
 });

--- a/extension/src/messages/en.json
+++ b/extension/src/messages/en.json
@@ -32,7 +32,9 @@
     "httpWarning": "This page uses HTTP. Filling credentials on insecure pages is risky.",
     "unlockSite": "Current site: {host}",
     "badgeCard": "Card",
-    "badgeIdentity": "Identity"
+    "badgeIdentity": "Identity",
+    "searchResults": "Search results",
+    "badgePasskey": "Passkey"
   },
   "options": {
     "title": "Settings",

--- a/extension/src/messages/ja.json
+++ b/extension/src/messages/ja.json
@@ -32,7 +32,9 @@
     "httpWarning": "このページは HTTP です。安全でないページへの入力にはリスクがあります。",
     "unlockSite": "現在のサイト: {host}",
     "badgeCard": "カード",
-    "badgeIdentity": "個人情報"
+    "badgeIdentity": "個人情報",
+    "searchResults": "検索結果",
+    "badgePasskey": "パスキー"
   },
   "options": {
     "title": "設定",

--- a/extension/src/popup/components/MatchList.tsx
+++ b/extension/src/popup/components/MatchList.tsx
@@ -115,6 +115,9 @@ export function MatchList({ tabUrl }: Props) {
     if (type === EXT_ENTRY_TYPE.IDENTITY) {
       return <span className="text-[10px] font-medium text-green-700 bg-green-50 border border-green-200 px-1.5 py-0.5 rounded">{t("popup.badgeIdentity")}</span>;
     }
+    if (type === EXT_ENTRY_TYPE.PASSKEY) {
+      return <span className="text-[10px] font-medium text-amber-700 bg-amber-50 border border-amber-200 px-1.5 py-0.5 rounded">{t("popup.badgePasskey")}</span>;
+    }
     return null;
   };
 
@@ -131,6 +134,7 @@ export function MatchList({ tabUrl }: Props) {
   const sorted = sortByUrlMatch(entries, tabHost);
   const matched = tabHost
     ? sorted.filter((e) => {
+        if (e.entryType === EXT_ENTRY_TYPE.PASSKEY) return false;
         if (e.urlHost && isHostMatch(e.urlHost, tabHost)) return true;
         return (e.additionalUrlHosts ?? []).some((h) => isHostMatch(h, tabHost));
       })
@@ -149,8 +153,8 @@ export function MatchList({ tabUrl }: Props) {
   const displayHost = (e: DecryptedEntry): string => {
     if (e.urlHost && tabHost && isHostMatch(e.urlHost, tabHost)) return e.urlHost;
     if (tabHost) {
-      const matched = (e.additionalUrlHosts ?? []).find((h) => isHostMatch(h, tabHost));
-      if (matched) return matched;
+      const additionalMatch = (e.additionalUrlHosts ?? []).find((h) => isHostMatch(h, tabHost));
+      if (additionalMatch) return additionalMatch;
     }
     return e.urlHost || e.additionalUrlHosts?.[0] || "";
   };
@@ -166,8 +170,78 @@ export function MatchList({ tabUrl }: Props) {
         (e.additionalUrlHosts ?? []).some((h) => h.toLowerCase().includes(lower)),
     );
   };
-  const filteredMatched = filterEntries(matched, query);
-  const filteredUnmatched = filterEntries(unmatched, query);
+
+  // Search mode: query applied to the FULL sorted entry set (FR1/FR3)
+  const isSearching = query !== "";
+  const searchResults = filterEntries(sorted, query);
+
+  // canFill: autofillable type AND on a web page AND (not LOGIN OR host matches tab)
+  const entryMatchesTab = (e: DecryptedEntry): boolean =>
+    tabHost !== null &&
+    (isHostMatch(e.urlHost, tabHost) ||
+      (e.additionalUrlHosts ?? []).some((h) => isHostMatch(h, tabHost)));
+
+  const canFill = (e: DecryptedEntry): boolean =>
+    isAutofillable(e.entryType) &&
+    tabHost !== null &&
+    (e.entryType !== EXT_ENTRY_TYPE.LOGIN || entryMatchesTab(e));
+
+  const renderEntryRow = (e: DecryptedEntry, variant: "matched" | "plain") => {
+    const liClass =
+      variant === "matched"
+        ? "rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors px-3 py-2"
+        : "rounded-md border border-gray-200 dark:border-gray-700 px-3 py-2";
+    const h = displayHost(e);
+    return (
+      <li key={`${e.teamId ?? "personal"}-${e.id}`} className={liClass}>
+        <div className="flex items-center justify-between gap-2 min-w-0">
+          <div className="flex items-center gap-1.5 truncate min-w-0">
+            <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+              {e.title || "(Untitled)"}
+            </span>
+            {entryTypeBadge(e.entryType)}
+            {teamBadge(e.teamName)}
+          </div>
+          {(canFill(e) || e.entryType === EXT_ENTRY_TYPE.LOGIN) && (
+            <div className="flex items-center gap-1 shrink-0">
+              {canFill(e) && (
+                <button
+                  onClick={() => handleFill(e.id, e.entryType, e.teamId)}
+                  disabled={filling}
+                  title={t("popup.fill")}
+                  className="p-1.5 rounded-md text-white bg-gray-900 dark:bg-gray-200 dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-300 active:bg-gray-950 transition-colors disabled:opacity-60"
+                >
+                  <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
+                </button>
+              )}
+              {e.entryType === EXT_ENTRY_TYPE.LOGIN && (
+                <>
+                  <button
+                    onClick={() => handleCopyTotp(e.id, e.teamId)}
+                    title={t("popup.copyTotp")}
+                    className="p-1.5 rounded-md text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600 active:bg-gray-300 dark:active:bg-gray-500 transition-colors"
+                  >
+                    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                  </button>
+                  <button
+                    onClick={() => handleCopy(e.id, e.teamId)}
+                    title={t("popup.copy")}
+                    className="p-1.5 rounded-md text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600 active:bg-gray-300 dark:active:bg-gray-500 transition-colors"
+                  >
+                    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                  </button>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+        {e.username && (
+          <div className="text-xs text-gray-600 dark:text-gray-400">{e.username}</div>
+        )}
+        {h ? <div className="text-xs text-gray-500 dark:text-gray-400">{h}</div> : null}
+      </li>
+    );
+  };
 
   return (
     <div className="flex flex-col gap-2">
@@ -201,131 +275,45 @@ export function MatchList({ tabUrl }: Props) {
             className="h-8 px-2.5 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-xs text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-600 focus:border-gray-900 dark:focus:border-gray-400 transition-shadow"
           />
 
-          {query && filteredMatched.length === 0 && filteredUnmatched.length === 0 && (
+          {isSearching && searchResults.length === 0 && (
             <p className="text-sm text-gray-500 dark:text-gray-400">{t("popup.noResults", { query })}</p>
           )}
 
-          {hasTabUrl && (
+          {isSearching && (
+            <div className="text-xs font-medium text-gray-500 dark:text-gray-400">
+              {t("popup.searchResults")}
+            </div>
+          )}
+
+          {isSearching && searchResults.length > 0 && (
+            <ul className="flex flex-col gap-2">
+              {searchResults.map((e) => renderEntryRow(e, "plain"))}
+            </ul>
+          )}
+
+          {!isSearching && hasTabUrl && (
             <div className="text-xs font-medium text-gray-500 dark:text-gray-400">
               {tabHost
-                ? filteredMatched.length > 0
+                ? matched.length > 0
                   ? t("popup.matchesFor", { host: tabHost })
                   : t("popup.noMatchesFor", { host: tabHost })
                 : t("popup.noMatchesForPage")}
             </div>
           )}
 
-          {filteredMatched.length > 0 && (
+          {!isSearching && matched.length > 0 && (
             <ul className="flex flex-col gap-2">
-              {filteredMatched.map((e) => (
-                <li
-                  key={`${e.teamId ?? "personal"}-${e.id}`}
-                  className="rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors px-3 py-2"
-                >
-                  <div className="flex items-center justify-between gap-2 min-w-0">
-                    <div className="flex items-center gap-1.5 truncate min-w-0">
-                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                        {e.title || "(Untitled)"}
-                      </span>
-                      {entryTypeBadge(e.entryType)}
-                      {teamBadge(e.teamName)}
-                    </div>
-                    {isAutofillable(e.entryType) && (
-                      <div className="flex items-center gap-1 shrink-0">
-                        <button
-                          onClick={() => handleFill(e.id, e.entryType, e.teamId)}
-                          disabled={filling}
-                          title={t("popup.fill")}
-                          className="p-1.5 rounded-md text-white bg-gray-900 dark:bg-gray-200 dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-300 active:bg-gray-950 transition-colors disabled:opacity-60"
-                        >
-                          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
-                        </button>
-                        {e.entryType === EXT_ENTRY_TYPE.LOGIN && (
-                          <>
-                            <button
-                              onClick={() => handleCopyTotp(e.id, e.teamId)}
-                              title={t("popup.copyTotp")}
-                              className="p-1.5 rounded-md text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600 active:bg-gray-300 dark:active:bg-gray-500 transition-colors"
-                            >
-                              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-                            </button>
-                            <button
-                              onClick={() => handleCopy(e.id, e.teamId)}
-                              title={t("popup.copy")}
-                              className="p-1.5 rounded-md text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600 active:bg-gray-300 dark:active:bg-gray-500 transition-colors"
-                            >
-                              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                            </button>
-                          </>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                  {e.username && (
-                    <div className="text-xs text-gray-600 dark:text-gray-400">{e.username}</div>
-                  )}
-                  {(() => { const h = displayHost(e); return h ? <div className="text-xs text-gray-500 dark:text-gray-400">{h}</div> : null; })()}
-                </li>
-              ))}
+              {matched.map((e) => renderEntryRow(e, "matched"))}
             </ul>
           )}
 
-          {tabHost && filteredUnmatched.length > 0 && (
+          {!isSearching && tabHost && unmatched.length > 0 && (
             <div className="text-xs font-medium text-gray-500 dark:text-gray-400">{t("popup.otherEntries")}</div>
           )}
 
-          {filteredUnmatched.length > 0 && (
+          {!isSearching && unmatched.length > 0 && (
             <ul className="flex flex-col gap-2">
-              {filteredUnmatched.map((e) => (
-                <li
-                  key={`${e.teamId ?? "personal"}-${e.id}`}
-                  className="rounded-md border border-gray-200 dark:border-gray-700 px-3 py-2"
-                >
-                  <div className="flex items-center justify-between gap-2 min-w-0">
-                    <div className="flex items-center gap-1.5 truncate min-w-0">
-                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                        {e.title || "(Untitled)"}
-                      </span>
-                      {entryTypeBadge(e.entryType)}
-                      {teamBadge(e.teamName)}
-                    </div>
-                    {isAutofillable(e.entryType) && (
-                      <div className="flex items-center gap-1 shrink-0">
-                        <button
-                          onClick={() => handleFill(e.id, e.entryType, e.teamId)}
-                          disabled={filling}
-                          title={t("popup.fill")}
-                          className="p-1.5 rounded-md text-white bg-gray-900 dark:bg-gray-200 dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-300 active:bg-gray-950 transition-colors disabled:opacity-60"
-                        >
-                          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
-                        </button>
-                        {e.entryType === EXT_ENTRY_TYPE.LOGIN && (
-                          <>
-                            <button
-                              onClick={() => handleCopyTotp(e.id, e.teamId)}
-                              title={t("popup.copyTotp")}
-                              className="p-1.5 rounded-md text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600 active:bg-gray-300 dark:active:bg-gray-500 transition-colors"
-                            >
-                              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-                            </button>
-                            <button
-                              onClick={() => handleCopy(e.id, e.teamId)}
-                              title={t("popup.copy")}
-                              className="p-1.5 rounded-md text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600 active:bg-gray-300 dark:active:bg-gray-500 transition-colors"
-                            >
-                              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                            </button>
-                          </>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                  {e.username && (
-                    <div className="text-xs text-gray-600 dark:text-gray-400">{e.username}</div>
-                  )}
-                  {(() => { const h = displayHost(e); return h ? <div className="text-xs text-gray-500 dark:text-gray-400">{h}</div> : null; })()}
-                </li>
-              ))}
+              {unmatched.map((e) => renderEntryRow(e, "plain"))}
             </ul>
           )}
 

--- a/extension/src/popup/components/MatchList.tsx
+++ b/extension/src/popup/components/MatchList.tsx
@@ -275,14 +275,14 @@ export function MatchList({ tabUrl }: Props) {
             className="h-8 px-2.5 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-xs text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-600 focus:border-gray-900 dark:focus:border-gray-400 transition-shadow"
           />
 
-          {isSearching && searchResults.length === 0 && (
-            <p className="text-sm text-gray-500 dark:text-gray-400">{t("popup.noResults", { query })}</p>
-          )}
-
           {isSearching && (
             <div className="text-xs font-medium text-gray-500 dark:text-gray-400">
               {t("popup.searchResults")}
             </div>
+          )}
+
+          {isSearching && searchResults.length === 0 && (
+            <p className="text-sm text-gray-500 dark:text-gray-400">{t("popup.noResults", { query })}</p>
           )}
 
           {isSearching && searchResults.length > 0 && (


### PR DESCRIPTION
## Summary
- Implement full-vault search in the extension popup while preserving existing non-search behavior.
- Add security-aware fill gating (`canFill`) to prevent cross-domain autofill in search mode.
- Introduce a shared row-render helper and a PASSKEY badge, and de-duplicate duplicated JSX.
- Update i18n, tests, and documentation to cover the new "Search results" UI and behavior.

## Motivation
The popup only filtered entries already displayed for the current tab, causing three problems: (1) LOGIN entries for other sites were unreachable via search, (2) non-web pages (chrome:// etc.) had no searchable entries at all, and (3) PASSKEY entries were never visible. All entries are already fetched and decrypted at popup open, so this is a popup-only change — no backend or service-worker API is touched.

## Implementation notes
- `isSearching = query !== ""`; `searchResults = filterEntries(sortByUrlMatch(entries, tabHost), query)` over the full entry set in `extension/src/popup/components/MatchList.tsx`; no-results condition is `isSearching && searchResults.length === 0`.
- **Security (plan finding S1)**: `performAutofillForEntry` has no host-match check — display suppression was the only gate. New `canFill(e)` renders Fill only for host-matching LOGIN entries (cross-domain LOGIN rows are Copy/TOTP-only; no Fill at all when `tabHost === null`). SW-layer host check + `AUTOFILL` sender validation tracked as `TODO(extension-search-all-vault)` (pre-existing, not widened here).
- Extracted duplicated `<li>` markup into a plain render function `renderEntryRow(e, variant)`; renamed the pre-existing `matched` shadow in `displayHost` (I10).
- **Deviation D1**: PASSKEY is now excluded from the `matched` list too (previously only from "Other entries"), so passkeys appear only in search mode — resolves the A3b/I2 contract conflict; documented in the deviation log.
- New i18n keys `popup.searchResults` ("Search results" / 「検索結果」) and `popup.badgePasskey` ("Passkey" / 「パスキー」) in both locales; search mode shows the "Search results" header and suppresses the site-context/"Other entries" headers (I7).
- Tests: regression A1/A2 (verified failing pre-change), PASSKEY A3a/A3b, empty-query A4, ordering A5, header A8 (incl. DOM-order guard), row-scoped A9a/A9b via `within()`; duplicate test name renamed.

## Review artifacts (triangulate: 3 plan rounds + 2 code-review rounds)
- `docs/archive/review/extension-search-all-vault-plan.md`
- `docs/archive/review/extension-search-all-vault-review.md`
- `docs/archive/review/extension-search-all-vault-deviation.md`
- `docs/archive/review/extension-search-all-vault-code-review.md`

## Test plan
- [x] Extension suite: `npm test` in `extension/` — 759/759 pass
- [x] Root suite: `npx vitest run` — 11,228 pass / 1 pre-existing skip
- [x] `scripts/pre-pr.sh` — 32/32 checks (incl. lint + `next build`)
- [x] Extension build: `npm run build` in `extension/`
- [ ] Manual smoke (VE1, non-gating): load unpacked extension; cross-site search shows Copy-only rows; `chrome://extensions` search returns results without Fill; empty-query view unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)