### PR TITLE
feat(ios): team vault support — AutoFill QuickType, fill, and in-app team vault

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -35,8 +35,9 @@ regexes = [
 ]
 
 [[allowlists]]
-description = "CryptoKit type name in crypto source, not a credential (generic-api-key false positive on `let privateKey: P256.Signing.PrivateKey` in PasskeyRegistration.swift)."
+description = "CryptoKit type names in crypto source, not credentials (generic-api-key false positives on `P256.Signing.PrivateKey` in PasskeyRegistration.swift and `P256.KeyAgreement.PrivateKey` in the team-key ECDH code)."
 regexTarget = "match"
 regexes = [
   '''P256\.Signing\.PrivateKey''',
+  '''P256\.KeyAgreement\.PrivateKey''',
 ]

--- a/docs/archive/review/ios-team-quicktype-code-review.md
+++ b/docs/archive/review/ios-team-quicktype-code-review.md
@@ -185,6 +185,12 @@ None.
     NIST CAVP / RFC test vectors). Removing them yields no cross-platform anchor (the whole point of C9).
 - **Orchestrator sign-off**: accepted — committing synthetic crypto test vectors is correct and intended; the
   risk is bounded false-positive scanner noise, not a real secret exposure.
+- **CI follow-up (gitleaks)**: the fixture is already exempt via the `^ios/.*Tests/.*` allowlist path in
+  `.gitleaks.toml`, so it did NOT trip the scanner. The actual CI secret-scan failure was a *separate*
+  false-positive: `generic-api-key` matched the CryptoKit type name `P256.KeyAgreement.PrivateKey` in
+  `HostSyncService.swift` (production source, not a credential) — the same class as the pre-existing
+  `P256.Signing.PrivateKey` allowlist entry. Resolved by adding `P256\.KeyAgreement\.PrivateKey` to that
+  allowlist. Verified: 0 gitleaks findings across all git-tracked files (clean-checkout = CI condition).
 
 ### T1 — golden-vector self-check → strengthened-or-documented (regression subagent)
 - Action: attempt `derRepresentation == f.pkcs8PrivKeyHex`; keep if it passes, else revert with an explicit

--- a/docs/archive/review/ios-team-quicktype-code-review.md
+++ b/docs/archive/review/ios-team-quicktype-code-review.md
@@ -1,0 +1,210 @@
+# Code Review: ios-team-quicktype
+
+Date: 2026-06-15
+Review round: 1 (Phase 3, implementation review)
+
+## Changes from Previous Round
+
+Initial Phase-3 implementation review of the iOS team-key AutoFill + QuickType + in-app team vault
+feature (contracts C1-C10 + implementation deviations D1-D3), reviewed against the uncommitted working tree
+(base = ios-main). Three expert sub-agents (functionality, security, testing). **No security escalation**
+(`escalate: false`): the proxy Bearer-bypass boundary change (D1) was independently verified safe. 3
+Critical/Major behavioral findings + several Minor defense-in-depth / test-quality findings — all resolved
+in this round (no deferrals).
+
+## Functionality Findings
+
+- **F1 (Critical → resolved)** `HostSyncService.performSync` wiped all team keys on a transient
+  `/api/teams` (membership-list) fetch failure.
+  - File: `ios/PasswdSSOApp/Vault/HostSyncService.swift`
+  - Problem: a non-auth failure of `fetchTeamMemberships()` set `teams = []`; with the ECDH key present,
+    `refreshTeamKeys` did a "full rewrite" `saveTeamKeys([])`, wiping still-valid team keys (and the team
+    directory). Indistinguishable from "user is on zero teams". Violated the C7 resilience intent.
+  - Impact: any transient network/5xx on `/api/teams` during sync → team fill + in-app team display outage
+    until the next successful sync (self-healing, but a full team-feature blackout in between).
+  - Fix: track `teamsAuthoritative`; `refreshTeamKeys` returns early (touching nothing) when the list was a
+    transient-failure fallback. The authoritative empty list (genuinely 0 teams) still full-rewrites so
+    revocation correctly drops teams.
+- **F2 (Major → resolved)** team-directory blob not wiped on sign-out (same root cause as **S13**).
+  - File: `ios/PasswdSSOApp/Vault/AutoLockService.swift`
+  - Problem: `signOut()` called `wrappedKeyStore.clearAll()` (vault/team/ECDH blobs) but never cleared the
+    `TeamDirectoryStore` (`vault/team-directory.json`), which lives outside `WrappedKeyStore`. Contradicts
+    plan C10b ("cleared in clearAll()/sign-out").
+  - Impact: encrypted team-name residue survives sign-out (metadata: prior account was on ≥1 team). R25/R39
+    sign-out-wipe gap.
+  - Fix: inject `teamDirectoryStore: any TeamDirectoryStoring = TeamDirectoryStore()` into `AutoLockService`;
+    `signOut()` now calls `teamDirectoryStore.clear()`.
+- **F3 (Major → resolved)** `CredentialResolver.decryptEntryDetail` (fill path) had no team-key staleness
+  check.
+  - File: `ios/Shared/AutoFill/CredentialResolver.swift`
+  - Problem: `resolveCandidates` (the QuickType list) enforces the 15-min `teamKeyMaxAge` bound, but the
+    fill path `decryptEntryDetail` did not — a stale team key (post-revocation, sync not yet run) would
+    still FILL the credential beyond the revocation window.
+  - Impact: breaks the "revoked membership stops filling within ≤15 min" guarantee on the fill path.
+  - Fix: `decryptEntryDetail` now throws `Error.entryNotFound` when `now() - wrapped.issuedAt > teamKeyMaxAge`,
+    matching `resolveCandidates`.
+- **F4 (Minor → resolved)** `EntryDetailView.loadDetail()` did not pass `cacheKey` explicitly, relying on the
+  VM's `loadedCacheKey` fallback (nil before `loadFromCache` → silent team-detail decrypt failure at a
+  cold-launch edge).
+  - Fix: pass `cacheKey: cacheKey` to `viewModel.loadDetail`.
+- **F5 (Minor → resolved)** malformed/undecryptable persisted ECDH key left stale team keys uncleaned (the
+  all-stale cleanup only ran on the no-ECDH branch).
+  - Fix: extracted `clearTeamKeysIfAllStale(now:)`; both the no-ECDH and malformed-ECDH branches now run it.
+
+## Security Findings
+
+- **Proxy Bearer-bypass boundary (D1) — VERIFIED SAFE, no finding, escalate: false.** Every `/api/teams/*`
+  route enforces its own authorization: scope-gated routes use `checkAuth(..., { scope: PASSWORDS_READ })` +
+  team-membership checks (list, per-team passwords, member-key — the three the iOS token uses); session-only
+  sub-routes (`members`, `rotate-key`, `invitations`, `webhooks`, `policy`, `tags`, `folders`, `audit-logs`)
+  use `auth()` and reject cookieless Bearer with 401 from the handler. No team route delegates authz to the
+  proxy session gate. `startsWith(route + "/")` child matching exposes no un-authz'd sub-route. CORS preflight
+  allows chrome-extension origins on Bearer routes without credentialed CORS; baseline CSRF still fires on
+  cookie-bearing mutating requests. Covered by cors-gate.test.ts + api-route.test.ts.
+- **AAD binding symmetry — VERIFIED correct, no finding.** `buildLocalWrapAAD` ("LW") is a single impl called
+  by both host write and on-device read via `TeamEntryDecryptor`; `userId` on both sides is
+  `cacheData.header.userId` (F16). Team-key wrap AAD "OK" (4-field) byte-identical to the extension (golden
+  vector). kty/crv P-256 validated (S6). Plan findings S1/S2/S6 confirmed implemented.
+- **S13 (Major → resolved)** = F2 (team-directory not wiped on sign-out). Resolved in `AutoLockService`.
+- **S15 (Minor → resolved)** missing defensive `assert(wrapped.teamId == teamId)` (plan S12).
+  - Fix: added the assert in `TeamEntryDecryptor.teamEntryKey` after the lookup (defense for a future
+    lookup/unwrap decoupling; AEAD `wrapped.teamId` binding remains the actual enforcement).
+- **S16 (Minor → resolved)** ECDH shared-secret bytes (`sharedBytes`) not zeroized in
+  `TeamKeyCrypto.unwrapTeamKey`. Fix: `var` + `defer resetBytes` (R39, matches PKCS#8 pattern).
+- **S17 (Minor → resolved)** team-enc-key bytes (`keyBytes`) not zeroized in `TeamEntryDecryptor.wrapTeamKey`.
+  Fix: `var` + `defer resetBytes`.
+- **S18 (Minor → resolved)** item-key plaintext (`itemKeyData`) not zeroized in
+  `TeamEntryDecryptor.resolveTeamEntryKey`. Fix: `guard var` + `defer resetBytes`.
+- **S14 (Major → accepted with justification, see Resolution Status)** plaintext key material
+  (`secretKeyHex`, `pkcs8PrivKeyHex`, `rawTeamKeyHex`, item keys) in the committed golden-vector fixture
+  `team-key-fixture.json`. These are synthetic, randomly-generated test vectors and are REQUIRED inputs/
+  expected-values to anchor the cross-platform crypto chain (standard for crypto golden vectors, cf. NIST
+  CAVP / RFC test vectors) — removing them would make the golden vectors impossible. Not production secrets.
+
+## Testing Findings
+
+- **T1 (Critical→see resolution)** golden-vector test (a) `testUnwrapEcdhPrivateKey_importsAndRoundTrips`
+  loaded `f.pkcs8PrivKeyHex` but asserted only an iOS-vs-iOS self round-trip. Resolution: strengthen to assert
+  `derRepresentation == f.pkcs8PrivKeyHex` if byte-identical; otherwise revert to self-check WITH an explicit
+  comment that cross-platform import correctness is anchored transitively by tests (b)/(c)/(d) (rawTeamKey,
+  teamEncKey, overview all match the extension — the ECDH key MUST have imported correctly to produce them).
+  Severity downgraded from Critical: the import IS anchored downstream, so this is a clarity/anchoring
+  improvement, not an un-tested-correctness gap.
+- **T4 (Minor → resolved)** no negative test for tampered ECDH-private-key ciphertext (S5 gap). Fix: add
+  `testUnwrapEcdhPrivateKey_tamperedCiphertext_throws`.
+- **T7 (Minor → resolved)** `fetchTeamMemberKey` 200 test did not assert `ephemeralPublicKey` decode. Fix: add
+  the assertion.
+- **T8 (Minor → resolved)** team-key sync test did not assert `storedKey.teamKeyVersion` threading. Fix: add
+  the assertion.
+- **T2/T3/T5/T6 — no action.** T2 (itemKeyVersion1 anchored to fixture itemEncKeyHex — correct), T3
+  (sync `throws`, `XCTAssertThrowsError` correct — N/A), T5 (resilience assertions correct), T6 (AAD
+  hand-computed string value correct; readability-only).
+- **Regression tests for F1/F2/F3** added alongside the fixes (a fix without a failing-before test is
+  incomplete): HostSyncService transient-list-failure → set unchanged; CredentialResolver stale fill →
+  entryNotFound; AutoLockService signOut → team directory cleared.
+
+## Adjacent Findings
+- Functionality expert noted the session-only `/api/teams` sub-routes are unreachable by the iOS Bearer token
+  (correct — iOS only needs list + member-key + passwords, all `checkAuth`-gated) → routed to Security,
+  confirmed safe (no finding).
+
+## Quality Warnings
+None.
+
+## Recurring Issue Check (consolidated)
+
+### Functionality
+- R1 (shared helper reuse) PASS — TeamEntryDecryptor is the single team-decrypt path; no duplication in
+  CredentialResolver. R3 (cacheKey propagation) PASS after F4 (all call sites pass the real
+  UnlockResult.cacheKey; none derive from readDirect()). R25 (persist/hydrate) PASS after F2 (ECDH + team
+  keys + team directory all save/load/clear-on-signout). R38 (fail-open) addressed: F1 prevents
+  transient-failure wipe; signOut clears all. R40 (cross-boundary serialization) PASS — TeamMemberKeyResponse
+  decodes the server's actual JSON shape (ephemeralPublicKey is a String on both sides). R41 (declared
+  capability backing) PASS — QuickType registration wired at all sync sites with cacheKey. R2/R12/R19 N/A or
+  PASS.
+
+### Security
+- RS3 (input validation) PASS (JSONDecoder fails closed; server validates keyVersion; kty/crv validated).
+  RS4 — fixture key material accepted-with-justification (S14); no secrets in logs. RS5 (untrusted crypto
+  params) PASS for kty/crv; hkdfSalt length not floored (advisory, HKDF-safe). R18 (allowlist sync) PASS (D1
+  + tests). R39 (zeroization) PASS after S16/S17/S18. RS1 (HKDF infos are domain separators, not secrets)
+  N/A. R3 PASS (cacheKey threading via UnlockResult.cacheKey; no readDirect() derivation).
+
+### Testing
+- RT1 (mock-reality) PASS (member-key stub matches TeamMemberKeyResponse). RT2 PASS. RT5 (production
+  call-path) PASS. RT6 (new exports tested) PASS. RT7 (provably-red guards) PASS after T1/T4. R19 (mock
+  alignment — all WrappedKeyStore conformers updated) PASS. R25 (round-trip crosses real fs boundary) PASS.
+
+## Environment Verification Report
+- R35 Tier-2 manual-test artifact: `docs/archive/review/ios-team-quicktype-manual-test.md` present
+  (Pre-conditions / Scenarios 1-4 / Adversarial: revocation-15min, sign-out wipe, clock-skew, cross-tenant /
+  Rollback). Device-only paths are `blocked-deferred` to manual execution by design (AutoFill + biometric +
+  cross-process key lifecycle cannot be unit-tested) — predicted by the plan's R35 Tier-2 classification.
+- Automated gates: iOS 506 tests (504 unit + 2 UI) — re-run after this round's fixes/regression tests (see
+  Resolution Status); server `npx vitest run` (11322 pass; 1 load-induced flake, passes in isolation);
+  `npx next build` green (after the tsconfig exclude for the new fixture script).
+
+## Resolution Status
+
+### F1 Critical — team-key wipe on transient membership-list failure — Fixed
+- Action: added `teamsAuthoritative` flag in `performSync`; `refreshTeamKeys` returns early when not
+  authoritative (no save / no directory write). Regression test added (transient `/api/teams` failure →
+  existing set unchanged).
+- Modified: ios/PasswdSSOApp/Vault/HostSyncService.swift
+
+### F2 / S13 Major — team directory not wiped on sign-out — Fixed
+- Action: injected `TeamDirectoryStoring` into AutoLockService; `signOut()` calls `clear()`. Regression test
+  added (signOut → directory cleared).
+- Modified: ios/PasswdSSOApp/Vault/AutoLockService.swift
+
+### F3 Major — fill-path missing staleness check — Fixed
+- Action: `decryptEntryDetail` enforces `teamKeyMaxAge`. Regression test added (stale key → entryNotFound).
+- Modified: ios/Shared/AutoFill/CredentialResolver.swift
+
+### F4 Minor — EntryDetailView cacheKey not threaded — Fixed
+- Modified: ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
+
+### F5 Minor — malformed ECDH leaves stale keys — Fixed
+- Action: `clearTeamKeysIfAllStale(now:)` run in both no-ECDH and malformed-ECDH branches.
+- Modified: ios/PasswdSSOApp/Vault/HostSyncService.swift
+
+### S15 Minor — defensive teamId assert — Fixed
+- Modified: ios/Shared/AutoFill/TeamEntryDecryptor.swift
+
+### S16/S17/S18 Minor — key-material zeroization — Fixed
+- Modified: ios/Shared/Crypto/TeamKeyCrypto.swift, ios/Shared/AutoFill/TeamEntryDecryptor.swift
+
+### S14 Major — plaintext keys in committed fixture — Accepted
+- **Anti-Deferral check**: acceptable risk (quantified).
+- **Justification**:
+  - Worst case: a secret scanner emits a false-positive on a 32-byte hex string in a test fixture.
+  - Likelihood: low — these are randomly-generated synthetic test vectors (not provider-format tokens that
+    GitHub/trufflehog secret scanners match); the file is a test fixture, not config.
+  - Cost to fix "properly" (remove the keys): would destroy the golden vectors — the secretKey/PKCS#8/rawTeamKey
+    are the REQUIRED inputs+expected-values that anchor cross-platform crypto parity (standard practice, cf.
+    NIST CAVP / RFC test vectors). Removing them yields no cross-platform anchor (the whole point of C9).
+- **Orchestrator sign-off**: accepted — committing synthetic crypto test vectors is correct and intended; the
+  risk is bounded false-positive scanner noise, not a real secret exposure.
+
+### T1 — golden-vector self-check → strengthened-or-documented (regression subagent)
+- Action: attempt `derRepresentation == f.pkcs8PrivKeyHex`; keep if it passes, else revert with an explicit
+  anchoring comment. Outcome recorded by the regression subagent.
+- Modified: ios/PasswdSSOTests/TeamKeyCryptoTests.swift
+
+### T4/T7/T8 Minor — added negative + assertion coverage — Fixed
+- Modified: ios/PasswdSSOTests/{TeamKeyCryptoTests,MobileAPIClientTests,HostSyncServiceTests}.swift
+
+### Final verification — DONE (all gates green)
+- **iOS**: `xcodegen generate` + `build-for-testing` (`** TEST BUILD SUCCEEDED **`) +
+  `test-without-building` → **511 unit + 2 UI tests, 0 failures** (`** TEST EXECUTE SUCCEEDED **`), verified
+  independently in the orchestrator context (R21). +7 tests over the pre-round 504 (regression F1/F2/F3 +
+  T1/T4/T7/T8). T1 outcome: the stronger cross-platform anchor was KEPT — CryptoKit `derRepresentation` is
+  byte-identical to WebCrypto pkcs8 for the fixture key.
+- **Server**: `npx vitest run` 11322 pass (1 load-induced flake, passes in isolation); `npx next build`
+  green (after the tsconfig exclude for scripts/generate-team-key-fixture.ts). No server code changed after
+  these runs (iOS-only fixes this round).
+
+## Resolution
+
+All Critical/Major findings resolved; review converged in round 1. No commit made (per repository convention —
+commit only on explicit request).

--- a/docs/archive/review/ios-team-quicktype-manual-test.md
+++ b/docs/archive/review/ios-team-quicktype-manual-test.md
@@ -1,0 +1,84 @@
+# Manual Test Plan: iOS team-entry AutoFill + QuickType + in-app team vault
+
+Device-only verification for the team-key pipeline (R35 **Tier-2** — cryptographic-material handling: account
+ECDH key, team keys). The crypto chain and resilience branches are covered by golden-vector unit tests
+(`TeamKeyCryptoTests`, `HostSyncServiceTests`, `CredentialResolverTests`, `CredentialIdentityRegistrarTests`);
+this artifact covers what unit tests cannot: real key lifecycle across unlock/sync/background, AutoFill
+visibility, the in-app vault switcher, and the security-sensitive teardown/revocation paths.
+
+Plan: [[ios-team-quicktype-plan]]. Note this branch also carries a **server change** (proxy Bearer-bypass
+allowlist gains `/api/teams` — deviation D1), so the **server must be redeployed** before device testing or every
+`/api/teams/*` call from the iOS token will 401.
+
+## Pre-conditions
+- A real iPhone (Simulator AutoFill config is unreliable — see [[ios-autofill-host-entitlement]]).
+- The server build that includes the `/api/teams` proxy allowlist change is deployed and reachable.
+- A **team** exists in the web app with a **distributed key**, and the device's account is a confirmed member
+  with the team key distributed to it (verify in the web app: the member shows "key confirmed", not "pending").
+- The team contains at least one LOGIN entry for a real site (e.g. `https://github.com`), ideally **two**: one
+  with `itemKeyVersion == 0` and one with `itemKeyVersion >= 1` (per-entry ItemKey), so both crypto paths are
+  exercised. Create them in the web app.
+- The account also has ≥1 **personal** LOGIN entry (to prove scope separation).
+- Signed in on device; vault unlocked **with passphrase at least once** (ECDH key is persisted only at the
+  passphrase path — biometric-only unlock cannot seed it).
+- The passwd-sso AutoFill provider enabled in iOS Settings → Passwords → Password Options (host + extension
+  entitlement both present — [[ios-autofill-host-entitlement]]).
+
+## Scenario 1 — Team entry fills via AutoFill (QuickType + picker)
+- Steps: passphrase-unlock the app → background it (let a sync complete; wait a few seconds) → open Safari on the
+  team site's login form.
+- Expected (QuickType): the team LOGIN appears as a QuickType suggestion in the keyboard bar; selecting it →
+  Face ID → fills username + password correctly.
+- Expected (picker): tapping the passwords key → the AutoFill list includes the team entry under the team; Face
+  ID-gated; fills correctly.
+- Repeat for the `itemKeyVersion >= 1` entry — it must fill identically (guards the item-enc HKDF step, D2).
+
+## Scenario 2 — In-app team vault display + switcher (C10)
+- Steps: open the app (vault unlocked) → observe the top vault switcher.
+- Expected: a segmented switcher shows **個人 (Personal)** + each team's name. Selecting a team scopes the
+  category grid + list to that team only; team entries appear ONLY under their team, personal entries ONLY under
+  個人 (no mixing). Category counts reflect the selected scope.
+- Expected (create guard): under a team scope the `+` (create) button is hidden; the existing
+  `teamEditNotSupported` guard remains the backstop if reached.
+- Expected (cold start): force-quit and relaunch, unlock → the switcher still shows correct team names (proves
+  `TeamDirectoryStore` persisted + decrypts the labels).
+
+## Scenario 3 — Personal-only account unchanged (no regression)
+- Pre-condition: an account on **no team** (or with no distributed key).
+- Steps: unlock → sync → use AutoFill on a personal-site login.
+- Expected: no vault switcher shown; personal entries fill exactly as before; **no errors** in logs about
+  missing ECDH/team keys; sync completes normally.
+
+## Scenario 4 — Background-only (biometric) refresh keeps team fill alive
+- Pre-condition: passphrase-unlocked once (ECDH key persisted), then app backgrounded long enough that the next
+  unlock is biometric.
+- Steps: leave the app backgrounded across a background-sync cycle (do not passphrase-unlock again).
+- Expected: team entries still fill after a background refresh (the persisted ECDH key re-derives team keys
+  without a secretKey). The 15-min staleness self-refreshes on each sync.
+
+## Adversarial / security scenarios (R35 Tier-2 — the unit tests do NOT cover these)
+1. **Revocation latency**: in the web app, remove the device's membership (or rotate the team key without
+   redistributing). On device, do NOT unlock again. Within **≤15 min** the stale team key is refused → team
+   entries stop appearing in QuickType and stop filling; personal entries unaffected. (The bound is the 15-min
+   `teamKeyMaxAge`; verify it does NOT keep filling indefinitely.)
+2. **Sign-out wipes key material**: sign out. Using a file inspector / debugger on the App Group container,
+   confirm BOTH `vault/wrapped-ecdh-private-key.json` AND `vault/wrapped-team-keys.json` (and
+   `vault/team-directory.json`) are **deleted** (clearAll). Re-launch → no team entries until a fresh passphrase
+   unlock + sync. (Guards the security-downgrade / leftover-key-material risk, S4/S10.)
+3. **Clock skew**: set the device clock **back ~30 min**. Confirm previously-stale team keys do NOT re-appear as
+   valid (staleness compares against the wrap's `issuedAt`; turning the clock back must not resurrect a key).
+   Reset the clock afterward.
+4. **Cross-tenant / unauthorized teamId**: with a token whose membership does not cover a given team (or after
+   revocation), confirm `/api/teams/{id}/member-key` yields no usable key and the team simply does not appear —
+   no other team's entries leak, no crash. (Server authorization is the primary control; this verifies the
+   client degrades to "team absent" rather than erroring or cross-filling.)
+
+## Rollback
+If any of the following occur, do **not** ship and disable the team path (the personal flow is independent and
+must keep working):
+- team entries fill but are invisible in-app (the C10 switcher half-state the plan explicitly closed), or
+- a team entry fails to decrypt/fill (especially the `itemKeyVersion >= 1` case — indicates the item-enc HKDF
+  regression D2 reappeared), or
+- sign-out leaves any `wrapped-ecdh-private-key.json` / team-key / team-directory file on disk, or
+- revoked membership keeps filling past the 15-min bound, or
+- a personal-only account sees errors, a spurious switcher, or broken personal fill (regression).

--- a/docs/archive/review/ios-team-quicktype-plan.md
+++ b/docs/archive/review/ios-team-quicktype-plan.md
@@ -1,0 +1,464 @@
+# Plan: iOS team-entry AutoFill + QuickType (team key pipeline)
+
+## Project context
+
+- **Type**: mixed repo; primarily iOS (Swift). **Plan originally assumed "no server change"** because the data
+  contracts (`/api/vault/unlock/data` ECDH fields; `/api/teams/{teamId}/member-key`) already existed. **During
+  implementation this proved false**: the proxy Bearer-bypass allowlist did not include `/api/teams`, so the
+  iOS mobile token was rejected with 401 before reaching the (correctly authorizing) handler. A one-line proxy
+  change was required — see the **Implementation deviations** section at the end. The change touches
+  `src/lib/proxy/cors-gate.ts` (+ tests), so server proxy tests (`npx vitest run`) are now part of the gate.
+- **Test infrastructure**: XCTest unit tests + CI (macos-latest, Xcode 16.4 / iOS 18 SDK). Tests expected.
+  **No iOS 26-only APIs** (CI is iOS 18 SDK).
+- **Security-critical**: this is cryptographic-material handling (account ECDH key, team keys). R35 **Tier-2** —
+  a manual-test artifact with adversarial scenarios is required. Golden-vector tests are mandatory.
+- **BridgeKeyStore(service:)** in tests must end with `"bridge-key"` (precondition aborts otherwise).
+
+## Objective
+
+Make TEAM password entries fillable on iOS — both as inline QuickType suggestions (host registrar) and via the
+AutoFill picker (CredentialResolver). Today the team-key scaffolding exists (`WrappedTeamKey`, resolver team
+path, 15-min staleness, "wrap under cacheKey") but **the pipeline that populates it was never built**:
+`saveTeamKeys()` is called only in tests, so `loadTeamKeys()` always returns `[]` and team entries fill nowhere.
+
+## Background — verified facts (file:line)
+
+### Crypto recipe (mirror the browser extension exactly)
+The extension (`extension/src/lib/crypto-team.ts`) is the source of truth. The chain to obtain a team
+entry-decryption key:
+
+1. **Unwrap account ECDH private key** (needs the vault **secretKey**):
+   `ecdhWrappingKey = HKDF-SHA256(secretKey, salt=Data(count:32, zeros), info="passwd-sso-ecdh-v1", 32B)`
+   (crypto-team.ts:192-210, `deriveEcdhWrappingKey`); then AES-256-GCM **decrypt** `encryptedEcdhPrivateKey`
+   (IV `ecdhPrivateKeyIv`, tag `ecdhPrivateKeyAuthTag`) → **PKCS#8** private-key bytes
+   (`unwrapEcdhPrivateKey`, crypto-team.ts:~218; `importEcdhPrivateKey` imports `"pkcs8"`, P-256, crypto-team.ts:169-178).
+   The ECDH-privkey unwrap uses **no AAD** (confirm during impl).
+2. **ECDH agree + derive team wrapping key** (per team member-key):
+   `sharedBits = ECDH(memberPrivateKey, ephemeralPublicKey)` (raw X-coord, 32B; WebCrypto `deriveBits` 256 ==
+   CryptoKit `SharedSecret` raw); `teamWrappingKey = HKDF-SHA256(sharedBits, salt=hexDecode(hkdfSalt),
+   info="passwd-sso-team-v1", 32B)` (crypto-team.ts:265, `deriveTeamWrappingKey`).
+3. **Decrypt the wrapped team key** with AAD:
+   `rawTeamKey = AES-256-GCM.decrypt(encryptedTeamKey, teamKeyIv, teamKeyAuthTag, teamWrappingKey,
+   aad=buildTeamKeyWrapAAD{teamId,toUserId,keyVersion,wrapVersion})` (`unwrapTeamKey`, crypto-team.ts:280-317).
+   AAD scope is `"OK"`, 4 fields (crypto-team.ts:145-152).
+4. **Derive the team ENCRYPTION key** (the value entries are actually encrypted under):
+   `teamEncKey = HKDF-SHA256(rawTeamKey, salt=Data(count:32, zeros), info="passwd-sso-team-enc-v1", 32B)`
+   (`deriveTeamEncryptionKey`, crypto-team.ts:325-348).
+
+### iOS resolver consumes the DERIVED enc key directly (critical)
+`CredentialResolver` (the consumer) does **not** apply the team-enc HKDF: `decryptTeamKey` unwraps the stored
+`WrappedTeamKey` under cacheKey and uses the result **directly** as the entry key (itemKeyVersion==0) or to
+unwrap the per-entry ItemKey (itemKeyVersion>=1) — `CredentialResolver.swift:756-771` (decryptTeamKey),
+`:721-752` (resolveTeamEntryKey). The extension reaches the same point only after `deriveTeamEncryptionKey`.
+**Therefore the host MUST store the step-4 `teamEncKey` (not the raw step-3 team key) in `WrappedTeamKey`** so
+the resolver/registrar decrypt correctly. End-to-end golden vectors must prove this.
+
+### Server contracts (no change)
+- `GET /api/vault/unlock/data` returns (among others) `ecdhPublicKey`, `encryptedEcdhPrivateKey`,
+  `ecdhPrivateKeyIv`, `ecdhPrivateKeyAuthTag` (all may be null for accounts without an ECDH keypair)
+  (`src/app/api/vault/unlock/data/route.ts:114-135`; model `prisma/schema.prisma:142-146`).
+- `GET /api/teams/{teamId}/member-key` returns `{encryptedTeamKey, teamKeyIv, teamKeyAuthTag,
+  ephemeralPublicKey, hkdfSalt, keyVersion, wrapVersion}` (route.ts GET; model `schema.prisma:662-681`).
+  Requires `EXTENSION_TOKEN_SCOPE.PASSWORDS_READ` — the iOS mobile token already reads team entries via
+  `/api/teams/{teamId}/passwords` (same scope), so it is authorized; **verify during impl**. Error envelopes:
+  `KEY_NOT_DISTRIBUTED`, `MEMBER_KEY_NOT_FOUND`.
+
+### Key lifecycle seam (where each step runs)
+- **secretKey** is in scope ONLY during passphrase unlock (`VaultUnlocker.swift:130-147`), discarded after
+  deriving vaultKey. Biometric/offline unlock has **no** secretKey (`VaultUnlocker.swift:186-242`).
+- **cacheKey** = `deriveCacheVaultKey(bridgeKey:)` — derived from bridge_key (no passphrase), available to host
+  AND extension at any time the bridge_key is readable.
+- **Sync** (`HostSyncService.performSync`, foreground + background via `BackgroundSyncCoordinator`) has vaultKey
+  + readable bridge_key, but **NOT** secretKey.
+- **Design A (chosen)**: persist the unwrapped ECDH private key **re-wrapped under cacheKey** at passphrase
+  unlock (when secretKey exists), mirroring `WrappedVaultKey`. Then sync (incl. background, incl. after
+  biometric unlock) loads + unwraps it with cacheKey, fetches team member-keys, derives team enc keys, and
+  writes `WrappedTeamKey` blobs (wrapped under cacheKey) every sync. The 15-min staleness self-refreshes.
+  Design B (derive team keys only at passphrase unlock) is rejected: team keys would expire 15 min post-unlock
+  with no way to refresh in background.
+
+## Requirements
+
+- Functional: team entries appear as QuickType suggestions AND are fillable via the picker, biometric-gated,
+  offline (from cache), matching personal-entry behavior. Personal-only behavior unchanged.
+- Crypto: byte-for-byte compatible with the extension's team-key crypto (golden vectors prove it).
+- Resilience: accounts without an ECDH keypair, teams without a distributed key, or background sync without a
+  persisted ECDH key MUST degrade gracefully (personal sync/fill keeps working; team entries simply absent).
+- Security: ECDH private key and team enc keys are persisted only **wrapped under cacheKey** (same protection
+  level as the already-persisted vaultKey). No plaintext key material persisted. Cleared on sign-out.
+
+## Technical approach
+
+Mirror the extension crypto in a new `Shared/Crypto/TeamKeyCrypto.swift` using CryptoKit
+(`P256.KeyAgreement`, `HKDF<SHA256>`, existing `AESGCM`/`AAD`/`hex`). Persist the ECDH private key via a new
+`WrappedECDHPrivateKey` in `WrappedKeyStore` (mirrors `WrappedVaultKey`). Populate `WrappedTeamKey` blobs in
+`HostSyncService`. Extend `CredentialIdentityRegistrar` to register team entries (it already has all the
+decrypt building blocks in `CredentialResolver` — factor the shared team-decrypt helper to avoid duplication,
+R1).
+
+## Contracts
+
+### C1 — `VaultUnlockData` gains optional ECDH fields
+- **Location**: `ios/PasswdSSOApp/Network/MobileAPIClient.swift` (`VaultUnlockData`, ~lines 7-58; CodingKeys).
+- **Add (all `String?`, optional — may be null server-side)**: `ecdhPublicKey`, `encryptedEcdhPrivateKey`,
+  `ecdhPrivateKeyIv`, `ecdhPrivateKeyAuthTag`.
+- **F6**: the struct has an **explicit `CodingKeys` enum** — the 4 new fields MUST be added there too, else the
+  decoder silently skips them → always `nil` → ECDH key never persisted. Wire names are snake-less camelCase
+  matching the server JSON (`ecdhPublicKey`, `encryptedEcdhPrivateKey`, `ecdhPrivateKeyIv`,
+  `ecdhPrivateKeyAuthTag` — confirm exact casing against `src/app/api/vault/unlock/data/route.ts`).
+- **Invariant**: decode tolerates absence (no team support for that account) — never throws on missing fields.
+- **Acceptance**: unlock-data JSON with and without the ECDH fields both decode; a fixture WITH the fields
+  populated round-trips into non-nil properties (guards the CodingKeys wiring).
+
+### C2 — team-key-wrap AAD + local-wrap AAD on iOS
+- **Location**: `ios/Shared/Crypto/AAD.swift`.
+- **Add (server-compat, mirrors extension)**: `case teamKey = "OK"` to `AADScope`;
+  `public func buildTeamKeyWrapAAD(teamId:toUserId:keyVersion:wrapVersion:) throws -> Data`
+  = `buildAADBytes(scope: .teamKey, fields: [teamId, toUserId, String(keyVersion), String(wrapVersion)])`.
+  Byte-identical to extension `buildTeamKeyWrapAAD` (scope `"OK"`, aadVersion 1, 4 length-prefixed fields).
+- **Add (iOS-local, NEW — S1/S2 blob-binding)**: `case localWrap = "LW"`;
+  `public func buildLocalWrapAAD(kind: String, userId: String, teamId: String = "") throws -> Data`
+  = `buildAADBytes(scope: .localWrap, fields: [kind, userId, teamId])`. Used ONLY for the on-device cacheKey
+  wraps introduced by this plan (`kind` ∈ {`"ecdh"`, `"team"`}). This binds each persisted blob to the user
+  (and team) it was derived for, so a blob transplanted from another user/team fails AEAD. It is **not** shared
+  with the server/extension (purely an iOS-internal integrity binding). The pre-existing `WrappedVaultKey`
+  remains AAD-less (out of scope; same threat model as today).
+- **Invariant**: `"OK"` AAD byte-identical to the extension; `"LW"` AAD is consumed symmetrically by the host
+  writer (C5/C7) and the on-device reader (`CredentialResolver.decryptTeamKey`, C8) — same `kind`/`userId`/`teamId`.
+- **Acceptance**: a golden-vector test asserts the **full byte sequence** (not just header bytes — follow
+  `AADParityTests` pattern) for the `"OK"` AAD against the extension output, and for the `"LW"` AAD against a
+  hand-computed known-good sequence (T3).
+
+### C3 — `Shared/Crypto/TeamKeyCrypto.swift` (new) — the crypto mirror
+- **Functions** (pure, `nonisolated`, throwing):
+  - `deriveEcdhWrappingKey(secretKey: SymmetricKey) -> SymmetricKey` — HKDF(secretKey, salt=32 zero bytes,
+    info `"passwd-sso-ecdh-v1"`, 32B). (NB: the extension JSDoc says "salt=empty" but the code uses
+    `new ArrayBuffer(32)` = 32 zero bytes — follow the code; same for `deriveTeamEncryptionKey`.)
+  - `unwrapEcdhPrivateKey(encrypted: EncryptedData, wrappingKey: SymmetricKey) -> P256.KeyAgreement.PrivateKey`
+    — AES-GCM decrypt (no AAD) → PKCS#8 bytes → import → return the **key directly**. The intermediate PKCS#8
+    `Data` is **zeroized** in a `defer` before returning (S9 — mirrors `VaultUnlocker.zeroData`), so the caller
+    never holds raw private-key bytes.
+  - **import detail** (internal to the above): use `P256.KeyAgreement.PrivateKey(derRepresentation:)` — **NOTE
+    (F15): `pkcs8DERRepresentation` does NOT exist on CryptoKit's P256 key types; the correct API is
+    `derRepresentation`**, which for a private key emits/accepts PKCS#8 `PrivateKeyInfo` DER (verified against
+    the iOS SDK: bytes begin `30 81 87 02 01 00 30 13…`). WebCrypto exports PKCS#8 (`importEcdhPrivateKey` uses
+    `"pkcs8"`, crypto-team.ts:173), so `derRepresentation` is format-compatible with the wrapped bytes. **F10**:
+    no expected fallback; if `init(derRepresentation:)` throws on the real bytes, parse the 32-byte private
+    scalar out of the PKCS#8 and use `init(rawRepresentation:)`. The golden vector (C9) pins which path the real
+    bytes take — do not ship the fallback unless the vector proves it is needed.
+  - `importEphemeralPublicKey(jwk: String) -> P256.KeyAgreement.PublicKey` — parse `{kty,crv,x,y}`; **validate
+    `kty == "EC"` and `crv == "P-256"`** before use, throwing `TeamKeyCryptoError.unsupportedKeyType` otherwise
+    (S6); base64url-decode x/y (32B each) → `P256.KeyAgreement.PublicKey(x963Representation: 0x04‖x‖y)`.
+  - `unwrapTeamKey(encrypted:EncryptedData, ephemeralPublicKeyJWK:String, memberPrivateKey:P256.KeyAgreement.PrivateKey, hkdfSalt:String, teamId:String, toUserId:String, keyVersion:Int, wrapVersion:Int) -> SymmetricKey`
+    — ECDH `sharedSecret(with:)` → raw bytes → HKDF(salt=hexDecode(hkdfSalt), info `"passwd-sso-team-v1"`, 32B) →
+    AES-GCM decrypt with `buildTeamKeyWrapAAD` → **rawTeamKey**.
+  - `deriveTeamEncryptionKey(rawTeamKey: SymmetricKey) -> SymmetricKey` — HKDF(rawTeamKey, salt=32 zero bytes,
+    info `"passwd-sso-team-enc-v1"`, 32B). **This is the value stored in `WrappedTeamKey`** (per the resolver
+    consumption fact above).
+- **Invariant**: ECDH shared secret uses the raw X-coordinate (SEC1 Z), matching WebCrypto `deriveBits`. HKDF
+  salts/infos exactly as above. No AAD on ECDH-privkey unwrap; AAD `"OK"`/4-field on team-key unwrap.
+- **Forbidden patterns**:
+  - `pattern: SharedSecret.*hkdfDerivedSymmetricKey` — reason: must feed raw shared bytes to the project HKDF to
+    match the extension's two-step (deriveBits → HKDF) exactly; CryptoKit's combined helper uses a different
+    construction.
+- **Acceptance (golden vectors, mandatory)**: with fixtures captured from the extension's own functions
+  (known secretKey, encryptedEcdhPrivateKey, member-key blob, a team entry overview), iOS reproduces: (a) the
+  unwrapped PKCS#8 privkey bytes, (b) the rawTeamKey, (c) the teamEncKey, (d) a decrypted team entry overview
+  identical to the extension's. Consumer-flow: the produced teamEncKey, when stored as `WrappedTeamKey` and fed
+  to `CredentialResolver`/registrar, decrypts a real team entry overview (full round-trip golden vector).
+
+### C4 — `WrappedECDHPrivateKey` persistence
+- **Location**: `ios/Shared/Storage/WrappedKeyStore.swift`.
+- **Add**: `WrappedECDHPrivateKey` struct (ciphertext/iv/authTag: Data) mirroring `WrappedVaultKey`;
+  protocol `saveECDHPrivateKey(_:)` / `loadECDHPrivateKey() -> WrappedECDHPrivateKey?`; a `clearTeamKeys()`
+  protocol method (S11 — used by C7's stale-branch); a private `ecdhPrivateKeyURL()` path helper; and **delete
+  the ECDH path in `clearAll()`** (S4/S10 — sign-out must wipe it). Persisted as
+  `vault/wrapped-ecdh-private-key.json` (App Group, atomic write).
+- **Stored value**: the PKCS#8 ECDH private-key bytes AES-GCM-encrypted under **cacheKey with AAD =
+  `buildLocalWrapAAD(kind:"ecdh", userId:)`** (S1).
+- **Mock update obligation (T4/F14/S11)**: the `WrappedKeyStore` protocol gains 3 methods
+  (`saveECDHPrivateKey`, `loadECDHPrivateKey`, `clearTeamKeys`) → EVERY conformer must be updated in the SAME
+  change or the test target fails to compile: `MockWrappedKeyStore`
+  (`PasswdSSOTests/CredentialResolverTests.swift:18-37`), `TempDirWrappedKeyStore`
+  (`WrappedKeyStoreTests.swift:~147`), and any other conformer (grep `: WrappedKeyStore`). Add in-memory ECDH
+  storage; `clearTeamKeys()` resets the in-memory team-key array to `[]`; `clearAll()` resets ECDH + team-key
+  in-memory state to nil/[] (not just file paths) so `HostSyncServiceTests` (T10) observe the clear.
+- **Invariant (R25 persist/hydrate)**: cleared by `clearAll()` (sign-out) alongside vault/team keys; stored only
+  wrapped under cacheKey (with userId AAD).
+- **Acceptance**: round-trip save/load; **`clearAll()` removes the file (mandatory pre-merge test gate, not just
+  a nice-to-have)** — the test seeds an ECDH blob then asserts `loadECDHPrivateKey() == nil` after `clearAll()`.
+
+### C5 — persist ECDH key at passphrase unlock
+- **Location**: `ios/PasswdSSOApp/Vault/VaultUnlocker.swift` (passphrase path, where `secretKey` + `cacheKey` are
+  in scope, ~line 130-160).
+- **Behavior**: if `unlockData` carries the ECDH fields → `deriveEcdhWrappingKey(secretKey)` →
+  `unwrapEcdhPrivateKey` (returns the imported key; re-export its PKCS#8 via
+  `privateKey.derRepresentation` for re-wrapping — F15: `derRepresentation`, not `pkcs8DERRepresentation`) → re-encrypt those PKCS#8 bytes under **cacheKey with AAD
+  `buildLocalWrapAAD(kind:"ecdh", userId:)`** (S1) → `wrappedKeyStore.saveECDHPrivateKey(...)`, zeroizing the
+  re-export bytes after. If fields absent or unwrap fails → skip (log, non-fatal).
+- **Biometric path**: no secretKey → no-op (relies on the ECDH key persisted at the last passphrase unlock).
+- **Invariant**: `UnlockResult` shape unchanged; failure here never blocks unlock (personal vault must still
+  open).
+- **Acceptance**: after passphrase unlock with ECDH fields, `loadECDHPrivateKey()` returns a blob that unwraps
+  (under cacheKey) to the same PKCS#8 bytes; absent fields → no blob, unlock still succeeds.
+
+### C6 — `MobileAPIClient.fetchTeamMemberKey`
+- **Location**: `ios/PasswdSSOApp/Network/MobileAPIClient.swift`.
+- **Signature**: `func fetchTeamMemberKey(teamId: String) async throws -> TeamMemberKeyResponse` — GET
+  `/api/teams/{teamId}/member-key` (DPoP, existing auth ladder).
+- **`TeamMemberKeyResponse: Decodable`**: `encryptedTeamKey, teamKeyIv, teamKeyAuthTag, ephemeralPublicKey,
+  hkdfSalt: String; keyVersion, wrapVersion: Int`.
+- **Invariant**: a `KEY_NOT_DISTRIBUTED` / `MEMBER_KEY_NOT_FOUND` / 404 surfaces as a **named typed error**
+  `MobileAPIError.teamKeyNotDistributed` (T8) that the caller treats as "skip this team" (not a hard sync
+  failure). Map both the 403/404 status and the error-code body to this case (reuse the C-quota body-envelope
+  decode pattern from the shipped `decodeBodyResponse`).
+- **Acceptance**: 200 decodes into `TeamMemberKeyResponse`; `KEY_NOT_DISTRIBUTED` / `MEMBER_KEY_NOT_FOUND` /
+  bare 404 → `MobileAPIError.teamKeyNotDistributed`.
+
+### C7 — `HostSyncService` populates `WrappedTeamKey`
+- **Location**: `ios/PasswdSSOApp/Vault/HostSyncService.swift` (`performSync`).
+- **Behavior**: derive `cacheKey = deriveCacheVaultKey(bridgeKey: blob.bridgeKey)`; load+unwrap the persisted
+  ECDH private key (under cacheKey, AAD `buildLocalWrapAAD(kind:"ecdh", userId:)`) → import. For each team
+  membership: `fetchTeamMemberKey` → `unwrapTeamKey` → `deriveTeamEncryptionKey` → AES-GCM encrypt that key
+  under **cacheKey with AAD `buildLocalWrapAAD(kind:"team", userId:, teamId:)`** (S2) →
+  `WrappedTeamKey(teamId:, ciphertext:, iv:, authTag:, issuedAt: now(), teamKeyVersion: resp.keyVersion)`.
+  Collect all → `wrappedKeyStore.saveTeamKeys(blobs)` (one write; overwrites the previous set so revoked/
+  key-not-distributed teams drop out).
+- **Resilience**:
+  - ECDH key **available** → always rewrite the FULL set (a team that now returns
+    `teamKeyNotDistributed` simply isn't in the new array → revocation drops it). Per-team fetch/unwrap failure →
+    skip that team, continue others.
+  - ECDH key **unavailable** (e.g. background sync before any passphrase unlock) → do NOT blow away a possibly
+    still-valid set, BUT avoid keeping revoked keys forever: if **all** existing `WrappedTeamKey` blobs are
+    already older than the 15-min staleness window, clear them via `wrappedKeyStore.clearTeamKeys()` (S11 — a
+    dedicated protocol method, NOT a direct file delete, so mocks capture it); otherwise leave the set untouched
+    (F3/S3). Never call `saveTeamKeys([])` as a "skip" — that would wipe a valid set (T10).
+- **Clock**: `issuedAt` and the staleness comparison use the injected clock (testable).
+- **Invariant**: personal sync path and its cache write are unchanged; team-key population is additive and
+  best-effort. `issuedAt` uses the injected clock (testable).
+- **Consumer-flow walkthrough**:
+  - `CredentialResolver.resolveCandidates` (extension) reads `loadTeamKeys()` → `decryptTeamKey(cacheKey:)` →
+    uses the key directly (itemKeyVersion==0) or unwraps ItemKey (>=1). It needs: `teamId` (lookup), `issuedAt`
+    (staleness), `ciphertext/iv/authTag` (the cacheKey-wrapped **teamEncKey**), `teamKeyVersion`. All provided. ✔
+  - `CredentialIdentityRegistrar` (C8) reads the same set the same way. ✔
+- **Acceptance**: after a sync with a team membership + distributed key, `loadTeamKeys()` returns a blob whose
+  cacheKey-unwrap → resolver decrypts the team entry overview (golden round-trip).
+
+### C8 — `CredentialIdentityRegistrar` registers team entries (+ shared helper, + AAD consumer change)
+- **R1 shared helper**: extract the team-decrypt logic into a single new type
+  `ios/Shared/AutoFill/TeamEntryDecryptor.swift` exposing e.g.
+  `decryptTeamSummary(entry: CacheEntry, teamKeys: [WrappedTeamKey], cacheKey: SymmetricKey, userId: String, now: () -> Date) -> VaultEntrySummary?`
+  — it does: team-key lookup by `teamId`, 15-min staleness (`teamKeyMaxAge`), `decryptTeamKey` (now AAD-aware),
+  `resolveTeamEntryKey`, overview decrypt (team-entry AAD). **Both** `CredentialResolver` and the registrar call
+  it (do NOT duplicate). `CredentialResolver`'s existing inline team path is refactored to use it.
+- **AAD consumer change (S2)**: `decryptTeamKey` must now pass `buildLocalWrapAAD(kind:"team", userId:, teamId:)`
+  to `decryptAESGCM` (matching the host write in C7). Signature gains `userId` + uses `wrapped.teamId`. This
+  changes existing `CredentialResolver.decryptTeamKey` (safe — the team path was never exercised in production
+  since `saveTeamKeys` was test-only).
+- **AAD symmetry enforcement (F16/F17/S12)**: to guarantee the host writer (C7) and the on-device reader use the
+  identical AAD, both wrap and unwrap of the team enc key go through **one shared pair** on `TeamEntryDecryptor`
+  (or a sibling `LocalKeyWrap` helper): `wrapTeamKey(teamEncKey, cacheKey, userId, teamId) -> WrappedTeamKey`
+  and `unwrapTeamKey(WrappedTeamKey, cacheKey, userId) -> SymmetricKey`. `HostSyncService` calls the wrap
+  helper; the resolver/registrar call the unwrap helper. **F16**: the `userId` passed on BOTH sides MUST be
+  `cacheData.header.userId` (the value the host wrote at sync time) — never a session-layer userId sourced
+  independently. At `CredentialResolver` call sites (resolveCandidates ~199, decryptEntryDetail ~327) `userId`
+  is already bound from `cacheData.header.userId` — pass that. **S12**: the unwrap helper asserts
+  `wrapped.teamId == lookupTeamId` (debug assert) so a lookup-key logic bug surfaces directly rather than as an
+  opaque AEAD failure. The same shared-pair pattern applies to the ECDH key (`wrapEcdhKey`/`unwrapEcdhKey` with
+  `kind:"ecdh"` AAD) so C5's write and C7's read agree.
+- **Registrar behavior** (`CredentialIdentityRegistrar.swift`): `decryptPersonalOverviews` /
+  `buildPasskeyIdentitySpecs` currently skip `where entry.teamId == nil`. Add a team branch that calls
+  `TeamEntryDecryptor` for `entry.teamId != nil` entries and includes them with `teamId: entry.teamId`.
+- **Call-site cacheKey provisioning (F2/F4/R3)** — `refreshCredentialIdentities(...)` gains `cacheKey:
+  SymmetricKey?` and `wrappedKeyStore:`. Each caller supplies cacheKey by `deriveCacheVaultKey(bridgeKey:)` from
+  a `BridgeKeyStore.readDirect()`:
+  - `RootView.swift:~318` (handleVaultUnlocked) and `:~413` (debug) — bridge_key readable post-unlock; derive there.
+  - `PasswdSSOAppApp.swift:~92` (foreground `.active` sync) — **`BackgroundSyncContext` must gain a
+    `BridgeKeyStore` reference** (or store the derived cacheKey at unlock) so this site can pass it.
+  - `VaultViewModel.swift:~227` and `:~285` — `VaultViewModel` has no bridge access today; **inject `cacheKey:
+    SymmetricKey?` into the relevant methods (or the VM)** from the view layer that already holds it. When
+    cacheKey is `nil`, the registrar falls back to personal-only (no crash).
+- **Background QuickType (F13)** — decide + document: `BackgroundSyncTask` currently does NOT call
+  `refreshCredentialIdentities` after `runSync`. To make team entries appear in QuickType after a background
+  refresh (User scenario 1), add a `refreshCredentialIdentities` call (with cacheKey from bridge_key) at the end
+  of the background sync path. If deferred, the plan MUST state "team QuickType updates only on next foreground"
+  — but since the scenario explicitly promises background appearance, **wire it in background**.
+- **Invariant**: personal registration unchanged when cacheKey is nil or no team keys present; team entries
+  register only when a fresh (<15 min) team key exists.
+- **Acceptance**: with team keys present + cacheKey passed, team entries appear in the registered identity set;
+  cacheKey nil OR no team keys → only personal (no regression). `TeamEntryDecryptor` is the single decrypt path
+  (grep: no duplicated team-decrypt logic remains in `CredentialResolver`).
+
+### C9 — tests + manual-test artifact
+- **Golden-vector capture (MANDATORY deliverable, T1/T2/T11/T12)**: a one-time capture script
+  `scripts/generate-team-key-fixture.ts` run via the repo-root `tsx` (add an npm script
+  `"generate:team-key-fixture": "tsx scripts/generate-team-key-fixture.ts"`) — **`.ts` not `.mjs`**, so it
+  `import`s the **extension's actual** `extension/src/lib/crypto-team.ts` (T11: a `.mjs` cannot import the `.ts`
+  source and would silently inline a drifting copy). `crypto-team.ts` uses only `globalThis.crypto.subtle`
+  (Node 20+ native) — no browser globals — so it runs under tsx. The DECRYPT side exercises the real extension
+  functions (`unwrapEcdhPrivateKey`, `unwrapTeamKey`, `deriveTeamEncryptionKey`); the ENCRYPT side (producing
+  `encryptedEcdhPrivateKey`/`encryptedTeamKey` fixtures) uses raw Web Crypto and MUST match the server's stored
+  layout — `ciphertext || authTag` with the 16-byte tag split off into a separate hex field, IV separate (T12).
+  Emits `ios/PasswdSSOTests/fixtures/team-key-fixture.json` containing: `secretKey`,
+  `pkcs8PrivKeyHex`, `ephemeralPublicKeyJWK`, `hkdfSalt`, `encryptedEcdhPrivateKey{ct,iv,tag}`,
+  `encryptedTeamKey{ct,iv,tag}`, `teamId/toUserId/keyVersion/wrapVersion`, `rawTeamKeyHex`, `teamEncKeyHex`, and
+  a sample `encryptedOverview{...}` produced under the teamEncKey. The fixture is bundled in the test target via
+  the same bundle-search pattern as `VaultUnlockerTests.testUnlockDecodesWebGeneratedFixture`
+  (`VaultUnlockerTests.swift:~421`). **Forbidden**: fixtures produced by running the iOS implementation itself —
+  every golden vector loads the external fixture and asserts iOS-output == the EXTENSION's captured hex (a
+  test that calls `TeamKeyCrypto.*` to produce both expected and actual is a vacuous self-check and must be
+  rejected). Document capture provenance in the test header.
+- **`TeamKeyCryptoTests`** (golden vectors against the fixture): (a) `unwrapEcdhPrivateKey` →
+  `pkcs8DERRepresentation` equals `pkcs8PrivKeyHex`; (b) `unwrapTeamKey` raw == `rawTeamKeyHex`; (c)
+  `deriveTeamEncryptionKey` == `teamEncKeyHex`; (d) decrypt the sample `encryptedOverview` under the derived key
+  → expected overview. **Negative tests (S5)**: tampered team-key ciphertext (flip 1 byte) → throws; wrong-AAD
+  (different teamId/userId) → throws; non-EC/`P-384` JWK → `unsupportedKeyType`. **T13**: these targets are
+  `async throws` — use the `do { _ = try await …; XCTFail("expected throw") } catch { }` pattern, NOT
+  `XCTAssertThrowsError` (its closure is synchronous and silently passes an un-awaited async call → vacuous).
+- **`AADParityTests`** (C2, full-byte — T3): `buildTeamKeyWrapAAD` exact bytes == extension fixture (or
+  hand-computed); `buildLocalWrapAAD(kind:"team",userId:,teamId:)` and `(kind:"ecdh",userId:)` exact bytes vs
+  hand-computed known-good sequences. Header-only assertions are insufficient.
+- **`WrappedKeyStoreTests`** (T4): ECDH key round-trip; `clearAll()` removes the ECDH file (mandatory gate);
+  `TempDirWrappedKeyStore` gains the new methods.
+- **`VaultUnlockerTests`** (T5): add `makeVaultUnlockDataWithECDH(...)` builder that generates a real
+  `P256.KeyAgreement.PrivateKey`, exports PKCS#8, encrypts under the HKDF-derived ecdhWrappingKey, and populates
+  the fields. Tests: passphrase unlock with ECDH fields → `loadECDHPrivateKey()` non-nil and unwraps (under
+  cacheKey + ecdh AAD) to the same PKCS#8; absent fields → no blob, unlock still succeeds; biometric path → no-op.
+- **`MobileAPIClientTests`** (T8): `fetchTeamMemberKey` 200 → `TeamMemberKeyResponse` decode (real JSON body,
+  `seedAccessToken()`); `KEY_NOT_DISTRIBUTED` / `MEMBER_KEY_NOT_FOUND` / bare 404 →
+  `MobileAPIError.teamKeyNotDistributed`.
+- **`HostSyncServiceTests`** (T6/T10): with `MockURLProtocol` stubbing `/member-key` + a `MockWrappedKeyStore`
+  seeded with the ECDH blob (wrapped under cacheKey), `performSync` writes a `WrappedTeamKey` whose cacheKey+AAD
+  unwrap == the fixture `teamEncKeyHex`; **no ECDH key + non-empty fresh team-key set → set unchanged** (assert
+  count unchanged, NOT `[]`); no ECDH key + all-stale set → cleared; per-team `teamKeyNotDistributed` → that team
+  absent, others written.
+- **`CredentialIdentityRegistrarTests`** (T7): seed `MockWrappedKeyStore` with a team key (wrapped under cacheKey
+  via the fixture), pass `cacheKey`, assert the team entry's host appears in the replaced specs; cacheKey nil OR
+  no team keys → personal-only. Move/share the `makeTeamCacheEntry` helper (currently in CredentialResolverTests)
+  to a shared test helper.
+- **`TeamEntryDecryptor`** is covered transitively by the resolver + registrar tests; add a focused round-trip
+  test using the fixture.
+- **Manual-test** (`ios-team-quicktype-manual-test.md`, R35 Tier-2): Pre-conditions (a team with a distributed
+  key, a member account on device), Steps (passphrase unlock → background → AutoFill a team-site login),
+  Expected (team entry appears in QuickType + fills, biometric-gated), Rollback. **Adversarial scenarios (T9 —
+  pick the ones NOT already unit-covered)**: (1) revoked membership → team entries stop filling within ≤15 min;
+  (2) **sign-out wipes** `vault/wrapped-ecdh-private-key.json` + team keys (verify via debugger); (3) **clock-skew**:
+  set device clock back 30 min → stale team keys do NOT re-appear; (4) cross-tenant/unauthorized teamId yields no
+  key. (Tampered-AEAD is already a unit test — omit from manual.)
+
+## Testing strategy
+
+Unit + golden vectors per C9. `xcodegen generate` → `build-for-testing` + `test-without-building` on simulator
+(iOS 26.1 local OK), full suite green, no crashes. Golden vectors are the primary correctness gate; capture
+fixtures by running the extension's `crypto-team.ts` functions on fixed inputs (document the capture method in
+the test file header).
+
+## Considerations & constraints
+
+- **Out of scope**: team entry **create/edit** on iOS (read/fill only); team key **rotation** UI; changing the
+  15-min staleness window; any server change; team passkeys.
+- **R1 reuse**: the team-decrypt helper MUST be shared between `CredentialResolver` and the registrar.
+- **R25**: ECDH key + team keys are persisted state crossing the process boundary (host writes, AutoFill ext
+  reads) — both persist and hydrate paths covered; `clearAll()` wipes on sign-out (security downgrade guard).
+- **Background sync**: degrades gracefully without a persisted ECDH key; never clears a possibly-valid team-key
+  set when it cannot refresh.
+- **Token scope**: confirm the iOS mobile token passes `PASSWORDS_READ` on `/member-key` (same scope as the
+  already-working team-entries fetch).
+- **PKCS#8 import risk**: `P256.KeyAgreement.PrivateKey(pkcs8DERRepresentation:)` must accept WebCrypto's pkcs8
+  export — pinned by golden vector; if it rejects, parse the 32-byte scalar from the PKCS#8 and use
+  `init(rawRepresentation:)`.
+
+## User operation scenarios
+
+1. Member of a team unlocks with passphrase → app persists the ECDH key → next sync fetches team member-keys and
+   writes team keys → user backgrounds the app → on a team-site login form, the team credential appears as a
+   QuickType suggestion and fills after Face ID.
+2. Account with no ECDH keypair / not on any team → unlock + sync + personal fill all work unchanged; no team
+   entries (no errors).
+3. Membership revoked → within ≤15 min the stale team key is refused; team entries stop filling.
+4. Background sync while only biometric-unlocked → uses the persisted ECDH key to refresh team keys.
+
+### C10 — in-app team display + vault switcher (UX: "separate vault" emphasis)
+Added after user UX review: AutoFill alone is a confusing half-state (team creds fill in AutoFill but are
+invisible in-app). The app must SHOW team entries in-app AND clearly separate the team vault from the personal
+vault via a top **vault switcher** (segmented control: 個人 / チームA / チームB…), scoping the whole view
+(category grid + list) to the selected vault.
+- **C10a — VaultViewModel team decrypt**: `loadFromCache` gains `cacheKey: SymmetricKey?` (+ a `WrappedKeyStore`,
+  default `AppGroupWrappedKeyStore()`). For `entry.teamId != nil` entries, decrypt via
+  `TeamEntryDecryptor.decryptTeamSummary` (team keys + cacheKey); personal entries unchanged (vaultKey). When
+  cacheKey/team keys absent → team entries simply omitted (no regression for personal-only users).
+- **C10b — team directory persistence**: team names (`TeamMembership.name`, already fetched) must survive cold
+  load for the switcher labels. `HostSyncService` persists a `[TeamDirectoryEntry{id,name}]` encrypted under
+  cacheKey (AAD `buildLocalWrapAAD(kind:"teamdir", userId:)`) via a new `TeamDirectoryStore` (App Group file
+  `vault/team-directory.json`); cleared in `clearAll()`/sign-out. VaultViewModel loads + decrypts it for labels.
+- **C10c — vault switcher UI** (`VaultListView`): a `VaultScope` state (`.personal` | `.team(teamId)`); a
+  segmented `Picker` shown ONLY when ≥1 team exists (personal-only users see no change). `filteredSummaries`
+  filters by scope: `.personal` → `teamId == nil`; `.team(id)` → `teamId == id`. The category grid counts +
+  drill-down operate within the selected scope. The Create (+) button is hidden under a team scope (team create
+  unsupported — existing `teamEditNotSupported` guard remains the backstop).
+- **i18n**: new key "Personal" (個人) for the switcher's personal segment; team segments use dynamic names (not
+  localized). No internal jargon (R37).
+- **Acceptance**: with team keys + directory present, the switcher lists 個人 + each team; switching scopes the
+  grid/list; team entries appear only under their team; personal-only users see no switcher and unchanged UI.
+  Tests: VaultViewModel decrypts team entries with cacheKey (fixture-backed); scope filtering; switcher hidden
+  when no teams.
+
+## Go/No-Go Gate
+
+| ID  | Subject                                                              | Status |
+|-----|---------------------------------------------------------------------|--------|
+| C1  | `VaultUnlockData` optional ECDH fields                              | locked |
+| C2  | team-key-wrap AAD (`"OK"`, 4-field) on iOS                          | locked |
+| C3  | `TeamKeyCrypto.swift` crypto mirror + golden vectors               | locked |
+| C4  | `WrappedECDHPrivateKey` persistence (+ clearAll)                    | locked |
+| C5  | persist ECDH key at passphrase unlock (biometric no-op)            | locked |
+| C6  | `MobileAPIClient.fetchTeamMemberKey` + typed skip errors           | locked |
+| C7  | `HostSyncService` populates `WrappedTeamKey` (resilient)           | locked |
+| C8  | `CredentialIdentityRegistrar` team registration (shared helper)    | locked |
+| C9  | tests (golden vectors) + Tier-2 manual-test artifact               | locked |
+
+## Implementation deviations (recorded post-implementation)
+
+Three issues surfaced during implementation that the locked plan (C1–C10) did not anticipate. All were fixed in
+this branch; recorded here so the plan reflects shipped reality. Each is a correctness/security fix, not a scope
+change.
+
+### D1 — proxy Bearer-bypass allowlist missing `/api/teams` (server change — contradicts "no server change")
+
+- **Symptom**: the iOS mobile (extension) token could fetch `/api/passwords` and `/api/vault/unlock/data` but
+  every `/api/teams/*` request (team list, per-team passwords, `/member-key`) returned **401 at the proxy** —
+  before the route handler ran. Team fill was therefore impossible end-to-end, independent of the crypto.
+- **Root cause**: `EXTENSION_TOKEN_ROUTES` in `src/lib/proxy/cors-gate.ts` lacked `API_PATH.TEAMS`. The proxy
+  validates a session cookie for non-allowlisted routes; a cookieless Bearer request to `/api/teams` never
+  reached the handler's `checkAuth` + `requireTeamPermission`.
+- **Fix**: add `API_PATH.TEAMS` to `EXTENSION_TOKEN_ROUTES` (child paths allowed via the existing
+  `startsWith(route + "/")` rule, so `/api/teams/{id}/member-key` and `/api/teams/{id}/passwords` are covered).
+  Authorization is unchanged and still enforced in the handlers (scope + `requireTeamPermission`); the proxy only
+  stops pre-rejecting the request. Covered by `cors-gate.test.ts` + `api-route.test.ts` updates.
+- **Security note**: this widens the proxy Bearer-bypass surface to the entire `/api/teams/*` tree. The handlers
+  already gate every team route on token scope and team membership, so no authorization is delegated to the
+  proxy — but this is a security-boundary change and is the primary focus of the Phase-3 security review.
+
+### D2 — item-encryption HKDF missing for `itemKeyVersion >= 1` team entries
+
+- **Symptom**: team entries with a per-entry ItemKey (`itemKeyVersion >= 1`) failed to decrypt; the raw
+  unwrapped ItemKey was being used directly as the entry key.
+- **Root cause**: the consumer (`CredentialResolver`) skipped the final `HKDF("passwd-sso-item-enc-v1")`
+  derivation that the extension applies after unwrapping the ItemKey. (Plan §"iOS resolver consumes the DERIVED
+  enc key directly" correctly handled the team-enc key but not the per-item key.)
+- **Fix**: `TeamEntryDecryptor.resolveTeamEntryKey` applies `TeamKeyCrypto.deriveItemEncryptionKey` (HKDF
+  `passwd-sso-item-enc-v1`, salt=zero32) to the unwrapped ItemKey for `itemKeyVersion >= 1`; `==0` still uses the
+  team enc key directly. Regression-guarded by golden vectors for **both** `itemKeyVersion` 0 and 1.
+
+### D3 — `readDirect()` returns an EMPTY bridge_key → cacheKey threading via `UnlockResult.cacheKey`
+
+- **Symptom**: deriving cacheKey from `BridgeKeyStore.readDirect()` (as C8 originally proposed for the call
+  sites) produced a key derived from an EMPTY bridge_key, so the cacheKey-AAD unwrap of team/ECDH blobs failed.
+- **Root cause**: `BridgeKeyStore.readDirect()` intentionally returns `bridgeKey: Data()` (empty); the real
+  bridge_key is only materialized during unlock. C8's "derive cacheKey from `readDirect()` at each call site" was
+  therefore unsound.
+- **Fix**: capture the REAL cacheKey at unlock and thread it explicitly. `UnlockResult` gains
+  `cacheKey: SymmetricKey` (VaultUnlocker, both passphrase and biometric paths derive it from the actual
+  `blob.bridgeKey`). It is threaded RootView → VaultListView → HostSyncService / CredentialIdentityRegistrar /
+  VaultViewModel / EntryEditForm / EntryDetailView / background sync. **Invariant**: never derive cacheKey from a
+  `readDirect()` result. This supersedes C8's `deriveCacheVaultKey(bridgeKey: readDirect())` call-site guidance.

--- a/docs/archive/review/ios-team-quicktype-review.md
+++ b/docs/archive/review/ios-team-quicktype-review.md
@@ -1,0 +1,126 @@
+# Plan Review: ios-team-quicktype
+
+Date: 2026-06-14
+Review round: 1
+
+## Changes from Previous Round
+
+Initial 3-expert plan review of the iOS team-key pipeline. No Critical findings; no security escalation.
+25 findings (8 functionality, 10 security, 10 testing) — all resolved in the plan.
+
+## Functionality Findings (resolved)
+
+- **F2 (Major)** cacheKey provisioning at `PasswdSSOAppApp` call site (BackgroundSyncContext lacks BridgeKeyStore)
+  → C8: BackgroundSyncContext gains a BridgeKeyStore ref (or stores derived cacheKey at unlock).
+- **F4 (Major)** `VaultViewModel` has no BridgeKeyStore → C8: inject `cacheKey: SymmetricKey?` into the VM
+  methods from the view layer; nil → personal-only fallback.
+- **F6 (Major)** C1 must add the 4 ECDH fields to the explicit `CodingKeys` enum (else silent nil) → C1 fixed.
+- **F13 (Minor)** `BackgroundSyncTask` doesn't call `refreshCredentialIdentities` → C8: wire it in background
+  (scenario 1 promises background QuickType appearance).
+- **F3 (Minor)** leftover team key when ECDH absent + revoked → C7: clear file if ALL blobs already stale.
+- **F14 (Minor)** existing WrappedKeyStore mocks need new methods → C4 mock-update obligation + C9.
+- **F10 (Minor)** PKCS#8 fallback condition unclear → C3: pkcs8 is primary (WebCrypto exports pkcs8);
+  raw-scalar fallback only if the golden vector proves it; don't ship unused fallback.
+- **R1** shared team-decrypt helper unspecified → C8: new `TeamEntryDecryptor.swift`, reused by resolver+registrar.
+
+## Security Findings (resolved; no Critical, escalate:false)
+
+- **S1 (Medium)** no userId-binding AAD on the cacheKey re-wrap of the ECDH key + team enc keys → C2 adds
+  `buildLocalWrapAAD` ("LW"); C5/C7 wrap with `kind+userId(+teamId)` AAD. (Pre-existing WrappedVaultKey left
+  AAD-less; out of scope, same threat model.)
+- **S2 (Medium)** WrappedTeamKey teamId not AEAD-bound (blob-swap) → C7 wraps team key with teamId in AAD; C8
+  updates `CredentialResolver.decryptTeamKey` to verify the same AAD (consumer side).
+- **S4 (Medium)** clearAll must wipe the ECDH key → C4: explicit `ecdhPrivateKeyURL()` + clearAll delete +
+  mandatory test gate.
+- **S5 (Low)** no negative AEAD tests → C9: tampered ciphertext, wrong-AAD, bad-curve tests.
+- **S6 (Low)** importEphemeralPublicKey lacks kty/crv validation → C3: validate, throw `unsupportedKeyType`.
+- **S9 (Low)** PKCS#8 intermediate not zeroized → C3: `unwrapEcdhPrivateKey` returns the imported key directly,
+  zeroizing the intermediate bytes.
+- **S10 (Low)** clearAll omission risk → C4: named path + gate test.
+- **S3 (Low)** "leave untouched" revocation delay → reviewed sound; refined by F3 (clear-if-all-stale).
+- **S7/S8 (Info)** at-rest protection == existing WrappedVaultKey; token scope pre-existing → no action.
+
+## Testing Findings (resolved)
+
+- **T1/T2 (High)** golden-vector capture must come from the EXTENSION, not iOS self → C9: mandatory
+  `scripts/generate-team-key-fixture.mjs` deliverable + external fixture + forbid self-checks.
+- **T8 (High)** no fetchTeamMemberKey test + unnamed skip error → C6 names `MobileAPIError.teamKeyNotDistributed`;
+  C9 adds the tests.
+- **T3 (Medium)** AAD test must be full-byte → C9/C2 (AADParityTests pattern).
+- **T4 (Medium)** MockWrappedKeyStore/TempDirWrappedKeyStore need new methods (compile break) → C4/C9.
+- **T5 (Medium)** VaultUnlockerTests need `makeVaultUnlockDataWithECDH` builder (real P256/PKCS8) → C9.
+- **T6 (Medium)** HostSyncServiceTests stub is personal-only → C9: MockURLProtocol member-key + seeded ECDH key.
+- **T7 (Medium)** registrar test needs cacheKey + shared `makeTeamCacheEntry` helper → C9.
+- **T9 (Low)** manual-test adversarial scenarios refined (clock-skew, sign-out wipe) → C9.
+- **T10 (Low)** test "no ECDH key → existing set untouched (not [])" → C9.
+
+## Adjacent Findings
+- F3 flagged [Adjacent]→security; merged with S3.
+
+## Quality Warnings
+None.
+
+## Recurring Issue Check
+- Functionality: R1 (shared helper — C8), R3 (call-site propagation — C8 enumerates all 5 + provisioning),
+  R19 (CodingKeys/exact-shape — C1), R25 (persist/hydrate — C4 clearAll), R37 (clock — C7 injected). Addressed.
+- Security: R25 (clearAll wipe — C4 gate), RS1 (no hardcoded secrets — HKDF infos are domain separators),
+  RS4 (no key material in logs/artifacts), AAD binding (S1/S2 — C2/C7/C8). Addressed.
+- Testing: RT1 (mock-reality — fixtures from extension, C9), RT2 (vacuous-pass — external fixture, forbid
+  self-check). Addressed.
+
+## Resolution Status
+All 25 round-1 findings resolved in the plan (no deferrals). Proceeded to round 2.
+
+---
+
+# Review round 2 (incremental)
+
+Verified all round-1 resolutions; the local-wrap AAD design was confirmed cryptographically sound (security).
+8 new findings, all plan-text precision fixes — resolved:
+
+- **F15 (Critical — plan-text API name)**: `pkcs8DERRepresentation` is not a CryptoKit API; verified the correct
+  one is `derRepresentation` (emits/accepts PKCS#8 PrivateKeyInfo, WebCrypto-pkcs8 compatible) → C3/C5 fixed.
+- **F16 (Major)**: AAD `userId` provenance must be `cacheData.header.userId` on both writer + reader → C8 made
+  explicit.
+- **F17 (Minor)**: enforce AAD writer/reader symmetry via a single shared wrap/unwrap pair (TeamEntryDecryptor /
+  LocalKeyWrap) → C8.
+- **S11 (Low)**: stale-branch clear via a `clearTeamKeys()` protocol method (not direct file delete) + mocks
+  reset in-memory state → C4/C7.
+- **S12 (Low)**: defensive `assert(wrapped.teamId == lookupTeamId)` in the unwrap helper → C8.
+- **T11/T12 (Medium)**: capture script `.ts` via repo-root `tsx` importing the real `crypto-team.ts` (not `.mjs`
+  inline-drift); encrypt-side fixture layout (`ct||tag` split) specified → C9.
+- **T13 (Medium)**: async-throw negative tests must use `do/try await/XCTFail/catch`, not `XCTAssertThrowsError`
+  → C9.
+- **T14 (Low)**: "forbid self-check" is review-time only — acceptable (committed external fixture is the anchor).
+
+Security: no Critical, escalate:false (both rounds). Core design (key lifecycle, AAD binding, golden-vector
+strategy) verified sound. **Plan converged — all contracts C1-C9 locked.**
+
+---
+
+# Implementation notes (post-implementation) — deviations from the locked plan
+
+Date: 2026-06-15
+
+Three issues surfaced during implementation that the locked plan did not anticipate. All fixed in-branch; full
+detail (symptom / root cause / fix / invariant) is in the plan's **Implementation deviations** section (D1–D3).
+Summarized here so the review record reflects shipped reality, with the Phase-3 review focus called out.
+
+- **D1 — proxy Bearer-bypass allowlist missing `/api/teams` (SERVER CHANGE)**: invalidates the plan's "iOS-only /
+  no server change" framing. `EXTENSION_TOKEN_ROUTES` (`src/lib/proxy/cors-gate.ts`) lacked `API_PATH.TEAMS`, so
+  the mobile Bearer token was 401'd at the proxy before any handler ran — team fill was impossible end-to-end.
+  Fix adds `API_PATH.TEAMS`; handlers still enforce scope + `requireTeamPermission` (no authz moved to the
+  proxy). **Phase-3 review focus (security)**: this widens the proxy Bearer-bypass surface across the entire
+  `/api/teams/*` tree — confirm no team route relies on the proxy session check for authorization, and that
+  preflight/CORS behavior for the new tree is correct.
+- **D2 — item-enc HKDF missing for `itemKeyVersion >= 1`**: consumer used the raw unwrapped ItemKey directly;
+  fix applies `TeamKeyCrypto.deriveItemEncryptionKey` (HKDF `passwd-sso-item-enc-v1`) in
+  `TeamEntryDecryptor.resolveTeamEntryKey`. Golden-vector regression for itemKeyVersion 0 **and** 1.
+- **D3 — `readDirect()` empty bridge_key → cacheKey threading**: C8's "derive cacheKey from `readDirect()` at
+  each call site" was unsound (`readDirect()` returns an empty bridge_key by design). Superseded by capturing the
+  real cacheKey at unlock (`UnlockResult.cacheKey`) and threading it RootView → VaultListView → sync / registrar
+  / VM / forms / background. **Invariant**: never derive cacheKey from a `readDirect()` result.
+
+Phase-3 review (functionality / security / testing) is scheduled against the implemented branch; its findings
+will be appended below. Key review targets: the D1 proxy allowlist change (security boundary), cacheKey
+threading correctness (D3), AAD binding symmetry, key zeroization, and `clearAll()` wiping every key blob.

--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		1C61EBA902B63AA436EDFED4 /* VaultListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF803DEFD9DF8AF7683EE422 /* VaultListView.swift */; };
 		1FECDEBE12AA76923178DF37 /* VaultViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC5DA8C56C2D47372666388 /* VaultViewModelTests.swift */; };
 		20391C4492AC914382EF7F0A /* VaultCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564FD260758BB7131E59A188 /* VaultCategory.swift */; };
+		20AF809AB4BCADC6CEE46FF8 /* TeamKeyCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9496DBB2550578117CE8944 /* TeamKeyCryptoTests.swift */; };
 		270E924C1DDE26ACB7454E34 /* RollbackFlagDrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB996D498008FC6F399B7078 /* RollbackFlagDrainTests.swift */; };
 		27597DEF7D7C04078DDB8212 /* VaultUnlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D415409924052B276B874809 /* VaultUnlockView.swift */; };
 		275CA45AE18A3AD75D9EDA8C /* CredentialIdentityRegistrarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C62D90660DD31E8DCA4CD77 /* CredentialIdentityRegistrarTests.swift */; };
@@ -92,6 +93,7 @@
 		A3CEA13B7C87135CC54039D6 /* TeamContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8901EA2724A715ACFBEEDBEF /* TeamContext.swift */; };
 		A457C9391F7E1E8164C97A46 /* AutoLockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C68DCFC79DBA6600F27E36 /* AutoLockService.swift */; };
 		A49DCEFF5ABDE722BF33C324 /* SPKIEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FBC66A0BFC38B393757852 /* SPKIEncoder.swift */; };
+		A593FD25556BA7A6EB040FAE /* team-key-fixture.json in Resources */ = {isa = PBXBuildFile; fileRef = B8AE8A147DAB81877B408F77 /* team-key-fixture.json */; };
 		A5FA7118BBC2D9CE7C30901E /* MobileAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7D6EC824EE87139CFBABE4 /* MobileAPIClient.swift */; };
 		A7DAE27E6B8224EAD297A40C /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 655496E4AA02111C447C8897 /* Localizable.xcstrings */; };
 		AA4D5B1010D5702791244F19 /* PasskeyRegistrationOutcomeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EAECA9F4E2D5A9B57AA94D /* PasskeyRegistrationOutcomeTests.swift */; };
@@ -114,6 +116,7 @@
 		CCC9A05E9E45777A96B84BDF /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296B0035C443158058EA4866 /* Shared.framework */; };
 		CCF7AB22A048CA0D633DC740 /* CredentialResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C90FE49C237E8EB2ABC26 /* CredentialResolver.swift */; };
 		D034CB85FCE2181F6E9490EE /* AppSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C2D35912411C20F34DA986 /* AppSettingsStore.swift */; };
+		D3E9450606ECCA248DEF4B75 /* TeamEntryDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36E02F2DF62F07EDFD1D4AC /* TeamEntryDecryptor.swift */; };
 		D5D219073C574D1919EE94D6 /* AutofillTokenRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093A4C680F943C38DC91C965 /* AutofillTokenRefresherTests.swift */; };
 		D818CC3D8994859EC9B470F2 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F670E8B421F3D4CB3734A6 /* RootView.swift */; };
 		D8EA7B209BAE0D68AB7DB5D5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2BB90663584E9586FF0945C /* ContentView.swift */; };
@@ -128,6 +131,8 @@
 		E425C49CE0F5257C1821EB50 /* VaultEntryDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00236EB9F799A708CF1C4FC /* VaultEntryDetail.swift */; };
 		E61FA83E34E321C09B0D7176 /* TOTPVectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB624E102C09D08D7B9BB8D /* TOTPVectorTests.swift */; };
 		E6242A08FB6CD768CBCED638 /* StaleBlobRecoveryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EFD0AD3F8896F5D18F2967 /* StaleBlobRecoveryServiceTests.swift */; };
+		E7DD10FDBE035875BB7A93E5 /* TeamKeyCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123297FA521C8B4A2D71A5A3 /* TeamKeyCrypto.swift */; };
+		EE5586305A8A75C6F0DE9A47 /* TeamDirectoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820C1F588B1209A77A6C0A36 /* TeamDirectoryStore.swift */; };
 		EEDC524C6F56E4E378F8DB16 /* DebugVaultLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6190750A2E1A027047EDBB4 /* DebugVaultLoader.swift */; };
 		EF9407000E17ADEB5E667D88 /* EntryCacheFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CD914CFF8AD6DD6DAB0129 /* EntryCacheFileTests.swift */; };
 		F376E57211FDE0E03F285949 /* LockedFallbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6E4E71B2DDEE6BBA03CBF4 /* LockedFallbackView.swift */; };
@@ -222,6 +227,7 @@
 		0BDD66BD3FF47585E7183FC8 /* fixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; name = fixtures; path = ../extension/test/fixtures; sourceTree = SOURCE_ROOT; };
 		0CB624E102C09D08D7B9BB8D /* TOTPVectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPVectorTests.swift; sourceTree = "<group>"; };
 		120E0D108C572BDFE0A5E79E /* SecureEnclaveKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureEnclaveKey.swift; sourceTree = "<group>"; };
+		123297FA521C8B4A2D71A5A3 /* TeamKeyCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamKeyCrypto.swift; sourceTree = "<group>"; };
 		13E66C8E3793F0F33D64AAB4 /* VaultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultViewModel.swift; sourceTree = "<group>"; };
 		160063572DE97E6E16AE7A3D /* SPKIEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPKIEncoderTests.swift; sourceTree = "<group>"; };
 		1682BC8C00C9060F5E4DC11D /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
@@ -282,6 +288,7 @@
 		7AFCE015CCAE07263B30B8B4 /* LockStateReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockStateReducerTests.swift; sourceTree = "<group>"; };
 		80BC3E2908650479CBBE6D07 /* EntryBlobDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryBlobDecoderTests.swift; sourceTree = "<group>"; };
 		81279161CAE5152A36AAAC35 /* WrappedKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappedKeyStore.swift; sourceTree = "<group>"; };
+		820C1F588B1209A77A6C0A36 /* TeamDirectoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamDirectoryStore.swift; sourceTree = "<group>"; };
 		881416D87A323B49E40CCCC3 /* PasskeyRegistrationOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrationOutcome.swift; sourceTree = "<group>"; };
 		8901EA2724A715ACFBEEDBEF /* TeamContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamContext.swift; sourceTree = "<group>"; };
 		8AC8C547AA2FF81B4A670924 /* CredentialResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialResolverTests.swift; sourceTree = "<group>"; };
@@ -304,9 +311,11 @@
 		AFB5F0EE6A3D22DF1F2C53B2 /* AutofillTokenRefresher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillTokenRefresher.swift; sourceTree = "<group>"; };
 		B088B96E6D37D767B517A837 /* StaleBlobRecoveryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaleBlobRecoveryService.swift; sourceTree = "<group>"; };
 		B19DB7B9B5F953AC7FC8CE8E /* BridgeKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeKeyStoreTests.swift; sourceTree = "<group>"; };
+		B36E02F2DF62F07EDFD1D4AC /* TeamEntryDecryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamEntryDecryptor.swift; sourceTree = "<group>"; };
 		B4DEECF70DC7351FAF2E7CB7 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		B61C70648C7D9DE6F493F1AD /* SecureClipboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureClipboardTests.swift; sourceTree = "<group>"; };
 		B67A2748B3B1C69F7543EB64 /* PasswdSSOTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PasswdSSOTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B8AE8A147DAB81877B408F77 /* team-key-fixture.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "team-key-fixture.json"; sourceTree = "<group>"; };
 		BB8D42DAB6AE67B22BFFB262 /* BackgroundSyncCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSyncCoordinator.swift; sourceTree = "<group>"; };
 		BBBBBBBE5688A781ED154534 /* EntryFormTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryFormTests.swift; sourceTree = "<group>"; };
 		C02778E2A8EE7B7A09B671C4 /* KDF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KDF.swift; sourceTree = "<group>"; };
@@ -333,6 +342,7 @@
 		D696B8B99CFDB4FFFDC090E1 /* EntryUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryUploader.swift; sourceTree = "<group>"; };
 		D844C1C788162BAC9B723269 /* AuthCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCoordinatorTests.swift; sourceTree = "<group>"; };
 		D86EB7DC9441141057919E49 /* AESGCM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AESGCM.swift; sourceTree = "<group>"; };
+		D9496DBB2550578117CE8944 /* TeamKeyCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamKeyCryptoTests.swift; sourceTree = "<group>"; };
 		DA9CDF313B63803B2922146A /* UploadTokenStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadTokenStoreTests.swift; sourceTree = "<group>"; };
 		DB996D498008FC6F399B7078 /* RollbackFlagDrainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollbackFlagDrainTests.swift; sourceTree = "<group>"; };
 		DF803DEFD9DF8AF7683EE422 /* VaultListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultListView.swift; sourceTree = "<group>"; };
@@ -385,6 +395,7 @@
 		05BA435F126C68DBC307F646 /* PasswdSSOTests */ = {
 			isa = PBXGroup;
 			children = (
+				D65F7572FD660C475D7266B0 /* fixtures */,
 				62893F31F539812D3B5BE334 /* AADParityTests.swift */,
 				2DAD672FE74D0EB78FA99F1C /* AESGCMTests.swift */,
 				430B7C32D3A606C25EDA8568 /* AppSettingsStoreTests.swift */,
@@ -429,6 +440,7 @@
 				C1F6D6429583F4DF936E38A0 /* SharedFrameworkTests.swift */,
 				160063572DE97E6E16AE7A3D /* SPKIEncoderTests.swift */,
 				65EFD0AD3F8896F5D18F2967 /* StaleBlobRecoveryServiceTests.swift */,
+				D9496DBB2550578117CE8944 /* TeamKeyCryptoTests.swift */,
 				0CB624E102C09D08D7B9BB8D /* TOTPVectorTests.swift */,
 				DA9CDF313B63803B2922146A /* UploadTokenStoreTests.swift */,
 				92BFAE8E878C252FF7DF4D68 /* URLMatchingTests.swift */,
@@ -482,6 +494,7 @@
 				D22C90FE49C237E8EB2ABC26 /* CredentialResolver.swift */,
 				881416D87A323B49E40CCCC3 /* PasskeyRegistrationOutcome.swift */,
 				7546B006E2E44B4AB2F80A42 /* RollbackFlagWriter.swift */,
+				B36E02F2DF62F07EDFD1D4AC /* TeamEntryDecryptor.swift */,
 			);
 			path = AutoFill;
 			sourceTree = "<group>";
@@ -632,6 +645,7 @@
 				CA0A9545A79418E5DCAF4109 /* PasskeyRegistration.swift */,
 				120E0D108C572BDFE0A5E79E /* SecureEnclaveKey.swift */,
 				A3FBC66A0BFC38B393757852 /* SPKIEncoder.swift */,
+				123297FA521C8B4A2D71A5A3 /* TeamKeyCrypto.swift */,
 			);
 			path = Crypto;
 			sourceTree = "<group>";
@@ -690,6 +704,14 @@
 			path = PasswdSSOApp;
 			sourceTree = "<group>";
 		};
+		D65F7572FD660C475D7266B0 /* fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				B8AE8A147DAB81877B408F77 /* team-key-fixture.json */,
+			);
+			path = fixtures;
+			sourceTree = "<group>";
+		};
 		D8971D5431C5B996B592DD95 /* TOTP */ = {
 			isa = PBXGroup;
 			children = (
@@ -739,6 +761,7 @@
 				8AFD6C1D7BB52C3C67DF3BD2 /* EntryCacheFile.swift */,
 				00C68B395A2ACE49D3F116CB /* HostTokenStore.swift */,
 				469C94A411CE66C4D3EAB9AA /* PasskeySignCountStore.swift */,
+				820C1F588B1209A77A6C0A36 /* TeamDirectoryStore.swift */,
 				C29F7DCD8033069009E3E5EF /* UploadTokenStore.swift */,
 				81279161CAE5152A36AAAC35 /* WrappedKeyStore.swift */,
 			);
@@ -909,6 +932,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C643AAE37D9DA7E0DCC0DAA /* fixtures in Resources */,
+				A593FD25556BA7A6EB040FAE /* team-key-fixture.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1014,6 +1038,7 @@
 				61C3FD90259F677EA6150C8F /* SharedFrameworkTests.swift in Sources */,
 				E6242A08FB6CD768CBCED638 /* StaleBlobRecoveryServiceTests.swift in Sources */,
 				E61FA83E34E321C09B0D7176 /* TOTPVectorTests.swift in Sources */,
+				20AF809AB4BCADC6CEE46FF8 /* TeamKeyCryptoTests.swift in Sources */,
 				CB194266359903474FE04F9D /* URLMatchingTests.swift in Sources */,
 				B8C977958109D9B3AFC3D13E /* UploadTokenStoreTests.swift in Sources */,
 				364D3AC186509520589AB21A /* VaultCategoryTests.swift in Sources */,
@@ -1064,6 +1089,9 @@
 				88B94C8725C6BEA507605D39 /* Shared.swift in Sources */,
 				BE01EC8587AC154A545C44F6 /* TOTPGenerator.swift in Sources */,
 				A3CEA13B7C87135CC54039D6 /* TeamContext.swift in Sources */,
+				EE5586305A8A75C6F0DE9A47 /* TeamDirectoryStore.swift in Sources */,
+				D3E9450606ECCA248DEF4B75 /* TeamEntryDecryptor.swift in Sources */,
+				E7DD10FDBE035875BB7A93E5 /* TeamKeyCrypto.swift in Sources */,
 				F6D4F11AC118415488FB8DCF /* URLMatcher.swift in Sources */,
 				51DAB59DC908DF2838680335 /* UploadTokenStore.swift in Sources */,
 				E425C49CE0F5257C1821EB50 /* VaultEntryDetail.swift in Sources */,

--- a/ios/PasswdSSOApp/Background/BackgroundSyncTask.swift
+++ b/ios/PasswdSSOApp/Background/BackgroundSyncTask.swift
@@ -15,9 +15,11 @@ public enum BackgroundSyncTask {
   public static func register(
     syncService: @Sendable @escaping () -> HostSyncService?,
     vaultKey: @Sendable @escaping () -> SymmetricKey?,
-    userId: @Sendable @escaping () -> String?
+    userId: @Sendable @escaping () -> String?,
+    cacheKey: @Sendable @escaping () -> SymmetricKey? = { nil }
   ) {
-    let runner = BackgroundSyncRunner(syncService: syncService, vaultKey: vaultKey, userId: userId)
+    let runner = BackgroundSyncRunner(
+      syncService: syncService, vaultKey: vaultKey, userId: userId, cacheKey: cacheKey)
     BGTaskScheduler.shared.register(
       forTaskWithIdentifier: identifier,
       using: nil,
@@ -46,15 +48,25 @@ public final class BackgroundSyncContext: @unchecked Sendable {
   private var syncService: HostSyncService?
   private var vaultKey: SymmetricKey?
   private var userId: String?
+  private var cacheKey: SymmetricKey?
 
   public init() {}
 
-  public func update(syncService: HostSyncService, vaultKey: SymmetricKey, userId: String) {
+  public func update(
+    syncService: HostSyncService, vaultKey: SymmetricKey, userId: String, cacheKey: SymmetricKey? = nil
+  ) {
     lock.lock()
     defer { lock.unlock() }
     self.syncService = syncService
     self.vaultKey = vaultKey
     self.userId = userId
+    self.cacheKey = cacheKey
+  }
+
+  public func currentCacheKey() -> SymmetricKey? {
+    lock.lock()
+    defer { lock.unlock() }
+    return cacheKey
   }
 
   public func currentSyncService() -> HostSyncService? {
@@ -83,15 +95,18 @@ final class BackgroundSyncRunner: @unchecked Sendable {
   private let syncService: @Sendable () -> HostSyncService?
   private let vaultKey: @Sendable () -> SymmetricKey?
   private let userId: @Sendable () -> String?
+  private let cacheKey: @Sendable () -> SymmetricKey?
 
   init(
     syncService: @Sendable @escaping () -> HostSyncService?,
     vaultKey: @Sendable @escaping () -> SymmetricKey?,
-    userId: @Sendable @escaping () -> String?
+    userId: @Sendable @escaping () -> String?,
+    cacheKey: @Sendable @escaping () -> SymmetricKey? = { nil }
   ) {
     self.syncService = syncService
     self.vaultKey = vaultKey
     self.userId = userId
+    self.cacheKey = cacheKey
   }
 
   func run(task bgTask: BGTask) {
@@ -100,8 +115,9 @@ final class BackgroundSyncRunner: @unchecked Sendable {
     let serviceProvider = syncService
     let keyProvider = vaultKey
     let userIdProvider = userId
+    let cacheKeyProvider = cacheKey
     Task {
-      await runAsync(box: box, serviceProvider: serviceProvider, keyProvider: keyProvider, userIdProvider: userIdProvider)
+      await runAsync(box: box, serviceProvider: serviceProvider, keyProvider: keyProvider, userIdProvider: userIdProvider, cacheKeyProvider: cacheKeyProvider)
     }
   }
 
@@ -109,15 +125,24 @@ final class BackgroundSyncRunner: @unchecked Sendable {
     box: TaskBox,
     serviceProvider: @Sendable () -> HostSyncService?,
     keyProvider: @Sendable () -> SymmetricKey?,
-    userIdProvider: @Sendable () -> String?
+    userIdProvider: @Sendable () -> String?,
+    cacheKeyProvider: @Sendable () -> SymmetricKey? = { nil }
   ) async {
     guard let service = serviceProvider(), let key = keyProvider(), let uid = userIdProvider() else {
       box.task.setTaskCompleted(success: false)
       BackgroundSyncTask.scheduleNext()
       return
     }
+    let cacheKey = cacheKeyProvider()
     do {
-      _ = try await service.runSync(vaultKey: key, userId: uid)
+      let report = try await service.runSync(vaultKey: key, userId: uid, cacheKey: cacheKey)
+      // Re-register QuickType identities so team entries appear after a background
+      // refresh (not only after returning to the foreground). Personal + team.
+      if let cacheData = report.cacheData {
+        await refreshCredentialIdentities(
+          from: cacheData, vaultKey: key, userId: uid,
+          cacheKey: cacheKey, wrappedKeyStore: AppGroupWrappedKeyStore())
+      }
       box.task.setTaskCompleted(success: true)
       BackgroundSyncTask.scheduleNext()
     } catch MobileAPIError.authenticationRequired {

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -877,6 +877,23 @@
         }
       }
     },
+    "Personal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personal"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "個人"
+          }
+        }
+      }
+    },
     "Recording — content hidden" : {
       "localizations" : {
         "en" : {
@@ -1449,6 +1466,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ユーザー名"
+          }
+        }
+      }
+    },
+    "Vault" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vault"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保管庫"
           }
         }
       }

--- a/ios/PasswdSSOApp/Network/MobileAPIClient.swift
+++ b/ios/PasswdSSOApp/Network/MobileAPIClient.swift
@@ -19,6 +19,12 @@ public struct VaultUnlockData: Sendable, Codable, Equatable {
   /// Tenant-enforced auto-lock interval (minutes), or nil when the tenant sets no
   /// policy. Optional → the synthesized decoder treats null/absent as nil.
   public let vaultAutoLockMinutes: Int?
+  /// Account ECDH keypair material (team E2E). All nil for accounts without an
+  /// ECDH keypair / no team membership. Used to unwrap team keys.
+  public let ecdhPublicKey: String?
+  public let encryptedEcdhPrivateKey: String?
+  public let ecdhPrivateKeyIv: String?
+  public let ecdhPrivateKeyAuthTag: String?
 
   enum CodingKeys: String, CodingKey {
     case accountSalt
@@ -30,6 +36,10 @@ public struct VaultUnlockData: Sendable, Codable, Equatable {
     case kdfIterations
     case userId
     case vaultAutoLockMinutes
+    case ecdhPublicKey
+    case encryptedEcdhPrivateKey
+    case ecdhPrivateKeyIv
+    case ecdhPrivateKeyAuthTag
   }
 
   // Explicit memberwise init with vaultAutoLockMinutes defaulted LAST so existing
@@ -44,7 +54,11 @@ public struct VaultUnlockData: Sendable, Codable, Equatable {
     kdfType: Int,
     kdfIterations: Int,
     userId: String,
-    vaultAutoLockMinutes: Int? = nil
+    vaultAutoLockMinutes: Int? = nil,
+    ecdhPublicKey: String? = nil,
+    encryptedEcdhPrivateKey: String? = nil,
+    ecdhPrivateKeyIv: String? = nil,
+    ecdhPrivateKeyAuthTag: String? = nil
   ) {
     self.accountSalt = accountSalt
     self.encryptedSecretKey = encryptedSecretKey
@@ -55,10 +69,25 @@ public struct VaultUnlockData: Sendable, Codable, Equatable {
     self.kdfIterations = kdfIterations
     self.userId = userId
     self.vaultAutoLockMinutes = vaultAutoLockMinutes
+    self.ecdhPublicKey = ecdhPublicKey
+    self.encryptedEcdhPrivateKey = encryptedEcdhPrivateKey
+    self.ecdhPrivateKeyIv = ecdhPrivateKeyIv
+    self.ecdhPrivateKeyAuthTag = ecdhPrivateKeyAuthTag
   }
 }
 
 // MARK: - Response types
+
+/// GET /api/teams/{teamId}/member-key response (team E2E key material).
+public struct TeamMemberKeyResponse: Sendable, Codable, Equatable {
+  public let encryptedTeamKey: String
+  public let teamKeyIv: String
+  public let teamKeyAuthTag: String
+  public let ephemeralPublicKey: String
+  public let hkdfSalt: String
+  public let keyVersion: Int
+  public let wrapVersion: Int
+}
 
 public struct TokenExchangeResponse: Sendable, Codable, Equatable {
   public let accessToken: String
@@ -96,6 +125,9 @@ public enum MobileAPIError: Error, Equatable {
   /// Server rejected a create because a per-resource quota is exhausted
   /// (HTTP 403 carrying the server's quota-exhaustion error code).
   case quotaExceeded
+  /// The team member key has not been distributed to this user (or no longer
+  /// exists). Treated as "skip this team" during sync, not a hard failure.
+  case teamKeyNotDistributed
   case serverError(status: Int)
   case networkError(URLError)
   /// The refresh token is dead (no refresh token, or refresh endpoint returned 401/dpopInvalid).
@@ -282,6 +314,19 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     }
     let data = try await performAuthedGET(url: endpointURL)
     return try JSONDecoder().decode([TeamEncryptedEntry].self, from: data)
+  }
+
+  /// Fetch this user's wrapped team key for a team (GET /api/teams/{id}/member-key).
+  /// 403 (KEY_NOT_DISTRIBUTED) / 404 (MEMBER_KEY_NOT_FOUND) → `teamKeyNotDistributed`
+  /// so the sync caller skips the team rather than failing the whole sync.
+  public func fetchTeamMemberKey(teamId: String) async throws -> TeamMemberKeyResponse {
+    let url = serverURL.appending(path: "/api/teams/\(teamId)/member-key", directoryHint: .notDirectory)
+    do {
+      let data = try await performAuthedGET(url: url)
+      return try JSONDecoder().decode(TeamMemberKeyResponse.self, from: data)
+    } catch MobileAPIError.serverError(let status) where status == 403 || status == 404 {
+      throw MobileAPIError.teamKeyNotDistributed
+    }
   }
 
   /// Fetch encrypted entries from a GET endpoint (personal or team).

--- a/ios/PasswdSSOApp/PasswdSSOAppApp.swift
+++ b/ios/PasswdSSOApp/PasswdSSOAppApp.swift
@@ -11,6 +11,7 @@ struct PasswdSSOAppApp: App {
   @State private var activeDrain: RollbackFlagDrain?
   @State private var currentVaultKey: SymmetricKey?
   @State private var currentUserId: String?
+  @State private var currentCacheKey: SymmetricKey?
   @State private var activeTokenRefresher: AutofillTokenRefresher?
 
   private let backgroundSyncContext = BackgroundSyncContext()
@@ -25,7 +26,8 @@ struct PasswdSSOAppApp: App {
     BackgroundSyncTask.register(
       syncService: { context.currentSyncService() },
       vaultKey: { context.currentVaultKey() },
-      userId: { context.currentUserId() }
+      userId: { context.currentUserId() },
+      cacheKey: { context.currentCacheKey() }
     )
   }
 
@@ -33,14 +35,15 @@ struct PasswdSSOAppApp: App {
     WindowGroup {
       ZStack {
         RootView(
-          onVaultReady: { syncService, drain, vaultKey, userId, tokenRefresher in
+          onVaultReady: { syncService, drain, vaultKey, userId, tokenRefresher, cacheKey in
             activeSyncService = syncService
             activeDrain = drain
             currentVaultKey = vaultKey
             currentUserId = userId
+            currentCacheKey = cacheKey
             activeTokenRefresher = tokenRefresher
             backgroundSyncContext.update(
-              syncService: syncService, vaultKey: vaultKey, userId: userId
+              syncService: syncService, vaultKey: vaultKey, userId: userId, cacheKey: cacheKey
             )
             BackgroundSyncTask.scheduleNext()
           }
@@ -80,7 +83,8 @@ struct PasswdSSOAppApp: App {
                   let userId = currentUserId else { return }
             let report: SyncReport?
             do {
-              report = try await syncService.runSync(vaultKey: vaultKey, userId: userId)
+              report = try await syncService.runSync(
+                vaultKey: vaultKey, userId: userId, cacheKey: currentCacheKey)
             } catch MobileAPIError.authenticationRequired {
               // Refresh token dead — no recovery in background; just stop.
               return
@@ -88,10 +92,12 @@ struct PasswdSSOAppApp: App {
               // Transient error — keep using cached data; do nothing.
               return
             }
-            // 3. Re-register QuickType identities for the freshly-synced set.
+            // 3. Re-register QuickType identities for the freshly-synced set
+            //    (personal + team via cacheKey-unwrapped team keys).
             if let cacheData = report?.cacheData {
               await refreshCredentialIdentities(
-                from: cacheData, vaultKey: vaultKey, userId: userId
+                from: cacheData, vaultKey: vaultKey, userId: userId,
+                cacheKey: currentCacheKey, wrappedKeyStore: AppGroupWrappedKeyStore()
               )
             }
           }

--- a/ios/PasswdSSOApp/Vault/AutoLockService.swift
+++ b/ios/PasswdSSOApp/Vault/AutoLockService.swift
@@ -30,6 +30,7 @@ import Shared
   private let clock: Clock
   private let bridgeKeyStore: BridgeKeyStore
   private let wrappedKeyStore: WrappedKeyStore
+  private let teamDirectoryStore: TeamDirectoryStoring
   private let tokenStore: HostTokenStore
   private let uploadTokenStore: UploadTokenStore
   private let cacheURL: URL
@@ -39,6 +40,7 @@ import Shared
     clock: Clock = SystemClock(),
     bridgeKeyStore: BridgeKeyStore,
     wrappedKeyStore: any WrappedKeyStore,
+    teamDirectoryStore: any TeamDirectoryStoring = TeamDirectoryStore(),
     tokenStore: HostTokenStore,
     uploadTokenStore: UploadTokenStore = UploadTokenStore(),
     cacheURL: URL
@@ -47,6 +49,7 @@ import Shared
     self.clock = clock
     self.bridgeKeyStore = bridgeKeyStore
     self.wrappedKeyStore = wrappedKeyStore
+    self.teamDirectoryStore = teamDirectoryStore
     self.tokenStore = tokenStore
     self.uploadTokenStore = uploadTokenStore
     self.cacheURL = cacheURL
@@ -93,6 +96,8 @@ import Shared
     lock()
     try? tokenStore.deleteAll()
     try? wrappedKeyStore.clearAll()
+    // Wipe the team-directory blob too (it lives outside WrappedKeyStore.clearAll).
+    try? teamDirectoryStore.clear()
     let fm = FileManager.default
     if fm.fileExists(atPath: cacheURL.path) {
       try? fm.removeItem(at: cacheURL)

--- a/ios/PasswdSSOApp/Vault/HostSyncService.swift
+++ b/ios/PasswdSSOApp/Vault/HostSyncService.swift
@@ -11,6 +11,7 @@ public actor HostSyncService {
   private let entryFetcher: EntryFetcher
   private let bridgeKeyStore: BridgeKeyStore
   private let wrappedKeyStore: WrappedKeyStore
+  private let teamDirectoryStore: TeamDirectoryStoring
   private let cacheURL: URL
 
   public init(
@@ -18,12 +19,14 @@ public actor HostSyncService {
     entryFetcher: EntryFetcher,
     bridgeKeyStore: BridgeKeyStore,
     wrappedKeyStore: any WrappedKeyStore,
-    cacheURL: URL
+    cacheURL: URL,
+    teamDirectoryStore: any TeamDirectoryStoring = TeamDirectoryStore()
   ) {
     self.apiClient = apiClient
     self.entryFetcher = entryFetcher
     self.bridgeKeyStore = bridgeKeyStore
     self.wrappedKeyStore = wrappedKeyStore
+    self.teamDirectoryStore = teamDirectoryStore
     self.cacheURL = cacheURL
   }
 
@@ -36,9 +39,15 @@ public actor HostSyncService {
   /// Full host sync. Concurrent calls join the in-flight sync and share its
   /// result. Reentrant-safe: while a caller awaits the task value the actor is
   /// free, so a second caller sees `inFlight` and joins the same task.
-  public func runSync(vaultKey: SymmetricKey, userId: String) async throws -> SyncReport {
+  /// - Parameter cacheKey: the REAL cacheKey captured at unlock (UnlockResult.cacheKey).
+  ///   Required to wrap/persist team keys + the team directory for the AutoFill
+  ///   extension + in-app team display. nil → personal-only sync (team keys skipped);
+  ///   never derive it from `readDirect()` (that bridge_key is empty).
+  public func runSync(
+    vaultKey: SymmetricKey, userId: String, cacheKey: SymmetricKey? = nil
+  ) async throws -> SyncReport {
     if let inFlight { return try await inFlight.value }
-    let task = Task { try await self.performSync(vaultKey: vaultKey, userId: userId) }
+    let task = Task { try await self.performSync(vaultKey: vaultKey, userId: userId, cacheKey: cacheKey) }
     inFlight = task
     defer { inFlight = nil }
     return try await task.value
@@ -49,7 +58,9 @@ public actor HostSyncService {
   /// - Parameters:
   ///   - vaultKey: Vault encryption key (never persisted).
   ///   - userId: User ID from the unlock response; stored in the cache header for AAD construction.
-  private func performSync(vaultKey: SymmetricKey, userId: String) async throws -> SyncReport {
+  private func performSync(
+    vaultKey: SymmetricKey, userId: String, cacheKey: SymmetricKey?
+  ) async throws -> SyncReport {
     let now = Date()
 
     // Read current blob to get counter and UUID
@@ -64,12 +75,19 @@ public actor HostSyncService {
     // but a dead refresh token (authenticationRequired) MUST surface so the caller
     // routes to re-sign-in (C4) rather than silently syncing personal-only.
     let teams: [TeamMembership]
+    // Whether `teams` is an authoritative list from the server (vs. an empty
+    // fallback after a transient fetch failure). A transient failure must NOT be
+    // treated as "user is on zero teams" — that would full-rewrite the team-key
+    // set to empty and wipe still-valid keys (see refreshTeamKeys).
+    let teamsAuthoritative: Bool
     do {
       teams = try await teamMemberships
+      teamsAuthoritative = true
     } catch MobileAPIError.authenticationRequired {
       throw MobileAPIError.authenticationRequired
     } catch {
       teams = []
+      teamsAuthoritative = false
     }
 
     // Convert personal entries to CacheEntry (aadVersion/keyVersion/entryType
@@ -80,6 +98,14 @@ public actor HostSyncService {
     for team in teams {
       let teamCacheEntries = try await entryFetcher.fetchTeamAsCacheEntries(teamId: team.id)
       allCacheEntries.append(contentsOf: teamCacheEntries)
+    }
+
+    // Populate per-team keys (best-effort; never fails the personal sync).
+    // Requires the REAL cacheKey from unlock — skip when absent.
+    if let cacheKey {
+      try await refreshTeamKeys(
+        teams: teams, teamsAuthoritative: teamsAuthoritative,
+        cacheKey: cacheKey, userId: userId, now: now)
     }
 
     // Encode all entries as JSON
@@ -122,6 +148,86 @@ public actor HostSyncService {
       lastSuccessfulRefreshAt: now,
       cacheData: cacheData
     )
+  }
+
+  /// Fetch each team's member key, ECDH-unwrap the team key, derive the team
+  /// encryption key, and persist it wrapped under cacheKey (bound to userId+teamId).
+  /// The AutoFill extension + host registrar read these to decrypt team entries.
+  ///
+  /// Resilience: when the persisted ECDH key is unavailable (e.g. background sync
+  /// before any passphrase unlock), do NOT wipe a possibly still-valid set — clear
+  /// it only if every blob is already past the 15-min staleness window. Auth-dead
+  /// surfaces; all other failures are best-effort (team fill simply degrades).
+  private func refreshTeamKeys(
+    teams: [TeamMembership], teamsAuthoritative: Bool,
+    cacheKey: SymmetricKey, userId: String, now: Date
+  ) async throws {
+    // A non-authoritative (transient-failure) empty list must not touch persisted
+    // state: overwriting the directory/team-key set with empty would wipe valid
+    // labels + keys until the next successful sync. Leave everything untouched.
+    guard teamsAuthoritative else { return }
+
+    // Persist the team directory (id → name) for the in-app vault switcher labels,
+    // regardless of whether team keys can be derived this round.
+    let directory = teams.map { TeamDirectoryEntry(id: $0.id, name: $0.name) }
+    try? teamDirectoryStore.save(directory, cacheKey: cacheKey, userId: userId)
+
+    guard let wrappedEcdh = try? wrappedKeyStore.loadECDHPrivateKey(),
+          var pkcs8 = TeamEntryDecryptor.unwrapEcdhPrivateKey(
+            wrappedEcdh, cacheKey: cacheKey, userId: userId)
+    else {
+      // No usable ECDH key: clear only if the whole set is already stale.
+      clearTeamKeysIfAllStale(now: now)
+      return
+    }
+    defer { pkcs8.resetBytes(in: 0..<pkcs8.count) }
+
+    let memberKey: P256.KeyAgreement.PrivateKey
+    do {
+      memberKey = try TeamKeyCrypto.importEcdhPrivateKey(pkcs8: pkcs8)
+    } catch {
+      // Malformed ECDH key (e.g. storage corruption): same posture as "no ECDH" —
+      // cannot refresh, so clear only if the whole set is already stale.
+      clearTeamKeysIfAllStale(now: now)
+      return
+    }
+
+    var blobs: [WrappedTeamKey] = []
+    for team in teams {
+      do {
+        let resp = try await apiClient.fetchTeamMemberKey(teamId: team.id)
+        let rawTeamKey = try TeamKeyCrypto.unwrapTeamKey(
+          encrypted: EncryptedData(
+            ciphertext: resp.encryptedTeamKey, iv: resp.teamKeyIv, authTag: resp.teamKeyAuthTag),
+          ephemeralPublicKeyJWK: resp.ephemeralPublicKey,
+          memberPrivateKey: memberKey,
+          hkdfSalt: resp.hkdfSalt,
+          teamId: team.id, toUserId: userId,
+          keyVersion: resp.keyVersion, wrapVersion: resp.wrapVersion)
+        let teamEncKey = TeamKeyCrypto.deriveTeamEncryptionKey(rawTeamKey: rawTeamKey)
+        blobs.append(try TeamEntryDecryptor.wrapTeamKey(
+          teamEncKey: teamEncKey, cacheKey: cacheKey, userId: userId,
+          teamId: team.id, teamKeyVersion: resp.keyVersion, issuedAt: now))
+      } catch MobileAPIError.authenticationRequired {
+        throw MobileAPIError.authenticationRequired
+      } catch {
+        continue  // skip this team (not distributed, network blip, decode error)
+      }
+    }
+    // Full rewrite — revoked / no-longer-distributed teams drop out of the set.
+    try? wrappedKeyStore.saveTeamKeys(blobs)
+  }
+
+  /// Clear the persisted team-key set only when every blob is already past the
+  /// staleness window. Used when team keys cannot be refreshed this round (no /
+  /// malformed ECDH key) so revoked keys still expire, but a possibly-valid set
+  /// is never wiped.
+  private func clearTeamKeysIfAllStale(now: Date) {
+    let existing = (try? wrappedKeyStore.loadTeamKeys()) ?? []
+    if !existing.isEmpty,
+       existing.allSatisfy({ now.timeIntervalSince($0.issuedAt) > TeamEntryDecryptor.teamKeyMaxAge }) {
+      try? wrappedKeyStore.clearTeamKeys()
+    }
   }
 }
 

--- a/ios/PasswdSSOApp/Vault/VaultUnlocker.swift
+++ b/ios/PasswdSSOApp/Vault/VaultUnlocker.swift
@@ -26,6 +26,11 @@ public struct UnlockResult: Sendable, Equatable {
   /// fetch; nil from the biometric/offline path (which reuses the persisted value).
   /// NOT defaulted — both construction sites must state it explicitly.
   public let tenantAutoLockMinutes: Int?
+  /// The REAL cacheKey (HKDF of the actual bridge_key), captured at unlock when the
+  /// bridge_key is in hand. Required for team-key wrap/unwrap + in-app team decrypt —
+  /// `readDirect()` returns an EMPTY bridge_key, so cacheKey CANNOT be re-derived
+  /// later without a biometric `readForFill`. Thread this from unlock instead.
+  public let cacheKey: SymmetricKey
 }
 
 /// Source of the encrypted vault-unlock material. `MobileAPIClient` is the
@@ -168,12 +173,36 @@ public actor VaultUnlocker {
     )
     try wrappedKeyStore.saveVaultKey(wrapped)
 
+    // Step 6b: if the account has an ECDH keypair (team E2E), unwrap it with the
+    // secretKey and re-persist it wrapped under cacheKey (bound to userId), so
+    // sync (incl. background / post-biometric) can derive team keys without the
+    // secretKey. Best-effort: a failure here must never block unlocking the vault.
+    if let encPriv = unlockData.encryptedEcdhPrivateKey,
+       let ivHex = unlockData.ecdhPrivateKeyIv,
+       let tagHex = unlockData.ecdhPrivateKeyAuthTag {
+      do {
+        let wrappingKey = TeamKeyCrypto.deriveEcdhWrappingKey(
+          secretKey: SymmetricKey(data: secretKey))
+        let ecdhKey = try TeamKeyCrypto.unwrapEcdhPrivateKey(
+          encrypted: EncryptedData(ciphertext: encPriv, iv: ivHex, authTag: tagHex),
+          wrappingKey: wrappingKey)
+        var pkcs8 = ecdhKey.derRepresentation
+        defer { pkcs8.resetBytes(in: 0..<pkcs8.count) }
+        let wrappedEcdh = try TeamEntryDecryptor.wrapEcdhPrivateKey(
+          pkcs8: pkcs8, cacheKey: cacheKey, userId: unlockData.userId, issuedAt: Date())
+        try wrappedKeyStore.saveECDHPrivateKey(wrappedEcdh)
+      } catch {
+        // Non-fatal: team entries simply won't be available until a later unlock.
+      }
+    }
+
     // Step 7: return in-memory vault_key + userId + live keyVersion
     return UnlockResult(
       vaultKey: vaultKey,
       userId: unlockData.userId,
       keyVersion: unlockData.keyVersion,
-      tenantAutoLockMinutes: unlockData.vaultAutoLockMinutes
+      tenantAutoLockMinutes: unlockData.vaultAutoLockMinutes,
+      cacheKey: cacheKey
     )
   }
 
@@ -237,7 +266,8 @@ public actor VaultUnlocker {
       vaultKey: vaultKey,
       userId: cache.header.userId,
       keyVersion: keyVersion,
-      tenantAutoLockMinutes: nil
+      tenantAutoLockMinutes: nil,
+      cacheKey: cacheKey
     )
   }
 

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -17,7 +17,8 @@ enum AppState {
     keyVersion: Int,
     cacheData: CacheData,
     autoLockService: AutoLockService,
-    apiClient: MobileAPIClient
+    apiClient: MobileAPIClient,
+    cacheKey: SymmetricKey?
   )
   // Locked but still signed in: re-unlock needs only the passphrase, keeping the
   // server config + token (no OAuth re-sign-in). Carries serverConfig/apiClient
@@ -30,7 +31,7 @@ enum AppState {
 struct RootView: View {
   /// Called when vault is unlocked so the app shell can wire foreground sync +
   /// drain + AutoFill upload-token re-mint.
-  let onVaultReady: (HostSyncService, RollbackFlagDrain, SymmetricKey, String, AutofillTokenRefresher?) -> Void
+  let onVaultReady: (HostSyncService, RollbackFlagDrain, SymmetricKey, String, AutofillTokenRefresher?, SymmetricKey) -> Void
 
   @State private var appState: AppState = .setup
 
@@ -54,7 +55,7 @@ struct RootView: View {
         // Arriving via sign-in / app entry → auto-prompt Face ID on appear.
         vaultLockedScreen(serverConfig: serverConfig, apiClient: apiClient, autoPromptOnAppear: true)
 
-      case .vaultUnlocked(let serverConfig, let vaultKey, let userId, let keyVersion, let cacheData, let autoLockService, let apiClient):
+      case .vaultUnlocked(let serverConfig, let vaultKey, let userId, let keyVersion, let cacheData, let autoLockService, let apiClient, let cacheKey):
         VaultListView(
           cacheData: cacheData,
           vaultKey: vaultKey,
@@ -62,7 +63,8 @@ struct RootView: View {
           keyVersion: keyVersion,
           autoLockService: autoLockService,
           apiClient: apiClient,
-          hostSyncService: hostSyncService ?? makeFallbackSyncService(apiClient: apiClient)
+          hostSyncService: hostSyncService ?? makeFallbackSyncService(apiClient: apiClient),
+          cacheKey: cacheKey
         )
         .onChange(of: autoLockService.state) { _, newState in
           switch newState {
@@ -256,7 +258,8 @@ struct RootView: View {
 
     let syncReport: SyncReport?
     do {
-      syncReport = try await syncService.runSync(vaultKey: vaultKey, userId: unlockResult.userId)
+      syncReport = try await syncService.runSync(
+        vaultKey: vaultKey, userId: unlockResult.userId, cacheKey: unlockResult.cacheKey)
     } catch {
       // The user has just unlocked with a valid vault key + session. A sync
       // failure here (network, server, or auth) must NOT bounce them back to
@@ -312,10 +315,14 @@ struct RootView: View {
     let tokenRefresher = AutofillTokenRefresher(apiClient: apiClient)
     await tokenRefresher.refresh()
 
-    onVaultReady(syncService, drain, vaultKey, unlockResult.userId, tokenRefresher)
+    onVaultReady(syncService, drain, vaultKey, unlockResult.userId, tokenRefresher, unlockResult.cacheKey)
 
-    // Register QuickType inline-suggestion identities for the just-synced set.
-    await refreshCredentialIdentities(from: cacheData, vaultKey: vaultKey, userId: unlockResult.userId)
+    // Register QuickType inline-suggestion identities for the just-synced set
+    // (personal + team — team requires the REAL cacheKey from unlock to unwrap
+    // the persisted team keys; readDirect's bridge_key is empty).
+    await refreshCredentialIdentities(
+      from: cacheData, vaultKey: vaultKey, userId: unlockResult.userId,
+      cacheKey: unlockResult.cacheKey, wrappedKeyStore: AppGroupWrappedKeyStore())
 
     applyPersistedTimeout(to: autoLockService)
     autoLockService.startTimer()
@@ -326,7 +333,8 @@ struct RootView: View {
       keyVersion: unlockResult.keyVersion,
       cacheData: cacheData,
       autoLockService: autoLockService,
-      apiClient: apiClient
+      apiClient: apiClient,
+      cacheKey: unlockResult.cacheKey
     )
   }
 
@@ -410,7 +418,10 @@ struct RootView: View {
     let cacheData = state.cacheData
     let vaultKey = state.vaultKey
     let userId = state.userId
-    Task { await refreshCredentialIdentities(from: cacheData, vaultKey: vaultKey, userId: userId) }
+    Task {
+      await refreshCredentialIdentities(
+        from: cacheData, vaultKey: vaultKey, userId: userId)
+    }
     appState = .vaultUnlocked(
       serverConfig: serverConfig,
       vaultKey: state.vaultKey,
@@ -418,7 +429,8 @@ struct RootView: View {
       keyVersion: state.keyVersion,
       cacheData: state.cacheData,
       autoLockService: autoLockService,
-      apiClient: debugApiClient
+      apiClient: debugApiClient,
+      cacheKey: nil
     )
   }
   #endif

--- a/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
@@ -16,6 +16,7 @@ struct EntryDetailView: View {
   @Bindable var viewModel: VaultViewModel
   let apiClient: MobileAPIClient
   let hostSyncService: HostSyncService
+  var cacheKey: SymmetricKey? = nil
 
   @State private var detail: VaultEntryDetail?
   @State private var loadFailed: Bool = false
@@ -72,7 +73,8 @@ struct EntryDetailView: View {
           keyVersion: keyVersion,
           viewModel: viewModel,
           apiClient: apiClient,
-          hostSyncService: hostSyncService
+          hostSyncService: hostSyncService,
+          cacheKey: cacheKey
         )
       }
     }
@@ -221,7 +223,8 @@ struct EntryDetailView: View {
       for: summary.id,
       cacheData: effectiveCacheData,
       vaultKey: vaultKey,
-      userId: userId
+      userId: userId,
+      cacheKey: cacheKey
     )
     detail = loaded
     loadFailed = (loaded == nil)

--- a/ios/PasswdSSOApp/Views/Vault/EntryEditForm.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryEditForm.swift
@@ -22,6 +22,7 @@ struct EntryForm: View {
   @Bindable var viewModel: VaultViewModel
   let apiClient: MobileAPIClient
   let hostSyncService: HostSyncService
+  var cacheKey: SymmetricKey? = nil
 
   @State private var title: String
   @State private var username: String
@@ -42,7 +43,8 @@ struct EntryForm: View {
     keyVersion: Int,
     viewModel: VaultViewModel,
     apiClient: MobileAPIClient,
-    hostSyncService: HostSyncService
+    hostSyncService: HostSyncService,
+    cacheKey: SymmetricKey? = nil
   ) {
     self.mode = mode
     self.vaultKey = vaultKey
@@ -51,6 +53,7 @@ struct EntryForm: View {
     self.viewModel = viewModel
     self.apiClient = apiClient
     self.hostSyncService = hostSyncService
+    self.cacheKey = cacheKey
 
     switch mode {
     case .create:
@@ -192,7 +195,8 @@ struct EntryForm: View {
           vaultKey: vaultKey,
           keyVersion: keyVersion,
           apiClient: apiClient,
-          hostSyncService: hostSyncService
+          hostSyncService: hostSyncService,
+          cacheKey: cacheKey
         )
       case .edit(let summary, _):
         try await viewModel.saveEntry(
@@ -202,7 +206,8 @@ struct EntryForm: View {
           vaultKey: vaultKey,
           keyVersion: keyVersion,
           apiClient: apiClient,
-          hostSyncService: hostSyncService
+          hostSyncService: hostSyncService,
+          cacheKey: cacheKey
         )
       }
       dismiss()

--- a/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
@@ -64,6 +64,7 @@ struct VaultCategoryListView: View {
   @Bindable var viewModel: VaultViewModel
   let apiClient: MobileAPIClient
   let hostSyncService: HostSyncService
+  var cacheKey: SymmetricKey? = nil
 
   // Seed synchronously so an already-active recording never shows a frame of
   // entries before onAppear flips the flag.
@@ -90,7 +91,8 @@ struct VaultCategoryListView: View {
               autoLockService: autoLockService,
               viewModel: viewModel,
               apiClient: apiClient,
-              hostSyncService: hostSyncService
+              hostSyncService: hostSyncService,
+              cacheKey: cacheKey
             )
           } label: {
             EntrySummaryRow(summary: summary)

--- a/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
@@ -19,6 +19,9 @@ struct VaultListView: View {
   let autoLockService: AutoLockService
   let apiClient: MobileAPIClient
   let hostSyncService: HostSyncService
+  /// The REAL cacheKey from unlock (nil in debug). Needed to decrypt team entries
+  /// in-app + persist/read team keys; cannot be re-derived (readDirect is empty).
+  let cacheKey: SymmetricKey?
 
   @State private var isScreenRecording: Bool = UIScreen.main.isCaptured
   @State private var isShowingSettings: Bool = false
@@ -31,13 +34,16 @@ struct VaultListView: View {
 
   var body: some View {
     NavigationStack {
-      Group {
-        if isScreenRecording {
-          ScreenRecordingOverlay()
-        } else if viewModel.searchQuery.isEmpty {
-          categoryGrid
-        } else {
-          entryList
+      VStack(spacing: 0) {
+        vaultSwitcher
+        Group {
+          if isScreenRecording {
+            ScreenRecordingOverlay()
+          } else if viewModel.searchQuery.isEmpty {
+            categoryGrid
+          } else {
+            entryList
+          }
         }
       }
       .navigationTitle("passwd-sso")
@@ -98,7 +104,8 @@ struct VaultListView: View {
           keyVersion: keyVersion,
           viewModel: viewModel,
           apiClient: apiClient,
-          hostSyncService: hostSyncService
+          hostSyncService: hostSyncService,
+          cacheKey: cacheKey
         )
       }
       // Search moved from the top navigation drawer to the bottom bar (native
@@ -138,7 +145,7 @@ struct VaultListView: View {
       }
     }
     .onAppear {
-      viewModel.loadFromCache(cacheData: cacheData, vaultKey: vaultKey, userId: userId)
+      reload(cacheData)
       updateScreenRecordingState()
     }
     .onReceive(
@@ -146,6 +153,38 @@ struct VaultListView: View {
     ) { _ in
       updateScreenRecordingState()
     }
+  }
+
+  // MARK: - Vault switcher (personal vs team)
+
+  /// Segmented switcher making the team vault clearly separate from the personal
+  /// one. Hidden entirely when the user belongs to no team (personal-only users
+  /// see no change). Switching scope re-filters the grid/list to that vault.
+  @ViewBuilder private var vaultSwitcher: some View {
+    if !viewModel.teamDirectory.isEmpty {
+      Picker("Vault", selection: $viewModel.scope) {
+        Text("Personal").tag(VaultScope.personal)
+        ForEach(viewModel.teamDirectory) { team in
+          Text(team.name).tag(VaultScope.team(team.id))
+        }
+      }
+      .pickerStyle(.segmented)
+      .padding(.horizontal)
+      .padding(.vertical, 8)
+      .onChange(of: viewModel.scope) { _, _ in
+        autoLockService.recordActivity()
+        viewModel.searchQuery = ""
+      }
+    }
+  }
+
+  /// Decrypt + bind a fresh cache: use the unlock-time cacheKey (for team entries)
+  /// and load the team directory (for switcher labels), then hand both to the VM.
+  private func reload(_ data: CacheData) {
+    let teamDir = cacheKey.map { TeamDirectoryStore().load(cacheKey: $0, userId: userId) } ?? []
+    viewModel.loadFromCache(
+      cacheData: data, vaultKey: vaultKey, userId: userId,
+      cacheKey: cacheKey, teamDirectory: teamDir)
   }
 
   // MARK: - Bottom bar (search + create)
@@ -179,7 +218,7 @@ struct VaultListView: View {
       .frame(minHeight: 44)
       .background(Color(.secondarySystemBackground), in: Capsule())
 
-      if viewModel.filterTeamId == nil {
+      if !viewModel.isTeamScope {
         Button {
           autoLockService.recordActivity()
           isShowingCreateForm = true
@@ -259,7 +298,8 @@ struct VaultListView: View {
               autoLockService: autoLockService,
               viewModel: viewModel,
               apiClient: apiClient,
-              hostSyncService: hostSyncService
+              hostSyncService: hostSyncService,
+              cacheKey: cacheKey
             )
           } label: {
             CategoryCard(symbol: item.symbol, label: item.label, count: item.count)
@@ -293,7 +333,8 @@ struct VaultListView: View {
           autoLockService: autoLockService,
           viewModel: viewModel,
           apiClient: apiClient,
-          hostSyncService: hostSyncService
+          hostSyncService: hostSyncService,
+          cacheKey: cacheKey
         )
       } label: {
         EntrySummaryRow(summary: summary)
@@ -332,9 +373,10 @@ struct VaultListView: View {
     // auto-lock window just because the app returned to the foreground.
     if surfaceErrors { autoLockService.recordActivity() }
     do {
-      let report = try await hostSyncService.runSync(vaultKey: vaultKey, userId: userId)
+      let report = try await hostSyncService.runSync(
+        vaultKey: vaultKey, userId: userId, cacheKey: cacheKey)
       if let fresh = report.cacheData {
-        viewModel.loadFromCache(cacheData: fresh, vaultKey: vaultKey, userId: userId)
+        reload(fresh)
       }
     } catch MobileAPIError.authenticationRequired {
       if surfaceErrors {

--- a/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
@@ -18,12 +18,29 @@ public enum VaultViewModelError: Error, Equatable {
 /// Observable view-model for the vault list and detail screens.
 /// Holds decrypted summaries in memory. The vault_key must be held by the caller;
 /// this view-model receives it at unlock time only.
+/// Which vault the in-app list is currently showing. `.personal` shows entries
+/// with no teamId; `.team(id)` shows only that team's entries. Drives the top
+/// vault switcher so the team vault is clearly separated from the personal one.
+public enum VaultScope: Hashable, Sendable {
+  case personal
+  case team(String)
+}
+
 @Observable @MainActor public final class VaultViewModel {
   public private(set) var summaries: [VaultEntrySummary] = []
   public var searchQuery: String = ""
-  public var filterTeamId: String? = nil  // nil = all, non-nil = specific team
+  /// Selected vault (personal by default — team entries are NOT mixed into the
+  /// personal list; the user switches vaults explicitly).
+  public var scope: VaultScope = .personal
+  /// Teams the user belongs to, for the switcher labels (populated from the
+  /// cacheKey-decrypted team directory at load time).
+  public var teamDirectory: [TeamDirectoryEntry] = []
 
   var allSummaries: [VaultEntrySummary] = []
+
+  /// cacheKey from the last `loadFromCache`, retained so `loadDetail` can decrypt
+  /// team entries without re-threading it from every call site.
+  private var loadedCacheKey: SymmetricKey?
 
   /// The most recently loaded cache. Set by `loadFromCache` and refreshed after
   /// every successful write+sync so `saveEntry`/`loadDetail` always read fresh data.
@@ -32,7 +49,13 @@ public enum VaultViewModelError: Error, Equatable {
   // MARK: - Filtered results
 
   public var filteredSummaries: [VaultEntrySummary] {
-    var result = allSummaries
+    var result: [VaultEntrySummary]
+    switch scope {
+    case .personal:
+      result = allSummaries.filter { $0.teamId == nil }
+    case .team(let teamId):
+      result = allSummaries.filter { $0.teamId == teamId }
+    }
     if !searchQuery.isEmpty {
       let q = searchQuery.lowercased()
       result = result.filter {
@@ -41,10 +64,13 @@ public enum VaultViewModelError: Error, Equatable {
         $0.urlHost.lowercased().contains(q)
       }
     }
-    if let teamId = filterTeamId {
-      result = result.filter { $0.teamId == teamId }
-    }
     return result
+  }
+
+  /// True when the currently selected scope is a team vault (create is disabled).
+  public var isTeamScope: Bool {
+    if case .team = scope { return true }
+    return false
   }
 
   // MARK: - Load from cache
@@ -56,15 +82,35 @@ public enum VaultViewModelError: Error, Equatable {
   /// construction). HostSyncService and DebugVaultLoader both write this
   /// shape; the previous `[EncryptedEntry]` decode path was a dead Step-7
   /// type that never matched the on-disk format.
-  public func loadFromCache(cacheData: CacheData, vaultKey: SymmetricKey, userId: String) {
+  /// - Parameters:
+  ///   - cacheKey: when provided (with team keys present), team entries are decrypted
+  ///     too and shown under their team vault. nil → personal-only (no regression).
+  ///   - teamDirectory: team id→name list for the switcher labels.
+  public func loadFromCache(
+    cacheData: CacheData,
+    vaultKey: SymmetricKey,
+    userId: String,
+    cacheKey: SymmetricKey? = nil,
+    wrappedKeyStore: WrappedKeyStore = AppGroupWrappedKeyStore(),
+    teamDirectory: [TeamDirectoryEntry] = []
+  ) {
     self.cacheData = cacheData
+    self.teamDirectory = teamDirectory
+    self.loadedCacheKey = cacheKey
     guard let entries = try? JSONDecoder().decode([CacheEntry].self, from: cacheData.entries) else {
       return
     }
+    let teamKeys: [WrappedTeamKey] = cacheKey != nil ? ((try? wrappedKeyStore.loadTeamKeys()) ?? []) : []
 
     var decoded: [VaultEntrySummary] = []
     for entry in entries {
-      if let summary = decryptOverview(entry: entry, vaultKey: vaultKey, userId: userId) {
+      if entry.teamId != nil {
+        if let cacheKey,
+           let summary = TeamEntryDecryptor.decryptTeamSummary(
+             entry: entry, teamKeys: teamKeys, cacheKey: cacheKey, userId: userId, now: { Date() }) {
+          decoded.append(summary)
+        }
+      } else if let summary = decryptOverview(entry: entry, vaultKey: vaultKey, userId: userId) {
         decoded.append(summary)
       }
     }
@@ -78,11 +124,19 @@ public enum VaultViewModelError: Error, Equatable {
     for entryId: String,
     cacheData: CacheData,
     vaultKey: SymmetricKey,
-    userId: String
+    userId: String,
+    cacheKey: SymmetricKey? = nil,
+    wrappedKeyStore: WrappedKeyStore = AppGroupWrappedKeyStore()
   ) -> VaultEntryDetail? {
     guard let entries = try? JSONDecoder().decode([CacheEntry].self, from: cacheData.entries),
           let entry = entries.first(where: { $0.id == entryId }) else {
       return nil
+    }
+    if entry.teamId != nil {
+      guard let key = cacheKey ?? loadedCacheKey else { return nil }
+      let teamKeys = (try? wrappedKeyStore.loadTeamKeys()) ?? []
+      return TeamEntryDecryptor.decryptTeamDetail(
+        entry: entry, teamKeys: teamKeys, cacheKey: key, userId: userId, now: { Date() })
     }
     return decryptBlob(entry: entry, vaultKey: vaultKey, userId: userId)
   }
@@ -192,7 +246,8 @@ extension VaultViewModel {
     vaultKey: SymmetricKey,
     keyVersion: Int,
     apiClient: MobileAPIClient,
-    hostSyncService: HostSyncService
+    hostSyncService: HostSyncService,
+    cacheKey: SymmetricKey? = nil
   ) async throws {
     let entryId = UUID().uuidString.lowercased()
     let (blobData, overviewData) = try PersonalEntryBlobBuilder.buildCreate(fields: fields)
@@ -219,12 +274,19 @@ extension VaultViewModel {
     }
 
     // Refresh from sync — no optimistic prepend; allSummaries rebuilt from the cache.
-    let report = try await hostSyncService.runSync(vaultKey: vaultKey, userId: userId)
+    let report = try await hostSyncService.runSync(
+      vaultKey: vaultKey, userId: userId, cacheKey: cacheKey)
     if let freshCache = report.cacheData {
-      loadFromCache(cacheData: freshCache, vaultKey: vaultKey, userId: userId)
+      // Preserve team visibility (pass cacheKey + current directory) so team
+      // entries don't vanish from the in-app list after a personal create.
+      loadFromCache(
+        cacheData: freshCache, vaultKey: vaultKey, userId: userId,
+        cacheKey: cacheKey, teamDirectory: teamDirectory)
       // Keep QuickType identities in step with the mutation — without this the
       // new/edited entry is missing from AutoFill until the next foreground sync.
-      await refreshCredentialIdentities(from: freshCache, vaultKey: vaultKey, userId: userId)
+      await refreshCredentialIdentities(
+        from: freshCache, vaultKey: vaultKey, userId: userId,
+        cacheKey: cacheKey, wrappedKeyStore: AppGroupWrappedKeyStore())
     }
   }
 
@@ -238,7 +300,8 @@ extension VaultViewModel {
     vaultKey: SymmetricKey,
     keyVersion: Int,
     apiClient: MobileAPIClient,
-    hostSyncService: HostSyncService
+    hostSyncService: HostSyncService,
+    cacheKey: SymmetricKey? = nil
   ) async throws {
     // Reject team entries — out of scope for MVP.
     if let summary = allSummaries.first(where: { $0.id == entryId }),
@@ -277,12 +340,17 @@ extension VaultViewModel {
     try await apiClient.updateEntry(entryId: entryId, body: updateReq)
 
     // Refresh cache after server confirms success.
-    let report = try await hostSyncService.runSync(vaultKey: vaultKey, userId: userId)
+    let report = try await hostSyncService.runSync(
+      vaultKey: vaultKey, userId: userId, cacheKey: cacheKey)
     if let freshCache = report.cacheData {
-      loadFromCache(cacheData: freshCache, vaultKey: vaultKey, userId: userId)
+      loadFromCache(
+        cacheData: freshCache, vaultKey: vaultKey, userId: userId,
+        cacheKey: cacheKey, teamDirectory: teamDirectory)
       // Keep QuickType identities in step with the mutation — without this the
       // new/edited entry is missing from AutoFill until the next foreground sync.
-      await refreshCredentialIdentities(from: freshCache, vaultKey: vaultKey, userId: userId)
+      await refreshCredentialIdentities(
+        from: freshCache, vaultKey: vaultKey, userId: userId,
+        cacheKey: cacheKey, wrappedKeyStore: AppGroupWrappedKeyStore())
     }
   }
 }

--- a/ios/PasswdSSOTests/AutoLockServiceTests.swift
+++ b/ios/PasswdSSOTests/AutoLockServiceTests.swift
@@ -318,6 +318,53 @@ final class AutoLockServiceTests: XCTestCase {
     )
   }
 
+  // MARK: - F2/S13 regression: signOut clears the team-directory blob
+
+  /// Regression for F2/S13: before the fix, AutoLockService.signOut() did NOT call
+  /// teamDirectoryStore.clear(), leaving the team-directory blob on disk after sign-out.
+  /// This test fails against the old code (clear() never called → spy.didClear == false)
+  /// and passes with the fix (signOut calls teamDirectoryStore.clear()).
+  func testSignOut_clearsTeamDirectory() throws {
+    let tmpDir = makeTmpDir()
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+    let keychain = MockKeychain()
+    seedKeychain(keychain)
+
+    // Spy TeamDirectoryStoring that records whether clear() was called.
+    final class SpyTeamDirectoryStore: TeamDirectoryStoring, @unchecked Sendable {
+      private(set) var didClear = false
+      func save(_ entries: [TeamDirectoryEntry], cacheKey: SymmetricKey, userId: String) throws {}
+      func load(cacheKey: SymmetricKey, userId: String) -> [TeamDirectoryEntry] { [] }
+      func clear() throws { didClear = true }
+    }
+
+    let spy = SpyTeamDirectoryStore()
+    let bks = BridgeKeyStore(
+      accessGroup: "test",
+      service: "com.passwd-sso.test.bridge-key",
+      keychain: keychain
+    )
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    let tokenStore = HostTokenStore(
+      service: "com.passwd-sso.test.tokens",
+      keychain: keychain
+    )
+    let cacheURL = tmpDir.appending(path: "test.cache", directoryHint: .notDirectory)
+    let service = AutoLockService(
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      teamDirectoryStore: spy,
+      tokenStore: tokenStore,
+      cacheURL: cacheURL
+    )
+    service.startTimer()
+    service.signOut()
+
+    XCTAssertTrue(spy.didClear,
+      "signOut() must call teamDirectoryStore.clear() to wipe the team-directory blob (F2/S13 regression)")
+    XCTAssertEqual(service.state, .loggedOut)
+  }
+
   // MARK: - autoLockMinutes clamping
 
   func testAutoLockMinutesClamped() {

--- a/ios/PasswdSSOTests/CredentialIdentityRegistrarTests.swift
+++ b/ios/PasswdSSOTests/CredentialIdentityRegistrarTests.swift
@@ -405,6 +405,170 @@ final class CredentialIdentityRegistrarTests: XCTestCase {
     )
     return CacheData(header: header, entries: try JSONEncoder().encode(entries))
   }
+
+  // MARK: - Team entry QuickType registration (C9 wiring)
+
+  /// A team cache entry + seeded WrappedTeamKey + cacheKey → the team entry's
+  /// host appears in the replaced/registered specs.
+  func testDecryptTeamOverviews_withTeamKeyAndCacheKey_producesSpecs() throws {
+    let cacheKey = SymmetricKey(size: .bits256)
+    let userId = "user-team-reg"
+    let teamId = "team-reg-1"
+    let teamEncKey = SymmetricKey(size: .bits256)
+
+    // Wrap the team key under cacheKey (matching the host-sync wiring).
+    let wrappedTeamKey = try TeamEntryDecryptor.wrapTeamKey(
+      teamEncKey: teamEncKey, cacheKey: cacheKey, userId: userId,
+      teamId: teamId, teamKeyVersion: 1, issuedAt: Date()
+    )
+
+    // Build a team cache entry with urlHost "team.example.com".
+    let summary = VaultEntrySummary(
+      id: "te-reg-1", title: "Team Login", username: "teamuser",
+      urlHost: "team.example.com", teamId: teamId
+    )
+    let overviewBlob = TestOverviewBlob(
+      title: summary.title, username: summary.username, urlHost: summary.urlHost
+    )
+    let overviewData = try JSONEncoder().encode(overviewBlob)
+    let overviewAAD = try buildTeamEntryAAD(
+      teamId: teamId, entryId: summary.id, vaultType: VaultType.overview, itemKeyVersion: 0
+    )
+    let overviewEnc = try encryptAESGCMEncoded(plaintext: overviewData, key: teamEncKey, aad: overviewAAD)
+    let dummyBlob = try encryptAESGCMEncoded(plaintext: Data("{}".utf8), key: teamEncKey, aad: nil)
+    let teamEntry = CacheEntry(
+      id: summary.id, teamId: teamId, aadVersion: 1, keyVersion: 0,
+      teamKeyVersion: 1, itemKeyVersion: 0,
+      encryptedItemKey: nil,
+      encryptedBlob: dummyBlob,
+      encryptedOverview: overviewEnc
+    )
+
+    let wks = MockWrappedKeyStore()
+    try wks.saveTeamKeys([wrappedTeamKey])
+
+    let cache = try makeCache([teamEntry], userId: userId)
+
+    let summaries = decryptTeamOverviews(
+      from: cache, cacheKey: cacheKey, userId: userId, wrappedKeyStore: wks
+    )
+
+    XCTAssertEqual(summaries.count, 1, "One team entry must decrypt to one summary")
+    XCTAssertEqual(summaries.first?.urlHost, "team.example.com")
+    XCTAssertEqual(summaries.first?.teamId, teamId)
+  }
+
+  /// cacheKey nil → only personal summaries, no team entries, no crash.
+  func testDecryptTeamOverviews_noCacheKey_returnsEmpty() throws {
+    let userId = "user-no-cachekey"
+    let teamId = "team-no-key"
+    let dummyEnc = try encryptAESGCMEncoded(plaintext: Data("{}".utf8), key: SymmetricKey(size: .bits256), aad: nil)
+    let teamEntry = CacheEntry(
+      id: "te-no-key", teamId: teamId, aadVersion: 0,
+      encryptedBlob: dummyEnc, encryptedOverview: dummyEnc
+    )
+    let cache = try makeCache([teamEntry], userId: userId)
+
+    // Passing a random cacheKey with no team keys saved → empty (no team keys in store).
+    let wks = MockWrappedKeyStore()
+    // wks has no team keys.
+    let summaries = decryptTeamOverviews(
+      from: cache, cacheKey: SymmetricKey(size: .bits256), userId: userId, wrappedKeyStore: wks
+    )
+
+    XCTAssertTrue(summaries.isEmpty,
+      "decryptTeamOverviews with empty team key store must return empty (not crash)")
+  }
+
+  // MARK: - refreshCredentialIdentities with team keys
+
+  func testRefreshCredentialIdentities_withTeamKey_registersTeamHostInPasswordSpecs() async throws {
+    let vaultKey = SymmetricKey(size: .bits256)
+    let cacheKey = SymmetricKey(size: .bits256)
+    let userId = "user-team-refresh"
+    let teamId = "team-refresh-1"
+    let teamEncKey = SymmetricKey(size: .bits256)
+
+    let wrappedTeamKey = try TeamEntryDecryptor.wrapTeamKey(
+      teamEncKey: teamEncKey, cacheKey: cacheKey, userId: userId,
+      teamId: teamId, teamKeyVersion: 1, issuedAt: Date()
+    )
+
+    // Personal entry.
+    let personalEntry = try self.personalEntry(
+      id: "pe-1", urlHost: "personal.com", username: "alice",
+      userId: userId, aadVersion: 1, vaultKey: vaultKey
+    )
+
+    // Team entry.
+    let teamOverviewBlob = TestOverviewBlob(
+      title: "Team App", username: "teamuser", urlHost: "teamapp.com"
+    )
+    let teamOverviewData = try JSONEncoder().encode(teamOverviewBlob)
+    let overviewAAD = try buildTeamEntryAAD(
+      teamId: teamId, entryId: "te-1", vaultType: VaultType.overview, itemKeyVersion: 0
+    )
+    let teamOverviewEnc = try encryptAESGCMEncoded(
+      plaintext: teamOverviewData, key: teamEncKey, aad: overviewAAD
+    )
+    let dummyBlob = try encryptAESGCMEncoded(plaintext: Data("{}".utf8), key: vaultKey, aad: nil)
+    let teamEntry = CacheEntry(
+      id: "te-1", teamId: teamId, aadVersion: 1, keyVersion: 0,
+      teamKeyVersion: 1, itemKeyVersion: 0,
+      encryptedItemKey: nil,
+      encryptedBlob: dummyBlob,
+      encryptedOverview: teamOverviewEnc
+    )
+
+    let wks = MockWrappedKeyStore()
+    try wks.saveTeamKeys([wrappedTeamKey])
+
+    let cache = try makeCache([personalEntry, teamEntry], userId: userId)
+    let store = FakeIdentityStore(enabled: true)
+    let registrar = CredentialIdentityRegistrar(store: store)
+
+    await refreshCredentialIdentities(
+      from: cache, vaultKey: vaultKey, userId: userId,
+      cacheKey: cacheKey, wrappedKeyStore: wks, registrar: registrar
+    )
+
+    let passwords = await store.replacedPasswordSpecs
+    XCTAssertNotNil(passwords, "replace must be called")
+    let hosts = passwords?.map(\.host) ?? []
+    XCTAssertTrue(hosts.contains("personal.com"), "Personal entry host must appear in specs")
+    XCTAssertTrue(hosts.contains("teamapp.com"), "Team entry host must appear in specs when team key is available")
+  }
+
+  func testRefreshCredentialIdentities_noTeamKeys_personalOnly() async throws {
+    let vaultKey = SymmetricKey(size: .bits256)
+    let userId = "user-personal-only"
+
+    let personalEntry = try self.personalEntry(
+      id: "pe-2", urlHost: "onlypersonal.com", username: "bob",
+      userId: userId, aadVersion: 1, vaultKey: vaultKey
+    )
+    let dummyEnc = try encryptAESGCMEncoded(plaintext: Data("{}".utf8), key: vaultKey, aad: nil)
+    let teamEntry = CacheEntry(
+      id: "te-2", teamId: "some-team", aadVersion: 0,
+      encryptedBlob: dummyEnc, encryptedOverview: dummyEnc
+    )
+    let cache = try makeCache([personalEntry, teamEntry], userId: userId)
+
+    let store = FakeIdentityStore(enabled: true)
+    let registrar = CredentialIdentityRegistrar(store: store)
+
+    // No cacheKey/wrappedKeyStore → personal-only.
+    await refreshCredentialIdentities(
+      from: cache, vaultKey: vaultKey, userId: userId, registrar: registrar
+    )
+
+    let passwords = await store.replacedPasswordSpecs
+    let hosts = passwords?.map(\.host) ?? []
+    XCTAssertEqual(hosts, ["onlypersonal.com"],
+      "Without cacheKey, only personal entries must be registered")
+    XCTAssertFalse(hosts.contains("some-team"),
+      "Team entries must not appear without cacheKey")
+  }
 }
 
 /// In-memory fake for CredentialIdentityStoring (actor → Sendable, no real

--- a/ios/PasswdSSOTests/CredentialResolverTests.swift
+++ b/ios/PasswdSSOTests/CredentialResolverTests.swift
@@ -18,6 +18,7 @@ final class MockRollbackFlagWriter: RollbackFlagWriter, @unchecked Sendable {
 final class MockWrappedKeyStore: WrappedKeyStore, @unchecked Sendable {
   var storedVaultKey: WrappedVaultKey?
   var teamKeys: [WrappedTeamKey] = []
+  var storedECDHPrivateKey: WrappedECDHPrivateKey?
 
   func saveVaultKey(_ wrapped: WrappedVaultKey) throws {
     storedVaultKey = wrapped
@@ -30,9 +31,18 @@ final class MockWrappedKeyStore: WrappedKeyStore, @unchecked Sendable {
   }
 
   func loadTeamKeys() throws -> [WrappedTeamKey] { teamKeys }
+  func clearTeamKeys() throws { teamKeys = [] }
+
+  func saveECDHPrivateKey(_ wrapped: WrappedECDHPrivateKey) throws {
+    storedECDHPrivateKey = wrapped
+  }
+
+  func loadECDHPrivateKey() throws -> WrappedECDHPrivateKey? { storedECDHPrivateKey }
+
   func clearAll() throws {
     storedVaultKey = nil
     teamKeys = []
+    storedECDHPrivateKey = nil
   }
 }
 
@@ -305,7 +315,9 @@ private func makeTeamCacheEntry(
       teamId: teamId, entryId: entryId, teamKeyVersion: teamKeyVersion
     )
     let itemKeyBytes = rawItemKey.withUnsafeBytes { Data($0) }
-    entryKey = rawItemKey
+    // Production decrypts the entry under deriveItemEncryptionKey(itemKey), NOT the
+    // raw ItemKey — mirror that so the fixture matches the resolver.
+    entryKey = TeamKeyCrypto.deriveItemEncryptionKey(itemKey: rawItemKey)
     encryptedItemKey = try encryptAESGCMEncoded(
       plaintext: itemKeyBytes, key: teamKey, aad: wrapAAD
     )
@@ -327,24 +339,20 @@ private func makeTeamCacheEntry(
   )
 }
 
-/// Wrap a team key under cacheKey and build a WrappedTeamKey (no AAD on team key wrapping).
+/// Wrap a team key under cacheKey with the localWrap AAD (kind:"team", userId, teamId),
+/// matching the host-side TeamEntryDecryptor.wrapTeamKey. userId defaults to the
+/// buildCacheFile default ("test-user-id") so the resolver's AAD reconstruction matches.
 private func wrapTeamKey(
   _ teamKey: SymmetricKey,
   teamId: String,
   teamKeyVersion: Int,
   cacheKey: SymmetricKey,
+  userId: String = "test-user-id",
   issuedAt: Date = Date()
 ) throws -> WrappedTeamKey {
-  let teamKeyData = teamKey.withUnsafeBytes { Data($0) }
-  let (cipher, iv, tag) = try encryptAESGCM(plaintext: teamKeyData, key: cacheKey)
-  return WrappedTeamKey(
-    teamId: teamId,
-    ciphertext: cipher,
-    iv: iv,
-    authTag: tag,
-    issuedAt: issuedAt,
-    teamKeyVersion: teamKeyVersion
-  )
+  try TeamEntryDecryptor.wrapTeamKey(
+    teamEncKey: teamKey, cacheKey: cacheKey, userId: userId,
+    teamId: teamId, teamKeyVersion: teamKeyVersion, issuedAt: issuedAt)
 }
 
 // MARK: - Tests
@@ -993,7 +1001,7 @@ final class CredentialResolverTests: XCTestCase {
     let teamId = "team-x"
     let teamKey = SymmetricKey(size: .bits256)
     // Team keys are wrapped under cacheKey (not vaultKey) in the corrected architecture.
-    let wrappedTeamKey = try wrapTeamKey(teamKey, teamId: teamId, teamKeyVersion: 1, cacheKey: cacheKey)
+    let wrappedTeamKey = try wrapTeamKey(teamKey, teamId: teamId, teamKeyVersion: 1, cacheKey: cacheKey, userId: "u-1")
 
     let summary = VaultEntrySummary(
       id: "te-0", title: "T", username: "u", urlHost: "y.com", teamId: teamId
@@ -1031,7 +1039,7 @@ final class CredentialResolverTests: XCTestCase {
 
     let teamId = "team-y"
     let teamKey = SymmetricKey(size: .bits256)
-    let wrappedTeamKey = try wrapTeamKey(teamKey, teamId: teamId, teamKeyVersion: 2, cacheKey: cacheKey)
+    let wrappedTeamKey = try wrapTeamKey(teamKey, teamId: teamId, teamKeyVersion: 2, cacheKey: cacheKey, userId: "u-1")
 
     let summary = VaultEntrySummary(
       id: "te-1", title: "T", username: "u", urlHost: "z.com", teamId: teamId
@@ -1069,7 +1077,7 @@ final class CredentialResolverTests: XCTestCase {
 
     let teamId = "team-z"
     let teamKey = SymmetricKey(size: .bits256)
-    let wrappedTeamKey = try wrapTeamKey(teamKey, teamId: teamId, teamKeyVersion: 1, cacheKey: cacheKey)
+    let wrappedTeamKey = try wrapTeamKey(teamKey, teamId: teamId, teamKeyVersion: 1, cacheKey: cacheKey, userId: "u-1")
 
     let summary = VaultEntrySummary(
       id: "te-missing", title: "T", username: "u", urlHost: "w.com", teamId: teamId
@@ -1125,7 +1133,7 @@ final class CredentialResolverTests: XCTestCase {
 
     let teamId = "team-w"
     let teamKey = SymmetricKey(size: .bits256)
-    let wrappedTeamKey = try wrapTeamKey(teamKey, teamId: teamId, teamKeyVersion: 1, cacheKey: cacheKey)
+    let wrappedTeamKey = try wrapTeamKey(teamKey, teamId: teamId, teamKeyVersion: 1, cacheKey: cacheKey, userId: "u-1")
 
     let summary = VaultEntrySummary(
       id: "te-wrong-aad", title: "T", username: "u", urlHost: "v.com", teamId: teamId
@@ -1290,6 +1298,77 @@ final class CredentialResolverTests: XCTestCase {
     let entries = try JSONDecoder().decode([CacheEntry].self, from: cache.entries)
     XCTAssertEqual(entries.map(\.id).sorted(), ["login-1", entryId].sorted())
     XCTAssertEqual(entries.first(where: { $0.id == entryId })?.entryType, "PASSKEY")
+  }
+
+  // MARK: - F3 regression: decryptEntryDetail enforces 15-min staleness on team keys
+
+  /// Regression for F3: previously decryptEntryDetail had NO staleness check on the
+  /// team key, so a revoked-and-stale team key could still fill credentials. The fix
+  /// adds the same staleness guard as resolveCandidates. This test will FAIL against
+  /// the old code (no guard → detail decrypts → no throw), and PASS with the fix.
+  func testDecryptEntryDetail_staleTeamKey_throwsEntryNotFound() async throws {
+    let keychain = MockKeychainAccessor()
+    let (bridgeKeyStore, blob) = try makeBridgeKeyBlob(keychain: keychain)
+    let cacheKey = try deriveCacheVaultKey(bridgeKey: blob.bridgeKey)
+    let vaultKey = SymmetricKey(size: .bits256)
+
+    let mockWKS = MockWrappedKeyStore()
+    try wrapAndSaveVaultKey(vaultKey: vaultKey, cacheKey: cacheKey, store: mockWKS)
+
+    // A stale team key: issuedAt is 16 minutes ago (past the 15-min window).
+    let teamId = "team-stale-fill"
+    let teamKey = SymmetricKey(size: .bits256)
+    let staleIssuedAt = Date().addingTimeInterval(-16 * 60)
+    let wrappedStale = try wrapTeamKey(
+      teamKey, teamId: teamId, teamKeyVersion: 1,
+      cacheKey: cacheKey, userId: "test-user-id", issuedAt: staleIssuedAt
+    )
+
+    let entryId = "team-entry-stale-fill"
+    let summary = VaultEntrySummary(
+      id: entryId, title: "Team Fill", username: "alice",
+      urlHost: "fill.example.com", teamId: teamId
+    )
+    let detail = VaultEntryDetail(
+      id: entryId, title: "Team Fill", username: "alice",
+      urlHost: "fill.example.com", teamId: teamId,
+      password: "secret123", url: "https://fill.example.com"
+    )
+    let entry = try makeTeamCacheEntry(
+      summary: summary, detail: detail, teamKey: teamKey,
+      teamId: teamId, teamKeyVersion: 1, itemKeyVersion: 0
+    )
+    try buildCacheFile(
+      at: cacheURL, entries: [entry], vaultKey: vaultKey,
+      hostInstallUUID: blob.hostInstallUUID, counter: blob.cacheVersionCounter,
+      userId: "test-user-id"
+    )
+    try mockWKS.saveTeamKeys([wrappedStale])
+
+    // Use injectable `now` set to a fixed time so the staleness check is deterministic.
+    // The fixed now is after the stale window (issuedAt was 16 min ago from real Date()).
+    let fixedNow = Date()
+    let resolver = CredentialResolver(
+      bridgeKeyStore: bridgeKeyStore,
+      wrappedKeyStore: mockWKS,
+      cacheURL: cacheURL,
+      now: { fixedNow }
+    )
+
+    // First prime the retained blob via resolveCandidates (expected to throw teamKeyStale).
+    do {
+      _ = try await resolver.resolveCandidates(for: [])
+    } catch CredentialResolver.Error.teamKeyStale {
+      // expected — primes the retained blob in the process
+    }
+
+    // decryptEntryDetail must also refuse the stale team key and throw entryNotFound.
+    do {
+      _ = try await resolver.decryptEntryDetail(entryId: entryId)
+      XCTFail("Expected entryNotFound for a stale team key in decryptEntryDetail (F3 regression)")
+    } catch CredentialResolver.Error.entryNotFound {
+      // expected: the staleness guard fires
+    }
   }
 
   /// Full round-trip (T4 spirit): real generated passkey → blob builder →

--- a/ios/PasswdSSOTests/HostSyncServiceTests.swift
+++ b/ios/PasswdSSOTests/HostSyncServiceTests.swift
@@ -4,6 +4,15 @@ import XCTest
 @testable import PasswdSSOApp
 @testable import Shared
 
+// MARK: - Null TeamDirectoryStore for tests
+
+/// A no-op store that avoids App Group container access in tests.
+private struct NullTeamDirectoryStore: TeamDirectoryStoring {
+  func save(_ entries: [TeamDirectoryEntry], cacheKey: SymmetricKey, userId: String) throws {}
+  func load(cacheKey: SymmetricKey, userId: String) -> [TeamDirectoryEntry] { [] }
+  func clear() throws {}
+}
+
 // MARK: - Test helpers for HostSyncService
 
 /// Pre-seed the mock keychain with v2-split items (bridge-key-v2 + bridge-meta-v2)
@@ -181,6 +190,431 @@ final class HostSyncServiceTests: XCTestCase {
     XCTAssertEqual(blob.cacheVersionCounter, 6)
   }
 
+  // MARK: - Team key refresh: happy path using fixture
+
+  /// performSync with the fixture ECDH blob + team member-key endpoint → the stored
+  /// WrappedTeamKey decrypts to the fixture's teamEncKeyHex.
+  func testRefreshTeamKeys_writesTeamKeyUnwrappedToFixtureEncKey() async throws {
+    // Load the fixture.
+    let bundle = Bundle(for: type(of: self))
+    let fixtureURL = try XCTUnwrap(
+      bundle.url(forResource: "team-key-fixture", withExtension: "json")
+        ?? bundle.url(forResource: "team-key-fixture", withExtension: "json", subdirectory: "fixtures"),
+      "team-key-fixture.json must be bundled in the test target"
+    )
+    struct Fixture: Decodable {
+      struct EncData: Decodable { let ciphertext: String; let iv: String; let authTag: String }
+      let secretKeyHex: String
+      let encryptedEcdhPrivateKey: EncData
+      let teamId: String; let toUserId: String
+      let keyVersion: Int; let wrapVersion: Int
+      let hkdfSaltHex: String
+      let encryptedTeamKey: EncData
+      let ephemeralPublicKeyJwk: String
+      let teamEncKeyHex: String
+    }
+    let f = try JSONDecoder().decode(Fixture.self, from: Data(contentsOf: fixtureURL))
+
+    // Derive a real cacheKey and wrap the ECDH key under it.
+    let cacheKey = SymmetricKey(size: .bits256)
+    let userId = f.toUserId
+
+    let secretKeyBytes = try hexDecode(f.secretKeyHex)
+    let ecdhWrappingKey = TeamKeyCrypto.deriveEcdhWrappingKey(
+      secretKey: SymmetricKey(data: secretKeyBytes))
+    let memberKey = try TeamKeyCrypto.unwrapEcdhPrivateKey(
+      encrypted: EncryptedData(
+        ciphertext: f.encryptedEcdhPrivateKey.ciphertext,
+        iv: f.encryptedEcdhPrivateKey.iv,
+        authTag: f.encryptedEcdhPrivateKey.authTag),
+      wrappingKey: ecdhWrappingKey)
+    var pkcs8 = memberKey.derRepresentation
+    defer { pkcs8.resetBytes(in: 0..<pkcs8.count) }
+    let wrappedEcdh = try TeamEntryDecryptor.wrapEcdhPrivateKey(
+      pkcs8: pkcs8, cacheKey: cacheKey, userId: userId, issuedAt: Date())
+
+    // Set up the real infrastructure.
+    let keychain = MockKeychain()
+    seedBlobInKeychain(keychain, counter: 1, service: "com.passwd-sso.test.team-sync.bridge-key")
+    let bks = BridgeKeyStore(
+      accessGroup: "test",
+      service: "com.passwd-sso.test.team-sync.bridge-key",
+      keychain: keychain
+    )
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    try wks.saveECDHPrivateKey(wrappedEcdh)
+    let cacheURL = tmpDir.appending(path: "team-sync.cache", directoryHint: .notDirectory)
+
+    // Build the vault key.
+    let vaultKey = SymmetricKey(size: .bits256)
+
+    // Wire MockURLProtocol stubs.
+    let fakeKeychain = FakeKeychain()
+    let tokenStore = HostTokenStore(service: "com.test.team-sync.tokens", keychain: fakeKeychain)
+    try? tokenStore.saveTokens(
+      access: "acc_team_sync",
+      refresh: "ref_team_sync",
+      expiresAt: Date().addingTimeInterval(3600)
+    )
+    let session = makeSession()
+
+    let teamId = f.teamId
+
+    // Pre-encode the member-key response so the closure captures Data (not throwing).
+    // ephemeralPublicKey is a String field — use Codable to avoid manual JSON escaping.
+    struct MemberKeyBody: Encodable {
+      let encryptedTeamKey: String; let teamKeyIv: String; let teamKeyAuthTag: String
+      let ephemeralPublicKey: String; let hkdfSalt: String
+      let keyVersion: Int; let wrapVersion: Int
+    }
+    let memberKeyBody = MemberKeyBody(
+      encryptedTeamKey: f.encryptedTeamKey.ciphertext,
+      teamKeyIv: f.encryptedTeamKey.iv,
+      teamKeyAuthTag: f.encryptedTeamKey.authTag,
+      ephemeralPublicKey: f.ephemeralPublicKeyJwk,
+      hkdfSalt: f.hkdfSaltHex,
+      keyVersion: f.keyVersion,
+      wrapVersion: f.wrapVersion
+    )
+    let memberKeyData = try JSONEncoder().encode(memberKeyBody)
+    let teamsListData = Data(#"[{"id":"\#(teamId)","name":"Fixture Team"}]"#.utf8)
+
+    MockURLProtocol.requestHandler = { request in
+      let path = request.url?.path ?? ""
+      let baseURL = URL(string: "https://test.team-sync.example")!
+      if path.hasSuffix("/api/passwords") {
+        return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+      }
+      if path.hasSuffix("/api/teams") {
+        return (teamsListData, httpResponse(status: 200, url: request.url!))
+      }
+      if path.contains("/passwords") && path.contains(teamId) {
+        return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+      }
+      if path.hasSuffix("/member-key") && path.contains(teamId) {
+        return (memberKeyData, httpResponse(status: 200, url: request.url!))
+      }
+      return (Data("[]".utf8), httpResponse(status: 200, url: baseURL))
+    }
+
+    let apiClient = MobileAPIClient(
+      serverURL: URL(string: "https://test.team-sync.example")!,
+      signer: FakeSigner(),
+      jwk: ["kty": "EC", "crv": "P-256",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"],
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+    let fetcher = EntryFetcher(apiClient: apiClient)
+    let syncService = HostSyncService(
+      apiClient: apiClient,
+      entryFetcher: fetcher,
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      cacheURL: cacheURL,
+      teamDirectoryStore: NullTeamDirectoryStore()
+    )
+
+    let now = Date()
+    _ = try await syncService.runSync(vaultKey: vaultKey, userId: userId, cacheKey: cacheKey)
+
+    // The stored team key must unwrap to the fixture's teamEncKeyHex.
+    let storedKeys = try wks.loadTeamKeys()
+    let storedKey = try XCTUnwrap(storedKeys.first(where: { $0.teamId == teamId }),
+      "A WrappedTeamKey must be stored for the fixture team after sync")
+
+    let unwrapped = try XCTUnwrap(
+      TeamEntryDecryptor.unwrapTeamKey(storedKey, cacheKey: cacheKey, userId: userId),
+      "Stored WrappedTeamKey must unwrap under the test cacheKey"
+    )
+    let unwrappedHex = unwrapped.withUnsafeBytes { hexEncode(Data($0)) }
+    XCTAssertEqual(unwrappedHex, f.teamEncKeyHex,
+      "Unwrapped team enc key must match the fixture's teamEncKeyHex")
+
+    // Issued-at must be recent (within 5 seconds of now).
+    XCTAssertLessThanOrEqual(abs(storedKey.issuedAt.timeIntervalSince(now)), 5)
+  }
+
+  // MARK: - No ECDH key: non-empty non-stale set → unchanged
+
+  /// When the ECDH key is absent but the existing team-key set is non-empty and
+  /// NOT all stale, performSync must leave the set unchanged (not wipe it).
+  func testRefreshTeamKeys_noECDH_nonStaleSet_unchanged() async throws {
+    let keychain = MockKeychain()
+    seedBlobInKeychain(keychain, counter: 1, service: "com.passwd-sso.test.noecdh-fresh.bridge-key")
+    let bks = BridgeKeyStore(
+      accessGroup: "test",
+      service: "com.passwd-sso.test.noecdh-fresh.bridge-key",
+      keychain: keychain
+    )
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    // No ECDH key — wks has no ECDHPrivateKey.
+
+    // Seed a fresh (non-stale) team key.
+    let cacheKey = SymmetricKey(size: .bits256)
+    let teamKey = SymmetricKey(size: .bits256)
+    let wrappedTeamKey = try TeamEntryDecryptor.wrapTeamKey(
+      teamEncKey: teamKey, cacheKey: cacheKey, userId: "no-ecdh-user",
+      teamId: "team-noecdh-fresh", teamKeyVersion: 1, issuedAt: Date()
+    )
+    try wks.saveTeamKeys([wrappedTeamKey])
+
+    let fakeKeychain = FakeKeychain()
+    let tokenStore = HostTokenStore(service: "com.test.noecdh-fresh.tokens", keychain: fakeKeychain)
+    try? tokenStore.saveTokens(
+      access: "acc_noecdh_fresh", refresh: "ref_noecdh_fresh",
+      expiresAt: Date().addingTimeInterval(3600)
+    )
+    let session = makeSession()
+
+    MockURLProtocol.requestHandler = { request in
+      let path = request.url?.path ?? ""
+      if path.hasSuffix("/api/passwords") {
+        return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+      }
+      if path.hasSuffix("/api/teams") {
+        return (Data(#"[{"id":"team-noecdh-fresh","name":"No ECDH Fresh"}]"#.utf8),
+                httpResponse(status: 200, url: request.url!))
+      }
+      return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+    }
+
+    let vaultKey = SymmetricKey(size: .bits256)
+    let apiClient = MobileAPIClient(
+      serverURL: URL(string: "https://test.noecdh-fresh.example")!,
+      signer: FakeSigner(),
+      jwk: ["kty": "EC", "crv": "P-256",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"],
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+    let fetcher = EntryFetcher(apiClient: apiClient)
+    let cacheURL = tmpDir.appending(path: "noecdh-fresh.cache", directoryHint: .notDirectory)
+    let syncService = HostSyncService(
+      apiClient: apiClient,
+      entryFetcher: fetcher,
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      cacheURL: cacheURL,
+      teamDirectoryStore: NullTeamDirectoryStore()
+    )
+
+    _ = try await syncService.runSync(vaultKey: vaultKey, userId: "no-ecdh-user", cacheKey: cacheKey)
+
+    // The existing non-stale team key must still be present.
+    let remaining = try wks.loadTeamKeys()
+    XCTAssertEqual(remaining.count, 1,
+      "Non-stale team key set must be left unchanged when ECDH key is absent")
+    XCTAssertEqual(remaining.first?.teamId, "team-noecdh-fresh")
+  }
+
+  // MARK: - No ECDH key: all-stale set → cleared
+
+  func testRefreshTeamKeys_noECDH_allStaleSet_cleared() async throws {
+    let keychain = MockKeychain()
+    seedBlobInKeychain(keychain, counter: 1, service: "com.passwd-sso.test.noecdh-stale.bridge-key")
+    let bks = BridgeKeyStore(
+      accessGroup: "test",
+      service: "com.passwd-sso.test.noecdh-stale.bridge-key",
+      keychain: keychain
+    )
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+
+    // Seed an all-stale team key (issued 20 min ago → past the 15-min window).
+    let cacheKey = SymmetricKey(size: .bits256)
+    let teamKey = SymmetricKey(size: .bits256)
+    let staleIssuedAt = Date().addingTimeInterval(-20 * 60)
+    let staleTeamKey = try TeamEntryDecryptor.wrapTeamKey(
+      teamEncKey: teamKey, cacheKey: cacheKey, userId: "stale-user",
+      teamId: "team-stale", teamKeyVersion: 1, issuedAt: staleIssuedAt
+    )
+    try wks.saveTeamKeys([staleTeamKey])
+
+    let fakeKeychain = FakeKeychain()
+    let tokenStore = HostTokenStore(service: "com.test.noecdh-stale.tokens", keychain: fakeKeychain)
+    try? tokenStore.saveTokens(
+      access: "acc_stale", refresh: "ref_stale",
+      expiresAt: Date().addingTimeInterval(3600)
+    )
+    let session = makeSession()
+
+    MockURLProtocol.requestHandler = { request in
+      let path = request.url?.path ?? ""
+      if path.hasSuffix("/api/passwords") {
+        return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+      }
+      if path.hasSuffix("/api/teams") {
+        return (Data(#"[{"id":"team-stale","name":"Stale Team"}]"#.utf8),
+                httpResponse(status: 200, url: request.url!))
+      }
+      return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+    }
+
+    let vaultKey = SymmetricKey(size: .bits256)
+    let apiClient = MobileAPIClient(
+      serverURL: URL(string: "https://test.noecdh-stale.example")!,
+      signer: FakeSigner(),
+      jwk: ["kty": "EC", "crv": "P-256",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"],
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+    let fetcher = EntryFetcher(apiClient: apiClient)
+    let cacheURL = tmpDir.appending(path: "noecdh-stale.cache", directoryHint: .notDirectory)
+    let syncService = HostSyncService(
+      apiClient: apiClient,
+      entryFetcher: fetcher,
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      cacheURL: cacheURL,
+      teamDirectoryStore: NullTeamDirectoryStore()
+    )
+
+    _ = try await syncService.runSync(vaultKey: vaultKey, userId: "stale-user", cacheKey: cacheKey)
+
+    let remaining = try wks.loadTeamKeys()
+    XCTAssertTrue(remaining.isEmpty,
+      "All-stale team key set must be cleared when ECDH key is absent")
+  }
+
+  // MARK: - Per-team teamKeyNotDistributed → team absent, others written
+
+  func testRefreshTeamKeys_oneTeamNotDistributed_otherTeamWritten() async throws {
+    let bundle = Bundle(for: type(of: self))
+    let fixtureURL = try XCTUnwrap(
+      bundle.url(forResource: "team-key-fixture", withExtension: "json")
+        ?? bundle.url(forResource: "team-key-fixture", withExtension: "json", subdirectory: "fixtures")
+    )
+    struct FixtureMin: Decodable {
+      struct EncData: Decodable { let ciphertext: String; let iv: String; let authTag: String }
+      let secretKeyHex: String
+      let encryptedEcdhPrivateKey: EncData
+      let teamId: String; let toUserId: String
+      let keyVersion: Int; let wrapVersion: Int
+      let hkdfSaltHex: String
+      let encryptedTeamKey: EncData
+      let ephemeralPublicKeyJwk: String
+      let teamEncKeyHex: String
+    }
+    let f = try JSONDecoder().decode(FixtureMin.self, from: Data(contentsOf: fixtureURL))
+
+    let cacheKey = SymmetricKey(size: .bits256)
+    let userId = f.toUserId
+
+    let secretKeyBytes = try hexDecode(f.secretKeyHex)
+    let ecdhWrappingKey = TeamKeyCrypto.deriveEcdhWrappingKey(
+      secretKey: SymmetricKey(data: secretKeyBytes))
+    let memberKey = try TeamKeyCrypto.unwrapEcdhPrivateKey(
+      encrypted: EncryptedData(
+        ciphertext: f.encryptedEcdhPrivateKey.ciphertext,
+        iv: f.encryptedEcdhPrivateKey.iv,
+        authTag: f.encryptedEcdhPrivateKey.authTag),
+      wrappingKey: ecdhWrappingKey)
+    var pkcs8 = memberKey.derRepresentation
+    defer { pkcs8.resetBytes(in: 0..<pkcs8.count) }
+    let wrappedEcdh = try TeamEntryDecryptor.wrapEcdhPrivateKey(
+      pkcs8: pkcs8, cacheKey: cacheKey, userId: userId, issuedAt: Date())
+
+    let keychain = MockKeychain()
+    seedBlobInKeychain(keychain, counter: 1, service: "com.passwd-sso.test.two-teams.bridge-key")
+    let bks = BridgeKeyStore(
+      accessGroup: "test",
+      service: "com.passwd-sso.test.two-teams.bridge-key",
+      keychain: keychain
+    )
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    try wks.saveECDHPrivateKey(wrappedEcdh)
+
+    let goodTeamId = f.teamId
+    let badTeamId = "team-not-distributed"
+
+    let fakeKeychain2 = FakeKeychain()
+    let tokenStore2 = HostTokenStore(service: "com.test.two-teams.tokens", keychain: fakeKeychain2)
+    try? tokenStore2.saveTokens(
+      access: "acc_two_teams", refresh: "ref_two_teams",
+      expiresAt: Date().addingTimeInterval(3600)
+    )
+    let session2 = makeSession()
+
+    // Pre-encode the good-team member-key response.
+    struct MemberKeyBody2: Encodable {
+      let encryptedTeamKey: String; let teamKeyIv: String; let teamKeyAuthTag: String
+      let ephemeralPublicKey: String; let hkdfSalt: String
+      let keyVersion: Int; let wrapVersion: Int
+    }
+    let goodMemberKeyData = try JSONEncoder().encode(MemberKeyBody2(
+      encryptedTeamKey: f.encryptedTeamKey.ciphertext,
+      teamKeyIv: f.encryptedTeamKey.iv,
+      teamKeyAuthTag: f.encryptedTeamKey.authTag,
+      ephemeralPublicKey: f.ephemeralPublicKeyJwk,
+      hkdfSalt: f.hkdfSaltHex,
+      keyVersion: f.keyVersion,
+      wrapVersion: f.wrapVersion
+    ))
+    let twoTeamsListData = Data("""
+    [{"id":"\(goodTeamId)","name":"Good Team"},{"id":"\(badTeamId)","name":"Bad Team"}]
+    """.utf8)
+
+    MockURLProtocol.requestHandler = { request in
+      let path = request.url?.path ?? ""
+      if path.hasSuffix("/api/passwords") {
+        return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+      }
+      if path.hasSuffix("/api/teams") {
+        return (twoTeamsListData, httpResponse(status: 200, url: request.url!))
+      }
+      // Team entries endpoint for both teams.
+      if path.contains("/passwords") {
+        return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+      }
+      // member-key: good team → real fixture data; bad team → 403.
+      if path.hasSuffix("/member-key") {
+        if path.contains(goodTeamId) {
+          return (goodMemberKeyData, httpResponse(status: 200, url: request.url!))
+        } else {
+          // 403 KEY_NOT_DISTRIBUTED for badTeamId.
+          return (Data(#"{"error":"KEY_NOT_DISTRIBUTED"}"#.utf8),
+                  httpResponse(status: 403, url: request.url!))
+        }
+      }
+      return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+    }
+
+    let vaultKey = SymmetricKey(size: .bits256)
+    let apiClient2 = MobileAPIClient(
+      serverURL: URL(string: "https://test.two-teams.example")!,
+      signer: FakeSigner(),
+      jwk: ["kty": "EC", "crv": "P-256",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"],
+      tokenStore: tokenStore2,
+      urlSession: session2
+    )
+    let fetcher2 = EntryFetcher(apiClient: apiClient2)
+    let cacheURL2 = tmpDir.appending(path: "two-teams.cache", directoryHint: .notDirectory)
+    let syncService2 = HostSyncService(
+      apiClient: apiClient2,
+      entryFetcher: fetcher2,
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      cacheURL: cacheURL2,
+      teamDirectoryStore: NullTeamDirectoryStore()
+    )
+
+    _ = try await syncService2.runSync(vaultKey: vaultKey, userId: userId, cacheKey: cacheKey)
+
+    let stored = try wks.loadTeamKeys()
+    // Good team must be present.
+    XCTAssertNotNil(stored.first(where: { $0.teamId == goodTeamId }),
+      "Good team with distributed key must appear in stored team keys")
+    // Bad team must be absent.
+    XCTAssertNil(stored.first(where: { $0.teamId == badTeamId }),
+      "Team with KEY_NOT_DISTRIBUTED must be absent from stored team keys")
+  }
+
   func testPersonalCacheEntryPropagatesEntryType() {
     let enc = EncryptedData(ciphertext: "00", iv: "00", authTag: "00")
     let passkey = EncryptedEntry(
@@ -190,6 +624,328 @@ final class HostSyncServiceTests: XCTestCase {
 
     let login = EncryptedEntry(id: "e1", encryptedOverview: enc, encryptedBlob: enc)
     XCTAssertEqual(login.toPersonalCacheEntry().entryType, "LOGIN")
+  }
+
+  // MARK: - F1 regression: transient /api/teams error must NOT wipe valid team keys
+
+  /// Regression for F1: when fetchTeamMemberships() receives an HTTP 500 (transient,
+  /// non-auth error), teamsAuthoritative=false and refreshTeamKeys returns early.
+  /// Previously the code called saveTeamKeys([]) wiping valid persisted keys.
+  /// This test fails against the old behaviour (saveTeamKeys([]) path) because
+  /// storedKeys.count would be 0 instead of 1.
+  func testRefreshTeamKeys_transientTeamsError_doesNotWipeExistingKeys() async throws {
+    let bundle = Bundle(for: type(of: self))
+    let fixtureURL = try XCTUnwrap(
+      bundle.url(forResource: "team-key-fixture", withExtension: "json")
+        ?? bundle.url(forResource: "team-key-fixture", withExtension: "json", subdirectory: "fixtures")
+    )
+    struct FixtureMin: Decodable {
+      struct EncData: Decodable { let ciphertext: String; let iv: String; let authTag: String }
+      let secretKeyHex: String
+      let encryptedEcdhPrivateKey: EncData
+      let teamId: String; let toUserId: String
+      let keyVersion: Int; let wrapVersion: Int
+    }
+    let f = try JSONDecoder().decode(FixtureMin.self, from: Data(contentsOf: fixtureURL))
+
+    let cacheKey = SymmetricKey(size: .bits256)
+    let userId = f.toUserId
+
+    // Wrap the ECDH private key so it IS available (not the no-ECDH branch).
+    let secretKeyBytes = try hexDecode(f.secretKeyHex)
+    let ecdhWrappingKey = TeamKeyCrypto.deriveEcdhWrappingKey(
+      secretKey: SymmetricKey(data: secretKeyBytes))
+    let memberKey = try TeamKeyCrypto.unwrapEcdhPrivateKey(
+      encrypted: EncryptedData(
+        ciphertext: f.encryptedEcdhPrivateKey.ciphertext,
+        iv: f.encryptedEcdhPrivateKey.iv,
+        authTag: f.encryptedEcdhPrivateKey.authTag),
+      wrappingKey: ecdhWrappingKey)
+    var pkcs8 = memberKey.derRepresentation
+    defer { pkcs8.resetBytes(in: 0..<pkcs8.count) }
+    let wrappedEcdh = try TeamEntryDecryptor.wrapEcdhPrivateKey(
+      pkcs8: pkcs8, cacheKey: cacheKey, userId: userId, issuedAt: Date())
+
+    // Seed infrastructure.
+    let keychain = MockKeychain()
+    seedBlobInKeychain(keychain, counter: 1,
+                       service: "com.passwd-sso.test.transient-teams.bridge-key")
+    let bks = BridgeKeyStore(
+      accessGroup: "test",
+      service: "com.passwd-sso.test.transient-teams.bridge-key",
+      keychain: keychain
+    )
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    try wks.saveECDHPrivateKey(wrappedEcdh)
+
+    // Seed a fresh (non-stale) team key in the wrapped key store.
+    let existingTeamKey = SymmetricKey(size: .bits256)
+    let existingWrapped = try TeamEntryDecryptor.wrapTeamKey(
+      teamEncKey: existingTeamKey, cacheKey: cacheKey, userId: userId,
+      teamId: f.teamId, teamKeyVersion: 1, issuedAt: Date()
+    )
+    try wks.saveTeamKeys([existingWrapped])
+
+    let fakeKeychain = FakeKeychain()
+    let tokenStore = HostTokenStore(
+      service: "com.test.transient-teams.tokens", keychain: fakeKeychain)
+    try? tokenStore.saveTokens(
+      access: "acc_transient", refresh: "ref_transient",
+      expiresAt: Date().addingTimeInterval(3600)
+    )
+    let session = makeSession()
+
+    // Stub: /api/passwords → 200 [], /api/teams → HTTP 500 (transient, non-auth error).
+    MockURLProtocol.requestHandler = { request in
+      let path = request.url?.path ?? ""
+      if path.hasSuffix("/api/passwords") {
+        return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+      }
+      if path.hasSuffix("/api/teams") {
+        // HTTP 500 is a transient server error — not authenticationRequired.
+        return (Data(#"{"error":"internal"}"#.utf8),
+                httpResponse(status: 500, url: request.url!))
+      }
+      return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+    }
+
+    let vaultKey = SymmetricKey(size: .bits256)
+    let apiClient = MobileAPIClient(
+      serverURL: URL(string: "https://test.transient-teams.example")!,
+      signer: FakeSigner(),
+      jwk: ["kty": "EC", "crv": "P-256",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"],
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+    let fetcher = EntryFetcher(apiClient: apiClient)
+    let cacheURL = tmpDir.appending(path: "transient-teams.cache", directoryHint: .notDirectory)
+    let syncService = HostSyncService(
+      apiClient: apiClient,
+      entryFetcher: fetcher,
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      cacheURL: cacheURL,
+      teamDirectoryStore: NullTeamDirectoryStore()
+    )
+
+    _ = try await syncService.runSync(vaultKey: vaultKey, userId: userId, cacheKey: cacheKey)
+
+    // The existing fresh team key must still be present, NOT wiped.
+    let remaining = try wks.loadTeamKeys()
+    XCTAssertEqual(remaining.count, 1,
+      "Transient /api/teams failure must NOT wipe valid persisted team keys (F1 regression)")
+    XCTAssertEqual(remaining.first?.teamId, f.teamId,
+      "The surviving key must be the originally seeded team's key")
+  }
+
+  // MARK: - F1 bonus: malformed ECDH + all-stale set → cleared
+
+  /// Mirrors testRefreshTeamKeys_noECDH_allStaleSet_cleared but via the malformed-ECDH
+  /// branch (importEcdhPrivateKey fails). Both code paths now route to clearTeamKeysIfAllStale.
+  func testRefreshTeamKeys_malformedECDH_allStaleSet_cleared() async throws {
+    let keychain = MockKeychain()
+    seedBlobInKeychain(keychain, counter: 1,
+                       service: "com.passwd-sso.test.malformed-ecdh.bridge-key")
+    let bks = BridgeKeyStore(
+      accessGroup: "test",
+      service: "com.passwd-sso.test.malformed-ecdh.bridge-key",
+      keychain: keychain
+    )
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+
+    // Store a WrappedECDHPrivateKey whose payload decrypts to garbage (not a valid P-256
+    // PKCS#8 key). TeamEntryDecryptor.unwrapEcdhPrivateKey succeeds (returns the bytes),
+    // but TeamKeyCrypto.importEcdhPrivateKey rejects them → same posture as "no ECDH".
+    let cacheKey = SymmetricKey(size: .bits256)
+    let userId = "malformed-user"
+    // 32 bytes of garbage — decrypts fine, but not a valid PKCS#8 DER key.
+    let garbagePKCS8 = Data(repeating: 0xDE, count: 32)
+    let wrappedGarbageEcdh = try TeamEntryDecryptor.wrapEcdhPrivateKey(
+      pkcs8: garbagePKCS8, cacheKey: cacheKey, userId: userId, issuedAt: Date()
+    )
+    try wks.saveECDHPrivateKey(wrappedGarbageEcdh)
+
+    // Seed an all-stale team key (issued 20 min ago).
+    let teamKey = SymmetricKey(size: .bits256)
+    let staleIssuedAt = Date().addingTimeInterval(-20 * 60)
+    let staleTeamKey = try TeamEntryDecryptor.wrapTeamKey(
+      teamEncKey: teamKey, cacheKey: cacheKey, userId: userId,
+      teamId: "team-malformed-stale", teamKeyVersion: 1, issuedAt: staleIssuedAt
+    )
+    try wks.saveTeamKeys([staleTeamKey])
+
+    let fakeKeychain = FakeKeychain()
+    let tokenStore = HostTokenStore(
+      service: "com.test.malformed-ecdh.tokens", keychain: fakeKeychain)
+    try? tokenStore.saveTokens(
+      access: "acc_malformed", refresh: "ref_malformed",
+      expiresAt: Date().addingTimeInterval(3600)
+    )
+    let session = makeSession()
+
+    MockURLProtocol.requestHandler = { request in
+      let path = request.url?.path ?? ""
+      if path.hasSuffix("/api/passwords") {
+        return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+      }
+      if path.hasSuffix("/api/teams") {
+        return (Data(#"[{"id":"team-malformed-stale","name":"Malformed ECDH Team"}]"#.utf8),
+                httpResponse(status: 200, url: request.url!))
+      }
+      return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+    }
+
+    let vaultKey = SymmetricKey(size: .bits256)
+    let apiClient = MobileAPIClient(
+      serverURL: URL(string: "https://test.malformed-ecdh.example")!,
+      signer: FakeSigner(),
+      jwk: ["kty": "EC", "crv": "P-256",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"],
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+    let fetcher = EntryFetcher(apiClient: apiClient)
+    let cacheURL = tmpDir.appending(path: "malformed-ecdh.cache", directoryHint: .notDirectory)
+    let syncService = HostSyncService(
+      apiClient: apiClient,
+      entryFetcher: fetcher,
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      cacheURL: cacheURL,
+      teamDirectoryStore: NullTeamDirectoryStore()
+    )
+
+    _ = try await syncService.runSync(vaultKey: vaultKey, userId: userId, cacheKey: cacheKey)
+
+    let remaining = try wks.loadTeamKeys()
+    XCTAssertTrue(remaining.isEmpty,
+      "All-stale team key set must be cleared when ECDH key is malformed (F1 bonus regression)")
+  }
+
+  // MARK: - T8: happy-path fixture sync stores correct teamKeyVersion
+
+  /// Extends testRefreshTeamKeys_writesTeamKeyUnwrappedToFixtureEncKey with a
+  /// teamKeyVersion assertion. Fails if the stored blob's version is wrong/zero.
+  func testRefreshTeamKeys_fixtureSync_storesCorrectTeamKeyVersion() async throws {
+    let bundle = Bundle(for: type(of: self))
+    let fixtureURL = try XCTUnwrap(
+      bundle.url(forResource: "team-key-fixture", withExtension: "json")
+        ?? bundle.url(forResource: "team-key-fixture", withExtension: "json", subdirectory: "fixtures")
+    )
+    struct Fixture: Decodable {
+      struct EncData: Decodable { let ciphertext: String; let iv: String; let authTag: String }
+      let secretKeyHex: String
+      let encryptedEcdhPrivateKey: EncData
+      let teamId: String; let toUserId: String
+      let keyVersion: Int; let wrapVersion: Int
+      let hkdfSaltHex: String
+      let encryptedTeamKey: EncData
+      let ephemeralPublicKeyJwk: String
+    }
+    let f = try JSONDecoder().decode(Fixture.self, from: Data(contentsOf: fixtureURL))
+
+    let cacheKey = SymmetricKey(size: .bits256)
+    let userId = f.toUserId
+
+    let secretKeyBytes = try hexDecode(f.secretKeyHex)
+    let ecdhWrappingKey = TeamKeyCrypto.deriveEcdhWrappingKey(
+      secretKey: SymmetricKey(data: secretKeyBytes))
+    let memberKey = try TeamKeyCrypto.unwrapEcdhPrivateKey(
+      encrypted: EncryptedData(
+        ciphertext: f.encryptedEcdhPrivateKey.ciphertext,
+        iv: f.encryptedEcdhPrivateKey.iv,
+        authTag: f.encryptedEcdhPrivateKey.authTag),
+      wrappingKey: ecdhWrappingKey)
+    var pkcs8 = memberKey.derRepresentation
+    defer { pkcs8.resetBytes(in: 0..<pkcs8.count) }
+    let wrappedEcdh = try TeamEntryDecryptor.wrapEcdhPrivateKey(
+      pkcs8: pkcs8, cacheKey: cacheKey, userId: userId, issuedAt: Date())
+
+    let keychain = MockKeychain()
+    seedBlobInKeychain(keychain, counter: 1, service: "com.passwd-sso.test.t8.bridge-key")
+    let bks = BridgeKeyStore(
+      accessGroup: "test",
+      service: "com.passwd-sso.test.t8.bridge-key",
+      keychain: keychain
+    )
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    try wks.saveECDHPrivateKey(wrappedEcdh)
+
+    let fakeKeychain = FakeKeychain()
+    let tokenStore = HostTokenStore(service: "com.test.t8.tokens", keychain: fakeKeychain)
+    try? tokenStore.saveTokens(
+      access: "acc_t8", refresh: "ref_t8",
+      expiresAt: Date().addingTimeInterval(3600)
+    )
+    let session = makeSession()
+
+    struct MemberKeyBody: Encodable {
+      let encryptedTeamKey: String; let teamKeyIv: String; let teamKeyAuthTag: String
+      let ephemeralPublicKey: String; let hkdfSalt: String
+      let keyVersion: Int; let wrapVersion: Int
+    }
+    let memberKeyData = try JSONEncoder().encode(MemberKeyBody(
+      encryptedTeamKey: f.encryptedTeamKey.ciphertext,
+      teamKeyIv: f.encryptedTeamKey.iv,
+      teamKeyAuthTag: f.encryptedTeamKey.authTag,
+      ephemeralPublicKey: f.ephemeralPublicKeyJwk,
+      hkdfSalt: f.hkdfSaltHex,
+      keyVersion: f.keyVersion,
+      wrapVersion: f.wrapVersion
+    ))
+    let teamsListData = Data(#"[{"id":"\#(f.teamId)","name":"Fixture Team"}]"#.utf8)
+
+    MockURLProtocol.requestHandler = { request in
+      let path = request.url?.path ?? ""
+      if path.hasSuffix("/api/passwords") {
+        return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+      }
+      if path.hasSuffix("/api/teams") {
+        return (teamsListData, httpResponse(status: 200, url: request.url!))
+      }
+      if path.contains("/passwords") {
+        return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+      }
+      if path.hasSuffix("/member-key") && path.contains(f.teamId) {
+        return (memberKeyData, httpResponse(status: 200, url: request.url!))
+      }
+      return (Data("[]".utf8), httpResponse(status: 200, url: request.url!))
+    }
+
+    let vaultKey = SymmetricKey(size: .bits256)
+    let apiClient = MobileAPIClient(
+      serverURL: URL(string: "https://test.t8.example")!,
+      signer: FakeSigner(),
+      jwk: ["kty": "EC", "crv": "P-256",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"],
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+    let fetcher = EntryFetcher(apiClient: apiClient)
+    let cacheURL = tmpDir.appending(path: "t8.cache", directoryHint: .notDirectory)
+    let syncService = HostSyncService(
+      apiClient: apiClient,
+      entryFetcher: fetcher,
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      cacheURL: cacheURL,
+      teamDirectoryStore: NullTeamDirectoryStore()
+    )
+
+    _ = try await syncService.runSync(vaultKey: vaultKey, userId: userId, cacheKey: cacheKey)
+
+    let storedKeys = try wks.loadTeamKeys()
+    let storedKey = try XCTUnwrap(
+      storedKeys.first(where: { $0.teamId == f.teamId }),
+      "WrappedTeamKey must be stored for the fixture team after sync (T8)"
+    )
+    // T8: the stored key's teamKeyVersion must equal the fixture's keyVersion.
+    XCTAssertEqual(storedKey.teamKeyVersion, f.keyVersion,
+      "Stored WrappedTeamKey.teamKeyVersion must match the server's keyVersion (T8)")
   }
 }
 

--- a/ios/PasswdSSOTests/MobileAPIClientTests.swift
+++ b/ios/PasswdSSOTests/MobileAPIClientTests.swift
@@ -614,6 +614,141 @@ final class MobileAPIClientTests: XCTestCase {
     }
   }
 
+  // MARK: - fetchTeamMemberKey
+
+  private func stubTeamMemberKey(status: Int, body: Data, teamId: String = "team-1") {
+    let url = serverURL.appending(path: "/api/teams/\(teamId)/member-key", directoryHint: .notDirectory)
+    MockURLProtocol.requestHandler = { _ in (body, httpResponse(status: status, url: url)) }
+  }
+
+  private func teamMemberKeyJSON() -> Data {
+    Data("""
+    {
+      "encryptedTeamKey": "aabbcc",
+      "teamKeyIv": "112233445566778899aabbcc",
+      "teamKeyAuthTag": "deadbeefdeadbeefdeadbeefdeadbeef",
+      "ephemeralPublicKey": "{\\"kty\\":\\"EC\\",\\"crv\\":\\"P-256\\",\\"x\\":\\"AAAA\\",\\"y\\":\\"BBBB\\"}",
+      "hkdfSalt": "ccddee",
+      "keyVersion": 2,
+      "wrapVersion": 1
+    }
+    """.utf8)
+  }
+
+  func testFetchTeamMemberKey_200_decodesResponse() async throws {
+    seedAccessToken()
+    stubTeamMemberKey(status: 200, body: teamMemberKeyJSON())
+
+    let client = MobileAPIClient(
+      serverURL: serverURL,
+      signer: FakeSigner(),
+      jwk: knownJWK,
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+
+    let resp = try await client.fetchTeamMemberKey(teamId: "team-1")
+
+    XCTAssertEqual(resp.encryptedTeamKey, "aabbcc")
+    XCTAssertEqual(resp.teamKeyIv, "112233445566778899aabbcc")
+    XCTAssertEqual(resp.teamKeyAuthTag, "deadbeefdeadbeefdeadbeefdeadbeef")
+    XCTAssertEqual(resp.keyVersion, 2)
+    XCTAssertEqual(resp.wrapVersion, 1)
+    XCTAssertEqual(resp.hkdfSalt, "ccddee")
+    // T7: ephemeralPublicKey must decode to the expected non-empty string value.
+    XCTAssertFalse(resp.ephemeralPublicKey.isEmpty,
+      "ephemeralPublicKey must be non-empty after decoding (T7)")
+    XCTAssertEqual(
+      resp.ephemeralPublicKey,
+      #"{"kty":"EC","crv":"P-256","x":"AAAA","y":"BBBB"}"#,
+      "ephemeralPublicKey must match the stub's JSON value exactly (T7)"
+    )
+  }
+
+  func testFetchTeamMemberKey_403_keyNotDistributed_throwsTeamKeyNotDistributed() async throws {
+    seedAccessToken()
+    let errorBody = Data(#"{"error":"KEY_NOT_DISTRIBUTED"}"#.utf8)
+    stubTeamMemberKey(status: 403, body: errorBody)
+
+    let client = MobileAPIClient(
+      serverURL: serverURL,
+      signer: FakeSigner(),
+      jwk: knownJWK,
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+
+    do {
+      _ = try await client.fetchTeamMemberKey(teamId: "team-1")
+      XCTFail("Expected teamKeyNotDistributed")
+    } catch MobileAPIError.teamKeyNotDistributed {
+      // expected
+    }
+  }
+
+  func testFetchTeamMemberKey_404_memberKeyNotFound_throwsTeamKeyNotDistributed() async throws {
+    seedAccessToken()
+    let errorBody = Data(#"{"error":"MEMBER_KEY_NOT_FOUND"}"#.utf8)
+    stubTeamMemberKey(status: 404, body: errorBody)
+
+    let client = MobileAPIClient(
+      serverURL: serverURL,
+      signer: FakeSigner(),
+      jwk: knownJWK,
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+
+    do {
+      _ = try await client.fetchTeamMemberKey(teamId: "team-1")
+      XCTFail("Expected teamKeyNotDistributed")
+    } catch MobileAPIError.teamKeyNotDistributed {
+      // expected
+    }
+  }
+
+  func testFetchTeamMemberKey_403_emptyBody_throwsTeamKeyNotDistributed() async throws {
+    // A bare 403 with no body (e.g. generic auth rejection) should still map to
+    // teamKeyNotDistributed because the server contract says 403 = key not available.
+    seedAccessToken()
+    stubTeamMemberKey(status: 403, body: Data())
+
+    let client = MobileAPIClient(
+      serverURL: serverURL,
+      signer: FakeSigner(),
+      jwk: knownJWK,
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+
+    do {
+      _ = try await client.fetchTeamMemberKey(teamId: "team-1")
+      XCTFail("Expected teamKeyNotDistributed for bare 403")
+    } catch MobileAPIError.teamKeyNotDistributed {
+      // expected
+    }
+  }
+
+  func testFetchTeamMemberKey_404_emptyBody_throwsTeamKeyNotDistributed() async throws {
+    seedAccessToken()
+    stubTeamMemberKey(status: 404, body: Data())
+
+    let client = MobileAPIClient(
+      serverURL: serverURL,
+      signer: FakeSigner(),
+      jwk: knownJWK,
+      tokenStore: tokenStore,
+      urlSession: session
+    )
+
+    do {
+      _ = try await client.fetchTeamMemberKey(teamId: "team-1")
+      XCTFail("Expected teamKeyNotDistributed for bare 404")
+    } catch MobileAPIError.teamKeyNotDistributed {
+      // expected
+    }
+  }
+
   func testUpdateEntry_persistsNonceFromResponse() async throws {
     seedAccessToken()
 

--- a/ios/PasswdSSOTests/TeamKeyCryptoTests.swift
+++ b/ios/PasswdSSOTests/TeamKeyCryptoTests.swift
@@ -1,0 +1,227 @@
+import CryptoKit
+import XCTest
+
+@testable import Shared
+
+/// Golden vectors for TeamKeyCrypto, captured from the browser extension's actual
+/// crypto-team.ts via scripts/generate-team-key-fixture.ts. These assert iOS
+/// reproduces the EXTENSION's outputs (cross-platform parity), not iOS-vs-iOS.
+final class TeamKeyCryptoTests: XCTestCase {
+
+  private struct Fixture: Decodable {
+    let secretKeyHex: String
+    let encryptedEcdhPrivateKey: EncryptedData
+    let pkcs8PrivKeyHex: String
+    let ephemeralPublicKeyJwk: String
+    let hkdfSaltHex: String
+    let encryptedTeamKey: EncryptedData
+    let teamId: String
+    let toUserId: String
+    let keyVersion: Int
+    let wrapVersion: Int
+    let rawTeamKeyHex: String
+    let teamEncKeyHex: String
+    let entryId: String
+    let encryptedOverview: EncryptedData
+    let overviewPlaintext: String
+    let teamKeyWrapAADHex: String
+    let overviewAADHex: String
+    // itemKeyVersion >= 1
+    let teamKeyVersion: Int
+    let entryIdV1: String
+    let encryptedItemKey: EncryptedData
+    let itemEncKeyHex: String
+    let encryptedOverviewV1: EncryptedData
+    let overviewPlaintextV1: String
+  }
+
+  private func loadFixture() throws -> Fixture {
+    let bundle = Bundle(for: type(of: self))
+    let url = try XCTUnwrap(
+      bundle.url(forResource: "team-key-fixture", withExtension: "json")
+        ?? bundle.url(forResource: "team-key-fixture", withExtension: "json", subdirectory: "fixtures"),
+      "team-key-fixture.json must be bundled in the test target"
+    )
+    return try JSONDecoder().decode(Fixture.self, from: Data(contentsOf: url))
+  }
+
+  private func hex(_ key: SymmetricKey) -> String { key.withUnsafeBytes { hexEncode(Data($0)) } }
+
+  // Convenience: run the full decrypt chain and return the member private key + raw team key.
+  private func recover(_ f: Fixture) throws -> (P256.KeyAgreement.PrivateKey, SymmetricKey) {
+    let secretKey = SymmetricKey(data: try hexDecode(f.secretKeyHex))
+    let wrappingKey = TeamKeyCrypto.deriveEcdhWrappingKey(secretKey: secretKey)
+    let memberKey = try TeamKeyCrypto.unwrapEcdhPrivateKey(
+      encrypted: f.encryptedEcdhPrivateKey, wrappingKey: wrappingKey)
+    let rawTeamKey = try TeamKeyCrypto.unwrapTeamKey(
+      encrypted: f.encryptedTeamKey,
+      ephemeralPublicKeyJWK: f.ephemeralPublicKeyJwk,
+      memberPrivateKey: memberKey,
+      hkdfSalt: f.hkdfSaltHex,
+      teamId: f.teamId, toUserId: f.toUserId,
+      keyVersion: f.keyVersion, wrapVersion: f.wrapVersion)
+    return (memberKey, rawTeamKey)
+  }
+
+  // (a) ECDH private key imports from the extension's PKCS#8 and is self-consistent.
+  func testUnwrapEcdhPrivateKey_importsAndRoundTrips() throws {
+    let f = try loadFixture()
+    let (memberKey, _) = try recover(f)
+    // derRepresentation may not be byte-identical to WebCrypto's pkcs8, but must
+    // re-import to the same key (self-consistency); cross-platform correctness is
+    // proven by the team-key round-trip (test b).
+    let reimported = try P256.KeyAgreement.PrivateKey(derRepresentation: memberKey.derRepresentation)
+    XCTAssertEqual(reimported.rawRepresentation, memberKey.rawRepresentation)
+  }
+
+  // (b) Cross-platform: iOS unwraps the team key to the SAME bytes the extension produced.
+  func testUnwrapTeamKey_matchesExtension() throws {
+    let f = try loadFixture()
+    let (_, rawTeamKey) = try recover(f)
+    XCTAssertEqual(hex(rawTeamKey), f.rawTeamKeyHex)
+  }
+
+  // (c) iOS derives the same team ENCRYPTION key as the extension.
+  func testDeriveTeamEncryptionKey_matchesExtension() throws {
+    let f = try loadFixture()
+    let (_, rawTeamKey) = try recover(f)
+    let enc = TeamKeyCrypto.deriveTeamEncryptionKey(rawTeamKey: rawTeamKey)
+    XCTAssertEqual(hex(enc), f.teamEncKeyHex)
+  }
+
+  // (d) Full round-trip: the derived key decrypts a real team entry overview.
+  func testDecryptsTeamOverview() throws {
+    let f = try loadFixture()
+    let (_, rawTeamKey) = try recover(f)
+    let enc = TeamKeyCrypto.deriveTeamEncryptionKey(rawTeamKey: rawTeamKey)
+    let aad = try buildTeamEntryAAD(teamId: f.teamId, entryId: f.entryId, vaultType: "overview", itemKeyVersion: 0)
+    let plain = try decryptAESGCM(
+      ciphertext: try hexDecode(f.encryptedOverview.ciphertext),
+      iv: try hexDecode(f.encryptedOverview.iv),
+      tag: try hexDecode(f.encryptedOverview.authTag),
+      key: enc, aad: aad)
+    XCTAssertEqual(String(data: plain, encoding: .utf8), f.overviewPlaintext)
+  }
+
+  // (e) itemKeyVersion >= 1: resolveTeamEntryKey applies the item-enc HKDF, and
+  // the full decryptTeamSummary round-trip decodes a per-entry-keyed team entry.
+  // Regression guard for the missing deriveItemEncryptionKey step.
+  func testTeamEntry_itemKeyVersion1_decrypts() throws {
+    let f = try loadFixture()
+    let (_, rawTeamKey) = try recover(f)
+    let teamEncKey = TeamKeyCrypto.deriveTeamEncryptionKey(rawTeamKey: rawTeamKey)
+
+    let entry = CacheEntry(
+      id: f.entryIdV1, teamId: f.teamId, aadVersion: 1, keyVersion: 0,
+      teamKeyVersion: f.teamKeyVersion, itemKeyVersion: 1,
+      encryptedItemKey: f.encryptedItemKey,
+      encryptedBlob: f.encryptedOverviewV1,
+      encryptedOverview: f.encryptedOverviewV1)
+
+    let entryKey = try XCTUnwrap(TeamEntryDecryptor.resolveTeamEntryKey(entry: entry, teamKey: teamEncKey))
+    XCTAssertEqual(hex(entryKey), f.itemEncKeyHex)
+
+    let cacheKey = SymmetricKey(size: .bits256)
+    let wrapped = try TeamEntryDecryptor.wrapTeamKey(
+      teamEncKey: teamEncKey, cacheKey: cacheKey, userId: f.toUserId,
+      teamId: f.teamId, teamKeyVersion: f.teamKeyVersion, issuedAt: Date())
+    let summary = try XCTUnwrap(TeamEntryDecryptor.decryptTeamSummary(
+      entry: entry, teamKeys: [wrapped], cacheKey: cacheKey, userId: f.toUserId, now: { Date() }))
+    XCTAssertEqual(summary.title, "Team Login v1")
+  }
+
+  // AAD byte-parity with the extension.
+  func testTeamKeyWrapAAD_byteIdentical() throws {
+    let f = try loadFixture()
+    let aad = try buildTeamKeyWrapAAD(
+      teamId: f.teamId, toUserId: f.toUserId, keyVersion: f.keyVersion, wrapVersion: f.wrapVersion)
+    XCTAssertEqual(hexEncode(aad), f.teamKeyWrapAADHex)
+  }
+
+  func testTeamEntryAAD_byteIdentical() throws {
+    let f = try loadFixture()
+    let aad = try buildTeamEntryAAD(teamId: f.teamId, entryId: f.entryId, vaultType: "overview", itemKeyVersion: 0)
+    XCTAssertEqual(hexEncode(aad), f.overviewAADHex)
+  }
+
+  // Local-wrap AAD: hand-computed known-good bytes.
+  // "LW"(2) + aadVersion=1 + nFields=3 + [len2+"team"][len2+"u1"][len2+"t1"]
+  func testLocalWrapAAD_handComputed() throws {
+    let aad = try buildLocalWrapAAD(kind: "team", userId: "u1", teamId: "t1")
+    let expected = "4c5701030004" + "7465616d" + "000275"+"31" + "000274"+"31"
+    XCTAssertEqual(hexEncode(aad), expected)
+  }
+
+  // Negative: tampered team-key ciphertext fails AEAD.
+  func testUnwrapTeamKey_tamperedCiphertext_throws() throws {
+    let f = try loadFixture()
+    let secretKey = SymmetricKey(data: try hexDecode(f.secretKeyHex))
+    let memberKey = try TeamKeyCrypto.unwrapEcdhPrivateKey(
+      encrypted: f.encryptedEcdhPrivateKey,
+      wrappingKey: TeamKeyCrypto.deriveEcdhWrappingKey(secretKey: secretKey))
+    var ct = Array(try hexDecode(f.encryptedTeamKey.ciphertext))
+    ct[0] ^= 0xFF
+    let tampered = EncryptedData(ciphertext: hexEncode(Data(ct)), iv: f.encryptedTeamKey.iv, authTag: f.encryptedTeamKey.authTag)
+    XCTAssertThrowsError(try TeamKeyCrypto.unwrapTeamKey(
+      encrypted: tampered, ephemeralPublicKeyJWK: f.ephemeralPublicKeyJwk, memberPrivateKey: memberKey,
+      hkdfSalt: f.hkdfSaltHex, teamId: f.teamId, toUserId: f.toUserId, keyVersion: f.keyVersion, wrapVersion: f.wrapVersion))
+  }
+
+  // Negative: wrong AAD (different teamId) fails AEAD.
+  func testUnwrapTeamKey_wrongAAD_throws() throws {
+    let f = try loadFixture()
+    let secretKey = SymmetricKey(data: try hexDecode(f.secretKeyHex))
+    let memberKey = try TeamKeyCrypto.unwrapEcdhPrivateKey(
+      encrypted: f.encryptedEcdhPrivateKey,
+      wrappingKey: TeamKeyCrypto.deriveEcdhWrappingKey(secretKey: secretKey))
+    XCTAssertThrowsError(try TeamKeyCrypto.unwrapTeamKey(
+      encrypted: f.encryptedTeamKey, ephemeralPublicKeyJWK: f.ephemeralPublicKeyJwk, memberPrivateKey: memberKey,
+      hkdfSalt: f.hkdfSaltHex, teamId: "wrong-team", toUserId: f.toUserId, keyVersion: f.keyVersion, wrapVersion: f.wrapVersion))
+  }
+
+  // Negative: non-P-256 JWK rejected.
+  func testImportEphemeralPublicKey_wrongCurve_throws() {
+    let jwk = #"{"kty":"EC","crv":"P-384","x":"AAAA","y":"BBBB"}"#
+    XCTAssertThrowsError(try TeamKeyCrypto.importEphemeralPublicKey(jwk: jwk)) { error in
+      XCTAssertEqual(error as? TeamKeyCrypto.TeamKeyCryptoError, .unsupportedKeyType)
+    }
+  }
+
+  // T4: tampered ECDH ciphertext must fail AES-GCM authentication.
+  func testUnwrapEcdhPrivateKey_tamperedCiphertext_throws() throws {
+    let f = try loadFixture()
+    let secretKey = SymmetricKey(data: try hexDecode(f.secretKeyHex))
+    let wrappingKey = TeamKeyCrypto.deriveEcdhWrappingKey(secretKey: secretKey)
+    var ct = Array(try hexDecode(f.encryptedEcdhPrivateKey.ciphertext))
+    ct[0] ^= 0xFF
+    let tampered = EncryptedData(
+      ciphertext: hexEncode(Data(ct)),
+      iv: f.encryptedEcdhPrivateKey.iv,
+      authTag: f.encryptedEcdhPrivateKey.authTag
+    )
+    XCTAssertThrowsError(
+      try TeamKeyCrypto.unwrapEcdhPrivateKey(encrypted: tampered, wrappingKey: wrappingKey),
+      "Tampered ECDH ciphertext must fail AES-GCM authentication (T4)"
+    )
+  }
+
+  // T1 stronger assertion: check whether CryptoKit derRepresentation is byte-identical
+  // to the WebCrypto pkcs8 export from the fixture. If it passes, we keep the stronger
+  // cross-platform anchor. If it fails (format mismatch), the self-check version is
+  // correct and we rely on tests (b)/(c)/(d) for cross-platform parity.
+  func testUnwrapEcdhPrivateKey_derRepresentationMatchesPkcs8() throws {
+    let f = try loadFixture()
+    let secretKey = SymmetricKey(data: try hexDecode(f.secretKeyHex))
+    let wrappingKey = TeamKeyCrypto.deriveEcdhWrappingKey(secretKey: secretKey)
+    let memberKey = try TeamKeyCrypto.unwrapEcdhPrivateKey(
+      encrypted: f.encryptedEcdhPrivateKey, wrappingKey: wrappingKey)
+    let actual = hexEncode(memberKey.derRepresentation)
+    // If derRepresentation is byte-identical to the WebCrypto pkcs8 export, this
+    // passes and provides a strong cross-platform anchor. If it fails, CryptoKit's
+    // DER serialisation differs from WebCrypto's pkcs8 format; cross-platform
+    // correctness is then anchored by testUnwrapTeamKey_matchesExtension (b),
+    // testDeriveTeamEncryptionKey_matchesExtension (c), testDecryptsTeamOverview (d).
+    XCTAssertEqual(actual, f.pkcs8PrivKeyHex,
+      "CryptoKit derRepresentation must be byte-identical to WebCrypto pkcs8 export (T1 cross-platform anchor)")
+  }
+}

--- a/ios/PasswdSSOTests/VaultUnlockerTests.swift
+++ b/ios/PasswdSSOTests/VaultUnlockerTests.swift
@@ -4,6 +4,52 @@ import XCTest
 @testable import PasswdSSOApp
 @testable import Shared
 
+// MARK: - ECDH VaultUnlockData builder
+
+/// Build VaultUnlockData with ECDH fields populated. Generates a real P-256
+/// keypair, exports PKCS#8, encrypts it under deriveEcdhWrappingKey(secretKey),
+/// and injects the 4 ECDH fields. Returns the data, the plain secretKey bytes,
+/// and the generated member key so callers can verify the stored blob.
+private func makeVaultUnlockDataWithECDH(
+  passphrase: String,
+  userId: String = "ecdh-user-1"
+) throws -> (data: VaultUnlockData, secretKey: Data, memberKey: P256.KeyAgreement.PrivateKey) {
+  let saltData = Data(repeating: 0xBB, count: 32)
+  let wrappingKey = try deriveWrappingKeyPBKDF2(
+    passphrase: passphrase,
+    salt: saltData,
+    iterations: pbkdf2Iterations
+  )
+  let secretKey = Data(repeating: 0x55, count: 32)
+  let (cipher, iv, tag) = try encryptAESGCM(plaintext: secretKey, key: wrappingKey)
+
+  // Generate a fresh P-256 keypair.
+  let memberKey = P256.KeyAgreement.PrivateKey()
+  var pkcs8 = memberKey.derRepresentation
+  defer { pkcs8.resetBytes(in: 0..<pkcs8.count) }
+
+  // Encrypt PKCS#8 under the ECDH wrapping key (HKDF of secretKey).
+  let ecdhWrappingKey = TeamKeyCrypto.deriveEcdhWrappingKey(
+    secretKey: SymmetricKey(data: secretKey)
+  )
+  let (ecdhCipher, ecdhIV, ecdhTag) = try encryptAESGCM(plaintext: pkcs8, key: ecdhWrappingKey)
+
+  let data = VaultUnlockData(
+    accountSalt: hexEncode(saltData),
+    encryptedSecretKey: hexEncode(cipher),
+    secretKeyIv: hexEncode(iv),
+    secretKeyAuthTag: hexEncode(tag),
+    keyVersion: 1,
+    kdfType: 0,
+    kdfIterations: pbkdf2Iterations,
+    userId: userId,
+    encryptedEcdhPrivateKey: hexEncode(ecdhCipher),
+    ecdhPrivateKeyIv: hexEncode(ecdhIV),
+    ecdhPrivateKeyAuthTag: hexEncode(ecdhTag)
+  )
+  return (data, secretKey, memberKey)
+}
+
 // MARK: - Mock VaultUnlockData provider
 
 /// Simulates a vault unlock by providing pre-computed encrypted key material.
@@ -716,6 +762,131 @@ final class VaultUnlockerTests: XCTestCase {
     )
 
     XCTAssertFalse(unlocker.biometricUnlockAvailable(), "must be false when wrapped key is absent")
+  }
+
+  // MARK: - ECDH key persistence on passphrase unlock
+
+  /// Passphrase unlock WITH ECDH fields → wrappedKeyStore.loadECDHPrivateKey() is
+  /// non-nil and the blob unwraps back to the original PKCS#8 bytes.
+  func testUnlock_withECDHFields_persistsECDHBlob() async throws {
+    let passphrase = "ecdh-test-pass"
+    let userId = "ecdh-user-persist"
+    let (unlockData, _, memberKey) = try makeVaultUnlockDataWithECDH(
+      passphrase: passphrase, userId: userId
+    )
+
+    let keychain = MockKeychain()
+    let bks = BridgeKeyStore(
+      accessGroup: "test",
+      service: "com.passwd-sso.test.ecdh.bridge-key",
+      keychain: keychain
+    )
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+
+    let unlocker = VaultUnlocker(
+      apiClient: StubVaultAPIClient(mode: .success(unlockData)),
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      cacheURL: tmpDir.appending(path: "ecdh.cache", directoryHint: .notDirectory)
+    )
+
+    let result = try await unlocker.unlock(passphrase: passphrase)
+
+    // ECDH blob must be saved.
+    let wrappedEcdh = try XCTUnwrap(try wks.loadECDHPrivateKey(),
+      "ECDH key must be persisted after passphrase unlock when ECDH fields are present")
+
+    // Unwrap it under the cacheKey with the correct userId AAD and verify bytes.
+    let cacheKey = result.cacheKey
+    let unwrapped = try XCTUnwrap(
+      TeamEntryDecryptor.unwrapEcdhPrivateKey(wrappedEcdh, cacheKey: cacheKey, userId: userId),
+      "Stored ECDH blob must unwrap under the cacheKey + userId AAD"
+    )
+
+    // The unwrapped PKCS#8 must re-import to the same key.
+    let reimported = try P256.KeyAgreement.PrivateKey(derRepresentation: unwrapped)
+    XCTAssertEqual(
+      reimported.rawRepresentation,
+      memberKey.rawRepresentation,
+      "Unwrapped PKCS#8 must round-trip to the original member key"
+    )
+  }
+
+  /// Passphrase unlock WITHOUT ECDH fields → no ECDH blob saved, but unlock succeeds.
+  func testUnlock_withoutECDHFields_noECDHBlob() async throws {
+    let passphrase = "no-ecdh-pass"
+    let (unlockData, _) = try makeVaultUnlockData(passphrase: passphrase)
+    // unlockData has no ECDH fields (ecdhPrivateKey* == nil by default).
+
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    let bks = BridgeKeyStore(
+      accessGroup: "test",
+      service: "com.passwd-sso.test.noecdh.bridge-key",
+      keychain: MockKeychain()
+    )
+
+    let unlocker = VaultUnlocker(
+      apiClient: StubVaultAPIClient(mode: .success(unlockData)),
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      cacheURL: tmpDir.appending(path: "noecdh.cache", directoryHint: .notDirectory)
+    )
+
+    let result = try await unlocker.unlock(passphrase: passphrase)
+
+    XCTAssertNotNil(result.vaultKey, "unlock must succeed even without ECDH fields")
+    XCTAssertNil(try wks.loadECDHPrivateKey(),
+      "No ECDH blob must be saved when the server returns no ECDH fields")
+  }
+
+  /// Biometric path: ECDH blob is a no-op — existing blob untouched, unlock succeeds.
+  func testUnlockWithBiometrics_ECDHIsNoOp() async throws {
+    let keychain = MockKeychainAccessor()
+    let bks = BridgeKeyStore(
+      accessGroup: "test.jp.jpng.passwd-sso.shared",
+      keychain: keychain
+    )
+    let blob = try bks.create()
+    let cacheKey = try deriveCacheVaultKey(bridgeKey: blob.bridgeKey)
+    let vaultKey = SymmetricKey(size: .bits256)
+
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    try wrapAndSaveVaultKeyToStore(vaultKey: vaultKey, cacheKey: cacheKey, store: wks)
+
+    // Pre-seed an ECDH blob to verify it is left untouched by biometric unlock.
+    let ecdhSentinel = WrappedECDHPrivateKey(
+      ciphertext: Data([0xDE, 0xAD]),
+      iv: Data(repeating: 0x11, count: 12),
+      authTag: Data(repeating: 0x22, count: 16),
+      issuedAt: Date()
+    )
+    try wks.saveECDHPrivateKey(ecdhSentinel)
+
+    let cacheURL = tmpDir.appending(path: "biometric-ecdh.cache", directoryHint: .notDirectory)
+    let entry = try makePersonalCacheEntryForBiometricTest(
+      vaultKey: vaultKey, userId: "ecdh-bio-user", keyVersion: 1
+    )
+    try buildCacheFileForBiometricTest(
+      at: cacheURL, entries: [entry], vaultKey: vaultKey,
+      hostInstallUUID: blob.hostInstallUUID, counter: blob.cacheVersionCounter,
+      userId: "ecdh-bio-user", now: Date()
+    )
+
+    let unlocker = VaultUnlocker(
+      apiClient: StubVaultAPIClient(mode: .wrongPassphrase),
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      cacheURL: cacheURL,
+      now: { Date() }
+    )
+
+    _ = try await unlocker.unlockWithBiometrics(reason: "test")
+
+    // The ECDH blob must be unchanged — biometric path is a no-op for ECDH.
+    let stored = try XCTUnwrap(try wks.loadECDHPrivateKey(),
+      "Pre-seeded ECDH blob must still be present after biometric unlock")
+    XCTAssertEqual(stored, ecdhSentinel,
+      "Biometric unlock must not modify the existing ECDH blob")
   }
 
   // MARK: - biometricUnlockAvailable only touches bridge-meta-v2 (T3)

--- a/ios/PasswdSSOTests/VaultViewModelTests.swift
+++ b/ios/PasswdSSOTests/VaultViewModelTests.swift
@@ -496,6 +496,245 @@ final class VaultViewModelTests: XCTestCase {
     XCTAssertEqual(summaryCount, 0, "allSummaries must come from sync, not an optimistic prepend")
   }
 
+  // MARK: - loadFromCache with team entries (C9 wiring)
+
+  /// loadFromCache with cacheKey + seeded team key → team entries appear in allSummaries.
+  func testLoadFromCache_withTeamKeyAndCacheKey_decryptsTeamEntries() async throws {
+    let localVaultKey = vaultKey
+    let localUserId = userId
+
+    let cacheKey = SymmetricKey(size: .bits256)
+    let teamId = "team-vm-1"
+    let teamEncKey = SymmetricKey(size: .bits256)
+
+    // Wrap the team key and seed into a MockWrappedKeyStore.
+    let wrappedTeamKey = try TeamEntryDecryptor.wrapTeamKey(
+      teamEncKey: teamEncKey, cacheKey: cacheKey, userId: localUserId,
+      teamId: teamId, teamKeyVersion: 1, issuedAt: Date()
+    )
+    let wks = MockWrappedKeyStore()
+    try wks.saveTeamKeys([wrappedTeamKey])
+
+    // Build a team cache entry.
+    let teamOverviewAAD = try buildTeamEntryAAD(
+      teamId: teamId, entryId: "te-vm-1", vaultType: VaultType.overview, itemKeyVersion: 0
+    )
+    struct OverviewBlob: Encodable { let title: String; let username: String; let urlHost: String }
+    let overviewData = try JSONEncoder().encode(
+      OverviewBlob(title: "Team Login", username: "teamuser", urlHost: "team.example.com")
+    )
+    let teamOverviewEnc = try encryptAESGCMEncoded(
+      plaintext: overviewData, key: teamEncKey, aad: teamOverviewAAD
+    )
+    let dummyBlob = try encryptAESGCMEncoded(plaintext: Data("{}".utf8), key: localVaultKey, aad: nil)
+    let teamEntry = CacheEntry(
+      id: "te-vm-1", teamId: teamId, aadVersion: 1, keyVersion: 0,
+      teamKeyVersion: 1, itemKeyVersion: 0,
+      encryptedItemKey: nil,
+      encryptedBlob: dummyBlob,
+      encryptedOverview: teamOverviewEnc
+    )
+
+    // Also add a personal entry.
+    let personalEntry = CacheEntry(
+      id: "pe-vm-1", teamId: nil, aadVersion: 0,
+      encryptedBlob: try encryptAESGCMEncoded(plaintext: Data(#"{"title":"P","username":"alice","password":"pw","url":"","notes":"","tags":[]}"#.utf8), key: localVaultKey, aad: nil),
+      encryptedOverview: try encryptAESGCMEncoded(plaintext: Data(#"{"title":"P","username":"alice","urlHost":"personal.com"}"#.utf8), key: localVaultKey, aad: nil)
+    )
+
+    let header = CacheHeader(
+      cacheVersionCounter: 1, cacheIssuedAt: Date(), lastSuccessfulRefreshAt: Date(),
+      entryCount: 2, hostInstallUUID: Data(repeating: 0, count: 16), userId: localUserId
+    )
+    let cacheData = CacheData(
+      header: header, entries: try JSONEncoder().encode([personalEntry, teamEntry])
+    )
+
+    let vm = await VaultViewModel()
+    await MainActor.run {
+      vm.loadFromCache(
+        cacheData: cacheData, vaultKey: localVaultKey, userId: localUserId,
+        cacheKey: cacheKey, wrappedKeyStore: wks
+      )
+    }
+
+    let all = await MainActor.run { vm.allSummaries }
+    XCTAssertEqual(all.count, 2, "Both personal and team entries must appear in allSummaries")
+    XCTAssertNotNil(all.first(where: { $0.id == "te-vm-1" }),
+      "Team entry must appear in allSummaries when cacheKey + team key are provided")
+    XCTAssertNotNil(all.first(where: { $0.id == "pe-vm-1" }),
+      "Personal entry must still appear in allSummaries")
+  }
+
+  // MARK: - VaultScope filtering
+
+  func testLoadFromCache_personalScopeFiltersToTeamIdNil() async throws {
+    let localVaultKey = vaultKey
+    let localUserId = userId
+
+    let cacheKey = SymmetricKey(size: .bits256)
+    let teamId = "team-scope"
+    let teamEncKey = SymmetricKey(size: .bits256)
+    let wrappedTeamKey = try TeamEntryDecryptor.wrapTeamKey(
+      teamEncKey: teamEncKey, cacheKey: cacheKey, userId: localUserId,
+      teamId: teamId, teamKeyVersion: 1, issuedAt: Date()
+    )
+    let wks = MockWrappedKeyStore()
+    try wks.saveTeamKeys([wrappedTeamKey])
+
+    struct OverviewBlob: Encodable { let title: String; let username: String; let urlHost: String }
+    let teamAAD = try buildTeamEntryAAD(
+      teamId: teamId, entryId: "te-scope-1", vaultType: VaultType.overview, itemKeyVersion: 0
+    )
+    let teamOverviewEnc = try encryptAESGCMEncoded(
+      plaintext: try JSONEncoder().encode(OverviewBlob(title: "T", username: "u", urlHost: "scope.example.com")),
+      key: teamEncKey, aad: teamAAD
+    )
+    let dummyBlob = try encryptAESGCMEncoded(plaintext: Data("{}".utf8), key: localVaultKey, aad: nil)
+    let teamEntry = CacheEntry(
+      id: "te-scope-1", teamId: teamId, aadVersion: 1, keyVersion: 0,
+      teamKeyVersion: 1, itemKeyVersion: 0,
+      encryptedItemKey: nil, encryptedBlob: dummyBlob, encryptedOverview: teamOverviewEnc
+    )
+    let personalEntry = CacheEntry(
+      id: "pe-scope-1", teamId: nil, aadVersion: 0,
+      encryptedBlob: try encryptAESGCMEncoded(plaintext: Data(#"{"title":"P","username":"p","password":"pw","url":"","notes":"","tags":[]}"#.utf8), key: localVaultKey, aad: nil),
+      encryptedOverview: try encryptAESGCMEncoded(plaintext: Data(#"{"title":"P","username":"p","urlHost":"personal.example.com"}"#.utf8), key: localVaultKey, aad: nil)
+    )
+    let header = CacheHeader(
+      cacheVersionCounter: 1, cacheIssuedAt: Date(), lastSuccessfulRefreshAt: Date(),
+      entryCount: 2, hostInstallUUID: Data(repeating: 0, count: 16), userId: localUserId
+    )
+    let cacheData = CacheData(header: header, entries: try JSONEncoder().encode([personalEntry, teamEntry]))
+
+    let vm = await VaultViewModel()
+    await MainActor.run {
+      vm.loadFromCache(cacheData: cacheData, vaultKey: localVaultKey, userId: localUserId,
+                       cacheKey: cacheKey, wrappedKeyStore: wks)
+      vm.scope = .personal
+    }
+
+    let filtered = await MainActor.run { vm.filteredSummaries }
+    XCTAssertEqual(filtered.count, 1, ".personal scope must show only personal entries")
+    XCTAssertEqual(filtered.first?.id, "pe-scope-1")
+    XCTAssertEqual(filtered.first?.teamId, nil)
+  }
+
+  func testLoadFromCache_teamScopeFiltersToOneTeam() async throws {
+    let localVaultKey = vaultKey
+    let localUserId = userId
+
+    let cacheKey = SymmetricKey(size: .bits256)
+    let teamId = "team-scope-filter"
+    let teamEncKey = SymmetricKey(size: .bits256)
+    let wrappedTeamKey = try TeamEntryDecryptor.wrapTeamKey(
+      teamEncKey: teamEncKey, cacheKey: cacheKey, userId: localUserId,
+      teamId: teamId, teamKeyVersion: 1, issuedAt: Date()
+    )
+    let wks = MockWrappedKeyStore()
+    try wks.saveTeamKeys([wrappedTeamKey])
+
+    struct OverviewBlob: Encodable { let title: String; let username: String; let urlHost: String }
+    let teamAAD = try buildTeamEntryAAD(
+      teamId: teamId, entryId: "te-filter-1", vaultType: VaultType.overview, itemKeyVersion: 0
+    )
+    let teamOverviewEnc = try encryptAESGCMEncoded(
+      plaintext: try JSONEncoder().encode(OverviewBlob(title: "T", username: "u", urlHost: "filter.example.com")),
+      key: teamEncKey, aad: teamAAD
+    )
+    let dummyBlob = try encryptAESGCMEncoded(plaintext: Data("{}".utf8), key: localVaultKey, aad: nil)
+    let teamEntry = CacheEntry(
+      id: "te-filter-1", teamId: teamId, aadVersion: 1, keyVersion: 0,
+      teamKeyVersion: 1, itemKeyVersion: 0,
+      encryptedItemKey: nil, encryptedBlob: dummyBlob, encryptedOverview: teamOverviewEnc
+    )
+    let personalEntry = CacheEntry(
+      id: "pe-filter-1", teamId: nil, aadVersion: 0,
+      encryptedBlob: try encryptAESGCMEncoded(plaintext: Data(#"{"title":"P","username":"p","password":"pw","url":"","notes":"","tags":[]}"#.utf8), key: localVaultKey, aad: nil),
+      encryptedOverview: try encryptAESGCMEncoded(plaintext: Data(#"{"title":"P","username":"p","urlHost":"personal.filter.com"}"#.utf8), key: localVaultKey, aad: nil)
+    )
+    let header = CacheHeader(
+      cacheVersionCounter: 1, cacheIssuedAt: Date(), lastSuccessfulRefreshAt: Date(),
+      entryCount: 2, hostInstallUUID: Data(repeating: 0, count: 16), userId: localUserId
+    )
+    let cacheData = CacheData(header: header, entries: try JSONEncoder().encode([personalEntry, teamEntry]))
+
+    let vm = await VaultViewModel()
+    await MainActor.run {
+      vm.loadFromCache(cacheData: cacheData, vaultKey: localVaultKey, userId: localUserId,
+                       cacheKey: cacheKey, wrappedKeyStore: wks)
+      vm.scope = .team(teamId)
+    }
+
+    let filtered = await MainActor.run { vm.filteredSummaries }
+    XCTAssertEqual(filtered.count, 1, ".team scope must show only that team's entries")
+    XCTAssertEqual(filtered.first?.id, "te-filter-1")
+    XCTAssertEqual(filtered.first?.teamId, teamId)
+  }
+
+  /// teamDirectory labels are loaded from cacheKey-decrypted directory.
+  func testLoadFromCache_teamDirectoryLabels() async throws {
+    let localVaultKey = vaultKey
+    let localUserId = userId
+    let localEntryId = entryId
+
+    let directory = [
+      TeamDirectoryEntry(id: "team-dir-1", name: "Alpha Team"),
+      TeamDirectoryEntry(id: "team-dir-2", name: "Beta Team"),
+    ]
+    let cacheData = try makeCacheData(
+      entryId: localEntryId, userId: localUserId, vaultKey: localVaultKey,
+      blobJSON: #"{"title":"T","username":"u","password":"pw","url":null,"notes":null}"#,
+      overviewJSON: #"{"title":"T","username":"u","urlHost":null}"#,
+      aadVersion: 0
+    )
+
+    let vm = await VaultViewModel()
+    await MainActor.run {
+      vm.loadFromCache(
+        cacheData: cacheData, vaultKey: localVaultKey, userId: localUserId,
+        teamDirectory: directory
+      )
+    }
+
+    let labels = await MainActor.run { vm.teamDirectory }
+    XCTAssertEqual(labels.count, 2)
+    XCTAssertEqual(labels.first(where: { $0.id == "team-dir-1" })?.name, "Alpha Team")
+    XCTAssertEqual(labels.first(where: { $0.id == "team-dir-2" })?.name, "Beta Team")
+  }
+
+  /// No cacheKey → personal-only, team entries skipped, no crash.
+  func testLoadFromCache_noCacheKey_personalOnly() async throws {
+    let localVaultKey = vaultKey
+    let localUserId = userId
+
+    let dummyEnc = try encryptAESGCMEncoded(plaintext: Data("{}".utf8), key: localVaultKey, aad: nil)
+    let teamEntry = CacheEntry(
+      id: "te-nocache", teamId: "some-team", aadVersion: 0,
+      encryptedBlob: dummyEnc, encryptedOverview: dummyEnc
+    )
+    let personalEntry = CacheEntry(
+      id: "pe-nocache", teamId: nil, aadVersion: 0,
+      encryptedBlob: try encryptAESGCMEncoded(plaintext: Data(#"{"title":"P","username":"p","password":"pw","url":"","notes":"","tags":[]}"#.utf8), key: localVaultKey, aad: nil),
+      encryptedOverview: try encryptAESGCMEncoded(plaintext: Data(#"{"title":"P","username":"p","urlHost":"only.personal.com"}"#.utf8), key: localVaultKey, aad: nil)
+    )
+    let header = CacheHeader(
+      cacheVersionCounter: 1, cacheIssuedAt: Date(), lastSuccessfulRefreshAt: Date(),
+      entryCount: 2, hostInstallUUID: Data(repeating: 0, count: 16), userId: localUserId
+    )
+    let cacheData = CacheData(header: header, entries: try JSONEncoder().encode([personalEntry, teamEntry]))
+
+    let vm = await VaultViewModel()
+    await MainActor.run {
+      // No cacheKey → personal-only (no team key store access).
+      vm.loadFromCache(cacheData: cacheData, vaultKey: localVaultKey, userId: localUserId)
+    }
+
+    let all = await MainActor.run { vm.allSummaries }
+    XCTAssertEqual(all.count, 1, "Without cacheKey only personal entries must be in allSummaries")
+    XCTAssertEqual(all.first?.id, "pe-nocache")
+  }
+
   // MARK: - createEntry 401 + nonce retry
 
   func testCreateEntry_retriesOnceWith401AndNewNonce() async throws {

--- a/ios/PasswdSSOTests/WrappedKeyStoreTests.swift
+++ b/ios/PasswdSSOTests/WrappedKeyStoreTests.swift
@@ -92,6 +92,44 @@ final class WrappedKeyStoreTests: XCTestCase {
     XCTAssertTrue(loaded.isEmpty)
   }
 
+  // MARK: - ECDH private key round-trip
+
+  func testECDHPrivateKeyRoundTrip() throws {
+    XCTAssertNil(try store.loadECDHPrivateKey(), "Should be nil before save")
+
+    let wrapped = WrappedECDHPrivateKey(
+      ciphertext: Data([0xAB, 0xCD]),
+      iv: Data(repeating: 0x11, count: 12),
+      authTag: Data(repeating: 0x22, count: 16),
+      issuedAt: Date(timeIntervalSince1970: 2_000_000)
+    )
+    try store.saveECDHPrivateKey(wrapped)
+
+    let loaded = try store.loadECDHPrivateKey()
+    XCTAssertNotNil(loaded)
+    XCTAssertEqual(loaded, wrapped)
+  }
+
+  func testECDHPrivateKeyOverwrite() throws {
+    let first = WrappedECDHPrivateKey(
+      ciphertext: Data([0x01]),
+      iv: Data(repeating: 0x10, count: 12),
+      authTag: Data(repeating: 0x10, count: 16),
+      issuedAt: Date(timeIntervalSince1970: 1000)
+    )
+    let second = WrappedECDHPrivateKey(
+      ciphertext: Data([0x02]),
+      iv: Data(repeating: 0x20, count: 12),
+      authTag: Data(repeating: 0x20, count: 16),
+      issuedAt: Date(timeIntervalSince1970: 2000)
+    )
+    try store.saveECDHPrivateKey(first)
+    try store.saveECDHPrivateKey(second)
+
+    let loaded = try store.loadECDHPrivateKey()
+    XCTAssertEqual(loaded, second, "Second write should replace first")
+  }
+
   // MARK: - clearAll
 
   func testClearAllDeletesBothFiles() throws {
@@ -118,6 +156,65 @@ final class WrappedKeyStoreTests: XCTestCase {
 
     XCTAssertNil(try store.loadVaultKey())
     XCTAssertTrue((try store.loadTeamKeys()).isEmpty)
+  }
+
+  // MARK: - clearAll removes ECDH file too
+
+  func testClearAllDeletesECDHFile() throws {
+    let vk = WrappedVaultKey(
+      ciphertext: Data([0x01]),
+      iv: Data(repeating: 0x01, count: 12),
+      authTag: Data(repeating: 0x01, count: 16),
+      issuedAt: Date()
+    )
+    let ecdh = WrappedECDHPrivateKey(
+      ciphertext: Data([0xAB]),
+      iv: Data(repeating: 0xAB, count: 12),
+      authTag: Data(repeating: 0xAB, count: 16),
+      issuedAt: Date()
+    )
+    try store.saveVaultKey(vk)
+    try store.saveECDHPrivateKey(ecdh)
+
+    // Confirm files exist before clearing.
+    XCTAssertNotNil(try store.loadVaultKey())
+    XCTAssertNotNil(try store.loadECDHPrivateKey())
+
+    try store.clearAll()
+
+    XCTAssertNil(try store.loadVaultKey(), "vault key must be deleted by clearAll")
+    XCTAssertNil(try store.loadECDHPrivateKey(), "ECDH key must be deleted by clearAll")
+  }
+
+  // MARK: - clearTeamKeys leaves vault key intact
+
+  func testClearTeamKeysRemovesTeamKeysButLeavesVaultKey() throws {
+    let vk = WrappedVaultKey(
+      ciphertext: Data([0x01]),
+      iv: Data(repeating: 0x01, count: 12),
+      authTag: Data(repeating: 0x01, count: 16),
+      issuedAt: Date()
+    )
+    let keys = [
+      WrappedTeamKey(
+        teamId: "team-clear",
+        ciphertext: Data([0xAA]),
+        iv: Data(repeating: 0x05, count: 12),
+        authTag: Data(repeating: 0x06, count: 16),
+        issuedAt: Date(),
+        teamKeyVersion: 1
+      )
+    ]
+    try store.saveVaultKey(vk)
+    try store.saveTeamKeys(keys)
+
+    try store.clearTeamKeys()
+
+    // Team keys must be gone.
+    XCTAssertTrue((try store.loadTeamKeys()).isEmpty, "clearTeamKeys must remove team keys")
+    // Vault key must survive.
+    XCTAssertNotNil(try store.loadVaultKey(), "clearTeamKeys must NOT touch the vault key")
+    XCTAssertEqual(try store.loadVaultKey(), vk)
   }
 
   // MARK: - Atomic write (no torn .tmp left behind)
@@ -159,6 +256,10 @@ final class TempDirWrappedKeyStore: WrappedKeyStore, @unchecked Sendable {
     baseDir.appending(path: "vault/wrapped-team-keys.json", directoryHint: .notDirectory)
   }
 
+  private var ecdhKeyURL: URL {
+    baseDir.appending(path: "vault/wrapped-ecdh-private-key.json", directoryHint: .notDirectory)
+  }
+
   func saveVaultKey(_ wrapped: WrappedVaultKey) throws {
     try ensureVaultDir()
     let data = try JSONEncoder().encode(wrapped)
@@ -183,10 +284,28 @@ final class TempDirWrappedKeyStore: WrappedKeyStore, @unchecked Sendable {
     return try JSONDecoder().decode([WrappedTeamKey].self, from: data)
   }
 
+  func clearTeamKeys() throws {
+    let fm = FileManager.default
+    if fm.fileExists(atPath: teamKeysURL.path) { try fm.removeItem(at: teamKeysURL) }
+  }
+
+  func saveECDHPrivateKey(_ wrapped: WrappedECDHPrivateKey) throws {
+    try ensureVaultDir()
+    let data = try JSONEncoder().encode(wrapped)
+    try atomicWrite(data: data, to: ecdhKeyURL)
+  }
+
+  func loadECDHPrivateKey() throws -> WrappedECDHPrivateKey? {
+    guard FileManager.default.fileExists(atPath: ecdhKeyURL.path) else { return nil }
+    let data = try Data(contentsOf: ecdhKeyURL)
+    return try JSONDecoder().decode(WrappedECDHPrivateKey.self, from: data)
+  }
+
   func clearAll() throws {
     let fm = FileManager.default
     if fm.fileExists(atPath: vaultKeyURL.path) { try fm.removeItem(at: vaultKeyURL) }
     if fm.fileExists(atPath: teamKeysURL.path) { try fm.removeItem(at: teamKeysURL) }
+    if fm.fileExists(atPath: ecdhKeyURL.path) { try fm.removeItem(at: ecdhKeyURL) }
   }
 
   private func ensureVaultDir() throws {

--- a/ios/PasswdSSOTests/fixtures/team-key-fixture.json
+++ b/ios/PasswdSSOTests/fixtures/team-key-fixture.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "Captured from extension/src/lib/crypto-team.ts via scripts/generate-team-key-fixture.ts. Do not hand-edit.",
+  "secretKeyHex": "6d7db94189161de9bf187fc3319bfbca64e2a8dedce95d04af1c816675437c61",
+  "encryptedEcdhPrivateKey": {
+    "ciphertext": "8cd3c55bdef4da4ccb7244f8b6a6e35de4a469da40dc0889c5b9aa96d36a3895a109d162d9491a299ba8be1de2a4c2809259c075ccc9bc8a7faad73db2971531a25cef67b6b2c78442423db4bb8c06ea2d2ad9bf25b0187349446afbfd8642ffb9a14216eb9ef8748c16e71a484830f2f73579585052bfcd1bf08de60e85293deb45708804e554a1ac67",
+    "iv": "3d8e1e29eb802a1b48743042",
+    "authTag": "208ad74b32c63da9acaca6ea1f913570"
+  },
+  "pkcs8PrivKeyHex": "308187020100301306072a8648ce3d020106082a8648ce3d030107046d306b0201010420cbab82ca640a0f73d69913f548127bba3952bf821cf1bc9f5070b5cbd7de1ee8a144034200040dffada9b085558760062417026336e7ca6e9a2777a2e33822482fb14313238ad8ad72c3c748ec6d62ef9e6cf5c0b6f1f7896432df5ac8886c3f225d59da446a",
+  "ephemeralPublicKeyJwk": "{\"key_ops\":[],\"ext\":true,\"kty\":\"EC\",\"x\":\"hVWa0N08Pf_hKr61uyhI-gqCr7TsCooA8NhmVVXu464\",\"y\":\"zUL1SkuUSzKS40FNHtcifhb6URte1lvyPLq4JXN2IpI\",\"crv\":\"P-256\"}",
+  "hkdfSaltHex": "a00d9d3036012a3c8d4fb6351e445753709028f61634a3c42e1348f8f0ccaced",
+  "encryptedTeamKey": {
+    "ciphertext": "0e99ed127bce28d7a432c31b042bf67d0d49f337c0c2b266568ae909618c159f",
+    "iv": "9b627fd74b9f0b57d5516a1c",
+    "authTag": "0af1d0a8614e15d78074e913f2ca9749"
+  },
+  "teamId": "team-fixture-1",
+  "toUserId": "user-fixture-1",
+  "keyVersion": 1,
+  "wrapVersion": 1,
+  "rawTeamKeyHex": "84cd6fcbde7321a46010ec1ae9bbc5c48da70a44aec4a7e01eea59adfcee9c70",
+  "teamEncKeyHex": "a0edf4345c8f72ca5b8e57ef98ba203ff12dd7c9ebc896a4b5a2fe3be48dd39c",
+  "entryId": "00000000-0000-4000-8000-000000000001",
+  "encryptedOverview": {
+    "ciphertext": "a9a31b56f6999c035b4fe69aaf94d13ca8f86c927e484f74a32f1dda559c6a94044b7c8581418533874ceadb51832e1b52401f9ec643f86b0695dd3f2629515e3fa9c516023a8f63a916375acc9a128ee24c",
+    "iv": "3e830c5b051cd61716aff6dd",
+    "authTag": "c23eac81fe4ec471cb9deebfa6ccfee1"
+  },
+  "overviewPlaintext": "{\"title\":\"Team Login\",\"username\":\"alice@example.com\",\"urlHost\":\"team.example.com\"}",
+  "teamKeyWrapAADHex": "4f4b0104000e7465616d2d666978747572652d31000e757365722d666978747572652d31000131000131",
+  "overviewAADHex": "4f560104000e7465616d2d666978747572652d31002430303030303030302d303030302d343030302d383030302d30303030303030303030303100086f76657276696577000130",
+  "memberPublicKeyRawHex": "040dffada9b085558760062417026336e7ca6e9a2777a2e33822482fb14313238ad8ad72c3c748ec6d62ef9e6cf5c0b6f1f7896432df5ac8886c3f225d59da446a",
+  "teamKeyVersion": 1,
+  "entryIdV1": "00000000-0000-4000-8000-000000000002",
+  "encryptedItemKey": {
+    "ciphertext": "f350060cbe18651de2dfea5736ba1e84325056c0cf3d03cad26d8f941fa59c99",
+    "iv": "bdb424760c7222f6bbfe2a7d",
+    "authTag": "bfa064d3a98217c24ec361a049df025a"
+  },
+  "itemKeyHex": "ed83464ac61093ed668a46a8076573858f2e1cf6b0fb52877360176a0aff53ba",
+  "itemEncKeyHex": "d9009e40cc335b67bb0a59b1c7b22512cd230bcf9e5d971eb5170b2fcdafb605",
+  "encryptedOverviewV1": {
+    "ciphertext": "b7f4d456e5f3c96eb51519957c1b8d14d818f1d3e5508a2c314e534140c69d5ea39521a3ca63e361d432c87eac33b143493eb7d2fd12734401e7a4e17474c77a1c646e7099b49cb279ea14139198e7acd9",
+    "iv": "1c0facb464ec43af7ab24028",
+    "authTag": "6c5e041a28d1b9ad64af76c42d3a1dde"
+  },
+  "overviewPlaintextV1": "{\"title\":\"Team Login v1\",\"username\":\"bob@example.com\",\"urlHost\":\"v1.example.com\"}"
+}

--- a/ios/Shared/AutoFill/CredentialIdentityRegistrar.swift
+++ b/ios/Shared/AutoFill/CredentialIdentityRegistrar.swift
@@ -98,19 +98,54 @@ public func buildPasskeyIdentitySpecs(
   return result
 }
 
+/// Decrypt TEAM entry overviews for QuickType registration. Requires the cacheKey
+/// (to unwrap the persisted team keys) — when cacheKey/team keys are absent the
+/// caller simply gets no team suggestions (personal-only, no regression). Shares
+/// the exact decrypt path with `CredentialResolver` via `TeamEntryDecryptor`.
+public func decryptTeamOverviews(
+  from cacheData: CacheData,
+  cacheKey: SymmetricKey,
+  userId: String,
+  wrappedKeyStore: WrappedKeyStore,
+  now: @escaping () -> Date = { Date() }
+) -> [VaultEntrySummary] {
+  guard let entries = try? JSONDecoder().decode([CacheEntry].self, from: cacheData.entries) else {
+    return []
+  }
+  let teamKeys = (try? wrappedKeyStore.loadTeamKeys()) ?? []
+  guard !teamKeys.isEmpty else { return [] }
+  var result: [VaultEntrySummary] = []
+  for entry in entries where entry.teamId != nil {
+    if let summary = TeamEntryDecryptor.decryptTeamSummary(
+      entry: entry, teamKeys: teamKeys, cacheKey: cacheKey, userId: userId, now: now) {
+      result.append(summary)
+    }
+  }
+  return result
+}
+
 // MARK: - One-step refresh
 
 /// Decrypt personal summaries + passkey specs from a fresh cache and replace
 /// the OS credential-identity store in one step. Single entry point for every
 /// refresh site (foreground sync, vault unlock, entry create/save) so the
 /// summaries/passkeys/replace sequence cannot drift between call sites.
+///
+/// When `cacheKey` + `wrappedKeyStore` are supplied, TEAM entries are registered
+/// too (QuickType for team credentials). Omitting them registers personal-only.
 public func refreshCredentialIdentities(
   from cacheData: CacheData,
   vaultKey: SymmetricKey,
   userId: String,
+  cacheKey: SymmetricKey? = nil,
+  wrappedKeyStore: WrappedKeyStore? = nil,
   registrar: CredentialIdentityRegistrar = CredentialIdentityRegistrar()
 ) async {
-  let summaries = decryptPersonalOverviews(from: cacheData, vaultKey: vaultKey, userId: userId)
+  var summaries = decryptPersonalOverviews(from: cacheData, vaultKey: vaultKey, userId: userId)
+  if let cacheKey, let wrappedKeyStore {
+    summaries += decryptTeamOverviews(
+      from: cacheData, cacheKey: cacheKey, userId: userId, wrappedKeyStore: wrappedKeyStore)
+  }
   let passkeys = buildPasskeyIdentitySpecs(from: cacheData, vaultKey: vaultKey, userId: userId)
   await registrar.replace(with: summaries, passkeys: passkeys)
 }

--- a/ios/Shared/AutoFill/CredentialResolver.swift
+++ b/ios/Shared/AutoFill/CredentialResolver.swift
@@ -214,11 +214,11 @@ public actor CredentialResolver {
           continue
         }
         // Unwrap team key using cacheKey (team keys are wrapped under cacheKey, not vault_key).
-        guard let teamKey = decryptTeamKey(wrappedTeamKey, cacheKey: cacheKey) else {
+        guard let teamKey = TeamEntryDecryptor.unwrapTeamKey(wrappedTeamKey, cacheKey: cacheKey, userId: userId) else {
           continue
         }
         // Unwrap ItemKey if itemKeyVersion >= 1.
-        guard let entryKey = resolveTeamEntryKey(entry: entry, teamKey: teamKey) else {
+        guard let entryKey = TeamEntryDecryptor.resolveTeamEntryKey(entry: entry, teamKey: teamKey) else {
           continue
         }
         if let summary = decryptSummary(entry: entry, key: entryKey, userId: userId) {
@@ -331,11 +331,17 @@ public actor CredentialResolver {
       guard let wrappedTeamKey = teamKeys.first(where: { $0.teamId == teamId }) else {
         throw Error.entryNotFound
       }
-      // Team keys are wrapped under cacheKey (same as vault_key wrapping).
-      guard let teamKey = decryptTeamKey(wrappedTeamKey, cacheKey: cacheKey) else {
+      // Enforce the same 15-min staleness bound as resolveCandidates: a revoked
+      // membership must stop FILLING (not just stop appearing in the list) within
+      // the revocation window, even if the stale key still decrypts.
+      guard now().timeIntervalSince(wrappedTeamKey.issuedAt) <= teamKeyMaxAge else {
         throw Error.entryNotFound
       }
-      guard let entryKey = resolveTeamEntryKey(entry: entry, teamKey: teamKey) else {
+      // Team keys are wrapped under cacheKey (same as vault_key wrapping).
+      guard let teamKey = TeamEntryDecryptor.unwrapTeamKey(wrappedTeamKey, cacheKey: cacheKey, userId: userId) else {
+        throw Error.entryNotFound
+      }
+      guard let entryKey = TeamEntryDecryptor.resolveTeamEntryKey(entry: entry, teamKey: teamKey) else {
         throw Error.entryNotFound
       }
       decryptKey = entryKey
@@ -715,60 +721,8 @@ public actor CredentialResolver {
     }
   }
 
-  /// Resolve the entry-level key:
-  /// - itemKeyVersion == 0 → use teamKey directly.
-  /// - itemKeyVersion >= 1 → decrypt encryptedItemKey with teamKey + wrap AAD.
-  private func resolveTeamEntryKey(
-    entry: CacheEntry,
-    teamKey: SymmetricKey
-  ) -> SymmetricKey? {
-    let itemKeyVersion = entry.itemKeyVersion ?? 0
-    if itemKeyVersion == 0 {
-      return teamKey
-    }
-    guard
-      let teamId = entry.teamId,
-      let teamKeyVersion = entry.teamKeyVersion,
-      let wrapped = entry.encryptedItemKey,
-      let aad = try? buildItemKeyWrapAAD(
-        teamId: teamId,
-        entryId: entry.id,
-        teamKeyVersion: teamKeyVersion
-      ),
-      let cipher = try? hexDecode(wrapped.ciphertext),
-      let iv = try? hexDecode(wrapped.iv),
-      let tag = try? hexDecode(wrapped.authTag),
-      let itemKeyData = try? decryptAESGCM(
-        ciphertext: cipher,
-        iv: iv,
-        tag: tag,
-        key: teamKey,
-        aad: aad
-      )
-    else {
-      return nil
-    }
-    return SymmetricKey(data: itemKeyData)
-  }
-
-  /// Unwrap a stored team key using cacheKey (the HKDF-derived bridge_key derivative).
-  /// Team keys are wrapped under cacheKey, matching the vault_key wrapping scheme.
-  private func decryptTeamKey(
-    _ wrapped: WrappedTeamKey,
-    cacheKey: SymmetricKey
-  ) -> SymmetricKey? {
-    guard
-      let plaintext = try? decryptAESGCM(
-        ciphertext: wrapped.ciphertext,
-        iv: wrapped.iv,
-        tag: wrapped.authTag,
-        key: cacheKey
-      )
-    else {
-      return nil
-    }
-    return SymmetricKey(data: plaintext)
-  }
+  // Team-key unwrap + entry-key resolution moved to the shared `TeamEntryDecryptor`
+  // (single source of truth; also used by CredentialIdentityRegistrar + HostSyncService).
 
   private func writeRollbackFlag(
     kind: CacheRejectionKind,

--- a/ios/Shared/AutoFill/TeamEntryDecryptor.swift
+++ b/ios/Shared/AutoFill/TeamEntryDecryptor.swift
@@ -1,0 +1,146 @@
+import CryptoKit
+import Foundation
+
+/// Shared team-entry decrypt logic used by BOTH `CredentialResolver` (AutoFill
+/// fill path) and `CredentialIdentityRegistrar` (QuickType registration), and the
+/// host-side wrap path in `HostSyncService`. Single source of truth for the
+/// on-device cacheKey wrap/unwrap of team keys and the ECDH private key, so the
+/// `buildLocalWrapAAD` binding is constructed identically on write and read.
+public enum TeamEntryDecryptor {
+  /// Reject wrapped team keys older than this (revocation bound). Matches the
+  /// `CredentialResolver` default.
+  public static let teamKeyMaxAge: TimeInterval = 15 * 60
+
+  // MARK: - ECDH private key wrap/unwrap (cacheKey, AAD kind:"ecdh")
+
+  public static func wrapEcdhPrivateKey(
+    pkcs8: Data, cacheKey: SymmetricKey, userId: String, issuedAt: Date
+  ) throws -> WrappedECDHPrivateKey {
+    let aad = try buildLocalWrapAAD(kind: "ecdh", userId: userId)
+    let (ct, iv, tag) = try encryptAESGCM(plaintext: pkcs8, key: cacheKey, aad: aad)
+    return WrappedECDHPrivateKey(ciphertext: ct, iv: iv, authTag: tag, issuedAt: issuedAt)
+  }
+
+  /// Returns the PKCS#8 bytes; caller is responsible for zeroizing them.
+  public static func unwrapEcdhPrivateKey(
+    _ wrapped: WrappedECDHPrivateKey, cacheKey: SymmetricKey, userId: String
+  ) -> Data? {
+    guard let aad = try? buildLocalWrapAAD(kind: "ecdh", userId: userId) else { return nil }
+    return try? decryptAESGCM(
+      ciphertext: wrapped.ciphertext, iv: wrapped.iv, tag: wrapped.authTag, key: cacheKey, aad: aad)
+  }
+
+  // MARK: - Team key wrap/unwrap (cacheKey, AAD kind:"team")
+
+  /// Host (sync) side: wrap the DERIVED team encryption key under cacheKey.
+  public static func wrapTeamKey(
+    teamEncKey: SymmetricKey, cacheKey: SymmetricKey, userId: String,
+    teamId: String, teamKeyVersion: Int, issuedAt: Date
+  ) throws -> WrappedTeamKey {
+    let aad = try buildLocalWrapAAD(kind: "team", userId: userId, teamId: teamId)
+    var keyBytes = teamEncKey.withUnsafeBytes { Data($0) }
+    defer { keyBytes.resetBytes(in: 0..<keyBytes.count) }
+    let (ct, iv, tag) = try encryptAESGCM(plaintext: keyBytes, key: cacheKey, aad: aad)
+    return WrappedTeamKey(
+      teamId: teamId, ciphertext: ct, iv: iv, authTag: tag,
+      issuedAt: issuedAt, teamKeyVersion: teamKeyVersion)
+  }
+
+  /// Read side: unwrap the stored team encryption key, verifying the localWrap AAD.
+  public static func unwrapTeamKey(
+    _ wrapped: WrappedTeamKey, cacheKey: SymmetricKey, userId: String
+  ) -> SymmetricKey? {
+    guard let aad = try? buildLocalWrapAAD(kind: "team", userId: userId, teamId: wrapped.teamId),
+          let plain = try? decryptAESGCM(
+            ciphertext: wrapped.ciphertext, iv: wrapped.iv, tag: wrapped.authTag,
+            key: cacheKey, aad: aad)
+    else { return nil }
+    return SymmetricKey(data: plain)
+  }
+
+  // MARK: - Entry-level key + summary decrypt
+
+  /// Resolve the entry-level key:
+  /// - itemKeyVersion==0 → the team encryption key directly.
+  /// - itemKeyVersion>=1 → unwrap the per-entry ItemKey with the team enc key +
+  ///   item-key-wrap AAD, THEN derive the item encryption key (HKDF
+  ///   "passwd-sso-item-enc-v1"). The raw unwrapped ItemKey is NOT the entry key.
+  public static func resolveTeamEntryKey(entry: CacheEntry, teamKey: SymmetricKey) -> SymmetricKey? {
+    let itemKeyVersion = entry.itemKeyVersion ?? 0
+    if itemKeyVersion == 0 { return teamKey }
+    guard
+      let teamId = entry.teamId,
+      let teamKeyVersion = entry.teamKeyVersion,
+      let wrapped = entry.encryptedItemKey,
+      let aad = try? buildItemKeyWrapAAD(teamId: teamId, entryId: entry.id, teamKeyVersion: teamKeyVersion),
+      let cipher = try? hexDecode(wrapped.ciphertext),
+      let iv = try? hexDecode(wrapped.iv),
+      let tag = try? hexDecode(wrapped.authTag),
+      var itemKeyData = try? decryptAESGCM(ciphertext: cipher, iv: iv, tag: tag, key: teamKey, aad: aad)
+    else { return nil }
+    defer { itemKeyData.resetBytes(in: 0..<itemKeyData.count) }
+    return TeamKeyCrypto.deriveItemEncryptionKey(itemKey: SymmetricKey(data: itemKeyData))
+  }
+
+  /// Resolve the per-entry decryption key for a team entry: lookup by teamId,
+  /// 15-min staleness, cacheKey unwrap, item-key resolve. Returns nil to skip.
+  public static func teamEntryKey(
+    entry: CacheEntry, teamKeys: [WrappedTeamKey], cacheKey: SymmetricKey,
+    userId: String, now: () -> Date
+  ) -> SymmetricKey? {
+    guard
+      let teamId = entry.teamId,
+      let wrapped = teamKeys.first(where: { $0.teamId == teamId }),
+      now().timeIntervalSince(wrapped.issuedAt) <= teamKeyMaxAge,
+      let teamKey = unwrapTeamKey(wrapped, cacheKey: cacheKey, userId: userId)
+    else { return nil }
+    // Defensive: the AAD binding uses wrapped.teamId; if a future refactor decouples
+    // lookup from unwrap, this surfaces a key-mismatch bug directly (S12) instead of
+    // as an opaque AEAD failure. Today the lookup guarantees equality.
+    assert(wrapped.teamId == teamId, "teamEntryKey: wrapped.teamId \(wrapped.teamId) != \(teamId)")
+    return resolveTeamEntryKey(entry: entry, teamKey: teamKey)
+  }
+
+  /// Full team-entry overview decrypt for QuickType registration + in-app list.
+  /// Returns nil (skip) on any failure — callers offer only what decrypts.
+  public static func decryptTeamSummary(
+    entry: CacheEntry, teamKeys: [WrappedTeamKey], cacheKey: SymmetricKey,
+    userId: String, now: () -> Date
+  ) -> VaultEntrySummary? {
+    guard
+      let teamId = entry.teamId,
+      let entryKey = teamEntryKey(
+        entry: entry, teamKeys: teamKeys, cacheKey: cacheKey, userId: userId, now: now),
+      let aad = try? buildTeamEntryAAD(
+        teamId: teamId, entryId: entry.id, vaultType: VaultType.overview,
+        itemKeyVersion: entry.itemKeyVersion ?? 0),
+      let iv = try? hexDecode(entry.encryptedOverview.iv),
+      let cipher = try? hexDecode(entry.encryptedOverview.ciphertext),
+      let tag = try? hexDecode(entry.encryptedOverview.authTag),
+      let plaintext = try? decryptAESGCM(ciphertext: cipher, iv: iv, tag: tag, key: entryKey, aad: aad)
+    else { return nil }
+    return EntryBlobDecoder.summary(
+      plaintext: plaintext, entryId: entry.id, teamId: teamId,
+      entryType: entry.entryType, isFavorite: entry.isFavorite ?? false)
+  }
+
+  /// Full team-entry detail (blob) decrypt for the in-app detail screen.
+  public static func decryptTeamDetail(
+    entry: CacheEntry, teamKeys: [WrappedTeamKey], cacheKey: SymmetricKey,
+    userId: String, now: () -> Date
+  ) -> VaultEntryDetail? {
+    guard
+      let teamId = entry.teamId,
+      let entryKey = teamEntryKey(
+        entry: entry, teamKeys: teamKeys, cacheKey: cacheKey, userId: userId, now: now),
+      let aad = try? buildTeamEntryAAD(
+        teamId: teamId, entryId: entry.id, vaultType: VaultType.blob,
+        itemKeyVersion: entry.itemKeyVersion ?? 0),
+      let iv = try? hexDecode(entry.encryptedBlob.iv),
+      let cipher = try? hexDecode(entry.encryptedBlob.ciphertext),
+      let tag = try? hexDecode(entry.encryptedBlob.authTag),
+      let plaintext = try? decryptAESGCM(ciphertext: cipher, iv: iv, tag: tag, key: entryKey, aad: aad)
+    else { return nil }
+    return EntryBlobDecoder.detail(plaintext: plaintext, entryId: entry.id, teamId: teamId)
+  }
+}

--- a/ios/Shared/Crypto/AAD.swift
+++ b/ios/Shared/Crypto/AAD.swift
@@ -13,6 +13,10 @@ public enum AADScope: String {
   case team = "OV"
   case attachment = "AT"
   case itemKey = "IK"
+  /// TeamMemberKey wrapping (server-compat, mirrors extension crypto-team.ts).
+  case teamKey = "OK"
+  /// iOS-local cacheKey wraps (ECDH key + team enc keys) — NOT shared with server.
+  case localWrap = "LW"
 }
 
 /// Vault-field discriminators used in the AAD `vaultType` field, mirroring
@@ -94,6 +98,31 @@ public func buildItemKeyWrapAAD(
 /// Build AAD for an attachment (entryId, attachmentId).
 public func buildAttachmentAAD(entryId: String, attachmentId: String) throws -> Data {
   try buildAADBytes(scope: .attachment, fields: [entryId, attachmentId])
+}
+
+/// Build AAD for the server-side TeamMemberKey wrap (teamId, toUserId, keyVersion,
+/// wrapVersion). Byte-identical to the extension's buildTeamKeyWrapAAD (scope "OK").
+public func buildTeamKeyWrapAAD(
+  teamId: String,
+  toUserId: String,
+  keyVersion: Int,
+  wrapVersion: Int
+) throws -> Data {
+  try buildAADBytes(
+    scope: .teamKey,
+    fields: [teamId, toUserId, String(keyVersion), String(wrapVersion)]
+  )
+}
+
+/// Build AAD for an on-device cacheKey wrap (scope "LW"). Binds the wrapped blob
+/// to the user (and team) it was derived for so a transplanted blob fails AEAD.
+/// `kind` is "ecdh" or "team"; `teamId` is "" for the ECDH key.
+public func buildLocalWrapAAD(
+  kind: String,
+  userId: String,
+  teamId: String = ""
+) throws -> Data {
+  try buildAADBytes(scope: .localWrap, fields: [kind, userId, teamId])
 }
 
 public enum AADError: Error, Equatable {

--- a/ios/Shared/Crypto/TeamKeyCrypto.swift
+++ b/ios/Shared/Crypto/TeamKeyCrypto.swift
@@ -1,0 +1,141 @@
+import CryptoKit
+import Foundation
+
+/// Team-key crypto, mirroring the browser extension's `crypto-team.ts` so iOS can
+/// decrypt team entries. Verified byte-for-byte by golden vectors (TeamKeyCryptoTests).
+///
+/// Derivation chain (read/decrypt side only):
+///   secretKey → HKDF("passwd-sso-ecdh-v1", salt=zero32) → ecdhWrappingKey → AES-GCM → ECDH private key
+///   ECDH(member, ephemeral) → HKDF("passwd-sso-team-v1", salt=memberKey.hkdfSalt) → AES-GCM(AAD "OK") → rawTeamKey
+///   rawTeamKey → HKDF("passwd-sso-team-enc-v1", salt=zero32) → teamEncKey (entry decryption key)
+public enum TeamKeyCrypto {
+  private static let zeroSalt = Data(repeating: 0, count: 32)
+  private static let ecdhWrapInfo = "passwd-sso-ecdh-v1"
+  private static let teamWrapInfo = "passwd-sso-team-v1"
+  private static let teamEncInfo = "passwd-sso-team-enc-v1"
+  private static let itemEncInfo = "passwd-sso-item-enc-v1"
+
+  public enum TeamKeyCryptoError: Error, Equatable {
+    case unsupportedKeyType
+    case malformedPublicKey
+  }
+
+  /// HKDF(secretKey, salt=zero32, info="passwd-sso-ecdh-v1") → 32-byte AES key
+  /// that wraps the account ECDH private key.
+  public static func deriveEcdhWrappingKey(secretKey: SymmetricKey) -> SymmetricKey {
+    HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: secretKey,
+      salt: zeroSalt,
+      info: Data(ecdhWrapInfo.utf8),
+      outputByteCount: 32
+    )
+  }
+
+  /// Decrypt the wrapped account ECDH private key (PKCS#8, no AAD) and import it.
+  /// Returns the imported key directly; the intermediate PKCS#8 bytes are zeroized.
+  public static func unwrapEcdhPrivateKey(
+    encrypted: EncryptedData,
+    wrappingKey: SymmetricKey
+  ) throws -> P256.KeyAgreement.PrivateKey {
+    var pkcs8 = try decryptAESGCM(
+      ciphertext: try hexDecode(encrypted.ciphertext),
+      iv: try hexDecode(encrypted.iv),
+      tag: try hexDecode(encrypted.authTag),
+      key: wrappingKey
+    )
+    defer { pkcs8.resetBytes(in: 0..<pkcs8.count) }
+    return try importEcdhPrivateKey(pkcs8: pkcs8)
+  }
+
+  /// Import a PKCS#8 DER ECDH private key. CryptoKit's `derRepresentation`
+  /// accepts PKCS#8 PrivateKeyInfo (what WebCrypto exports via "pkcs8").
+  public static func importEcdhPrivateKey(pkcs8: Data) throws -> P256.KeyAgreement.PrivateKey {
+    try P256.KeyAgreement.PrivateKey(derRepresentation: pkcs8)
+  }
+
+  /// Import an ephemeral P-256 public key from a JWK string `{kty,crv,x,y}`.
+  static func importEphemeralPublicKey(jwk: String) throws -> P256.KeyAgreement.PublicKey {
+    struct JWK: Decodable { let kty: String; let crv: String; let x: String; let y: String }
+    guard let data = jwk.data(using: .utf8),
+          let key = try? JSONDecoder().decode(JWK.self, from: data)
+    else { throw TeamKeyCryptoError.malformedPublicKey }
+    guard key.kty == "EC", key.crv == "P-256" else {
+      throw TeamKeyCryptoError.unsupportedKeyType
+    }
+    guard let x = base64URLDecode(key.x), x.count == 32,
+          let y = base64URLDecode(key.y), y.count == 32
+    else { throw TeamKeyCryptoError.malformedPublicKey }
+    var x963 = Data([0x04])
+    x963.append(x)
+    x963.append(y)
+    return try P256.KeyAgreement.PublicKey(x963Representation: x963)
+  }
+
+  /// ECDH(member, ephemeral) → HKDF("passwd-sso-team-v1", salt) → AES-GCM decrypt
+  /// (AAD = team-key-wrap "OK") → raw team symmetric key.
+  public static func unwrapTeamKey(
+    encrypted: EncryptedData,
+    ephemeralPublicKeyJWK: String,
+    memberPrivateKey: P256.KeyAgreement.PrivateKey,
+    hkdfSalt: String,
+    teamId: String,
+    toUserId: String,
+    keyVersion: Int,
+    wrapVersion: Int
+  ) throws -> SymmetricKey {
+    let ephemeral = try importEphemeralPublicKey(jwk: ephemeralPublicKeyJWK)
+    let shared = try memberPrivateKey.sharedSecretFromKeyAgreement(with: ephemeral)
+    // Raw ECDH Z (x-coordinate, 32 bytes) — matches WebCrypto deriveBits(256).
+    // The shared secret is the most sensitive intermediate; zeroize the heap copy.
+    var sharedBytes = shared.withUnsafeBytes { Data($0) }
+    defer { sharedBytes.resetBytes(in: 0..<sharedBytes.count) }
+    let wrappingKey = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: SymmetricKey(data: sharedBytes),
+      salt: try hexDecode(hkdfSalt),
+      info: Data(teamWrapInfo.utf8),
+      outputByteCount: 32
+    )
+    let aad = try buildTeamKeyWrapAAD(
+      teamId: teamId, toUserId: toUserId, keyVersion: keyVersion, wrapVersion: wrapVersion
+    )
+    let raw = try decryptAESGCM(
+      ciphertext: try hexDecode(encrypted.ciphertext),
+      iv: try hexDecode(encrypted.iv),
+      tag: try hexDecode(encrypted.authTag),
+      key: wrappingKey,
+      aad: aad
+    )
+    return SymmetricKey(data: raw)
+  }
+
+  /// HKDF(rawTeamKey, salt=zero32, info="passwd-sso-team-enc-v1") → the key team
+  /// entries are actually encrypted under (and the value persisted in WrappedTeamKey).
+  public static func deriveTeamEncryptionKey(rawTeamKey: SymmetricKey) -> SymmetricKey {
+    HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: rawTeamKey,
+      salt: zeroSalt,
+      info: Data(teamEncInfo.utf8),
+      outputByteCount: 32
+    )
+  }
+
+  /// HKDF(itemKey, salt=zero32, info="passwd-sso-item-enc-v1") → the per-entry
+  /// encryption key for team entries with itemKeyVersion >= 1. The unwrapped raw
+  /// ItemKey is NOT used directly — this HKDF step is required (mirrors the
+  /// extension's deriveItemEncryptionKey).
+  public static func deriveItemEncryptionKey(itemKey: SymmetricKey) -> SymmetricKey {
+    HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: itemKey,
+      salt: zeroSalt,
+      info: Data(itemEncInfo.utf8),
+      outputByteCount: 32
+    )
+  }
+
+  private static func base64URLDecode(_ s: String) -> Data? {
+    var b64 = s.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+    let rem = b64.count % 4
+    if rem != 0 { b64 += String(repeating: "=", count: 4 - rem) }
+    return Data(base64Encoded: b64)
+  }
+}

--- a/ios/Shared/Storage/TeamDirectoryStore.swift
+++ b/ios/Shared/Storage/TeamDirectoryStore.swift
@@ -1,0 +1,64 @@
+import CryptoKit
+import Foundation
+
+/// A team the user belongs to, for in-app vault-switcher labels. Persisted
+/// encrypted under cacheKey (team names are not E2E secrets but are kept off
+/// plaintext disk for consistency with the rest of the vault material).
+public struct TeamDirectoryEntry: Sendable, Codable, Equatable, Identifiable {
+  public let id: String
+  public let name: String
+  public init(id: String, name: String) {
+    self.id = id
+    self.name = name
+  }
+}
+
+/// Persists the team directory (teamId → name) as a cacheKey-encrypted JSON file
+/// in the App Group, so the vault switcher has labels on cold load.
+public protocol TeamDirectoryStoring: Sendable {
+  func save(_ entries: [TeamDirectoryEntry], cacheKey: SymmetricKey, userId: String) throws
+  func load(cacheKey: SymmetricKey, userId: String) -> [TeamDirectoryEntry]
+  func clear() throws
+}
+
+public struct TeamDirectoryStore: TeamDirectoryStoring, Sendable {
+  public init() {}
+
+  public func save(_ entries: [TeamDirectoryEntry], cacheKey: SymmetricKey, userId: String) throws {
+    let json = try JSONEncoder().encode(entries)
+    let aad = try buildLocalWrapAAD(kind: "teamdir", userId: userId)
+    let encrypted = try encryptAESGCMEncoded(plaintext: json, key: cacheKey, aad: aad)
+    let data = try JSONEncoder().encode(encrypted)
+    try AppGroupContainer.ensureDirectoryExists()
+    let url = try directoryURL()
+    let tmp = url.deletingLastPathComponent()
+      .appending(path: url.lastPathComponent + ".tmp", directoryHint: .notDirectory)
+    try data.write(to: tmp, options: .atomic)
+    _ = try FileManager.default.replaceItemAt(url, withItemAt: tmp)
+  }
+
+  public func load(cacheKey: SymmetricKey, userId: String) -> [TeamDirectoryEntry] {
+    guard let url = try? directoryURL(),
+          FileManager.default.fileExists(atPath: url.path),
+          let data = try? Data(contentsOf: url),
+          let encrypted = try? JSONDecoder().decode(EncryptedData.self, from: data),
+          let aad = try? buildLocalWrapAAD(kind: "teamdir", userId: userId),
+          let json = try? decryptAESGCMEncoded(encrypted: encrypted, key: cacheKey, aad: aad),
+          let entries = try? JSONDecoder().decode([TeamDirectoryEntry].self, from: json)
+    else { return [] }
+    return entries
+  }
+
+  public func clear() throws {
+    let url = try directoryURL()
+    if FileManager.default.fileExists(atPath: url.path) {
+      try FileManager.default.removeItem(at: url)
+    }
+  }
+
+  private func directoryURL() throws -> URL {
+    try AppGroupContainer.url()
+      .appending(path: "vault", directoryHint: .isDirectory)
+      .appending(path: "team-directory.json", directoryHint: .notDirectory)
+  }
+}

--- a/ios/Shared/Storage/WrappedKeyStore.swift
+++ b/ios/Shared/Storage/WrappedKeyStore.swift
@@ -41,6 +41,23 @@ public struct WrappedTeamKey: Sendable, Codable, Equatable {
   }
 }
 
+/// The account ECDH private key (PKCS#8), wrapped under cacheKey with a
+/// `buildLocalWrapAAD(kind:"ecdh", userId:)` binding. Persisted so sync (incl.
+/// background, post-biometric) can unwrap team keys without the vault secretKey.
+public struct WrappedECDHPrivateKey: Sendable, Codable, Equatable {
+  public let ciphertext: Data
+  public let iv: Data
+  public let authTag: Data
+  public let issuedAt: Date
+
+  public init(ciphertext: Data, iv: Data, authTag: Data, issuedAt: Date) {
+    self.ciphertext = ciphertext
+    self.iv = iv
+    self.authTag = authTag
+    self.issuedAt = issuedAt
+  }
+}
+
 // MARK: - Protocol
 
 public protocol WrappedKeyStore: Sendable {
@@ -48,6 +65,9 @@ public protocol WrappedKeyStore: Sendable {
   func loadVaultKey() throws -> WrappedVaultKey?
   func saveTeamKeys(_ keys: [WrappedTeamKey]) throws
   func loadTeamKeys() throws -> [WrappedTeamKey]
+  func clearTeamKeys() throws
+  func saveECDHPrivateKey(_ wrapped: WrappedECDHPrivateKey) throws
+  func loadECDHPrivateKey() throws -> WrappedECDHPrivateKey?
   func clearAll() throws
 }
 
@@ -87,17 +107,35 @@ public struct AppGroupWrappedKeyStore: WrappedKeyStore, Sendable {
     return try JSONDecoder().decode([WrappedTeamKey].self, from: data)
   }
 
+  public func clearTeamKeys() throws {
+    let path = try teamKeysURL().path
+    if FileManager.default.fileExists(atPath: path) {
+      try FileManager.default.removeItem(atPath: path)
+    }
+  }
+
+  // MARK: - ECDH private key
+
+  public func saveECDHPrivateKey(_ wrapped: WrappedECDHPrivateKey) throws {
+    let data = try JSONEncoder().encode(wrapped)
+    try atomicWrite(data: data, to: ecdhPrivateKeyURL())
+  }
+
+  public func loadECDHPrivateKey() throws -> WrappedECDHPrivateKey? {
+    let url = try ecdhPrivateKeyURL()
+    guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(WrappedECDHPrivateKey.self, from: data)
+  }
+
   // MARK: - Clear
 
   public func clearAll() throws {
     let fm = FileManager.default
-    let vaultKeyPath = try vaultKeyURL().path
-    let teamKeysPath = try teamKeysURL().path
-    if fm.fileExists(atPath: vaultKeyPath) {
-      try fm.removeItem(atPath: vaultKeyPath)
-    }
-    if fm.fileExists(atPath: teamKeysPath) {
-      try fm.removeItem(atPath: teamKeysPath)
+    for path in [try vaultKeyURL().path, try teamKeysURL().path, try ecdhPrivateKeyURL().path] {
+      if fm.fileExists(atPath: path) {
+        try fm.removeItem(atPath: path)
+      }
     }
   }
 
@@ -113,6 +151,12 @@ public struct AppGroupWrappedKeyStore: WrappedKeyStore, Sendable {
     try AppGroupContainer.url()
       .appending(path: "vault", directoryHint: .isDirectory)
       .appending(path: "wrapped-team-keys.json", directoryHint: .notDirectory)
+  }
+
+  private func ecdhPrivateKeyURL() throws -> URL {
+    try AppGroupContainer.url()
+      .appending(path: "vault", directoryHint: .isDirectory)
+      .appending(path: "wrapped-ecdh-private-key.json", directoryHint: .notDirectory)
   }
 
   private func atomicWrite(data: Data, to url: URL) throws {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "generate:key": "node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"",
     "generate:audit-anchor-signing-key": "bash scripts/generate-audit-anchor-signing-key.sh",
     "generate:audit-anchor-tag-secret": "bash scripts/generate-audit-anchor-tag-secret.sh",
+    "generate:team-key-fixture": "tsx scripts/generate-team-key-fixture.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/generate-team-key-fixture.ts
+++ b/scripts/generate-team-key-fixture.ts
@@ -1,0 +1,204 @@
+/**
+ * Golden-vector capture for the iOS team-key crypto (C9).
+ *
+ * Runs the browser extension's ACTUAL crypto-team.ts decrypt functions on fixed
+ * inputs and emits ios/PasswdSSOTests/fixtures/team-key-fixture.json. The iOS
+ * TeamKeyCryptoTests load this fixture and assert the iOS implementation
+ * reproduces the same outputs — proving byte-for-byte parity with the extension.
+ *
+ * The DECRYPT path (unwrapEcdhPrivateKey / unwrapTeamKey / deriveTeamEncryptionKey)
+ * exercises the real extension code. The ENCRYPT path (producing the wrapped
+ * blobs) uses raw Web Crypto and mirrors the server's storage layout
+ * (ciphertext || authTag split, IV separate). Run:
+ *   node_modules/.bin/tsx scripts/generate-team-key-fixture.ts
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  buildTeamKeyWrapAAD,
+  buildTeamEntryAAD,
+  buildItemKeyWrapAAD,
+  deriveEcdhWrappingKey,
+  importEcdhPrivateKey,
+  unwrapEcdhPrivateKey,
+  unwrapTeamKey,
+  deriveTeamEncryptionKey,
+  deriveItemEncryptionKey,
+} from "../extension/src/lib/crypto-team.ts";
+import { hexEncode, type EncryptedData } from "../extension/src/lib/crypto.ts";
+
+const HKDF_TEAM_WRAP_INFO = "passwd-sso-team-v1";
+
+function ab(arr: Uint8Array): ArrayBuffer {
+  return arr.buffer.slice(arr.byteOffset, arr.byteOffset + arr.byteLength) as ArrayBuffer;
+}
+function rand(n: number): Uint8Array {
+  const a = new Uint8Array(n);
+  crypto.getRandomValues(a);
+  return a;
+}
+/** AES-256-GCM encrypt → split into {ciphertext, iv, authTag} hex (server layout). */
+async function aesGcmEncrypt(
+  key: CryptoKey,
+  plaintext: Uint8Array,
+  iv: Uint8Array,
+  aad?: Uint8Array,
+): Promise<EncryptedData> {
+  const params: AesGcmParams = { name: "AES-GCM", iv: ab(iv) };
+  if (aad) params.additionalData = ab(aad);
+  const out = new Uint8Array(await crypto.subtle.encrypt(params, key, ab(plaintext)));
+  const ct = out.slice(0, out.length - 16);
+  const tag = out.slice(out.length - 16);
+  return { ciphertext: hexEncode(ct), iv: hexEncode(iv), authTag: hexEncode(tag) };
+}
+
+async function main() {
+  // --- Fixed identity / context ---
+  const teamId = "team-fixture-1";
+  const toUserId = "user-fixture-1";
+  const entryId = "00000000-0000-4000-8000-000000000001";
+  const keyVersion = 1;
+  const wrapVersion = 1;
+
+  // --- Member account ECDH keypair (P-256) ---
+  const memberPair = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" }, true, ["deriveBits"],
+  );
+  const memberPkcs8 = new Uint8Array(await crypto.subtle.exportKey("pkcs8", memberPair.privateKey));
+  const memberPubRaw = await crypto.subtle.exportKey("raw", memberPair.publicKey); // 0x04‖x‖y
+
+  // --- Wrap the member ECDH private key under HKDF(secretKey,"passwd-sso-ecdh-v1") ---
+  const secretKey = rand(32);
+  const ecdhWrappingKey = await deriveEcdhWrappingKey(secretKey);
+  const encryptedEcdhPrivateKey = await aesGcmEncrypt(ecdhWrappingKey, memberPkcs8, rand(12));
+
+  // --- Server-side team-key wrap: ECDH(ephemeral, member) → HKDF(team-v1, salt) → AES-GCM(teamKey, AAD) ---
+  const rawTeamKey = rand(32);
+  const ephemeralPair = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" }, true, ["deriveBits"],
+  );
+  const ephemeralPublicKeyJwk = JSON.stringify(
+    await crypto.subtle.exportKey("jwk", ephemeralPair.publicKey),
+  );
+  const hkdfSaltBytes = rand(32);
+  // wrappingKey = HKDF(ECDH(ephemeralPriv, memberPub), salt, info=team-v1)
+  const sharedBits = await crypto.subtle.deriveBits(
+    { name: "ECDH", public: memberPair.publicKey }, ephemeralPair.privateKey, 256,
+  );
+  const hkdfKey = await crypto.subtle.importKey("raw", sharedBits, "HKDF", false, ["deriveKey"]);
+  const teamWrappingKey = await crypto.subtle.deriveKey(
+    { name: "HKDF", hash: "SHA-256", salt: ab(hkdfSaltBytes), info: ab(new TextEncoder().encode(HKDF_TEAM_WRAP_INFO)) },
+    hkdfKey, { name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"],
+  );
+  const teamKeyWrapAAD = buildTeamKeyWrapAAD({ teamId, toUserId, keyVersion, wrapVersion });
+  const encryptedTeamKey = await aesGcmEncrypt(teamWrappingKey, rawTeamKey, rand(12), teamKeyWrapAAD);
+
+  // --- Sample team entry overview encrypted under the DERIVED team enc key ---
+  const teamEncKeyBytes = await crypto.subtle.exportKey(
+    "raw",
+    await crypto.subtle.importKey("raw", ab(rawTeamKey), "HKDF", false, ["deriveKey"]).then((k) =>
+      crypto.subtle.deriveKey(
+        { name: "HKDF", hash: "SHA-256", salt: new ArrayBuffer(32), info: ab(new TextEncoder().encode("passwd-sso-team-enc-v1")) },
+        k, { name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"],
+      ),
+    ),
+  );
+  const overviewPlain = new TextEncoder().encode(
+    JSON.stringify({ title: "Team Login", username: "alice@example.com", urlHost: "team.example.com" }),
+  );
+  const teamEncKeyForEnc = await crypto.subtle.importKey("raw", teamEncKeyBytes, { name: "AES-GCM" }, false, ["encrypt"]);
+  const overviewAAD = buildTeamEntryAAD(teamId, entryId, "overview", 0);
+  const encryptedOverview = await aesGcmEncrypt(teamEncKeyForEnc, overviewPlain, rand(12), overviewAAD);
+
+  // --- VERIFY via the REAL extension decrypt functions; capture canonical hex ---
+  const recoveredPkcs8 = await unwrapEcdhPrivateKey(encryptedEcdhPrivateKey, ecdhWrappingKey);
+  const memberPriv = await importEcdhPrivateKey(recoveredPkcs8);
+  const recoveredTeamKey = await unwrapTeamKey(
+    encryptedTeamKey, ephemeralPublicKeyJwk, memberPriv, hexEncode(hkdfSaltBytes),
+    { teamId, toUserId, keyVersion, wrapVersion },
+  );
+  if (hexEncode(recoveredTeamKey) !== hexEncode(rawTeamKey)) throw new Error("team key round-trip mismatch");
+  // The extension derives a NON-extractable enc key, so prove equivalence by
+  // decrypting the overview (encrypted under our extractable teamEncKeyBytes)
+  // with the extension-derived key — success proves the two keys are identical.
+  const teamEncKey = await deriveTeamEncryptionKey(recoveredTeamKey);
+  const combined = new Uint8Array([
+    ...Array.from(Buffer.from(encryptedOverview.ciphertext, "hex")),
+    ...Array.from(Buffer.from(encryptedOverview.authTag, "hex")),
+  ]);
+  const dec = new Uint8Array(await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: ab(Buffer.from(encryptedOverview.iv, "hex")), additionalData: ab(overviewAAD) },
+    teamEncKey, ab(combined),
+  ));
+  if (new TextDecoder().decode(dec) !== new TextDecoder().decode(overviewPlain)) {
+    throw new Error("team enc key mismatch (overview decrypt failed)");
+  }
+  const teamEncKeyHex = hexEncode(new Uint8Array(teamEncKeyBytes));
+
+  // --- itemKeyVersion >= 1 entry: per-entry ItemKey wrapped under teamEncKey,
+  //     entry encrypted under deriveItemEncryptionKey(itemKey) (regression guard
+  //     for the item-enc HKDF step). ---
+  const entryIdV1 = "00000000-0000-4000-8000-000000000002";
+  const itemKey = rand(32);
+  const itemKeyWrapAAD = buildItemKeyWrapAAD(teamId, entryIdV1, keyVersion);
+  const encryptedItemKey = await aesGcmEncrypt(teamEncKeyForEnc, itemKey, rand(12), itemKeyWrapAAD);
+  const itemEncKeyBytes = await crypto.subtle.exportKey(
+    "raw",
+    await crypto.subtle.importKey("raw", ab(itemKey), "HKDF", false, ["deriveKey"]).then((k) =>
+      crypto.subtle.deriveKey(
+        { name: "HKDF", hash: "SHA-256", salt: new ArrayBuffer(32), info: ab(new TextEncoder().encode("passwd-sso-item-enc-v1")) },
+        k, { name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"]),
+    ),
+  );
+  const overviewPlainV1 = new TextEncoder().encode(
+    JSON.stringify({ title: "Team Login v1", username: "bob@example.com", urlHost: "v1.example.com" }));
+  const itemEncKeyForEnc = await crypto.subtle.importKey("raw", itemEncKeyBytes, { name: "AES-GCM" }, false, ["encrypt"]);
+  const overviewAADV1 = buildTeamEntryAAD(teamId, entryIdV1, "overview", 1);
+  const encryptedOverviewV1 = await aesGcmEncrypt(itemEncKeyForEnc, overviewPlainV1, rand(12), overviewAADV1);
+  // Verify via the REAL extension deriveItemEncryptionKey.
+  const extItemEncKey = await deriveItemEncryptionKey(itemKey);
+  const combinedV1 = new Uint8Array([
+    ...Array.from(Buffer.from(encryptedOverviewV1.ciphertext, "hex")),
+    ...Array.from(Buffer.from(encryptedOverviewV1.authTag, "hex")),
+  ]);
+  const decV1 = new Uint8Array(await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: ab(Buffer.from(encryptedOverviewV1.iv, "hex")), additionalData: ab(overviewAADV1) },
+    extItemEncKey, ab(combinedV1)));
+  if (new TextDecoder().decode(decV1) !== new TextDecoder().decode(overviewPlainV1)) {
+    throw new Error("item enc key mismatch (v1 overview decrypt failed)");
+  }
+
+  const fixture = {
+    _comment: "Captured from extension/src/lib/crypto-team.ts via scripts/generate-team-key-fixture.ts. Do not hand-edit.",
+    secretKeyHex: hexEncode(secretKey),
+    encryptedEcdhPrivateKey,
+    pkcs8PrivKeyHex: hexEncode(recoveredPkcs8),
+    ephemeralPublicKeyJwk,
+    hkdfSaltHex: hexEncode(hkdfSaltBytes),
+    encryptedTeamKey,
+    teamId, toUserId, keyVersion, wrapVersion,
+    rawTeamKeyHex: hexEncode(rawTeamKey),
+    teamEncKeyHex,
+    entryId,
+    encryptedOverview,
+    overviewPlaintext: new TextDecoder().decode(overviewPlain),
+    teamKeyWrapAADHex: hexEncode(teamKeyWrapAAD),
+    overviewAADHex: hexEncode(overviewAAD),
+    memberPublicKeyRawHex: hexEncode(new Uint8Array(memberPubRaw)),
+    // itemKeyVersion >= 1 entry (per-entry ItemKey + item-enc HKDF).
+    teamKeyVersion: keyVersion,
+    entryIdV1,
+    encryptedItemKey,
+    itemKeyHex: hexEncode(itemKey),
+    itemEncKeyHex: hexEncode(new Uint8Array(itemEncKeyBytes)),
+    encryptedOverviewV1,
+    overviewPlaintextV1: new TextDecoder().decode(overviewPlainV1),
+  };
+
+  const out = join(dirname(new URL(import.meta.url).pathname), "../ios/PasswdSSOTests/fixtures/team-key-fixture.json");
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, JSON.stringify(fixture, null, 2) + "\n");
+  console.log("wrote", out);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/lib/proxy/api-route.test.ts
+++ b/src/lib/proxy/api-route.test.ts
@@ -130,7 +130,7 @@ describe("handleApiAuth — Bearer-bypass dispatch", () => {
 
   it("Bearer + non-bypass route + cookie → session check fires (no bypass)", async () => {
     const res = await handleApiAuth(
-      makeRequest("/api/teams", "GET", {
+      makeRequest("/api/tags", "GET", {
         Authorization: "Bearer tok",
         Cookie: "authjs.session-token=sess-2",
       }),
@@ -141,7 +141,7 @@ describe("handleApiAuth — Bearer-bypass dispatch", () => {
 
   it("Cookie only + non-Bearer route → session check fires", async () => {
     const res = await handleApiAuth(
-      makeRequest("/api/teams", "GET", { Cookie: "authjs.session-token=sess-3" }),
+      makeRequest("/api/tags", "GET", { Cookie: "authjs.session-token=sess-3" }),
     );
     expect(res.status).toBe(401);
     expect(fetchSpy).toHaveBeenCalled();

--- a/src/lib/proxy/cors-gate.test.ts
+++ b/src/lib/proxy/cors-gate.test.ts
@@ -30,6 +30,9 @@ describe("isBearerBypassRoute — Bearer-bypass detection truth table", () => {
     { path: "/api/vault/status", expected: true, reason: "vault status exact" },
     { path: "/api/vault/unlock/data", expected: true, reason: "vault unlock data exact" },
     { path: "/api/vault/unlock/data/extra", expected: true, reason: "child of vault unlock data" },
+    { path: "/api/teams", expected: true, reason: "teams list — Bearer (iOS app / extension)" },
+    { path: "/api/teams/t1/passwords", expected: true, reason: "team passwords — child of teams" },
+    { path: "/api/teams/t1/member-key", expected: true, reason: "team member-key — child of teams" },
     { path: "/api/api-keys", expected: false, reason: "api-keys removed from Bearer-bypass list (session-only post-C2)" },
     { path: "/api/api-keys/k1", expected: false, reason: "api-keys child also session-only post-C2" },
     { path: "/api/extension/token", expected: true, reason: "extension token EXACT only" },
@@ -40,7 +43,6 @@ describe("isBearerBypassRoute — Bearer-bypass detection truth table", () => {
     { path: "/api/vault/ssh/sign-authorize", expected: true, reason: "SSH agent sign-authorize — CLI Bearer" },
 
     // Deny (NOT Bearer-bypass)
-    { path: "/api/teams", expected: false, reason: "teams not in list" },
     { path: "/api/tags", expected: false, reason: "tags not in list" },
     { path: "/api/notifications", expected: false, reason: "notifications not in list" },
     { path: "/api/extension/token/extra", expected: false, reason: "child of token (not in EXACT-list)" },

--- a/src/lib/proxy/cors-gate.ts
+++ b/src/lib/proxy/cors-gate.ts
@@ -20,6 +20,7 @@ import { handlePreflight, applyCorsHeaders } from "@/lib/http/cors";
  */
 export const EXTENSION_TOKEN_ROUTES: readonly string[] = [
   API_PATH.PASSWORDS,
+  API_PATH.TEAMS,                   // team list + per-team passwords/member-key — Bearer (iOS app / extension); handlers enforce scope + requireTeamPermission
   API_PATH.VAULT_STATUS,
   API_PATH.VAULT_UNLOCK_DATA,
   API_PATH.EXTENSION_TOKEN,         // DELETE (revoke) — validated by route handler

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
   "exclude": [
     "node_modules",
     "extension",
-    "cli"
+    "cli",
+    "scripts/generate-team-key-fixture.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- Add the full team-key pipeline on iOS: AutoFill QuickType suggestions, picker fill, and an in-app team vault switcher.
- Persist the account ECDH private key and derived team encryption keys wrapped under the device cacheKey with userId/teamId-bound local AAD; wiped on sign-out.
- New `TeamKeyCrypto`, `TeamEntryDecryptor`, `TeamDirectoryStore`, `WrappedECDHPrivateKey`; `HostSyncService` now populates `WrappedTeamKey`.
- **Server:** add `/api/teams` to the proxy Bearer-bypass allowlist (D1) — the iOS mobile token was 401'd at the proxy before reaching the handlers (which enforce scope + team membership themselves).

## Motivation
Team entries were unfillable on iOS: the scaffolding existed but the pipeline that populates it was never built (`saveTeamKeys()` was test-only, so `loadTeamKeys()` always returned `[]`). Team credentials filled nowhere and were invisible in-app.

## Implementation notes
- **Crypto mirror** (`TeamKeyCrypto.swift`): exact HKDF/ECDH/AES-GCM steps from `extension/src/lib/crypto-team.ts`; golden vectors captured from the real extension source anchor cross-platform parity (incl. itemKeyVersion≥1 item-enc HKDF — D2).
- **Key lifecycle (Design A):** ECDH private key re-wrapped under cacheKey at passphrase unlock; sync (incl. background/biometric) reuses it to refresh team keys; 15-min staleness self-refreshes and bounds revocation.
- **cacheKey threading (D3):** `UnlockResult.cacheKey` carries the REAL cacheKey; never derived from `BridgeKeyStore.readDirect()` (empty bridge_key).
- **Shared helper:** `TeamEntryDecryptor` centralizes unwrap / AAD / staleness / item-key HKDF; used by both resolver and registrar.
- **In-app switcher:** `VaultScope` (Personal / per-team), `TeamDirectoryStore` for cacheKey-encrypted team names on cold load.

## Review (triangulate Phase 3 — functionality / security / testing)
- **Proxy boundary verified safe**: every `/api/teams/*` route enforces its own authz; none delegate to the proxy session gate.
- **Fixed**: transient `/api/teams` failure wiping valid team keys (F1); fill-path missing 15-min staleness (F3); sign-out not wiping the team directory (F2/S13); key-material zeroization (S16-S18); + Minor F4/F5/S15.
- Artifacts: [plan](./docs/archive/review/ios-team-quicktype-plan.md) · [plan-review](./docs/archive/review/ios-team-quicktype-review.md) · [code-review](./docs/archive/review/ios-team-quicktype-code-review.md) · [manual-test](./docs/archive/review/ios-team-quicktype-manual-test.md)

## Test status
- iOS: **511 unit + 2 UI tests, 0 failures** (incl. regression tests for F1/F2/F3).
- Server `npx vitest run` (11322 pass; 1 load-induced flake, passes in isolation) · `npx next build`.
- **Device-only manual test pending** (Tier-2, R35): QuickType/picker fill, switcher UI, revocation ≤15min, sign-out wipe, clock-skew, cross-tenant — see the manual-test doc.

## ⚠️ Deploy prerequisite
This PR includes a **server proxy change (D1)**. The server **must be redeployed** before/with the iOS build, or every `/api/teams/*` request from the iOS token will 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
