### PR TITLE
feat(ios): dedicated quota-exceeded message on entry create (S10-A)

### DIFF
--- a/docs/archive/review/ios-quota-exceeded-message-code-review.md
+++ b/docs/archive/review/ios-quota-exceeded-message-code-review.md
@@ -1,0 +1,90 @@
+# Code Review: ios-quota-exceeded-message
+
+Date: 2026-06-14
+Review round: 1
+
+## Changes from Previous Round
+
+Initial Phase 3 code review (3 expert agents) of the implemented diff
+(`MobileAPIClient.swift`, `EntryEditForm.swift`, `Localizable.xcstrings`, 3 test files).
+
+## Functionality Findings
+
+- **F1 (Minor) — missing in-code TODO anchor**: the plan's Considerations specify a grep-able
+  `TODO(ios-quota-exceeded-message)` marker for the deferred S1 follow-up (`MobileAPIError: LocalizedError`),
+  but it was not present in code (the deviation log is reviewed once and does not survive as a trigger).
+  → RESOLVED: added the TODO comment above `EntryForm.saveErrorMessage(for:)`.
+- Verified clean: C1-C5 all implemented as locked; C2 `try?` fall-through on empty/malformed bodies; body-code
+  (not status) detection; 401-retry path covered; no exhaustive `switch` over `MobileAPIError` (only a single
+  `if case .networkError`); C4 both keys translated, old `"Save failed: %@"` removed.
+
+## Security Findings
+
+- **No findings.** S1 confirmed closed (else branch returns a static localized string, zero
+  `localizedDescription` interpolation). New catalog strings jargon-free (R37). `decodeBodyResponse` body parse
+  is bounded, `try?`-guarded, value used only in an exact `==` and never rendered/logged. 403→quotaExceeded does
+  not mask genuine authz failures (FORBIDDEN → serverError). Test fixtures synthetic only (RS4 clean).
+  escalate: false.
+
+## Testing Findings
+
+- **T1 (Minor) — equality assertion weaker than it looks**: in en locale a deleted catalog key makes both sides
+  fall back to the key literal, so `quota == expectedQuota` could pass vacuously. → RESOLVED: added
+  `generic == expectedGeneric` (T6) and rely on `quota != generic` (locale-robust branch-selection proof) plus
+  `LocalizationCatalogTests` (independently guarantees both keys exist + ja translated). A locale-fragile
+  `contains("item limit")` sentinel was considered and rejected (breaks when the simulator runs non-en).
+- **T6 [Adjacent] (Minor) — generic message text unasserted**: → RESOLVED by the `generic == expectedGeneric`
+  assertion above.
+- **T2 (informational) — stub fires once**: documented with a comment on `stubCreate` (createEntry retries only
+  on 401).
+- Verified clean (RT1/RT2): 4 MobileAPIClientTests use real JSON bodies + seed access tokens + assert exact
+  case; VM propagation test returns 403 immediately and asserts `.quotaExceeded`; helper is `nonisolated static`
+  → directly callable from XCTest.
+
+## Adjacent Findings
+
+- T6 (testing→functionality boundary) — merged into the EntryFormTests fix above.
+
+## Quality Warnings
+
+None.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R3: clean (no internal error interpolation into UI). R19: clean (no exhaustive switch over MobileAPIError).
+  R37: clean (catalog strings jargon-free). R1-R2,R4-R18,R20-R36: N/A (client-only Swift change).
+
+### Security expert
+- R37: clean. RS4: clean (synthetic fixtures). R3/R19/R25: clean. RS1-RS3 + all other R*: N/A.
+
+### Testing expert
+- RT1: satisfied (real wire-shape bodies; empty/malformed edge cases modeled). RT2: satisfied (nonisolated
+  static, no MainActor dispatch). RT3-RT5: N/A. R*: N/A.
+
+## Resolution Status
+
+### F1 Minor — missing TODO anchor
+- Action: added `// TODO(ios-quota-exceeded-message): consider MobileAPIError: LocalizedError ...` above the helper.
+- Modified file: ios/PasswdSSOApp/Views/Vault/EntryEditForm.swift (saveErrorMessage doc block).
+
+### T1 / T6 Minor — test assertion strength
+- Action: added `XCTAssertEqual(generic, expectedGeneric)`; kept locale-robust `quota != generic`; documented
+  reliance on LocalizationCatalogTests for catalog presence.
+- Modified file: ios/PasswdSSOTests/EntryFormTests.swift.
+
+### T2 Informational — stub-fires-once
+- Action: clarifying comment added.
+- Modified file: ios/PasswdSSOTests/MobileAPIClientTests.swift (stubCreate).
+
+## Tightening-only skip — Round 1
+Findings applied directly (no Round 2 review):
+- [F1] [Minor] missing TODO anchor — EntryEditForm.swift — applied verbatim (comment only)
+- [T1/T6] [Minor] test assertion strength — EntryFormTests.swift — test-only, within round-1 fix scope
+- [T2] [Informational] stub comment — MobileAPIClientTests.swift — comment only
+
+Justification: every finding is inline-minor (comment text / test-assertion), scoped within the round-1 change,
+and touches no security boundary (production behavior unchanged by all three fixes). Re-verified by full suite:
+468 unit + 2 UI tests green, TEST BUILD SUCCEEDED, no crashes.
+
+All findings resolved. No open findings.

--- a/docs/archive/review/ios-quota-exceeded-message-deviation.md
+++ b/docs/archive/review/ios-quota-exceeded-message-deviation.md
@@ -1,0 +1,21 @@
+# Coding Deviation Log: ios-quota-exceeded-message
+
+## Phase 2 implementation
+
+All five contracts (C1-C5) implemented as locked. No functional deviations from the plan.
+
+Minor, non-functional notes:
+- The `MobileAPIError.quotaExceeded` doc comment was worded to describe the server's quota error code
+  *without* embedding the literal `"QUOTA_EXCEEDED"` token, so the C2 forbidden-pattern grep
+  (`"QUOTA_EXCEEDED"` must appear at most once in `MobileAPIClient.swift`) resolves to exactly one hit (the
+  detection comparison). Documentation value preserved; not a behavior change.
+- Test helper naming: the 4 quota tests live in the `MobileAPIClientTests` class, which constructs clients
+  inline (its `makeClient(...)` helper belongs to a different test class in the same file). Added a local
+  `makeCreateClient()` helper mirroring the existing inline construction pattern — not a deviation, just
+  matching the class's established style.
+
+Verification:
+- `xcodegen generate` → `build-for-testing` (TEST BUILD SUCCEEDED) → `test-without-building`:
+  468 unit tests + 2 UI tests, 0 failures, no crashes (iPhone 15 Pro simulator).
+- Contract conformance grep: `status == 403` quota-branch absent; `"QUOTA_EXCEEDED"` appears once; no jargon in
+  catalog strings; old `"Save failed: %@"` key fully removed (no residual references).

--- a/docs/archive/review/ios-quota-exceeded-message-plan.md
+++ b/docs/archive/review/ios-quota-exceeded-message-plan.md
@@ -1,0 +1,213 @@
+# Plan: iOS quota-exceeded dedicated error message (S10-A)
+
+## Project context
+
+- **Type**: mixed repo (Next.js web app + iOS app). This change is **iOS-only** (Swift); no server change.
+- **Test infrastructure**: unit tests (XCTest, ~351 iOS tests) + CI. Tests are expected for new logic.
+- **CI constraint**: CI runs `macos-latest` Xcode 16.4 / iOS 18 SDK. **No iOS 26-only APIs.** Local is Xcode 26;
+  verify against CI assumptions. (See memory `ios-extension-parity-roadmap`.)
+- **BridgeKeyStore test note**: any `BridgeKeyStore(service:)` in tests must end with `"bridge-key"` (precondition
+  aborts the process otherwise). Not touched by this change, but holds for any new test file.
+
+## Objective
+
+When creating a new entry hits the server's per-resource quota limit, iOS currently surfaces a generic
+`serverError(status: 403)` → the user sees "Save failed: <generic HTTP 403 text>". Replace this with a
+dedicated `MobileAPIError.quotaExceeded` case and a clear, localized user-facing message.
+
+## Background (verified facts)
+
+- **Server (no change needed)**: `POST /api/passwords` returns **HTTP 403** with body
+  `{ "error": "QUOTA_EXCEEDED", "resource": "passwords", "current": <int>, "max": <int> }` when the password
+  quota is exceeded (`src/app/api/passwords/route.ts:146-157`; code `API_ERROR.QUOTA_EXCEEDED`,
+  status map `src/lib/http/api-error-codes.ts`). 403 is **also** used for non-quota authz failures, so the
+  client MUST key off the body `error` string, not the HTTP status.
+- **Client today**: `createEntry` → `performCreateHTTP` → `performBodyHTTP` → `decodeBodyResponse(data, status:)`
+  (`ios/PasswdSSOApp/Network/MobileAPIClient.swift:749-758`). `decodeBodyResponse` already receives the response
+  `data` but **discards it** for non-2xx, mapping everything except 404 to `serverError(status:)`.
+- **Error enum**: `MobileAPIError` (`MobileAPIClient.swift:89-101`) is `Error, Equatable`; no `quotaExceeded`.
+- **UI**: `VaultViewModel.createEntry` (`VaultViewModel.swift:189`) rethrows without mapping. The only consumer
+  is the SwiftUI view `EntryForm.save()` (the type is named **`EntryForm`**, declared in the file
+  `ios/PasswdSSOApp/Views/Vault/EntryEditForm.swift:12`, annotated `@MainActor struct EntryForm: View`),
+  whose `catch` sets `saveError = String(localized: "Save failed: \(error.localizedDescription)")` (line 210).
+  **Naming note**: the file is `EntryEditForm.swift` but the Swift type is `EntryForm` — all contracts/tests
+  reference the type `EntryForm`.
+- **Shared chokepoint**: `decodeBodyResponse` is shared by ALL body-returning requests via `performBodyHTTP`.
+  Besides `createEntry`, `mintAutofillToken` (`MobileAPIClient.swift:~426`, `POST /api/mobile/autofill-token`)
+  also routes through it; its caller `AutofillTokenRefresher` swallows all errors. So mapping QUOTA_EXCEEDED at
+  this chokepoint changes `mintAutofillToken`'s thrown error *type* only in the (non-occurring) case that
+  endpoint returns a QUOTA_EXCEEDED body — no user-visible path. Detection is **body-code-keyed** (not status),
+  which keeps it forward-compatible and prevents false positives on unrelated 403s on any endpoint.
+- **MobileAPIError.localizedDescription leak (S1)**: `MobileAPIError` does NOT conform to `LocalizedError`, so
+  `error.localizedDescription` falls back to the `NSError` bridge — on DEBUG/TestFlight builds this can render
+  the case label *and associated values* (e.g. `dpopInvalid(newNonce: Optional("…"))`) into the visible
+  `saveError` string. The fix scopes the `else` branch to a controlled generic message (C3).
+- **i18n**: host catalog `ios/PasswdSSOApp/Localizable.xcstrings` uses the **English text as the key**
+  (e.g. key `"Save failed: %@"` → en/ja values). Hand-editing is the reliable path (xcodebuild does not write
+  back extraction — memory `ios-string-catalog-notes`). The create flow is host-only; the AutoFill extension
+  catalog is NOT involved.
+
+## Requirements
+
+- Functional: a 403 + `{error:"QUOTA_EXCEEDED"}` create response maps to `MobileAPIError.quotaExceeded`; the
+  user sees a dedicated localized message (en + ja) instead of the generic "Save failed: …".
+- Non-functional / no-regression: every non-quota error keeps its current message and mapping
+  (403-without-quota-code still → `serverError(403)`; 404 still → `notFound`; etc.).
+- No internal jargon in the UI string (R37): no "quota", "QUOTA_EXCEEDED", "resource"; use plain wording
+  ("item limit" / 「上限」). "Vault"→「保管庫」 per prior directive.
+
+## Technical approach
+
+- Detect quota at the single existing chokepoint `decodeBodyResponse` (shared by all body-returning requests;
+  create is the only path that can realistically return it — harmless for the others). Decode a minimal error
+  envelope `{ error: String }` from the body on non-success and branch on the code string.
+- Add `case quotaExceeded` (no associated values — KISS; the create flow's resource is always `passwords` and a
+  single generic-but-clear message covers it. Richer messaging with `max` is explicitly out of scope unless a
+  reviewer shows a concrete need).
+- Extract the save-error → message mapping into a **testable `nonisolated static` helper** on `EntryForm` so it
+  can be unit-tested without driving SwiftUI or MainActor dispatch, then special-case `.quotaExceeded` there.
+- Add the localized strings to the host String Catalog (en + ja), hand-authored.
+
+## Contracts
+
+### C1 — `MobileAPIError.quotaExceeded` case
+- **Location**: `ios/PasswdSSOApp/Network/MobileAPIClient.swift`, enum `MobileAPIError` (lines 89-101).
+- **Signature**: add `case quotaExceeded` (enum remains `Error, Equatable`; no associated values).
+- **Invariant**: no associated values — keeps `Equatable` synthesis trivial and matches the single create resource.
+- **Acceptance**: `MobileAPIError.quotaExceeded == MobileAPIError.quotaExceeded` is `true`; distinct from every
+  other case. **No exhaustive `switch` over `MobileAPIError` exists in the iOS tree** (verified round 1, F3) —
+  adding a case breaks nothing; re-verify with grep at implementation time (R19).
+
+### C2 — quota detection in `decodeBodyResponse`
+- **Location**: `MobileAPIClient.swift:749-758`.
+- **Signature (unchanged)**: `private func decodeBodyResponse(_ data: Data, status: Int) throws -> Data`.
+- **New private type**: `private struct APIErrorEnvelope: Decodable { let error: String }`.
+- **Behavior**: `case 200, 201` unchanged (return data); `case 404` unchanged (`throw .notFound`); **default**:
+  if `try? JSONDecoder().decode(APIErrorEnvelope.self, from: data)` succeeds AND `error == "QUOTA_EXCEEDED"` →
+  `throw .quotaExceeded`; otherwise `throw .serverError(status: status)`. (`try?` makes empty/malformed bodies
+  fall through safely — no crash; extra body fields `resource`/`current`/`max` are ignored by JSONDecoder.)
+- **Invariant**: quota detection keys off the **body `error` string** (exact `==`, not prefix/substring), never
+  off the HTTP status alone. This is the single detection point; the literal `"QUOTA_EXCEEDED"` appears exactly
+  once in `MobileAPIClient.swift`.
+- **Shared-chokepoint note (F2/S2)**: `decodeBodyResponse` is shared (also serves `mintAutofillToken`). Mapping
+  here is intentional and forward-compatible. The only UI-surfaced consumer is `createEntry`→`EntryForm`; all
+  other body-returning callers either propagate (no quota body in practice) or swallow (`AutofillTokenRefresher`).
+  No regression. The behavior is body-code-keyed so unrelated 403s on any endpoint still map to `.serverError`.
+- **Forbidden patterns**:
+  - `pattern: status == 403` (as the quota branch condition) — reason: must not branch quota on status; detection
+    is body-code based and forward-compatible.
+  - `pattern: "QUOTA_EXCEEDED"` appearing more than once in `MobileAPIClient.swift` — reason: single detection
+    point; no scattered string checks.
+- **Acceptance**:
+  - 403 body `{"error":"QUOTA_EXCEEDED",...}` → throws `.quotaExceeded`.
+  - 403 body `{"error":"FORBIDDEN"}` → throws `.serverError(status: 403)` (over-broad-detection guard).
+  - 403 **empty** body (`Data()`) → throws `.serverError(status: 403)` (no crash).
+  - 403 **malformed** body (`{invalid`) → throws `.serverError(status: 403)` (no crash).
+  - 200/201 → returns data unchanged; 404 → `.notFound`.
+- **Consumer-flow walkthrough**:
+  - `performBodyHTTP` non-retry path (`MobileAPIClient.swift:746`) and **401-nonce-retry path (line 743)** BOTH
+    route through `decodeBodyResponse` — quota detection is preserved on a post-retry 403. ✔
+  - `performCreateHTTP` (`MobileAPIClient.swift:762-769`) reads `Data` only on success; on throw it propagates the
+    error unchanged. Uses no error fields — pass-through. ✔
+  - `VaultViewModel.createEntry` (`VaultViewModel.swift:189-229`) does not catch; propagates the thrown
+    `MobileAPIError` unchanged. ✔
+  - `EntryForm.save()` (`EntryEditForm.swift:186-211`) catches and routes through C3, which pattern-matches the
+    `.quotaExceeded` case identity (the only field it needs; locked shape provides it). ✔
+
+### C3 — testable save-error message mapping in `EntryForm`
+- **Location**: `ios/PasswdSSOApp/Views/Vault/EntryEditForm.swift` (type `EntryForm`).
+- **Signature**: `nonisolated static func saveErrorMessage(for error: Error) -> String`.
+  - `nonisolated` so XCTest can call it without `@MainActor`/`await MainActor.run` (T2/T7).
+  - `internal` (the Swift default) — **must NOT be `private`/`fileprivate`** (F5); `PasswdSSOTests` is a hosted
+    test target (`BUNDLE_LOADER`/`TEST_HOST`), so internal symbols are reachable.
+- **Behavior**:
+  - if `(error as? MobileAPIError) == .quotaExceeded` → return `String(localized: "<C4 quota key>")`.
+  - else → return `String(localized: "<C4 generic key>")` — a controlled generic message. **Does NOT interpolate
+    `error.localizedDescription`** (fixes S1: prevents leaking `MobileAPIError` case labels / associated values
+    such as a DPoP nonce into the UI on debug builds).
+- **Call site change**: `save()` catch becomes `saveError = EntryForm.saveErrorMessage(for: error)` (replaces the
+  inline `String(localized: "Save failed: \(error.localizedDescription)")`). The same `catch` handles create and
+  edit; `.quotaExceeded` is only reachable on the create path (edit → `decodeVoidResponse`, never quota) — the
+  helper handling it for edit is harmless dead-branch coverage (F8).
+- **Invariant**: the helper is a pure function (no view state, no actor isolation); identical input → identical
+  output. Behavior change vs. today is intentional and limited to non-quota errors now showing a controlled
+  generic message instead of an interpolated `localizedDescription` (S1 hardening).
+- **Acceptance**: `saveErrorMessage(for: MobileAPIError.quotaExceeded)` `==` `String(localized: "<C4 quota key>")`
+  AND `!=` `saveErrorMessage(for: MobileAPIError.notFound)`.
+
+### C4 — localized strings (host catalog)
+- **Location**: `ios/PasswdSSOApp/Localizable.xcstrings` (host only; AutoFill extension catalog not involved).
+- **Keys (literal-English-as-key, matching project convention)**:
+  - quota key: `"You've reached your vault's item limit. Remove unused items and try again."`
+  - generic key: `"Could not save. Please try again."`
+- **Localizations** — each key gets `en` + `ja` `stringUnit`s; **the `ja` `stringUnit` MUST be**
+  `"state": "translated"` (NOT `"needs_review"`) or `LocalizationCatalogTests` fails (T4). Set the entry's
+  `extractionState: "manual"` (hand-authored). Exact JSON shape to mirror the existing `"Save failed: %@"` entry:
+  ```json
+  "You've reached your vault's item limit. Remove unused items and try again." : {
+    "extractionState" : "manual",
+    "localizations" : {
+      "en" : { "stringUnit" : { "state" : "translated", "value" : "You've reached your vault's item limit. Remove unused items and try again." } },
+      "ja" : { "stringUnit" : { "state" : "translated", "value" : "保管庫の項目数が上限に達しました。不要な項目を削除してから、もう一度お試しください。" } }
+    }
+  }
+  ```
+  generic key ja value: 「保存できませんでした。もう一度お試しください。」
+- **Cleanup**: the old `"Save failed: %@"` key becomes unused once C3 stops interpolating — remove it from the
+  catalog (avoids a stale `extractionState:"stale"` entry; verify no other references with grep).
+- **Invariant (R37)**: no implementation jargon ("quota"/"QUOTA_EXCEEDED"/"resource"/"403") in any value;
+  "Vault"→「保管庫」 per prior directive.
+- **Acceptance**: both keys present with `en`+`ja` translated units; `LocalizationCatalogTests` green.
+
+### C5 — tests
+All stubbed HTTP responses use **real JSON body bytes**, never `Data()` where the body must be decoded (T1, RT1).
+- **MobileAPIClientTests** (`ios/PasswdSSOTests/MobileAPIClientTests.swift`): each test below MUST first seed a
+  valid access token (`seedAccessToken()`, or inline `tokenStore.saveTokens(...)`) — `createEntry` calls
+  `validAccessToken()` first and throws `.authenticationRequired` before the mock is reached otherwise (T8).
+  - `testCreateEntry_quotaExceededBodyMapsToQuotaExceeded`: stub `(Data(#"{"error":"QUOTA_EXCEEDED","resource":"passwords","current":10000,"max":10000}"#.utf8), httpResponse(status: 403, ...))` → `createEntry` throws `MobileAPIError.quotaExceeded`.
+  - `testCreateEntry_403WithoutQuotaCodeMapsToServerError`: stub `(Data(#"{"error":"FORBIDDEN"}"#.utf8), 403)` → throws `.serverError(status: 403)`.
+  - `testCreateEntry_403WithEmptyBodyMapsToServerError`: stub `(Data(), 403)` → `.serverError(status: 403)` (no crash) (T5).
+  - `testCreateEntry_403WithMalformedBodyMapsToServerError`: stub `(Data("{invalid".utf8), 403)` → `.serverError(status: 403)` (no crash) (T5).
+- **VaultViewModelTests** (`ios/PasswdSSOTests/VaultViewModelTests.swift`):
+  - `testCreateEntry_quotaExceededPropagates`: stub the 403+QUOTA_EXCEEDED body via `MockURLProtocol.requestHandler` (the existing HTTP-layer mock pattern — there is NO protocol mock over the concrete `MobileAPIClient` actor; T3/F7), the handler returns 403 immediately (no preceding 201 — T6) → `viewModel.createEntry(...)` throws `MobileAPIError.quotaExceeded`.
+- **EntryForm mapping** (new file `ios/PasswdSSOTests/EntryFormTests.swift`):
+  - `testSaveErrorMessage_quotaExceededIsDedicated`: assert `EntryForm.saveErrorMessage(for: MobileAPIError.quotaExceeded)` `==` `String(localized: "<C4 quota key>")` (compute expected via the same `String(localized:)` call so resolution is identical — avoids vacuous/locale-fragile compare; T2) AND `!=` `EntryForm.saveErrorMessage(for: MobileAPIError.notFound)`. Helper is `nonisolated` → no MainActor wrapping needed.
+- **Invariant (RT1)**: stubbed HTTP responses match the real server wire shape (403 + the documented JSON body).
+
+## Testing strategy
+
+- Unit tests per C5. Run on simulator (iOS 26.1 local OK) via `xcodegen generate` → `build-for-testing` +
+  `test-without-building`; full suite green, no crashes.
+- Manual smoke (optional, documented in considerations): trigger a real create against a quota-exhausted vault
+  and confirm the dedicated message renders in both locales. Not blocking (requires a seeded over-quota account).
+
+## Considerations & constraints
+
+- **Out of scope**: carrying `resource`/`current`/`max` into the message; team-entry quota; attachment/file-send
+  quota; any server change; `decodeVoidResponse` (no create-quota path flows through it; edit/PUT uses it).
+- **No new endpoint / no new network call** — pure client-side mapping of an already-returned response.
+- **R37**: UI strings must avoid internal tokens (enforced by C4 invariant + reviewer grep).
+- **R19**: `MobileAPIError` is `Equatable`; adding a no-payload case cannot break exact-shape decoders; round 1
+  confirmed no exhaustive `switch` over `MobileAPIError` — re-grep at implementation time.
+- **S1 follow-up (not in this PR)**: a full `MobileAPIError: LocalizedError` conformance with per-case localized
+  messages would give richer non-quota messages, but expands scope (≈8 new strings). Deferred as a tracked TODO;
+  this PR's controlled generic fallback already closes the info-leak. `TODO(ios-quota-exceeded-message): consider
+  MobileAPIError: LocalizedError for richer per-case save messages.`
+
+## User operation scenarios
+
+1. Free/limited vault at the password cap → user taps "+", fills a login, taps Save → server 403
+   QUOTA_EXCEEDED → form shows the dedicated localized "item limit reached" message; the form stays open so the
+   user can cancel or free space. (Today: confusing generic "Save failed: …403".)
+2. Save fails for an unrelated reason (network, 404, other 403) → unchanged generic message (no regression).
+3. Japanese-locale device → quota message renders in Japanese.
+
+## Go/No-Go Gate
+
+| ID  | Subject                                                   | Status |
+|-----|----------------------------------------------------------|--------|
+| C1  | `MobileAPIError.quotaExceeded` case                      | locked |
+| C2  | quota detection in `decodeBodyResponse` (body-code keyed)| locked |
+| C3  | testable `EntryForm.saveErrorMessage(for:)` mapping      | locked |
+| C4  | localized quota string (en + ja, host catalog)           | locked |
+| C5  | unit tests (client mapping, VM propagation, UI message)  | locked |

--- a/docs/archive/review/ios-quota-exceeded-message-review.md
+++ b/docs/archive/review/ios-quota-exceeded-message-review.md
@@ -1,0 +1,134 @@
+# Plan Review: ios-quota-exceeded-message
+
+Date: 2026-06-14
+Review round: 1
+
+## Changes from Previous Round
+
+Initial review (3 expert agents: functionality / security / testing) of the S10-A quota-exceeded plan.
+
+## Functionality Findings
+
+- **F1 (Critical) — wrong type name**: plan used `EntryEditForm`; the Swift type is `EntryForm`
+  (file `EntryEditForm.swift:12`). → RESOLVED: plan now references type `EntryForm` (file path unchanged).
+- **F2 (Major) — shared chokepoint "harmless" claim unsubstantiated**: `decodeBodyResponse` also serves
+  `mintAutofillToken`. → RESOLVED: C2 documents the shared chokepoint, body-code-keyed forward-compat design,
+  and that the only UI-surfaced consumer is create; others propagate/swallow (no regression).
+- **F3 (positive) — no exhaustive `switch` over `MobileAPIError`** anywhere → adding a case is safe. Recorded in
+  C1; re-grep at impl time (R19).
+- **F4 (positive) — JSONDecoder ignores extra body fields** (`resource/current/max`) → `{error:String}` decode is
+  safe. Recorded in C2.
+- **F5 (Major) — access control**: helper must be `internal`, not `private`; hosted test target reaches internal
+  symbols. → RESOLVED: C3 specifies `nonisolated static` + internal, "must NOT be private".
+- **F6 (Major) — incomplete walkthrough**: 401-nonce-retry path (line 743) also routes through
+  `decodeBodyResponse`. → RESOLVED: C2 walkthrough now covers both retry and non-retry paths.
+- **F7 (Minor) — VM test infra**: `MobileAPIClient` is a concrete actor (no protocol mock); stub via HTTP layer.
+  → RESOLVED (folded into T3): C5 VM test uses `MockURLProtocol`.
+- **F8 (Minor) — shared catch for create+edit**: `.quotaExceeded` unreachable on edit. → RESOLVED: C3 notes the
+  dead-branch coverage is harmless.
+
+## Security Findings
+
+- **S1 (Minor) — info leak**: `MobileAPIError.localizedDescription` exposes case labels/associated values (e.g.
+  DPoP nonce) in debug/TestFlight UI via the `else` branch. → RESOLVED: C3 `else` branch now returns a controlled
+  generic localized message (C4 generic key), no `localizedDescription` interpolation. Full `LocalizedError`
+  conformance deferred as a tracked TODO (richer messages, +8 strings — out of this PR's small scope).
+- **S2 (Minor) — chokepoint placement** → same as F2; body-code-keyed detection accepted (no masking of genuine
+  403s; exact `==` compare). RESOLVED via C2 documentation.
+- **S3 (none) — untrusted body decode**: bounded, single-string, `try?`-guarded, never rendered/logged/shelled.
+  Safe.
+- **S4 (none) — error oracle**: no new info channel; server already discriminates on the wire.
+- **S5 / RS4 (none)** — test fixtures use synthetic numbers only; no PII/secrets.
+- escalate: false (no Critical security findings).
+
+## Testing Findings
+
+- **T1 (Critical) — RT1 mock-reality**: existing non-2xx tests stub `Data()`; quota tests MUST stub real JSON
+  bodies or they fail/pass vacuously. → RESOLVED: C5 specifies `Data(#"{...}"#.utf8)` bodies.
+- **T2 (Critical) — testability**: `String(localized:)` bundle resolution + `@MainActor` dispatch. → RESOLVED:
+  C3 helper is `nonisolated static` (no MainActor wrap); C5 test computes the expected string via the same
+  `String(localized:)` call (identical resolution, not a hardcoded literal) → non-vacuous, locale-robust.
+- **T3 (Major) — VM test infra**: no protocol mock; use `MockURLProtocol`. → RESOLVED in C5.
+- **T4 (Major) — LocalizationCatalogTests checks `state:"translated"`**: → RESOLVED: C4 mandates
+  `state:"translated"` on `ja` units + exact JSON shape.
+- **T5 (Major) — missing negative tests**: empty/malformed body. → RESOLVED: C5 adds
+  `testCreateEntry_403WithEmptyBodyMapsToServerError` + `...MalformedBody...`.
+- **T6 (Minor) — VM handler must return 403 immediately** (no preceding 201). → RESOLVED: noted in C5.
+- **T7 (Minor) — @MainActor dispatch** → RESOLVED by `nonisolated static` (C3).
+
+## Adjacent Findings
+
+None requiring cross-routing beyond those already merged above.
+
+## Quality Warnings
+
+None (all findings carried file:line evidence and concrete fixes).
+
+## Recurring Issue Check
+
+### Functionality expert
+- R3: in scope — error propagation verified (VM rethrows, UI catches), no swallowing. R19: in scope — no
+  exhaustive switch over MobileAPIError (verified). R25: N/A (transient error, not persisted). R37: in scope —
+  C4 strings jargon-free. R1-R2, R4-R18, R20-R36: N/A (client-only Swift change).
+
+### Security expert
+- R37: partial→resolved (S1 else-branch hardened). RS4: clear (synthetic fixtures). R19/R25: clear (no
+  exhaustive switch; no persisted state). RS1-RS3, all other R*: N/A (no auth/crypto/SQL/shell/new endpoint).
+
+### Testing expert
+- RT1: was failing→resolved (real JSON bodies). RT2: was partial→resolved (nonisolated static + same-resolution
+  expected). RT3: resolved (HTTP-layer mock). RT4: N/A (no concurrency/cardinality test). RT5: N/A. R37: covered
+  by C4 + reviewer grep. Other R*: N/A.
+
+## Resolution Status
+
+All round-1 findings (F1-F8, S1-S5, T1-T7) are RESOLVED in the plan or recorded as positive/no-action. One
+tracked deferral:
+
+### S1-followup (Minor) `MobileAPIError: LocalizedError` full conformance — Out of scope (different feature)
+- **Anti-Deferral check**: out of scope (different feature / larger change).
+- **Justification**: the info-leak itself IS fixed in this PR (C3 controlled generic else-branch). What is
+  deferred is the *enhancement* of richer per-case localized messages, which needs ~8 new localized strings and
+  a `LocalizedError` extension — beyond S10-A's "small" scope as scoped by the user. Tracked via grep-able
+  `TODO(ios-quota-exceeded-message)` marker in the plan's Considerations section.
+- **Orchestrator sign-off**: the security-relevant leak is closed in-PR; only a non-security UX enhancement is
+  deferred with a TODO marker. Exception satisfied.
+
+---
+
+# Review round 2 (incremental)
+
+## Changes from Previous Round
+
+Verified all round-1 resolutions in the updated plan. Functionality + Testing each raised one new Minor;
+Security: No findings (S1 confirmed fully resolved by the C3 controlled else-branch).
+
+## Functionality Findings (round 2)
+- **F9 (Minor, new) — stale type name in Go/No-Go table**: gate row C3 still read `EntryEditForm`. → RESOLVED:
+  gate row now `EntryForm.saveErrorMessage(for:)`.
+- Confirmed clean: removing `"Save failed: %@"` is safe (only refs: catalog + the call site being replaced;
+  AutoFill ext catalog unaffected). `nonisolated static` on `@MainActor struct` is valid Swift 6
+  (project `SWIFT_STRICT_CONCURRENCY: complete`; matches `VaultUnlocker.swift:247` pattern).
+
+## Security Findings (round 2)
+- No findings. S1 leak closed by construction (static localized string, no `localizedDescription` interpolation);
+  C4 strings jargon-free (R37); deferral is UX-only. escalate: false.
+
+## Testing Findings (round 2)
+- **T8 (Minor, new) — access-token seeding**: `createEntry` calls `validAccessToken()` first → throws
+  `.authenticationRequired` before the mock unless a token is seeded. → RESOLVED: C5 now requires
+  `seedAccessToken()` at the start of each MobileAPIClientTests quota test. (VaultViewModelTests already seeds in
+  `setUp()`.)
+- Confirmed clean: `httpResponse(status:url:)` helper (`MobileAPIClientTests.swift:53`) and
+  `MockURLProtocol.requestHandler` `(Data, HTTPURLResponse)` shapes match C5; `LocalizationCatalogTests` reads
+  source `.xcstrings` and enforces ja `state=="translated"` (line 130-136); XcodeGen auto-discovers
+  `PasswdSSOTests/*.swift`; hosted-test `Bundle.main` resolves to the host app so `String(localized:)` finds the
+  new keys.
+
+## Recurring Issue Check (round 2)
+- All experts: round-1 items verified resolved; F9/T8 resolved; no Critical/Major remaining. R19/R37/RT1/RT2/RS4
+  all clean.
+
+## Resolution Status (round 2)
+All round-2 findings (F9, T8) RESOLVED in the plan. No open findings. **Plan converged** — proceeding to Phase 2.
+All contracts C1-C5 `locked`.

--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		F50C3FCB3A6C9F4A5419B71E /* PasskeyRegistrationOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881416D87A323B49E40CCCC3 /* PasskeyRegistrationOutcome.swift */; };
 		F67226652335D3241D5B1ADD /* PasskeySignCountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469C94A411CE66C4D3EAB9AA /* PasskeySignCountStore.swift */; };
 		F6D4F11AC118415488FB8DCF /* URLMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6C27CE52EFE55D86666E7C /* URLMatcher.swift */; };
+		F7972AB668F0D8073EBA5172 /* EntryFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBBBBBE5688A781ED154534 /* EntryFormTests.swift */; };
 		FC74F7D953B2978FE27D3B85 /* EntryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD65567EDF5CDCFB425499EA /* EntryDetailView.swift */; };
 		FD86EB17606A4DC5301497AA /* TOTPCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D235AC82775464BDF11F292F /* TOTPCodeView.swift */; };
 		FEC853759999A05E6F0867F4 /* EntryUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D696B8B99CFDB4FFFDC090E1 /* EntryUploader.swift */; };
@@ -307,6 +308,7 @@
 		B61C70648C7D9DE6F493F1AD /* SecureClipboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureClipboardTests.swift; sourceTree = "<group>"; };
 		B67A2748B3B1C69F7543EB64 /* PasswdSSOTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PasswdSSOTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB8D42DAB6AE67B22BFFB262 /* BackgroundSyncCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSyncCoordinator.swift; sourceTree = "<group>"; };
+		BBBBBBBE5688A781ED154534 /* EntryFormTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryFormTests.swift; sourceTree = "<group>"; };
 		C02778E2A8EE7B7A09B671C4 /* KDF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KDF.swift; sourceTree = "<group>"; };
 		C19D6A107E63BFA725F2C0F3 /* WrappedKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappedKeyStoreTests.swift; sourceTree = "<group>"; };
 		C1F6D6429583F4DF936E38A0 /* SharedFrameworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedFrameworkTests.swift; sourceTree = "<group>"; };
@@ -403,6 +405,7 @@
 				24CD914CFF8AD6DD6DAB0129 /* EntryCacheFileTests.swift */,
 				628885DD1B6E8E32503A7DD9 /* EntryEncrypterTests.swift */,
 				28A274ABCE6A2833F3A66EF5 /* EntryFetcherTests.swift */,
+				BBBBBBBE5688A781ED154534 /* EntryFormTests.swift */,
 				38C0939161B9D1614DD3053E /* EntryTypeCategoryTests.swift */,
 				D2EE0867F2772AB2952888FA /* EntryUploaderTests.swift */,
 				CFD016B2D5D9999A41CCA92F /* HostSyncServiceTests.swift */,
@@ -988,6 +991,7 @@
 				EF9407000E17ADEB5E667D88 /* EntryCacheFileTests.swift in Sources */,
 				96A710A8F83E4FEB146E39D4 /* EntryEncrypterTests.swift in Sources */,
 				53BABB8B7A6B12FE9A269D87 /* EntryFetcherTests.swift in Sources */,
+				F7972AB668F0D8073EBA5172 /* EntryFormTests.swift in Sources */,
 				0CDECAF833B17127DDB5B59B /* EntryTypeCategoryTests.swift in Sources */,
 				7309070E13EA38FE4F57C277 /* EntryUploaderTests.swift in Sources */,
 				1600D1BA3846CDCAEA02EF7E /* HostSyncServiceTests.swift in Sources */,

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -1,227 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "All" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべて"
-          }
-        }
-      }
-    },
-    "Logins" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Logins"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログイン"
-          }
-        }
-      }
-    },
-    "Secure Notes" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Secure Notes"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セキュアメモ"
-          }
-        }
-      }
-    },
-    "Credit Cards" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Credit Cards"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "クレジットカード"
-          }
-        }
-      }
-    },
-    "Identities" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Identities"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "個人情報"
-          }
-        }
-      }
-    },
-    "Bank Accounts" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bank Accounts"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "銀行口座"
-          }
-        }
-      }
-    },
-    "SSH Keys" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSH Keys"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSHキー"
-          }
-        }
-      }
-    },
-    "Software Licenses" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Software Licenses"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ソフトウェアライセンス"
-          }
-        }
-      }
-    },
-    "Passkeys" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passkeys"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パスキー"
-          }
-        }
-      }
-    },
-    "Codes" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Codes"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コード"
-          }
-        }
-      }
-    },
-    "Favorites" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Favorites"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "お気に入り"
-          }
-        }
-      }
-    },
-    "Auto-copy TOTP after fill" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-copy TOTP after fill"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "入力後にTOTPを自動コピー"
-          }
-        }
-      }
-    },
-    "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices." : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オンにすると、ワンタイムコードを持つログインを入力した際に、現在のコードをクリップボードにコピーします。クリップボードは上記の時間が経過すると消去され、ほかのデバイスには同期されません。"
-          }
-        }
-      }
-    },
     "%@" : {
       "comment" : "Xcode-editor extraction placeholder for the TOTP countdown Int; the compiler emits the %lld key. Pure number — not translated.",
       "shouldTranslate" : false
@@ -304,6 +83,23 @@
         }
       }
     },
+    "All" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて"
+          }
+        }
+      }
+    },
     "Appearance" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -338,6 +134,23 @@
         }
       }
     },
+    "Auto-copy TOTP after fill" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-copy TOTP after fill"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "入力後にTOTPを自動コピー"
+          }
+        }
+      }
+    },
     "Auto-Lock" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -351,6 +164,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自動ロック"
+          }
+        }
+      }
+    },
+    "Bank Accounts" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bank Accounts"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "銀行口座"
           }
         }
       }
@@ -408,7 +238,6 @@
       }
     },
     "Clipboard" : {
-      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -420,6 +249,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "クリップボード"
+          }
+        }
+      }
+    },
+    "Codes" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コード"
           }
         }
       }
@@ -491,6 +337,23 @@
         }
       }
     },
+    "Could not save. Please try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not save. Please try again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存できませんでした。もう一度お試しください。"
+          }
+        }
+      }
+    },
     "Couldn't decrypt this entry." : {
       "localizations" : {
         "en" : {
@@ -503,6 +366,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このエントリを復号できませんでした。"
+          }
+        }
+      }
+    },
+    "Couldn't sync. Check your connection and try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't sync. Check your connection and try again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同期できませんでした。接続を確認して再試行してください。"
           }
         }
       }
@@ -520,6 +400,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "エントリを作成"
+          }
+        }
+      }
+    },
+    "Credit Cards" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credit Cards"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クレジットカード"
           }
         }
       }
@@ -658,6 +555,40 @@
         }
       }
     },
+    "Favorites" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favorites"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お気に入り"
+          }
+        }
+      }
+    },
+    "Identities" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Identities"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "個人情報"
+          }
+        }
+      }
+    },
     "Incorrect passphrase. Please try again." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -724,6 +655,23 @@
         }
       }
     },
+    "Logins" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logins"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログイン"
+          }
+        }
+      }
+    },
     "Master passphrase" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -776,7 +724,6 @@
       }
     },
     "No entries" : {
-      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -793,7 +740,6 @@
       }
     },
     "No matches" : {
-      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -842,6 +788,23 @@
         }
       }
     },
+    "OK" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
+    },
     "On Timeout" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -872,6 +835,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ワンタイムコード"
+          }
+        }
+      }
+    },
+    "Passkeys" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passkeys"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスキー"
           }
         }
       }
@@ -947,23 +927,6 @@
         }
       }
     },
-    "Save failed: %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save failed: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存に失敗しました: %@"
-          }
-        }
-      }
-    },
     "Search" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -977,6 +940,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "検索"
+          }
+        }
+      }
+    },
+    "Secure Notes" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secure Notes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュアメモ"
           }
         }
       }
@@ -1131,6 +1111,74 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "サインインしています…"
+          }
+        }
+      }
+    },
+    "Software Licenses" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Software Licenses"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソフトウェアライセンス"
+          }
+        }
+      }
+    },
+    "SSH Keys" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH Keys"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSHキー"
+          }
+        }
+      }
+    },
+    "Sync failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync failed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同期に失敗しました"
+          }
+        }
+      }
+    },
+    "Sync now" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync now"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今すぐ同期"
           }
         }
       }
@@ -1405,70 +1453,36 @@
         }
       }
     },
-    "Sync now" : {
-      "extractionState" : "manual",
+    "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices." : {
+      "extractionState" : "translated",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sync now"
+            "value" : "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "今すぐ同期"
+            "value" : "オンにすると、ワンタイムコードを持つログインを入力した際に、現在のコードをクリップボードにコピーします。クリップボードは上記の時間が経過すると消去され、ほかのデバイスには同期されません。"
           }
         }
       }
     },
-    "Sync failed" : {
+    "You've reached your vault's item limit. Remove unused items and try again." : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sync failed"
+            "value" : "You've reached your vault's item limit. Remove unused items and try again."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "同期に失敗しました"
-          }
-        }
-      }
-    },
-    "OK" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        }
-      }
-    },
-    "Couldn't sync. Check your connection and try again." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't sync. Check your connection and try again."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "同期できませんでした。接続を確認して再試行してください。"
+            "value" : "保管庫の項目数が上限に達しました。不要な項目を削除してから、もう一度お試しください。"
           }
         }
       }

--- a/ios/PasswdSSOApp/Network/MobileAPIClient.swift
+++ b/ios/PasswdSSOApp/Network/MobileAPIClient.swift
@@ -93,6 +93,9 @@ public enum MobileAPIError: Error, Equatable {
   case dpopInvalid(newNonce: String?)
   case rateLimited(retryAfter: TimeInterval)
   case notFound
+  /// Server rejected a create because a per-resource quota is exhausted
+  /// (HTTP 403 carrying the server's quota-exhaustion error code).
+  case quotaExceeded
   case serverError(status: Int)
   case networkError(URLError)
   /// The refresh token is dead (no refresh token, or refresh endpoint returned 401/dpopInvalid).
@@ -753,6 +756,13 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     case 404:
       throw MobileAPIError.notFound
     default:
+      // Map the server's quota-exhaustion envelope to a dedicated case so the UI
+      // can show an actionable message. Keyed off the body `error` code (not the
+      // HTTP status) so unrelated 403s still surface as .serverError.
+      if let envelope = try? JSONDecoder().decode(APIErrorEnvelope.self, from: data),
+         envelope.error == "QUOTA_EXCEEDED" {
+        throw MobileAPIError.quotaExceeded
+      }
       throw MobileAPIError.serverError(status: status)
     }
   }
@@ -773,4 +783,10 @@ public actor MobileAPIClient: VaultUnlockDataSource {
 
 private struct CreateEntryResponse: Decodable {
   let id: String
+}
+
+/// Minimal error envelope used to detect server error codes on non-2xx
+/// responses. Extra fields (resource/current/max) are ignored by JSONDecoder.
+private struct APIErrorEnvelope: Decodable {
+  let error: String
 }

--- a/ios/PasswdSSOApp/Views/Vault/EntryEditForm.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryEditForm.swift
@@ -207,7 +207,20 @@ struct EntryForm: View {
       }
       dismiss()
     } catch {
-      saveError = String(localized: "Save failed: \(error.localizedDescription)")
+      saveError = EntryForm.saveErrorMessage(for: error)
     }
+  }
+
+  /// Map a save error to a user-facing, localized message. Pure and
+  /// `nonisolated` so it is unit-testable without MainActor dispatch.
+  /// Does not interpolate `error.localizedDescription` — that would leak
+  /// internal `MobileAPIError` case labels/associated values into the UI.
+  // TODO(ios-quota-exceeded-message): consider MobileAPIError: LocalizedError
+  // for richer per-case save messages instead of one generic fallback.
+  nonisolated static func saveErrorMessage(for error: Error) -> String {
+    if (error as? MobileAPIError) == .quotaExceeded {
+      return String(localized: "You've reached your vault's item limit. Remove unused items and try again.")
+    }
+    return String(localized: "Could not save. Please try again.")
   }
 }

--- a/ios/PasswdSSOTests/EntryFormTests.swift
+++ b/ios/PasswdSSOTests/EntryFormTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import XCTest
+
+@testable import PasswdSSOApp
+
+final class EntryFormTests: XCTestCase {
+
+  func testSaveErrorMessage_quotaExceededIsDedicated() {
+    let quota = EntryForm.saveErrorMessage(for: MobileAPIError.quotaExceeded)
+    let generic = EntryForm.saveErrorMessage(for: MobileAPIError.notFound)
+
+    // Compute the expected localized string via the same resolution path so the
+    // assertion is non-vacuous and locale-robust.
+    let expectedQuota = String(
+      localized: "You've reached your vault's item limit. Remove unused items and try again."
+    )
+    let expectedGeneric = String(localized: "Could not save. Please try again.")
+
+    // The helper picks the correct key per case (locale-robust: both sides
+    // resolve through the same bundle). Catalog presence + ja translation is
+    // guaranteed separately by LocalizationCatalogTests.
+    XCTAssertEqual(quota, expectedQuota)
+    XCTAssertEqual(generic, expectedGeneric)
+    XCTAssertNotEqual(quota, generic, "quota message must differ from the generic save-failure message")
+  }
+}

--- a/ios/PasswdSSOTests/MobileAPIClientTests.swift
+++ b/ios/PasswdSSOTests/MobileAPIClientTests.swift
@@ -537,6 +537,83 @@ final class MobileAPIClientTests: XCTestCase {
     XCTAssertEqual(payload["htm"]?.value as? String, "POST")
   }
 
+  // MARK: - createEntry quota mapping
+
+  private func makeCreateBody() -> CreateEntryRequest {
+    let enc = EncryptedData(
+      ciphertext: "aabbcc",
+      iv: "112233445566778899aabbcc",
+      authTag: "deadbeefdeadbeefdeadbeefdeadbeef"
+    )
+    return CreateEntryRequest(
+      id: "e1", encryptedBlob: enc, encryptedOverview: enc,
+      keyVersion: 1, aadVersion: 1, entryType: "LOGIN"
+    )
+  }
+
+  private func stubCreate(status: Int, body: Data) {
+    let createURL = serverURL.appending(path: "/api/passwords", directoryHint: .notDirectory)
+    // createEntry retries only on 401, so a 403/quota stub fires exactly once.
+    MockURLProtocol.requestHandler = { _ in (body, httpResponse(status: status, url: createURL)) }
+  }
+
+  private func makeCreateClient() -> MobileAPIClient {
+    MobileAPIClient(
+      serverURL: serverURL,
+      signer: FakeSigner(),
+      jwk: knownJWK,
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+  }
+
+  func testCreateEntry_quotaExceededBodyMapsToQuotaExceeded() async throws {
+    seedAccessToken()
+    stubCreate(
+      status: 403,
+      body: Data(#"{"error":"QUOTA_EXCEEDED","resource":"passwords","current":10000,"max":10000}"#.utf8)
+    )
+    do {
+      _ = try await makeCreateClient().createEntry(body: makeCreateBody())
+      XCTFail("expected quotaExceeded")
+    } catch {
+      XCTAssertEqual(error as? MobileAPIError, .quotaExceeded)
+    }
+  }
+
+  func testCreateEntry_403WithoutQuotaCodeMapsToServerError() async throws {
+    seedAccessToken()
+    stubCreate(status: 403, body: Data(#"{"error":"FORBIDDEN"}"#.utf8))
+    do {
+      _ = try await makeCreateClient().createEntry(body: makeCreateBody())
+      XCTFail("expected serverError")
+    } catch {
+      XCTAssertEqual(error as? MobileAPIError, .serverError(status: 403))
+    }
+  }
+
+  func testCreateEntry_403WithEmptyBodyMapsToServerError() async throws {
+    seedAccessToken()
+    stubCreate(status: 403, body: Data())
+    do {
+      _ = try await makeCreateClient().createEntry(body: makeCreateBody())
+      XCTFail("expected serverError")
+    } catch {
+      XCTAssertEqual(error as? MobileAPIError, .serverError(status: 403))
+    }
+  }
+
+  func testCreateEntry_403WithMalformedBodyMapsToServerError() async throws {
+    seedAccessToken()
+    stubCreate(status: 403, body: Data("{invalid".utf8))
+    do {
+      _ = try await makeCreateClient().createEntry(body: makeCreateBody())
+      XCTFail("expected serverError")
+    } catch {
+      XCTAssertEqual(error as? MobileAPIError, .serverError(status: 403))
+    }
+  }
+
   func testUpdateEntry_persistsNonceFromResponse() async throws {
     seedAccessToken()
 

--- a/ios/PasswdSSOTests/VaultViewModelTests.swift
+++ b/ios/PasswdSSOTests/VaultViewModelTests.swift
@@ -438,6 +438,32 @@ final class VaultViewModelTests: XCTestCase {
     XCTAssertEqual(count, 0, "allSummaries must not change on entryIdMismatch")
   }
 
+  // MARK: - createEntry propagates quotaExceeded
+
+  func testCreateEntry_quotaExceededPropagates() async throws {
+    let createURL = serverURL.appending(path: "/api/passwords", directoryHint: .notDirectory)
+    MockURLProtocol.requestHandler = { _ in
+      // 403 returned immediately — createEntry throws before any sync runs.
+      (Data(#"{"error":"QUOTA_EXCEEDED","resource":"passwords","current":10000,"max":10000}"#.utf8),
+       httpResponse(status: 403, url: createURL))
+    }
+
+    let (apiClient, syncService) = makeClientAndSyncService()
+    let vm = await VaultViewModel()
+
+    do {
+      try await vm.createEntry(
+        userId: userId,
+        fields: EditableEntryFields(title: "T", username: "", password: "p"),
+        vaultKey: vaultKey, keyVersion: liveKeyVersion,
+        apiClient: apiClient, hostSyncService: syncService
+      )
+      XCTFail("Expected quotaExceeded")
+    } catch {
+      XCTAssertEqual(error as? MobileAPIError, .quotaExceeded)
+    }
+  }
+
   // MARK: - createEntry no-optimistic-prepend proof (T10)
 
   func testCreateEntry_noOptimisticPrepend_whenSyncReturnsEmptyCache() async throws {


### PR DESCRIPTION
## What

When creating a vault entry hits the server's per-resource quota, iOS now shows a clear, actionable message instead of a generic server error.

- Add `MobileAPIError.quotaExceeded`.
- Detect the server's `HTTP 403 {"error":"QUOTA_EXCEEDED", ...}` create response in `decodeBodyResponse`, keyed off the **body error code** (not the HTTP status) — unrelated 403s (e.g. `FORBIDDEN`) still map to `serverError`, and empty/malformed bodies fall through safely via `try?`.
- Extract the save-error→message mapping into a testable `nonisolated static EntryForm.saveErrorMessage(for:)`. The else branch no longer interpolates `error.localizedDescription`, which previously leaked `MobileAPIError` case labels / associated values (e.g. a DPoP nonce) into the UI on debug builds.
- Add localized strings (en + ja); remove the now-unused `Save failed: %@` key. No internal jargon in user-facing text.

Server side is unchanged — this is a pure client-side mapping of an already-returned response.

## Why

Roadmap follow-up **S10-A**: `VaultViewModel.createEntry` surfaced quota exhaustion as a generic `serverError(403)`, leaving the user with a confusing "Save failed: …403" message and no idea how to recover.

## How it was built

Developed via `/triangulate` (functionality / security / testing experts):
- Plan review: 2 rounds → all findings resolved, contracts C1–C5 locked.
- Code review: 1 round → security clean; remaining minors (TODO anchor, test-assertion strength) resolved.

Artifacts under `docs/archive/review/ios-quota-exceeded-message-*.md` (plan / review / deviation / code-review).

## Tests

- `MobileAPIClientTests`: 403+`QUOTA_EXCEEDED` → `.quotaExceeded`; 403+`FORBIDDEN`, empty body, malformed body → `.serverError(403)`.
- `VaultViewModelTests`: `.quotaExceeded` propagates through `createEntry`.
- `EntryFormTests`: quota vs generic message mapping (locale-robust).

`xcodegen generate` → `build-for-testing` → `test-without-building`: **468 unit + 2 UI tests green**, no crashes (iOS Simulator).

## Out of scope / follow-up

- `MobileAPIError: LocalizedError` for richer per-case messages — tracked via `TODO(ios-quota-exceeded-message)` (the info-leak itself is fixed here).
- Team-entry quota messaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)