### PR TITLE
feat(ios): auto-copy TOTP to clipboard after AutoFill login (opt-in)

### DIFF
--- a/docs/archive/review/ios-auto-copy-totp-manual-test.md
+++ b/docs/archive/review/ios-auto-copy-totp-manual-test.md
@@ -1,0 +1,38 @@
+# Manual Test: ios-auto-copy-totp
+
+Security-sensitive (AutoFill credential-fill path). Run on a real device or simulator with a synced
+vault containing at least one LOGIN entry that has a TOTP secret.
+
+## Pre-conditions
+- Server URL configured, signed in, vault unlocked at least once (AutoFill cache populated).
+- A LOGIN entry `<totp-login>` with a TOTP secret; a second LOGIN entry `<plain-login>` without TOTP.
+- passwd-sso enabled under Settings → Passwords → Password Options as an AutoFill provider.
+
+## Steps / Expected
+
+1. **Default is OFF.** Fresh install (or after deleting the app): open Settings → Clipboard. "Auto-copy
+   TOTP after fill" is **off**. → Fill `<totp-login>` in Safari; the clipboard does NOT contain the TOTP
+   (paste into Notes shows nothing new).
+2. **Enable + picker fill.** Turn the toggle ON. In Safari, tap the AutoFill key icon, choose
+   `<totp-login>` from the list (picker path). → username/password fill; paste into the 2FA field shows
+   the current 6-digit code; it matches the code shown in the app's entry detail.
+3. **QuickType direct fill.** On a form where iOS shows `<totp-login>` directly above the keyboard, tap
+   it (single-credential `prepareInterfaceToProvideCredential` path). → TOTP is also copied (both paths).
+4. **No TOTP entry.** Fill `<plain-login>`. → nothing copied; no error.
+5. **Auto-clear.** After a copy, wait `clipboardClearSeconds` (Settings → Clipboard → Auto-Clear). →
+   pasting afterward yields nothing (clipboard expired).
+6. **Non-default TOTP params.** If available, an entry with an 8-digit / SHA256 TOTP → the copied code
+   matches the app's displayed code (param fidelity).
+
+## Adversarial
+- **Foreground-app clipboard read.** With the toggle ON, after a fill the calling app foregrounds and
+  could read `UIPasteboard`. Confirm the exposure is bounded: the value is `.localOnly` (Step 7) and
+  expires (Step 5). This is why the default is OFF (opt-in).
+- **Universal Clipboard.** With Handoff enabled and a second Apple device on the same iCloud account,
+  after a copy the TOTP does NOT appear in the other device's clipboard (`.localOnly: true`).
+- **Setting tamper.** N/A by design — the setting is a non-secret App Group bool; toggling it OFF
+  immediately stops copying on the next fill.
+
+## Rollback
+Revert the branch / disable the toggle. No persisted state beyond the `autoCopyTotp` App Group bool
+(absent → OFF). No server-side change.

--- a/docs/archive/review/ios-auto-copy-totp-manual-test.md
+++ b/docs/archive/review/ios-auto-copy-totp-manual-test.md
@@ -25,6 +25,10 @@ vault containing at least one LOGIN entry that has a TOTP secret.
    matches the app's displayed code (param fidelity).
 
 ## Adversarial
+- **Corrupted TOTP secret still fills.** With the toggle ON, fill an entry whose `totpSecret` is invalid
+  base32 (or otherwise un-generatable). → the username/password fill STILL completes normally; nothing is
+  copied; no crash. (Verifies the best-effort invariant the VC path can't unit-test against the sealed
+  `ASCredentialProviderExtensionContext`; the `totpToCopy`-returns-nil half is unit-covered.)
 - **Foreground-app clipboard read.** With the toggle ON, after a fill the calling app foregrounds and
   could read `UIPasteboard`. Confirm the exposure is bounded: the value is `.localOnly` (Step 7) and
   expires (Step 5). This is why the default is OFF (opt-in).

--- a/docs/archive/review/ios-auto-copy-totp-plan.md
+++ b/docs/archive/review/ios-auto-copy-totp-plan.md
@@ -1,0 +1,186 @@
+# Plan: ios-auto-copy-totp
+
+> Revised after Phase-1 round-1 review (functionality / security / testing). See
+> `ios-auto-copy-totp-review.md`. Key corrections: two password-fill paths (not one);
+> `AppSettingsStore` must move to `Shared`; default is **OFF** (opt-in); TOTP params
+> (algorithm/digits/period) must propagate; clipboard writer is an injectable seam.
+
+## Project context
+
+- **Type**: mixed (SwiftUI iOS host app + ASCredentialProvider AutoFill extension, under `ios/`).
+- **Test infrastructure**: XCTest unit tests (via `xcodebuild test`); no E2E. Launch-screen UI smoke tests only.
+- Base branch: `feat/ios-auto-copy-totp` from `ios-main` (== `origin/main`, post-#552/#554). Local `main` is STALE.
+
+## Objective
+
+After a successful AutoFill **login (password) fill**, optionally copy the entry's current TOTP code to
+the clipboard — matching the browser extension's `autoCopyTotp` — gated by a user setting (**default
+OFF**) and respecting `clipboardClearSeconds` auto-clear. Closes parity item 4 (`autoCopyTotp`).
+
+## Requirements
+
+### Functional
+- When the user fills a **login** credential via AutoFill and that entry has a TOTP secret, AND
+  `autoCopyTotp` is enabled, copy the freshly-generated TOTP code to the clipboard.
+- Both interactive password-fill paths are covered (see C3): the picker path AND the
+  single-credential `prepareInterfaceToProvideCredential` path.
+- The clipboard entry auto-clears after `clipboardClearSeconds` and must NOT sync to other devices
+  (Universal Clipboard off).
+- A new Settings toggle "Auto-copy TOTP after fill" (localized en/ja), **default OFF**.
+
+### Non-functional
+- Entirely offline inside the extension; TOTP secret + params come from the already-decrypted detail blob.
+- Copy completes BEFORE `extensionContext.completeRequest(...)` dismisses the extension.
+- No behavior change to the standalone OS one-time-code fill (`completeTOTPFill` / `ASOneTimeCodeCredential`).
+- TOTP generation failure MUST NOT block the password fill (best-effort).
+
+## Technical approach
+
+### Two fill paths (round-1 F1/T5 correction)
+The extension completes interactive login fills via **two** sites, both confirmed on post-#552 main
+(`ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift`):
+1. `completePasswordFill(for:)` (~L401) — the picker `onSelect` path.
+2. `prepareInterfaceToProvideCredential(for:)` `.password` case (~L189-227) — iOS supplies a single
+   already-chosen credential (QuickType direct tap); decrypts detail and calls `completeRequest` directly,
+   NOT via `completePasswordFill`.
+
+Both decrypt `VaultEntryDetail` (which carries `totpSecret`) before completing. The auto-copy must fire
+at BOTH. To avoid divergence, the copy decision+side-effect is a single helper called from both sites.
+
+The non-interactive `provideCredentialWithoutUserInteraction` path cancels/escalates (cannot decrypt
+offline without the biometric bridge_key read) — OUT of scope, documented.
+
+### Settings access from the extension (round-1 F2/T1 correction)
+`AppSettingsStore` currently lives in the `PasswdSSOApp` app target; an app-extension cannot link the
+host binary, so it cannot import the type. **Fix: move `AppSettingsStore` (and the `UserDefaults.appGroup`
+extension + the `VaultTimeoutAction`/`AppTheme` enums it defines) into the `Shared` framework**, made
+`public`, so both the app and the extension `import Shared` and read the same App Group suite. The
+underlying `UserDefaults` data was always shared; only the *type* needs relocating. `AutoLockLimits` is
+already in `Shared`.
+
+### TOTP parameter fidelity (round-1 F3 — pre-existing bug, changed file → fix now)
+`EntryBlobDecoder.detail()` currently maps only `totpSecret`, dropping `TotpPayload.algorithm/digits/period`;
+`completeTOTPFill` then calls `TOTPParams(secret:)` with SHA1/6/30 defaults → wrong codes for non-default
+TOTP configs. Since `CredentialProviderViewController` and `EntryBlobDecoder` are both changed by this PR,
+fix it here: thread `totpAlgorithm/totpDigits/totpPeriod` onto `VaultEntryDetail`, populate them in
+`detail()`, and construct full `TOTPParams` in BOTH the new copy path and the existing `completeTOTPFill`.
+
+### Clipboard helper + testable seam (round-1 T2/S2 corrections)
+`UIPasteboard` write options are not readable back, so the helper takes an injectable writer. `UIPasteboard`
+is extension-safe, so `import UIKit` compiles under the Shared framework's `APPLICATION_EXTENSION_API_ONLY`
+(verified at build). The three existing inline clipboard sites adopt the new helper (R17/R22 — done now, not deferred).
+
+## Contracts
+
+### C1 — `SecureClipboard` + injectable `PasteboardWriter` (Shared)
+- **New file**: `ios/Shared/Clipboard/SecureClipboard.swift` (target: Shared).
+- **Signatures**:
+  ```swift
+  import UIKit
+  public protocol PasteboardWriter { func write(_ value: String, options: [UIPasteboard.OptionsKey: Any]) }
+  public struct SystemPasteboardWriter: PasteboardWriter {
+    public init() {}
+    public func write(_ value: String, options: [UIPasteboard.OptionsKey: Any]) {
+      UIPasteboard.general.setItems([[UIPasteboard.typeAutomatic: value]], options: options)
+    }
+  }
+  public enum SecureClipboard {
+    static let minClearSeconds = 1, maxClearSeconds = 600
+    /// Local-only (no Universal Clipboard), auto-expiring copy. `seconds` is clamped to [1,600].
+    public static func copy(_ value: String, clearAfter seconds: Int,
+                            writer: PasteboardWriter = SystemPasteboardWriter())
+  }
+  ```
+- **Body**: `let bounded = max(minClearSeconds, min(maxClearSeconds, seconds)); writer.write(value, options: [.localOnly: true, .expirationDate: Date().addingTimeInterval(Double(bounded))])`.
+- **Invariants**: `.localOnly: true` and a finite future `.expirationDate` ALWAYS set; `seconds` clamped (S2).
+- **Acceptance**: a `MockPasteboardWriter` captures `options`; tests assert `.localOnly == true`, `.expirationDate` is in the future, and clamping at both bounds.
+
+### C2 — `AppSettingsStore.autoCopyTotp` + relocation to Shared
+- **Move**: `AppSettingsStore.swift` → `ios/Shared/Storage/AppSettingsStore.swift`; make `AppSettingsStore`, `VaultTimeoutAction`, `AppTheme`, `UserDefaults.appGroup` `public`. Update `project.yml` source membership (file moves from app-only path into Shared's path) and the test target import.
+- **New property**: `public var autoCopyTotp: Bool { get nonmutating set }`, `Key.autoCopyTotp = "autoCopyTotp"`.
+- **Semantics — default OFF (fail-closed, consistent with the class's documented contract)**:
+  ```swift
+  var autoCopyTotp: Bool {
+    get { defaults.bool(forKey: Key.autoCopyTotp) }   // absent → false
+    nonmutating set { defaults.set(newValue, forKey: Key.autoCopyTotp) }
+  }
+  ```
+- **Invariant**: absent key → `false`. No fail-open exception to the class contract (resolves S1/S4/S7).
+- **Consumer-flow walkthrough**:
+  - Consumer A (extension, C3) `import Shared` → `AppSettingsStore()` reads `{ autoCopyTotp, clipboardClearSeconds }` from the App Group suite. Type now visible to the extension (post-move). ✓
+  - Consumer B (host `SettingsView`) reads/writes `autoCopyTotp` via a `Toggle`. ✓
+- **Acceptance**: absent→false; set true→true; set false→false; cross-suite round-trip (app writes, extension-side instance reads same suite).
+
+### C3 — `totpToCopy` decision seam + hook at BOTH fill paths
+- **New pure function** (target: Shared, so `PasswdSSOTests` can test it):
+  ```swift
+  /// Returns the TOTP code to copy, or nil. Pure; swallows generation errors.
+  public func totpToCopy(detail: VaultEntryDetail, autoCopy: Bool, now: Date) -> String?
+  ```
+  Body: `guard autoCopy, let secret = detail.totpSecret else { return nil }; return try? generateTOTPCode(params: TOTPParams(secret: secret, algorithm: detail.totpAlgorithm, digits: detail.totpDigits, period: detail.totpPeriod), at: now)` (using the C-F3 params).
+- **Hook** — in `CredentialProviderViewController`, a private helper called from BOTH sites, BEFORE each `completeRequest(withSelectedCredential:)`:
+  ```swift
+  private func autoCopyTotpIfEnabled(_ detail: VaultEntryDetail) {
+    let s = AppSettingsStore()
+    if let code = totpToCopy(detail: detail, autoCopy: s.autoCopyTotp, now: Date()) {
+      SecureClipboard.copy(code, clearAfter: s.clipboardClearSeconds)
+    }
+  }
+  ```
+  Called in `completePasswordFill` and in `prepareInterfaceToProvideCredential`'s `.password` case, each immediately before its existing `completeRequest`.
+- **Invariants**: best-effort (nil → no copy, fill always completes); copy strictly before `completeRequest`; `completeTOTPFill` (OS one-time-code path) UNCHANGED.
+- **Forbidden patterns**:
+  - `pattern: completeTOTPFill[\s\S]{0,200}SecureClipboard` — reason: must NOT touch the OS one-time-code path.
+  - `pattern: completeRequest\(withSelectedCredential[\s\S]{0,80}(SecureClipboard|autoCopyTotpIfEnabled)` — reason: copy must precede completeRequest.
+- **Acceptance**: `totpToCopy` matrix (below); both fill sites invoke `autoCopyTotpIfEnabled` before completion (code-review + grep).
+
+### C4 — TOTP param fidelity (F3)
+- `VaultEntryDetail` gains `totpAlgorithm: String?`, `totpDigits: Int?`, `totpPeriod: Int?`.
+- `EntryBlobDecoder.detail()` populates them from `p.totp`.
+- `completeTOTPFill` and `totpToCopy` build `TOTPParams(secret:algorithm:digits:period:)`.
+- **R19 note**: `VaultEntryDetail` gains fields → update its memberwise-init call sites in tests (CredentialResolverTests stub) with defaults.
+- **Acceptance**: detail decode test asserts algorithm/digits/period propagate; a SHA256/8-digit vector generates the correct code.
+
+### C5 — Settings toggle (localized, default OFF)
+- Add a `Toggle("Auto-copy TOTP after fill", isOn:)` bound to `AppSettingsStore().autoCopyTotp` in `SettingsView`'s clipboard/security section, with an explanatory footnote. en + 「入力後にTOTPを自動コピー」(ja).
+- **Acceptance**: toggling persists under `autoCopyTotp` (C2 tests).
+
+### C6 — Adopt `SecureClipboard` at existing sites (R17/R22, done now)
+- Migrate `EntryDetailView.copySecurely` (~L234) and `TOTPCodeView` (~L80) to call `SecureClipboard.copy(value, clearAfter: AppSettingsStore().clipboardClearSeconds)`. No behavior change (same options).
+- **Acceptance**: build + existing tests green; the raw `UIPasteboard.general.setItems(...)` literal no longer appears at those two sites.
+
+## Testing strategy
+
+- **C1**: `MockPasteboardWriter` asserts options (`.localOnly`, future `.expirationDate`) + clamp at 1 and 600.
+- **C2**: `AppSettingsStoreTests` — absent→false, true/false round-trip, cross-suite (app writes / extension-side reads same `suiteName`). (T6)
+- **C3 `totpToCopy` matrix** (5 cases, T7): (1) autoCopy=false→nil; (2) autoCopy=true,secret=nil→nil; (3) true,valid→code; (4) true,malformed secret→nil (throw swallowed, T4); (5) true,valid,fixed `now`→exact RFC-6238 vector.
+- **C4**: detail decode propagates algorithm/digits/period; non-default-param code vector.
+- **C6**: existing EntryDetail/TOTP tests stay green.
+- **Manual-test artifact** (R35, security-sensitive auth flow): `docs/archive/review/ios-auto-copy-totp-manual-test.md` — Pre-conditions, Steps, Expected, Rollback, + Adversarial (foreground app reads clipboard after fill; setting tamper via App Group; non-default TOTP config).
+- Full `xcodebuild test` before completion.
+
+## Considerations & constraints
+
+- **Default OFF** (decided): the iOS threat model differs from the browser extension — after `completeRequest`, the calling (possibly hostile) app foregrounds and can read `UIPasteboard.general`. Opt-in avoids silently weakening 2FA. `.localOnly` + finite `.expirationDate` further bound exposure once enabled.
+- **Out of scope**: non-interactive QuickType fill (can't decrypt offline); team-entry fills (personal-only, per #537).
+- **Build risk** (F4): `import UIKit` in Shared under `APPLICATION_EXTENSION_API_ONLY` — `UIPasteboard` is extension-safe; confirmed at build. If it unexpectedly fails, fall back to placing `SecureClipboard` in a tiny extension-API-only-clean spot, but the expectation is it compiles.
+
+## User operation scenarios
+
+1. Setting ON, login WITH TOTP, picker fill → password fills, TOTP on clipboard, clears after N s.
+2. Setting ON, same entry, QuickType direct tap (`prepareInterfaceToProvideCredential`) → TOTP also copied (both paths).
+3. Setting OFF (default) → nothing copied.
+4. Non-default TOTP (SHA256/8-digit) → correct code copied (C4).
+5. Malformed secret → password still fills, no copy, no crash.
+6. Another device → TOTP not propagated (`.localOnly`).
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | `SecureClipboard` + injectable `PasteboardWriter` (Shared, clamped) | locked |
+| C2 | `AppSettingsStore` → Shared + `autoCopyTotp` (default OFF) | locked |
+| C3 | `totpToCopy` seam + hook at BOTH fill paths | locked |
+| C4 | TOTP param fidelity (algorithm/digits/period) | locked |
+| C5 | Settings toggle (localized, default OFF) | locked |
+| C6 | Adopt `SecureClipboard` at existing 2 sites | locked |

--- a/docs/archive/review/ios-auto-copy-totp-review.md
+++ b/docs/archive/review/ios-auto-copy-totp-review.md
@@ -1,0 +1,56 @@
+# Plan Review: ios-auto-copy-totp
+
+Date: 2026-06-13
+Review round: 1 (functionality / security / testing, 3 parallel expert sub-agents)
+
+## Changes from Previous Round
+
+Initial review. All findings grounded against post-#552 `origin/main`.
+
+## Functionality Findings
+
+- **F1 [Critical] — second password-fill path bypasses `completePasswordFill`.** `prepareInterfaceToProvideCredential(.password)` (CredentialProviderViewController ~L189-227) decrypts detail and calls `completeRequest` directly; the plan's "single funnel" premise was wrong. **Resolved** → C3 now hooks BOTH sites via `autoCopyTotpIfEnabled`.
+- **F2 [Critical] — `AppSettingsStore` not importable from the extension** (lives in `PasswdSSOApp` target; app-extensions can't link the host). **Resolved** → C2 moves it to `Shared`, made public.
+- **F3 [Major] — `VaultEntryDetail.totpSecret` drops algorithm/digits/period** (EntryBlobDecoder.detail), so non-default TOTP configs generate wrong codes; pre-existing bug in a changed file. **Resolved** → C4 propagates the params and fixes `completeTOTPFill` too.
+- **F4 [Major] — Shared is `APPLICATION_EXTENSION_API_ONLY` with no UIKit imports today;** adding `UIPasteboard` is an unvalidated build risk. **Resolved (accepted)** → `UIPasteboard` is extension-safe; confirmed at build (Considerations notes fallback).
+- **F5/F6 [Minor]** — double `AppSettingsStore()` init; pseudocode ordering. **Resolved** → C3 reads settings once.
+
+## Security Findings
+
+- **S1/S7 [Major] — default-ON silently copies a 2FA code; iOS threat model differs from the extension** (calling app foregrounds after `completeRequest` and can read `UIPasteboard`). **Resolved (user decision)** → default **OFF**, opt-in.
+- **S2 [Minor] — `SecureClipboard.copy` had no bound on `clearAfter`.** **Resolved** → clamped [1,600] in C1.
+- **S4 [Minor] — fail-open `autoCopyTotp` would break the `AppSettingsStore` "fail-closed" class contract.** **Resolved** → default OFF is fail-closed, contract intact.
+- S5/S6 confirmed clean (no logging of secret; `.localOnly` closes Universal Clipboard).
+- **R17/R22 [Major, Adjacent-F] — existing clipboard sites not migrated.** **Resolved** → C6 migrates both now.
+- **R35 [Adjacent-T] — no manual-test plan for the auth-flow change.** **Resolved** → manual-test artifact required (Testing strategy).
+
+## Testing Findings
+
+- **T1 [Critical]** = F2 (extension can't access AppSettingsStore → C3 test won't compile). **Resolved** via C2 move.
+- **T2 [Critical/RT2] — `UIPasteboard` write-options are not readable back;** the planned "assert expirationDate" acceptance was unreachable. **Resolved** → injectable `PasteboardWriter` seam (C1).
+- **T3 [Major] — `totpToCopy` placed in extension target would be untestable** (PasswdSSOTests doesn't link the extension). **Resolved** → placed in `Shared`.
+- **T4 [Major] — no regression test for "fill completes even if TOTP throws".** **Resolved** → matrix case 4.
+- **T5 [Major]** = F1 (second fill path). **Resolved**.
+- **T6 [Major] — no cross-App-Group-suite round-trip test.** **Resolved** → C2 acceptance.
+- **T7/T8 [Minor]** — explicit 5-case matrix; tearDown clipboard clear. **Resolved**.
+
+## Adjacent Findings
+
+- R17/R22 (security→functionality): existing site migration — folded into C6.
+- R35 (security→testing): manual-test artifact — folded into Testing strategy.
+
+## Resolution Summary
+
+All Critical/Major findings reflected in the revised plan (`ios-auto-copy-totp-plan.md`). No findings
+deferred. The round-1 corrections were structural plan errors (wrong fill-path count, wrong target
+membership, unreachable test assertion) rather than design disputes; the revised contracts address each.
+Phase-3 review will verify the implemented diff against these resolutions.
+
+## Recurring Issue Check (consolidated)
+
+R1 helper extraction (SecureClipboard, clean) · R3/R17/R22 propagation (existing sites migrated, C6) ·
+R19 memberwise-init updates (C4 note) · R25 persist/hydrate (autoCopyTotp getter+setter, default-absent
+= false) · R34 pre-existing bug in changed file (F3 totp params, fixed) · R35 manual-test artifact (added).
+RS1-RS4: no credential comparison / no new endpoint / no network boundary / no PII in artifacts.
+RT1 mock-reality (VaultEntryDetail stub matches) · RT2 testability (PasteboardWriter seam) · RT5 call-path
+includes `generateTOTPCode`. Others N/A (no DB/event/migration/CI surface).

--- a/docs/archive/review/ios-category-landing-plan.md
+++ b/docs/archive/review/ios-category-landing-plan.md
@@ -1,0 +1,186 @@
+# Plan: ios-category-landing
+
+## Project context
+
+- **Type**: web-app-adjacent native client — SwiftUI iOS host app under `ios/PasswdSSOApp`. UI redesign of the post-unlock landing surface.
+- **Test infrastructure**: unit tests only (XCTest via `xcodebuild test`). No snapshot/UI-assertion harness beyond launch smoke tests — so view *logic* (counts, filtering, category model) is unit-tested; pixel layout is not.
+- Base branch: `feat/ios-category-landing` from `ios-main` (tracks `origin/main`). Local `main` ref is STALE.
+
+## Objective
+
+Replace the flat post-unlock password list with an Apple-Passwords-style **category landing grid**: cards
+for All / entry types / Codes / Favorites / Tags, each showing a count, drilling into a filtered list
+(the existing `VaultListView` rendering). Closes parity roadmap item 6.
+
+## Requirements
+
+### Functional
+- After unlock, show a grid of category cards (count + icon + localized label) instead of the flat list.
+- Tapping a card pushes a filtered entry list (reusing the current list row + `EntryDetailView` nav).
+- Categories (in-scope this branch):
+  - **All** — every active personal entry (always shown).
+  - **By entry type** — Login, Secure Note, Credit Card, Identity, Bank Account, SSH Key, Software License, Passkey. A type card is shown ONLY when its count > 0 (Apple-Passwords behavior).
+  - **Codes** — entries with `hasTOTP == true`.
+  - **Favorites** — entries with `isFavorite == true`.
+  - **Tags** — one entry per distinct tag, with per-tag count.
+- Search remains available (within All, or globally from the landing — see C6).
+
+### Deferred (explicit, with rationale — see Considerations)
+- **Trash (削除済み)** — the offline cache does not currently store trashed/archived entries; supporting this needs a sync/fetch change (server already exposes `isArchived`, but trashed rows aren't synced to the device). Architecture leaves a slot for it.
+- **Watchtower-Security** — no iOS security-audit backend or client exists; web-only today. Out of scope until a security-scan API client lands.
+
+### Non-functional
+- Counts computed from already-decrypted summaries in memory — no extra network or decrypt.
+- Legacy cache rows (no `entryType`) MUST still appear (treated as Login) — no entry silently disappears.
+- Backward compatible: a device with an old cache (missing the new fields) degrades gracefully (no crash, entries default to Login / not-favorite) until the next sync repopulates.
+
+## Technical approach
+
+### Data gap and propagation
+`VaultEntrySummary` (`ios/Shared/Models/VaultEntrySummary.swift`) currently lacks `entryType` and
+`isFavorite`; both are non-secret metadata already present on the wire model `EncryptedEntry`
+(`ios/PasswdSSOApp/Vault/EntryFetcher.swift:7-13`: `entryType: String`, `isFavorite: Bool`,
+`isArchived: Bool`). They are dropped in `EncryptedEntry.toPersonalCacheEntry()` and never reach the
+summary. The fix is a straight propagation: wire → `CacheEntry` → `VaultEntrySummary`.
+
+- `CacheEntry` (`ios/Shared/AutoFill/CredentialResolver.swift:199-216`) already carries
+  `entryType: String?` (added for passkeys). Add `isFavorite: Bool?` (optional → legacy rows decode as nil → false).
+- `EncryptedEntry.toPersonalCacheEntry()` copies `isFavorite` alongside the existing `entryType`.
+- `EntryBlobDecoder.summary(_:)` (`ios/Shared/Models/EntryBlobDecoder.swift:80-103`) copies `entryType`
+  and `isFavorite` from the `CacheEntry` into the produced `VaultEntrySummary`.
+
+`entryType` stays a raw `String?` end-to-end (the wire contract is a string); a presentation enum
+(`EntryTypeCategory`) maps known raw values to labels/icons, with unknown/nil → Login.
+
+### View architecture
+- New `VaultCategoryLandingView` becomes the content rendered by `RootView` for `.vaultUnlocked`
+  (replacing the direct `VaultListView`). It owns the `NavigationStack`.
+- Each card is a `NavigationLink { VaultListView(category: …) } label: { CategoryCard(…) }`.
+- `VaultListView` gains an optional `category:` input; when set, it filters to that category and is a
+  pushed detail screen (no longer the root `NavigationStack` owner — the landing owns it). When the
+  category is `.all`, behavior == today's full list.
+- `VaultViewModel` is shared (single source of decrypted summaries). Category filtering is a pure
+  computed function (C3); the landing reads counts from the same view model.
+
+## Contracts
+
+### C1 — Summary/cache field propagation
+- **Files**: `ios/Shared/Models/VaultEntrySummary.swift`, `ios/Shared/AutoFill/CredentialResolver.swift` (CacheEntry), `ios/PasswdSSOApp/Vault/EntryFetcher.swift` (`toPersonalCacheEntry`), `ios/Shared/Models/EntryBlobDecoder.swift` (`summary`).
+- **Signatures**:
+  - `VaultEntrySummary` gains `public let entryType: String?` and `public let isFavorite: Bool` (non-optional; default false at decode).
+  - `CacheEntry` gains `public let isFavorite: Bool?` (optional for legacy rows; already has `entryType: String?`).
+  - `toPersonalCacheEntry()` sets `isFavorite: self.isFavorite` (from `EncryptedEntry`).
+  - `EntryBlobDecoder.summary(_ entry: CacheEntry) -> VaultEntrySummary` sets `entryType: entry.entryType`, `isFavorite: entry.isFavorite ?? false`.
+- **Invariants**:
+  - `VaultEntrySummary` remains `Codable`; adding fields must not break decode of any persisted summary cache. **Decode-compat check**: if summaries are persisted as JSON anywhere, the new non-optional `isFavorite` needs a default — make the decoder tolerate absence (custom `init(from:)` or optional-with-default). Verify whether summaries are persisted or always rebuilt from `CacheEntry` each launch (if always rebuilt, no migration needed).
+  - Legacy `CacheEntry` (no `entryType`, no `isFavorite`) → summary with `entryType == nil`, `isFavorite == false`. No crash, no dropped entry.
+- **Consumer-flow walkthrough**:
+  - Consumer A (`VaultCategoryLandingView` / C3 count function) reads `{ entryType, hasTOTP, isFavorite, tags }` from each summary and uses them to bucket+count. All four must be present on the summary → C1 adds the two missing ones. ✓
+  - Consumer B (`VaultListView` row, existing) reads `{ title, username, urlHost, hasTOTP, relyingPartyId }` — unaffected by additions. ✓
+  - Consumer C (AutoFill extension, existing `CredentialResolver` consumers of `CacheEntry`) — adding an optional `isFavorite` to `CacheEntry` is additive; existing reads unaffected. ✓
+- **Acceptance**: decode tests — legacy cache row → `entryType nil`/`isFavorite false`; populated row → values propagate to summary.
+
+### C2 — `EntryTypeCategory` presentation enum
+- **New file**: `ios/Shared/Models/EntryTypeCategory.swift` (or host target if presentation-only).
+- **Signature**:
+  ```swift
+  public enum EntryTypeCategory: String, CaseIterable {
+    case login = "LOGIN", secureNote = "SECURE_NOTE", creditCard = "CREDIT_CARD",
+         identity = "IDENTITY", bankAccount = "BANK_ACCOUNT", sshKey = "SSH_KEY",
+         softwareLicense = "SOFTWARE_LICENSE", passkey = "PASSKEY"
+    public static func from(rawType: String?) -> EntryTypeCategory  // nil/unknown → .login
+    public var sfSymbol: String { get }
+    // display label provided at the view layer via String(localized:) keyed on the case
+  }
+  ```
+- **Invariant**: `from(rawType:)` is total — every `String?` maps to a case; unknown raw strings and `nil` map to `.login` (so no entry is uncategorizable). This mirrors the wire default.
+- **Forbidden patterns**:
+  - `pattern: entryType == "` — reason: raw-string comparisons of entryType outside `EntryTypeCategory.from` invite typos; route all type logic through the enum.
+- **Acceptance**: `from("PASSKEY") == .passkey`; `from(nil) == .login`; `from("FUTURE_TYPE") == .login`; `allCases.count == 8`.
+
+### C3 — Category model + pure count/filter function
+- **New file**: `ios/PasswdSSOApp/Views/Vault/VaultCategory.swift`
+- **Signatures**:
+  ```swift
+  enum VaultCategory: Hashable {
+    case all
+    case type(EntryTypeCategory)
+    case codes
+    case favorites
+    case tag(String)
+  }
+  // pure, side-effect free, testable
+  func matches(_ summary: VaultEntrySummary, _ category: VaultCategory) -> Bool
+  func categoryCounts(_ summaries: [VaultEntrySummary]) -> [VaultCategory: Int]
+  ```
+- **Semantics**:
+  - `.all` → every summary.
+  - `.type(t)` → `EntryTypeCategory.from(summary.entryType) == t`.
+  - `.codes` → `summary.hasTOTP`.
+  - `.favorites` → `summary.isFavorite`.
+  - `.tag(name)` → `summary.tags.contains(name)`.
+- **Invariants**:
+  - Pure: no I/O, no `UIPasteboard`, no `Date()`-dependent branching. Deterministic for the same input.
+  - An entry may appear under multiple categories (Login + Codes + Favorite + Tag) — categories are filters, not a partition. `.all` count == `summaries.count`.
+- **Acceptance**: unit tests over a fixture array covering each case, multi-membership, empty tags, legacy `entryType nil` counted under Login, zero-count types absent from a "non-empty types" helper.
+
+### C4 — `VaultListView(category:)` filtered mode
+- **File**: `ios/PasswdSSOApp/Views/Vault/VaultListView.swift`, `ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift`
+- **Change**: `VaultListView` gains `let category: VaultCategory` (default `.all` to preserve existing call sites during transition). The rendered list = `viewModel.filteredSummaries` further filtered by `matches(_, category)`. `VaultViewModel.filteredSummaries` is extended OR the view applies `matches` on top of the existing search filter. Navigation title reflects the category (localized).
+- **Invariants**:
+  - When `category == .all`, output is identical to the current flat list (search behavior preserved).
+  - Search composes with category (search within the selected category).
+  - The favorites filter that today is a no-op placeholder (`VaultViewModel.swift:` `filterFavoritesOnly` does nothing because the summary lacked `isFavorite`) is now backed by real data via C1 — reconcile or remove the placeholder so there is ONE favorites path, not two divergent ones.
+- **Acceptance**: filtering tests at the view-model level (category × search matrix); `.all` parity with pre-change output.
+
+### C5 — `VaultCategoryLandingView` + `CategoryCard`
+- **New files**: `ios/PasswdSSOApp/Views/Vault/VaultCategoryLandingView.swift`, `CategoryCard.swift`.
+- **Signature**: `VaultCategoryLandingView` owns the `NavigationStack`, reads the shared `VaultViewModel`, computes `categoryCounts`, renders a `LazyVGrid` of `CategoryCard` for: All, then non-empty entry types, Codes (if >0), Favorites (if >0), then a Tags section (one card per distinct tag). Each card is a `NavigationLink` to `VaultListView(category:)`. Toolbar (Settings / Lock / Sign Out) and the create button migrate from `VaultListView`'s root toolbar to the landing (since the landing is now the root). 
+- **Invariants**:
+  - Empty type/Codes/Favorites cards are hidden (count 0). All is always present.
+  - The existing top toolbar actions (Settings, Lock, Sign Out, Create) remain reachable from the new root.
+  - `RootView` renders `VaultCategoryLandingView` for `.vaultUnlocked` (replacing direct `VaultListView`).
+- **Acceptance**: no automated view assertion (no harness) — covered by C3 count logic tests + a manual-test checklist. Build must succeed; `RootView` wiring compiles.
+
+### C6 — i18n for category labels
+- **Files**: `ios/PasswdSSOApp/Localizable.xcstrings` (+ Swift `String(localized:)` sites).
+- **Change**: localized en/ja strings for: All, Logins, Secure Notes, Credit Cards, Identities, Bank Accounts, SSH Keys, Software Licenses, Passkeys, Codes, Favorites, Tags. Follow the established String Catalog workflow ([[ios-string-catalog-notes]]) — author entries by hand (xcodebuild does not write back extraction).
+- **Acceptance**: `LocalizationCatalogTests` (existing) stays green; each new `String(localized:)` key has en+ja entries.
+
+## Testing strategy
+
+- **C1**: decode/propagation unit tests (legacy vs populated cache row → summary fields). If summaries are persisted as JSON, add a missing-field decode test; if always rebuilt from `CacheEntry`, document that (no migration test needed).
+- **C2**: enum totality tests (`from` mapping, `allCases.count == 8`).
+- **C3**: the core logic — exhaustive `matches`/`categoryCounts` tests over a fixture covering every case, multi-membership, legacy nil type, empty tags.
+- **C4**: view-model filtering tests (category × search; `.all` parity).
+- **C6**: existing `LocalizationCatalogTests` coverage.
+- Manual-test checklist (no UI harness): landing renders, counts correct, each card drills into the right filtered list, empty types hidden, search works within a category, legacy-cache device shows all entries under Login, toolbar actions reachable.
+- Full `xcodebuild test` before completion.
+
+## Considerations & constraints
+
+- **Scope cut surfaced for sign-off**: Trash and Watchtower are deferred because the data doesn't exist on-device (trashed entries aren't synced; no security-audit client). The grid is built to accept new `VaultCategory` cases without refactor. If the user wants Trash now, that's a sync-layer change (separate, larger) — recommend a follow-up branch.
+- **Favorites double-path**: C4 must collapse the existing dead `filterFavoritesOnly` placeholder into the real `isFavorite` data so there isn't one working path (landing) and one broken path (old toggle).
+- **Decode/migration risk** (C1): the single highest-risk item — adding a non-optional field to a `Codable` that may be persisted. The plan mandates verifying the persistence model and adding a default-tolerant decode if needed. Reviewer must confirm.
+- **Team entries**: personal-only, consistent with the rest of iOS AutoFill parity (#537). Team category counts out of scope.
+- **Navigation ownership move**: relocating the root `NavigationStack` + toolbar from `VaultListView` to the landing is the main regression surface (lost toolbar action, double nav bar, broken back). Manual checklist covers it.
+
+## User operation scenarios
+
+1. Unlock → landing grid shows All (42), Logins (30), Codes (8), Credit Cards (3), Favorites (5), and a tag card per tag. Secure Notes count 0 → no card. Tap Logins → filtered list of 30 logins → tap one → detail.
+2. Tap Codes → only TOTP entries; each row still shows its TOTP indicator.
+3. Search from All → same behavior as today. Search inside Logins → filters within logins only.
+4. Legacy-cache device (pre-sync, entries have no `entryType`) → all entries appear under Logins; no crash; after next sync, types populate.
+5. User taps Favorites with zero favorites → card hidden (no dead-end empty screen).
+6. From the landing, user opens Settings / Locks / Signs Out / taps Create — all still reachable.
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | Summary/cache field propagation (entryType, isFavorite) | locked |
+| C2 | `EntryTypeCategory` presentation enum (total mapping) | locked |
+| C3 | `VaultCategory` model + pure count/filter | locked |
+| C4 | `VaultListView(category:)` filtered mode + favorites reconcile | locked |
+| C5 | `VaultCategoryLandingView` + `CategoryCard` + RootView wiring | locked |
+| C6 | i18n category labels (en/ja) | locked |

--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -25,7 +25,9 @@
 		27597DEF7D7C04078DDB8212 /* VaultUnlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D415409924052B276B874809 /* VaultUnlockView.swift */; };
 		275CA45AE18A3AD75D9EDA8C /* CredentialIdentityRegistrarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C62D90660DD31E8DCA4CD77 /* CredentialIdentityRegistrarTests.swift */; };
 		27B85B5BB2953C5C07D971A7 /* PasswdSSOUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2552C6B9513BA62A3BFFE149 /* PasswdSSOUITests.swift */; };
+		29D3F2AD7DEF39F185E5ABEA /* SecureClipboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61C70648C7D9DE6F493F1AD /* SecureClipboardTests.swift */; };
 		29F6A1C04FE63C84CDE05FB9 /* VaultUnlockerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1700F0FA67A25FFE7775B771 /* VaultUnlockerTests.swift */; };
+		2BB04FBDDE2909DE64314F4A /* AutoCopyTOTPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEAF3455FECF141A96EFBB8 /* AutoCopyTOTPTests.swift */; };
 		2F1B42C2B8566A94C6155FEE /* LockState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40C54B860C6D1B296674038 /* LockState.swift */; };
 		347F2D6168FB578E0E7687EC /* ServerURLSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9710064A995CE5E0D639202D /* ServerURLSetupView.swift */; };
 		34E13CBD9ED4C6D8D72D6EFE /* AppGroupContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720107D734C7B5EBBBFCB91E /* AppGroupContainer.swift */; };
@@ -33,10 +35,11 @@
 		3602BE17465AD01B73DA82AC /* PasskeyAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3000F818C09142AEC4837294 /* PasskeyAssertion.swift */; };
 		393E223C042BBEF961AB0EFA /* SecureEnclaveDPoPSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F706FEFB55F6B0111CDFF17B /* SecureEnclaveDPoPSigner.swift */; };
 		3D23FF146F64052F0EC31277 /* WrappedKeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19D6A107E63BFA725F2C0F3 /* WrappedKeyStoreTests.swift */; };
+		3E108ED6C538686316A3B694 /* AutoCopyTOTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5663016688BE4902C4F1E41 /* AutoCopyTOTP.swift */; };
 		4372EB553FD8B0AE2BF33972 /* StaleBlobRecoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B088B96E6D37D767B517A837 /* StaleBlobRecoveryService.swift */; };
 		4C643AAE37D9DA7E0DCC0DAA /* fixtures in Resources */ = {isa = PBXBuildFile; fileRef = 0BDD66BD3FF47585E7183FC8 /* fixtures */; };
 		4D0A43663B1F311CD3A16903 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 327A83D67306CD99E0CB3270 /* Localizable.xcstrings */; };
-		4E461E21D8BD9D66C885604C /* AppSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F18A1CBA491C45DDCC5DE8F /* AppSettingsStore.swift */; };
+		4E56AE164F22FCD21F81770B /* SecureClipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23842E34485154B227229627 /* SecureClipboard.swift */; };
 		4FB785329A7B8D8BDF40FC5E /* MobileAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFF49A0C20D6BD5D36E24D92 /* MobileAPIClientTests.swift */; };
 		535C62C94E581BE693C1A5B6 /* WrappedKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81279161CAE5152A36AAAC35 /* WrappedKeyStore.swift */; };
 		53BABB8B7A6B12FE9A269D87 /* EntryFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A274ABCE6A2833F3A66EF5 /* EntryFetcherTests.swift */; };
@@ -95,6 +98,7 @@
 		CB194266359903474FE04F9D /* URLMatchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BFAE8E878C252FF7DF4D68 /* URLMatchingTests.swift */; };
 		CCC9A05E9E45777A96B84BDF /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296B0035C443158058EA4866 /* Shared.framework */; };
 		CCF7AB22A048CA0D633DC740 /* CredentialResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C90FE49C237E8EB2ABC26 /* CredentialResolver.swift */; };
+		D034CB85FCE2181F6E9490EE /* AppSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C2D35912411C20F34DA986 /* AppSettingsStore.swift */; };
 		D818CC3D8994859EC9B470F2 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F670E8B421F3D4CB3734A6 /* RootView.swift */; };
 		D8EA7B209BAE0D68AB7DB5D5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2BB90663584E9586FF0945C /* ContentView.swift */; };
 		DBFB20A7E48448D3D840FDE7 /* RollbackFlagWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C6B815B59EF7FAADB00EB /* RollbackFlagWriterTests.swift */; };
@@ -201,12 +205,13 @@
 		1682BC8C00C9060F5E4DC11D /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		1700F0FA67A25FFE7775B771 /* VaultUnlockerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultUnlockerTests.swift; sourceTree = "<group>"; };
 		1C62D90660DD31E8DCA4CD77 /* CredentialIdentityRegistrarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialIdentityRegistrarTests.swift; sourceTree = "<group>"; };
-		1F18A1CBA491C45DDCC5DE8F /* AppSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStore.swift; sourceTree = "<group>"; };
 		2113CB60ADE2776FF6176EA2 /* SessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionState.swift; sourceTree = "<group>"; };
+		23842E34485154B227229627 /* SecureClipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureClipboard.swift; sourceTree = "<group>"; };
 		24CD914CFF8AD6DD6DAB0129 /* EntryCacheFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryCacheFileTests.swift; sourceTree = "<group>"; };
 		2552C6B9513BA62A3BFFE149 /* PasswdSSOUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswdSSOUITests.swift; sourceTree = "<group>"; };
 		28A274ABCE6A2833F3A66EF5 /* EntryFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryFetcherTests.swift; sourceTree = "<group>"; };
 		296B0035C443158058EA4866 /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		29C2D35912411C20F34DA986 /* AppSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStore.swift; sourceTree = "<group>"; };
 		2A3E40BD15B72CC7D2465FA1 /* EntryEditForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryEditForm.swift; sourceTree = "<group>"; };
 		2C025655D57D0A2807DB8625 /* PasswdSSOAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswdSSOAppApp.swift; sourceTree = "<group>"; };
 		2DAD672FE74D0EB78FA99F1C /* AESGCMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AESGCMTests.swift; sourceTree = "<group>"; };
@@ -261,12 +266,14 @@
 		9FEC5AE0DBB56D25F0537D3C /* DPoPProofBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DPoPProofBuilder.swift; sourceTree = "<group>"; };
 		A2CB0DAE185BE8F6CC8E6351 /* AuthCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCoordinator.swift; sourceTree = "<group>"; };
 		A3FBC66A0BFC38B393757852 /* SPKIEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPKIEncoder.swift; sourceTree = "<group>"; };
+		A5663016688BE4902C4F1E41 /* AutoCopyTOTP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoCopyTOTP.swift; sourceTree = "<group>"; };
 		A6190750A2E1A027047EDBB4 /* DebugVaultLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugVaultLoader.swift; sourceTree = "<group>"; };
 		AB5881187BA33EA8F91B91B7 /* LocalizationCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationCatalogTests.swift; sourceTree = "<group>"; };
 		AD0E81B9E8C8455625BADD51 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B088B96E6D37D767B517A837 /* StaleBlobRecoveryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaleBlobRecoveryService.swift; sourceTree = "<group>"; };
 		B19DB7B9B5F953AC7FC8CE8E /* BridgeKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeKeyStoreTests.swift; sourceTree = "<group>"; };
 		B4DEECF70DC7351FAF2E7CB7 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
+		B61C70648C7D9DE6F493F1AD /* SecureClipboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureClipboardTests.swift; sourceTree = "<group>"; };
 		B67A2748B3B1C69F7543EB64 /* PasswdSSOTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PasswdSSOTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB8D42DAB6AE67B22BFFB262 /* BackgroundSyncCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSyncCoordinator.swift; sourceTree = "<group>"; };
 		C02778E2A8EE7B7A09B671C4 /* KDF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KDF.swift; sourceTree = "<group>"; };
@@ -302,6 +309,7 @@
 		F706FEFB55F6B0111CDFF17B /* SecureEnclaveDPoPSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureEnclaveDPoPSigner.swift; sourceTree = "<group>"; };
 		FC38F9BDA78209BF77E16CC7 /* CryptoUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoUtils.swift; sourceTree = "<group>"; };
 		FD65567EDF5CDCFB425499EA /* EntryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDetailView.swift; sourceTree = "<group>"; };
+		FEEAF3455FECF141A96EFBB8 /* AutoCopyTOTPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoCopyTOTPTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -339,6 +347,7 @@
 				2DAD672FE74D0EB78FA99F1C /* AESGCMTests.swift */,
 				430B7C32D3A606C25EDA8568 /* AppSettingsStoreTests.swift */,
 				D844C1C788162BAC9B723269 /* AuthCoordinatorTests.swift */,
+				FEEAF3455FECF141A96EFBB8 /* AutoCopyTOTPTests.swift */,
 				C330CB177E3117289263E7F5 /* AutoFillCandidateTests.swift */,
 				3E865DC09076361C7278C2FC /* AutoLockServiceTests.swift */,
 				F106978821523916DACB99BB /* BackgroundSyncContextTests.swift */,
@@ -365,6 +374,7 @@
 				D1FBE5BA0C4B6D7DE1B50B32 /* PersonalEntryBlobBuilderTests.swift */,
 				DB996D498008FC6F399B7078 /* RollbackFlagDrainTests.swift */,
 				775C6B815B59EF7FAADB00EB /* RollbackFlagWriterTests.swift */,
+				B61C70648C7D9DE6F493F1AD /* SecureClipboardTests.swift */,
 				662E445816ED2184809324A5 /* ServerTrustServiceTests.swift */,
 				C1F6D6429583F4DF936E38A0 /* SharedFrameworkTests.swift */,
 				160063572DE97E6E16AE7A3D /* SPKIEncoderTests.swift */,
@@ -435,6 +445,7 @@
 			children = (
 				362743E755F1060166F47588 /* Auth */,
 				139C9DD1DC8A8A6682950F82 /* AutoFill */,
+				77440B072C2E75FAEAD8B26F /* Clipboard */,
 				968A0B040C79415ECA3D3BAB /* Crypto */,
 				141623ED3B330AA288C40D74 /* Lock */,
 				F7356EF35B04FC0D0B740CC4 /* Models */,
@@ -501,6 +512,14 @@
 				692EA0DCA5D3E783869B28F1 /* BackgroundSyncTask.swift */,
 			);
 			path = Background;
+			sourceTree = "<group>";
+		};
+		77440B072C2E75FAEAD8B26F /* Clipboard */ = {
+			isa = PBXGroup;
+			children = (
+				23842E34485154B227229627 /* SecureClipboard.swift */,
+			);
+			path = Clipboard;
 			sourceTree = "<group>";
 		};
 		831DA2A399A896ABE739ED44 /* Vault */ = {
@@ -573,7 +592,6 @@
 		C87A10A5ED598D69E9F6E73D /* Vault */ = {
 			isa = PBXGroup;
 			children = (
-				1F18A1CBA491C45DDCC5DE8F /* AppSettingsStore.swift */,
 				00C68DCFC79DBA6600F27E36 /* AutoLockService.swift */,
 				9597EAEFA6081B3BDBA1FAFF /* DeviceIdentifier.swift */,
 				77B346160EEA436AAF564277 /* EntryFetcher.swift */,
@@ -605,6 +623,7 @@
 		D8971D5431C5B996B592DD95 /* TOTP */ = {
 			isa = PBXGroup;
 			children = (
+				A5663016688BE4902C4F1E41 /* AutoCopyTOTP.swift */,
 				F014597B4A4ACC5890EAC159 /* TOTPGenerator.swift */,
 			);
 			path = TOTP;
@@ -645,6 +664,7 @@
 			isa = PBXGroup;
 			children = (
 				720107D734C7B5EBBBFCB91E /* AppGroupContainer.swift */,
+				29C2D35912411C20F34DA986 /* AppSettingsStore.swift */,
 				E0EAAD69A5C2E24912DEB8D1 /* BridgeKeyStore.swift */,
 				8AFD6C1D7BB52C3C67DF3BD2 /* EntryCacheFile.swift */,
 				00C68B395A2ACE49D3F116CB /* HostTokenStore.swift */,
@@ -845,7 +865,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4E461E21D8BD9D66C885604C /* AppSettingsStore.swift in Sources */,
 				81106935658B44BFA292133A /* AuthCoordinator.swift in Sources */,
 				A457C9391F7E1E8164C97A46 /* AutoLockService.swift in Sources */,
 				84EB3A5F0E1899E9DC4A7822 /* BackgroundSyncTask.swift in Sources */,
@@ -881,6 +900,7 @@
 				5421D67E38D403D16E75A584 /* AESGCMTests.swift in Sources */,
 				9A96ED5C6D3D068E439BF341 /* AppSettingsStoreTests.swift in Sources */,
 				B324E00C768C3F3B498A0BCA /* AuthCoordinatorTests.swift in Sources */,
+				2BB04FBDDE2909DE64314F4A /* AutoCopyTOTPTests.swift in Sources */,
 				AECB0836C18828A74C015D24 /* AutoFillCandidateTests.swift in Sources */,
 				8BE8F6E7C0F4C6C96943DC74 /* AutoLockServiceTests.swift in Sources */,
 				003E1BF459D2ECEAB50D8AF5 /* BackgroundSyncContextTests.swift in Sources */,
@@ -906,6 +926,7 @@
 				270E924C1DDE26ACB7454E34 /* RollbackFlagDrainTests.swift in Sources */,
 				DBFB20A7E48448D3D840FDE7 /* RollbackFlagWriterTests.swift in Sources */,
 				FFA7B60616C41F7692F7271C /* SPKIEncoderTests.swift in Sources */,
+				29D3F2AD7DEF39F185E5ABEA /* SecureClipboardTests.swift in Sources */,
 				E0832EF8431014E47A2A4636 /* ServerTrustServiceTests.swift in Sources */,
 				61C3FD90259F677EA6150C8F /* SharedFrameworkTests.swift in Sources */,
 				E6242A08FB6CD768CBCED638 /* StaleBlobRecoveryServiceTests.swift in Sources */,
@@ -924,6 +945,8 @@
 				B51FF4981CF7716A4F01CF18 /* AAD.swift in Sources */,
 				60AD9C0835A9502C54C79E90 /* AESGCM.swift in Sources */,
 				34E13CBD9ED4C6D8D72D6EFE /* AppGroupContainer.swift in Sources */,
+				D034CB85FCE2181F6E9490EE /* AppSettingsStore.swift in Sources */,
+				3E108ED6C538686316A3B694 /* AutoCopyTOTP.swift in Sources */,
 				857B8B7F838C6E4A1A6BC148 /* BackgroundSyncCoordinator.swift in Sources */,
 				1ACA702DAFCBA5F5EDD82475 /* BridgeKeyStore.swift in Sources */,
 				8065245BE0FB70308D802C22 /* CredentialIdentityRegistrar.swift in Sources */,
@@ -942,6 +965,7 @@
 				0A26FC6678B43677C57CEB9D /* PersonalEntryBlobBuilder.swift in Sources */,
 				765B1E34A07F76D0203E28D3 /* RollbackFlagWriter.swift in Sources */,
 				A49DCEFF5ABDE722BF33C324 /* SPKIEncoder.swift in Sources */,
+				4E56AE164F22FCD21F81770B /* SecureClipboard.swift in Sources */,
 				393E223C042BBEF961AB0EFA /* SecureEnclaveDPoPSigner.swift in Sources */,
 				E300850EF22C24B05B82D25B /* SecureEnclaveKey.swift in Sources */,
 				0411C3B077EC09539E34D620 /* ServerConfig.swift in Sources */,

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -1,6 +1,40 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Auto-copy TOTP after fill" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-copy TOTP after fill"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "入力後にTOTPを自動コピー"
+          }
+        }
+      }
+    },
+    "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices." : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンにすると、ワンタイムコードを持つログインを入力した際に、現在のコードをクリップボードにコピーします。クリップボードは上記の時間が経過すると消去され、ほかのデバイスには同期されません。"
+          }
+        }
+      }
+    },
     "%@" : {
       "comment" : "Xcode-editor extraction placeholder for the TOTP countdown Int; the compiler emits the %lld key. Pure number — not translated.",
       "shouldTranslate" : false

--- a/ios/PasswdSSOApp/Views/SettingsView.swift
+++ b/ios/PasswdSSOApp/Views/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Shared
 
 extension AppTheme {
   var colorScheme: ColorScheme? {
@@ -74,6 +75,16 @@ struct SettingsView: View {
     )
   }
 
+  private var autoCopyTotpSelection: Binding<Bool> {
+    Binding(
+      get: { store.autoCopyTotp },
+      set: { newValue in
+        store.autoCopyTotp = newValue
+        autoLockService.recordActivity()
+      }
+    )
+  }
+
   var body: some View {
     NavigationStack {
       Form {
@@ -103,12 +114,17 @@ struct SettingsView: View {
           }
         }
 
-        Section("Clipboard") {
+        Section {
           Picker("Auto-Clear", selection: clipboardSelection) {
             ForEach(AppSettingsStore.clipboardOptions, id: \.self) { seconds in
               Text("\(seconds) seconds").tag(seconds)
             }
           }
+          Toggle("Auto-copy TOTP after fill", isOn: autoCopyTotpSelection)
+        } header: {
+          Text("Clipboard")
+        } footer: {
+          Text("When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices.")
         }
 
         Section("Appearance") {

--- a/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
@@ -232,13 +232,6 @@ struct EntryDetailView: View {
   /// Copy to pasteboard with localOnly + a configurable auto-clear expiration
   /// (AppSettingsStore.clipboardClearSeconds) per plan §"Side-Channel Controls".
   private func copySecurely(value: String) {
-    let seconds = Double(AppSettingsStore().clipboardClearSeconds)
-    UIPasteboard.general.setItems(
-      [[UIPasteboard.typeAutomatic: value]],
-      options: [
-        .localOnly: true,
-        .expirationDate: Date().addingTimeInterval(seconds),
-      ]
-    )
+    SecureClipboard.copy(value, clearAfter: AppSettingsStore().clipboardClearSeconds)
   }
 }

--- a/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
@@ -120,7 +120,12 @@ struct EntryDetailView: View {
 
       Section("One-Time Code") {
         if let totpSecret = d.totpSecret, !totpSecret.isEmpty {
-          TOTPCodeView(params: TOTPParams(secret: totpSecret))
+          TOTPCodeView(params: TOTPParams(
+            secret: totpSecret,
+            algorithm: d.totpAlgorithm,
+            digits: d.totpDigits,
+            period: d.totpPeriod
+          ))
         } else {
           notSetText
         }

--- a/ios/PasswdSSOApp/Views/Vault/TOTPCodeView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/TOTPCodeView.swift
@@ -78,14 +78,7 @@ struct TOTPCodeView: View {
   }
 
   private func copyToClipboard() {
-    let seconds = Double(AppSettingsStore().clipboardClearSeconds)
-    UIPasteboard.general.setItems(
-      [[UIPasteboard.typeAutomatic: currentCode]],
-      options: [
-        .localOnly: true,
-        .expirationDate: Date().addingTimeInterval(seconds),
-      ]
-    )
+    SecureClipboard.copy(currentCode, clearAfter: AppSettingsStore().clipboardClearSeconds)
     withAnimation { copyConfirmed = true }
     Task { @MainActor in
       try? await Task.sleep(nanoseconds: 2_000_000_000)

--- a/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
+++ b/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
@@ -224,6 +224,7 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
       do {
         let detail = try await resolver.decryptEntryDetail(entryId: recordId)
         let credential = ASPasswordCredential(user: detail.username, password: detail.password)
+        autoCopyTotpIfEnabled(detail)
         extensionContext.completeRequest(withSelectedCredential: credential)
       } catch {
         cancel(with: error)
@@ -398,11 +399,24 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
 
   // MARK: - Completion
 
+  /// Best-effort: after a login fill, copy the entry's current TOTP code to the
+  /// clipboard when the user opted in. Must run BEFORE `completeRequest`, which
+  /// dismisses (and may tear down) the extension. Never throws — a TOTP failure
+  /// must not affect the password fill.
+  @MainActor
+  private func autoCopyTotpIfEnabled(_ detail: VaultEntryDetail) {
+    let settings = AppSettingsStore()
+    if let code = totpToCopy(detail: detail, autoCopy: settings.autoCopyTotp, now: Date()) {
+      SecureClipboard.copy(code, clearAfter: settings.clipboardClearSeconds)
+    }
+  }
+
   private func completePasswordFill(for summary: VaultEntrySummary) {
     Task { @MainActor in
       do {
         let detail = try await resolver.decryptEntryDetail(entryId: summary.id)
         let credential = ASPasswordCredential(user: detail.username, password: detail.password)
+        autoCopyTotpIfEnabled(detail)
         extensionContext.completeRequest(withSelectedCredential: credential)
       } catch {
         cancel(with: error)
@@ -418,7 +432,15 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
           cancel(with: nil)
           return
         }
-        let code = try generateTOTPCode(params: TOTPParams(secret: secret), at: Date())
+        let code = try generateTOTPCode(
+          params: TOTPParams(
+            secret: secret,
+            algorithm: detail.totpAlgorithm,
+            digits: detail.totpDigits,
+            period: detail.totpPeriod
+          ),
+          at: Date()
+        )
         if #available(iOS 18.0, *) {
           let credential = ASOneTimeCodeCredential(code: code)
           await extensionContext.completeOneTimeCodeRequest(using: credential)

--- a/ios/PasswdSSOTests/AppSettingsStoreTests.swift
+++ b/ios/PasswdSSOTests/AppSettingsStoreTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+import Shared
 
 @testable import PasswdSSOApp
 
@@ -150,6 +151,29 @@ final class AppSettingsStoreTests: XCTestCase {
     let store = AppSettingsStore(defaults: defaults)
     store.minutes = 30
     XCTAssertEqual(store.effectiveAutoLockMinutes, 30)
+  }
+
+  // MARK: - Auto-copy TOTP (default OFF / opt-in)
+
+  func testAutoCopyTotpAbsentReturnsFalse() {
+    XCTAssertFalse(AppSettingsStore(defaults: defaults).autoCopyTotp)
+  }
+
+  func testAutoCopyTotpRoundTrip() {
+    let store = AppSettingsStore(defaults: defaults)
+    store.autoCopyTotp = true
+    XCTAssertTrue(store.autoCopyTotp)
+    store.autoCopyTotp = false
+    XCTAssertFalse(store.autoCopyTotp)
+  }
+
+  /// The host app and the AutoFill extension instantiate separate stores over the
+  /// same App Group suite; what one writes the other must read.
+  func testAutoCopyTotpReadsAcrossSeparateStoresOnSameSuite() {
+    let appSide = AppSettingsStore(defaults: defaults)
+    let extensionSide = AppSettingsStore(defaults: UserDefaults(suiteName: suiteName)!)
+    appSide.autoCopyTotp = true
+    XCTAssertTrue(extensionSide.autoCopyTotp)
   }
 
   func testApplyTenantPolicyAuthoritativeWritesValue() {

--- a/ios/PasswdSSOTests/AutoCopyTOTPTests.swift
+++ b/ios/PasswdSSOTests/AutoCopyTOTPTests.swift
@@ -46,4 +46,22 @@ final class AutoCopyTOTPTests: XCTestCase {
     )
     XCTAssertEqual(code, "94287082")
   }
+
+  /// Algorithm strings are normalized case-insensitively (relies on `.uppercased()`).
+  func testLowercaseAlgorithmStillMapsToSHA1() {
+    let code = totpToCopy(
+      detail: detail(totpSecret: rfcSecret, algorithm: "sha1", digits: 8, period: 30),
+      autoCopy: true, now: t59
+    )
+    XCTAssertEqual(code, "94287082")
+  }
+
+  /// Unknown/garbage algorithm falls back to SHA1 (mirrors the wire default).
+  func testUnknownAlgorithmFallsBackToSHA1() {
+    let code = totpToCopy(
+      detail: detail(totpSecret: rfcSecret, algorithm: "BOGUS", digits: 8, period: 30),
+      autoCopy: true, now: t59
+    )
+    XCTAssertEqual(code, "94287082")
+  }
 }

--- a/ios/PasswdSSOTests/AutoCopyTOTPTests.swift
+++ b/ios/PasswdSSOTests/AutoCopyTOTPTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+import Shared
+
+/// `totpToCopy` decision matrix (autoCopy × secret presence × generation) and
+/// TOTP-parameter fidelity. RFC 6238 SHA1 test vector: secret = base32 of
+/// "12345678901234567890", at T=59s → 8-digit "94287082".
+final class AutoCopyTOTPTests: XCTestCase {
+  private let rfcSecret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+  private let t59 = Date(timeIntervalSince1970: 59)
+
+  private func detail(
+    totpSecret: String?,
+    algorithm: String? = nil,
+    digits: Int? = nil,
+    period: Int? = nil
+  ) -> VaultEntryDetail {
+    VaultEntryDetail(
+      id: "e1", title: "T", username: "u", urlHost: "example.com",
+      password: "pw", url: "", totpSecret: totpSecret,
+      totpAlgorithm: algorithm, totpDigits: digits, totpPeriod: period
+    )
+  }
+
+  func testDisabledReturnsNil() {
+    XCTAssertNil(totpToCopy(detail: detail(totpSecret: rfcSecret), autoCopy: false, now: t59))
+  }
+
+  func testNoSecretReturnsNil() {
+    XCTAssertNil(totpToCopy(detail: detail(totpSecret: nil), autoCopy: true, now: t59))
+  }
+
+  func testMalformedSecretReturnsNilNotThrows() {
+    XCTAssertNil(totpToCopy(detail: detail(totpSecret: "!!!not-base32!!!"), autoCopy: true, now: t59))
+  }
+
+  func testValidSecretSixDigitDefault() {
+    // 6-digit truncation of the 94287082 vector.
+    XCTAssertEqual(totpToCopy(detail: detail(totpSecret: rfcSecret), autoCopy: true, now: t59), "287082")
+  }
+
+  func testHonorsDigitsAndAlgorithm() {
+    let code = totpToCopy(
+      detail: detail(totpSecret: rfcSecret, algorithm: "SHA1", digits: 8, period: 30),
+      autoCopy: true, now: t59
+    )
+    XCTAssertEqual(code, "94287082")
+  }
+}

--- a/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
+++ b/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
@@ -113,6 +113,22 @@ final class EntryBlobDecoderTests: XCTestCase {
     XCTAssertEqual(detail.notes, "hi")
     XCTAssertEqual(detail.tags, ["work"])
     XCTAssertEqual(detail.totpSecret, "JBSWY3DPEHPK3PXP")
+    XCTAssertEqual(detail.totpDigits, 6)
+    XCTAssertEqual(detail.totpPeriod, 30)
+    XCTAssertNil(detail.totpAlgorithm)  // absent in JSON
+  }
+
+  func testDetailDecodesTOTPAlgorithmDigitsPeriod() throws {
+    let json = #"""
+    {"title":"Login","username":"a","password":"p",
+     "totp":{"secret":"JBSWY3DPEHPK3PXP","algorithm":"SHA256","digits":8,"period":60}}
+    """#
+    let detail = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "e6b", teamId: nil)
+    )
+    XCTAssertEqual(detail.totpAlgorithm, "SHA256")
+    XCTAssertEqual(detail.totpDigits, 8)
+    XCTAssertEqual(detail.totpPeriod, 60)
   }
 
   func testDetailDecodesNonLoginBlobWithAbsentPassword() throws {

--- a/ios/PasswdSSOTests/SecureClipboardTests.swift
+++ b/ios/PasswdSSOTests/SecureClipboardTests.swift
@@ -15,36 +15,37 @@ private final class MockPasteboardWriter: PasteboardWriter {
 }
 
 final class SecureClipboardTests: XCTestCase {
-  func testCopySetsValueLocalOnlyAndFutureExpiration() {
+  func testCopySetsValueLocalOnlyAndFutureExpiration() throws {
     let writer = MockPasteboardWriter()
     let before = Date()
     SecureClipboard.copy("hunter2", clearAfter: 30, writer: writer)
 
     XCTAssertEqual(writer.lastValue, "hunter2")
     XCTAssertEqual(writer.lastOptions?[.localOnly] as? Bool, true)
-    let expiry = try? XCTUnwrap(writer.lastOptions?[.expirationDate] as? Date)
-    XCTAssertNotNil(expiry)
-    XCTAssertGreaterThan(expiry!, before)
-    XCTAssertLessThanOrEqual(expiry!.timeIntervalSince(before), 31)
+    let expiry = try XCTUnwrap(writer.lastOptions?[.expirationDate] as? Date)
+    XCTAssertGreaterThan(expiry, before)
+    XCTAssertLessThanOrEqual(expiry.timeIntervalSince(before), 31)
   }
 
-  func testCopyClampsBelowMinimum() {
+  func testCopyClampsBelowMinimum() throws {
     let writer = MockPasteboardWriter()
     let before = Date()
     SecureClipboard.copy("x", clearAfter: 0, writer: writer)
-    let expiry = writer.lastOptions?[.expirationDate] as? Date
+    XCTAssertEqual(writer.lastOptions?[.localOnly] as? Bool, true)
+    let expiry = try XCTUnwrap(writer.lastOptions?[.expirationDate] as? Date)
     // Clamped up to minClearSeconds (1), so still in the future, not in the past.
-    XCTAssertGreaterThan(expiry ?? .distantPast, before)
-    XCTAssertLessThanOrEqual((expiry ?? .distantFuture).timeIntervalSince(before), 2)
+    XCTAssertGreaterThan(expiry, before)
+    XCTAssertLessThanOrEqual(expiry.timeIntervalSince(before), 2)
   }
 
-  func testCopyClampsAboveMaximum() {
+  func testCopyClampsAboveMaximum() throws {
     let writer = MockPasteboardWriter()
     let before = Date()
     SecureClipboard.copy("x", clearAfter: 100_000, writer: writer)
-    let expiry = writer.lastOptions?[.expirationDate] as? Date
+    XCTAssertEqual(writer.lastOptions?[.localOnly] as? Bool, true)
+    let expiry = try XCTUnwrap(writer.lastOptions?[.expirationDate] as? Date)
     XCTAssertLessThanOrEqual(
-      (expiry ?? .distantFuture).timeIntervalSince(before),
+      expiry.timeIntervalSince(before),
       Double(SecureClipboard.maxClearSeconds) + 1
     )
   }

--- a/ios/PasswdSSOTests/SecureClipboardTests.swift
+++ b/ios/PasswdSSOTests/SecureClipboardTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import UIKit
+import XCTest
+import Shared
+
+/// Captures the options passed to `SecureClipboard.copy` (UIPasteboard does not
+/// expose them for read-back).
+private final class MockPasteboardWriter: PasteboardWriter {
+  var lastValue: String?
+  var lastOptions: [UIPasteboard.OptionsKey: Any]?
+  func write(_ value: String, options: [UIPasteboard.OptionsKey: Any]) {
+    lastValue = value
+    lastOptions = options
+  }
+}
+
+final class SecureClipboardTests: XCTestCase {
+  func testCopySetsValueLocalOnlyAndFutureExpiration() {
+    let writer = MockPasteboardWriter()
+    let before = Date()
+    SecureClipboard.copy("hunter2", clearAfter: 30, writer: writer)
+
+    XCTAssertEqual(writer.lastValue, "hunter2")
+    XCTAssertEqual(writer.lastOptions?[.localOnly] as? Bool, true)
+    let expiry = try? XCTUnwrap(writer.lastOptions?[.expirationDate] as? Date)
+    XCTAssertNotNil(expiry)
+    XCTAssertGreaterThan(expiry!, before)
+    XCTAssertLessThanOrEqual(expiry!.timeIntervalSince(before), 31)
+  }
+
+  func testCopyClampsBelowMinimum() {
+    let writer = MockPasteboardWriter()
+    let before = Date()
+    SecureClipboard.copy("x", clearAfter: 0, writer: writer)
+    let expiry = writer.lastOptions?[.expirationDate] as? Date
+    // Clamped up to minClearSeconds (1), so still in the future, not in the past.
+    XCTAssertGreaterThan(expiry ?? .distantPast, before)
+    XCTAssertLessThanOrEqual((expiry ?? .distantFuture).timeIntervalSince(before), 2)
+  }
+
+  func testCopyClampsAboveMaximum() {
+    let writer = MockPasteboardWriter()
+    let before = Date()
+    SecureClipboard.copy("x", clearAfter: 100_000, writer: writer)
+    let expiry = writer.lastOptions?[.expirationDate] as? Date
+    XCTAssertLessThanOrEqual(
+      (expiry ?? .distantFuture).timeIntervalSince(before),
+      Double(SecureClipboard.maxClearSeconds) + 1
+    )
+  }
+}

--- a/ios/Shared/Clipboard/SecureClipboard.swift
+++ b/ios/Shared/Clipboard/SecureClipboard.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+/// Seam over the system pasteboard so the copy options (which `UIPasteboard`
+/// does not expose for read-back) are assertable in tests.
+public protocol PasteboardWriter {
+  func write(_ value: String, options: [UIPasteboard.OptionsKey: Any])
+}
+
+public struct SystemPasteboardWriter: PasteboardWriter {
+  public init() {}
+  public func write(_ value: String, options: [UIPasteboard.OptionsKey: Any]) {
+    UIPasteboard.general.setItems([[UIPasteboard.typeAutomatic: value]], options: options)
+  }
+}
+
+/// Copies a secret to the pasteboard with the same protections used app-wide:
+/// `.localOnly` (no Universal Clipboard / Handoff) and a finite `.expirationDate`
+/// so the value self-clears. Single source for every clipboard write of vault
+/// material (entry fields, TOTP codes, AutoFill auto-copy).
+public enum SecureClipboard {
+  public static let minClearSeconds = 1
+  public static let maxClearSeconds = 600
+
+  public static func copy(
+    _ value: String,
+    clearAfter seconds: Int,
+    writer: PasteboardWriter = SystemPasteboardWriter()
+  ) {
+    let bounded = max(minClearSeconds, min(maxClearSeconds, seconds))
+    writer.write(
+      value,
+      options: [
+        .localOnly: true,
+        .expirationDate: Date().addingTimeInterval(Double(bounded)),
+      ]
+    )
+  }
+}

--- a/ios/Shared/Models/EntryBlobDecoder.swift
+++ b/ios/Shared/Models/EntryBlobDecoder.swift
@@ -158,6 +158,9 @@ public enum EntryBlobDecoder {
       url: p.url ?? "",
       notes: p.notes ?? "",
       totpSecret: p.totp?.secret,
+      totpAlgorithm: p.totp?.algorithm,
+      totpDigits: p.totp?.digits,
+      totpPeriod: p.totp?.period,
       generatorSettings: nil
     )
   }

--- a/ios/Shared/Models/VaultEntryDetail.swift
+++ b/ios/Shared/Models/VaultEntryDetail.swift
@@ -14,6 +14,9 @@ public struct VaultEntryDetail: Codable, Sendable, Equatable, Identifiable {
   public let url: String
   public let notes: String
   public let totpSecret: String?
+  public let totpAlgorithm: String?
+  public let totpDigits: Int?
+  public let totpPeriod: Int?
   public let generatorSettings: GeneratorSettings?
 
   public struct GeneratorSettings: Codable, Sendable, Equatable {
@@ -51,6 +54,9 @@ public struct VaultEntryDetail: Codable, Sendable, Equatable, Identifiable {
     url: String,
     notes: String = "",
     totpSecret: String? = nil,
+    totpAlgorithm: String? = nil,
+    totpDigits: Int? = nil,
+    totpPeriod: Int? = nil,
     generatorSettings: GeneratorSettings? = nil
   ) {
     self.id = id
@@ -65,6 +71,9 @@ public struct VaultEntryDetail: Codable, Sendable, Equatable, Identifiable {
     self.url = url
     self.notes = notes
     self.totpSecret = totpSecret
+    self.totpAlgorithm = totpAlgorithm
+    self.totpDigits = totpDigits
+    self.totpPeriod = totpPeriod
     self.generatorSettings = generatorSettings
   }
 }

--- a/ios/Shared/Storage/AppSettingsStore.swift
+++ b/ios/Shared/Storage/AppSettingsStore.swift
@@ -1,15 +1,14 @@
 import Foundation
-import Shared
 
 /// What happens when the idle vault timeout fires (mirrors the extension's
 /// `vaultTimeoutAction`).
-enum VaultTimeoutAction: String, CaseIterable {
+public enum VaultTimeoutAction: String, CaseIterable {
   case lock    // drop keys, keep tokens/cache — re-unlock with passphrase
   case logout  // full sign-out — clear tokens, cache, wrapped keys
 }
 
 /// App UI theme override (mirrors the extension's `theme`).
-enum AppTheme: String, CaseIterable {
+public enum AppTheme: String, CaseIterable {
   case system
   case light
   case dark
@@ -19,7 +18,7 @@ extension UserDefaults {
   /// Shared App Group suite used for all persisted app settings.
   /// UserDefaults is thread-safe but not `Sendable`; the unsafe annotation
   /// vouches for that across the concurrency checker.
-  nonisolated(unsafe) static let appGroup =
+  nonisolated(unsafe) public static let appGroup =
     UserDefaults(suiteName: AppGroupContainer.identifier) ?? .standard
 }
 
@@ -28,31 +27,35 @@ extension UserDefaults {
 /// auto-clear). Theme is handled separately via `@AppStorage("appTheme")` so it
 /// applies app-wide reactively.
 ///
+/// Lives in `Shared` so the AutoFill extension (which cannot link the host app)
+/// can read the same settings — see `autoCopyTotp` / `clipboardClearSeconds`.
+///
 /// All getters fail-closed: missing/garbage values return secure defaults.
-struct AppSettingsStore {
-  static let defaultMinutes = 15
-  static let minMinutes = 5
-  static let maxMinutes = 60
-  static let clipboardOptions = [10, 20, 30, 60, 120, 300]
-  static let defaultClipboardSeconds = 30
+public struct AppSettingsStore {
+  public static let defaultMinutes = 15
+  public static let minMinutes = 5
+  public static let maxMinutes = 60
+  public static let clipboardOptions = [10, 20, 30, 60, 120, 300]
+  public static let defaultClipboardSeconds = 30
 
   private enum Key {
     static let autoLockMinutes = "autoLockMinutes"
     static let vaultTimeoutAction = "vaultTimeoutAction"
     static let clipboardClearSeconds = "clipboardClearSeconds"
     static let tenantAutoLockMinutes = "tenantAutoLockMinutes"
+    static let autoCopyTotp = "autoCopyTotp"
   }
 
   private let defaults: UserDefaults
 
-  init(defaults: UserDefaults = .appGroup) {
+  public init(defaults: UserDefaults = .appGroup) {
     self.defaults = defaults
   }
 
   /// Auto-lock idle timeout in minutes. Range [5, 60]; absent → 15. There is
   /// intentionally no "never" (a permanently-unlocked local vault would outlive
   /// the session).
-  var minutes: Int {
+  public var minutes: Int {
     get {
       guard defaults.object(forKey: Key.autoLockMinutes) != nil else { return Self.defaultMinutes }
       return max(Self.minMinutes, min(Self.maxMinutes, defaults.integer(forKey: Key.autoLockMinutes)))
@@ -63,7 +66,7 @@ struct AppSettingsStore {
   }
 
   /// Action taken when the idle timeout fires. Absent/garbage → `.lock`.
-  var vaultTimeoutAction: VaultTimeoutAction {
+  public var vaultTimeoutAction: VaultTimeoutAction {
     get {
       guard let raw = defaults.string(forKey: Key.vaultTimeoutAction),
         let action = VaultTimeoutAction(rawValue: raw)
@@ -83,7 +86,7 @@ struct AppSettingsStore {
   /// App Group UserDefaults (not Keychain) is the right store; client-side
   /// auto-lock is defense-in-depth, the enforced boundary is the server-side
   /// token idle timeout.
-  var tenantAutoLockMinutes: Int? {
+  public var tenantAutoLockMinutes: Int? {
     get {
       guard defaults.object(forKey: Key.tenantAutoLockMinutes) != nil else { return nil }
       let raw = defaults.integer(forKey: Key.tenantAutoLockMinutes)
@@ -101,27 +104,27 @@ struct AppSettingsStore {
   /// The auto-lock interval actually applied: tenant override when present,
   /// else the user's setting. Single precedence point (the getter already
   /// guarantees `[tenantMin, max]`-or-nil, so no second clamp here).
-  var effectiveAutoLockMinutes: Int { tenantAutoLockMinutes ?? minutes }
+  public var effectiveAutoLockMinutes: Int { tenantAutoLockMinutes ?? minutes }
 
   /// Apply a tenant policy received at unlock. `policyAuthoritative` is true only
   /// for the passphrase unlock (which freshly fetched the policy); the biometric
   /// offline path passes false so it never wipes a previously-persisted value.
   /// - authoritative + value → write; authoritative + nil → clear (server removed
   ///   the policy); non-authoritative → no-op (regardless of value).
-  nonmutating func applyTenantPolicy(_ value: Int?, policyAuthoritative: Bool) {
+  public nonmutating func applyTenantPolicy(_ value: Int?, policyAuthoritative: Bool) {
     guard policyAuthoritative else { return }
     tenantAutoLockMinutes = value
   }
 
   /// Remove the tenant policy (sign-out / logout). Mirrors the extension clearing
   /// `tenantAutoLockMinutes` on disconnect.
-  nonmutating func clearTenantPolicy() {
+  public nonmutating func clearTenantPolicy() {
     tenantAutoLockMinutes = nil
   }
 
   /// Clipboard auto-clear delay in seconds, from the fixed option set. Absent or
   /// any value outside the options → 30.
-  var clipboardClearSeconds: Int {
+  public var clipboardClearSeconds: Int {
     get {
       guard defaults.object(forKey: Key.clipboardClearSeconds) != nil else {
         return Self.defaultClipboardSeconds
@@ -133,5 +136,14 @@ struct AppSettingsStore {
       let value = Self.clipboardOptions.contains(newValue) ? newValue : Self.defaultClipboardSeconds
       defaults.set(value, forKey: Key.clipboardClearSeconds)
     }
+  }
+
+  /// Whether to auto-copy an entry's current TOTP code to the clipboard after a
+  /// successful login AutoFill (mirrors the extension's `autoCopyTotp`). Absent
+  /// key → `false` (opt-in): on iOS the calling app foregrounds right after the
+  /// fill and can read the system clipboard, so the secure default is off.
+  public var autoCopyTotp: Bool {
+    get { defaults.bool(forKey: Key.autoCopyTotp) }
+    nonmutating set { defaults.set(newValue, forKey: Key.autoCopyTotp) }
   }
 }

--- a/ios/Shared/TOTP/AutoCopyTOTP.swift
+++ b/ios/Shared/TOTP/AutoCopyTOTP.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Decides the TOTP code (if any) to auto-copy after a login fill. Pure and
+/// best-effort: returns nil when disabled, when the entry has no TOTP, or when
+/// code generation fails (a bad secret must never block the password fill).
+public func totpToCopy(detail: VaultEntryDetail, autoCopy: Bool, now: Date = Date()) -> String? {
+  guard autoCopy, let secret = detail.totpSecret else { return nil }
+  return try? generateTOTPCode(
+    params: TOTPParams(
+      secret: secret,
+      algorithm: detail.totpAlgorithm,
+      digits: detail.totpDigits,
+      period: detail.totpPeriod
+    ),
+    at: now
+  )
+}

--- a/ios/Shared/TOTP/TOTPGenerator.swift
+++ b/ios/Shared/TOTP/TOTPGenerator.swift
@@ -26,6 +26,17 @@ public struct TOTPParams: Sendable, Equatable {
     self.digits = digits
     self.period = period
   }
+
+  /// Build from stored-blob values (algorithm as a string, optional digits/period).
+  /// Unknown/absent algorithm → SHA1; absent digits/period → 6 / 30 (RFC 6238 defaults).
+  public init(secret: String, algorithm: String?, digits: Int?, period: Int?) {
+    self.init(
+      secret: secret,
+      algorithm: algorithm.flatMap { TOTPAlgorithm(rawValue: $0.uppercased()) } ?? .sha1,
+      digits: digits ?? 6,
+      period: period ?? 30
+    )
+  }
 }
 
 public enum TOTPError: Error, Equatable {


### PR DESCRIPTION
## What

Closes iOS↔extension parity item: **`autoCopyTotp`**. After a login AutoFill, optionally copy the entry's current TOTP code to the clipboard so it can be pasted into the 2FA field — mirroring the browser extension.

## Key decision: default **OFF** (opt-in)

On iOS the calling (possibly hostile) app foregrounds right after the fill and can read the system clipboard — a different threat model from the browser extension. So the secure default is off; the user enables it in Settings → Clipboard. The copy is `.localOnly` (no Universal Clipboard) and expires after `clipboardClearSeconds`.

## Changes
- Hook **both** interactive password-fill paths (picker `completePasswordFill` and the single-credential `prepareInterfaceToProvideCredential`), best-effort so a TOTP failure never blocks the login fill.
- Move `AppSettingsStore` into `Shared` so the AutoFill extension can read the setting (an app-extension can't link the host binary).
- New `SecureClipboard` helper with an injectable `PasteboardWriter` seam (UIPasteboard write-options aren't readable back); adopt it at the two existing clipboard sites.
- Propagate TOTP `algorithm`/`digits`/`period` through `VaultEntryDetail` so non-default configs generate correct codes (also fixes `completeTOTPFill` and the entry-detail display).

## Process (triangulate)
Plan → 3-expert review (round 1) → implement → 3-expert Phase-3 review → fixes. Artifacts in `docs/archive/review/ios-auto-copy-totp-{plan,review,manual-test}.md`.

## Testing
`xcodebuild test` green — **397 unit tests** (+ new `SecureClipboardTests`, `AutoCopyTOTPTests`, decoder + settings coverage) and the launch UI tests. Manual-test plan with adversarial scenarios included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)