### PR TITLE
chore(release): sync the iOS app version with release-please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,15 @@ jobs:
           ROOT_VER=$(node -p "require('./package.json').version") || exit 1
           CLI_VER=$(node -p "require('./cli/package.json').version") || exit 1
           EXT_VER=$(node -p "require('./extension/package.json').version") || exit 1
+          # All MARKETING_VERSION lines in project.yml must carry one value
+          # (sort -u collapses them; >1 distinct value fails the comparison).
+          IOS_VER=$(grep -o 'MARKETING_VERSION: "[0-9.]*"' ios/project.yml \
+            | grep -o '[0-9][0-9.]*' | sort -u | tr '\n' ' ' | sed 's/ $//')
 
           echo "Root:      $ROOT_VER"
           echo "CLI:       $CLI_VER"
           echo "Extension: $EXT_VER"
+          echo "iOS:       $IOS_VER"
 
           FAIL=0
           if [ "$CLI_VER" != "$ROOT_VER" ]; then
@@ -114,6 +119,10 @@ jobs:
           fi
           if [ "$EXT_VER" != "$ROOT_VER" ]; then
             echo "::error::Extension version ($EXT_VER) does not match root ($ROOT_VER)"
+            FAIL=1
+          fi
+          if [ "$IOS_VER" != "$ROOT_VER" ]; then
+            echo "::error::iOS MARKETING_VERSION ($IOS_VER) does not match root ($ROOT_VER)"
             FAIL=1
           fi
           exit $FAIL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,7 +508,7 @@ feature PR → merge to main → release-please auto-updates Release PR
 How it works:
 1. Every push to main, release-please analyzes new conventional commits
 2. It creates/updates a "Release PR" with version bump + CHANGELOG
-3. The Release PR updates `package.json`, `cli/package.json`, `extension/package.json` automatically
+3. The Release PR updates `package.json`, `cli/package.json`, `extension/package.json`, and `ios/project.yml` (`MARKETING_VERSION`, via `x-release-please-version` annotations) automatically
 4. When you merge the Release PR, a GitHub Release + git tag is created
 Config files: `release-please-config.json`, `.release-please-manifest.json`
 
@@ -528,6 +528,7 @@ npm run version:bump -- 0.3.0  # Explicit version
 | `package.json` | Single source of truth (SSOT) |
 | `cli/package.json` | Synced by `bump-version.sh` |
 | `extension/package.json` | Synced by `bump-version.sh` |
+| `ios/project.yml` (`MARKETING_VERSION` ×5 targets) | Synced by release-please generic updater (`# x-release-please-version` line annotations) and `bump-version.sh`; xcodegen propagates into Info.plist via `$(MARKETING_VERSION)`. `CURRENT_PROJECT_VERSION` (build number) stays manual |
 | `cli/src/index.ts` | Reads `cli/package.json` at runtime via `createRequire` |
 | `extension/manifest.config.ts` | Imports root `package.json` at build time |
 | `src/lib/openapi-spec.ts` | Independent API version (`1.0.0`) — not synced |

--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -1007,7 +1007,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.4.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOUITests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1027,7 +1027,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.4.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOAutofillExtension";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1050,7 +1050,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.4.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.Shared";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1139,7 +1139,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.4.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOAutofillExtension";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1158,7 +1158,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.4.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOTests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1177,7 +1177,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.4.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOUITests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1258,7 +1258,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.4.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1277,7 +1277,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.4.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1296,7 +1296,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.4.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOTests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1320,7 +1320,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.4.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.Shared";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -49,7 +49,7 @@ targets:
         SKIP_INSTALL: YES
         GENERATE_INFOPLIST_FILE: YES
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "0.4.56" # x-release-please-version
 
   PasswdSSOApp:
     type: application
@@ -106,7 +106,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: jp.jpng.passwd-sso
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "0.4.56" # x-release-please-version
         TARGETED_DEVICE_FAMILY: "1"
         # Single-size (1024) AppIcon in PasswdSSOApp/Assets.xcassets. xcodegen
         # also auto-derives this from the AppIcon.appiconset presence; the
@@ -173,7 +173,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: jp.jpng.passwd-sso.PasswdSSOAutofillExtension
         APPLICATION_EXTENSION_API_ONLY: YES
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "0.4.56" # x-release-please-version
         TARGETED_DEVICE_FAMILY: "1"
     dependencies:
       - target: Shared
@@ -206,7 +206,7 @@ targets:
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/PasswdSSOApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PasswdSSOApp
         BUNDLE_LOADER: $(TEST_HOST)
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "0.4.56" # x-release-please-version
     dependencies:
       - target: Shared
         link: true
@@ -228,7 +228,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: jp.jpng.passwd-sso.PasswdSSOUITests
         TEST_TARGET_NAME: PasswdSSOApp
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "0.4.56" # x-release-please-version
     dependencies:
       - target: PasswdSSOApp
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,10 @@
           "type": "json",
           "path": "extension/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "generic",
+          "path": "ios/project.yml"
         }
       ]
     }

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -114,6 +114,19 @@ for PKG in "$ROOT/package.json" "$ROOT/cli/package.json" "$ROOT/extension/packag
   echo "Updated: $PKG → $VERSION"
 done
 
+# Sync the iOS app's marketing version (xcodegen project.yml is the SSoT for
+# build settings; CI regenerates the pbxproj from it). Matches the lines
+# annotated for release-please's generic updater.
+node -e "
+  const fs = require('fs');
+  const p = process.argv[1];
+  let s = fs.readFileSync(p, 'utf8');
+  s = s.replace(/MARKETING_VERSION: \"[0-9]+\.[0-9]+\.[0-9]+\"/g,
+                'MARKETING_VERSION: \"' + process.argv[2] + '\"');
+  fs.writeFileSync(p, s);
+" "$ROOT/ios/project.yml" "$VERSION"
+echo "Updated: $ROOT/ios/project.yml → $VERSION"
+
 # Sync lock files
 for DIR in "$ROOT" "$ROOT/cli" "$ROOT/extension"; do
   if [ -f "$DIR/package-lock.json" ]; then
@@ -126,7 +139,7 @@ echo ""
 echo "Version bumped to $VERSION"
 echo ""
 echo "Next steps:"
-echo "  git add package.json cli/package.json extension/package.json"
+echo "  git add package.json cli/package.json extension/package.json ios/project.yml"
 echo "  git add package-lock.json cli/package-lock.json extension/package-lock.json"
 echo "  git commit -m 'chore: bump version to $VERSION'"
 echo "  git tag v$VERSION"


### PR DESCRIPTION
## Summary

The iOS targets' `MARKETING_VERSION` was frozen at `0.1.0` while root `package.json` (the documented version SSoT) moved on to `0.4.56`. This wires the iOS app into the existing release-please flow so the Release PR bumps it together with `cli/` and `extension/`.

## Changes

- **ios/project.yml** — the five `MARKETING_VERSION` lines set to the current root version (`0.4.56`) and annotated with `# x-release-please-version`; xcodegen propagates into the pbxproj and Info.plist via `$(MARKETING_VERSION)`
- **release-please-config.json** — `ios/project.yml` registered as a `generic` extra-file, so the Release PR rewrites the annotated lines automatically
- **scripts/bump-version.sh** — the manual fallback rewrites the same lines (annotation-preserving; verified)
- **CI `version-check`** — now fails when any `MARKETING_VERSION` drifts from root (`sort -u` collapses the five lines, so a split value also fails)
- **CLAUDE.md** — Version Locations table + release-process description updated

`CURRENT_PROJECT_VERSION` (build number) intentionally stays manual.

## Verification

- YAML validity (ci.yml / project.yml), iOS app build green
- version-check simulated locally: root=ios=0.4.56 PASS
- bump-script replacement tested against a copy — annotations preserved

## Operational note

The Release PR updates `project.yml` only; the committed pbxproj follows the next `xcodegen generate` (ios-ci regenerates before building, so CI is always consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)