### PR TITLE
fix(security): harden multi-tenant boundaries (TOCTOU, token tenant cross-checks, mutation scoping)

### DIFF
--- a/docs/archive/review/tenant-boundary-defensive-hardening-code-review.md
+++ b/docs/archive/review/tenant-boundary-defensive-hardening-code-review.md
@@ -1,0 +1,59 @@
+# Code Review: tenant-boundary-defensive-hardening
+
+Date: 2026-06-15
+Review round: 1 (Phase 3 standalone — branch review, no plan file; review-driven work)
+Branch: `fix/tenant-boundary-defensive-hardening`
+Scope: `git diff main...HEAD` — 4 commits, 72 files (+398/−146)
+
+## Changes reviewed
+1. JIT approval TOCTOU CAS + SA-token tenant cross-check + SA composite FK + team password delete scoping.
+2. Horizontal rollout: MCP auth-code single-use CAS, MCP token tenant cross-checks, AccessRequest composite FK, ~44 single-row mutations scoped by `{id, owner}`.
+3. Attachment delete scoped by parent entry id.
+4. Password-history trim deletes scoped by parent `entryId`.
+
+## Functionality Findings
+**No findings.** Composite-`where` mutations are all preceded by an ownership pre-check guaranteeing the scope value matches the row (no spurious P2025). deleteMany/updateMany+count→404 refactors, invitation-accept tx refactor, MCP auth-code CAS, and the `expiresAt:{gt}` transition all preserve correct happy-path behavior and response shapes. Composite-FK migrations are correctly ordered (unique index before FK), `onDelete: Cascade` preserved, schema matches SQL.
+Recurring check: R5 OK / R9 OK / R19 OK / R24 — migrations intentionally strict (fail closed on pre-existing divergent rows), no mid-migration fail-open window.
+
+## Security Findings
+**No findings.** Each fix verified to close its gap and fail closed:
+- All three CAS paths (MCP auth-code, invitation accept, JIT approval) claim the row BEFORE the side effect; the loser never mints/upserts. Claim-then-act ordering correct.
+- Tenant cross-checks fail closed (parent tenantId selected; non-null token column makes both-null impossible; `null !== uuid` rejects).
+- Composite FK migrations preserve onDelete semantics; make divergent rows impossible.
+- ~15 mutation-scope additions spot-checked: correct owner column throughout (userId for personal — RLS is tenant-only; teamId/tenantId for team/tenant resources). Family-revoke tenantId additions match the rows' tenantId — no token escapes revocation.
+- R35: auth/authz + migration changes — recommend an end-to-end post-migration manual/integration verification (see Deferred).
+
+## Testing Findings
+- **T1 (Major):** New MCP tenant-mismatch reject branches (`validateMcpToken`, `exchangeRefreshToken`) had no test — pass-branch mocks aligned but revert was invisible. → FIXED.
+- **T2 (Major):** New `deleteTeamPassword` count!==1→404 race path untested. → FIXED.
+- **T3 (Major):** New access-requests `sa.tenantId !== tenantId → SA_NOT_FOUND` branch untested. → FIXED.
+- **T4 (Minor):** Composite-FK migrations have no integration test asserting the DB rejects a mismatched insert. → DEFERRED (see below).
+- Confirmed sound: invitation-accept CAS test (executes callback, asserts upsert-not-called on race), MCP auth-code CAS test, JIT expiresAt-atomic test (captures transition where) — all load-bearing; R7 where-assertions use concrete matching literals; R19 mocks aligned.
+
+## Resolution Status
+### T1 [Major] MCP tenant-mismatch reject branches untested — FIXED
+- Action: added `validateMcpToken` mismatch test (`mcpClient.tenantId: "tenant-OTHER"` → invalid_token) and `exchangeRefreshToken` mismatch test (divergent client tenantId → invalid_client, CAS not run).
+- Files: src/lib/mcp/oauth-server.test.ts, src/__tests__/lib/mcp/refresh-token.test.ts
+
+### T2 [Major] deleteTeamPassword count:0 path untested — FIXED
+- Action: added permanent + soft-delete tests where the scoped mutation matches 0 rows → 404.
+- File: src/app/api/teams/[teamId]/passwords/[id]/route.test.ts
+
+### T3 [Major] access-requests SA tenant-mismatch untested — FIXED
+- Action: added SA self-service test with `sa.tenantId: "tenant-OTHER"` → SA_NOT_FOUND (404), create not called.
+- File: src/app/api/tenant/access-requests/route.test.ts
+
+### T4 [Minor] Composite-FK integration test — Deferred
+- **Anti-Deferral check**: acceptable risk, quantified.
+  - Worst case: a future schema edit silently drops the composite FK and CI stays green; the DB-level last-line-of-defense regresses (app-layer checks still hold).
+  - Likelihood: low — the FK is in schema.prisma + a committed migration; a drop requires a deliberate schema edit + new migration.
+  - Cost to fix: an integration test requires the real-DB harness (`test:integration`) with bespoke mismatched-row insert setup — >30 min, and the primary guard (app-layer tenant checks) is now covered by T1/T3.
+- TODO marker: `TODO(tenant-boundary-defensive-hardening): add integration test asserting the (service_account_id, tenant_id) and (access_requests) composite FKs reject a cross-tenant insert.`
+- The FK was manually verified present via psql during implementation (both migrations applied to dev DB).
+- **Orchestrator sign-off**: acceptable-risk exception satisfied (worst case / likelihood / cost stated; app-layer guard tested).
+
+## Recommendation (non-blocking, R35)
+Before merge, run the two composite-FK migrations against a dev DB with existing SA/token/access-request rows and confirm a legitimate SA-token issuance + JIT approval + invitation accept still succeed end-to-end. (Migrations were applied to the local dev DB during implementation; a clean-DB rehearsal on a representative dataset is the residual step.)
+
+## Outcome
+Functionality + Security: clean. Testing: 3 Major fixed, 1 Minor deferred with justification. Full suite 11,332 passed / 1 skipped; lint 0 errors; production build succeeds.

--- a/docs/archive/review/tenant-boundary-defensive-hardening-code-review.md
+++ b/docs/archive/review/tenant-boundary-defensive-hardening-code-review.md
@@ -27,7 +27,7 @@ Recurring check: R5 OK / R9 OK / R19 OK / R24 — migrations intentionally stric
 - **T1 (Major):** New MCP tenant-mismatch reject branches (`validateMcpToken`, `exchangeRefreshToken`) had no test — pass-branch mocks aligned but revert was invisible. → FIXED.
 - **T2 (Major):** New `deleteTeamPassword` count!==1→404 race path untested. → FIXED.
 - **T3 (Major):** New access-requests `sa.tenantId !== tenantId → SA_NOT_FOUND` branch untested. → FIXED.
-- **T4 (Minor):** Composite-FK migrations have no integration test asserting the DB rejects a mismatched insert. → DEFERRED (see below).
+- **T4 (Minor):** Composite-FK migrations have no integration test asserting the DB rejects a mismatched insert. → FIXED (real-DB integration test added via /test-gen).
 - Confirmed sound: invitation-accept CAS test (executes callback, asserts upsert-not-called on race), MCP auth-code CAS test, JIT expiresAt-atomic test (captures transition where) — all load-bearing; R7 where-assertions use concrete matching literals; R19 mocks aligned.
 
 ## Resolution Status
@@ -43,14 +43,9 @@ Recurring check: R5 OK / R9 OK / R19 OK / R24 — migrations intentionally stric
 - Action: added SA self-service test with `sa.tenantId: "tenant-OTHER"` → SA_NOT_FOUND (404), create not called.
 - File: src/app/api/tenant/access-requests/route.test.ts
 
-### T4 [Minor] Composite-FK integration test — Deferred
-- **Anti-Deferral check**: acceptable risk, quantified.
-  - Worst case: a future schema edit silently drops the composite FK and CI stays green; the DB-level last-line-of-defense regresses (app-layer checks still hold).
-  - Likelihood: low — the FK is in schema.prisma + a committed migration; a drop requires a deliberate schema edit + new migration.
-  - Cost to fix: an integration test requires the real-DB harness (`test:integration`) with bespoke mismatched-row insert setup — >30 min, and the primary guard (app-layer tenant checks) is now covered by T1/T3.
-- TODO marker: `TODO(tenant-boundary-defensive-hardening): add integration test asserting the (service_account_id, tenant_id) and (access_requests) composite FKs reject a cross-tenant insert.`
-- The FK was manually verified present via psql during implementation (both migrations applied to dev DB).
-- **Orchestrator sign-off**: acceptable-risk exception satisfied (worst case / likelihood / cost stated; app-layer guard tested).
+### T4 [Minor] Composite-FK integration test — FIXED
+- Action: added a real-DB integration test (`src/__tests__/db-integration/service-account-tenant-fk.integration.test.ts`) using the existing `createTestContext` harness. It seeds an SA in tenant A and asserts the composite FK REJECTS inserting a `service_account_tokens` / `access_requests` row with tenant B (matcher `/service_account_id_tenant_id_fkey/`), and ACCEPTS the matching-tenant insert. 4 tests, all passing against the dev DB via `vitest --config vitest.integration.config.ts`.
+- This supersedes the earlier deferral: the DB-level backstop is now covered, so a future schema edit dropping either composite FK fails CI.
 
 ## Recommendation (non-blocking, R35)
 Before merge, run the two composite-FK migrations against a dev DB with existing SA/token/access-request rows and confirm a legitimate SA-token issuance + JIT approval + invitation accept still succeed end-to-end. (Migrations were applied to the local dev DB during implementation; a clean-DB rehearsal on a representative dataset is the residual step.)

--- a/prisma/migrations/20260615000001_sa_token_tenant_composite_fk/migration.sql
+++ b/prisma/migrations/20260615000001_sa_token_tenant_composite_fk/migration.sql
@@ -1,0 +1,14 @@
+-- Enforce tenant-boundary consistency between a service-account token and its
+-- parent service account at the DB level. A token's (service_account_id,
+-- tenant_id) pair must reference an existing service_accounts (id, tenant_id)
+-- pair, making it impossible to persist a token whose tenant_id differs from
+-- its SA's tenant_id.
+
+-- DropForeignKey
+ALTER TABLE "service_account_tokens" DROP CONSTRAINT "service_account_tokens_service_account_id_fkey";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "service_accounts_id_tenant_id_key" ON "service_accounts"("id", "tenant_id");
+
+-- AddForeignKey
+ALTER TABLE "service_account_tokens" ADD CONSTRAINT "service_account_tokens_service_account_id_tenant_id_fkey" FOREIGN KEY ("service_account_id", "tenant_id") REFERENCES "service_accounts"("id", "tenant_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260615000002_access_request_tenant_composite_fk/migration.sql
+++ b/prisma/migrations/20260615000002_access_request_tenant_composite_fk/migration.sql
@@ -1,0 +1,11 @@
+-- Enforce tenant-boundary consistency between an access request and its parent
+-- service account at the DB level. An access_requests (service_account_id,
+-- tenant_id) pair must reference an existing service_accounts (id, tenant_id)
+-- pair, making it impossible to persist a request whose tenant_id differs from
+-- its SA's tenant_id. Mirrors the service_account_tokens composite FK.
+
+-- DropForeignKey
+ALTER TABLE "access_requests" DROP CONSTRAINT "access_requests_service_account_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "access_requests" ADD CONSTRAINT "access_requests_service_account_id_tenant_id_fkey" FOREIGN KEY ("service_account_id", "tenant_id") REFERENCES "service_accounts"("id", "tenant_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1663,6 +1663,9 @@ model ServiceAccount {
   auditLogs               AuditLog[]
 
   @@unique([tenantId, name])
+  // Referenced by ServiceAccountToken's composite FK so a token's tenantId is
+  // guaranteed at the DB level to match its parent SA's tenantId.
+  @@unique([id, tenantId])
   @@index([tenantId, isActive])
   @@map("service_accounts")
 }
@@ -1680,7 +1683,10 @@ model ServiceAccountToken {
   revokedAt        DateTime? @map("revoked_at") @db.Timestamptz(3)
   lastUsedAt       DateTime? @map("last_used_at") @db.Timestamptz(3)
 
-  serviceAccount ServiceAccount @relation(fields: [serviceAccountId], references: [id], onDelete: Cascade)
+  // Composite FK (serviceAccountId, tenantId) → ServiceAccount(id, tenantId)
+  // enforces tenant-boundary consistency at the DB level: a token cannot point
+  // to an SA owned by a different tenant.
+  serviceAccount ServiceAccount @relation(fields: [serviceAccountId, tenantId], references: [id, tenantId], onDelete: Cascade)
   tenant         Tenant         @relation(fields: [tenantId], references: [id], onDelete: Restrict)
 
   @@index([serviceAccountId, revokedAt])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1223,7 +1223,9 @@ model AccessRequest {
   createdAt                   DateTime            @default(now()) @map("created_at") @db.Timestamptz(3)
 
   tenant                  Tenant          @relation(fields: [tenantId], references: [id], onDelete: Restrict)
-  serviceAccount          ServiceAccount  @relation(fields: [serviceAccountId], references: [id], onDelete: Cascade)
+  // Composite FK (serviceAccountId, tenantId) → ServiceAccount(id, tenantId):
+  // a request's tenantId is guaranteed at the DB level to match its SA's tenant.
+  serviceAccount          ServiceAccount  @relation(fields: [serviceAccountId, tenantId], references: [id, tenantId], onDelete: Cascade)
   approvedBy              User?           @relation("AccessRequestApprovedBy", fields: [approvedById], references: [id], onDelete: SetNull)
   requesterUser           User?           @relation("AccessRequestRequester", fields: [requesterUserId], references: [id], onDelete: SetNull)
   requesterServiceAccount ServiceAccount? @relation("AccessRequestSelfService", fields: [requesterServiceAccountId], references: [id], onDelete: SetNull)

--- a/src/__tests__/api/share-links/delete.test.ts
+++ b/src/__tests__/api/share-links/delete.test.ts
@@ -121,7 +121,7 @@ describe("DELETE /api/share-links/[id]", () => {
     expect(status).toBe(200);
     expect(json.ok).toBe(true);
     expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: "s1" },
+      where: { id: "s1", createdById: DEFAULT_SESSION.user.id },
       data: { revokedAt: expect.any(Date) },
     });
   });

--- a/src/__tests__/api/teams/team-attachment-download.test.ts
+++ b/src/__tests__/api/teams/team-attachment-download.test.ts
@@ -217,6 +217,6 @@ describe("DELETE /api/teams/[teamId]/passwords/[id]/attachments/[attachmentId]",
     const body = await res.json();
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
-    expect(mockAttachmentDelete).toHaveBeenCalledWith({ where: { id: "a1" } });
+    expect(mockAttachmentDelete).toHaveBeenCalledWith({ where: { id: "a1", teamPasswordEntryId: "e1" } });
   });
 });

--- a/src/__tests__/db-integration/service-account-tenant-fk.integration.test.ts
+++ b/src/__tests__/db-integration/service-account-tenant-fk.integration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Real-DB integration test for the tenant-boundary composite foreign keys added
+ * in migrations 20260615000001 / 20260615000002:
+ *
+ *   service_account_tokens (service_account_id, tenant_id)
+ *     → service_accounts (id, tenant_id)
+ *   access_requests        (service_account_id, tenant_id)
+ *     → service_accounts (id, tenant_id)
+ *
+ * These make it impossible to persist a token / access-request whose tenant_id
+ * diverges from its parent service account's tenant_id. The application-layer
+ * checks (validateServiceAccountToken, the access-request create path) are the
+ * primary guard; this test asserts the DB is the backstop, so a future schema
+ * edit that drops the composite FK fails CI rather than silently regressing.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { createTestContext, setBypassRlsGucs, type TestContext } from "./helpers";
+
+// Gracefully skip the entire suite if DATABASE_URL is not configured.
+const SKIP = !process.env.DATABASE_URL;
+
+describe("composite FK: service-account tenant boundary", () => {
+  let ctx: TestContext;
+  let tenantA: string; // owns the service account
+  let tenantB: string; // the "other" tenant a corrupted row would claim
+  let saCreatorId: string;
+  let saId: string;
+
+  beforeAll(async () => {
+    if (SKIP) return;
+    ctx = await createTestContext();
+    tenantA = await ctx.createTenant();
+    tenantB = await ctx.createTenant();
+    saCreatorId = await ctx.createUser(tenantA);
+    saId = randomUUID();
+
+    // Service account belongs to tenantA.
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO service_accounts (id, tenant_id, name, created_by_id, created_at, updated_at)
+         VALUES ($1::uuid, $2::uuid, $3, $4::uuid, now(), now())`,
+        saId,
+        tenantA,
+        `fk-test-sa-${saId.slice(0, 8)}`,
+        saCreatorId,
+      );
+    });
+  });
+
+  afterAll(async () => {
+    if (SKIP) return;
+    // Deleting the SA cascades its tokens + access requests; then drop tenants.
+    await ctx.deleteTestData(tenantA);
+    await ctx.deleteTestData(tenantB);
+    await ctx.cleanup();
+  });
+
+  async function insertSaToken(tenantId: string): Promise<void> {
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO service_account_tokens
+           (id, service_account_id, tenant_id, token_hash, prefix, name, scope, expires_at, created_at)
+         VALUES ($1::uuid, $2::uuid, $3::uuid, $4, $5, $6, $7, now() + interval '1 hour', now())`,
+        randomUUID(),
+        saId,
+        tenantId,
+        randomUUID().replace(/-/g, ""), // unique token_hash
+        "sa_test",
+        "fk-test-token",
+        "passwords:read",
+      );
+    });
+  }
+
+  async function insertAccessRequest(tenantId: string): Promise<void> {
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO access_requests
+           (id, tenant_id, service_account_id, requested_scope, expires_at, created_at)
+         VALUES ($1::uuid, $2::uuid, $3::uuid, $4, now() + interval '1 hour', now())`,
+        randomUUID(),
+        tenantId,
+        saId,
+        "passwords:read",
+      );
+    });
+  }
+
+  it.skipIf(SKIP)("rejects a service-account token whose tenant_id differs from its SA's tenant_id", async () => {
+    await expect(insertSaToken(tenantB)).rejects.toThrow(
+      /service_account_id_tenant_id_fkey/,
+    );
+  });
+
+  it.skipIf(SKIP)("accepts a service-account token whose tenant_id matches its SA's tenant_id", async () => {
+    await expect(insertSaToken(tenantA)).resolves.not.toThrow();
+  });
+
+  it.skipIf(SKIP)("rejects an access request whose tenant_id differs from its SA's tenant_id", async () => {
+    await expect(insertAccessRequest(tenantB)).rejects.toThrow(
+      /service_account_id_tenant_id_fkey/,
+    );
+  });
+
+  it.skipIf(SKIP)("accepts an access request whose tenant_id matches its SA's tenant_id", async () => {
+    await expect(insertAccessRequest(tenantA)).resolves.not.toThrow();
+  });
+});

--- a/src/__tests__/integration/mcp-oauth-flow.test.ts
+++ b/src/__tests__/integration/mcp-oauth-flow.test.ts
@@ -314,7 +314,7 @@ describe("Scenario 3: PKCE Token Exchange Success via /api/mcp/token", () => {
             codeChallengeMethod: "S256",
             scope: "credentials:list,credentials:use",
           }),
-          update: vi.fn().mockResolvedValue({}),
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
         },
         mcpAccessToken: {
           create: vi.fn().mockResolvedValue({ id: "new-token-id" }),

--- a/src/__tests__/integration/sa-lifecycle.test.ts
+++ b/src/__tests__/integration/sa-lifecycle.test.ts
@@ -325,7 +325,7 @@ describe("Scenario 2: SA token issuance and authentication", () => {
     // mockHashToken is already wired to return "hashed-token".
     mockServiceAccountTokenFindUnique.mockResolvedValue({
       ...BASE_TOKEN,
-      serviceAccount: { isActive: true },
+      serviceAccount: { isActive: true, tenantId: BASE_TOKEN.tenantId },
     });
     mockServiceAccountTokenUpdate.mockResolvedValue({});
 
@@ -360,7 +360,7 @@ describe("Scenario 3: SA deactivation → token rejection", () => {
   it("token validates when SA is active", async () => {
     mockServiceAccountTokenFindUnique.mockResolvedValue({
       ...BASE_TOKEN,
-      serviceAccount: { isActive: true },
+      serviceAccount: { isActive: true, tenantId: BASE_TOKEN.tenantId },
     });
     mockServiceAccountTokenUpdate.mockResolvedValue({});
 
@@ -496,7 +496,7 @@ describe("Scenario 5: SA token on v1 endpoint — authOrToken dispatch and scope
     mockServiceAccountTokenFindUnique.mockResolvedValue({
       ...BASE_TOKEN,
       scope: storedScope,
-      serviceAccount: { isActive: true },
+      serviceAccount: { isActive: true, tenantId: BASE_TOKEN.tenantId },
     });
     mockServiceAccountTokenUpdate.mockResolvedValue({});
 

--- a/src/__tests__/lib/mcp/refresh-token.test.ts
+++ b/src/__tests__/lib/mcp/refresh-token.test.ts
@@ -257,6 +257,28 @@ describe("exchangeRefreshToken", () => {
     if (!result.ok) expect(result.error).toBe("invalid_grant");
   });
 
+  it("returns invalid_client when the token's tenantId differs from its client's tenantId", async () => {
+    // Defensive tenant-boundary check: a corrupted source row must not propagate
+    // a divergent tenantId into a freshly minted token pair.
+    const { mockRefreshUpdateMany } = await setupPrisma({
+      rt: {
+        ...VALID_RT,
+        mcpClient: { ...VALID_CLIENT, tenantId: "tenant-OTHER" },
+      },
+    });
+
+    const result = await exchangeRefreshToken({
+      refreshToken: "valid-refresh-token",
+      clientId: "mcpc_testclient",
+      clientSecretHash: "hashed:correct-secret",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("invalid_client");
+    // The rotation CAS must not run — no new pair is minted for a divergent row.
+    expect(mockRefreshUpdateMany).not.toHaveBeenCalled();
+  });
+
   it("REPLAY DETECTION: rotated token reuse triggers family-wide revocation", async () => {
     const { mockRefreshUpdateMany, mockAccessUpdateMany } = await setupPrisma({
       rt: {

--- a/src/__tests__/lib/mcp/refresh-token.test.ts
+++ b/src/__tests__/lib/mcp/refresh-token.test.ts
@@ -114,6 +114,7 @@ describe("exchangeRefreshToken", () => {
     clientId: "mcpc_testclient",
     clientSecretHash: "hashed:correct-secret",
     isActive: true,
+    tenantId: "tenant-uuid-123",
   };
 
   const VALID_RT = {

--- a/src/app/api/admin/rotate-master-key/[rotationId]/execute/route.test.ts
+++ b/src/app/api/admin/rotate-master-key/[rotationId]/execute/route.test.ts
@@ -280,7 +280,7 @@ describe("POST /api/admin/rotate-master-key/[rotationId]/execute", () => {
   it("records revokedShares on the rotation row after successful execute", async () => {
     await callPOST();
     expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: ROTATION_ID },
+      where: { id: ROTATION_ID, tenantId: TENANT },
       data: { revokedShares: 7 },
     });
   });

--- a/src/app/api/admin/rotate-master-key/[rotationId]/execute/route.ts
+++ b/src/app/api/admin/rotate-master-key/[rotationId]/execute/route.ts
@@ -197,7 +197,7 @@ async function handlePOST(
   try {
     await withTenantRls(prisma, auth.tenantId, async (tx) =>
       tx.masterKeyRotation.update({
-        where: { id: rotationId },
+        where: { id: rotationId, tenantId: auth.tenantId },
         data: { revokedShares },
       }),
     );

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -41,7 +41,7 @@ async function handleDELETE(
 
   await withUserTenantRls(userId, async () =>
     prisma.apiKey.update({
-      where: { id },
+      where: { id, userId },
       data: { revokedAt: new Date() },
     }),
   );

--- a/src/app/api/extension/token/route.ts
+++ b/src/app/api/extension/token/route.ts
@@ -109,7 +109,7 @@ async function handleDELETE(req: NextRequest) {
 
   await withUserTenantRls(result.data.userId, async () =>
     prisma.extensionToken.update({
-      where: { id: result.data.tokenId },
+      where: { id: result.data.tokenId, userId: result.data.userId },
       data: { revokedAt: new Date() },
     }),
   );

--- a/src/app/api/folders/[id]/route.ts
+++ b/src/app/api/folders/[id]/route.ts
@@ -143,7 +143,7 @@ async function handlePUT(
   try {
     folder = await withUserTenantRls(session.user.id, async () =>
       prisma.folder.update({
-        where: { id },
+        where: { id, userId: session.user.id },
         data: updateData,
       }),
     );
@@ -243,7 +243,7 @@ async function handleDELETE(
       for (const child of children) {
         const newName = renames.get(child.id);
         await tx.folder.update({
-          where: { id: child.id },
+          where: { id: child.id, userId: session.user.id },
           data: {
             parentId: existing.parentId,
             ...(newName ? { name: newName } : {}),
@@ -256,7 +256,7 @@ async function handleDELETE(
         data: { folderId: null },
       });
       // Delete the folder
-      await tx.folder.delete({ where: { id } });
+      await tx.folder.delete({ where: { id, userId: session.user.id } });
     }),
   );
 

--- a/src/app/api/notifications/[id]/route.test.ts
+++ b/src/app/api/notifications/[id]/route.test.ts
@@ -102,7 +102,7 @@ describe("PATCH /api/notifications/[id]", () => {
     expect(json.isRead).toBe(true);
 
     expect(mockPrismaNotification.update).toHaveBeenCalledWith({
-      where: { id: "n1" },
+      where: { id: "n1", userId: "user-1" },
       data: { isRead: true },
     });
   });
@@ -155,7 +155,7 @@ describe("DELETE /api/notifications/[id]", () => {
     expect(json.success).toBe(true);
 
     expect(mockPrismaNotification.delete).toHaveBeenCalledWith({
-      where: { id: "n1" },
+      where: { id: "n1", userId: "user-1" },
     });
   });
 });

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -26,7 +26,7 @@ async function handlePATCH(
 
   const notification = await withUserTenantRls(session.user.id, async () =>
     prisma.notification.update({
-      where: { id },
+      where: { id, userId: session.user.id },
       data: { isRead: true },
     }),
   );
@@ -57,7 +57,7 @@ async function handleDELETE(
   }
 
   await withUserTenantRls(session.user.id, async () =>
-    prisma.notification.delete({ where: { id } }),
+    prisma.notification.delete({ where: { id, userId: session.user.id } }),
   );
 
   return NextResponse.json({ success: true });

--- a/src/app/api/passwords/[id]/attachments/[attachmentId]/route.test.ts
+++ b/src/app/api/passwords/[id]/attachments/[attachmentId]/route.test.ts
@@ -258,7 +258,7 @@ describe("DELETE /api/passwords/[id]/attachments/[attachmentId]", () => {
     const json = await res.json();
     expect(json.success).toBe(true);
     expect(mockPrismaAttachment.delete).toHaveBeenCalledWith({
-      where: { id: "att-1" },
+      where: { id: "att-1", passwordEntryId: "pw-1" },
     });
   });
 });

--- a/src/app/api/passwords/[id]/attachments/[attachmentId]/route.ts
+++ b/src/app/api/passwords/[id]/attachments/[attachmentId]/route.ts
@@ -126,7 +126,7 @@ async function handleDELETE(
 
   await withUserTenantRls(session.user.id, async () =>
     prisma.attachment.delete({
-      where: { id: attachmentId },
+      where: { id: attachmentId, passwordEntryId: id },
     }),
   );
 

--- a/src/app/api/passwords/[id]/history/[historyId]/restore/route.ts
+++ b/src/app/api/passwords/[id]/history/[historyId]/restore/route.ts
@@ -93,7 +93,7 @@ async function handlePOST(
 
     // Restore history version
     await tx.passwordEntry.update({
-      where: { id },
+      where: { id, userId: session.user.id },
       data: {
         encryptedBlob: history.encryptedBlob,
         blobIv: history.blobIv,

--- a/src/app/api/passwords/[id]/history/[historyId]/restore/route.ts
+++ b/src/app/api/passwords/[id]/history/[historyId]/restore/route.ts
@@ -87,7 +87,7 @@ async function handlePOST(
     });
     if (all.length > 20) {
       await tx.passwordEntryHistory.deleteMany({
-        where: { id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
+        where: { entryId: id, id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
       });
     }
 

--- a/src/app/api/passwords/[id]/restore/route.test.ts
+++ b/src/app/api/passwords/[id]/restore/route.test.ts
@@ -89,7 +89,7 @@ describe("POST /api/passwords/[id]/restore", () => {
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
     expect(mockPrismaPasswordEntry.update).toHaveBeenCalledWith({
-      where: { id: PW_ID },
+      where: { id: PW_ID, userId: "test-user-id" },
       data: { deletedAt: null },
     });
   });

--- a/src/app/api/passwords/[id]/restore/route.ts
+++ b/src/app/api/passwords/[id]/restore/route.ts
@@ -43,7 +43,7 @@ async function handlePOST(
 
   await withUserTenantRls(session.user.id, async () =>
     prisma.passwordEntry.update({
-      where: { id },
+      where: { id, userId: session.user.id },
       data: { deletedAt: null },
     }),
   );

--- a/src/app/api/passwords/[id]/route.test.ts
+++ b/src/app/api/passwords/[id]/route.test.ts
@@ -936,7 +936,7 @@ describe("DELETE /api/passwords/[id]", () => {
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
-    expect(mockPrismaPasswordEntry.delete).toHaveBeenCalledWith({ where: { id: PW_ID } });
+    expect(mockPrismaPasswordEntry.delete).toHaveBeenCalledWith({ where: { id: PW_ID, userId: "test-user-id" } });
     expect(mockLogAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "ENTRY_PERMANENT_DELETE",

--- a/src/app/api/passwords/[id]/route.test.ts
+++ b/src/app/api/passwords/[id]/route.test.ts
@@ -643,7 +643,7 @@ describe("PUT /api/passwords/[id]", () => {
     );
 
     expect(txMock.passwordEntryHistory.deleteMany).toHaveBeenCalledWith({
-      where: { id: { in: ["hist-0"] } },
+      where: { entryId: PW_ID, id: { in: ["hist-0"] } },
     });
   });
 

--- a/src/app/api/passwords/[id]/route.ts
+++ b/src/app/api/passwords/[id]/route.ts
@@ -221,7 +221,7 @@ async function handlePUT(
           });
           if (all.length > 20) {
             await tx.passwordEntryHistory.deleteMany({
-              where: { id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
+              where: { entryId: id, id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
             });
           }
           return tx.passwordEntry.update({

--- a/src/app/api/passwords/[id]/route.ts
+++ b/src/app/api/passwords/[id]/route.ts
@@ -225,7 +225,7 @@ async function handlePUT(
             });
           }
           return tx.passwordEntry.update({
-            where: { id },
+            where: { id, userId },
             data: updateData,
             include: { tags: { select: { id: true } } },
           });
@@ -233,7 +233,7 @@ async function handlePUT(
       )
     : withUserTenantRls(userId, async () =>
         prisma.passwordEntry.update({
-          where: { id },
+          where: { id, userId },
           data: updateData,
           include: { tags: { select: { id: true } } },
         }),
@@ -314,14 +314,14 @@ async function handleDELETE(
         kind: "personal",
         entryIds: [id],
       });
-      await prisma.passwordEntry.delete({ where: { id } });
+      await prisma.passwordEntry.delete({ where: { id, userId } });
       return attachmentRefs;
     });
     await deleteAttachmentBlobs(refs);
   } else {
     await withUserTenantRls(userId, async () =>
       prisma.passwordEntry.update({
-        where: { id },
+        where: { id, userId },
         data: { deletedAt: new Date() },
       }),
     );

--- a/src/app/api/share-links/[id]/route.test.ts
+++ b/src/app/api/share-links/[id]/route.test.ts
@@ -124,7 +124,7 @@ describe("DELETE /api/share-links/[id]", () => {
     expect(json.ok).toBe(true);
     expect(mockPrismaPasswordShare.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: SHARE_ID },
+        where: { id: SHARE_ID, createdById: "user-1" },
         data: expect.objectContaining({ revokedAt: expect.any(Date) }),
       }),
     );

--- a/src/app/api/share-links/[id]/route.ts
+++ b/src/app/api/share-links/[id]/route.ts
@@ -47,7 +47,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
 
   await withUserTenantRls(session.user.id, async () =>
     prisma.passwordShare.update({
-      where: { id },
+      where: { id, createdById: session.user.id },
       data: { revokedAt: new Date() },
     }),
   );

--- a/src/app/api/tags/[id]/route.test.ts
+++ b/src/app/api/tags/[id]/route.test.ts
@@ -202,6 +202,6 @@ describe("DELETE /api/tags/[id]", () => {
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
-    expect(mockPrismaTag.delete).toHaveBeenCalledWith({ where: { id: TAG_ID } });
+    expect(mockPrismaTag.delete).toHaveBeenCalledWith({ where: { id: TAG_ID, userId: "test-user-id" } });
   });
 });

--- a/src/app/api/tags/[id]/route.ts
+++ b/src/app/api/tags/[id]/route.ts
@@ -95,7 +95,7 @@ async function handlePUT(
   try {
     tag = await withUserTenantRls(session.user.id, async () =>
       prisma.tag.update({
-        where: { id },
+        where: { id, userId: session.user.id },
         data: updateData,
       }),
     );
@@ -142,7 +142,7 @@ async function handleDELETE(
   }
 
   await withUserTenantRls(session.user.id, async () =>
-    prisma.tag.delete({ where: { id } }),
+    prisma.tag.delete({ where: { id, userId: session.user.id } }),
   );
 
   return NextResponse.json({ success: true });

--- a/src/app/api/teams/[teamId]/folders/[id]/route.ts
+++ b/src/app/api/teams/[teamId]/folders/[id]/route.ts
@@ -135,7 +135,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
   try {
     folder = await withTeamTenantRls(teamId, async () =>
       prisma.teamFolder.update({
-        where: { id },
+        where: { id, teamId },
         data: updateData,
       }),
     );
@@ -229,7 +229,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
       for (const child of children) {
         const newName = renames.get(child.id);
         await tx.teamFolder.update({
-          where: { id: child.id },
+          where: { id: child.id, teamId },
           data: {
             parentId: existing.parentId,
             ...(newName ? { name: newName } : {}),
@@ -240,7 +240,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
         where: { teamFolderId: id },
         data: { teamFolderId: null },
       });
-      await tx.teamFolder.delete({ where: { id } });
+      await tx.teamFolder.delete({ where: { id, teamId } });
     }),
   );
 

--- a/src/app/api/teams/[teamId]/invitations/[invId]/route.ts
+++ b/src/app/api/teams/[teamId]/invitations/[invId]/route.ts
@@ -36,7 +36,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
   }
 
   await withTeamTenantRls(teamId, async () =>
-    prisma.teamInvitation.delete({ where: { id: invId } }),
+    prisma.teamInvitation.delete({ where: { id: invId, teamId } }),
   );
 
   return NextResponse.json({ success: true });

--- a/src/app/api/teams/[teamId]/members/[memberId]/confirm-key/route.ts
+++ b/src/app/api/teams/[teamId]/members/[memberId]/confirm-key/route.ts
@@ -123,7 +123,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
       });
 
       await tx.teamMember.update({
-        where: { id: memberId },
+        where: { id: memberId, teamId },
         data: { keyDistributed: true },
       });
 

--- a/src/app/api/teams/[teamId]/members/[memberId]/route.test.ts
+++ b/src/app/api/teams/[teamId]/members/[memberId]/route.test.ts
@@ -255,7 +255,7 @@ describe("PUT /api/teams/[teamId]/members/[memberId]", () => {
     expect(json.role).toBe(TEAM_ROLE.OWNER);
     // Actor should be demoted to ADMIN
     expect(mockPrismaTeamMember.update).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: ownerMembership.id }, data: { role: TEAM_ROLE.ADMIN } }),
+      expect.objectContaining({ where: { id: ownerMembership.id, teamId: TEAM_ID }, data: { role: TEAM_ROLE.ADMIN } }),
     );
   });
 
@@ -468,7 +468,7 @@ describe("DELETE /api/teams/[teamId]/members/[memberId]", () => {
       where: { teamId: TEAM_ID, userId: "target-user" },
     });
     expect(mockPrismaTeamMember.delete).toHaveBeenCalledWith({
-      where: { id: MEMBER_ID },
+      where: { id: MEMBER_ID, teamId: TEAM_ID },
     });
   });
 

--- a/src/app/api/teams/[teamId]/members/[memberId]/route.ts
+++ b/src/app/api/teams/[teamId]/members/[memberId]/route.ts
@@ -85,11 +85,11 @@ async function handlePUT(req: NextRequest, { params }: Params) {
     const [, updated] = await withTeamTenantRls(teamId, async () =>
       prisma.$transaction([
         prisma.teamMember.update({
-          where: { id: actorMembership.id },
+          where: { id: actorMembership.id, teamId },
           data: { role: TEAM_ROLE.ADMIN },
         }),
         prisma.teamMember.update({
-          where: { id: memberId },
+          where: { id: memberId, teamId },
           data: { role: TEAM_ROLE.OWNER },
           select: {
             id: true,
@@ -127,7 +127,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
 
   const updated = await withTeamTenantRls(teamId, async () =>
     prisma.teamMember.update({
-      where: { id: memberId },
+      where: { id: memberId, teamId },
       data: { role: result.data.role },
       select: {
         id: true,
@@ -195,7 +195,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
   await withTeamTenantRls(teamId, async () =>
     prisma.$transaction([
       prisma.teamMemberKey.deleteMany({ where: { teamId: teamId, userId: target.userId } }),
-      prisma.teamMember.delete({ where: { id: memberId } }),
+      prisma.teamMember.delete({ where: { id: memberId, teamId } }),
     ]),
   );
 

--- a/src/app/api/teams/[teamId]/passwords/[id]/attachments/[attachmentId]/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/attachments/[attachmentId]/route.ts
@@ -124,7 +124,7 @@ async function handleDELETE(
 
   await withTeamTenantRls(teamId, async () =>
     prisma.attachment.delete({
-      where: { id: attachmentId },
+      where: { id: attachmentId, teamPasswordEntryId: id },
     }),
   );
 

--- a/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/restore/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/restore/route.test.ts
@@ -177,7 +177,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/history/[historyId]/restore", 
     );
     expect(txEntryUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: ENTRY_ID },
+        where: { id: ENTRY_ID, teamId: TEAM_ID },
         data: expect.objectContaining({
           encryptedBlob: baseHistory.encryptedBlob,
           teamKeyVersion: baseHistory.teamKeyVersion,

--- a/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/restore/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/restore/route.ts
@@ -88,7 +88,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     });
     if (all.length > 20) {
       await tx.teamPasswordEntryHistory.deleteMany({
-        where: { id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
+        where: { entryId: id, id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
       });
     }
 

--- a/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/restore/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/history/[historyId]/restore/route.ts
@@ -97,7 +97,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     // the client must detect the mismatch, decrypt with the old key via
     // GET /member-key?keyVersion=N, re-encrypt with the current key, and PUT.
     await tx.teamPasswordEntry.update({
-      where: { id },
+      where: { id, teamId },
       data: {
         encryptedBlob: history.encryptedBlob,
         blobIv: history.blobIv,

--- a/src/app/api/teams/[teamId]/passwords/[id]/restore/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/restore/route.test.ts
@@ -15,6 +15,7 @@ const { mockAuth, mockPrismaTeamPasswordEntry, mockRequireTeamPermission, TeamAu
     mockPrismaTeamPasswordEntry: {
       findUnique: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
     mockRequireTeamPermission: vi.fn(),
     TeamAuthError: _TeamAuthError,
@@ -105,7 +106,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/restore", () => {
       teamId: TEAM_ID,
       deletedAt: new Date(),
     });
-    mockPrismaTeamPasswordEntry.update.mockResolvedValue({});
+    mockPrismaTeamPasswordEntry.updateMany.mockResolvedValue({ count: 1 });
 
     const res = await POST(
       createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/${PW_ID}/restore`),
@@ -114,5 +115,10 @@ describe("POST /api/teams/[teamId]/passwords/[id]/restore", () => {
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
+    // Final mutation must be scoped by id + teamId (defense in depth).
+    expect(mockPrismaTeamPasswordEntry.updateMany).toHaveBeenCalledWith({
+      where: { id: PW_ID, teamId: TEAM_ID },
+      data: { deletedAt: null },
+    });
   });
 });

--- a/src/app/api/teams/[teamId]/passwords/[id]/restore/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/restore/route.ts
@@ -42,8 +42,8 @@ async function handlePOST(req: NextRequest, { params }: Params) {
   }
 
   await withTeamTenantRls(teamId, async () =>
-    prisma.teamPasswordEntry.update({
-      where: { id },
+    prisma.teamPasswordEntry.updateMany({
+      where: { id, teamId },
       data: { deletedAt: null },
     }),
   );

--- a/src/app/api/teams/[teamId]/passwords/[id]/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/route.test.ts
@@ -23,6 +23,8 @@ const {
       findUnique: vi.fn(),
       update: vi.fn(),
       delete: vi.fn(),
+      deleteMany: vi.fn(),
+      updateMany: vi.fn(),
     },
     mockPrismaTeamFolder: { findUnique: vi.fn() },
     mockPrismaTeam: { findUnique: vi.fn() },
@@ -682,9 +684,9 @@ describe("DELETE /api/teams/[teamId]/passwords/[id]", () => {
     expect(json.error).toBe("NOT_FOUND");
   });
 
-  it("soft deletes by default", async () => {
+  it("soft deletes by default, scoping the mutation by id + teamId", async () => {
     mockPrismaTeamPasswordEntry.findUnique.mockResolvedValue({ id: PW_ID, teamId: TEAM_ID });
-    mockPrismaTeamPasswordEntry.update.mockResolvedValue({});
+    mockPrismaTeamPasswordEntry.updateMany.mockResolvedValue({ count: 1 });
 
     const res = await DELETE(
       createRequest("DELETE", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/${PW_ID}`),
@@ -693,12 +695,14 @@ describe("DELETE /api/teams/[teamId]/passwords/[id]", () => {
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
-    expect(mockPrismaTeamPasswordEntry.update).toHaveBeenCalled();
+    expect(mockPrismaTeamPasswordEntry.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: PW_ID, teamId: TEAM_ID } }),
+    );
   });
 
-  it("permanently deletes when permanent=true", async () => {
+  it("permanently deletes when permanent=true, scoping the delete by id + teamId", async () => {
     mockPrismaTeamPasswordEntry.findUnique.mockResolvedValue({ id: PW_ID, teamId: TEAM_ID });
-    mockPrismaTeamPasswordEntry.delete.mockResolvedValue({});
+    mockPrismaTeamPasswordEntry.deleteMany.mockResolvedValue({ count: 1 });
 
     const res = await DELETE(
       createRequest("DELETE", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/${PW_ID}`, {
@@ -707,6 +711,8 @@ describe("DELETE /api/teams/[teamId]/passwords/[id]", () => {
       createParams({ teamId: TEAM_ID, id: PW_ID }),
     );
     expect(res.status).toBe(200);
-    expect(mockPrismaTeamPasswordEntry.delete).toHaveBeenCalled();
+    expect(mockPrismaTeamPasswordEntry.deleteMany).toHaveBeenCalledWith({
+      where: { id: PW_ID, teamId: TEAM_ID },
+    });
   });
 });

--- a/src/app/api/teams/[teamId]/passwords/[id]/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/route.test.ts
@@ -715,4 +715,28 @@ describe("DELETE /api/teams/[teamId]/passwords/[id]", () => {
       where: { id: PW_ID, teamId: TEAM_ID },
     });
   });
+
+  it("returns 404 when the scoped permanent delete matches no row (concurrent delete / wrong team)", async () => {
+    mockPrismaTeamPasswordEntry.findUnique.mockResolvedValue({ id: PW_ID, teamId: TEAM_ID });
+    mockPrismaTeamPasswordEntry.deleteMany.mockResolvedValue({ count: 0 });
+
+    const res = await DELETE(
+      createRequest("DELETE", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/${PW_ID}`, {
+        searchParams: { permanent: "true" },
+      }),
+      createParams({ teamId: TEAM_ID, id: PW_ID }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the scoped soft delete matches no row", async () => {
+    mockPrismaTeamPasswordEntry.findUnique.mockResolvedValue({ id: PW_ID, teamId: TEAM_ID });
+    mockPrismaTeamPasswordEntry.updateMany.mockResolvedValue({ count: 0 });
+
+    const res = await DELETE(
+      createRequest("DELETE", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/${PW_ID}`),
+      createParams({ teamId: TEAM_ID, id: PW_ID }),
+    );
+    expect(res.status).toBe(404);
+  });
 });

--- a/src/app/api/teams/[teamId]/passwords/[id]/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/route.ts
@@ -179,9 +179,17 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
   const { searchParams } = new URL(req.url);
   const permanent = searchParams.get("permanent") === "true";
 
-  const blobRefs = await withTeamTenantRls(teamId, () =>
-    teamPasswordService.deleteTeamPassword(teamId, id, permanent),
-  );
+  let blobRefs;
+  try {
+    blobRefs = await withTeamTenantRls(teamId, () =>
+      teamPasswordService.deleteTeamPassword(teamId, id, permanent),
+    );
+  } catch (e) {
+    if (e instanceof TeamPasswordServiceError) {
+      return errorResponse(e.code, e.statusHint);
+    }
+    throw e;
+  }
   // Purge external blobs after the RLS tx closes (don't hold a DB connection
   // open during blob-store network I/O).
   await deleteAttachmentBlobs(blobRefs);

--- a/src/app/api/teams/[teamId]/tags/[id]/route.ts
+++ b/src/app/api/teams/[teamId]/tags/[id]/route.ts
@@ -94,7 +94,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
   try {
     updated = await withTeamTenantRls(teamId, async () =>
       prisma.teamTag.update({
-        where: { id },
+        where: { id, teamId },
         data: updateData,
       }),
     );
@@ -139,7 +139,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
   }
 
   await withTeamTenantRls(teamId, async () =>
-    prisma.teamTag.delete({ where: { id } }),
+    prisma.teamTag.delete({ where: { id, teamId } }),
   );
 
   return NextResponse.json({ success: true });

--- a/src/app/api/teams/invitations/accept/route.test.ts
+++ b/src/app/api/teams/invitations/accept/route.test.ts
@@ -6,6 +6,7 @@ const { mockAuth, mockPrismaTeamInvitation, mockPrismaTeamMember, mockPrismaUser
   mockPrismaTeamInvitation: {
     findUnique: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
   },
   mockPrismaTeamMember: {
     findUnique: vi.fn(),
@@ -60,7 +61,18 @@ describe("POST /api/teams/invitations/accept", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue({ user: { id: "test-user-id", email: "user@test.com" } });
-    mockTransaction.mockResolvedValue([{}, {}]);
+    mockPrismaTeamInvitation.updateMany.mockResolvedValue({ count: 1 });
+    // The accept path runs prisma.$transaction(async (tx) => …); execute the
+    // callback with a tx whose invitation CAS wins by default so the real
+    // claim → upsert logic is exercised (not bypassed).
+    mockTransaction.mockImplementation(async (arg: unknown) =>
+      typeof arg === "function"
+        ? (arg as (tx: unknown) => unknown)({
+            teamInvitation: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+            teamMember: { upsert: vi.fn().mockResolvedValue({}) },
+          })
+        : [{}, {}],
+    );
     mockRateLimiter.check.mockResolvedValue({ allowed: true });
   });
 
@@ -181,6 +193,28 @@ describe("POST /api/teams/invitations/accept", () => {
     expect(json.role).toBe(TEAM_ROLE.MEMBER);
     expect(json.team.name).toBe("My Team");
     expect(mockTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 410 when the accept CAS loses a concurrent race", async () => {
+    mockPrismaTeamInvitation.findUnique.mockResolvedValue(validInvitation);
+    mockPrismaTeamMember.findUnique.mockResolvedValue(null);
+    mockPrismaUser.findUnique.mockResolvedValue({ ecdhPublicKey: "pub-key" });
+    // Status+expiry CAS matches 0 rows: another accept won concurrently (or the
+    // invitation expired between the pre-check and the write).
+    const upsert = vi.fn();
+    mockTransaction.mockImplementation(async (arg: unknown) =>
+      (arg as (tx: unknown) => unknown)({
+        teamInvitation: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        teamMember: { upsert },
+      }),
+    );
+
+    const res = await POST(createRequest("POST", "http://localhost:3000/api/teams/invitations/accept", {
+      body: { token: "valid-token" },
+    }));
+    expect(res.status).toBe(410);
+    // Membership must NOT be created when the claim is lost.
+    expect(upsert).not.toHaveBeenCalled();
   });
 
   it("returns needsKeyDistribution for team accept", async () => {

--- a/src/app/api/teams/invitations/accept/route.ts
+++ b/src/app/api/teams/invitations/accept/route.ts
@@ -58,8 +58,8 @@ async function handlePOST(req: NextRequest) {
 
   if (invitation.expiresAt < new Date()) {
     await withTeamTenantRls(invitation.teamId, async () =>
-      prisma.teamInvitation.update({
-        where: { id: invitation.id },
+      prisma.teamInvitation.updateMany({
+        where: { id: invitation.id, teamId: invitation.teamId, status: INVITATION_STATUS.PENDING },
         data: { status: INVITATION_STATUS.EXPIRED },
       }),
     );
@@ -90,8 +90,8 @@ async function handlePOST(req: NextRequest) {
     // Active member → already a member
     if (existingMember.deactivatedAt === null) {
       await withTeamTenantRls(invitation.teamId, async () =>
-        prisma.teamInvitation.update({
-          where: { id: invitation.id },
+        prisma.teamInvitation.updateMany({
+          where: { id: invitation.id, teamId: invitation.teamId, status: INVITATION_STATUS.PENDING },
           data: { status: INVITATION_STATUS.ACCEPTED },
         }),
       );
@@ -122,9 +122,23 @@ async function handlePOST(req: NextRequest) {
   // Create membership (or re-activate if previously deactivated) and mark invitation as accepted.
   // keyDistributed starts as false (admin must distribute team key).
   // Use team tenant context: team_members and team_invitations belong to the team's tenant.
-  await withTeamTenantRls(invitation.teamId, async () =>
-    prisma.$transaction([
-      prisma.teamMember.upsert({
+  const accepted = await withTeamTenantRls(invitation.teamId, async () =>
+    prisma.$transaction(async (tx) => {
+      // Claim the invitation atomically: re-assert PENDING + not-expired in the
+      // write so two concurrent accepts (or an accept straddling expiry) cannot
+      // both succeed. The pre-checks above are the fast path; this is the guard.
+      const claim = await tx.teamInvitation.updateMany({
+        where: {
+          id: invitation.id,
+          teamId: invitation.teamId,
+          status: INVITATION_STATUS.PENDING,
+          expiresAt: { gt: new Date() },
+        },
+        data: { status: INVITATION_STATUS.ACCEPTED },
+      });
+      if (claim.count === 0) return false;
+
+      await tx.teamMember.upsert({
         where: {
           teamId_userId: {
             teamId: invitation.teamId,
@@ -144,13 +158,14 @@ async function handlePOST(req: NextRequest) {
           deactivatedAt: null,
           scimManaged: false,
         },
-      }),
-      prisma.teamInvitation.update({
-        where: { id: invitation.id },
-        data: { status: INVITATION_STATUS.ACCEPTED },
-      }),
-    ]),
+      });
+      return true;
+    }),
   );
+
+  if (!accepted) {
+    return errorResponse(API_ERROR.INVITATION_ALREADY_USED);
+  }
 
   return NextResponse.json({
     team: invitation.team,

--- a/src/app/api/tenant/access-requests/[id]/approve/route.test.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.test.ts
@@ -140,6 +140,41 @@ describe("POST /api/tenant/access-requests/[id]/approve", () => {
     mockRequireRecentSession.mockResolvedValue(null);
   });
 
+  it("gates the approval transition on expiresAt atomically (closes TOCTOU window)", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockAccessRequestFindUnique.mockResolvedValue(makeAccessRequest());
+    mockTenantFindUnique.mockResolvedValue(null);
+
+    let capturedWhere: Record<string, unknown> | undefined;
+    mockPrismaTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        serviceAccountToken: {
+          count: vi.fn().mockResolvedValue(0),
+          create: vi.fn().mockResolvedValue({ id: "tok-1" }),
+        },
+        accessRequest: {
+          updateMany: vi.fn().mockImplementation((args: { where: Record<string, unknown> }) => {
+            capturedWhere = args.where;
+            return { count: 1 };
+          }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+      };
+      return fn(tx);
+    });
+
+    const req = createRequest(
+      "POST",
+      `http://localhost/api/tenant/access-requests/${REQUEST_ID}/approve`,
+    );
+    const res = await POST(req, createParams({ id: REQUEST_ID }));
+    expect((await parseResponse(res)).status).toBe(200);
+    // The status transition must carry an expiresAt > now predicate so a request
+    // that expires between the pre-transaction check and the write is excluded.
+    expect(capturedWhere).toMatchObject({ expiresAt: { gt: expect.any(Date) } });
+  });
+
   it("approves pending request and returns JIT token", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockRequireTenantPermission.mockResolvedValue(ACTOR);

--- a/src/app/api/tenant/access-requests/[id]/approve/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.ts
@@ -188,7 +188,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
       });
 
       await tx.accessRequest.update({
-        where: { id: requestId },
+        where: { id: requestId, tenantId: actor.tenantId },
         data: { grantedTokenId: token.id, grantedTokenTtlSec: ttlSec },
       });
 

--- a/src/app/api/tenant/access-requests/[id]/approve/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.ts
@@ -143,12 +143,17 @@ async function handlePOST(req: NextRequest, { params }: Params) {
         throw new Error("Token limit exceeded");
       }
 
-      // Optimistic lock: only update if still PENDING and belongs to this tenant.
+      // Optimistic lock: only update if still PENDING, belongs to this tenant,
+      // AND has not expired. The pre-transaction expiry check above is the
+      // common-case fast path; gating expiresAt atomically here closes the
+      // TOCTOU window where the request crosses its deadline between that read
+      // and this write — JIT expiry is a security boundary, so a token must not
+      // be issued for a request that expired mid-flight (race lands as CONFLICT).
       // C6: throw on { ok: false } to abort the transaction — SA-token creation
       // below must not commit if the status transition did not fire.
       const transitionResult = await transition({
         db: tx,
-        where: { id: requestId, tenantId: actor.tenantId },
+        where: { id: requestId, tenantId: actor.tenantId, expiresAt: { gt: new Date() } },
         to: AR_STATUS.APPROVED,
         actor: AR_ACTOR.ADMIN,
         extraData: { approvedById: session.user.id, approvedAt: new Date() },

--- a/src/app/api/tenant/access-requests/route.test.ts
+++ b/src/app/api/tenant/access-requests/route.test.ts
@@ -351,6 +351,7 @@ describe("POST /api/tenant/access-requests", () => {
     mockServiceAccountFindUnique.mockResolvedValue({
       isActive: true,
       createdById: DEFAULT_SESSION.user.id,
+      tenantId: "tenant-1",
     });
     const created = {
       id: "req-sa-1",
@@ -389,6 +390,7 @@ describe("POST /api/tenant/access-requests", () => {
     mockServiceAccountFindUnique.mockResolvedValue({
       isActive: true,
       createdById: DEFAULT_SESSION.user.id,
+      tenantId: "tenant-1",
     });
     const denied = new Response(
       JSON.stringify({ error: "ACCESS_DENIED" }),
@@ -433,6 +435,7 @@ describe("POST /api/tenant/access-requests", () => {
     mockServiceAccountFindUnique.mockResolvedValue({
       isActive: true,
       createdById: DEFAULT_SESSION.user.id,
+      tenantId: "tenant-1",
     });
     const created = {
       id: "req-sa-infer",

--- a/src/app/api/tenant/access-requests/route.test.ts
+++ b/src/app/api/tenant/access-requests/route.test.ts
@@ -379,6 +379,34 @@ describe("POST /api/tenant/access-requests", () => {
     expect(json.id).toBe("req-sa-1");
   });
 
+  it("returns SA_NOT_FOUND when the SA's tenantId differs from the token's tenantId", async () => {
+    // Defensive tenant-boundary check, symmetric with the admin path: a corrupted
+    // row where the SA belongs to another tenant must fail closed.
+    mockAuthOrToken.mockResolvedValue({
+      type: "service_account",
+      serviceAccountId: SA_ID,
+      tenantId: "tenant-1",
+      tokenId: "tok-1",
+      scopes: ["access-request:create"],
+    });
+    mockServiceAccountFindUnique.mockResolvedValue({
+      isActive: true,
+      createdById: DEFAULT_SESSION.user.id,
+      tenantId: "tenant-OTHER",
+    });
+
+    const req = createRequest("POST", "http://localhost/api/tenant/access-requests", {
+      headers: { Authorization: "Bearer sa_sometoken" },
+      body: { requestedScope: ["passwords:read"] },
+    });
+    const res = await POST(req);
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(404);
+    expect(json.error).toBe("SA_NOT_FOUND");
+    expect(mockAccessRequestCreate).not.toHaveBeenCalled();
+  });
+
   it("returns 403 when SA token request is from outside tenant IP range", async () => {
     mockAuthOrToken.mockResolvedValue({
       type: "service_account",

--- a/src/app/api/tenant/access-requests/route.ts
+++ b/src/app/api/tenant/access-requests/route.ts
@@ -176,10 +176,17 @@ async function handlePOST(req: NextRequest) {
     const sa = await withBypassRls(prisma, async (tx) =>
       tx.serviceAccount.findUnique({
         where: { id: serviceAccountId },
-        select: { isActive: true, createdById: true },
+        select: { isActive: true, createdById: true, tenantId: true },
       }),
     BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
     if (!sa) {
+      return errorResponse(API_ERROR.SA_NOT_FOUND);
+    }
+    // Defensive tenant-boundary check, symmetric with the admin path below.
+    // validateServiceAccountToken already enforces token.tenantId === sa.tenantId,
+    // so this only fires on a corrupted row; fail closed rather than create the
+    // request under the token's tenant for an SA owned by another tenant.
+    if (sa.tenantId !== tenantId) {
       return errorResponse(API_ERROR.SA_NOT_FOUND);
     }
     if (!sa.isActive) {

--- a/src/app/api/tenant/mcp-clients/[id]/route.ts
+++ b/src/app/api/tenant/mcp-clients/[id]/route.ts
@@ -101,7 +101,7 @@ async function handlePUT(
   try {
     updated = await withTenantRls(prisma, actor.tenantId, async (tx) =>
       tx.mcpClient.update({
-        where: { id },
+        where: { id, tenantId: actor.tenantId },
         data: updateData,
         select: { id: true, clientId: true, name: true, redirectUris: true, allowedScopes: true, isActive: true, isDcr: true, updatedAt: true },
       }),

--- a/src/app/api/tenant/members/[userId]/route.test.ts
+++ b/src/app/api/tenant/members/[userId]/route.test.ts
@@ -179,7 +179,7 @@ describe("PUT /api/tenant/members/[userId]", () => {
     expect(json.userId).toBe(TARGET_USER_ID);
     expect(mockPrismaTenantMember.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: TARGET_ADMIN.id },
+        where: { id: TARGET_ADMIN.id, tenantId: TENANT_ID },
         data: { role: "MEMBER" },
       }),
     );

--- a/src/app/api/tenant/members/[userId]/route.ts
+++ b/src/app/api/tenant/members/[userId]/route.ts
@@ -84,13 +84,13 @@ async function handlePUT(req: NextRequest, { params }: Params) {
 
       // Demote actor first (avoid transient dual-OWNER)
       await tx.tenantMember.update({
-        where: { id: currentActor.id },
+        where: { id: currentActor.id, tenantId: actor.tenantId },
         data: { role: TENANT_ROLE.ADMIN },
       });
 
       // Promote target to OWNER
       return tx.tenantMember.update({
-        where: { id: target.id },
+        where: { id: target.id, tenantId: actor.tenantId },
         data: { role: TENANT_ROLE.OWNER },
         include: {
           user: { select: { id: true, name: true, email: true, image: true } },
@@ -128,7 +128,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
   // Update role
   const updated = await withTenantRls(prisma, actor.tenantId, async (tx) =>
     tx.tenantMember.update({
-      where: { id: target.id },
+      where: { id: target.id, tenantId: actor.tenantId },
       data: { role: result.data.role },
       include: {
         user: { select: { id: true, name: true, email: true, image: true } },

--- a/src/app/api/tenant/operator-tokens/[id]/route.test.ts
+++ b/src/app/api/tenant/operator-tokens/[id]/route.test.ts
@@ -162,7 +162,7 @@ describe("DELETE /api/tenant/operator-tokens/[id]", () => {
     expect(body.success).toBe(true);
 
     expect(mockPrismaOperatorToken.update).toHaveBeenCalledWith({
-      where: { id: "tok-1" },
+      where: { id: "tok-1", tenantId: TENANT_ID },
       data: { revokedAt: expect.any(Date) },
     });
 

--- a/src/app/api/tenant/operator-tokens/[id]/route.ts
+++ b/src/app/api/tenant/operator-tokens/[id]/route.ts
@@ -69,7 +69,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
 
   await withTenantRls(prisma, actor.tenantId, async (tx) =>
     tx.operatorToken.update({
-      where: { id },
+      where: { id, tenantId: actor.tenantId },
       data: { revokedAt: new Date() },
     }),
   );

--- a/src/app/api/tenant/scim-tokens/[tokenId]/route.test.ts
+++ b/src/app/api/tenant/scim-tokens/[tokenId]/route.test.ts
@@ -148,7 +148,7 @@ describe("DELETE /api/tenant/scim-tokens/[tokenId]", () => {
     );
     expect(res.status).toBe(200);
     expect(mockPrismaScimToken.update).toHaveBeenCalledWith({
-      where: { id: "tok-1" },
+      where: { id: "tok-1", tenantId: TENANT_ID },
       data: { revokedAt: expect.any(Date) },
     });
     expect(mockLogAudit).toHaveBeenCalledWith(

--- a/src/app/api/tenant/scim-tokens/[tokenId]/route.ts
+++ b/src/app/api/tenant/scim-tokens/[tokenId]/route.ts
@@ -50,7 +50,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
 
   await withTenantRls(prisma, actor.tenantId, async (tx) =>
     tx.scimToken.update({
-      where: { id: tokenId },
+      where: { id: tokenId, tenantId: actor.tenantId },
       data: { revokedAt: new Date() },
     }),
   );

--- a/src/app/api/tenant/service-accounts/[id]/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/route.ts
@@ -105,7 +105,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
   try {
     sa = await withTenantRls(prisma, actor.tenantId, async (tx) =>
       tx.serviceAccount.update({
-        where: { id },
+        where: { id, tenantId: actor.tenantId },
         data: {
           ...(result.data.name !== undefined && { name: result.data.name }),
           ...(result.data.description !== undefined && { description: result.data.description }),
@@ -178,7 +178,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
   // Hard-delete: cascade removes tokens and access requests automatically
   await withTenantRls(prisma, actor.tenantId, async (tx) =>
     tx.serviceAccount.delete({
-      where: { id },
+      where: { id, tenantId: actor.tenantId },
     }),
   );
 

--- a/src/app/api/tenant/service-accounts/[id]/tokens/[tokenId]/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/[tokenId]/route.ts
@@ -61,7 +61,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
 
   await withTenantRls(prisma, actor.tenantId, async (tx) =>
     tx.serviceAccountToken.update({
-      where: { id: tokenId },
+      where: { id: tokenId, serviceAccountId: id, tenantId: actor.tenantId },
       data: { revokedAt: new Date() },
     }),
   );

--- a/src/app/api/user/mcp-tokens/[id]/route.ts
+++ b/src/app/api/user/mcp-tokens/[id]/route.ts
@@ -35,7 +35,7 @@ async function handleDELETE(
 
     const revokedDelegationSessionIds = await prisma.$transaction(async (tx) => {
       await tx.mcpAccessToken.update({
-        where: { id },
+        where: { id, userId, tenantId },
         data: { revokedAt: now },
       });
 

--- a/src/app/api/v1/passwords/[id]/route.test.ts
+++ b/src/app/api/v1/passwords/[id]/route.test.ts
@@ -289,7 +289,7 @@ describe("PUT /api/v1/passwords/[id]", () => {
     );
 
     expect(mockHistoryDeleteMany).toHaveBeenCalledWith({
-      where: { id: { in: ["hist-0"] } },
+      where: { entryId: PW_ID, id: { in: ["hist-0"] } },
     });
   });
 

--- a/src/app/api/v1/passwords/[id]/route.ts
+++ b/src/app/api/v1/passwords/[id]/route.ts
@@ -245,7 +245,7 @@ async function handlePUT(
       }
     }
     return tx.passwordEntry.update({
-      where: { id },
+      where: { id, userId },
       data: updateData,
       include: { tags: { select: { id: true } } },
     });
@@ -320,7 +320,7 @@ async function handleDELETE(
 
   await withTenantRls(prisma, tenantId, async (tx) =>
     tx.passwordEntry.update({
-      where: { id },
+      where: { id, userId },
       data: { deletedAt: new Date() },
     }),
   );

--- a/src/app/api/v1/passwords/[id]/route.ts
+++ b/src/app/api/v1/passwords/[id]/route.ts
@@ -240,7 +240,7 @@ async function handlePUT(
       });
       if (all.length > 20) {
         await tx.passwordEntryHistory.deleteMany({
-          where: { id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
+          where: { entryId: id, id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
         });
       }
     }

--- a/src/app/api/webauthn/credentials/[id]/prf/route.test.ts
+++ b/src/app/api/webauthn/credentials/[id]/prf/route.test.ts
@@ -172,7 +172,7 @@ describe("POST /api/webauthn/credentials/[id]/prf", () => {
     const res = await POST(createRequest("POST", URL, { body: validBody }), params);
     expect(res.status).toBe(200);
     expect(mockTxCredentialUpdate).toHaveBeenCalledWith({
-      where: { id: "cred-row-1" },
+      where: { id: "cred-row-1", userId: "user-1" },
       data: {
         prfEncryptedSecretKey: validBody.prfEncryptedSecretKey,
         prfSecretKeyIv: validBody.prfSecretKeyIv,

--- a/src/app/api/webauthn/credentials/[id]/prf/route.ts
+++ b/src/app/api/webauthn/credentials/[id]/prf/route.ts
@@ -161,7 +161,7 @@ async function handlePOST(
         }
 
         await tx.webAuthnCredential.update({
-          where: { id: credentialRowId },
+          where: { id: credentialRowId, userId },
           data: {
             prfEncryptedSecretKey: body.prfEncryptedSecretKey,
             prfSecretKeyIv: body.prfSecretKeyIv,

--- a/src/app/api/webauthn/credentials/[id]/route.test.ts
+++ b/src/app/api/webauthn/credentials/[id]/route.test.ts
@@ -119,7 +119,7 @@ describe("DELETE /api/webauthn/credentials/[id]", () => {
     expect(status).toBe(200);
     expect(json.success).toBe(true);
     expect(mockPrismaDelete).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: "cred-1" } }),
+      expect.objectContaining({ where: { id: "cred-1", userId: "user-1" } }),
     );
   });
 
@@ -205,7 +205,7 @@ describe("PATCH /api/webauthn/credentials/[id]", () => {
     expect(json.nickname).toBe("My YubiKey");
     expect(mockPrismaUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "cred-1" },
+        where: { id: "cred-1", userId: "user-1" },
         data: { nickname: "My YubiKey" },
       }),
     );

--- a/src/app/api/webauthn/credentials/[id]/route.ts
+++ b/src/app/api/webauthn/credentials/[id]/route.ts
@@ -51,7 +51,7 @@ async function handleDELETE(
 
   await withUserTenantRls(userId, async () =>
     prisma.webAuthnCredential.delete({
-      where: { id },
+      where: { id, userId },
     }),
   );
 
@@ -95,7 +95,7 @@ async function handlePATCH(
 
   const updated = await withUserTenantRls(userId, async () =>
     prisma.webAuthnCredential.update({
-      where: { id },
+      where: { id, userId },
       data: { nickname: data.nickname },
       select: {
         id: true,

--- a/src/lib/auth/tokens/mobile-token.test.ts
+++ b/src/lib/auth/tokens/mobile-token.test.ts
@@ -462,7 +462,7 @@ describe("refreshIosToken", () => {
     // Old family rows revoked.
     expect(mockExtUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { familyId: FAMILY_ID, revokedAt: null },
+        where: { familyId: FAMILY_ID, userId: USER_ID, revokedAt: null },
         data: expect.objectContaining({ revokedAt: expect.any(Date) }),
       }),
     );

--- a/src/lib/auth/tokens/mobile-token.ts
+++ b/src/lib/auth/tokens/mobile-token.ts
@@ -524,7 +524,7 @@ export async function refreshIosToken(
   const nowDate = new Date(now);
   await withUserTenantRls(oldRow.userId, async () =>
     prisma.extensionToken.updateMany({
-      where: { familyId: oldRow.familyId, revokedAt: null },
+      where: { familyId: oldRow.familyId, userId: oldRow.userId, revokedAt: null },
       data: { revokedAt: nowDate },
     }),
   );

--- a/src/lib/auth/tokens/service-account-token.test.ts
+++ b/src/lib/auth/tokens/service-account-token.test.ts
@@ -106,7 +106,7 @@ describe("validateServiceAccountToken", () => {
       expiresAt: new Date(Date.now() + 86400000),
       revokedAt: new Date(),
       lastUsedAt: null,
-      serviceAccount: { isActive: true },
+      serviceAccount: { isActive: true, tenantId: TENANT_ID },
     });
 
     const result = await validateServiceAccountToken(makeRequest("sa_test123"));
@@ -122,7 +122,7 @@ describe("validateServiceAccountToken", () => {
       expiresAt: new Date(Date.now() - 1000),
       revokedAt: null,
       lastUsedAt: null,
-      serviceAccount: { isActive: true },
+      serviceAccount: { isActive: true, tenantId: TENANT_ID },
     });
 
     const result = await validateServiceAccountToken(makeRequest("sa_test123"));
@@ -145,6 +145,24 @@ describe("validateServiceAccountToken", () => {
     expect(result).toEqual({ ok: false, error: "SA_INACTIVE" });
   });
 
+  it("returns SA_TOKEN_INVALID when the SA's own tenantId differs from the token's tenantId", async () => {
+    // Defensive tenant-boundary check: a corrupted/migration-broken row where the
+    // token claims one tenant but its parent SA belongs to another must fail closed.
+    mockPrisma.serviceAccountToken.findUnique.mockResolvedValue({
+      id: TOKEN_ID,
+      serviceAccountId: SA_ID,
+      tenantId: TENANT_ID,
+      scope: "passwords:read",
+      expiresAt: new Date(Date.now() + 86400000),
+      revokedAt: null,
+      lastUsedAt: null,
+      serviceAccount: { isActive: true, tenantId: "tenant-OTHER" },
+    });
+
+    const result = await validateServiceAccountToken(makeRequest("sa_test123"));
+    expect(result).toEqual({ ok: false, error: "SA_TOKEN_INVALID" });
+  });
+
   it("returns valid result for a valid token", async () => {
     mockPrisma.serviceAccountToken.findUnique.mockResolvedValue({
       id: TOKEN_ID,
@@ -154,7 +172,7 @@ describe("validateServiceAccountToken", () => {
       expiresAt: new Date(Date.now() + 86400000),
       revokedAt: null,
       lastUsedAt: null,
-      serviceAccount: { isActive: true },
+      serviceAccount: { isActive: true, tenantId: TENANT_ID },
     });
     mockPrisma.serviceAccountToken.update.mockResolvedValue({});
 
@@ -179,7 +197,7 @@ describe("validateServiceAccountToken", () => {
       expiresAt: new Date(Date.now() + 86400000),
       revokedAt: null,
       lastUsedAt: new Date(), // just now
-      serviceAccount: { isActive: true },
+      serviceAccount: { isActive: true, tenantId: TENANT_ID },
     });
 
     const result = await validateServiceAccountToken(makeRequest("sa_test123"));

--- a/src/lib/auth/tokens/service-account-token.ts
+++ b/src/lib/auth/tokens/service-account-token.ts
@@ -92,7 +92,7 @@ export async function validateServiceAccountToken(
         revokedAt: true,
         lastUsedAt: true,
         serviceAccount: {
-          select: { isActive: true },
+          select: { isActive: true, tenantId: true },
         },
       },
     }),
@@ -109,6 +109,14 @@ export async function validateServiceAccountToken(
   }
   if (!token.serviceAccount.isActive) {
     return { ok: false, error: "SA_INACTIVE" };
+  }
+  // Defensive tenant-boundary check: the token's tenantId and its parent SA's
+  // own tenantId must agree. Normal issuance keeps them consistent; a mismatch
+  // means a corrupted / migration-broken row. Fail closed (don't process the
+  // request under the token's tenant for an SA owned by another tenant) and
+  // collapse into SA_TOKEN_INVALID so callers cannot probe cross-tenant SA ids.
+  if (token.serviceAccount.tenantId !== token.tenantId) {
+    return { ok: false, error: "SA_TOKEN_INVALID" };
   }
 
   // Throttled lastUsedAt update (non-blocking)

--- a/src/lib/directory-sync/engine.ts
+++ b/src/lib/directory-sync/engine.ts
@@ -83,7 +83,7 @@ async function writeSyncError(
   try {
     await withTenantRls(prisma, tenantId, (tx) =>
       tx.directorySyncConfig.update({
-        where: { id: configId },
+        where: { id: configId, tenantId },
         data: {
           status: "ERROR",
           lastSyncError: sanitizeSyncError(error),
@@ -386,7 +386,7 @@ export async function runDirectorySync(
       // Reset config status
       await withTenantRls(prisma, tenantId, (tx) =>
         tx.directorySyncConfig.update({
-          where: { id: configId },
+          where: { id: configId, tenantId },
           data: {
             status: "ERROR",
             lastSyncError: sanitizeSyncError(msg),

--- a/src/lib/mcp/oauth-server.test.ts
+++ b/src/lib/mcp/oauth-server.test.ts
@@ -136,7 +136,7 @@ describe("exchangeCodeForToken", () => {
         id: "code-id",
         usedAt: new Date(),
         expiresAt: new Date(Date.now() + 60000),
-        mcpClient: { clientId: "mcpc_test", clientSecretHash: "hashed:secret", isActive: true },
+        mcpClient: { clientId: "mcpc_test", clientSecretHash: "hashed:secret", isActive: true, tenantId: "tenant-uuid" },
         clientId: "client-uuid",
         tenantId: "tenant-uuid",
         userId: "user-uuid",
@@ -167,7 +167,7 @@ describe("exchangeCodeForToken", () => {
         id: "code-id",
         usedAt: null,
         expiresAt: new Date(Date.now() - 1000), // expired
-        mcpClient: { clientId: "mcpc_test", clientSecretHash: "hashed:secret", isActive: true },
+        mcpClient: { clientId: "mcpc_test", clientSecretHash: "hashed:secret", isActive: true, tenantId: "tenant-uuid" },
         clientId: "client-uuid",
         tenantId: "tenant-uuid",
         userId: "user-uuid",
@@ -198,7 +198,7 @@ describe("exchangeCodeForToken", () => {
         id: "code-id",
         usedAt: null,
         expiresAt: new Date(Date.now() + 60000),
-        mcpClient: { clientId: "mcpc_other", clientSecretHash: "hashed:secret", isActive: true },
+        mcpClient: { clientId: "mcpc_other", clientSecretHash: "hashed:secret", isActive: true, tenantId: "tenant-uuid" },
         clientId: "client-uuid",
         tenantId: "tenant-uuid",
         userId: "user-uuid",
@@ -358,7 +358,7 @@ describe("exchangeCodeForToken", () => {
     const challenge = computeS256Challenge(verifier);
 
     const { prisma } = await import("@/lib/prisma");
-    const mockUpdate = vi.fn().mockResolvedValue({});
+    const mockConsume = vi.fn().mockResolvedValue({ count: 1 });
     const mockTokenCreate = vi.fn().mockResolvedValue({ id: "token-id" });
     (prisma as Record<string, unknown>).mcpAuthorizationCode = {
       findUnique: vi.fn().mockResolvedValue({
@@ -375,7 +375,7 @@ describe("exchangeCodeForToken", () => {
         codeChallengeMethod: "S256",
         scope: "credentials:read",
       }),
-      update: mockUpdate,
+      updateMany: mockConsume,
     };
     (prisma as Record<string, unknown>).mcpAccessToken = { create: mockTokenCreate };
 
@@ -394,8 +394,53 @@ describe("exchangeCodeForToken", () => {
       expect(result.data.expiresIn).toBeGreaterThan(0);
       expect(result.data.scope).toBe("credentials:read");
     }
-    expect(mockUpdate).toHaveBeenCalledOnce();
+    expect(mockConsume).toHaveBeenCalledOnce();
+    expect(mockConsume).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "code-id", usedAt: null } }),
+    );
     expect(mockTokenCreate).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a second concurrent exchange of the same code (single-use CAS)", async () => {
+    const verifier = "correct-verifier-string-for-test";
+    const challenge = computeS256Challenge(verifier);
+
+    const { prisma } = await import("@/lib/prisma");
+    // Simulate the CAS loser: findUnique still sees usedAt === null (no row lock),
+    // but the conditional consume matches 0 rows because the winner already set usedAt.
+    const mockConsume = vi.fn().mockResolvedValue({ count: 0 });
+    const mockTokenCreate = vi.fn().mockResolvedValue({ id: "token-id" });
+    (prisma as Record<string, unknown>).mcpAuthorizationCode = {
+      findUnique: vi.fn().mockResolvedValue({
+        id: "code-id",
+        usedAt: null,
+        expiresAt: new Date(Date.now() + 60000),
+        mcpClient: { clientId: "mcpc_test", clientSecretHash: "hashed:secret", isActive: true, tenantId: "tenant-uuid" },
+        clientId: "client-uuid",
+        tenantId: "tenant-uuid",
+        userId: "user-uuid",
+        serviceAccountId: null,
+        redirectUri: "https://example.com/callback",
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        scope: "credentials:read",
+      }),
+      updateMany: mockConsume,
+    };
+    (prisma as Record<string, unknown>).mcpAccessToken = { create: mockTokenCreate };
+
+    const result = await exchangeCodeForToken({
+      code: "valid-code",
+      clientId: "mcpc_test",
+      clientSecretHash: "hashed:secret",
+      redirectUri: "https://example.com/callback",
+      codeVerifier: verifier,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("invalid_grant");
+    // No token may be minted for the loser.
+    expect(mockTokenCreate).not.toHaveBeenCalled();
   });
 });
 
@@ -475,7 +520,7 @@ describe("validateMcpToken", () => {
         id: "token-id",
         tenantId: "tenant-uuid",
         clientId: "client-uuid",
-        mcpClient: { clientId: "mcpc_testclient123", isActive: true },
+        mcpClient: { clientId: "mcpc_testclient123", isActive: true, tenantId: "tenant-uuid" },
         userId: "user-uuid",
         serviceAccountId: null,
         scope: "credentials:read,credentials:list",
@@ -505,7 +550,7 @@ describe("validateMcpToken", () => {
         id: "token-id",
         tenantId: "t1",
         clientId: "c1",
-        mcpClient: { clientId: "mcpc_abc", isActive: true },
+        mcpClient: { clientId: "mcpc_abc", isActive: true, tenantId: "t1" },
         userId: "u1",
         serviceAccountId: null,
         scope: "credentials:list",
@@ -533,7 +578,7 @@ describe("validateMcpToken", () => {
         id: "token-id",
         tenantId: "t1",
         clientId: "c1",
-        mcpClient: { clientId: "mcpc_abc", isActive: true },
+        mcpClient: { clientId: "mcpc_abc", isActive: true, tenantId: "t1" },
         userId: "u1",
         serviceAccountId: null,
         scope: "credentials:list",
@@ -561,7 +606,7 @@ describe("validateMcpToken", () => {
         id: "token-id",
         tenantId: "t1",
         clientId: "c1",
-        mcpClient: { clientId: "mcpc_abc", isActive: true },
+        mcpClient: { clientId: "mcpc_abc", isActive: true, tenantId: "t1" },
         userId: "u1",
         serviceAccountId: null,
         scope: "credentials:list",
@@ -587,7 +632,7 @@ describe("validateMcpToken", () => {
         id: "token-id",
         tenantId: "t1",
         clientId: "c1",
-        mcpClient: { clientId: "mcpc_abc", isActive: false }, // deactivated
+        mcpClient: { clientId: "mcpc_abc", isActive: false, tenantId: "t1" }, // deactivated
         userId: "u1",
         serviceAccountId: null,
         scope: "credentials:list",
@@ -616,7 +661,7 @@ describe("validateMcpToken", () => {
         id: "token-id",
         tenantId: "tenant-uuid",
         clientId: "client-uuid",
-        mcpClient: { clientId: "mcpc_abc", isActive: true },
+        mcpClient: { clientId: "mcpc_abc", isActive: true, tenantId: "tenant-uuid" },
         userId: "user-uuid",
         serviceAccountId: null,
         scope: "credentials:list",
@@ -644,7 +689,7 @@ describe("validateMcpToken", () => {
         id: "token-id",
         tenantId: "tenant-A",
         clientId: "client-uuid",
-        mcpClient: { clientId: "mcpc_abc", isActive: true },
+        mcpClient: { clientId: "mcpc_abc", isActive: true, tenantId: "tenant-A" },
         userId: "user-uuid",
         serviceAccountId: null,
         scope: "credentials:list",
@@ -677,7 +722,7 @@ describe("validateMcpToken", () => {
         id: "token-id",
         tenantId: "tenant-uuid",
         clientId: "client-uuid",
-        mcpClient: { clientId: "mcpc_abc", isActive: true },
+        mcpClient: { clientId: "mcpc_abc", isActive: true, tenantId: "tenant-uuid" },
         userId: "user-uuid",
         serviceAccountId: null,
         scope: "credentials:list",
@@ -716,7 +761,7 @@ describe("validateMcpToken", () => {
       familyId: "fam-uuid",
       accessTokenId: "at-id",
       scope: "credentials:list",
-      mcpClient: { clientId: "mcpc_test", clientSecretHash: "", isActive: true },
+      mcpClient: { clientId: "mcpc_test", clientSecretHash: "", isActive: true, tenantId: "tenant-uuid" },
     };
     (prisma as Record<string, unknown>).mcpRefreshToken = {
       findUnique: vi.fn().mockResolvedValue(baseRt),
@@ -755,7 +800,7 @@ describe("validateMcpToken", () => {
       familyId: "fam-uuid",
       accessTokenId: "at-id",
       scope: "credentials:list",
-      mcpClient: { clientId: "mcpc_test", clientSecretHash: "", isActive: true },
+      mcpClient: { clientId: "mcpc_test", clientSecretHash: "", isActive: true, tenantId: "tenant-uuid" },
     };
     (prisma as Record<string, unknown>).mcpRefreshToken = {
       findUnique: vi.fn().mockResolvedValue(baseRt),
@@ -794,7 +839,7 @@ describe("validateMcpToken", () => {
       familyId: "fam-uuid",
       accessTokenId: "at-id",
       scope: "credentials:list",
-      mcpClient: { clientId: "mcpc_test", clientSecretHash: "", isActive: true },
+      mcpClient: { clientId: "mcpc_test", clientSecretHash: "", isActive: true, tenantId: "tenant-uuid" },
     };
     (prisma as Record<string, unknown>).mcpRefreshToken = {
       findUnique: vi.fn().mockResolvedValue(baseRt),
@@ -827,7 +872,7 @@ describe("validateMcpToken", () => {
         id: "token-id",
         tenantId: "tenant-uuid",
         clientId: "client-uuid",
-        mcpClient: { clientId: "mcpc_abc", isActive: true },
+        mcpClient: { clientId: "mcpc_abc", isActive: true, tenantId: "tenant-uuid" },
         userId: null,
         serviceAccountId: "sa-uuid",
         scope: "credentials:list",

--- a/src/lib/mcp/oauth-server.test.ts
+++ b/src/lib/mcp/oauth-server.test.ts
@@ -652,6 +652,35 @@ describe("validateMcpToken", () => {
     }
   });
 
+  // Defensive tenant-boundary check: token.tenantId must match its parent
+  // client's own tenantId. A corrupted row must fail closed.
+  it("rejects a token whose tenantId differs from its client's tenantId", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    (prisma as Record<string, unknown>).mcpAccessToken = {
+      findUnique: vi.fn().mockResolvedValue({
+        id: "token-id",
+        tenantId: "tenant-A",
+        clientId: "c1",
+        mcpClient: { clientId: "mcpc_abc", isActive: true, tenantId: "tenant-OTHER" },
+        userId: "u1",
+        serviceAccountId: null,
+        scope: "credentials:list",
+        expiresAt: new Date(Date.now() + 3600_000),
+        revokedAt: null,
+        lastUsedAt: null,
+      }),
+      update: vi.fn(),
+    };
+
+    const { validateMcpToken } = await import("./oauth-server");
+    const result = await validateMcpToken("mcp_valid_token");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("invalid_token");
+    }
+  });
+
   // ── C13: deactivated-user rejection ───────────────────────
 
   it("C13(a): deactivated-in-token-tenant ⇒ invalid_token", async () => {

--- a/src/lib/mcp/oauth-server.ts
+++ b/src/lib/mcp/oauth-server.ts
@@ -189,11 +189,16 @@ export async function exchangeCodeForToken(
       if (!verifyPkceS256(authCode.codeChallenge, params.codeVerifier))
         return { error: "invalid_grant" as const };
 
-      // Mark code as used (atomic within transaction)
-      await tx.mcpAuthorizationCode.update({
-        where: { id: authCode.id },
+      // Mark code as used via compare-and-swap. The findUnique above takes no
+      // row lock (Read Committed), so two concurrent exchanges can both observe
+      // usedAt === null; gating the consume on `usedAt: null` makes the loser's
+      // count === 0 and aborts it, preventing double-redemption of one code into
+      // multiple independent token families. Mirrors the refresh-token CAS below.
+      const consumed = await tx.mcpAuthorizationCode.updateMany({
+        where: { id: authCode.id, usedAt: null },
         data: { usedAt: new Date() },
       });
+      if (consumed.count === 0) return { error: "invalid_grant" as const };
 
       // Issue access token
       const plainToken = MCP_TOKEN_PREFIX + randomBytes(32).toString("base64url");
@@ -376,6 +381,12 @@ export async function exchangeRefreshToken(
         (!isPublicClient && !safeEqual(rt.mcpClient.clientSecretHash, params.clientSecretHash)) ||
         !rt.mcpClient.isActive
       ) {
+        return { type: "invalid_client" as const };
+      }
+
+      // Defensive tenant-boundary check: do not propagate a divergent tenantId
+      // from a corrupted source row into the freshly minted token pair.
+      if (rt.mcpClient.tenantId !== rt.tenantId) {
         return { type: "invalid_client" as const };
       }
 
@@ -590,7 +601,7 @@ export async function validateMcpToken(
         id: true,
         tenantId: true,
         clientId: true,
-        mcpClient: { select: { clientId: true, isActive: true } },
+        mcpClient: { select: { clientId: true, isActive: true, tenantId: true } },
         userId: true,
         serviceAccountId: true,
         scope: true,
@@ -607,6 +618,12 @@ export async function validateMcpToken(
   // A07-4: third McpClient lookup site — reject inactive clients so an admin's
   // "Deactivate client" action takes immediate effect, not just after token TTL.
   if (!record.mcpClient.isActive) return { ok: false, error: "invalid_token" };
+  // Defensive tenant-boundary check: the token's denormalized tenantId must match
+  // its parent client's own tenantId. Issuance keeps them consistent; a mismatch
+  // means a corrupted row — fail closed rather than trust the token's tenantId.
+  if (record.mcpClient.tenantId !== record.tenantId) {
+    return { ok: false, error: "invalid_token" };
+  }
 
   // C13: reject deactivated users — tenant-scoped to the token's own tenant.
   // SA-bound tokens (userId === null) skip the membership check: they are
@@ -679,18 +696,18 @@ export async function revokeToken(params: {
           if (!verifyRevokeClientAuth(rt.mcpClient.clientSecretHash, params.clientSecretHash)) return;
           // Revoke entire rotation family
           await tx.mcpRefreshToken.updateMany({
-            where: { familyId: rt.familyId, revokedAt: null },
+            where: { familyId: rt.familyId, tenantId: rt.tenantId, revokedAt: null },
             data: { revokedAt: new Date() },
           });
           // Revoke all associated access tokens in the family
           const familyTokens = await tx.mcpRefreshToken.findMany({
-            where: { familyId: rt.familyId },
+            where: { familyId: rt.familyId, tenantId: rt.tenantId },
             select: { accessTokenId: true },
           });
           const accessTokenIds = [...new Set(familyTokens.map((t) => t.accessTokenId))];
           if (accessTokenIds.length > 0) {
             await tx.mcpAccessToken.updateMany({
-              where: { id: { in: accessTokenIds }, revokedAt: null },
+              where: { id: { in: accessTokenIds }, tenantId: rt.tenantId, revokedAt: null },
               data: { revokedAt: new Date() },
             });
           }
@@ -707,7 +724,7 @@ export async function revokeToken(params: {
       if (at && at.mcpClient.clientId === params.clientId) {
         if (!verifyRevokeClientAuth(at.mcpClient.clientSecretHash, params.clientSecretHash)) return;
         await tx.mcpAccessToken.update({
-          where: { id: at.id },
+          where: { id: at.id, tenantId: at.tenantId },
           data: { revokedAt: new Date() },
         });
       }

--- a/src/lib/services/team-password-service.ts
+++ b/src/lib/services/team-password-service.ts
@@ -559,7 +559,7 @@ export async function updateTeamPassword(
       });
       if (all.length > 20) {
         await tx.teamPasswordEntryHistory.deleteMany({
-          where: { id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
+          where: { entryId: passwordId, id: { in: all.slice(0, all.length - 20).map((r) => r.id) } },
         });
       }
     }

--- a/src/lib/services/team-password-service.ts
+++ b/src/lib/services/team-password-service.ts
@@ -596,12 +596,23 @@ export async function deleteTeamPassword(
       teamId,
       entryIds: [passwordId],
     });
-    await prisma.teamPasswordEntry.delete({ where: { id: passwordId } });
+    // Scope the mutation by teamId (not the global PK alone) so a stale/mis-routed
+    // caller or a broken RLS context cannot delete an entry belonging to another
+    // team. Mirrors the id+teamId predicate used by updateTeamPassword.
+    const deleted = await prisma.teamPasswordEntry.deleteMany({
+      where: { id: passwordId, teamId },
+    });
+    if (deleted.count !== 1) {
+      throw new TeamPasswordServiceError(API_ERROR.NOT_FOUND, 404);
+    }
     return refs;
   }
-  await prisma.teamPasswordEntry.update({
-    where: { id: passwordId },
+  const trashed = await prisma.teamPasswordEntry.updateMany({
+    where: { id: passwordId, teamId },
     data: { deletedAt: new Date() },
   });
+  if (trashed.count !== 1) {
+    throw new TeamPasswordServiceError(API_ERROR.NOT_FOUND, 404);
+  }
   return [];
 }


### PR DESCRIPTION
## Summary
Defensive hardening of multi-tenant boundaries across the API, surfaced by an external static security review and extended by a cross-cutting audit. No reachable Critical/High issues were found; the changes close two real (low-amplification) TOCTOU bugs and systematically apply tenant/owner scoping plus DB-level constraints so the boundaries fail closed.

## What changed

### TOCTOU / single-use races (real bugs)
- JIT access-request approval: gate the status transition on `expiresAt` atomically — a request crossing its deadline mid-flight can no longer yield a token.
- MCP authorization-code exchange: consume the code via a `usedAt`-conditional compare-and-swap; concurrent replays can no longer mint multiple token families from one code.
- Team invitation accept: claim the invitation (status + expiry CAS) before creating membership — no double-accept / accept-after-expiry / EXPIRED-to-ACCEPTED resurrection.

### Tenant cross-checks (defense-in-depth)
- `validateServiceAccountToken`, `validateMcpToken`, and MCP refresh-token rotation now compare the parent (service account / client) tenant against the token's denormalized tenant and fail closed on mismatch.
- New composite foreign keys `(service_account_id, tenant_id)` referencing `service_accounts(id, tenant_id)` on `service_account_tokens` and `access_requests` make a tenant-divergent row impossible at the DB level (two additive migrations).

### Mutation scoping
- ~50 single-row `update`/`delete` mutations keyed by the global id alone now also carry their parent scope (`userId` / `teamId` / `tenantId` / `createdById`). RLS here is tenant-scoped only, so for personal resources this is a genuine cross-user guard, not just consistency.
- Child/grandchild rows (attachments, password-history trim) are scoped by their parent FK (`passwordEntryId` / `teamPasswordEntryId` / `entryId`) instead of left unscoped.

All sites were already pre-check-guarded, so behavior is unchanged for valid requests; the added predicates fail closed otherwise.

## Testing
- Regression tests for every reject branch: tenant-mismatch rejection (SA + MCP tokens, access-requests), CAS-loss paths (auth-code, invitation accept, team delete 404), and the JIT atomic-expiry predicate.
- New real-DB integration test asserting both composite FKs reject a cross-tenant insert and accept the matching-tenant insert.
- Full suite 11,332 passing / 1 skipped; lint 0 errors; production build passing; `scripts/pre-pr.sh` 36/36. Both migrations applied and verified on the dev DB.

## Notes
- Two additive migrations (`20260615000001`, `20260615000002`); the `ADD CONSTRAINT` fails closed if any pre-existing row has a divergent tenant — operators with corrupt rows must reconcile first (none in dev).
- Review record: `docs/archive/review/tenant-boundary-defensive-hardening-code-review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)