### PR TITLE
fix(ios): sync MARKETING_VERSION to released 0.4.57

### DIFF
--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -1023,7 +1023,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.56;
+				MARKETING_VERSION = 0.4.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOUITests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1043,7 +1043,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.4.56;
+				MARKETING_VERSION = 0.4.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOAutofillExtension";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1066,7 +1066,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.56;
+				MARKETING_VERSION = 0.4.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.Shared";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1155,7 +1155,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.4.56;
+				MARKETING_VERSION = 0.4.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOAutofillExtension";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1174,7 +1174,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.56;
+				MARKETING_VERSION = 0.4.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOTests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1193,7 +1193,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.56;
+				MARKETING_VERSION = 0.4.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOUITests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1274,7 +1274,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.56;
+				MARKETING_VERSION = 0.4.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1293,7 +1293,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.56;
+				MARKETING_VERSION = 0.4.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1312,7 +1312,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.56;
+				MARKETING_VERSION = 0.4.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOTests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1336,7 +1336,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.56;
+				MARKETING_VERSION = 0.4.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.Shared";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -49,7 +49,7 @@ targets:
         SKIP_INSTALL: YES
         GENERATE_INFOPLIST_FILE: YES
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: "0.4.56" # x-release-please-version
+        MARKETING_VERSION: "0.4.57" # x-release-please-version
 
   PasswdSSOApp:
     type: application
@@ -113,7 +113,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: jp.jpng.passwd-sso
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: "0.4.56" # x-release-please-version
+        MARKETING_VERSION: "0.4.57" # x-release-please-version
         TARGETED_DEVICE_FAMILY: "1"
         # Single-size (1024) AppIcon in PasswdSSOApp/Assets.xcassets. xcodegen
         # also auto-derives this from the AppIcon.appiconset presence; the
@@ -180,7 +180,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: jp.jpng.passwd-sso.PasswdSSOAutofillExtension
         APPLICATION_EXTENSION_API_ONLY: YES
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: "0.4.56" # x-release-please-version
+        MARKETING_VERSION: "0.4.57" # x-release-please-version
         TARGETED_DEVICE_FAMILY: "1"
     dependencies:
       - target: Shared
@@ -213,7 +213,7 @@ targets:
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/PasswdSSOApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PasswdSSOApp
         BUNDLE_LOADER: $(TEST_HOST)
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: "0.4.56" # x-release-please-version
+        MARKETING_VERSION: "0.4.57" # x-release-please-version
     dependencies:
       - target: Shared
         link: true
@@ -235,7 +235,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: jp.jpng.passwd-sso.PasswdSSOUITests
         TEST_TARGET_NAME: PasswdSSOApp
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: "0.4.56" # x-release-please-version
+        MARKETING_VERSION: "0.4.57" # x-release-please-version
     dependencies:
       - target: PasswdSSOApp
 


### PR DESCRIPTION
## Problem

`main` is internally version-inconsistent, so the **Version consistency** CI check is red on main and on every iOS PR (e.g. #555):

| File | Version |
|------|---------|
| `package.json` / `cli` / `extension` | 0.4.57 |
| `.release-please-manifest.json` | 0.4.57 |
| `ios/project.yml` MARKETING_VERSION | **0.4.56** ← drift |

## Cause

Release PR **#526** (`release passwd-sso 0.4.57`) was prepared *before* **#554** registered `ios/project.yml` as a release-please `generic` extra-file. So the 0.4.57 release bumped the JS packages + the manifest but never touched the five iOS `MARKETING_VERSION` lines — a one-time ordering drift, not a recurring config gap.

## Fix

Bump the five annotated `MARKETING_VERSION` lines to **0.4.57** (matching the released root). `xcodegen` propagates the value into `project.pbxproj` / Info.plist. The version-check now passes (`root == ios == 0.4.57`); future releases bump from 0.4.57 via the registered extra-file.

This unblocks the iOS PR queue (#555 and follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)