### PR TITLE
chore: align pre-pr.sh with CI gates (multi-package build/test, eslint .claude ignore, refactor-gate)

### DIFF
--- a/docs/archive/review/pre-pr-multipackage-build-lint-gate-code-review.md
+++ b/docs/archive/review/pre-pr-multipackage-build-lint-gate-code-review.md
@@ -1,0 +1,54 @@
+# Code Review: pre-pr-multipackage-build-lint-gate
+Date: 2026-06-14
+Review round: 1 (code)
+
+## Changes from Previous Round
+Initial code review of the implemented diff (uncommitted working tree): `eslint.config.mjs`, `scripts/pre-pr.sh`, `scripts/refactor-phase-verify.mjs`. Three expert sub-agents reviewed against the finalized plan + deviation log.
+
+## Outcome
+**Converged in Round 1. Zero actionable findings.** Functionality and Security returned "No findings". Testing returned 3 Minor items — all explicit "Fix: None needed" confirmations that the implementation is correct (not defects).
+
+## Functionality Findings
+No findings. Verified:
+- C5 control flow: `originSha`/`envSha`/`expectedSha` now block-scoped inside `if (!skipMergeQueueGuards)` (refactor-phase-verify.mjs:80-82); no later reference; `scripts[]` loop runs unconditionally; no-flag (`--force`) path byte-identical in effect.
+- C4 predicate safe under `set -euo pipefail` (`grep -qE` exit 1 in `if`-condition does not abort; `-- src` no word-split; two-dot `-M main` mirrors verify-move-only-diff.mjs).
+- C2/C3 deps-guards append to `failed`/`failures` (no `exit 1`); `run_step` captures `${PIPESTATUS[0]}` of the `bash -c` subshell correctly.
+- Placement: new block after App Build, before Results; C4 block replaced the old one in place (no duplicate).
+
+## Security Findings
+No findings (no escalations). Verified:
+- C1 `.claude/**` is legitimate scope-exclusion, NOT R36 suppression — root-anchored `src/**`/`e2e/**` rule globs never matched `.claude/worktrees/<id>/...`; zero tracked lintable files under `.claude/`.
+- C5 flag skips ONLY the stale-branch + parallel-branch guards; the four security checks (team-auth-rls/bypass-rls/crypto-domains/migration-drift) at `scripts[]` indices 0-3 still run; CI `--force` path unchanged.
+- C4 skip path still runs the four security checks via pre-pr.sh:140-143 (defense-in-depth).
+- C2/C3 under `STATIC_ONLY!=1`, after all `Static:` guards; `run_step` brackets `set +e`/`set -e` so a package failure cannot abort the run and skip later checks.
+- R33: single `PRE_PR_STATIC_ONLY=1` source; no duplicate CI config drift. R31: no state destruction (baseline `writeFileSync` is re-indent only).
+
+## Testing Findings
+- **[T1] Minor** — C5 negative test cause is specific: `Branch is stale` (line 101-106, inside `if (!skipMergeQueueGuards)`) precedes `checkParallelRefactorBranches` (line 138), so on the without-flag path with a stale baseline it is the proximate exit cause. Plan's grep-the-string acceptance is sound. **Fix: none.**
+- **[T2] Minor** — C4 fire-arm reachable (synthetic `R` line fires the predicate; orchestrator invocation is independently C5-tested). Not vacuous. **Fix: none.**
+- **[T3] Minor** — deps-guard appends empty logfile to `failures[]`; `show_failure_context` guards on `[ -n "$logfile" ]` and prints label-only, matching the manual-test-gate precedent. **Fix: none.**
+- RT1 PASS (order matches ci.yml byte-for-byte). RT2/RT3 PASS. Contract coverage: all C1–C5 implemented as planned.
+
+## Adjacent Findings
+None actionable. (Testing noted "no bats harness" as project-context Minor info — out of scope per plan; script validated by running it: full pre-pr.sh EXIT=0, Passed:36.)
+
+## Recurring Issue Check
+### Functionality expert
+- R33: clean (closes drift; order pinned to ci.yml with a comment). R36: clean (ignore-path, not suppression). R1–R32, R34–R37: N/A (dev-tooling).
+### Security expert
+- R31: N/A (no state deleted). R33: clean (single source). R36: clean. RS1–RS4: N/A (no route/auth/crypto/schema). R1–R30, R32, R34, R35, R37: N/A.
+### Testing expert
+- RT1: PASS. RT2: PASS. RT3: PASS. RT4–RT6: N/A. R33/R35/R36: respected.
+
+## Environment Verification Report
+All C1–C5 acceptance paths classified `verified-local`:
+- C1: `npx eslint .` EXIT=0.
+- C2: CLI Build→Test pass; named extensionless import → TS2835 EXIT=2 (regression class caught).
+- C3: Extension Test (769) → Build, both pass.
+- C4: 0-rename skip arm (no stale false-fail) + synthetic-rename fire-arm predicate.
+- C5: with-flag → 16 scripts run, no stale exit; without-flag → exit 1 on `Branch is stale`.
+- End-to-end: full `bash scripts/pre-pr.sh` EXIT=0, Passed:36. STATIC_ONLY path skips new steps.
+No `blocked-deferred` paths. N/A constraints declared none beyond fully-local verifiability.
+
+## Resolution Status
+No Critical/Major/actionable-Minor findings to resolve. Review complete.

--- a/docs/archive/review/pre-pr-multipackage-build-lint-gate-deviation.md
+++ b/docs/archive/review/pre-pr-multipackage-build-lint-gate-deviation.md
@@ -1,0 +1,7 @@
+# Coding Deviation Log: pre-pr-multipackage-build-lint-gate
+
+No deviations from the plan. All five contracts (C1–C5) implemented as specified.
+
+## Verification notes (not deviations)
+- **C2 negative-test nuance**: a *side-effect* extensionless import (`import "./index"`) does NOT trigger TS2835, but a *named* extensionless import (`import { x } from "./index"`) does (tsc EXIT=2). The actual #651 regression class is the named/`from`-clause form (`from "./time"`), so the gate (`cd cli && npm run build`) catches it. The initial harness used the side-effect form by mistake; re-tested with the named form → TS2835 confirmed.
+- Implemented files: `eslint.config.mjs` (C1), `scripts/refactor-phase-verify.mjs` (C5), `scripts/pre-pr.sh` (C2/C3/C4). All in working tree (uncommitted — commit pending user instruction).

--- a/docs/archive/review/pre-pr-multipackage-build-lint-gate-plan.md
+++ b/docs/archive/review/pre-pr-multipackage-build-lint-gate-plan.md
@@ -1,0 +1,123 @@
+# Plan: pre-pr multi-package build + lint-ignore + refactor-gate fixes (PR #651)
+
+## Project context
+
+- **Type**: `CLI tool` / dev-tooling (shell script `scripts/pre-pr.sh` + flat ESLint config `eslint.config.mjs` + Node orchestrator `scripts/refactor-phase-verify.mjs`). No runtime/app behavior changes.
+- **Test infrastructure**: `unit + integration + E2E + CI/CD`. The artifacts under change are themselves the CI-parity local gate; there is no unit-test harness for `pre-pr.sh` itself (it is exercised by running it).
+- **Verification environment constraints**: all three fixes are fully `verifiable-local` — the repo, the `cli/` and `extension/` packages (both have `node_modules`), and a `.claude/worktrees/` tree are all present locally. No paid-tier / external-service / hardware-attestation paths. CI equivalence is verifiable by reading `.github/workflows/ci.yml` + `refactor-phase-verify.yml`.
+- **Scope**: dev-tooling only. Per Phase-1 project-context rule, reviewers MUST NOT raise Major/Critical findings recommending new automated-test frameworks for the shell script.
+
+## Objective
+
+Make `scripts/pre-pr.sh` a faithful local mirror of the CI gates so that "what passes pre-pr passes CI", closing three gaps surfaced while shipping PR #651:
+
+1. **(most important) Multi-package build/test gap** — pre-pr verifies only the App (root `eslint .` / `vitest run` / `next build`). It never builds or tests `cli/` or `extension/`. A CLI ESM `.js`-extension omission (`tsc` TS2835, which `vitest`/esbuild tolerates) slipped past pre-pr and first failed in CI's "CLI: Build" job. The "don't push what doesn't build" contract was not enforceable at the pre-pr layer.
+2. **ESLint false-fail** — `npx eslint .` exits 1 locally with 6831 "errors", blocking the Lint step. Root cause (verified): **100% of those errors originate from `.claude/worktrees/**`** — throwaway full-repo worktree copies that are git-ignored but NOT eslint-ignored. Excluding `.claude`, the project has **0 errors / 49 warnings**. CI passes `npm run lint` precisely because a fresh checkout has no `.claude/worktrees`.
+3. **refactor-phase-verify false-fail (local-only)** — On a `refactor/*` branch, pre-pr runs `scripts/refactor-phase-verify.mjs`, whose stale-branch guard compares a fetched `origin/main` SHA against `.refactor-phase-verify-baseline` — a **git-ignored local file** that persists a stale SHA from a prior refactor session, yielding a false "Branch is stale" exit 1. CI passes because its fresh checkout has no baseline file (first-run records & passes). The guard is in fact **vacuous in CI** (always first-run) and only produces local false-positives.
+
+## Requirements
+
+### Functional
+- FR1: After the change, `npx eslint .` from the repo root exits 0 even when `.claude/worktrees/` is present, matching CI.
+- FR2: `scripts/pre-pr.sh` builds AND tests `cli/` and `extension/` (under the non-static guard), in the same per-package order CI uses: **CLI = Build → Test**, **Extension = Test → Build**.
+- FR3: A genuine build/test break in `cli/` or `extension/` causes `pre-pr.sh` to exit 1 with captured failure context (same `run_step` machinery as existing steps).
+- FR4: On a **content-only** refactor branch (no `src` renames), `pre-pr.sh` does NOT run the move-only refactor orchestrator and does NOT false-fail on the stale baseline.
+- FR5: On a **move** refactor branch (≥1 `src` rename), `pre-pr.sh` runs the refactor orchestrator's verification scripts WITHOUT the merge-queue-only guards (stale-baseline + parallel-branch) that cause local false-positives.
+
+### Non-functional
+- NFR1: iOS is intentionally excluded from pre-pr (CI-only `xcodebuild`); state this in a code comment.
+- NFR2: No `npm ci` inside pre-pr for `cli/`/`extension/` — assume installed deps (CI does `npm ci` in clean runners; locally that would be slow/destructive). If a package's `node_modules` is absent, the step must fail with a clear, actionable message rather than a cryptic one.
+- NFR3: All new package steps respect `PRE_PR_STATIC_ONLY=1` (skip — they are environment-dependent, like Lint/Test/Build).
+- NFR4: CI behavior is unchanged — `refactor-phase-verify.yml` keeps invoking `--force` with full guards.
+
+## Technical approach
+
+- **C1 (ESLint):** one-line addition to the existing `globalIgnores([...])` array in `eslint.config.mjs`: `".claude/**"`. Consistent with the existing `"extension/**"`, `"load-test/**"`, `"coverage/**"` entries. Nothing tracked under `.claude/` is project source the root config should lint (3 tracked files: a `.sh` hook, `settings.json`, a `SKILL.md` — none are `.ts/.tsx`).
+- **C2/C3 (multi-package):** add `run_step` invocations using `bash -c 'cd <pkg> && <npm script>'`. `cd` is required (not `npm --prefix`) because `tsc`/`vitest` resolve their config from CWD, not from the `package.json` location. Guard the block with `if [ "$STATIC_ONLY" != "1" ]`. Precede each package with a `node_modules` existence check that fails with a `cd <pkg> && npm ci` hint (NFR2).
+- **C4 (pre-pr refactor gate):** replace the bare `^refactor/` branch test with a compound condition that ALSO requires ≥1 renamed `src` path (`git diff --name-status -M main -- src | grep -E '^[RC]'`). When the branch is `refactor/*` but has no `src` renames, print an explanatory skip line (content-only refactor → CI's Refactor Phase Verify workflow remains authoritative). When it runs, pass `--skip-merge-queue-guards`.
+- **C5 (orchestrator flag):** add a `--skip-merge-queue-guards` flag to `scripts/refactor-phase-verify.mjs`. When set, skip BOTH the stale-branch baseline check and the parallel-refactor-branch (`gh pr list`) check; still run every verification script. CI continues without the flag.
+
+## Contracts
+
+### C1 — eslint ignores `.claude/**`
+- **File**: `eslint.config.mjs`
+- **Change**: add `".claude/**"` to the `globalIgnores([...])` array, with a trailing comment noting it excludes throwaway git-ignored worktree copies (parity with the existing `coverage/**`/`extension/**` entries), so it is not misread as a security-scope carve-out (S1). The `no-restricted-syntax` fetch()/e2e rules are root-anchored (`src/components/**`, `e2e/**`) and never matched worktree copies at `.claude/worktrees/<id>/...`, so coverage of real `src/`/`e2e/` is unchanged (S1 verified).
+- **Invariant** (app-enforced via tool exit code): running `npx eslint .` from repo root with a populated `.claude/worktrees/` present produces 0 errors → exit 0.
+- **Forbidden patterns**:
+  - `pattern: --max-warnings` in `eslint.config.mjs` or `scripts/pre-pr.sh` Lint step — reason: must NOT relax the gate; fix is ignore-path, not threshold.
+  - `pattern: eslint-disable` introduced in this diff — reason: R36, no suppression.
+- **Acceptance**: `npx eslint . ; echo $?` → `0`. `git grep -n '".claude/\*\*"' eslint.config.mjs` → 1 hit inside globalIgnores.
+
+### C2 — pre-pr builds + tests `cli/` (Build → Test)
+- **File**: `scripts/pre-pr.sh`
+- **Placement** (F6): a single dedicated `if [ "$STATIC_ONLY" != "1" ]; then ... fi` block placed immediately **after the App `Build` step (current line ~460) and before the `═══ Results ═══` summary (line 462)**. Holds C2 + C3 together (cheap tsc/vitest cluster after the expensive `next build`).
+- **Change**: `run_step "CLI: Build" bash -c 'cd cli && npm run build'` then `run_step "CLI: Test" bash -c 'cd cli && npm test'`, preceded by a `cli/node_modules` presence guard.
+- **node_modules guard** (F2 / Adjacent): implement as a bare `if [ ! -d cli/node_modules ]; then printf ERROR+hint; failed=$((failed+1)); failures+=("CLI: deps missing|"); else <run the two steps>; fi` — mirroring the Manual-test-artifact gate at `scripts/pre-pr.sh:422-431` (append to `failed`/`failures`, do NOT `exit 1` — `set -euo pipefail` would otherwise kill the run before the Results summary). The hint message: `run 'cd cli && npm ci' (deps not installed; pre-pr does not auto-install)`.
+- **Invariant**: order is Build-before-Test (matches CI "CLI: Build → Test", `ci.yml:393-394`; tsc must run before vitest so a `.js`-extension omission is caught by the build first). `cli/tsconfig.json` is `module/moduleResolution: NodeNext` (verified) so TS2835 fires on extensionless relative imports (F7).
+- **Acceptance**:
+  - **Order (T1)**: `grep -n 'CLI: Build' scripts/pre-pr.sh` line < `grep -n 'CLI: Test'` line.
+  - **Negative (T6)**: introduce a temporary extensionless relative import in `cli/src` → the "CLI: Build" step fails AND the captured failure context contains `error TS2835` (the exact #651 regression class; `show_failure_context` already greps `error TS[0-9]+` at `pre-pr.sh:40`); revert → passes.
+  - **Deps guard (Adjacent)**: temporarily rename `cli/node_modules` → run pre-pr → the actionable hint appears and the run still reaches the Results summary (exit 1, not a mid-run abort); restore.
+
+### C3 — pre-pr tests + builds `extension/` (Test → Build)
+- **File**: `scripts/pre-pr.sh` — same block as C2.
+- **Change**: `run_step "Extension: Test" bash -c 'cd extension && npm test'` then `run_step "Extension: Build" bash -c 'cd extension && npm run build'`, preceded by an `extension/node_modules` presence guard (same bare-`if` pattern as C2).
+- **Invariant**: order is Test-before-Build (matches CI "Extension: Test → Build", `ci.yml:286-287`).
+- **Acceptance**:
+  - **Order (T1)**: `grep -n 'Extension: Test'` line < `grep -n 'Extension: Build'` line.
+  - **Positive**: both steps run and pass on current tree (verified: ext test 769 pass, ext build OK).
+
+### C4 — pre-pr refactor gate requires `src` renames; passes skip flag
+- **File**: `scripts/pre-pr.sh`
+- **Change** (T3): **REPLACE the existing unconditional block at `scripts/pre-pr.sh:416-418`** (`if branch ~ ^refactor/; then run_step "Refactor phase verify" node scripts/refactor-phase-verify.mjs; fi`) — do NOT add a second block alongside it, or the old stale-baseline false-fail still fires. New condition: `STATIC_ONLY != 1` (T4 — keep the heavy orchestrator out of CI's `static-checks` job; aligns with NFR3) AND `branch ~ ^refactor/` AND `git diff --name-status -M main -- src` contains ≥1 `^[RC]` line. When it fires, invoke `node scripts/refactor-phase-verify.mjs --skip-merge-queue-guards`. When the branch is `refactor/*` but has 0 `src` renames, print an explanatory skip line (content-only refactor → CI's Refactor Phase Verify workflow is authoritative).
+- **Code comment** (F1): annotate the rename detector `# two-dot -M main (working tree) mirrors verify-move-only-diff.mjs:194; do NOT change to main...HEAD` — keeps the gate's detector aligned with the verifier it gates.
+- **Invariant**: a content-only `refactor/*` branch (0 `src` renames) never invokes the orchestrator from pre-pr; the four security checks (team-auth-rls/bypass-rls/crypto-domains/migration-drift) still run via their own top-level steps at `pre-pr.sh:140-143` (S2 — skipping the orchestrator does NOT skip security verification).
+- **Forbidden patterns**:
+  - `pattern: rm .*refactor-phase-verify-baseline` in `scripts/pre-pr.sh` — reason: do not silently delete a (git-ignored) state file as a workaround; fix is the skip flag.
+- **Acceptance**:
+  - **Skip arm**: on `refactor/hardcoded-values-to-constants` (0 src renames), the refactor step prints the skip line and pre-pr does not exit 1 on a stale baseline.
+  - **Fire arm (T2)**: unit-test the rename predicate in isolation — stage a synthetic `src` rename (`git mv` a throwaway `src` file in a scratch index, or feed a known `R100\told\tnew` line) and assert the condition evaluates true and would invoke the orchestrator `--skip-merge-queue-guards`. The predicate must not be left exercised only on its 0-rename arm.
+
+### C5 — `--skip-merge-queue-guards` flag on the orchestrator
+- **File**: `scripts/refactor-phase-verify.mjs`
+- **Signature**: new boolean CLI flag `--skip-merge-queue-guards` parsed from `process.argv`. When present, skip (a) the stale-branch baseline block (`fetchOriginMainSha` compare + `.refactor-phase-verify-baseline` read/write) and (b) `checkParallelRefactorBranches()`. All verification scripts in the `scripts[]` array still execute.
+- **fetch independence** (F4): `fetchOriginMainSha()`'s result (`originSha`) is consumed ONLY by the stale-branch comparison (`refactor-phase-verify.mjs:80-90`); every downstream `scripts[]` entry compares against the LOCAL `main` ref (`git diff -M main`, `git show main:`), not `origin/main`. Skipping the fetch with the flag therefore deprives no verification script of data.
+- **Invariant**: without the flag (CI's `--force` path in `refactor-phase-verify.yml`), behavior is byte-for-byte unchanged.
+- **Forbidden patterns**:
+  - `pattern: process.exit(0)` added inside the new skip branch that would bypass the verification-scripts loop — reason: skipping merge-queue guards MUST NOT skip the actual checks.
+- **Acceptance** (T5): with a deliberately-stale `.refactor-phase-verify-baseline` (SHA confirmed ≠ current `origin/main` at test time): `node scripts/refactor-phase-verify.mjs --skip-merge-queue-guards --force` runs the scripts loop (no exit). Running WITHOUT the flag exits 1 with the **specific** `Branch is stale` message on stderr (grep that string — not merely exit code 1, since `checkParallelRefactorBranches` could also exit 1 for an unrelated reason and falsely "confirm" the test).
+
+### Consumer-flow walkthrough
+None of C1–C5 define an API/persisted/event shape consumed by other code. The only "consumers" are CI workflows reading these scripts:
+- Consumer `ci.yml` "App: Lint → Test → Build" (reads `eslint.config.mjs` via `npm run lint`) uses the new ignore transparently — fresh checkout has no `.claude`, so behavior is unchanged in CI; the ignore only affects local runs. ✓
+- Consumer `refactor-phase-verify.yml` (invokes `scripts/refactor-phase-verify.mjs --force`) does NOT pass `--skip-merge-queue-guards`, so C5 leaves its path unchanged. ✓
+- Consumer `ci.yml` "static-checks" job (`PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh`) must still skip the new C2/C3 package steps and the C4 refactor step's heavy work — C2/C3 sit under the `STATIC_ONLY!=1` guard; C4's run path is gated on rename presence and is not part of the static set. ✓
+
+## Testing strategy
+
+- **C1**: `npx eslint .` exit-code assertion (0) with `.claude/worktrees` present; grep the config line.
+- **C2**: negative test — inject an extensionless import in `cli/src`, run the CLI Build step, confirm failure, revert.
+- **C3**: positive test — run the extension steps on the current tree (already verified green).
+- **C4**: run full `pre-pr.sh` on the current content-only refactor branch; assert the refactor step prints the skip line and the run reaches the Results summary without a refactor-gate failure.
+- **C5**: deliberately set `.refactor-phase-verify-baseline` to a stale SHA; run the orchestrator with and without the flag; assert flag→runs-scripts, no-flag→exits on stale.
+- **End-to-end**: run `bash scripts/pre-pr.sh` to completion on this branch and confirm all steps (including the new CLI/Extension ones) pass and Lint is green. This is the regression assertion that the line-416 block was REPLACED, not duplicated (T3).
+- **Static-only path** (T4): `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` output must NOT contain the labels `CLI: Build` / `CLI: Test` / `Extension: Test` / `Extension: Build` (positively assert ABSENCE — a green run alone would mask a step accidentally placed outside the guard) and must not invoke the refactor orchestrator (C4 condition now includes `STATIC_ONLY != 1`).
+
+## Considerations & constraints
+
+- **SC1 (out of scope)**: the 49 pre-existing `no-unused-vars` *warnings* (`tx` unused, etc.). They are warnings (eslint exits 0), config-intended (`no-unused-vars: "warn"`), and unrelated to PR #651. Owner: future cleanup; not tracked by a blocking issue.
+- **SC2 (out of scope)**: redesigning the stale-branch guard's fundamentally-vacuous-in-CI semantics or making the baseline per-branch. C5 neutralizes its local harm via an opt-in skip; a deeper redesign of `refactor-phase-verify.mjs`'s guard model is a separate tooling PR.
+- **SC3 (out of scope)**: adding `npm ci` / dependency-bootstrap automation for `cli/`/`extension/` inside pre-pr. NFR2 only requires a clear failure message when deps are missing.
+- **Risk**: `cd` inside `bash -c` within `run_step` — verified the existing script already uses `bash -c '...'` heredoc-style steps; the `tee`/`PIPESTATUS` capture in `run_step` works with `bash -c`. Pipe-fail semantics preserved.
+- **Risk**: adding CLI tsc + CLI vitest + ext vitest + ext tsc/vite adds wall-clock to pre-pr, but each is far cheaper than the existing `next build`; acceptable.
+- **Memory correction**: `project_pre_pr_refactor_verify_scope` previously recorded problem 2 as "6831 pre-existing errors needing gate relaxation" and problem 1 as "verify-move-only-diff structurally fails content refactors" — both were misdiagnoses corrected by this session's on-machine investigation (errors are 100% `.claude/worktrees`; verify-move-only-diff self-skips at 0 renames; the real local fail is the stale baseline). Update the memory after merge.
+
+## Go/No-Go Gate
+
+| ID  | Subject                                                        | Status |
+|-----|---------------------------------------------------------------|--------|
+| C1  | eslint.config.mjs ignores `.claude/**`                        | locked |
+| C2  | pre-pr builds+tests `cli/` (Build→Test)                       | locked |
+| C3  | pre-pr tests+builds `extension/` (Test→Build)                 | locked |
+| C4  | pre-pr refactor gate requires `src` renames + passes skip flag| locked |
+| C5  | `--skip-merge-queue-guards` flag on refactor-phase-verify.mjs | locked |

--- a/docs/archive/review/pre-pr-multipackage-build-lint-gate-review.md
+++ b/docs/archive/review/pre-pr-multipackage-build-lint-gate-review.md
@@ -1,0 +1,43 @@
+# Plan Review: pre-pr-multipackage-build-lint-gate
+Date: 2026-06-14
+Review round: 1 (plan)
+
+## Changes from Previous Round
+Initial review. Three expert sub-agents (functionality, security, testing) reviewed the plan against the live codebase.
+
+## Outcome
+**No Critical or Major design findings.** Two Major findings (T1, T2) were testing-acceptance-completeness gaps, not design defects — both resolved by strengthening acceptance criteria in the plan. All Minor findings adopted as plan refinements. No contract design changed; Go/No-Go gate stays all-`locked`.
+
+## Functionality Findings (F1–F7) — all Minor
+- **F1** — C4 `-M main` two-dot must stay (mirrors `verify-move-only-diff.mjs:194`). → **Adopted**: added code-comment requirement to C4.
+- **F2** — node_modules guard must append to `failed`/`failures` (like manual-test gate `pre-pr.sh:422-431`), NOT `exit 1` under `set -euo pipefail`. → **Adopted**: C2 node_modules-guard spec rewritten.
+- **F3** — pre-pr reuses installed deps vs CI `npm ci`; lockfile-drift false-green is a residual gap. → **Accepted (SC3)**: scoped out; NFR2 only requires a clear deps-missing message. Anti-Deferral: worst case = a lockfile-drift bug passes pre-pr but fails CI (caught one layer later, not shipped); likelihood = low; cost-to-fix = high (npm ci every run, slow/destructive). Scoped to SC3.
+- **F4** — document that `fetchOriginMainSha()` feeds only the stale-branch block; downstream scripts use local `main` ref. → **Adopted**: added "fetch independence" note to C5.
+- **F5** — confirmation: R33 does not apply; no second local lint surface needs the `.claude` ignore. → No action (confirmation).
+- **F6** — specify C2/C3 placement (after App Build line ~460, before Results 462). → **Adopted**: added Placement to C2.
+- **F7** — C2 negative test validity depends on `cli/tsconfig` NodeNext. → **Verified on-machine** (`module/moduleResolution: NodeNext`); pinned in C2 Invariant.
+
+## Security Findings (S1–S2) — Minor/informational, no gate weakened
+- **S1** — `.claude/**` ignore is legitimate scope-exclusion, not R36 suppression (fetch()/e2e rules are root-anchored, never matched worktree copies; only 3 tracked non-lintable files under `.claude/`). → **Adopted**: added clarifying comment requirement + S1-verified note to C1.
+- **S2** — skipping the orchestrator (C4) does NOT skip the four security checks — they run directly at `pre-pr.sh:140-143`. → **Adopted**: recorded as C4 Invariant (defense-in-depth).
+- Verified clean: R33 (single `pre-pr.sh` for local + CI static-checks, no duplicate guard defs), `set -euo pipefail` early-exit (run_step brackets `set +e`/`set -e`, records to `failures[]`), C5 flag scope (only skips merge-queue guards), R31 (no baseline deletion), secret-scan block untouched. **No escalation.**
+
+## Testing Findings (T1–T6 + Adjacent)
+- **T1 [Major]** — acceptance didn't verify Build/Test ORDER, only that both run. → **Adopted**: added grep line-number ordering assertions to C2/C3.
+- **T2 [Major]** — no test that a move refactor (rename>0) actually FIRES the orchestrator; only the 0-rename skip arm was tested. → **Adopted**: added "Fire arm" predicate test (synthetic `src` rename) to C4.
+- **T3 [Minor]** — clarify the line-416 block is REPLACED, not duplicated. → **Adopted**: C4 Change + End-to-end test note.
+- **T4 [Minor]** — STATIC_ONLY test should assert ABSENCE of new step labels; confirm C4 path under STATIC_ONLY. → **Adopted**: C4 condition now includes `STATIC_ONLY != 1`; Static-only test asserts label absence.
+- **T5 [Minor]** — C5 negative test could false-confirm via the parallel-branch guard. → **Adopted**: C5 acceptance greps the specific `Branch is stale` message.
+- **T6 [Minor]** — C2 negative test should assert `error TS2835` specifically. → **Adopted**: added to C2 negative acceptance.
+- **Adjacent** — node_modules deps-guard had no acceptance test. → **Adopted**: added deps-guard test to C2.
+
+## Recurring Issue Check
+### Functionality expert
+- R2, R33, R36: checked. R33 clean (no second lint/build surface drifts). R36 satisfied (ignore-path not suppression). R1, R3–R32, R34, R35, R37: N/A (dev-tooling, no runtime/app/data path).
+### Security expert
+- R31 clean (no baseline deletion), R33 clean (single script, no duplicate guards; no security gate drifts), R36 clean (legitimate scope-exclusion). R35 N/A. R1–R30, R32, R34, R37, RS1–RS4: N/A.
+### Testing expert
+- RT1 flagged (T1, resolved), RT2 flagged (T2/T4/T5, resolved), RT3 (C2 genuine failure-mode test, sharpened T6), RT4 (CI-equivalence orderings verified vs ci.yml), RT5 (end-to-end run-to-green, T3 caveat resolved), RT6 (STATIC_ONLY path, T4 resolved). R1–R37: N/A.
+
+## Convergence
+All findings resolved by plan refinement (no design change). Proceeding to Phase 2 (implementation). A second full plan-review round is not warranted — round-1 findings were acceptance/wording completeness, now closed.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,12 @@ const eslintConfig = defineConfig([
     "coverage/**",
     "extension/**",
     "load-test/**",
+    // Throwaway git-ignored worktree copies (Claude Code agent worktrees) that
+    // duplicate the whole repo, incl. node_modules/require-based files. They are
+    // not project source for the root config to lint — without this, local
+    // `eslint .` reports thousands of errors from .claude/worktrees that CI
+    // (fresh checkout, no .claude) never sees.
+    ".claude/**",
   ]),
   {
     // Prevent plain fetch() in client-side code — use fetchApi() instead.

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -413,8 +413,21 @@ else
   fi
 fi
 
-if git rev-parse --abbrev-ref HEAD | grep -q "^refactor/"; then
-  run_step "Refactor phase verify" node scripts/refactor-phase-verify.mjs
+# Refactor-phase verify — only for MOVE refactors (≥1 src rename). A content-only
+# refactor/* branch (0 renames) doesn't need the move-only orchestrator: its
+# rename-specific scripts no-op, and its rls/crypto/migration checks already run
+# as standalone "Static:" steps above. Pass --skip-merge-queue-guards so the
+# local run isn't false-failed by a stale, git-ignored
+# .refactor-phase-verify-baseline; CI's refactor-phase-verify.yml keeps using
+# --force WITHOUT the flag, so its behavior is unchanged.
+if [ "$STATIC_ONLY" != "1" ] && git rev-parse --abbrev-ref HEAD | grep -q "^refactor/"; then
+  # two-dot -M main (working tree) mirrors verify-move-only-diff.mjs:194; do NOT
+  # change to main...HEAD — the gate's rename detector must match the verifier.
+  if git diff --name-status -M main -- src | grep -qE '^[RC]'; then
+    run_step "Refactor phase verify" node scripts/refactor-phase-verify.mjs --skip-merge-queue-guards
+  else
+    printf "${BOLD}▸ Refactor phase verify${RESET}\n  (skipped — content-only refactor: 0 src renames; CI's Refactor Phase Verify workflow is authoritative)\n\n"
+  fi
 fi
 
 # Manual-test artifact gate (R35 Tier-1) — fails if admin-IA changes ship
@@ -457,6 +470,36 @@ fi
 
 if [ "$STATIC_ONLY" != "1" ]; then
   run_step "Build"                  npx next build
+fi
+
+# Multi-package build + test — mirror CI's "CLI: Build → Test" and
+# "Extension: Test → Build" jobs so a package-level break (e.g. an ESM .js
+# extension omission that tsc catches but vitest/esbuild tolerates) is caught
+# locally, not first in CI. iOS is intentionally excluded: its CI job is
+# `xcodebuild` on macos-latest and is not reproducible in this local gate.
+# pre-pr does NOT `npm ci` (slow/destructive); it reuses installed deps and
+# fails with an actionable hint if a package's node_modules is absent.
+if [ "$STATIC_ONLY" != "1" ]; then
+  # CLI: Build → Test (CI order — tsc must run first; cli/ is ESM NodeNext, so a
+  # missing .js extension is a tsc TS2835 error that vitest/esbuild tolerates).
+  if [ ! -d cli/node_modules ]; then
+    printf "${RED}ERROR: cli/node_modules missing — run 'cd cli && npm ci' (pre-pr does not auto-install)${RESET}\n\n" >&2
+    failed=$((failed + 1))
+    failures+=("CLI: deps missing|")
+  else
+    run_step "CLI: Build"  bash -c 'cd cli && npm run build'
+    run_step "CLI: Test"   bash -c 'cd cli && npm test'
+  fi
+
+  # Extension: Test → Build (CI order).
+  if [ ! -d extension/node_modules ]; then
+    printf "${RED}ERROR: extension/node_modules missing — run 'cd extension && npm ci' (pre-pr does not auto-install)${RESET}\n\n" >&2
+    failed=$((failed + 1))
+    failures+=("Extension: deps missing|")
+  else
+    run_step "Extension: Test"   bash -c 'cd extension && npm test'
+    run_step "Extension: Build"  bash -c 'cd extension && npm run build'
+  fi
 fi
 
 echo ""

--- a/scripts/refactor-phase-verify.mjs
+++ b/scripts/refactor-phase-verify.mjs
@@ -4,10 +4,18 @@
  * the current tree. Intended for merge-queue CI on refactor/* branches.
  *
  * Usage:
- *   node scripts/refactor-phase-verify.mjs [--force] [--verbose]
+ *   node scripts/refactor-phase-verify.mjs [--force] [--verbose] [--skip-merge-queue-guards]
  *
  * --force    Run even when not on a refactor/* branch.
  * --verbose  Print each command before running it.
+ * --skip-merge-queue-guards
+ *            Skip the merge-queue-only guards (stale-branch baseline check and
+ *            the parallel-refactor-branch check), but still run every
+ *            verification script. Intended for the local pre-pr.sh invocation:
+ *            those guards are vacuous in CI's fresh checkout (always first-run)
+ *            and only produce false-positives locally from a stale, git-ignored
+ *            .refactor-phase-verify-baseline. CI keeps using --force WITHOUT
+ *            this flag, so its behavior is unchanged.
  *
  * Stale-branch guard:
  *   Reads expected base SHA from env var EXPECTED_MAIN_SHA or the file
@@ -55,6 +63,7 @@ function runScript(label, cmd, verbose) {
 const args = process.argv.slice(2);
 const forceFlag = args.includes("--force");
 const verboseFlag = args.includes("--verbose");
+const skipMergeQueueGuards = args.includes("--skip-merge-queue-guards");
 
 // Branch guard
 const currentBranchName = currentBranch();
@@ -63,34 +72,39 @@ if (!forceFlag && !/^refactor\//.test(currentBranchName)) {
   process.exit(0);
 }
 
-// Stale-branch guard
-const originSha = fetchOriginMainSha();
-const envSha = process.env["EXPECTED_MAIN_SHA"] ?? "";
-let expectedSha = envSha;
+// Stale-branch guard (merge-queue-only). Skipped under --skip-merge-queue-guards:
+// it is vacuous in CI's fresh checkout (first-run always records & passes) and
+// only false-fails locally from a stale .refactor-phase-verify-baseline. The
+// verification scripts below still run regardless.
+if (!skipMergeQueueGuards) {
+  const originSha = fetchOriginMainSha();
+  const envSha = process.env["EXPECTED_MAIN_SHA"] ?? "";
+  let expectedSha = envSha;
 
-// Read the baseline directly and fall through to first-run on ENOENT.
-// Avoids the TOCTOU race between existsSync() and readFileSync()
-// (CodeQL: js/file-system-race).
-if (!expectedSha) {
-  try {
-    expectedSha = readFileSync(BASELINE_FILE, "utf8").trim();
-  } catch (err) {
-    if (err.code !== "ENOENT") throw err;
-    // First run: record current SHA as baseline
-    writeFileSync(BASELINE_FILE, originSha + "\n", "utf8");
-    console.log(`refactor-phase-verify: baseline recorded (${originSha}).`);
-    expectedSha = originSha;
+  // Read the baseline directly and fall through to first-run on ENOENT.
+  // Avoids the TOCTOU race between existsSync() and readFileSync()
+  // (CodeQL: js/file-system-race).
+  if (!expectedSha) {
+    try {
+      expectedSha = readFileSync(BASELINE_FILE, "utf8").trim();
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+      // First run: record current SHA as baseline
+      writeFileSync(BASELINE_FILE, originSha + "\n", "utf8");
+      console.log(`refactor-phase-verify: baseline recorded (${originSha}).`);
+      expectedSha = originSha;
+    }
   }
-}
 
-if (originSha !== expectedSha) {
-  console.error(
-    `Branch is stale vs origin/main.\n` +
-      `  expected: ${expectedSha}\n` +
-      `  current:  ${originSha}\n` +
-      `Rebase and re-run.`
-  );
-  process.exit(1);
+  if (originSha !== expectedSha) {
+    console.error(
+      `Branch is stale vs origin/main.\n` +
+        `  expected: ${expectedSha}\n` +
+        `  current:  ${originSha}\n` +
+        `Rebase and re-run.`
+    );
+    process.exit(1);
+  }
 }
 
 // Parallel-branch guard: fail if another refactor/* PR is open.
@@ -120,7 +134,8 @@ function checkParallelRefactorBranches() {
   }
 }
 
-if (!checkParallelRefactorBranches()) {
+// Parallel-branch guard is also merge-queue-only — skip under the same flag.
+if (!skipMergeQueueGuards && !checkParallelRefactorBranches()) {
   process.exit(1);
 }
 


### PR DESCRIPTION
## Why

`scripts/pre-pr.sh` only verified the App (root lint/test/build), so three gaps surfaced first in CI instead of locally — defeating the "what passes pre-pr passes CI" contract. All three were hit while working on the hardcoded-values refactor (`#561` / `#651`).

## Changes

**1. Multi-package build/test (the gap that bit us)**
pre-pr never built or tested `cli/` or `extension/`. A CLI ESM `.js`-extension omission — a `tsc` TS2835 error that `vitest`/esbuild tolerates — slipped past pre-pr and first failed CI's "CLI: Build" job. pre-pr now builds + tests both packages in the same order CI uses:
- CLI: Build → Test
- Extension: Test → Build

It reuses installed deps (no `npm ci`) and fails with an actionable hint if a package's `node_modules` is missing. iOS stays CI-only (`xcodebuild`).

**2. ESLint `.claude/**` ignore**
Local `eslint .` exited 1 with ~6831 errors — 100% from `.claude/worktrees/**`, throwaway git-ignored agent-worktree copies of the repo that a fresh CI checkout never has. Added `.claude/**` to `globalIgnores`, so local now matches CI (0 errors / 49 warnings). Scope-exclusion, not a gate relaxation (no `--max-warnings`, no `eslint-disable`).

**3. refactor-phase-verify gate**
On `refactor/*` branches, pre-pr false-failed locally on the stale-branch guard, which compares against `.refactor-phase-verify-baseline` — a git-ignored local file that persists a stale SHA across sessions. That guard is vacuous in CI (fresh checkout → always first-run). Now:
- pre-pr runs the orchestrator only for **move** refactors (≥1 `src` rename); content-only refactors skip it (their RLS/crypto/migration checks already run as standalone steps).
- A new `--skip-merge-queue-guards` flag skips the stale-branch + parallel-branch guards while keeping every verification script. CI's `refactor-phase-verify.yml` keeps `--force` without the flag — unchanged.

## Scope / impact
Dev-tooling only — no `app` / `cli` / `extension` runtime change, hence `chore:` (no version bump).

## Verification
- Full `bash scripts/pre-pr.sh` → EXIT 0 (Passed: 36), including the new CLI/Extension steps.
- `npx eslint .` → 0.
- `--skip-merge-queue-guards` runs all 16 verification scripts without the stale-baseline false-fail; without the flag it still fails on `Branch is stale`.
- A named extensionless import in `cli/src` correctly triggers TS2835 in the new CLI build step.

Planned and reviewed via triangulate (functionality / security / testing); artifacts under `docs/archive/review/pre-pr-multipackage-build-lint-gate-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)