### PR TITLE
feat(ios): category landing grid for the vault

### DIFF
--- a/docs/archive/review/ios-category-landing-manual-test.md
+++ b/docs/archive/review/ios-category-landing-manual-test.md
@@ -1,0 +1,32 @@
+# Manual Test: ios-category-landing
+
+UI feature (no snapshot harness) — the grid layout / navigation must be checked by hand.
+
+## Pre-conditions
+- Signed in, vault unlocked, cache populated with a mix of entries (some with TOTP, some favorited,
+  some tagged, ideally a non-LOGIN type if available).
+
+## Steps / Expected
+1. **Grid renders.** Unlock → the landing shows a 2-column grid of category cards (icon + label + count)
+   instead of the flat list. "All" is present with the total count.
+2. **Counts correct.** Each card's count matches the number of matching entries (cross-check All vs the
+   sum is NOT expected — categories overlap). Logins count = login entries (legacy/no-type count as Login).
+3. **Empty types hidden.** A type with zero entries (e.g. Secure Notes when none exist) has no card.
+   Codes / Favorites cards appear only when count > 0.
+4. **Drill-in.** Tap a card → a filtered list of exactly that category's entries → tap an entry → detail.
+   Back returns to the grid (not the lock screen).
+5. **Tags.** One card per distinct tag; tapping shows entries with that tag.
+6. **Search at root.** Type in the bottom search bar → the grid is replaced by flat search results across
+   all entries. Clear → the grid returns.
+7. **Search within a category.** Drill into a category, then type in the search bar → results are limited
+   to that category (composition).
+8. **Toolbar/create reachable.** From the grid, the ⋯ menu (Settings / Lock / Sign Out) and the bottom
+   Create (+) button work.
+9. **Legacy cache.** On a device whose cache predates entryType, all entries appear under Logins; no crash.
+   After the next foreground sync, type counts populate.
+10. **Screen recording.** Start a screen recording / AirPlay → the grid AND any pushed category list show
+    the "Recording — content hidden" overlay (parity with the entry-detail screen).
+
+## Rollback
+Revert the branch. No persisted-state or server change; `entryType`/`isFavorite` added to the in-memory
+summary + the App Group cache row (optional, backward-compatible) only.

--- a/docs/archive/review/ios-category-landing-plan.md
+++ b/docs/archive/review/ios-category-landing-plan.md
@@ -1,186 +1,141 @@
 # Plan: ios-category-landing
 
-## Project context
+> Revised after Phase-1 round-1 review. Corrections: `EntryBlobDecoder.summary`
+> real signature (`plaintext/entryId/teamId`, 4 call sites); `VaultEntrySummary`
+> is never persisted (no Codable migration — the real concern is `CacheEntry`
+> `Bool?`); `EntryTypeCategory` lives in the APP target (localized labels resolve
+> against the app catalog); landing is built **in-place** in `VaultListView` (no
+> NavigationStack/toolbar ownership move — the main regression surface in round-1);
+> new views get the screen-recording overlay; `EntryTypeCategory` has a
+> compiler-enforced `localizedLabel`.
 
-- **Type**: web-app-adjacent native client — SwiftUI iOS host app under `ios/PasswdSSOApp`. UI redesign of the post-unlock landing surface.
-- **Test infrastructure**: unit tests only (XCTest via `xcodebuild test`). No snapshot/UI-assertion harness beyond launch smoke tests — so view *logic* (counts, filtering, category model) is unit-tested; pixel layout is not.
-- Base branch: `feat/ios-category-landing` from `ios-main` (tracks `origin/main`). Local `main` ref is STALE.
+## Project context
+- **Type**: SwiftUI iOS app (`ios/PasswdSSOApp`). UI feature on the post-unlock surface.
+- **Tests**: XCTest unit only; no snapshot/UI-assertion harness (view logic is unit-tested, layout is manual).
+- Base: `feat/ios-category-landing` from `ios-main` (== `origin/main`).
 
 ## Objective
-
-Replace the flat post-unlock password list with an Apple-Passwords-style **category landing grid**: cards
-for All / entry types / Codes / Favorites / Tags, each showing a count, drilling into a filtered list
-(the existing `VaultListView` rendering). Closes parity roadmap item 6.
+Replace the flat post-unlock list with an Apple-Passwords-style **category grid** (cards with counts),
+each drilling into a filtered list (reusing the existing row + `EntryDetailView`). Closes parity item 6.
 
 ## Requirements
-
 ### Functional
-- After unlock, show a grid of category cards (count + icon + localized label) instead of the flat list.
-- Tapping a card pushes a filtered entry list (reusing the current list row + `EntryDetailView` nav).
-- Categories (in-scope this branch):
-  - **All** — every active personal entry (always shown).
-  - **By entry type** — Login, Secure Note, Credit Card, Identity, Bank Account, SSH Key, Software License, Passkey. A type card is shown ONLY when its count > 0 (Apple-Passwords behavior).
-  - **Codes** — entries with `hasTOTP == true`.
-  - **Favorites** — entries with `isFavorite == true`.
-  - **Tags** — one entry per distinct tag, with per-tag count.
-- Search remains available (within All, or globally from the landing — see C6).
+- After unlock, when not searching, show a grid of category cards (count + SF Symbol + localized label).
+- Tapping a card pushes a filtered entry list.
+- Categories (in scope): **All**; by entry type (Login, Secure Note, Credit Card, Identity, Bank Account,
+  SSH Key, Software License, Passkey) — a type card shows only when its count > 0; **Codes** (`hasTOTP`);
+  **Favorites** (`isFavorite`); **Tags** (one card per distinct tag).
+- **Search** still works: a non-empty query shows the flat search results at the root (across all
+  categories), bypassing the grid (Apple-Passwords behavior). Within a pushed category, search composes.
 
-### Deferred (explicit, with rationale — see Considerations)
-- **Trash (削除済み)** — the offline cache does not currently store trashed/archived entries; supporting this needs a sync/fetch change (server already exposes `isArchived`, but trashed rows aren't synced to the device). Architecture leaves a slot for it.
-- **Watchtower-Security** — no iOS security-audit backend or client exists; web-only today. Out of scope until a security-scan API client lands.
+### Deferred (confirmed correct in round-1)
+- **Trash** — `/api/passwords?include=blob` returns only `deletedAt: null, isArchived: false`; trashed
+  entries are never synced to the device. Needs a sync change → separate branch.
+- **Watchtower** — no iOS security-audit client exists. Out of scope.
 
 ### Non-functional
-- Counts computed from already-decrypted summaries in memory — no extra network or decrypt.
-- Legacy cache rows (no `entryType`) MUST still appear (treated as Login) — no entry silently disappears.
-- Backward compatible: a device with an old cache (missing the new fields) degrades gracefully (no crash, entries default to Login / not-favorite) until the next sync repopulates.
+- Counts from in-memory summaries; no extra network/decrypt.
+- Legacy cache rows (no `entryType`/`isFavorite`) still appear (treated as Login / not-favorite); no crash.
 
 ## Technical approach
+### Field propagation (round-1 F1/F2/F3 corrected)
+`VaultEntrySummary` lacks `entryType`/`isFavorite`. They are server metadata on the wire model
+`EncryptedEntry` (`isFavorite: Bool`, `entryType: String`), dropped in `toPersonalCacheEntry()`. Chain:
+1. `CacheEntry` gains `isFavorite: Bool?` (already has `entryType: String?`).
+2. `EncryptedEntry.toPersonalCacheEntry()` passes `isFavorite: self.isFavorite`.
+3. `EntryBlobDecoder.summary(plaintext:entryId:teamId:)` gains `entryType: String? = nil, isFavorite: Bool = false`
+   params (defaulted → the 3 other call sites — `CredentialIdentityRegistrar` ×2, `CredentialResolver`
+   — compile unchanged and don't need the fields). `VaultViewModel.decryptOverview` passes
+   `entryType: entry.entryType, isFavorite: entry.isFavorite ?? false`.
+4. `VaultEntrySummary` gains `entryType: String?` and `isFavorite: Bool` (defaulted in init).
 
-### Data gap and propagation
-`VaultEntrySummary` (`ios/Shared/Models/VaultEntrySummary.swift`) currently lacks `entryType` and
-`isFavorite`; both are non-secret metadata already present on the wire model `EncryptedEntry`
-(`ios/PasswdSSOApp/Vault/EntryFetcher.swift:7-13`: `entryType: String`, `isFavorite: Bool`,
-`isArchived: Bool`). They are dropped in `EncryptedEntry.toPersonalCacheEntry()` and never reach the
-summary. The fix is a straight propagation: wire → `CacheEntry` → `VaultEntrySummary`.
+`VaultEntrySummary` is **never persisted** (rebuilt from `CacheEntry` each load) → no Codable migration.
+`CacheEntry.isFavorite: Bool?` is JSON-backward-compatible (absent → nil → false).
 
-- `CacheEntry` (`ios/Shared/AutoFill/CredentialResolver.swift:199-216`) already carries
-  `entryType: String?` (added for passkeys). Add `isFavorite: Bool?` (optional → legacy rows decode as nil → false).
-- `EncryptedEntry.toPersonalCacheEntry()` copies `isFavorite` alongside the existing `entryType`.
-- `EntryBlobDecoder.summary(_:)` (`ios/Shared/Models/EntryBlobDecoder.swift:80-103`) copies `entryType`
-  and `isFavorite` from the `CacheEntry` into the produced `VaultEntrySummary`.
-
-`entryType` stays a raw `String?` end-to-end (the wire contract is a string); a presentation enum
-(`EntryTypeCategory`) maps known raw values to labels/icons, with unknown/nil → Login.
-
-### View architecture
-- New `VaultCategoryLandingView` becomes the content rendered by `RootView` for `.vaultUnlocked`
-  (replacing the direct `VaultListView`). It owns the `NavigationStack`.
-- Each card is a `NavigationLink { VaultListView(category: …) } label: { CategoryCard(…) }`.
-- `VaultListView` gains an optional `category:` input; when set, it filters to that category and is a
-  pushed detail screen (no longer the root `NavigationStack` owner — the landing owns it). When the
-  category is `.all`, behavior == today's full list.
-- `VaultViewModel` is shared (single source of decrypted summaries). Category filtering is a pure
-  computed function (C3); the landing reads counts from the same view model.
+### View architecture (in-place, no ownership move)
+`VaultListView` keeps the `NavigationStack`, `.toolbar`, `bottomBar` (search + create), screen-recording
+overlay, and sheets — UNCHANGED. Only its body content switches:
+- `searchQuery` non-empty → existing flat `entryList` (search across all).
+- else → `categoryGrid` (LazyVGrid of `CategoryCard`, each a `NavigationLink` to `VaultCategoryListView(category:)`).
+`VaultCategoryListView` renders `viewModel.filteredSummaries.filter { matches($0, category) }` with the
+existing row + `EntryDetailView` link, AND its own screen-recording overlay (parity with `EntryDetailView`).
 
 ## Contracts
 
-### C1 — Summary/cache field propagation
-- **Files**: `ios/Shared/Models/VaultEntrySummary.swift`, `ios/Shared/AutoFill/CredentialResolver.swift` (CacheEntry), `ios/PasswdSSOApp/Vault/EntryFetcher.swift` (`toPersonalCacheEntry`), `ios/Shared/Models/EntryBlobDecoder.swift` (`summary`).
-- **Signatures**:
-  - `VaultEntrySummary` gains `public let entryType: String?` and `public let isFavorite: Bool` (non-optional; default false at decode).
-  - `CacheEntry` gains `public let isFavorite: Bool?` (optional for legacy rows; already has `entryType: String?`).
-  - `toPersonalCacheEntry()` sets `isFavorite: self.isFavorite` (from `EncryptedEntry`).
-  - `EntryBlobDecoder.summary(_ entry: CacheEntry) -> VaultEntrySummary` sets `entryType: entry.entryType`, `isFavorite: entry.isFavorite ?? false`.
-- **Invariants**:
-  - `VaultEntrySummary` remains `Codable`; adding fields must not break decode of any persisted summary cache. **Decode-compat check**: if summaries are persisted as JSON anywhere, the new non-optional `isFavorite` needs a default — make the decoder tolerate absence (custom `init(from:)` or optional-with-default). Verify whether summaries are persisted or always rebuilt from `CacheEntry` each launch (if always rebuilt, no migration needed).
-  - Legacy `CacheEntry` (no `entryType`, no `isFavorite`) → summary with `entryType == nil`, `isFavorite == false`. No crash, no dropped entry.
-- **Consumer-flow walkthrough**:
-  - Consumer A (`VaultCategoryLandingView` / C3 count function) reads `{ entryType, hasTOTP, isFavorite, tags }` from each summary and uses them to bucket+count. All four must be present on the summary → C1 adds the two missing ones. ✓
-  - Consumer B (`VaultListView` row, existing) reads `{ title, username, urlHost, hasTOTP, relyingPartyId }` — unaffected by additions. ✓
-  - Consumer C (AutoFill extension, existing `CredentialResolver` consumers of `CacheEntry`) — adding an optional `isFavorite` to `CacheEntry` is additive; existing reads unaffected. ✓
-- **Acceptance**: decode tests — legacy cache row → `entryType nil`/`isFavorite false`; populated row → values propagate to summary.
+### C1 — Field propagation
+- `CacheEntry` (+`isFavorite: Bool? = nil` in struct + init), `EncryptedEntry.toPersonalCacheEntry()` (+`isFavorite:`),
+  `EntryBlobDecoder.summary(...)` (+`entryType`/`isFavorite` defaulted params), `VaultViewModel.decryptOverview`
+  (pass the two), `VaultEntrySummary` (+`entryType: String?`, `isFavorite: Bool`, defaulted in init).
+- **Invariants**: legacy row → `entryType nil`/`isFavorite false`; no entry dropped; `CacheEntry` JSON decode tolerant of absent `isFavorite`.
+- **Consumer walkthrough**: `VaultCategory.matches`/`categoryCounts` (C3) read `{ entryType, hasTOTP, isFavorite, tags }` — all present after C1 ✓. AutoFill `CacheEntry` consumers unaffected (additive optional) ✓.
+- **Acceptance**: decode test — legacy → nil/false; populated → propagates to summary.
 
-### C2 — `EntryTypeCategory` presentation enum
-- **New file**: `ios/Shared/Models/EntryTypeCategory.swift` (or host target if presentation-only).
-- **Signature**:
+### C2 — `EntryTypeCategory` (APP target, localized)
+- **New file**: `ios/PasswdSSOApp/Views/Vault/EntryTypeCategory.swift` (NOT Shared — `String(localized:)` resolves against the app catalog).
   ```swift
-  public enum EntryTypeCategory: String, CaseIterable {
-    case login = "LOGIN", secureNote = "SECURE_NOTE", creditCard = "CREDIT_CARD",
-         identity = "IDENTITY", bankAccount = "BANK_ACCOUNT", sshKey = "SSH_KEY",
-         softwareLicense = "SOFTWARE_LICENSE", passkey = "PASSKEY"
-    public static func from(rawType: String?) -> EntryTypeCategory  // nil/unknown → .login
-    public var sfSymbol: String { get }
-    // display label provided at the view layer via String(localized:) keyed on the case
+  enum EntryTypeCategory: String, CaseIterable {
+    case login="LOGIN", secureNote="SECURE_NOTE", creditCard="CREDIT_CARD", identity="IDENTITY",
+         bankAccount="BANK_ACCOUNT", sshKey="SSH_KEY", softwareLicense="SOFTWARE_LICENSE", passkey="PASSKEY"
+    static func from(rawType: String?) -> EntryTypeCategory   // nil/unknown → .login
+    var sfSymbol: String { get }
+    var localizedLabel: String { get }   // String(localized:) — compiler-enforced, no raw-string leak (S3)
   }
   ```
-- **Invariant**: `from(rawType:)` is total — every `String?` maps to a case; unknown raw strings and `nil` map to `.login` (so no entry is uncategorizable). This mirrors the wire default.
-- **Forbidden patterns**:
-  - `pattern: entryType == "` — reason: raw-string comparisons of entryType outside `EntryTypeCategory.from` invite typos; route all type logic through the enum.
-- **Acceptance**: `from("PASSKEY") == .passkey`; `from(nil) == .login`; `from("FUTURE_TYPE") == .login`; `allCases.count == 8`.
+- **Invariant**: `from` is total (unknown/nil → `.login`); the 8 raw values match the server `ENTRY_TYPE` set (round-1 confirmed all 8 exist).
+- **Forbidden**: `pattern: entryType == "` — route all type logic through `from`.
+- **Acceptance**: `from("PASSKEY")==.passkey`, `from(nil)==.login`, `from("X")==.login`, `allCases.count==8`.
 
-### C3 — Category model + pure count/filter function
-- **New file**: `ios/PasswdSSOApp/Views/Vault/VaultCategory.swift`
-- **Signatures**:
+### C3 — `VaultCategory` + pure count/filter (APP, testable)
+- **New file**: `ios/PasswdSSOApp/Views/Vault/VaultCategory.swift`.
   ```swift
-  enum VaultCategory: Hashable {
-    case all
-    case type(EntryTypeCategory)
-    case codes
-    case favorites
-    case tag(String)
-  }
-  // pure, side-effect free, testable
-  func matches(_ summary: VaultEntrySummary, _ category: VaultCategory) -> Bool
+  enum VaultCategory: Hashable { case all, type(EntryTypeCategory), codes, favorites, tag(String) }
+  func matches(_ s: VaultEntrySummary, _ c: VaultCategory) -> Bool
   func categoryCounts(_ summaries: [VaultEntrySummary]) -> [VaultCategory: Int]
+  func distinctTags(_ summaries: [VaultEntrySummary]) -> [String]   // sorted
   ```
-- **Semantics**:
-  - `.all` → every summary.
-  - `.type(t)` → `EntryTypeCategory.from(summary.entryType) == t`.
-  - `.codes` → `summary.hasTOTP`.
-  - `.favorites` → `summary.isFavorite`.
-  - `.tag(name)` → `summary.tags.contains(name)`.
-- **Invariants**:
-  - Pure: no I/O, no `UIPasteboard`, no `Date()`-dependent branching. Deterministic for the same input.
-  - An entry may appear under multiple categories (Login + Codes + Favorite + Tag) — categories are filters, not a partition. `.all` count == `summaries.count`.
-- **Acceptance**: unit tests over a fixture array covering each case, multi-membership, empty tags, legacy `entryType nil` counted under Login, zero-count types absent from a "non-empty types" helper.
+- **Semantics**: all→every; type(t)→`from(s.entryType)==t`; codes→`s.hasTOTP`; favorites→`s.isFavorite`; tag(n)→`s.tags.contains(n)`.
+- **Invariants**: pure/deterministic; multi-membership (an entry counts under Login+Codes+Favorite+Tag); `all` count == `summaries.count`.
+- **Acceptance**: matrix tests — each case, multi-membership, legacy nil→Login, empty tags, all==count.
 
-### C4 — `VaultListView(category:)` filtered mode
-- **File**: `ios/PasswdSSOApp/Views/Vault/VaultListView.swift`, `ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift`
-- **Change**: `VaultListView` gains `let category: VaultCategory` (default `.all` to preserve existing call sites during transition). The rendered list = `viewModel.filteredSummaries` further filtered by `matches(_, category)`. `VaultViewModel.filteredSummaries` is extended OR the view applies `matches` on top of the existing search filter. Navigation title reflects the category (localized).
-- **Invariants**:
-  - When `category == .all`, output is identical to the current flat list (search behavior preserved).
-  - Search composes with category (search within the selected category).
-  - The favorites filter that today is a no-op placeholder (`VaultViewModel.swift:` `filterFavoritesOnly` does nothing because the summary lacked `isFavorite`) is now backed by real data via C1 — reconcile or remove the placeholder so there is ONE favorites path, not two divergent ones.
-- **Acceptance**: filtering tests at the view-model level (category × search matrix); `.all` parity with pre-change output.
+### C4 — `VaultListView` grid + `VaultCategoryListView` + favorites reconcile
+- `VaultListView`: content = grid (searchQuery empty) | flat list (searching). Toolbar/bottomBar/overlay/sheets unchanged.
+- **New** `VaultCategoryListView(category:…)`: filtered list + its own screen-recording overlay (S2) + empty state; reuses the row + `EntryDetailView` navigation.
+- **New** `CategoryCard`: count + symbol + label; hidden when count 0 (except All).
+- Remove the dead `filterFavoritesOnly` placeholder in `VaultViewModel.filteredSummaries` (round-1: zero external callers) — favorites is now a `VaultCategory`. Single favorites path.
+- **Invariants**: `.all` list == today's flat list; search composes within a category; toolbar actions reachable (unchanged — no ownership move).
+- **Acceptance**: VM filter tests (`.all` parity, search compose); build; manual checklist.
 
-### C5 — `VaultCategoryLandingView` + `CategoryCard`
-- **New files**: `ios/PasswdSSOApp/Views/Vault/VaultCategoryLandingView.swift`, `CategoryCard.swift`.
-- **Signature**: `VaultCategoryLandingView` owns the `NavigationStack`, reads the shared `VaultViewModel`, computes `categoryCounts`, renders a `LazyVGrid` of `CategoryCard` for: All, then non-empty entry types, Codes (if >0), Favorites (if >0), then a Tags section (one card per distinct tag). Each card is a `NavigationLink` to `VaultListView(category:)`. Toolbar (Settings / Lock / Sign Out) and the create button migrate from `VaultListView`'s root toolbar to the landing (since the landing is now the root). 
-- **Invariants**:
-  - Empty type/Codes/Favorites cards are hidden (count 0). All is always present.
-  - The existing top toolbar actions (Settings, Lock, Sign Out, Create) remain reachable from the new root.
-  - `RootView` renders `VaultCategoryLandingView` for `.vaultUnlocked` (replacing direct `VaultListView`).
-- **Acceptance**: no automated view assertion (no harness) — covered by C3 count logic tests + a manual-test checklist. Build must succeed; `RootView` wiring compiles.
-
-### C6 — i18n for category labels
-- **Files**: `ios/PasswdSSOApp/Localizable.xcstrings` (+ Swift `String(localized:)` sites).
-- **Change**: localized en/ja strings for: All, Logins, Secure Notes, Credit Cards, Identities, Bank Accounts, SSH Keys, Software Licenses, Passkeys, Codes, Favorites, Tags. Follow the established String Catalog workflow ([[ios-string-catalog-notes]]) — author entries by hand (xcodebuild does not write back extraction).
-- **Acceptance**: `LocalizationCatalogTests` (existing) stays green; each new `String(localized:)` key has en+ja entries.
+### C5 — i18n labels (en/ja)
+- Add `String(localized:)` keys: All, Logins, Secure Notes, Credit Cards, Identities, Bank Accounts, SSH Keys, Software Licenses, Passkeys, Codes, Favorites, Tags (+ any card subtitle). Hand-author en+ja in `PasswdSSOApp/Localizable.xcstrings` ([[ios-string-catalog-notes]]).
+- **Acceptance**: `LocalizationCatalogTests` green.
 
 ## Testing strategy
-
-- **C1**: decode/propagation unit tests (legacy vs populated cache row → summary fields). If summaries are persisted as JSON, add a missing-field decode test; if always rebuilt from `CacheEntry`, document that (no migration test needed).
-- **C2**: enum totality tests (`from` mapping, `allCases.count == 8`).
-- **C3**: the core logic — exhaustive `matches`/`categoryCounts` tests over a fixture covering every case, multi-membership, legacy nil type, empty tags.
-- **C4**: view-model filtering tests (category × search; `.all` parity).
-- **C6**: existing `LocalizationCatalogTests` coverage.
-- Manual-test checklist (no UI harness): landing renders, counts correct, each card drills into the right filtered list, empty types hidden, search works within a category, legacy-cache device shows all entries under Login, toolbar actions reachable.
-- Full `xcodebuild test` before completion.
+- **C1**: decode/propagation (legacy vs populated `CacheEntry` → summary fields).
+- **C2**: `EntryTypeCategory.from` totality; `allCases.count==8`.
+- **C3**: the core — exhaustive `matches`/`categoryCounts`/`distinctTags` over a fixture (every case, multi-membership, legacy nil, empty tags, zero-count hidden, all==count).
+- **C4**: VM filter (`.all` parity, search compose). Test fixtures that build `VaultEntrySummary`/`CacheEntry` updated for the new fields (RT1/R19).
+- **Manual checklist** (no UI harness): grid renders; counts correct; each card → right filtered list; empty types hidden; search at root + within category; legacy-cache device shows all under Login; screen-recording hides the grid AND pushed category lists; toolbar/create/search reachable.
+- Full `xcodebuild test`.
 
 ## Considerations & constraints
-
-- **Scope cut surfaced for sign-off**: Trash and Watchtower are deferred because the data doesn't exist on-device (trashed entries aren't synced; no security-audit client). The grid is built to accept new `VaultCategory` cases without refactor. If the user wants Trash now, that's a sync-layer change (separate, larger) — recommend a follow-up branch.
-- **Favorites double-path**: C4 must collapse the existing dead `filterFavoritesOnly` placeholder into the real `isFavorite` data so there isn't one working path (landing) and one broken path (old toggle).
-- **Decode/migration risk** (C1): the single highest-risk item — adding a non-optional field to a `Codable` that may be persisted. The plan mandates verifying the persistence model and adding a default-tolerant decode if needed. Reviewer must confirm.
-- **Team entries**: personal-only, consistent with the rest of iOS AutoFill parity (#537). Team category counts out of scope.
-- **Navigation ownership move**: relocating the root `NavigationStack` + toolbar from `VaultListView` to the landing is the main regression surface (lost toolbar action, double nav bar, broken back). Manual checklist covers it.
+- **In-place landing** keeps the NavigationStack/toolbar in `VaultListView` → eliminates the round-1 nav-ownership-move regression surface.
+- **isFavorite exposure** (round-1 S1): server-visible metadata, same posture as the already-shipped `entryType`; encrypted at rest in the cache. No new exposure.
+- **Favorites single path**: the dead `filterFavoritesOnly` is removed, not left divergent.
+- Team entries: personal-only (consistent with #537); `filterTeamId` stays nil in the personal flow.
 
 ## User operation scenarios
-
-1. Unlock → landing grid shows All (42), Logins (30), Codes (8), Credit Cards (3), Favorites (5), and a tag card per tag. Secure Notes count 0 → no card. Tap Logins → filtered list of 30 logins → tap one → detail.
-2. Tap Codes → only TOTP entries; each row still shows its TOTP indicator.
-3. Search from All → same behavior as today. Search inside Logins → filters within logins only.
-4. Legacy-cache device (pre-sync, entries have no `entryType`) → all entries appear under Logins; no crash; after next sync, types populate.
-5. User taps Favorites with zero favorites → card hidden (no dead-end empty screen).
-6. From the landing, user opens Settings / Locks / Signs Out / taps Create — all still reachable.
+1. Unlock → grid: All(42), Logins(30), Codes(8), Credit Cards(3), Favorites(5), tag cards. Secure Notes 0 → hidden. Tap Logins → 30 logins → tap → detail.
+2. Tap Codes → only TOTP entries.
+3. Search at root → flat results across all; clear → grid returns. Search inside Logins → within logins.
+4. Legacy cache (no entryType) → all under Logins; no crash; types populate after next sync.
+5. Zero favorites → Favorites card hidden.
+6. Screen recording → grid AND any pushed category list show the hidden overlay.
 
 ## Go/No-Go Gate
-
 | ID | Subject | Status |
 |----|---------|--------|
-| C1 | Summary/cache field propagation (entryType, isFavorite) | locked |
-| C2 | `EntryTypeCategory` presentation enum (total mapping) | locked |
-| C3 | `VaultCategory` model + pure count/filter | locked |
-| C4 | `VaultListView(category:)` filtered mode + favorites reconcile | locked |
-| C5 | `VaultCategoryLandingView` + `CategoryCard` + RootView wiring | locked |
-| C6 | i18n category labels (en/ja) | locked |
+| C1 | Field propagation (entryType, isFavorite) via summary signature + 4 call sites | locked |
+| C2 | `EntryTypeCategory` (app target, localizedLabel) | locked |
+| C3 | `VaultCategory` + pure count/filter/distinctTags | locked |
+| C4 | `VaultListView` grid + `VaultCategoryListView` (own overlay) + favorites reconcile | locked |
+| C5 | i18n labels (en/ja) | locked |

--- a/docs/archive/review/ios-category-landing-review.md
+++ b/docs/archive/review/ios-category-landing-review.md
@@ -1,0 +1,41 @@
+# Plan Review: ios-category-landing
+
+Date: 2026-06-13
+Review round: 1 (functionality / security / testing, 3 parallel expert sub-agents)
+
+## Changes from Previous Round
+Initial review, grounded against post-#552 `origin/main`.
+
+## Functionality Findings
+- **F1/F2 [Major] — `EntryBlobDecoder.summary` real signature is `summary(plaintext:entryId:teamId:)`, 4 call sites; `entryType`/`isFavorite` are `CacheEntry` metadata, not in the overview blob.** **Resolved** → C1 threads defaulted `entryType`/`isFavorite` params through the signature; only `VaultViewModel.decryptOverview` passes them (the 3 AutoFill call sites keep defaults).
+- **F3/T2 [Major] — Codable migration risk over-stated: `VaultEntrySummary` is never persisted** (rebuilt from `CacheEntry`). **Resolved** → C1 drops the migration hedge; real concern is `CacheEntry.isFavorite: Bool?` (JSON-backward-compatible).
+- **F4 [Major] — `filterFavoritesOnly` reconcile under-specified; audit shows zero external callers.** **Resolved** → C4 removes the dead placeholder (single favorites path).
+- **F5 [Minor] — `VaultCategory` × `filterTeamId` composition.** **Resolved** → personal-only; `filterTeamId` stays nil; category filters on top of `filteredSummaries`.
+- **F6 [Minor]** — stale `CacheEntry` line ref. **Resolved** (verified 594-639).
+- Confirmed: all 8 entry-type raw values exist server-side; Trash/Watchtower deferral correct (server filters archived/trashed; no iOS Watchtower client).
+
+## Security Findings
+- **S1 [Minor] — `isFavorite` is server-visible metadata, same posture as the shipped `entryType`; encrypted at rest in the cache.** **Resolved (accepted)** → documented in Considerations; no new exposure.
+- **S2 [Minor] — screen-recording overlay must apply to the new landing/category views.** **Resolved** → C4 mandates the overlay on `VaultCategoryListView` (and the in-place grid lives inside `VaultListView`, which already overlays).
+- **S3 [Minor] — category labels must not leak raw type identifiers; add a compiler-enforced label.** **Resolved** → C2 `EntryTypeCategory.localizedLabel` (String(localized:)); forbidden raw `entryType == "` comparisons.
+- RS4: no PII in the plan doc.
+
+## Testing Findings
+- **T1 [Major] = F1; T2 [Major] = F3.** Resolved as above.
+- **T3 [Major] — no `.all` parity baseline test.** **Resolved** → C4 acceptance adds VM `.all`-parity + search-compose tests.
+- **T4/RT1 [Major] — test fixtures (`CacheEntry`/summary builders) need the new fields.** **Resolved** → C4 testing note; new optional/defaulted fields keep existing labeled-init call sites compiling; fixtures updated where a test needs `isFavorite`/`entryType`.
+- **T5/RT3 [Minor] — test raw type strings should use `EntryTypeCategory.rawValue`.** **Resolved** → C3 tests use the enum rawValue.
+- **T6/RT2 [Minor] — nav-ownership move not unit-testable.** **Resolved by design** → the in-place landing AVOIDS the ownership move entirely (lower regression surface); manual checklist covers layout.
+
+## Resolution Summary
+All Critical/Major findings reflected in the revised plan. The biggest correction was architectural: round-1
+assumed a NavigationStack/toolbar ownership move (high regression surface) — the revised plan builds the
+landing **in-place** inside `VaultListView`, eliminating that risk. No findings deferred. Phase-3 review
+verifies the implemented diff.
+
+## Recurring Issue Check (consolidated)
+R3/R17/R22 propagation (summary signature + 4 call sites enumerated) · R12 enum consumers (`EntryTypeCategory` total `from`) ·
+R19 new fields (summary/CacheEntry — labeled inits with defaults; fixtures updated) · R25 persist/hydrate
+(`CacheEntry.isFavorite: Bool?` optional, hydrate-tolerant; summary not persisted) · R8 UI consistency
+(grid follows native Passwords pattern). RS4 no PII. RT1 mock-reality (fixtures), RT2 testability (pure
+`matches`/`categoryCounts`; layout manual), RT3 shared constants (enum rawValue). Others N/A.

--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -11,16 +11,20 @@
 		028ADBEDD93783F5080BA973 /* DeviceIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9597EAEFA6081B3BDBA1FAFF /* DeviceIdentifier.swift */; };
 		0411C3B077EC09539E34D620 /* ServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D592E6D1C88CF478A0AC739 /* ServerConfig.swift */; };
 		06F0C988BE4B8925A0DC5C4A /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296B0035C443158058EA4866 /* Shared.framework */; };
+		08EA0B269AF22DD798989D8B /* VaultFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496F3DB17FF2E8AF388D4887 /* VaultFilterTests.swift */; };
 		0A26FC6678B43677C57CEB9D /* PersonalEntryBlobBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E806A6C00D78F85B1ABC89 /* PersonalEntryBlobBuilder.swift */; };
 		0A36948197E80ACA5ED17F22 /* DPoPProofBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBF559B979642506D203C806 /* DPoPProofBuilderTests.swift */; };
+		0CDECAF833B17127DDB5B59B /* EntryTypeCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C0939161B9D1614DD3053E /* EntryTypeCategoryTests.swift */; };
 		0DF2C117B49A7A20E36940F0 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F05C70517947F52709908366 /* SettingsView.swift */; };
 		0F7754D416476CE6B1AE0C81 /* EntryEncrypter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988D60F3AE7755637CFCFDD7 /* EntryEncrypter.swift */; };
+		113E5CCFD57F79E38FA47BF0 /* EntryTypeCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7158BC25C5EA94F9F042EEEE /* EntryTypeCategory.swift */; };
 		1600D1BA3846CDCAEA02EF7E /* HostSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD016B2D5D9999A41CCA92F /* HostSyncServiceTests.swift */; };
 		1633001879A14FC075CBC4A3 /* EntryBlobDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BC3E2908650479CBBE6D07 /* EntryBlobDecoderTests.swift */; };
 		1AB309165A8AB5830B2AE4DD /* VaultEntrySummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E4377840A9A939A6B88D9A /* VaultEntrySummary.swift */; };
 		1ACA702DAFCBA5F5EDD82475 /* BridgeKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0EAAD69A5C2E24912DEB8D1 /* BridgeKeyStore.swift */; };
 		1C61EBA902B63AA436EDFED4 /* VaultListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF803DEFD9DF8AF7683EE422 /* VaultListView.swift */; };
 		1FECDEBE12AA76923178DF37 /* VaultViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC5DA8C56C2D47372666388 /* VaultViewModelTests.swift */; };
+		20391C4492AC914382EF7F0A /* VaultCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564FD260758BB7131E59A188 /* VaultCategory.swift */; };
 		270E924C1DDE26ACB7454E34 /* RollbackFlagDrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB996D498008FC6F399B7078 /* RollbackFlagDrainTests.swift */; };
 		27597DEF7D7C04078DDB8212 /* VaultUnlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D415409924052B276B874809 /* VaultUnlockView.swift */; };
 		275CA45AE18A3AD75D9EDA8C /* CredentialIdentityRegistrarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C62D90660DD31E8DCA4CD77 /* CredentialIdentityRegistrarTests.swift */; };
@@ -33,6 +37,7 @@
 		34E13CBD9ED4C6D8D72D6EFE /* AppGroupContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720107D734C7B5EBBBFCB91E /* AppGroupContainer.swift */; };
 		3582DA3CD5414790F589E168 /* HostTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C68B395A2ACE49D3F116CB /* HostTokenStore.swift */; };
 		3602BE17465AD01B73DA82AC /* PasskeyAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3000F818C09142AEC4837294 /* PasskeyAssertion.swift */; };
+		364D3AC186509520589AB21A /* VaultCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D2FE699748F19F72A83259E /* VaultCategoryTests.swift */; };
 		393E223C042BBEF961AB0EFA /* SecureEnclaveDPoPSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F706FEFB55F6B0111CDFF17B /* SecureEnclaveDPoPSigner.swift */; };
 		3D23FF146F64052F0EC31277 /* WrappedKeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19D6A107E63BFA725F2C0F3 /* WrappedKeyStoreTests.swift */; };
 		3E108ED6C538686316A3B694 /* AutoCopyTOTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5663016688BE4902C4F1E41 /* AutoCopyTOTP.swift */; };
@@ -61,6 +66,7 @@
 		72BD7556CC6BAD53BD1F093D /* DPoPProofBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FEC5AE0DBB56D25F0537D3C /* DPoPProofBuilder.swift */; };
 		765B1E34A07F76D0203E28D3 /* RollbackFlagWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7546B006E2E44B4AB2F80A42 /* RollbackFlagWriter.swift */; };
 		77BB29B71060E99C8B62A235 /* PersonalEntryBlobBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FBE5BA0C4B6D7DE1B50B32 /* PersonalEntryBlobBuilderTests.swift */; };
+		79D1A9A41B28CF4BEBC3DC92 /* VaultCategoryLanding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3073F23D803A683034FF5D44 /* VaultCategoryLanding.swift */; };
 		8065245BE0FB70308D802C22 /* CredentialIdentityRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B1990896EF1B179AC18435 /* CredentialIdentityRegistrar.swift */; };
 		81106935658B44BFA292133A /* AuthCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2CB0DAE185BE8F6CC8E6351 /* AuthCoordinator.swift */; };
 		84EB3A5F0E1899E9DC4A7822 /* BackgroundSyncTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692EA0DCA5D3E783869B28F1 /* BackgroundSyncTask.swift */; };
@@ -103,6 +109,7 @@
 		D8EA7B209BAE0D68AB7DB5D5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2BB90663584E9586FF0945C /* ContentView.swift */; };
 		DBFB20A7E48448D3D840FDE7 /* RollbackFlagWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C6B815B59EF7FAADB00EB /* RollbackFlagWriterTests.swift */; };
 		DC4BEF76059ED0111E834689 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CC4B0DD9996CF6B29E2CEA6A /* Assets.xcassets */; };
+		DCA4385D86B0CEEFBE1492CB /* CacheEntryPropagationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F64F52EEBB1CEEBF012664 /* CacheEntryPropagationTests.swift */; };
 		E0832EF8431014E47A2A4636 /* ServerTrustServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662E445816ED2184809324A5 /* ServerTrustServiceTests.swift */; };
 		E0E33F33FBEB6BBA6CC22D06 /* KDFTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A24C3EFD4C6BA4ACDA40380 /* KDFTests.swift */; };
 		E1FA345EE6BF6D38163AD937 /* DebugVaultLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FED91E37F4E8005AEF7E9B6 /* DebugVaultLoaderTests.swift */; };
@@ -216,10 +223,12 @@
 		2C025655D57D0A2807DB8625 /* PasswdSSOAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswdSSOAppApp.swift; sourceTree = "<group>"; };
 		2DAD672FE74D0EB78FA99F1C /* AESGCMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AESGCMTests.swift; sourceTree = "<group>"; };
 		3000F818C09142AEC4837294 /* PasskeyAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAssertion.swift; sourceTree = "<group>"; };
+		3073F23D803A683034FF5D44 /* VaultCategoryLanding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultCategoryLanding.swift; sourceTree = "<group>"; };
 		327A83D67306CD99E0CB3270 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		32E806A6C00D78F85B1ABC89 /* PersonalEntryBlobBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalEntryBlobBuilder.swift; sourceTree = "<group>"; };
 		345F9CF0FA1F40F81B8D6074 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		36DABD88C20A969FBE8AA7BA /* HostTokenStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostTokenStoreTests.swift; sourceTree = "<group>"; };
+		38C0939161B9D1614DD3053E /* EntryTypeCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryTypeCategoryTests.swift; sourceTree = "<group>"; };
 		3D7D6EC824EE87139CFBABE4 /* MobileAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileAPIClient.swift; sourceTree = "<group>"; };
 		3E865DC09076361C7278C2FC /* AutoLockServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLockServiceTests.swift; sourceTree = "<group>"; };
 		3FED91E37F4E8005AEF7E9B6 /* DebugVaultLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugVaultLoaderTests.swift; sourceTree = "<group>"; };
@@ -228,11 +237,13 @@
 		469C94A411CE66C4D3EAB9AA /* PasskeySignCountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeySignCountStore.swift; sourceTree = "<group>"; };
 		49247874A1D0207489D6F624 /* PasswdSSOApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = PasswdSSOApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		493B2BB02D23F64F52EF0DAA /* PasskeyAssertionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAssertionTests.swift; sourceTree = "<group>"; };
+		496F3DB17FF2E8AF388D4887 /* VaultFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultFilterTests.swift; sourceTree = "<group>"; };
 		4A24C3EFD4C6BA4ACDA40380 /* KDFTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KDFTests.swift; sourceTree = "<group>"; };
 		4F631B3CA954B4A2A4EC5714 /* PasswdSSOAutofillExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = PasswdSSOAutofillExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		5008EABA0367B0BB5E55052F /* LockStateReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockStateReducer.swift; sourceTree = "<group>"; };
 		50EA48EEB5CB57F3E901EBE5 /* EntryBlobDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryBlobDecoder.swift; sourceTree = "<group>"; };
 		544AC22B1D47CCD69051F85B /* HostSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostSyncService.swift; sourceTree = "<group>"; };
+		564FD260758BB7131E59A188 /* VaultCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultCategory.swift; sourceTree = "<group>"; };
 		588F0525C544FC2740478510 /* RollbackFlagDrain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollbackFlagDrain.swift; sourceTree = "<group>"; };
 		5D592E6D1C88CF478A0AC739 /* ServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerConfig.swift; sourceTree = "<group>"; };
 		60B1990896EF1B179AC18435 /* CredentialIdentityRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialIdentityRegistrar.swift; sourceTree = "<group>"; };
@@ -244,6 +255,7 @@
 		692EA0DCA5D3E783869B28F1 /* BackgroundSyncTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSyncTask.swift; sourceTree = "<group>"; };
 		6B849351921A9E2E8B78154E /* PasswdSSOUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PasswdSSOUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E38F8248BD5540CEF7680AD /* PasskeySignCountStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeySignCountStoreTests.swift; sourceTree = "<group>"; };
+		7158BC25C5EA94F9F042EEEE /* EntryTypeCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryTypeCategory.swift; sourceTree = "<group>"; };
 		720107D734C7B5EBBBFCB91E /* AppGroupContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupContainer.swift; sourceTree = "<group>"; };
 		72F670E8B421F3D4CB3734A6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		7546B006E2E44B4AB2F80A42 /* RollbackFlagWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollbackFlagWriter.swift; sourceTree = "<group>"; };
@@ -257,6 +269,7 @@
 		8AC8C547AA2FF81B4A670924 /* CredentialResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialResolverTests.swift; sourceTree = "<group>"; };
 		8AFD6C1D7BB52C3C67DF3BD2 /* EntryCacheFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryCacheFile.swift; sourceTree = "<group>"; };
 		8C6E4E71B2DDEE6BBA03CBF4 /* LockedFallbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockedFallbackView.swift; sourceTree = "<group>"; };
+		8D2FE699748F19F72A83259E /* VaultCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultCategoryTests.swift; sourceTree = "<group>"; };
 		8F6C27CE52EFE55D86666E7C /* URLMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLMatcher.swift; sourceTree = "<group>"; };
 		920CAD5E7129591C09F8C23C /* CredentialProviderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialProviderViewController.swift; sourceTree = "<group>"; };
 		92BFAE8E878C252FF7DF4D68 /* URLMatchingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLMatchingTests.swift; sourceTree = "<group>"; };
@@ -283,6 +296,7 @@
 		C40C54B860C6D1B296674038 /* LockState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockState.swift; sourceTree = "<group>"; };
 		C579D0D8BCA69B900181743B /* VaultUnlocker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultUnlocker.swift; sourceTree = "<group>"; };
 		C6E3257A1A8F07C9FCFF37BA /* FillProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillProgressView.swift; sourceTree = "<group>"; };
+		C8F64F52EEBB1CEEBF012664 /* CacheEntryPropagationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheEntryPropagationTests.swift; sourceTree = "<group>"; };
 		C9E896E2CA0264206A65A0B8 /* ServerTrustService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerTrustService.swift; sourceTree = "<group>"; };
 		CC4B0DD9996CF6B29E2CEA6A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		CFD016B2D5D9999A41CCA92F /* HostSyncServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostSyncServiceTests.swift; sourceTree = "<group>"; };
@@ -353,6 +367,7 @@
 				F106978821523916DACB99BB /* BackgroundSyncContextTests.swift */,
 				77C0E5B05F04FC285CE89519 /* BackgroundSyncCoordinatorTests.swift */,
 				B19DB7B9B5F953AC7FC8CE8E /* BridgeKeyStoreTests.swift */,
+				C8F64F52EEBB1CEEBF012664 /* CacheEntryPropagationTests.swift */,
 				1C62D90660DD31E8DCA4CD77 /* CredentialIdentityRegistrarTests.swift */,
 				8AC8C547AA2FF81B4A670924 /* CredentialResolverTests.swift */,
 				3FED91E37F4E8005AEF7E9B6 /* DebugVaultLoaderTests.swift */,
@@ -361,6 +376,7 @@
 				24CD914CFF8AD6DD6DAB0129 /* EntryCacheFileTests.swift */,
 				628885DD1B6E8E32503A7DD9 /* EntryEncrypterTests.swift */,
 				28A274ABCE6A2833F3A66EF5 /* EntryFetcherTests.swift */,
+				38C0939161B9D1614DD3053E /* EntryTypeCategoryTests.swift */,
 				CFD016B2D5D9999A41CCA92F /* HostSyncServiceTests.swift */,
 				36DABD88C20A969FBE8AA7BA /* HostTokenStoreTests.swift */,
 				AD0E81B9E8C8455625BADD51 /* Info.plist */,
@@ -381,6 +397,8 @@
 				65EFD0AD3F8896F5D18F2967 /* StaleBlobRecoveryServiceTests.swift */,
 				0CB624E102C09D08D7B9BB8D /* TOTPVectorTests.swift */,
 				92BFAE8E878C252FF7DF4D68 /* URLMatchingTests.swift */,
+				8D2FE699748F19F72A83259E /* VaultCategoryTests.swift */,
+				496F3DB17FF2E8AF388D4887 /* VaultFilterTests.swift */,
 				1700F0FA67A25FFE7775B771 /* VaultUnlockerTests.swift */,
 				EDC5DA8C56C2D47372666388 /* VaultViewModelTests.swift */,
 				C19D6A107E63BFA725F2C0F3 /* WrappedKeyStoreTests.swift */,
@@ -527,7 +545,10 @@
 			children = (
 				FD65567EDF5CDCFB425499EA /* EntryDetailView.swift */,
 				2A3E40BD15B72CC7D2465FA1 /* EntryEditForm.swift */,
+				7158BC25C5EA94F9F042EEEE /* EntryTypeCategory.swift */,
 				D235AC82775464BDF11F292F /* TOTPCodeView.swift */,
+				564FD260758BB7131E59A188 /* VaultCategory.swift */,
+				3073F23D803A683034FF5D44 /* VaultCategoryLanding.swift */,
 				DF803DEFD9DF8AF7683EE422 /* VaultListView.swift */,
 				D415409924052B276B874809 /* VaultUnlockView.swift */,
 				13E66C8E3793F0F33D64AAB4 /* VaultViewModel.swift */,
@@ -874,6 +895,7 @@
 				FC74F7D953B2978FE27D3B85 /* EntryDetailView.swift in Sources */,
 				B0974C58F65B8B4CBE7FB084 /* EntryEditForm.swift in Sources */,
 				B083185D5D570CC65E2C2624 /* EntryFetcher.swift in Sources */,
+				113E5CCFD57F79E38FA47BF0 /* EntryTypeCategory.swift in Sources */,
 				92AF55E25B2A1C5F8C2802BC /* HostSyncService.swift in Sources */,
 				A5FA7118BBC2D9CE7C30901E /* MobileAPIClient.swift in Sources */,
 				69C540BACD28B65D0DDB74A3 /* PasswdSSOAppApp.swift in Sources */,
@@ -885,6 +907,8 @@
 				FFDB363D6F74C9F3DD0E54C3 /* SignInView.swift in Sources */,
 				4372EB553FD8B0AE2BF33972 /* StaleBlobRecoveryService.swift in Sources */,
 				FD86EB17606A4DC5301497AA /* TOTPCodeView.swift in Sources */,
+				20391C4492AC914382EF7F0A /* VaultCategory.swift in Sources */,
+				79D1A9A41B28CF4BEBC3DC92 /* VaultCategoryLanding.swift in Sources */,
 				1C61EBA902B63AA436EDFED4 /* VaultListView.swift in Sources */,
 				27597DEF7D7C04078DDB8212 /* VaultUnlockView.swift in Sources */,
 				61CCB2EB4F4413B770CCABF1 /* VaultUnlocker.swift in Sources */,
@@ -906,6 +930,7 @@
 				003E1BF459D2ECEAB50D8AF5 /* BackgroundSyncContextTests.swift in Sources */,
 				6C09DE06209A534D059F5B02 /* BackgroundSyncCoordinatorTests.swift in Sources */,
 				99EB5AFBB9A9C2E9C0818CF6 /* BridgeKeyStoreTests.swift in Sources */,
+				DCA4385D86B0CEEFBE1492CB /* CacheEntryPropagationTests.swift in Sources */,
 				275CA45AE18A3AD75D9EDA8C /* CredentialIdentityRegistrarTests.swift in Sources */,
 				B8E8B10956121151C6DF7F9C /* CredentialResolverTests.swift in Sources */,
 				0A36948197E80ACA5ED17F22 /* DPoPProofBuilderTests.swift in Sources */,
@@ -914,6 +939,7 @@
 				EF9407000E17ADEB5E667D88 /* EntryCacheFileTests.swift in Sources */,
 				96A710A8F83E4FEB146E39D4 /* EntryEncrypterTests.swift in Sources */,
 				53BABB8B7A6B12FE9A269D87 /* EntryFetcherTests.swift in Sources */,
+				0CDECAF833B17127DDB5B59B /* EntryTypeCategoryTests.swift in Sources */,
 				1600D1BA3846CDCAEA02EF7E /* HostSyncServiceTests.swift in Sources */,
 				66734B405C893DA325204500 /* HostTokenStoreTests.swift in Sources */,
 				E0E33F33FBEB6BBA6CC22D06 /* KDFTests.swift in Sources */,
@@ -932,6 +958,8 @@
 				E6242A08FB6CD768CBCED638 /* StaleBlobRecoveryServiceTests.swift in Sources */,
 				E61FA83E34E321C09B0D7176 /* TOTPVectorTests.swift in Sources */,
 				CB194266359903474FE04F9D /* URLMatchingTests.swift in Sources */,
+				364D3AC186509520589AB21A /* VaultCategoryTests.swift in Sources */,
+				08EA0B269AF22DD798989D8B /* VaultFilterTests.swift in Sources */,
 				29F6A1C04FE63C84CDE05FB9 /* VaultUnlockerTests.swift in Sources */,
 				1FECDEBE12AA76923178DF37 /* VaultViewModelTests.swift in Sources */,
 				3D23FF146F64052F0EC31277 /* WrappedKeyStoreTests.swift in Sources */,

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -1,6 +1,193 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "All" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて"
+          }
+        }
+      }
+    },
+    "Logins" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logins"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログイン"
+          }
+        }
+      }
+    },
+    "Secure Notes" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secure Notes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュアメモ"
+          }
+        }
+      }
+    },
+    "Credit Cards" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credit Cards"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クレジットカード"
+          }
+        }
+      }
+    },
+    "Identities" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Identities"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "個人情報"
+          }
+        }
+      }
+    },
+    "Bank Accounts" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bank Accounts"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "銀行口座"
+          }
+        }
+      }
+    },
+    "SSH Keys" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH Keys"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSHキー"
+          }
+        }
+      }
+    },
+    "Software Licenses" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Software Licenses"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソフトウェアライセンス"
+          }
+        }
+      }
+    },
+    "Passkeys" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passkeys"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスキー"
+          }
+        }
+      }
+    },
+    "Codes" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コード"
+          }
+        }
+      }
+    },
+    "Favorites" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favorites"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お気に入り"
+          }
+        }
+      }
+    },
     "Auto-copy TOTP after fill" : {
       "extractionState" : "translated",
       "localizations" : {

--- a/ios/PasswdSSOApp/Vault/EntryFetcher.swift
+++ b/ios/PasswdSSOApp/Vault/EntryFetcher.swift
@@ -135,7 +135,9 @@ public struct TeamEncryptedEntry: Sendable, Codable, Equatable {
       itemKeyVersion: itemKeyVersion,
       encryptedItemKey: itemKeyData,
       encryptedBlob: blobData,
-      encryptedOverview: overviewData
+      encryptedOverview: overviewData,
+      // entryType is not on the team wire model (nil → Login); isFavorite is.
+      isFavorite: isFavorite
     )
   }
 }

--- a/ios/PasswdSSOApp/Vault/EntryFetcher.swift
+++ b/ios/PasswdSSOApp/Vault/EntryFetcher.swift
@@ -75,7 +75,8 @@ public struct EncryptedEntry: Sendable, Codable, Equatable {
       encryptedItemKey: nil,
       encryptedBlob: encryptedBlob,
       encryptedOverview: encryptedOverview,
-      entryType: entryType
+      entryType: entryType,
+      isFavorite: isFavorite
     )
   }
 }

--- a/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
@@ -20,7 +20,7 @@ struct EntryDetailView: View {
   @State private var detail: VaultEntryDetail?
   @State private var loadFailed: Bool = false
   @State private var isPasswordVisible: Bool = false
-  @State private var isScreenRecording: Bool = false
+  @State private var isScreenRecording: Bool = UIScreen.main.isCaptured
   @State private var isShowingEditForm: Bool = false
 
   @Environment(\.dismiss) private var dismiss
@@ -28,14 +28,7 @@ struct EntryDetailView: View {
   var body: some View {
     Group {
       if isScreenRecording {
-        VStack(spacing: 16) {
-          Image(systemName: "eye.slash")
-            .font(.largeTitle)
-          Text("Recording — content hidden")
-            .font(.headline)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.regularMaterial)
+        ScreenRecordingOverlay()
       } else if let detail {
         detailContent(detail)
       } else if loadFailed {

--- a/ios/PasswdSSOApp/Views/Vault/EntryTypeCategory.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryTypeCategory.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Presentation mapping for the server entry-type strings. Lives in the app
+/// target (not Shared) so `localizedLabel` resolves against the app's String
+/// Catalog. `from` is total — unknown/nil maps to `.login`, mirroring the wire
+/// default, so no entry is uncategorizable.
+enum EntryTypeCategory: String, CaseIterable {
+  case login = "LOGIN"
+  case secureNote = "SECURE_NOTE"
+  case creditCard = "CREDIT_CARD"
+  case identity = "IDENTITY"
+  case bankAccount = "BANK_ACCOUNT"
+  case sshKey = "SSH_KEY"
+  case softwareLicense = "SOFTWARE_LICENSE"
+  case passkey = "PASSKEY"
+
+  static func from(rawType: String?) -> EntryTypeCategory {
+    guard let rawType, let category = EntryTypeCategory(rawValue: rawType) else { return .login }
+    return category
+  }
+
+  var sfSymbol: String {
+    switch self {
+    case .login: "person.text.rectangle"
+    case .secureNote: "note.text"
+    case .creditCard: "creditcard"
+    case .identity: "person.crop.square"
+    case .bankAccount: "building.columns"
+    case .sshKey: "terminal"
+    case .softwareLicense: "checkmark.seal"
+    case .passkey: "key.horizontal"
+    }
+  }
+
+  /// Plural, user-facing label. Compiler-routed through `String(localized:)` so
+  /// raw type identifiers never leak into the UI.
+  var localizedLabel: String {
+    switch self {
+    case .login: String(localized: "Logins")
+    case .secureNote: String(localized: "Secure Notes")
+    case .creditCard: String(localized: "Credit Cards")
+    case .identity: String(localized: "Identities")
+    case .bankAccount: String(localized: "Bank Accounts")
+    case .sshKey: String(localized: "SSH Keys")
+    case .softwareLicense: String(localized: "Software Licenses")
+    case .passkey: String(localized: "Passkeys")
+    }
+  }
+}

--- a/ios/PasswdSSOApp/Views/Vault/VaultCategory.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultCategory.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Shared
+
+/// A landing-grid category. Categories are filters, not a partition — an entry
+/// can match several (Login + Codes + Favorite + a Tag).
+enum VaultCategory: Hashable {
+  case all
+  case type(EntryTypeCategory)
+  case codes
+  case favorites
+  case tag(String)
+}
+
+/// Pure, deterministic membership test (no I/O, no clock).
+func matches(_ summary: VaultEntrySummary, _ category: VaultCategory) -> Bool {
+  switch category {
+  case .all: true
+  case .type(let t): EntryTypeCategory.from(rawType: summary.entryType) == t
+  case .codes: summary.hasTOTP
+  case .favorites: summary.isFavorite
+  case .tag(let name): summary.tags.contains(name)
+  }
+}
+
+/// Distinct tags across the summaries, sorted for stable display order.
+func distinctTags(_ summaries: [VaultEntrySummary]) -> [String] {
+  Set(summaries.flatMap { $0.tags }).sorted()
+}
+
+/// Count per category. Includes All / Codes / Favorites unconditionally, each
+/// entry type with a non-zero count, and one entry per distinct tag.
+func categoryCounts(_ summaries: [VaultEntrySummary]) -> [VaultCategory: Int] {
+  var counts: [VaultCategory: Int] = [
+    .all: summaries.count,
+    .codes: summaries.filter { matches($0, .codes) }.count,
+    .favorites: summaries.filter { matches($0, .favorites) }.count,
+  ]
+  for type in EntryTypeCategory.allCases {
+    let c = summaries.filter { matches($0, .type(type)) }.count
+    if c > 0 { counts[.type(type)] = c }
+  }
+  for tag in distinctTags(summaries) {
+    counts[.tag(tag)] = summaries.filter { matches($0, .tag(tag)) }.count
+  }
+  return counts
+}

--- a/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
@@ -65,7 +65,9 @@ struct VaultCategoryListView: View {
   let apiClient: MobileAPIClient
   let hostSyncService: HostSyncService
 
-  @State private var isScreenRecording = false
+  // Seed synchronously so an already-active recording never shows a frame of
+  // entries before onAppear flips the flag.
+  @State private var isScreenRecording = UIScreen.main.isCaptured
 
   // Compose with the live search query (filteredSummaries) then the category.
   private var entries: [VaultEntrySummary] {

--- a/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
@@ -1,0 +1,131 @@
+import CryptoKit
+import Foundation
+import Shared
+import SwiftUI
+import UIKit
+
+/// A single category card on the landing grid: icon + label + count.
+struct CategoryCard: View {
+  let symbol: String
+  let label: String
+  let count: Int
+
+  var body: some View {
+    HStack(spacing: 12) {
+      Image(systemName: symbol)
+        .font(.title2)
+        .frame(width: 32)
+        .foregroundStyle(.tint)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(label)
+          .font(.body)
+          .lineLimit(1)
+        Text("\(count)")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+      Spacer(minLength: 0)
+    }
+    .padding()
+    .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
+    .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+  }
+}
+
+/// Shared list row (title + username) used by the flat list and category lists.
+struct EntrySummaryRow: View {
+  let summary: VaultEntrySummary
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(summary.title)
+        .font(.body)
+        .lineLimit(1)
+      Text(summary.username)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+    }
+    .padding(.vertical, 2)
+  }
+}
+
+/// Filtered entry list pushed from a landing category card. Owns its own
+/// screen-recording overlay (it is a pushed view, not covered by the root's).
+@MainActor
+struct VaultCategoryListView: View {
+  let category: VaultCategory
+  let navigationTitle: String
+  let cacheData: CacheData
+  let vaultKey: SymmetricKey
+  let userId: String
+  let keyVersion: Int
+  let autoLockService: AutoLockService
+  @Bindable var viewModel: VaultViewModel
+  let apiClient: MobileAPIClient
+  let hostSyncService: HostSyncService
+
+  @State private var isScreenRecording = false
+
+  // Compose with the live search query (filteredSummaries) then the category.
+  private var entries: [VaultEntrySummary] {
+    viewModel.filteredSummaries.filter { matches($0, category) }
+  }
+
+  var body: some View {
+    Group {
+      if isScreenRecording {
+        ScreenRecordingOverlay()
+      } else {
+        List(entries) { summary in
+          NavigationLink {
+            EntryDetailView(
+              summary: summary,
+              cacheData: cacheData,
+              vaultKey: vaultKey,
+              userId: userId,
+              keyVersion: keyVersion,
+              autoLockService: autoLockService,
+              viewModel: viewModel,
+              apiClient: apiClient,
+              hostSyncService: hostSyncService
+            )
+          } label: {
+            EntrySummaryRow(summary: summary)
+          }
+        }
+        .listStyle(.plain)
+        .overlay {
+          if entries.isEmpty {
+            Text(viewModel.searchQuery.isEmpty ? "No entries" : "No matches")
+              .foregroundStyle(.secondary)
+              .frame(maxWidth: .infinity, maxHeight: .infinity)
+          }
+        }
+      }
+    }
+    .navigationTitle(navigationTitle)
+    .navigationBarTitleDisplayMode(.inline)
+    .onAppear { isScreenRecording = UIScreen.main.isCaptured }
+    .onReceive(
+      NotificationCenter.default.publisher(for: UIScreen.capturedDidChangeNotification)
+    ) { _ in
+      isScreenRecording = UIScreen.main.isCaptured
+    }
+  }
+}
+
+/// The "content hidden during screen recording" placeholder (shared by the
+/// vault screens so the cue is identical everywhere).
+struct ScreenRecordingOverlay: View {
+  var body: some View {
+    VStack(spacing: 16) {
+      Image(systemName: "eye.slash")
+        .font(.largeTitle)
+      Text("Recording — content hidden")
+        .font(.headline)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(.regularMaterial)
+  }
+}

--- a/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
@@ -30,7 +30,9 @@ struct VaultListView: View {
     NavigationStack {
       Group {
         if isScreenRecording {
-          screenRecordingOverlay
+          ScreenRecordingOverlay()
+        } else if viewModel.searchQuery.isEmpty {
+          categoryGrid
         } else {
           entryList
         }
@@ -168,7 +170,84 @@ struct VaultListView: View {
     .background(.bar)
   }
 
-  // MARK: - Entry list
+  // MARK: - Category landing grid
+
+  /// One card per displayed category. Type cards (and Codes/Favorites) appear
+  /// only when non-empty; All is always shown; one card per distinct tag.
+  private struct LandingItem: Identifiable {
+    let id: String
+    let category: VaultCategory
+    let symbol: String
+    let label: String
+    let count: Int
+  }
+
+  private var displayedCategories: [LandingItem] {
+    let counts = categoryCounts(viewModel.allSummaries)
+    var items: [LandingItem] = [
+      LandingItem(id: "all", category: .all, symbol: "tray.full",
+                  label: String(localized: "All"), count: counts[.all] ?? 0),
+    ]
+    for type in EntryTypeCategory.allCases {
+      let count = counts[.type(type)] ?? 0
+      if count > 0 {
+        items.append(LandingItem(id: "type-\(type.rawValue)", category: .type(type),
+                                 symbol: type.sfSymbol, label: type.localizedLabel, count: count))
+      }
+    }
+    if let count = counts[.codes], count > 0 {
+      items.append(LandingItem(id: "codes", category: .codes, symbol: "clock",
+                               label: String(localized: "Codes"), count: count))
+    }
+    if let count = counts[.favorites], count > 0 {
+      items.append(LandingItem(id: "favorites", category: .favorites, symbol: "star",
+                               label: String(localized: "Favorites"), count: count))
+    }
+    for tag in distinctTags(viewModel.allSummaries) {
+      items.append(LandingItem(id: "tag-\(tag)", category: .tag(tag), symbol: "tag",
+                               label: tag, count: counts[.tag(tag)] ?? 0))
+    }
+    return items
+  }
+
+  private var categoryGrid: some View {
+    ScrollView {
+      LazyVGrid(
+        columns: [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)],
+        spacing: 12
+      ) {
+        ForEach(displayedCategories) { item in
+          NavigationLink {
+            VaultCategoryListView(
+              category: item.category,
+              navigationTitle: item.label,
+              cacheData: cacheData,
+              vaultKey: vaultKey,
+              userId: userId,
+              keyVersion: keyVersion,
+              autoLockService: autoLockService,
+              viewModel: viewModel,
+              apiClient: apiClient,
+              hostSyncService: hostSyncService
+            )
+          } label: {
+            CategoryCard(symbol: item.symbol, label: item.label, count: item.count)
+          }
+          .buttonStyle(.plain)
+        }
+      }
+      .padding()
+    }
+    .overlay {
+      if viewModel.allSummaries.isEmpty {
+        Text("No entries")
+          .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+  }
+
+  // MARK: - Entry list (search results)
 
   private var entryList: some View {
     List(viewModel.filteredSummaries) { summary in
@@ -185,49 +264,17 @@ struct VaultListView: View {
           hostSyncService: hostSyncService
         )
       } label: {
-        entryRow(summary)
+        EntrySummaryRow(summary: summary)
       }
     }
     .listStyle(.plain)
     .overlay {
       if viewModel.filteredSummaries.isEmpty {
-        emptyState
+        Text("No matches")
+          .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
       }
     }
-  }
-
-  private func entryRow(_ summary: VaultEntrySummary) -> some View {
-    VStack(alignment: .leading, spacing: 2) {
-      Text(summary.title)
-        .font(.body)
-        .lineLimit(1)
-      Text(summary.username)
-        .font(.caption)
-        .foregroundStyle(.secondary)
-        .lineLimit(1)
-    }
-    .padding(.vertical, 2)
-  }
-
-  private var emptyState: some View {
-    VStack(spacing: 8) {
-      Text(viewModel.searchQuery.isEmpty ? "No entries" : "No matches")
-        .foregroundStyle(.secondary)
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-  }
-
-  // MARK: - Screen recording overlay
-
-  private var screenRecordingOverlay: some View {
-    VStack(spacing: 16) {
-      Image(systemName: "eye.slash")
-        .font(.largeTitle)
-      Text("Recording — content hidden")
-        .font(.headline)
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(.regularMaterial)
   }
 
   private func updateScreenRecordingState() {

--- a/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
@@ -20,7 +20,7 @@ struct VaultListView: View {
   let apiClient: MobileAPIClient
   let hostSyncService: HostSyncService
 
-  @State private var isScreenRecording: Bool = false
+  @State private var isScreenRecording: Bool = UIScreen.main.isCaptured
   @State private var isShowingSettings: Bool = false
   @State private var isShowingCreateForm: Bool = false
   @State private var isShowingSignOutConfirm: Bool = false
@@ -183,7 +183,9 @@ struct VaultListView: View {
   }
 
   private var displayedCategories: [LandingItem] {
-    let counts = categoryCounts(viewModel.allSummaries)
+    // Use filteredSummaries (== allSummaries while not searching, but also honors
+    // any team filter) so card counts match the entries the pushed list shows.
+    let counts = categoryCounts(viewModel.filteredSummaries)
     var items: [LandingItem] = [
       LandingItem(id: "all", category: .all, symbol: "tray.full",
                   label: String(localized: "All"), count: counts[.all] ?? 0),
@@ -203,7 +205,7 @@ struct VaultListView: View {
       items.append(LandingItem(id: "favorites", category: .favorites, symbol: "star",
                                label: String(localized: "Favorites"), count: count))
     }
-    for tag in distinctTags(viewModel.allSummaries) {
+    for tag in distinctTags(viewModel.filteredSummaries) {
       items.append(LandingItem(id: "tag-\(tag)", category: .tag(tag), symbol: "tag",
                                label: tag, count: counts[.tag(tag)] ?? 0))
     }
@@ -239,7 +241,7 @@ struct VaultListView: View {
       .padding()
     }
     .overlay {
-      if viewModel.allSummaries.isEmpty {
+      if viewModel.filteredSummaries.isEmpty {
         Text("No entries")
           .foregroundStyle(.secondary)
           .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
@@ -21,7 +21,6 @@ public enum VaultViewModelError: Error, Equatable {
 @Observable @MainActor public final class VaultViewModel {
   public private(set) var summaries: [VaultEntrySummary] = []
   public var searchQuery: String = ""
-  public var filterFavoritesOnly: Bool = false
   public var filterTeamId: String? = nil  // nil = all, non-nil = specific team
 
   var allSummaries: [VaultEntrySummary] = []
@@ -41,10 +40,6 @@ public enum VaultViewModelError: Error, Equatable {
         $0.username.lowercased().contains(q) ||
         $0.urlHost.lowercased().contains(q)
       }
-    }
-    if filterFavoritesOnly {
-      // Summary doesn't carry isFavorite; filtering by text only for now.
-      // isFavorite lives in the encrypted blob — used for display only in detail.
     }
     if let teamId = filterTeamId {
       result = result.filter { $0.teamId == teamId }
@@ -130,7 +125,13 @@ public enum VaultViewModelError: Error, Equatable {
       )
       // Shared decode: the server blob lacks `id` (injected from the cache row)
       // and uses null/omitted fields — direct decode into VaultEntrySummary fails.
-      return EntryBlobDecoder.summary(plaintext: plaintext, entryId: entry.id, teamId: entry.teamId)
+      return EntryBlobDecoder.summary(
+        plaintext: plaintext,
+        entryId: entry.id,
+        teamId: entry.teamId,
+        entryType: entry.entryType,
+        isFavorite: entry.isFavorite ?? false
+      )
     } catch {
       return nil
     }

--- a/ios/PasswdSSOTests/CacheEntryPropagationTests.swift
+++ b/ios/PasswdSSOTests/CacheEntryPropagationTests.swift
@@ -28,7 +28,7 @@ final class CacheEntryPropagationTests: XCTestCase {
   /// Legacy cache rows written before isFavorite existed decode to nil.
   func testCacheEntryDecodesNilIsFavoriteFromLegacyJSON() throws {
     let json = #"""
-    {"id":"e3","aadVersion":1,"keyVersion":1,
+    {"id":"e3","aadVersion":0,"keyVersion":0,
      "encryptedBlob":{"ciphertext":"aa","iv":"bb","authTag":"cc"},
      "encryptedOverview":{"ciphertext":"aa","iv":"bb","authTag":"cc"}}
     """#

--- a/ios/PasswdSSOTests/CacheEntryPropagationTests.swift
+++ b/ios/PasswdSSOTests/CacheEntryPropagationTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import XCTest
+@testable import PasswdSSOApp
+@testable import Shared
+
+/// C1: entryType / isFavorite propagate wire → CacheEntry → summary.
+final class CacheEntryPropagationTests: XCTestCase {
+  private func enc() -> EncryptedData {
+    EncryptedData(ciphertext: "aa", iv: "aabbccddeeff001122334455", authTag: "00112233445566778899aabbccddeeff")
+  }
+
+  func testToPersonalCacheEntryPropagatesEntryTypeAndFavorite() {
+    let wire = EncryptedEntry(
+      id: "e1", encryptedOverview: enc(), encryptedBlob: enc(),
+      entryType: "PASSKEY", isFavorite: true
+    )
+    let cache = wire.toPersonalCacheEntry()
+    XCTAssertEqual(cache.entryType, "PASSKEY")
+    XCTAssertEqual(cache.isFavorite, true)
+  }
+
+  func testToPersonalCacheEntryFavoriteFalse() {
+    let cache = EncryptedEntry(id: "e2", encryptedOverview: enc(), encryptedBlob: enc(), isFavorite: false)
+      .toPersonalCacheEntry()
+    XCTAssertEqual(cache.isFavorite, false)
+  }
+
+  /// Legacy cache rows written before isFavorite existed decode to nil.
+  func testCacheEntryDecodesNilIsFavoriteFromLegacyJSON() throws {
+    let json = #"""
+    {"id":"e3","aadVersion":1,"keyVersion":1,
+     "encryptedBlob":{"ciphertext":"aa","iv":"bb","authTag":"cc"},
+     "encryptedOverview":{"ciphertext":"aa","iv":"bb","authTag":"cc"}}
+    """#
+    let entry = try JSONDecoder().decode(CacheEntry.self, from: Data(json.utf8))
+    XCTAssertNil(entry.isFavorite)
+    XCTAssertNil(entry.entryType)
+  }
+
+  /// EntryBlobDecoder.summary carries the caller-supplied metadata through.
+  func testSummaryCarriesEntryTypeAndFavorite() throws {
+    let overview = Data(#"{"title":"T","tags":[]}"#.utf8)
+    let summary = try XCTUnwrap(
+      EntryBlobDecoder.summary(
+        plaintext: overview, entryId: "e4", teamId: nil,
+        entryType: "CREDIT_CARD", isFavorite: true
+      )
+    )
+    XCTAssertEqual(summary.entryType, "CREDIT_CARD")
+    XCTAssertTrue(summary.isFavorite)
+  }
+
+  func testSummaryDefaultsEntryTypeNilAndFavoriteFalse() throws {
+    let overview = Data(#"{"title":"T","tags":[]}"#.utf8)
+    let summary = try XCTUnwrap(
+      EntryBlobDecoder.summary(plaintext: overview, entryId: "e5", teamId: nil)
+    )
+    XCTAssertNil(summary.entryType)
+    XCTAssertFalse(summary.isFavorite)
+  }
+}

--- a/ios/PasswdSSOTests/EntryTypeCategoryTests.swift
+++ b/ios/PasswdSSOTests/EntryTypeCategoryTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import PasswdSSOApp
+
+final class EntryTypeCategoryTests: XCTestCase {
+  func testFromKnownRawValue() {
+    XCTAssertEqual(EntryTypeCategory.from(rawType: "PASSKEY"), .passkey)
+    XCTAssertEqual(EntryTypeCategory.from(rawType: "SECURE_NOTE"), .secureNote)
+    XCTAssertEqual(EntryTypeCategory.from(rawType: "BANK_ACCOUNT"), .bankAccount)
+  }
+
+  func testFromNilDefaultsToLogin() {
+    XCTAssertEqual(EntryTypeCategory.from(rawType: nil), .login)
+  }
+
+  func testFromUnknownDefaultsToLogin() {
+    XCTAssertEqual(EntryTypeCategory.from(rawType: "FUTURE_TYPE"), .login)
+  }
+
+  func testAllCasesCountIsEight() {
+    XCTAssertEqual(EntryTypeCategory.allCases.count, 8)
+  }
+}

--- a/ios/PasswdSSOTests/EntryTypeCategoryTests.swift
+++ b/ios/PasswdSSOTests/EntryTypeCategoryTests.swift
@@ -2,10 +2,21 @@ import XCTest
 @testable import PasswdSSOApp
 
 final class EntryTypeCategoryTests: XCTestCase {
-  func testFromKnownRawValue() {
-    XCTAssertEqual(EntryTypeCategory.from(rawType: "PASSKEY"), .passkey)
+  func testFromKnownRawValueAllEightCases() {
+    // Pins every raw string against the server ENTRY_TYPE contract.
+    XCTAssertEqual(EntryTypeCategory.from(rawType: "LOGIN"), .login)
     XCTAssertEqual(EntryTypeCategory.from(rawType: "SECURE_NOTE"), .secureNote)
+    XCTAssertEqual(EntryTypeCategory.from(rawType: "CREDIT_CARD"), .creditCard)
+    XCTAssertEqual(EntryTypeCategory.from(rawType: "IDENTITY"), .identity)
     XCTAssertEqual(EntryTypeCategory.from(rawType: "BANK_ACCOUNT"), .bankAccount)
+    XCTAssertEqual(EntryTypeCategory.from(rawType: "SSH_KEY"), .sshKey)
+    XCTAssertEqual(EntryTypeCategory.from(rawType: "SOFTWARE_LICENSE"), .softwareLicense)
+    XCTAssertEqual(EntryTypeCategory.from(rawType: "PASSKEY"), .passkey)
+  }
+
+  func testFromIsCaseSensitiveLowercaseFallsBackToLogin() {
+    // The server contract is uppercase; a lowercase value is not a known type.
+    XCTAssertEqual(EntryTypeCategory.from(rawType: "passkey"), .login)
   }
 
   func testFromNilDefaultsToLogin() {

--- a/ios/PasswdSSOTests/VaultCategoryTests.swift
+++ b/ios/PasswdSSOTests/VaultCategoryTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import Shared
+@testable import PasswdSSOApp
+
+final class VaultCategoryTests: XCTestCase {
+  private func summary(
+    id: String,
+    entryType: String? = nil,
+    hasTOTP: Bool = false,
+    isFavorite: Bool = false,
+    tags: [String] = []
+  ) -> VaultEntrySummary {
+    VaultEntrySummary(
+      id: id, title: id, username: "u", urlHost: "x.com",
+      tags: tags, hasTOTP: hasTOTP, entryType: entryType, isFavorite: isFavorite
+    )
+  }
+
+  func testMatchesPerCategory() {
+    let login = summary(id: "a", entryType: EntryTypeCategory.login.rawValue)
+    let passkey = summary(id: "b", entryType: EntryTypeCategory.passkey.rawValue)
+    XCTAssertTrue(matches(login, .all))
+    XCTAssertTrue(matches(login, .type(.login)))
+    XCTAssertFalse(matches(login, .type(.passkey)))
+    XCTAssertTrue(matches(passkey, .type(.passkey)))
+    XCTAssertTrue(matches(summary(id: "c", hasTOTP: true), .codes))
+    XCTAssertTrue(matches(summary(id: "d", isFavorite: true), .favorites))
+    XCTAssertTrue(matches(summary(id: "e", tags: ["work"]), .tag("work")))
+    XCTAssertFalse(matches(summary(id: "f", tags: ["home"]), .tag("work")))
+  }
+
+  func testLegacyNilEntryTypeCountsAsLogin() {
+    XCTAssertTrue(matches(summary(id: "a", entryType: nil), .type(.login)))
+  }
+
+  func testMultiMembership() {
+    let s = summary(id: "a", entryType: EntryTypeCategory.login.rawValue,
+                    hasTOTP: true, isFavorite: true, tags: ["work"])
+    XCTAssertTrue(matches(s, .type(.login)))
+    XCTAssertTrue(matches(s, .codes))
+    XCTAssertTrue(matches(s, .favorites))
+    XCTAssertTrue(matches(s, .tag("work")))
+  }
+
+  func testCategoryCountsAllEqualsTotalAndPerCategory() {
+    let summaries = [
+      summary(id: "a", entryType: "LOGIN", hasTOTP: true, isFavorite: true, tags: ["work"]),
+      summary(id: "b", entryType: "LOGIN"),
+      summary(id: "c", entryType: "PASSKEY", tags: ["work", "social"]),
+      summary(id: "d", entryType: nil),  // legacy → login
+    ]
+    let counts = categoryCounts(summaries)
+    XCTAssertEqual(counts[.all], 4)
+    XCTAssertEqual(counts[.type(.login)], 3)  // a, b, d(legacy)
+    XCTAssertEqual(counts[.type(.passkey)], 1)
+    XCTAssertEqual(counts[.codes], 1)
+    XCTAssertEqual(counts[.favorites], 1)
+    XCTAssertEqual(counts[.tag("work")], 2)
+    XCTAssertEqual(counts[.tag("social")], 1)
+  }
+
+  func testZeroCountTypeIsAbsent() {
+    let counts = categoryCounts([summary(id: "a", entryType: "LOGIN")])
+    XCTAssertNil(counts[.type(.creditCard)], "empty type must not appear")
+    XCTAssertNil(counts[.type(.passkey)])
+  }
+
+  func testDistinctTagsSortedUnique() {
+    let summaries = [
+      summary(id: "a", tags: ["work", "social"]),
+      summary(id: "b", tags: ["work"]),
+      summary(id: "c", tags: []),
+    ]
+    XCTAssertEqual(distinctTags(summaries), ["social", "work"])
+  }
+}

--- a/ios/PasswdSSOTests/VaultCategoryTests.swift
+++ b/ios/PasswdSSOTests/VaultCategoryTests.swift
@@ -24,7 +24,9 @@ final class VaultCategoryTests: XCTestCase {
     XCTAssertFalse(matches(login, .type(.passkey)))
     XCTAssertTrue(matches(passkey, .type(.passkey)))
     XCTAssertTrue(matches(summary(id: "c", hasTOTP: true), .codes))
+    XCTAssertFalse(matches(summary(id: "c2", hasTOTP: false), .codes))
     XCTAssertTrue(matches(summary(id: "d", isFavorite: true), .favorites))
+    XCTAssertFalse(matches(summary(id: "d2", isFavorite: false), .favorites))
     XCTAssertTrue(matches(summary(id: "e", tags: ["work"]), .tag("work")))
     XCTAssertFalse(matches(summary(id: "f", tags: ["home"]), .tag("work")))
   }
@@ -63,6 +65,10 @@ final class VaultCategoryTests: XCTestCase {
     let counts = categoryCounts([summary(id: "a", entryType: "LOGIN")])
     XCTAssertNil(counts[.type(.creditCard)], "empty type must not appear")
     XCTAssertNil(counts[.type(.passkey)])
+    // Codes/Favorites are always present (at 0) so the view's `if count > 0`
+    // guard keys off a real number, not a nil/absent distinction.
+    XCTAssertEqual(counts[.codes], 0)
+    XCTAssertEqual(counts[.favorites], 0)
   }
 
   func testDistinctTagsSortedUnique() {

--- a/ios/PasswdSSOTests/VaultFilterTests.swift
+++ b/ios/PasswdSSOTests/VaultFilterTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+import Shared
+@testable import PasswdSSOApp
+
+/// Guards that `filteredSummaries` (the basis for the `.all` category and the
+/// flat search list) keeps today's behavior after the landing refactor.
+@MainActor
+final class VaultFilterTests: XCTestCase {
+  private func s(_ id: String, title: String, username: String = "u", urlHost: String = "x.com") -> VaultEntrySummary {
+    VaultEntrySummary(id: id, title: title, username: username, urlHost: urlHost)
+  }
+
+  func testEmptySearchReturnsAll() {
+    let vm = VaultViewModel()
+    vm.injectSummaries([s("a", title: "Alpha"), s("b", title: "Beta")])
+    XCTAssertEqual(Set(vm.filteredSummaries.map(\.id)), ["a", "b"])
+  }
+
+  func testSearchFiltersByTitleUsernameHost() {
+    let vm = VaultViewModel()
+    vm.injectSummaries([
+      s("a", title: "GitHub", username: "alice"),
+      s("b", title: "GitLab", username: "bob", urlHost: "gitlab.com"),
+    ])
+    vm.searchQuery = "github"
+    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["a"])
+    vm.searchQuery = "bob"
+    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["b"])
+    vm.searchQuery = "gitlab.com"
+    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["b"])
+  }
+}

--- a/ios/Shared/AutoFill/CredentialResolver.swift
+++ b/ios/Shared/AutoFill/CredentialResolver.swift
@@ -612,6 +612,10 @@ public struct CacheEntry: Codable, Sendable {
   /// only as a fast pre-classifier — passkey detection falls back to the
   /// decrypted overview's relyingPartyId, so nil never causes a miss.
   public let entryType: String?
+  /// Server favorite flag (non-secret metadata, like `entryType`). Optional/
+  /// nil-tolerant: caches written before this field existed, and team rows,
+  /// decode to nil → treated as not-favorite.
+  public let isFavorite: Bool?
 
   public init(
     id: String,
@@ -623,7 +627,8 @@ public struct CacheEntry: Codable, Sendable {
     encryptedItemKey: EncryptedData? = nil,
     encryptedBlob: EncryptedData,
     encryptedOverview: EncryptedData,
-    entryType: String? = nil
+    entryType: String? = nil,
+    isFavorite: Bool? = nil
   ) {
     self.id = id
     self.teamId = teamId
@@ -635,5 +640,6 @@ public struct CacheEntry: Codable, Sendable {
     self.encryptedBlob = encryptedBlob
     self.encryptedOverview = encryptedOverview
     self.entryType = entryType
+    self.isFavorite = isFavorite
   }
 }

--- a/ios/Shared/Models/EntryBlobDecoder.swift
+++ b/ios/Shared/Models/EntryBlobDecoder.swift
@@ -80,10 +80,16 @@ public enum EntryBlobDecoder {
   /// overview blob's TOTP presence marker (written by the web client); it
   /// drives the one-time-code AutoFill picker filter. Entries encrypted before
   /// the marker shipped decode to `false` until their next save.
+  /// `entryType`/`isFavorite` are non-secret server metadata that live on the
+  /// cache row (not in the encrypted overview blob), so the caller supplies them
+  /// from the `CacheEntry`. They default so the AutoFill call sites — which don't
+  /// need them — stay unchanged.
   public static func summary(
     plaintext: Data,
     entryId: String,
-    teamId: String?
+    teamId: String?,
+    entryType: String? = nil,
+    isFavorite: Bool = false
   ) -> VaultEntrySummary? {
     guard let p = try? JSONDecoder().decode(OverviewBlobPayload.self, from: plaintext) else {
       return nil
@@ -102,7 +108,9 @@ public enum EntryBlobDecoder {
       // Keep travelSafe three-state (nil = absent): preserved verbatim on edit.
       travelSafe: p.travelSafe,
       relyingPartyId: p.relyingPartyId,
-      credentialId: p.credentialId
+      credentialId: p.credentialId,
+      entryType: entryType,
+      isFavorite: isFavorite
     )
   }
 

--- a/ios/Shared/Models/VaultEntrySummary.swift
+++ b/ios/Shared/Models/VaultEntrySummary.swift
@@ -28,6 +28,11 @@ public struct VaultEntrySummary: Codable, Sendable, Equatable, Identifiable {
   /// buildPasskeyIdentitySpecs).
   public let relyingPartyId: String?
   public let credentialId: String?
+  /// Server entry type ("LOGIN", "PASSKEY", …); nil for legacy cache rows. Drives
+  /// the category landing grid. Comes from the cache row, not the overview blob.
+  public let entryType: String?
+  /// Server favorite flag (cache-row metadata, not in the encrypted blob).
+  public let isFavorite: Bool
 
   public init(
     id: String,
@@ -42,7 +47,9 @@ public struct VaultEntrySummary: Codable, Sendable, Equatable, Identifiable {
     requireReprompt: Bool = false,
     travelSafe: Bool? = nil,
     relyingPartyId: String? = nil,
-    credentialId: String? = nil
+    credentialId: String? = nil,
+    entryType: String? = nil,
+    isFavorite: Bool = false
   ) {
     self.id = id
     self.title = title
@@ -57,5 +64,7 @@ public struct VaultEntrySummary: Codable, Sendable, Equatable, Identifiable {
     self.travelSafe = travelSafe
     self.relyingPartyId = relyingPartyId
     self.credentialId = credentialId
+    self.entryType = entryType
+    self.isFavorite = isFavorite
   }
 }


### PR DESCRIPTION
## What

Closes iOS↔extension parity item: an **Apple-Passwords-style category landing grid**. After unlock the vault opens to a grid of category cards (icon + label + count) instead of a flat list; each card drills into a filtered list.

Categories: **All**, each non-empty **entry type** (Login, Secure Note, Credit Card, Identity, Bank Account, SSH Key, Software License, Passkey), **Codes** (TOTP), **Favorites**, and one per **tag**.

## Changes
- Propagate `entryType` + `isFavorite` (non-secret server metadata) through `EncryptedEntry`/`TeamEncryptedEntry` → `CacheEntry` (`isFavorite: Bool?`, backward-compatible) → `EntryBlobDecoder.summary` → `VaultEntrySummary`. Legacy cache rows decode to nil/false (treated as Login / not-favorite).
- `EntryTypeCategory` (total mapping, localized labels) + pure, unit-tested `VaultCategory` `matches`/`categoryCounts`/`distinctTags`.
- Built **in-place** in `VaultListView` (keeps its NavigationStack / toolbar / search / create / screen-recording overlay) — no navigation-ownership move. The pushed `VaultCategoryListView` carries its own screen-recording overlay.
- Removed the dead `filterFavoritesOnly` placeholder (favorites is now a category).

Search at the root shows flat results across all entries; within a pushed category it composes. **Trash** and **Watchtower** are deferred (no on-device data — server filters trashed/archived; no iOS security-audit client).

## Process (triangulate)
Plan → 3-expert review (round 1) → implement → 3-expert Phase-3 review → fixes. Artifacts in `docs/archive/review/ios-category-landing-{plan,review,manual-test}.md`.

## Testing
`xcodebuild test` green — **401 unit tests** (new EntryTypeCategory / VaultCategory / propagation / VM-filter coverage) + launch UI tests. Manual-test checklist for the untestable UI surface (grid render, drill-in, empty-types-hidden, screen-recording on pushed view, nav back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)