### PR TITLE
feat(ios): restore session at launch — skip URL/sign-in screens for returning users

### DIFF
--- a/docs/archive/review/ios-signin-flow-ux-code-review.md
+++ b/docs/archive/review/ios-signin-flow-ux-code-review.md
@@ -1,0 +1,97 @@
+# Code Review: ios-signin-flow-ux
+
+Date: 2026-06-15
+Review round: 1 (converged)
+Scope: `git diff 3b7be112...HEAD -- ios/` (ios-main base → feature/ios-signin-flow-ux)
+
+## Changes from Previous Round
+Initial review.
+
+## Outcome
+**No Critical or Major findings** from any of the three experts. The implementation
+faithfully realizes contracts C1–C6 and honors the plan's S7 no-destructive-cleanup
+invariant. All checks (functional correctness, Swift-6 concurrency, security trust
+boundaries, test quality) passed.
+
+## Functionality Findings
+- **F1 (Minor)** — `PasswdSSOUITests.swift:17` comment was stale (launch now shows a
+  splash before routing). → **Fixed** (comment updated).
+- All 8 targeted checks clean: `.task` re-entry guard correct; `handleVaultUnlocked`
+  always terminates non-`.unlocking`; `hasTokens` double-optional flatten correct;
+  `AppState` switch exhaustive (single consumer); `.signedIn` 2-arg everywhere;
+  `SignInView.serverURL` sole constructor updated; no retain cycle in `.task`;
+  "Sign in again" reuses the persisted SE key via `getOrCreateDPoPKey`.
+
+## Security Findings
+- **No findings.** All 7 checks clean: no destructive cleanup in SessionRestorer or
+  the `.task` mapping (S1); no token/key logging (S2); production `dpopKeyLabel`
+  unchanged + `precondition` in init (S3); `.dead`→`.vaultLocked` grants no new server
+  access — unlock is local, dead-token sync fails closed (S4); server-URL display
+  leaks no secret (S5); "Sign in again" preserves DPoP cnf-binding (S6); launch-time
+  signing without biometric matches the existing SE-key posture (S7).
+- S3 observation (non-finding): `getOrCreateDPoPKey` loads via `loadDPoPKey` directly
+  rather than the new `keyLoader` seam — test-consistency only, no production impact.
+
+## Testing Findings
+- **T-05 (Moderate→Rejected)** — request for a 4th spy arm (signerExportFailed) in
+  `testRestore_validateNotCalledWhenPreconditionsFail`. **Rejected**: `restore()` has
+  exactly three precondition-failure branches (no config / no tokens / makeSession→nil);
+  "signer export failed" is not a distinct branch — it collapses into the single
+  `guard let client = await makeSession(config)`. The 3-arm spy is complete; a 4th arm
+  would exercise the identical code path.
+- **T-06 (Minor→Accepted, by design)** — `.loggedOut` routes to `.setup` (URL screen)
+  rather than `.signIn`. **Accepted**: the plan's Considerations explicitly designate
+  "Sign Out → `.setup`" as the *deliberate change-server entry point* (it is the only
+  remaining way to change the server URL after onboarding). Routing it to `.signIn`
+  would remove that capability. Surfaced to the user as an optional future refinement
+  (split manual Sign Out vs idle-timeout-logout) — not changed this round.
+- **T-01 (Minor→Accepted)** — the two `makeSession→nil` tests are redundant code paths.
+  Kept: the plan's T1f2 specified a distinct fixture as a forward-looking guard; both
+  correctly assert `.needsSignIn`. Harmless.
+- **T-07/T-08 (plan-approved)** — flicker-fix ordering and `.task` guard are not
+  unit-tested (no RootView harness). Per the plan's documented "Not unit-tested" note;
+  the flicker fix carries the mandatory inline regression-guard comment.
+- All other checks clean: 4-way matrix covered; CallCounter await correct; no vacuous
+  assertions; offline test uses `URLError` (not `NSError`) per T2f; `acc_test` rotation
+  asserted; `loadPersistedSigner` present-case exercises the real coordinator;
+  `DebugVaultLoaderTests` preserved and unbroken; MockURLProtocol reset in `setUp`;
+  no real-Keychain leakage (FakeKeychain / `kSecAttrIsPermanent:false`).
+
+## Adjacent Findings
+None.
+
+## Recurring Issue Check
+### Functionality expert
+- R8 (missing await): clean — all `loadPersistedSigner`/`ensureValidSession` call sites await.
+- R12 (enum-consumer coverage): clean — single `switch appState`, compiler-enforced exhaustiveness for `.launching`/`.unlocking`.
+- R25 (persisted-state symmetry): clean — restoration is read-only; destructive ops stay on the explicit sign-out path.
+- Dead-code completeness: clean — `onDebugVaultReady`/`Load Test Vault`/`handleDebugVaultLoaded` zero matches; `DebugVaultLoader` survives.
+
+### Security expert
+- RS1 (token leakage): clean. RS2 (dead-session cleanup): clean — no destructive ops in `.task`.
+- RS3 (trust boundary): clean. RS4 (no-destructive-cleanup invariant): clean — `.needsReauth`→`.vaultLocked` performs no cleanup.
+- RS5 (DPoP cnf-binding): clean — "Sign in again" reuses the same SE key.
+
+### Testing expert
+- RT1 (untested branches): only the plan-approved RootView view-state.
+- RT2 (vacuous assertions): none. RT3 (test isolation): clean. RT4 (bug-fix regression): flicker fix comment-guarded (plan-approved).
+- RT5 (mock shape): clean. RT6 (async correctness): clean. RT7 (state leakage): none.
+
+## Environment Verification Report
+N/A — no environment constraints declared in Phase 1. Build + full suite (525 unit +
+2 UI tests) executed `verified-local` on iPhone 16 Pro simulator (iOS 18.0), 0 failures.
+
+## Resolution Status
+### F1 Minor — stale UI-test comment
+- Action: updated the comment to describe the splash-then-route launch flow.
+- Modified file: PasswdSSOUITests.swift:17
+
+### T-05 Moderate — 4th spy arm — Rejected
+- **Anti-Deferral check**: not a defect — no distinct code path exists.
+- **Justification**: `restore()` has three precondition-failure branches, all covered; a "signer export failed" arm exercises the same `makeSession→nil` guard. Adding it tests identical code.
+- **Orchestrator sign-off**: confirmed by reading SessionRestorer.restore().
+
+### T-06 Minor — `.loggedOut`→`.setup` — Accepted (by design)
+- **Anti-Deferral check**: out of scope (different concern) — documented design decision.
+- **Justification**: the plan's Considerations designate Sign Out → `.setup` as the sole change-server entry point. Cite: plan "Out of scope: changing the server URL after onboarding (only via Sign Out → `.setup`…)". Surfaced to user as optional refinement.
+- **Orchestrator sign-off**: confirmed against plan Considerations.

--- a/docs/archive/review/ios-signin-flow-ux-plan.md
+++ b/docs/archive/review/ios-signin-flow-ux-plan.md
@@ -1,0 +1,249 @@
+# Plan: iOS Sign-in Flow UX Improvement
+
+## Project context
+
+- **Type**: mixed (this change is iOS host-app only — Swift / SwiftUI under `ios/`)
+- **Test infrastructure**: unit tests (XCTest, target `PasswdSSOTests`) + CI (`.github/workflows/ci.yml` runs `xcodebuild test` on an iOS Simulator). No iOS E2E.
+- Mandatory checks for this change: `xcodegen generate` (from `ios/`) then `xcodebuild -project ios/PasswdSSO.xcodeproj -scheme PasswdSSOApp -destination 'platform=iOS Simulator,name=iPhone 16' test`. `scripts/pre-pr.sh` does **not** run iOS tests; the CI `ios-ci` job is authoritative.
+
+## Objective
+
+Cut the launch path for a returning, already-onboarded user from **URL → Sign-in button → passphrase (flicker) → list** down to **(Face ID / passphrase) → list**, by restoring the persisted session at launch instead of always starting at `.setup`. Three concrete fixes (user-confirmed):
+
+1. **Skip the URL screen** when a server config is already persisted.
+2. **Skip the Sign-in button screen** when valid tokens exist; on token expiry, attempt a silent refresh and only fall back to the Sign-in screen when the *session is dead*. **Delete the DEBUG "Load Test Vault" path entirely.**
+3. **Remove the post-unlock flicker** where the passphrase screen lingers visibly while `handleVaultUnlocked` runs its async sync.
+
+## Requirements
+
+### Functional
+- Cold launch decision (in `RootView`):
+  - No persisted `ServerConfig` → URL setup screen (`.setup`). (First run only.)
+  - `ServerConfig` present, **no** tokens in Keychain → Sign-in screen (`.signIn`) — URL screen skipped.
+  - `ServerConfig` + tokens present + persisted DPoP SE key loadable:
+    - access token still valid → unlock screen directly (auto Face ID).
+    - access token expired → silent refresh:
+      - success → unlock screen.
+      - **dead session** (refresh rejected, e.g. family-revoke/replay) → Sign-in screen.
+      - **offline** (network error) → unlock screen (offline biometric unlock against cached vault; sync retries later).
+  - `ServerConfig` + tokens present but SE key missing → Sign-in screen.
+- No URL screen flash on every launch: the initial state must be a neutral loading state, not `.setup`.
+- After unlock succeeds, show a transitional loading state immediately so the passphrase/Face ID screen does not linger during sync.
+
+### Non-functional
+- **Offline-launch safe**: launch must never require network when the stored access token is still valid, and an offline refresh failure must NOT route to Sign-in.
+- **No security regression**: a dead session must route to re-auth, never silently grant access to network resources. Local vault decryption already requires the bridge key + passphrase/biometric; offline cached-vault viewing of one's own data is acceptable and pre-existing behavior.
+- **Testability**: the launch routing decision must be unit-testable without a real Secure Enclave or network — extract the decision behind injectable dependencies.
+
+## Technical approach
+
+### Current state (verified)
+- `RootView` (`ios/PasswdSSOApp/Views/RootView.swift`) owns `@State private var appState: AppState = .setup` (line 35). There is **no** launch-time restoration — every cold launch walks `.setup → .signIn → .signedIn`.
+- `AppState` cases: `.setup`, `.signIn(serverConfig, coordinator)`, `.signedIn(serverConfig, tokens, apiClient)`, `.vaultUnlocked(...)`, `.vaultLocked(serverConfig, apiClient)`.
+  - `.signedIn` renders `vaultLockedScreen(autoPromptOnAppear: true)` (auto Face ID). Its `tokens` payload is **unused** (matched as `_` at line 53; constructed only at RootView:119,135).
+- `ServerConfig` persistence: `loadServerConfig(defaults:)` / `saveServerConfig` in `ios/Shared/Models/ServerConfig.swift` (App Group `UserDefaults`, key `serverConfig`).
+- Tokens: `HostTokenStore` (`ios/Shared/Storage/HostTokenStore.swift`) — `loadAccess() -> (token, expiresAt)?`, `loadRefresh() -> String?`, `deleteAll()`, per-app Keychain.
+- DPoP SE key: persisted in Secure Enclave under label `com.passwd-sso.dpop.host`. `AuthCoordinator.currentSigner()/currentJWK()` (`ios/PasswdSSOApp/Auth/AuthCoordinator.swift:126-136`) **throw `keyGenerationFailed` until `loadedKey` is set**, and `loadedKey` is set **only** inside `startSignIn()` via the private `getOrCreateDPoPKey()`. → A returning launch that has not signed in cannot build a signing-capable API client. **This is the core blocker for silent refresh and is why C1 is required.**
+- Token refresh: `MobileAPIClient.refreshToken()` is public; the proactive/lazy path `validAccessToken()` (private, `MobileAPIClient.swift:541`) returns the stored token with **no network call** when it is outside the 60s skew window, otherwise refreshes via the single-flight gate. Refresh taxonomy (verified at `doRefreshAndPersist`, lines 512-523): `.networkError` is passed through; every other failure maps to `.authenticationRequired`. This is exactly the offline-vs-dead distinction the routing needs.
+- DEBUG path: `SignInView` (`onDebugVaultReady`, "Load Test Vault" button, `loadDebugVault()`), `RootView.makeSignInView` `#if DEBUG` branch + `handleDebugVaultLoaded`, and `DebugVaultLoader` (`ios/PasswdSSOApp/Debug/DebugVaultLoader.swift`). Grep confirms `DebugVaultLoader`'s only non-test, non-comment consumers are this DEBUG sign-in path → fully orphaned once removed.
+
+### Design
+1. **`AuthCoordinator.loadPersistedSigner()`** (C1): load the existing SE key into `loadedKey` **without generating** one. Absence ⇒ no prior session ⇒ caller routes to sign-in. Make the key label injectable via `init` (default = production label) so the load/absent branches are unit-testable on the simulator.
+2. **`MobileAPIClient.ensureValidSession()`** (C2): public launch-time probe wrapping `validAccessToken()`; returns when a usable token is available (valid or refreshed), throws `.authenticationRequired` for a dead session, `.networkError` when offline. No network call when the stored token is still valid.
+3. **`SessionRestorer`** (C3): a `Sendable` struct whose routing logic is expressed over **injected closures** (config load, token presence, session build, session validation), with production defaults wiring the real types. Returns `RestoredSession` (`.needsSetup` / `.needsSignIn(ServerConfig)` / `.needsUnlock(ServerConfig, MobileAPIClient)` / `.needsReauth(ServerConfig, MobileAPIClient)`). The routing matrix is the unit-tested unit.
+4. **`AppState` changes** (C4): add `.launching` (new initial state, neutral loading) and `.unlocking` (post-unlock transitional loading); drop the unused `tokens` payload from `.signedIn`.
+5. **`RootView` wiring** (C5): initial state `.launching`; a `.task` runs `SessionRestorer.restore()` once and maps `RestoredSession → AppState`; `.launching` and `.unlocking` render a `ProgressView` splash; `handleVaultUnlocked` sets `appState = .unlocking` as its first statement so the passphrase/Face ID screen is replaced immediately.
+6. **DEBUG removal** (C6): delete the DEBUG sign-in wiring and the now-orphaned `DebugVaultLoader.swift` + `DebugVaultLoaderTests.swift`; fix the stray doc comment in `VaultViewModel.swift:56`.
+
+## Contracts
+
+### C1 — `AuthCoordinator.loadPersistedSigner()` + injectable key label + injectable key loader
+**File**: `ios/PasswdSSOApp/Auth/AuthCoordinator.swift`
+
+- Change `private let dpopKeyLabel = "com.passwd-sso.dpop.host"` to an init-injected stored property defaulting to that literal, **and** inject the key-load seam (resolves the simulator-testability problem — see note below):
+  - `init(serverConfig: ServerConfig, tokenStore: HostTokenStore = HostTokenStore(), dpopKeyLabel: String = "com.passwd-sso.dpop.host", keyLoader: (@Sendable (String) throws -> SecKey)? = nil)`
+  - Store `self.keyLoader = keyLoader ?? { label in try loadDPoPKey(label: label) }` (default arg cannot reference `self.dpopKeyLabel`, so resolve in the init body).
+- New method:
+  - `public func loadPersistedSigner() -> Bool` (synchronous, actor-isolated; called from outside as `await coordinator.loadPersistedSigner()`) — body: `if let existing = try? keyLoader(dpopKeyLabel) { loadedKey = existing; return true }; return false`. MUST NOT call `generateDPoPKey`.
+  - The non-empty-label guard goes in `init` (`precondition(!dpopKeyLabel.isEmpty, "dpopKeyLabel must not be empty")`), NOT in `loadPersistedSigner()` — it is an invariant on the injected parameter, fires once at construction, and avoids a per-call `precondition` that would terminate the process from a hot path. (F13)
+- **Concurrency note (F14)**: `SecKey` is a CoreFoundation type that does not conform to `Sendable`, so `keyLoader: @Sendable (String) throws -> SecKey` may trip Swift 6 strict-concurrency depending on `SWIFT_STRICT_CONCURRENCY`. Phase 2 checks the target's setting; if flagged, wrap the return in an `@unchecked Sendable` box (precedent: `SendableSecKey` in `AuthCoordinatorTests.swift:109`) or store the closure `nonisolated(unsafe)`. The existing actor already holds `loadedKey: SecKey?` and `SecureEnclaveDPoPSigner` is `@unchecked Sendable`, so the project clearly already tolerates `SecKey` across isolation with a wrapper — reuse that pattern.
+- **Why the `keyLoader` seam is mandatory (testability)**: the real `loadDPoPKey(label:)` (`Shared/Crypto/SecureEnclaveKey.swift:54`) filters on `kSecAttrTokenID: kSecAttrTokenIDSecureEnclave`. The simulator-only software keys produced by `AuthCoordinatorTests.makeSoftwareP256Key` are created **without** that token-ID (and with `kSecAttrIsPermanent: false`), so `loadDPoPKey` can never find them. Without the seam, the "key found → coordinator ready" branch of `loadPersistedSigner()` is untestable on the simulator/CI. The injected `keyLoader` lets T3 return a software key directly.
+- **Invariants**:
+  - `loadPersistedSigner()` never creates a key (absence is a routing signal, not an error).
+  - After `loadPersistedSigner()` returns `true`, `currentSigner()` and `currentJWK()` succeed.
+  - The production label literal and the production `keyLoader` (`loadDPoPKey`) are unchanged (existing sessions keep working).
+  - `dpopKeyLabel` is non-empty (precondition; the only non-default callers are the `.live` factory and tests).
+- **Acceptance**:
+  - `keyLoader` that throws (key absent) → returns `false`, `loadedKey` stays nil, `currentSigner()` still throws.
+  - `keyLoader` that returns a (software) key → returns `true`, `currentSigner()`/`currentJWK()` succeed.
+
+### C2 — `MobileAPIClient.ensureValidSession()`
+**File**: `ios/PasswdSSOApp/Network/MobileAPIClient.swift`
+
+- New method:
+  - `public func ensureValidSession() async throws` — body: `_ = try await validAccessToken()`.
+- **Invariants**:
+  - Makes **no** network request when the stored access token is outside the refresh-skew window (offline-launch safe). (Inherited from `validAccessToken`.)
+  - Propagates `MobileAPIError.networkError` unchanged on offline refresh failure; surfaces `MobileAPIError.authenticationRequired` for a dead/missing session. (Inherited from `doRefreshAndPersist`.)
+  - Does not change `validAccessToken`'s existing single-flight / persistence behavior.
+- **Acceptance**:
+  - Valid stored token → returns without any URLProtocol request (assert request count 0).
+  - Expired token + refresh 200 → returns; rotated pair persisted (assert new access token in store).
+  - Expired token + refresh 401 → throws `.authenticationRequired`.
+  - Expired token + transport error → throws `.networkError`. **The test MUST make `MockURLProtocol.requestHandler` throw a concrete `URLError` (e.g. `throw URLError(.notConnectedToInternet)`), NOT an `NSError`.** `performHTTP` only maps to `MobileAPIError.networkError` via `catch let urlError as URLError`; an `NSError` (even in `NSURLErrorDomain`) fails that cast and is remapped to `.authenticationRequired` by `doRefreshAndPersist`, so the test would silently validate the dead-session path instead of the offline path. (T2f)
+
+### C3 — `SessionRestorer`
+**File (new)**: `ios/Shared/Session/SessionRestorer.swift` (or `ios/PasswdSSOApp/Auth/SessionRestorer.swift` — see open question O1)
+
+```
+public enum RestoredSession: Sendable {
+  case needsSetup
+  case needsSignIn(ServerConfig)                  // no local unlock material → OAuth required
+  case needsUnlock(ServerConfig, MobileAPIClient) // session usable (or offline) → auto-Face-ID unlock
+  case needsReauth(ServerConfig, MobileAPIClient) // refresh failed but local vault material exists → unlock-or-resign-in
+}
+
+public enum SessionValidation: Sendable { case ok, offline, dead }
+
+public struct SessionRestorer: Sendable {
+  // Injected seams (production defaults wire the real types):
+  var loadConfig: @Sendable () -> ServerConfig?
+  var hasTokens: @Sendable () -> Bool                                   // access AND refresh present
+  var makeSession: @Sendable (ServerConfig) async -> MobileAPIClient?   // loads SE signer; nil if key absent
+  var validate:    @Sendable (MobileAPIClient) async -> SessionValidation
+
+  public func restore() async -> RestoredSession
+}
+```
+
+- **Routing (the tested logic)**:
+  1. `loadConfig() == nil` → `.needsSetup`
+  2. `!hasTokens()` → `.needsSignIn(config)`
+  3. `makeSession(config) == nil` (SE key gone OR signer/JWK export failed) → `.needsSignIn(config)`
+  4. `validate(client)`:
+     - `.ok` → `.needsUnlock(config, client)`
+     - `.offline` → `.needsUnlock(config, client)`
+     - `.dead` → `.needsReauth(config, client)`
+- **Why `.needsReauth` is distinct from `.needsSignIn` (the core fork)**: cases 2–3 (`.needsSignIn`) have **no local unlock material** (no tokens, or the SE signer is gone) → the only way forward is a full OAuth sign-in. Case 4 (`.needsReauth`) still has tokens + a working SE signer + (typically) a bridge key, so the vault **can** be unlocked locally even though the network session is unusable. The dead-vs-transient signal is irreducibly ambiguous at launch (see below), so `.needsReauth` routes to a screen that serves **both**: biometric/passphrase unlock of the cached vault (a transient `5xx` recovers on the next sync; the user reads their data meanwhile) **and** a prominent "Sign in again" affordance (a genuine revoke re-establishes the session). This is the existing `.vaultLocked` screen.
+- **`restore()` performs NO destructive cleanup, and neither does the consumer** (S7 resolution). No arm calls `clearTenantPolicy()` / `CredentialIdentityRegistrar().clear()` / `deleteAll()`. Rationale: the refresh ladder collapses **every** non-network failure — genuine dead-session (401/replay), transient `5xx`, and `429` — into `MobileAPIError.authenticationRequired` (`doRefreshAndPersist`, MobileAPIClient.swift:512-523; verified: `decodeResponse` maps 5xx→`.serverError`, 429→`.rateLimited`, then the wrapper remaps every non-`networkError` to `.authenticationRequired`). `validate` therefore cannot tell a revoked session from a momentary server hiccup. An **irreversible** tenant-policy/QuickType wipe on that ambiguous signal would destroy a still-valid session's state on a single 500/503/429 at launch. Routing `.dead` to the unlock-or-resign-in screen is non-destructive and recoverable; the wipe stays on the explicit Sign-Out path (`AutoLockService.loggedOut` → RootView:75-82), and tenant policy + QuickType refresh on the next successful unlock.
+- **Production default wiring** (a static factory, e.g. `SessionRestorer.live(defaults:tokenStore:)`):
+  - `loadConfig` = `{ loadServerConfig(defaults:) }`
+  - `hasTokens` = `{ (try? tokenStore.loadAccess()) != nil && (try? tokenStore.loadRefresh()) != nil }` — the `try?` is intentional: a Keychain decode/access error becomes `false` → routes to `.needsSignIn` rather than throwing out of a non-throwing closure. Do NOT change `try?` to `try`. (F11)
+  - `makeSession` = build `AuthCoordinator`; `guard await coordinator.loadPersistedSigner() else { return nil }`; then `let signer = try? await coordinator.currentSigner()`, `let jwk = try? await coordinator.currentJWK()` (both are actor-isolated → **`await` is required**; F1); `guard let signer, let jwk else { return nil }`; build `MobileAPIClient(serverURL:, signer:, jwk:, tokenStore:)`. Mirror `RootView.buildRealAPIClient` (RootView:359) but return `nil` on missing signer instead of substituting `NoOpDPoPSigner` — for restoration a missing signer means re-auth, not a no-op client.
+  - `validate` = `{ client in do { try await client.ensureValidSession(); return .ok } catch MobileAPIError.networkError { return .offline } catch { return .dead } }` — `.networkError` (offline) is the only branch that maps to `.offline`; **every other failure (dead session, 5xx, 429) maps to `.dead` → `.needsReauth` → `.vaultLocked`** (acceptable because the consumer does no destructive cleanup, and `.vaultLocked` serves both local unlock and "Sign in again"; see the S7 resolution above and Considerations).
+- **Invariants**:
+  - `validate` is called **only** in branch 4 (after config + tokens + signer confirmed). Offline never downgrades to `.needsSignIn`.
+  - `SessionRestorer` performs no token mutation and touches no app-settings/identity state itself (refresh-and-persist stays inside `MobileAPIClient`).
+- **Forbidden**: `pattern: tokenStore.deleteAll\(\)` / `pattern: clearTenantPolicy` / `pattern: CredentialIdentityRegistrar` inside `SessionRestorer` OR the `RootView` launch-restore mapping — reason: restoration must not wipe tokens, tenant policy, or QuickType identities (the dead-vs-transient signal is ambiguous; wiping on a server blip corrupts a valid session). Cleanup stays on the explicit Sign-Out path.
+- **Acceptance** (routing matrix): see Testing strategy T1.
+
+### C3 consumer-flow walkthrough (mandatory — `RestoredSession` is consumed outside the producer)
+- **Consumer: `RootView.task` mapping** (path: `ios/PasswdSSOApp/Views/RootView.swift`) reads `RestoredSession` and:
+  - `.needsSetup` → sets `appState = .setup` (reads nothing else).
+  - `.needsSignIn(config)` → reads `config`; constructs `AuthCoordinator(serverConfig: config, tokenStore: HostTokenStore())`; sets `appState = .signIn(serverConfig: config, coordinator:)`. **No destructive cleanup** (S7 resolution). Needs only `ServerConfig` — satisfied.
+  - `.needsUnlock(config, apiClient)` → reads `config` and `apiClient`; sets `appState = .signedIn(serverConfig: config, apiClient: apiClient)` (post-C4 signature, no tokens; auto-Face-ID unlock). Needs `ServerConfig` + a signing-capable `MobileAPIClient` — both present; the `apiClient` carries the loaded SE signer so the subsequent passphrase-unlock network call and `handleVaultUnlocked` sync can DPoP-sign. Satisfied.
+  - `.needsReauth(config, apiClient)` → reads `config` and `apiClient`; sets `appState = .vaultLocked(serverConfig: config, apiClient: apiClient)` (the existing unlock-or-resign-in screen: biometric/passphrase unlock of the cached vault **plus** the "Sign in again" button). **No destructive cleanup.** Needs `ServerConfig` + `MobileAPIClient` — both present; `apiClient` carries the SE signer so a successful local unlock's `handleVaultUnlocked` sync can still DPoP-sign (and will succeed once a transient server error clears). Satisfied.
+- No consumer needs a field absent from `RestoredSession`. The `apiClient` returned for `.needsUnlock`/`.needsReauth` is the **same instance** validated by `validate`, so its single-flight refresh state carries into `handleVaultUnlocked`.
+
+### C4 — `AppState` shape change
+**File**: `ios/PasswdSSOApp/Views/RootView.swift`
+
+- Add `case launching` (rendered as splash; the new initial value).
+- Add `case unlocking` (rendered as splash; transitional, set at the top of `handleVaultUnlocked`).
+- Change `case signedIn(serverConfig: ServerConfig, tokens: TokenPair, apiClient: MobileAPIClient)` → `case signedIn(serverConfig: ServerConfig, apiClient: MobileAPIClient)` (drop unused `tokens`).
+- **Invariants**:
+  - `handleVaultUnlocked` always terminates by assigning a non-`.unlocking` state (today: `.vaultUnlocked` at line 322) so the splash cannot stick.
+  - `.launching` is only ever the pre-restore state; `restore()`'s result always replaces it.
+  - The single `switch appState` in `RootView.body` (RootView:42 — grep-confirmed the **only** consumer of `AppState`) MUST gain arms for `.launching` and `.unlocking`. `AppState` has no `@unknown default`, so omitting either is a compile error (exhaustiveness-enforced). List this switch update explicitly as part of C5. (F12)
+- **Forbidden patterns**:
+  - `pattern: appState: AppState = .setup` — reason: initial state must be `.launching`, not `.setup` (avoids URL-screen flash).
+  - `pattern: \.signedIn\([^)]*tokens:` — reason: `.signedIn` no longer carries `tokens`.
+- **Acceptance**: project compiles; the only `.signedIn` matches in the host target are the post-C4 2-arg form; `AppState` has `launching` and `unlocking`.
+
+### C5 — `RootView` restoration + flicker fix
+**File**: `ios/PasswdSSOApp/Views/RootView.swift`
+
+- `@State private var appState: AppState = .launching`.
+- Render `.launching` and `.unlocking` as a centered `ProgressView` (a `passwd-sso` splash; reuse existing branding).
+- Add a `.task` on the root `Group` that runs once:
+  - `guard case .launching = appState else { return }` (avoid re-running on later view re-appears). (F5)
+  - `let result = await SessionRestorer.live(...).restore()`
+  - map `result → appState` per the C3 consumer walkthrough (a plain 3-case switch; no destructive cleanup in any arm).
+- `handleVaultUnlocked(...)`: set `appState = .unlocking` as the **first** statement (it is already `@MainActor`). This replaces the passphrase/Face ID screen with the splash before the `await drain.drainPendingFlags` / `runSync` work. Add an inline comment: `// MUST be the first statement — regression guard for the post-unlock flicker fix (#3); do not move below the first await.` (T5 — there is no automated test for this ordering since RootView has no unit harness.)
+- Replace `makeSignInView` with a single (non-`#if DEBUG`) `SignInView(coordinator:, onSignedIn:)` factory (C6 removes the DEBUG branch).
+- **Re-point the `.vaultLocked` "Sign in again" button** (RootView:95-97) from `appState = .setup` to `appState = .signIn(serverConfig: config, coordinator:)` — constructing a fresh `AuthCoordinator(serverConfig: config)` (the `.vaultLocked` case already binds `serverConfig`). This skips the URL screen on explicit re-auth (consistent with the whole skip-URL goal) and is the destination for the new `.needsReauth` launch route. It also improves the existing in-app-lock → "Sign in again" path (config is already known). Acceptance: tapping "Sign in again" lands on the OAuth sign-in screen, never the URL setup screen.
+- **Acceptance**:
+  - On cold launch with persisted config+valid tokens, no URL screen and no Sign-in screen are shown (state goes `.launching → .signedIn → .unlocking → .vaultUnlocked`).
+  - On cold launch with no config, `.launching → .setup`.
+  - During unlock, the passphrase screen is replaced by the splash before list appears (no lingering passphrase screen).
+
+### C6 — Remove the DEBUG sign-in button + wiring (KEEP `DebugVaultLoader` + its test)
+**Decision (T4)**: remove only the user-facing DEBUG sign-in path (the user's request: "完全に削除" the button). **Do NOT delete `DebugVaultLoader.swift` or `DebugVaultLoaderTests.swift`** — `DebugVaultLoaderTests` is the **only** end-to-end test exercising the surviving production decrypt round-trip (`CredentialResolver.resolveCandidates` + `decryptEntryDetail`, AAD construction, AES-GCM helpers, `OverviewBlobPayload`/`FullBlobPayload` decode). Deleting it would leave the core AutoFill credential-delivery path with no integration coverage. `DebugVaultLoader` is `#if DEBUG`, has no App-Store footprint, and after this change is referenced only by its own test — an acceptable DEBUG-only fixture.
+
+**Files**:
+- `ios/PasswdSSOApp/Views/SignInView.swift`: remove the `onDebugVaultReady` property, the `#if DEBUG` "Load Test Vault" button, and `loadDebugVault()`. `SignInView` keeps `coordinator` + `onSignedIn`.
+- `ios/PasswdSSOApp/Views/RootView.swift`: collapse `makeSignInView` to a single non-`#if DEBUG` `SignInView(coordinator:, onSignedIn:)`; delete the `handleDebugVaultLoaded(...)` method and its `#if DEBUG` block.
+- `ios/PasswdSSOApp/Debug/DebugVaultLoader.swift`: **keep unchanged.**
+- `ios/PasswdSSOTests/DebugVaultLoaderTests.swift`: **keep unchanged** (preserves CredentialResolver round-trip coverage — RT2).
+- `ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift:56`: minor clarification — `DebugVaultLoader` now writes this cache shape only as a **test fixture** (no production caller after the button removal). Adjust the comment to read e.g. `HostSyncService writes this shape in production; DebugVaultLoader writes it as a test fixture.` so it doesn't imply two production writers. (F15)
+- **Forbidden patterns** (must not appear anywhere in `ios/` after the change):
+  - `pattern: onDebugVaultReady` — reason: DEBUG callback removed.
+  - `pattern: Load Test Vault` — reason: button removed.
+  - `pattern: handleDebugVaultLoaded` — reason: method removed.
+  - (`DebugVaultLoader` is intentionally NOT forbidden — the type + its test survive.)
+- **Pre-change grep gate** (Phase 2): `grep -rn 'onDebugVaultReady\|loadDebugVault\|handleDebugVaultLoaded' ios --include='*.swift'` enumerates exactly the SignInView + RootView sites to edit; after the edits it returns zero. `grep -rn 'DebugVaultLoader' ios --include='*.swift'` should afterwards match only `DebugVaultLoader.swift`, `DebugVaultLoaderTests.swift`, and the `VaultViewModel.swift:56` comment.
+- **Acceptance**: project + tests compile in both Debug and Release configs; the three forbidden patterns return zero matches; `DebugVaultLoaderTests` still runs and passes.
+
+## Testing strategy
+
+- **T1 — `SessionRestorerTests` (new, `ios/PasswdSSOTests/SessionRestorerTests.swift`)**: inject fakes for the four seams; assert the full routing matrix:
+  - no config → `.needsSetup`
+  - config, no tokens → `.needsSignIn`
+  - config, tokens, `makeSession`→nil (SE key gone) → `.needsSignIn`
+  - config, tokens, `makeSession`→nil (signer/JWK export failed — a **distinct fixture** from the key-gone case; guards against a future `makeSession` that throws) → `.needsSignIn` (T1f2)
+  - config, tokens, session, `validate`=`.ok` → `.needsUnlock`
+  - config, tokens, session, `validate`=`.offline` → `.needsUnlock`
+  - config, tokens, session, `validate`=`.dead` → `.needsReauth`
+  - Plus: `validate` is **not** invoked when config/tokens/session preconditions fail. The call-count spy MUST be a reference type — `actor CountSpy { var n = 0 }` or `final class CountSpy { ... }` — because a `@Sendable` closure cannot capture a mutable `var` local without `nonisolated(unsafe)`; document the pattern in the test file. (T1f3)
+- **T2 — `MobileAPIClient.ensureValidSession` tests** (extend `MobileAPIClientTests.swift`, reuse `MockURLProtocol` + `FakeSigner` + `FakeKeychain` + injectable `now()`): the four C2 acceptance cases. The offline (`.networkError` passthrough) case is the new-coverage one and MUST throw a `URLError` from the mock handler (see C2 acceptance, T2f) — the existing suite already covers valid/expired/401 for `validAccessToken`. Reset `MockURLProtocol.requestHandler` in `setUp()` (it is `nonisolated(unsafe) static var` — follow the existing pattern; RT5).
+- **T3 — `AuthCoordinator.loadPersistedSigner` tests** (extend `AuthCoordinatorTests.swift`): inject the new `keyLoader` seam (C1). A loader that throws → `loadPersistedSigner()` returns `false` and `currentSigner()` still throws; a loader returning a `makeSoftwareP256Key` key → returns `true` and `currentSigner()`/`currentJWK()` succeed. **Do NOT test via the real `loadDPoPKey`/`generateDPoPKey`** — its `kSecAttrTokenIDSecureEnclave` filter cannot see simulator software keys (T1f), and real `generateDPoPKey` with `kSecAttrIsPermanent: true` would persist across runs (if ever used in a test, add `deleteDPoPKey(label:)` in `tearDown`; RT3). The `keyLoader` seam avoids the Keychain entirely.
+- Build verification: `xcodegen generate` then `xcodebuild ... -scheme PasswdSSOApp test` (Debug). Also a Release build (`-configuration Release build`) to confirm the DEBUG-button removal did not leave a Release-only reference.
+- **Regression coverage preserved**: `DebugVaultLoaderTests` is **kept** (C6) so the `CredentialResolver` decrypt round-trip stays covered (RT2).
+- **Not unit-tested** (documented): `RootView` `.task` wiring, the `RestoredSession → AppState` mapping (a plain 3-case switch with no destructive side effects), and the `.launching`/`.unlocking` splash rendering are SwiftUI view-state with no existing RootView test harness; the routing decision they consume is covered by T1, and the flicker-fix ordering is guarded by the mandatory inline comment in C5. Per project context (no iOS E2E), this is an informational note, not a finding.
+
+## Considerations & constraints
+
+- **Offline launch correctness is the highest-risk axis.** The `.offline → .needsUnlock` branch is what keeps subway launches working; a regression that routes offline to `.needsSignIn` would lock users out of their cached vault. T1 pins this; C2's no-network-when-valid invariant pins the common case.
+- **Dead-session handling does not wipe tokens** (forbidden pattern in C3). Routing to `.signIn` is sufficient; a successful OAuth overwrites the stale pair. Worst case of leaving a dead refresh token: it is server-side revoked and useless; likelihood: only after family-revoke/replay; cost to wipe vs. keep: negligible either way — we keep to avoid deleting state an offline pass might still need. This mirrors the existing `.vaultLocked` "Sign in again" path which also does not wipe.
+- **Launch restoration performs NO destructive cleanup of tenant policy / QuickType identities (S7 resolution; S1 residual accepted)**. The refresh ladder collapses dead-session (401/replay), transient `5xx`, and `429` all into `MobileAPIError.authenticationRequired` (`doRefreshAndPersist`, MobileAPIClient.swift:512-523) — verified: `decodeResponse` maps 5xx→`.serverError`, 429→`.rateLimited`, then `doRefreshAndPersist` remaps every non-`networkError` to `.authenticationRequired`. So a launch-time `validate` cannot tell a genuinely-revoked session from a momentary server hiccup. An eager `clearTenantPolicy()` + `CredentialIdentityRegistrar().clear()` on that ambiguous signal would **irreversibly** corrupt a still-valid session's state on a single 500/503/429 at launch (S7, Critical if implemented). Resolution: launch never wipes; `.dead` routes to `.needsReauth` → `.vaultLocked` (non-destructive, unlock-or-resign-in). Residual S1 risk — a genuinely revoked user's device keeps stale QuickType suggestions + a stale tenant-policy value until the next event: worst case = the user's *own* credential metadata (usernames/sites) appears as inline AutoFill suggestions on their own device; **the QuickType store holds only metadata (host/username/record-UUID), no secrets, and the fill path gates on a fresh Face ID/Touch ID challenge (`BridgeKeyStore.readForFillAuthenticated`, biometric — not a network session) before any blob is decrypted**, so a stale identity cannot deliver a credential without the device owner's biometric auth; likelihood = only between server-revoke and the user's next sign-out/successful-unlock; cost-to-fix-properly = high (would require de-conflating 5xx from 401 deep in the shared refresh ladder, rippling through every `performAuthedGET` caller). Tenant policy + QuickType both refresh on the next successful unlock, and explicit Sign Out clears both. Accepted; matches the existing `.vaultLocked` re-auth precedent. (S1, S7, S8, S9)
+- **A transient server `5xx`/`429` at launch is handled gracefully without forcing OAuth** (this is why `.dead` routes to `.needsReauth`/`.vaultLocked`, not `.needsSignIn`). The user can biometric-unlock the cached vault and keep working; the next sync retries and succeeds once the server recovers. A genuine revoke is handled by the same screen's "Sign in again" button. This removes the earlier "transient blip bounces to OAuth" wart — there is no remaining TODO for launch routing.
+- **SE key availability at launch**: the persisted key survives reinstall-less launches; a Keychain reset (rare) makes `loadPersistedSigner()` return false → `.needsSignIn` (no local unlock material), which is correct (tokens without a signer are unusable).
+- **SE DPoP key is not biometric-gated (accepted trade-off, not a regression)**: the host DPoP key is created with `.privateKeyUsage` + `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` and **no** user-presence/biometry flag (`SecureEnclaveKey.swift:21-28`), so launch-time silent refresh can DPoP-sign without a biometric prompt. This matches every existing foreground DPoP request and is required for the offline/silent-launch goal; gating it on biometrics would force a Face ID prompt on every refresh and break offline launch. The vault key remains separately gated (bridge key + passphrase/biometric in `VaultUnlocker`), so a silent refresh yields at most a fresh access token for a still-locked vault — no plaintext credential exposure. Worst case: an attacker who already has device-unlock can mint an access token; likelihood: requires device-unlock (same precondition as reading the Keychain at all); cost to change: high + conflicts with requirements → accept. (S2)
+- **`buildRealAPIClient` (RootView:359)** already builds a client from `coordinator.currentSigner()`; `SessionRestorer.makeSession` follows the same pattern but with `loadPersistedSigner()` first. Phase 2 should reuse `buildRealAPIClient`'s shape (do not duplicate the NoOp fallback semantics — for restoration a missing signer means `.needsSignIn`, not a NoOp client).
+- **Skipping the server probe is not a pinning regression (pre-existing gap, tracked as a separate plan)**: `ServerURLSetupView.probeServer` only checks HTTP reachability — it never computes or stores `ServerConfig.pinnedAASAHash` / `pinnedTLSSPKIHash`, which are always persisted `nil` (`ServerConfig.swift:7-9`; `continueButtonTapped` builds `ServerConfig(baseURL:)`). TOFU pinning is modeled but not implemented, so skipping the setup screen on returning launches bypasses no enforced check. Implementing TLS-SPKI / AASA pinning (capture-on-first-use in the probe + a pin-verify step in the launch-restore path, or removing the vestigial fields) is an orthogonal security feature, **carved out into its own plan** (`ios-tofu-pinning`, to be created) rather than expanding this UX change. (S5)
+- **Out of scope**: changing the server URL after onboarding (only via Sign Out → `.setup`, or "Sign in again" → `.signIn`); proactive background token refresh; TOFU pinning (separate `ios-tofu-pinning` plan, above); team key pipeline (tracked separately in `ios-team-quicktype`). The release-please `MARKETING_VERSION` bump is automated and not touched here.
+
+## User operation scenarios
+
+1. **Returning user, app reopened minutes later (token valid)**: `.launching` splash → Face ID sheet → splash → list. No URL, no Sign-in, no passphrase flicker.
+2. **Returning user next morning (access token expired, refresh valid)**: `.launching` → silent refresh (200) → Face ID → splash → list.
+3. **Returning user on the subway (offline, token expired)**: `.launching` → refresh transport error → `.offline` → Face ID (offline, local decrypt) → splash → cached list. Sync silently retries when network returns.
+4. **Session revoked server-side (admin reset / replay)**: `.launching` → refresh fails → `.dead` → `.needsReauth` → `.vaultLocked` (unlock-or-resign-in screen). The user can biometric-unlock to read cached data, then tap **"Sign in again"** → `.signIn` (URL skipped) → OAuth re-establishes the session. No tenant-policy/QuickType wipe (S7).
+4b. **Transient server `5xx`/`429` at launch (still-valid session)**: identical routing to (4) since the failure is indistinguishable — `.dead` → `.vaultLocked`. But here the user just biometric-unlocks; the next sync succeeds once the server recovers, and "Sign in again" is never needed. Non-destructive, no forced OAuth.
+5. **Brand-new install**: `.launching` → no config → URL screen → probe → Sign-in → OAuth → first passphrase unlock (Face ID button hidden until bridge key exists) → splash → list.
+6. **Signed in but app killed before first unlock (tokens present, no bridge key)**: `.launching` → `.needsUnlock` → passphrase screen (no Face ID button, since `biometricUnlockAvailable()` requires a bridge key) → first passphrase unlock calls `/api/vault/unlock/data` (network) → splash → list. **Offline in this specific case is unrecoverable**: there is no bridge key and no cached vault yet, so the passphrase screen surfaces a "check your connection" error and the vault cannot be opened until network returns. This is pre-existing behavior (the first unlock has always required the server); biometric + offline access only become available after the first successful passphrase unlock establishes the bridge key. The acceptance criterion for this scenario is "network error shown offline", not "list reachable offline". (F4)
+
+## Open questions
+
+- **O1**: Place `SessionRestorer` in `ios/Shared/Session/` (reusable, matches `Shared/Storage`, `Shared/Models`) vs. `ios/PasswdSSOApp/Auth/`. It depends on `MobileAPIClient`/`AuthCoordinator`, which live in `PasswdSSOApp`, not `Shared` → it likely must live in `PasswdSSOApp` (Shared cannot import the app target). **Tentative decision: `ios/PasswdSSOApp/Auth/SessionRestorer.swift`.** Phase 2 confirms the module boundary before placing the file.
+
+## Go/No-Go Gate
+
+| ID | Subject                                                          | Status |
+|----|-----------------------------------------------------------------|--------|
+| C1 | `AuthCoordinator.loadPersistedSigner()` + injectable key label  | locked |
+| C2 | `MobileAPIClient.ensureValidSession()` public probe             | locked |
+| C3 | `SessionRestorer` struct + `RestoredSession`/`SessionValidation`+ routing | locked |
+| C4 | `AppState` adds `.launching`/`.unlocking`, drops `.signedIn` tokens | locked |
+| C5 | `RootView` `.task` restoration wiring + `.unlocking` flicker fix | locked |
+| C6 | Delete DEBUG sign-in path + orphaned `DebugVaultLoader`          | locked |

--- a/docs/archive/review/ios-signin-flow-ux-review.md
+++ b/docs/archive/review/ios-signin-flow-ux-review.md
@@ -1,0 +1,53 @@
+# Plan Review: ios-signin-flow-ux
+
+Date: 2026-06-14
+Review rounds: 2 full (functionality / security / testing) + 1 security confirmation
+Outcome: **converged — all Critical/Major findings resolved; remaining items accepted with quantified justification.**
+
+## Scope reviewed
+Plan: [ios-signin-flow-ux-plan.md](./ios-signin-flow-ux-plan.md) — launch-time session restoration to skip the URL + Sign-in screens for returning users, remove the DEBUG "Load Test Vault" path, and remove the post-unlock passphrase-screen flicker.
+
+## Round 1 findings & resolution
+
+### Functionality
+- **F1 (Minor)** — C3 `makeSession` must `await` the actor-isolated `currentSigner()/currentJWK()`. → Fixed in C3 wiring text.
+- **F4 (Major)** — Scenario 6 (tokens, no bridge key) is NOT offline-recoverable; plan's acceptance over-claimed "list reachable". → Scenario 6 reworded: offline shows a network error (pre-existing).
+- **F5 (Minor)** — Use `guard case .launching = appState else { return }`, not `if case`. → Fixed in C5.
+- **F11 (Minor)** — `try?` on `loadAccess()` in `hasTokens` is intentional. → Documented in C3.
+- **F12 (Minor)** — The single `switch appState` (RootView:42) must gain `.launching`/`.unlocking` arms (compile-enforced). → Listed explicitly in C4 invariant.
+- F6–F10 — verified correct (Task survives view teardown; no `.task`/autoprompt race; `validAccessToken` makes no network call when valid; `handleVaultUnlocked` does not bounce to sign-in on sync failure; `BackgroundSyncCoordinatorTests.signedIn` is a different enum).
+
+### Security
+- **S1 (Major)** — Dead-session routing to `.signIn` skipped the tenant-policy + QuickType cleanup that the `.loggedOut` path performs. → Round 1 added an eager-cleanup design; **superseded by the S7 resolution in round 2** (see below). Final disposition: launch does NOT wipe; residual accepted (quantified in Considerations).
+- **S2 (Minor)** — SE host DPoP key has no biometric gate; launch-time silent refresh signs without user presence. By design, not a regression; required for offline launch; vault key separately gated. → Documented as accepted trade-off.
+- **S5 (Major, pre-existing)** — `ServerConfig.pinnedAASAHash/pinnedTLSSPKIHash` are always nil; TOFU pinning is modeled but never implemented, so skipping the setup probe bypasses no enforced control. → `TODO(ios-signin-flow-ux)` follow-up; out of scope.
+- **S3, S4 (Minor)** — Leaving a server-revoked refresh token in Keychain, and offline self-vault read by a revoked user, both analyzed acceptable (server-side family-revoke + per-app Keychain + short access-token TTL; offline reads only the user's own cached data). → Accepted.
+
+### Testing
+- **T1f (Critical)** — `loadDPoPKey` filters on `kSecAttrTokenIDSecureEnclave`; simulator software keys are invisible, so `loadPersistedSigner()`'s found-branch was untestable. → C1 now injects a `keyLoader` seam; T3 injects a software-key loader.
+- **T2f (Major)** — The offline `.networkError` test must throw a concrete `URLError`, not an `NSError` (else it silently validates the dead-session path). → Mandated in C2 acceptance + T2.
+- **T4 (Major)** — Deleting `DebugVaultLoaderTests` would remove the only end-to-end `CredentialResolver` decrypt round-trip coverage. → C6 now KEEPS `DebugVaultLoader` + its test; removes only the button/wiring.
+- **T1f2/T1f3 (Major/Minor)** — Add a distinct `makeSession`-nil fixture; the call-count spy must be a reference type (`@Sendable` capture). → Added to T1.
+
+## Round 2 findings & resolution
+
+- **S7 (Critical)** — `doRefreshAndPersist` collapses 5xx, 429, and genuine 401 all into `.authenticationRequired` (verified MobileAPIClient.swift:512-523), so the round-1 `validate` could not distinguish a transient server blip from a dead session — and the eager `.deadSession` cleanup would then **irreversibly wipe tenant policy + QuickType for a still-valid session** on a single 500/503/429 at launch. The agent's "catch `.serverError` in validate" fix was itself incorrect (validate never sees `.serverError` — already remapped upstream). → **Resolution: drop the eager cleanup entirely.** Launch routes `.dead` → `.needsSignIn` non-destructively (matching the existing `.vaultLocked` "Sign in again" precedent, which also doesn't wipe). Cleanup stays on the explicit Sign-Out path; tenant policy + QuickType refresh on the next unlock. This also moots round-2 **T5/T6** (no untested security-relevant cleanup branch remains).
+- **S8 (Minor)** — 429 same bug class as S7. → Subsumed by the S7 resolution.
+- **S9 (Info)** — `dpopInvalid`→re-auth at launch is conservative but acceptable. → Documented.
+- **F13 (Minor)** — Move the non-empty-label `precondition` to `init` (not per-call in `loadPersistedSigner`). → Fixed in C1.
+- **F14 (Minor)** — `SecKey` is not `Sendable`; the `keyLoader` closure may trip strict concurrency. → C1 notes the Phase-2 check + the existing `SendableSecKey`/`@unchecked Sendable` precedent.
+- **F15 (Minor)** — After C6 the `VaultViewModel:56` comment implies two production cache writers. → C6 now adjusts the comment to mark `DebugVaultLoader` as a test fixture.
+- Round-1 fixes all re-verified correct (await idiom matches existing `buildRealAPIClient`; `guard case`; exhaustive-switch; keyLoader seam; offline `.dead` cannot be produced when offline — traced).
+
+## Round 3 (security confirmation of S7 resolution)
+- **S7 resolved, no new findings.** Removing the eager cleanup fully eliminates the irreversible-state-loss path. Critically verified that **no new credential-delivery hole** is introduced by leaving stale QuickType identities: the `ASCredentialIdentityStore` holds only metadata (host/username/record-UUID, no secrets), `provideCredentialWithoutUserInteraction` always returns `userInteractionRequired`, and the fill path gates on a fresh Face ID/Touch ID challenge (`BridgeKeyStore.readForFillAuthenticated`) before any blob is decrypted. A stale identity cannot deliver a credential without the device owner's biometric auth.
+
+## Post-review user decisions (folded into the plan, not left as TODOs)
+- **Launch routing for refresh-failure** — the dead-vs-transient signal is irreducibly ambiguous at launch (refresh ladder collapses 5xx/429/401 → `.authenticationRequired`). Decision (user-chosen): `.dead` routes to **`.needsReauth` → `.vaultLocked`** (the existing unlock-or-resign-in screen), NOT to the OAuth sign-in screen. This serves both cases — a transient `5xx` recovers via local biometric unlock + next-sync retry; a genuine revoke uses the screen's "Sign in again" button. A new `RestoredSession.needsReauth` case distinguishes "has local unlock material" (tokens+signer → `.vaultLocked`) from "no local material" (`.needsSignIn` → OAuth). The `.vaultLocked` "Sign in again" button is re-pointed from `.setup` to `.signIn` (skip URL). No destructive cleanup in any arm (S7). The earlier "transient bounces to OAuth" wart is eliminated — no launch-routing TODO remains.
+- **TOFU pinning (S5)** — carved out into its own plan (`ios-tofu-pinning`, to be created); orthogonal security feature, pre-existing, not regressed by this change.
+
+## Accepted (anti-deferral record)
+- **S1 residual** — stale QuickType suggestions + stale tenant policy persist for a genuinely-revoked session until next sign-out/unlock. Worst case: the user's *own* credential metadata shows as inline suggestions on their own device; no secret delivered without biometric auth (`BridgeKeyStore.readForFillAuthenticated` gate); tenant policy + QuickType refresh on next unlock; explicit Sign Out clears both. Likelihood: only between server-revoke and next user event. Cost to fix properly: high (de-conflate 5xx from 401 deep in the shared refresh ladder, rippling through all `performAuthedGET` callers). → Accepted; matches existing `.vaultLocked` precedent.
+
+## Go/No-Go
+All 6 contracts (C1–C6) **locked**. C3's `RestoredSession` final shape adds `.needsReauth(ServerConfig, MobileAPIClient)` (the user-chosen launch-routing fork) alongside `.needsSetup` / `.needsSignIn(ServerConfig)` / `.needsUnlock(ServerConfig, MobileAPIClient)`. Plan is ready for Phase 2 implementation.

--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		5421D67E38D403D16E75A584 /* AESGCMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAD672FE74D0EB78FA99F1C /* AESGCMTests.swift */; };
 		542B8D1BD03A73706A98778B /* KDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02778E2A8EE7B7A09B671C4 /* KDF.swift */; };
 		56F8D2D70DF4C0539E6A7988 /* PasskeyAssertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493B2BB02D23F64F52EF0DAA /* PasskeyAssertionTests.swift */; };
+		59428A468BFADE6726350ABB /* SessionRestorerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9460BB2F468F19DF7EC3A00 /* SessionRestorerTests.swift */; };
 		5B65C54AB593A685DC452BA4 /* OneTimeCodePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57AF6A21C048387AB2FC0C5 /* OneTimeCodePickerView.swift */; };
 		60AD9C0835A9502C54C79E90 /* AESGCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86EB7DC9441141057919E49 /* AESGCM.swift */; };
 		60C6D1BB9FB84DB9FA966478 /* PasswdSSOAutofillExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 4F631B3CA954B4A2A4EC5714 /* PasswdSSOAutofillExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -135,6 +136,7 @@
 		EE5586305A8A75C6F0DE9A47 /* TeamDirectoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820C1F588B1209A77A6C0A36 /* TeamDirectoryStore.swift */; };
 		EEDC524C6F56E4E378F8DB16 /* DebugVaultLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6190750A2E1A027047EDBB4 /* DebugVaultLoader.swift */; };
 		EF9407000E17ADEB5E667D88 /* EntryCacheFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CD914CFF8AD6DD6DAB0129 /* EntryCacheFileTests.swift */; };
+		F2FD2B81E009401CBD83DF77 /* SessionRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7711E89FA2346B9FE338E3 /* SessionRestorer.swift */; };
 		F376E57211FDE0E03F285949 /* LockedFallbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6E4E71B2DDEE6BBA03CBF4 /* LockedFallbackView.swift */; };
 		F50C3FCB3A6C9F4A5419B71E /* PasskeyRegistrationOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881416D87A323B49E40CCCC3 /* PasskeyRegistrationOutcome.swift */; };
 		F67226652335D3241D5B1ADD /* PasskeySignCountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469C94A411CE66C4D3EAB9AA /* PasskeySignCountStore.swift */; };
@@ -316,8 +318,10 @@
 		B61C70648C7D9DE6F493F1AD /* SecureClipboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureClipboardTests.swift; sourceTree = "<group>"; };
 		B67A2748B3B1C69F7543EB64 /* PasswdSSOTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PasswdSSOTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8AE8A147DAB81877B408F77 /* team-key-fixture.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "team-key-fixture.json"; sourceTree = "<group>"; };
+		B9460BB2F468F19DF7EC3A00 /* SessionRestorerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorerTests.swift; sourceTree = "<group>"; };
 		BB8D42DAB6AE67B22BFFB262 /* BackgroundSyncCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSyncCoordinator.swift; sourceTree = "<group>"; };
 		BBBBBBBE5688A781ED154534 /* EntryFormTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryFormTests.swift; sourceTree = "<group>"; };
+		BC7711E89FA2346B9FE338E3 /* SessionRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorer.swift; sourceTree = "<group>"; };
 		C02778E2A8EE7B7A09B671C4 /* KDF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KDF.swift; sourceTree = "<group>"; };
 		C19D6A107E63BFA725F2C0F3 /* WrappedKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappedKeyStoreTests.swift; sourceTree = "<group>"; };
 		C1F6D6429583F4DF936E38A0 /* SharedFrameworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedFrameworkTests.swift; sourceTree = "<group>"; };
@@ -437,6 +441,7 @@
 				775C6B815B59EF7FAADB00EB /* RollbackFlagWriterTests.swift */,
 				B61C70648C7D9DE6F493F1AD /* SecureClipboardTests.swift */,
 				662E445816ED2184809324A5 /* ServerTrustServiceTests.swift */,
+				B9460BB2F468F19DF7EC3A00 /* SessionRestorerTests.swift */,
 				C1F6D6429583F4DF936E38A0 /* SharedFrameworkTests.swift */,
 				160063572DE97E6E16AE7A3D /* SPKIEncoderTests.swift */,
 				65EFD0AD3F8896F5D18F2967 /* StaleBlobRecoveryServiceTests.swift */,
@@ -563,6 +568,7 @@
 				A2CB0DAE185BE8F6CC8E6351 /* AuthCoordinator.swift */,
 				AFB5F0EE6A3D22DF1F2C53B2 /* AutofillTokenRefresher.swift */,
 				C9E896E2CA0264206A65A0B8 /* ServerTrustService.swift */,
+				BC7711E89FA2346B9FE338E3 /* SessionRestorer.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -978,6 +984,7 @@
 				D818CC3D8994859EC9B470F2 /* RootView.swift in Sources */,
 				93D09C74C9EDAA9E4767D4C3 /* ServerTrustService.swift in Sources */,
 				347F2D6168FB578E0E7687EC /* ServerURLSetupView.swift in Sources */,
+				F2FD2B81E009401CBD83DF77 /* SessionRestorer.swift in Sources */,
 				0DF2C117B49A7A20E36940F0 /* SettingsView.swift in Sources */,
 				FFDB363D6F74C9F3DD0E54C3 /* SignInView.swift in Sources */,
 				4372EB553FD8B0AE2BF33972 /* StaleBlobRecoveryService.swift in Sources */,
@@ -1035,6 +1042,7 @@
 				FFA7B60616C41F7692F7271C /* SPKIEncoderTests.swift in Sources */,
 				29D3F2AD7DEF39F185E5ABEA /* SecureClipboardTests.swift in Sources */,
 				E0832EF8431014E47A2A4636 /* ServerTrustServiceTests.swift in Sources */,
+				59428A468BFADE6726350ABB /* SessionRestorerTests.swift in Sources */,
 				61C3FD90259F677EA6150C8F /* SharedFrameworkTests.swift in Sources */,
 				E6242A08FB6CD768CBCED638 /* StaleBlobRecoveryServiceTests.swift in Sources */,
 				E61FA83E34E321C09B0D7176 /* TOTPVectorTests.swift in Sources */,

--- a/ios/PasswdSSOApp/Auth/AuthCoordinator.swift
+++ b/ios/PasswdSSOApp/Auth/AuthCoordinator.swift
@@ -35,7 +35,11 @@ public enum AuthError: Error, Equatable {
 public actor AuthCoordinator {
   private let serverConfig: ServerConfig
   let tokenStore: HostTokenStore
-  private let dpopKeyLabel = "com.passwd-sso.dpop.host"
+  private let dpopKeyLabel: String
+  /// Seam for loading the persisted SE key. Defaults to `loadDPoPKey`, which
+  /// filters on `kSecAttrTokenIDSecureEnclave` — invisible to the simulator
+  /// software keys used in tests, so tests inject a software-key loader here.
+  private let keyLoader: @Sendable (String) throws -> SecKey
   /// Custom URL scheme the server redirects the ASWebAuthenticationSession to
   /// on successful sign-in (`passwd-sso://auth/callback?code&state`). Captured
   /// by scheme, so it works against any self-hosted server host — no Universal
@@ -45,9 +49,29 @@ public actor AuthCoordinator {
   /// Set after the first successful call to getOrCreateDPoPKey.
   private var loadedKey: SecKey?
 
-  public init(serverConfig: ServerConfig, tokenStore: HostTokenStore = HostTokenStore()) {
+  public init(
+    serverConfig: ServerConfig,
+    tokenStore: HostTokenStore = HostTokenStore(),
+    dpopKeyLabel: String = "com.passwd-sso.dpop.host",
+    keyLoader: (@Sendable (String) throws -> SecKey)? = nil
+  ) {
+    precondition(!dpopKeyLabel.isEmpty, "dpopKeyLabel must not be empty")
     self.serverConfig = serverConfig
     self.tokenStore = tokenStore
+    self.dpopKeyLabel = dpopKeyLabel
+    self.keyLoader = keyLoader ?? { label in try loadDPoPKey(label: label) }
+  }
+
+  /// Load the persisted Secure Enclave DPoP key into `loadedKey` WITHOUT
+  /// generating a new one. Returns true if an existing key was found. Used at
+  /// launch to rebuild a signing-capable API client without a full OAuth
+  /// sign-in; absence ⇒ no prior session ⇒ caller routes to sign-in.
+  public func loadPersistedSigner() -> Bool {
+    if let existing = try? keyLoader(dpopKeyLabel) {
+      loadedKey = existing
+      return true
+    }
+    return false
   }
 
   // MARK: - Public

--- a/ios/PasswdSSOApp/Auth/SessionRestorer.swift
+++ b/ios/PasswdSSOApp/Auth/SessionRestorer.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Shared
+
+// MARK: - Launch restoration outcome
+
+/// Outcome of launch-time session restoration; the consumer (RootView) maps it
+/// to the initial AppState. See docs/archive/review/ios-signin-flow-ux-plan.md (C3).
+public enum RestoredSession: Sendable {
+  /// No persisted server config — first run.
+  case needsSetup
+  /// No local unlock material (no tokens, or the SE signer is gone) → OAuth required.
+  case needsSignIn(ServerConfig)
+  /// Session usable (or offline) → auto-Face-ID unlock screen.
+  case needsUnlock(ServerConfig, MobileAPIClient)
+  /// Refresh failed but local vault material exists → unlock-or-resign-in screen.
+  /// The dead-vs-transient signal is ambiguous at launch, so this routes to a
+  /// screen that serves both (local unlock of the cached vault + "Sign in again").
+  case needsReauth(ServerConfig, MobileAPIClient)
+}
+
+/// Result of probing whether the persisted session can still reach the server.
+public enum SessionValidation: Sendable { case ok, offline, dead }
+
+// MARK: - Session restorer
+
+/// Decides the initial app state at launch from the persisted server config,
+/// Keychain tokens, and the Secure Enclave signer — WITHOUT ever performing
+/// destructive cleanup (tenant policy / QuickType / token wipe stay on the
+/// explicit Sign-Out path). The routing is expressed over injected closures so
+/// it is unit-testable without a real Secure Enclave or network.
+public struct SessionRestorer: Sendable {
+  let loadConfig: @Sendable () -> ServerConfig?
+  let hasTokens: @Sendable () -> Bool
+  let makeSession: @Sendable (ServerConfig) async -> MobileAPIClient?
+  let validate: @Sendable (MobileAPIClient) async -> SessionValidation
+
+  public init(
+    loadConfig: @escaping @Sendable () -> ServerConfig?,
+    hasTokens: @escaping @Sendable () -> Bool,
+    makeSession: @escaping @Sendable (ServerConfig) async -> MobileAPIClient?,
+    validate: @escaping @Sendable (MobileAPIClient) async -> SessionValidation
+  ) {
+    self.loadConfig = loadConfig
+    self.hasTokens = hasTokens
+    self.makeSession = makeSession
+    self.validate = validate
+  }
+
+  public func restore() async -> RestoredSession {
+    guard let config = loadConfig() else { return .needsSetup }
+    guard hasTokens() else { return .needsSignIn(config) }
+    guard let client = await makeSession(config) else { return .needsSignIn(config) }
+    switch await validate(client) {
+    case .ok, .offline:
+      return .needsUnlock(config, client)
+    case .dead:
+      return .needsReauth(config, client)
+    }
+  }
+}
+
+// MARK: - Production wiring
+
+extension SessionRestorer {
+  /// Production wiring: server config from the App Group defaults, tokens from
+  /// the Keychain, the persisted SE DPoP key, and the live refresh probe.
+  public static func live(tokenStore: HostTokenStore = HostTokenStore()) -> SessionRestorer {
+    SessionRestorer(
+      loadConfig: { loadServerConfig() },
+      hasTokens: {
+        // `try?` (and the `?? nil` flatten) are intentional: a Keychain
+        // decode/access error, or simply no stored token, both resolve to
+        // `false` → routes to `.needsSignIn` rather than throwing out of this
+        // non-throwing closure. Do NOT change to `try`.
+        ((try? tokenStore.loadAccess()) ?? nil) != nil
+          && ((try? tokenStore.loadRefresh()) ?? nil) != nil
+      },
+      makeSession: { config in
+        let coordinator = AuthCoordinator(serverConfig: config, tokenStore: tokenStore)
+        guard await coordinator.loadPersistedSigner() else { return nil }
+        guard let signer = try? await coordinator.currentSigner(),
+          let jwk = try? await coordinator.currentJWK()
+        else { return nil }
+        return MobileAPIClient(
+          serverURL: config.baseURL,
+          signer: signer,
+          jwk: jwk,
+          tokenStore: tokenStore
+        )
+      },
+      validate: { client in
+        do {
+          try await client.ensureValidSession()
+          return .ok
+        } catch MobileAPIError.networkError {
+          return .offline
+        } catch {
+          return .dead
+        }
+      }
+    )
+  }
+}

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -1,54 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "Not configured" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not configured"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未設定"
-          }
-        }
-      }
-    },
-    "Server" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サーバー"
-          }
-        }
-      }
-    },
-    "To use a different server, sign out and set up again." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To use a different server, sign out and set up again."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "別のサーバーを使うには、サインアウトして設定し直してください。"
-          }
-        }
-      }
-    },
     "%@" : {
       "comment" : "Xcode-editor extraction placeholder for the TOTP countdown Int; the compiler emits the %lld key. Pure number — not translated.",
       "shouldTranslate" : false
@@ -803,6 +755,23 @@
         }
       }
     },
+    "Not configured" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not configured"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未設定"
+          }
+        }
+      }
+    },
     "Not set" : {
       "localizations" : {
         "en" : {
@@ -1038,6 +1007,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "セキュリティ"
+          }
+        }
+      }
+    },
+    "Server" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サーバー"
           }
         }
       }
@@ -1376,6 +1361,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "タイトル"
+          }
+        }
+      }
+    },
+    "To use a different server, sign out and set up again." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To use a different server, sign out and set up again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "別のサーバーを使うには、サインアウトして設定し直してください。"
           }
         }
       }

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -1,6 +1,54 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Not configured" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not configured"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未設定"
+          }
+        }
+      }
+    },
+    "Server" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サーバー"
+          }
+        }
+      }
+    },
+    "To use a different server, sign out and set up again." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To use a different server, sign out and set up again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "別のサーバーを使うには、サインアウトして設定し直してください。"
+          }
+        }
+      }
+    },
     "%@" : {
       "comment" : "Xcode-editor extraction placeholder for the TOTP countdown Int; the compiler emits the %lld key. Pure number — not translated.",
       "shouldTranslate" : false

--- a/ios/PasswdSSOApp/Network/MobileAPIClient.swift
+++ b/ios/PasswdSSOApp/Network/MobileAPIClient.swift
@@ -591,6 +591,15 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     return try await ensureRefreshed(staleToken: token)
   }
 
+  /// Launch-time session probe: returns when a usable access token is available
+  /// (already valid, or refreshed), throws `.networkError` when offline, and
+  /// `.authenticationRequired` when the session is dead (refresh rejected).
+  /// Makes NO network request when the stored access token is still within its
+  /// validity window — safe to call on an offline launch.
+  public func ensureValidSession() async throws {
+    _ = try await validAccessToken()
+  }
+
   // MARK: - Shared authenticated GET (C1 + C3)
 
   /// Performs an authenticated GET request with the full C3 retry ladder:

--- a/ios/PasswdSSOApp/Vault/AutoLockService.swift
+++ b/ios/PasswdSSOApp/Vault/AutoLockService.swift
@@ -4,10 +4,16 @@ import Shared
 /// Manages auto-lock and manual lock for the host app.
 /// `LockStateReducer` contains the pure logic; this class owns the live timer.
 @Observable @MainActor public final class AutoLockService {
+  /// Why a full sign-out happened — drives where the app routes afterward.
+  public enum LogoutReason: Sendable, Equatable {
+    case manual       // explicit "Sign Out" — offer the URL screen (change-server path)
+    case idleTimeout  // logout-on-timeout — skip the URL screen, go straight to sign-in
+  }
+
   public enum State: Sendable, Equatable {
     case unlocked
-    case locked      // idle lock / manual Lock — tokens kept, re-unlock with passphrase
-    case loggedOut   // logout-on-timeout — tokens cleared, must sign in again
+    case locked                          // idle lock / manual Lock — tokens kept, re-unlock with passphrase
+    case loggedOut(reason: LogoutReason) // tokens cleared, must sign in again
   }
 
   public private(set) var state: State = .locked
@@ -91,7 +97,7 @@ import Shared
   /// Full sign-out: lock + delete tokens + clear cache + clear wrapped blobs.
   /// Ends in `.loggedOut` (not `.locked`) so the app routes to sign-in rather
   /// than the passphrase re-unlock screen (which has no token to re-unlock with).
-  public func signOut() {
+  public func signOut(reason: LogoutReason = .manual) {
     try? bridgeKeyStore.delete()
     lock()
     try? tokenStore.deleteAll()
@@ -102,7 +108,7 @@ import Shared
     if fm.fileExists(atPath: cacheURL.path) {
       try? fm.removeItem(at: cacheURL)
     }
-    state = .loggedOut
+    state = .loggedOut(reason: reason)
   }
 
   // MARK: - Private
@@ -114,7 +120,7 @@ import Shared
     if elapsed >= Double(_autoLockMinutes * 60) {
       switch timeoutAction {
       case .lock: lock()
-      case .logout: signOut()
+      case .logout: signOut(reason: .idleTimeout)
       }
     }
   }

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -7,9 +7,16 @@ import SwiftUI
 // MARK: - Root app state
 
 enum AppState {
+  /// Pre-restore splash. Initial state on cold launch; replaced by the result of
+  /// SessionRestorer.restore() in RootView's .task before anything else renders
+  /// (so the URL screen never flashes on a returning launch).
+  case launching
   case setup
   case signIn(serverConfig: ServerConfig, coordinator: AuthCoordinator)
-  case signedIn(serverConfig: ServerConfig, tokens: TokenPair, apiClient: MobileAPIClient)
+  case signedIn(serverConfig: ServerConfig, apiClient: MobileAPIClient)
+  /// Transitional splash shown while handleVaultUnlocked runs its async sync,
+  /// so the passphrase/Face ID screen does not linger during the unlock→list gap.
+  case unlocking
   case vaultUnlocked(
     serverConfig: ServerConfig,
     vaultKey: SymmetricKey,
@@ -33,7 +40,7 @@ struct RootView: View {
   /// drain + AutoFill upload-token re-mint.
   let onVaultReady: (HostSyncService, RollbackFlagDrain, SymmetricKey, String, AutofillTokenRefresher?, SymmetricKey) -> Void
 
-  @State private var appState: AppState = .setup
+  @State private var appState: AppState = .launching
 
   // Shared dependency instances kept alive across state transitions
   @State private var hostSyncService: HostSyncService?
@@ -41,6 +48,11 @@ struct RootView: View {
   var body: some View {
     Group {
       switch appState {
+      case .launching, .unlocking:
+        // Neutral splash: launch restoration runs in .task (so the URL screen
+        // never flashes); .unlocking covers the post-unlock sync gap.
+        launchSplash
+
       case .setup:
         ServerURLSetupView { config in
           let tokenStore = HostTokenStore()
@@ -51,7 +63,7 @@ struct RootView: View {
       case .signIn(let config, let coordinator):
         makeSignInView(config: config, coordinator: coordinator)
 
-      case .signedIn(let serverConfig, _, let apiClient):
+      case .signedIn(let serverConfig, let apiClient):
         // Arriving via sign-in / app entry → auto-prompt Face ID on appear.
         vaultLockedScreen(serverConfig: serverConfig, apiClient: apiClient, autoPromptOnAppear: true)
 
@@ -95,7 +107,12 @@ struct RootView: View {
           // is present). A real foreground re-entry still auto-prompts (scenePhase).
           vaultLockedScreen(serverConfig: serverConfig, apiClient: apiClient, autoPromptOnAppear: false)
           Button("Sign in again") {
-            appState = .setup
+            // Skip the URL screen on explicit re-auth — the server config is
+            // already known. A fresh coordinator reuses the persisted SE key.
+            appState = .signIn(
+              serverConfig: serverConfig,
+              coordinator: AuthCoordinator(serverConfig: serverConfig)
+            )
           }
           .buttonStyle(.bordered)
           .controlSize(.large)
@@ -103,42 +120,55 @@ struct RootView: View {
         }
       }
     }
+    .task {
+      // One-shot launch restoration. Guard on .launching so a later view
+      // re-appear does not re-run it.
+      guard case .launching = appState else { return }
+      let result = await SessionRestorer.live().restore()
+      switch result {
+      case .needsSetup:
+        appState = .setup
+      case .needsSignIn(let config):
+        appState = .signIn(
+          serverConfig: config,
+          coordinator: AuthCoordinator(serverConfig: config)
+        )
+      case .needsUnlock(let config, let apiClient):
+        appState = .signedIn(serverConfig: config, apiClient: apiClient)
+      case .needsReauth(let config, let apiClient):
+        // Refresh failed (dead session OR transient server error — ambiguous at
+        // launch). Route to the unlock-or-resign-in screen: local unlock of the
+        // cached vault works offline, and "Sign in again" re-auths. No
+        // destructive cleanup (the signal is not reliably "revoked").
+        appState = .vaultLocked(serverConfig: config, apiClient: apiClient)
+      }
+    }
+  }
+
+  /// Neutral branded splash for `.launching` / `.unlocking`.
+  private var launchSplash: some View {
+    VStack(spacing: 24) {
+      Text("passwd-sso").font(.largeTitle.bold())
+      ProgressView()
+    }
   }
 
   // MARK: - Sign-in view factory
 
   @ViewBuilder
   private func makeSignInView(config: ServerConfig, coordinator: AuthCoordinator) -> some View {
-    #if DEBUG
     SignInView(
       coordinator: coordinator,
-      onSignedIn: { pair in
+      onSignedIn: { _ in
         Task { @MainActor in
           let apiClient = await buildRealAPIClient(
             serverConfig: config,
             coordinator: coordinator
           )
-          appState = .signedIn(serverConfig: config, tokens: pair, apiClient: apiClient)
-        }
-      },
-      onDebugVaultReady: { state in
-        handleDebugVaultLoaded(state, serverConfig: config, coordinator: coordinator)
-      }
-    )
-    #else
-    SignInView(
-      coordinator: coordinator,
-      onSignedIn: { pair in
-        Task { @MainActor in
-          let apiClient = await buildRealAPIClient(
-            serverConfig: config,
-            coordinator: coordinator
-          )
-          appState = .signedIn(serverConfig: config, tokens: pair, apiClient: apiClient)
+          appState = .signedIn(serverConfig: config, apiClient: apiClient)
         }
       }
     )
-    #endif
   }
 
   // MARK: - Vault locked / unlock entry
@@ -225,6 +255,12 @@ struct RootView: View {
     wrappedKeyStore: any WrappedKeyStore,
     policyAuthoritative: Bool
   ) async {
+    // MUST be the first statement — regression guard for the post-unlock flicker
+    // fix (#3): replaces the passphrase/Face ID screen with the splash before the
+    // async sync below, so it does not linger during the unlock→list gap. Do not
+    // move below the first await.
+    appState = .unlocking
+
     // Persist the tenant auto-lock policy BEFORE applyPersistedTimeout reads the
     // effective interval. Biometric (non-authoritative) is a no-op so it can't
     // wipe the value persisted by the last passphrase unlock.
@@ -388,52 +424,6 @@ struct RootView: View {
       tokenStore: tokenStore
     )
   }
-
-  #if DEBUG
-  /// Transition directly to .vaultUnlocked using the fixture state loaded by DebugVaultLoader.
-  /// The apiClient uses a NoOpDPoPSigner since the DEBUG vault doesn't sync.
-  @MainActor
-  private func handleDebugVaultLoaded(
-    _ state: DebugVaultLoader.LoadedState,
-    serverConfig: ServerConfig,
-    coordinator: AuthCoordinator
-  ) {
-    let debugApiClient = MobileAPIClient(
-      serverURL: URL(string: "https://debug.local")!,
-      signer: NoOpDPoPSigner(),
-      jwk: [:],
-      tokenStore: HostTokenStore()
-    )
-    let bks = BridgeKeyStore()
-    let wks = AppGroupWrappedKeyStore()
-    let cacheURL = (try? AppGroupContainer.cacheFileURL()) ?? URL(fileURLWithPath: "/dev/null")
-    let autoLockService = AutoLockService(
-      bridgeKeyStore: bks,
-      wrappedKeyStore: wks,
-      tokenStore: HostTokenStore(),
-      cacheURL: cacheURL
-    )
-    applyPersistedTimeout(to: autoLockService)
-    autoLockService.startTimer()
-    let cacheData = state.cacheData
-    let vaultKey = state.vaultKey
-    let userId = state.userId
-    Task {
-      await refreshCredentialIdentities(
-        from: cacheData, vaultKey: vaultKey, userId: userId)
-    }
-    appState = .vaultUnlocked(
-      serverConfig: serverConfig,
-      vaultKey: state.vaultKey,
-      userId: state.userId,
-      keyVersion: state.keyVersion,
-      cacheData: state.cacheData,
-      autoLockService: autoLockService,
-      apiClient: debugApiClient,
-      cacheKey: nil
-    )
-  }
-  #endif
 }
 
 

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -159,6 +159,7 @@ struct RootView: View {
   private func makeSignInView(config: ServerConfig, coordinator: AuthCoordinator) -> some View {
     SignInView(
       coordinator: coordinator,
+      serverURL: config.baseURL,
       onSignedIn: { _ in
         Task { @MainActor in
           let apiClient = await buildRealAPIClient(

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -86,11 +86,22 @@ struct RootView: View {
             appState = .vaultLocked(serverConfig: serverConfig, apiClient: apiClient)
             // Clear QuickType identities — no inline hints for a locked vault.
             Task { await CredentialIdentityRegistrar().clear() }
-          case .loggedOut:
-            // Manual Sign Out or logout-on-timeout cleared tokens/cache — route
-            // to setup/sign-in. Single chokepoint for clearing the tenant policy
-            // (mirrors the extension clearing it on disconnect).
-            appState = .setup
+          case .loggedOut(let reason):
+            // Tokens/cache already cleared by signOut(). Manual Sign Out routes to
+            // the URL screen (the deliberate change-server path); an idle-timeout
+            // logout skips it and goes straight to sign-in (the server is known).
+            switch reason {
+            case .manual:
+              appState = .setup
+            case .idleTimeout:
+              appState = .signIn(
+                serverConfig: serverConfig,
+                coordinator: AuthCoordinator(serverConfig: serverConfig)
+              )
+            }
+            // Single chokepoint for clearing the tenant policy + QuickType
+            // (mirrors the extension clearing it on disconnect). Runs for both
+            // reasons — both are full sign-outs.
             AppSettingsStore().clearTenantPolicy()
             Task { await CredentialIdentityRegistrar().clear() }
           case .unlocked:

--- a/ios/PasswdSSOApp/Views/SettingsView.swift
+++ b/ios/PasswdSSOApp/Views/SettingsView.swift
@@ -85,6 +85,12 @@ struct SettingsView: View {
     )
   }
 
+  /// Current server URL — surfaced here because launch restoration skips the
+  /// setup screen, so this is the only place a signed-in user can confirm it.
+  private var serverURLDisplay: String {
+    loadServerConfig()?.baseURL.absoluteString ?? String(localized: "Not configured")
+  }
+
   var body: some View {
     NavigationStack {
       Form {
@@ -133,6 +139,18 @@ struct SettingsView: View {
               Text(option.label).tag(option)
             }
           }
+        }
+
+        Section {
+          LabeledContent("URL") {
+            Text(serverURLDisplay)
+              .foregroundStyle(.secondary)
+              .textSelection(.enabled)
+          }
+        } header: {
+          Text("Server")
+        } footer: {
+          Text("To use a different server, sign out and set up again.")
         }
       }
       .navigationTitle("Settings")

--- a/ios/PasswdSSOApp/Views/SignInView.swift
+++ b/ios/PasswdSSOApp/Views/SignInView.swift
@@ -30,6 +30,9 @@ final class WindowProvider: NSObject, ASWebAuthenticationPresentationContextProv
 
 struct SignInView: View {
   let coordinator: AuthCoordinator
+  /// The server the OAuth flow will target — shown so the user can confirm it
+  /// before authenticating (the URL setup screen is skipped on a known server).
+  let serverURL: URL
   let onSignedIn: (TokenPair) -> Void
 
   @State private var state: SignInViewState = .idle
@@ -39,8 +42,15 @@ struct SignInView: View {
     VStack(spacing: 32) {
       Spacer()
 
-      Text("passwd-sso")
-        .font(.largeTitle.bold())
+      VStack(spacing: 4) {
+        Text("passwd-sso")
+          .font(.largeTitle.bold())
+        Text(serverURL.absoluteString)
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+          .multilineTextAlignment(.center)
+          .textSelection(.enabled)
+      }
 
       switch state {
       case .idle:

--- a/ios/PasswdSSOApp/Views/SignInView.swift
+++ b/ios/PasswdSSOApp/Views/SignInView.swift
@@ -31,9 +31,6 @@ final class WindowProvider: NSObject, ASWebAuthenticationPresentationContextProv
 struct SignInView: View {
   let coordinator: AuthCoordinator
   let onSignedIn: (TokenPair) -> Void
-  #if DEBUG
-  let onDebugVaultReady: (DebugVaultLoader.LoadedState) -> Void
-  #endif
 
   @State private var state: SignInViewState = .idle
   @State private var windowProvider = WindowProvider()
@@ -69,16 +66,6 @@ struct SignInView: View {
       .accessibilityIdentifier("sign-in-primary-button")
       .disabled(state == .signingIn)
 
-      #if DEBUG
-      Button("Load Test Vault (DEBUG)") {
-        Task { await loadDebugVault() }
-      }
-      .buttonStyle(.bordered)
-      .controlSize(.large)
-      .tint(.orange)
-      .disabled(state == .signingIn)
-      #endif
-
       Spacer()
       Spacer()
     }
@@ -100,20 +87,6 @@ struct SignInView: View {
       state = .error(message: error.localizedDescription)
     }
   }
-
-  #if DEBUG
-  @MainActor
-  private func loadDebugVault() async {
-    state = .signingIn
-    do {
-      try DebugVaultLoader.reset()
-      let loadedState = try await DebugVaultLoader.loadFixtureVault()
-      onDebugVaultReady(loadedState)
-    } catch {
-      state = .error(message: "DEBUG: \(error.localizedDescription)")
-    }
-  }
-  #endif
 }
 
 // MARK: - Window capture helper

--- a/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
@@ -130,7 +130,8 @@ struct VaultListView: View {
         Text(syncError ?? "")
       }
       // Anchored at body level (NOT inside the Menu, where dismissal races the
-      // menu collapse). signOut() ends in .loggedOut → RootView routes to setup.
+      // menu collapse). Manual signOut() ends in .loggedOut(.manual) → RootView
+      // routes to the URL setup screen (the deliberate change-server path).
       .confirmationDialog(
         "Sign out of passwd-sso?",
         isPresented: $isShowingSignOutConfirm,

--- a/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
@@ -79,9 +79,10 @@ public enum VaultScope: Hashable, Sendable {
   ///
   /// The cache stores `[CacheEntry]` (the on-disk wire model carrying
   /// aadVersion/keyVersion/teamKeyVersion/itemKeyVersion needed for AAD
-  /// construction). HostSyncService and DebugVaultLoader both write this
-  /// shape; the previous `[EncryptedEntry]` decode path was a dead Step-7
-  /// type that never matched the on-disk format.
+  /// construction). HostSyncService writes this shape in production;
+  /// DebugVaultLoader writes it as a test fixture. The previous
+  /// `[EncryptedEntry]` decode path was a dead Step-7 type that never matched
+  /// the on-disk format.
   /// - Parameters:
   ///   - cacheKey: when provided (with team keys present), team entries are decrypted
   ///     too and shown under their team vault. nil → personal-only (no regression).

--- a/ios/PasswdSSOTests/AuthCoordinatorTests.swift
+++ b/ios/PasswdSSOTests/AuthCoordinatorTests.swift
@@ -81,6 +81,47 @@ final class AuthCoordinatorTests: XCTestCase {
     XCTAssertNotNil(jwk["y"], "JWK must contain y coordinate")
   }
 
+  // MARK: - loadPersistedSigner (C1)
+
+  func testLoadPersistedSigner_keyPresent_returnsTrueAndEnablesSigner() async throws {
+    // Inject a software-key loader: the real loadDPoPKey filters on
+    // kSecAttrTokenIDSecureEnclave and can never see simulator software keys.
+    let raw = try makeSoftwareP256Key(label: "com.test.persist.\(UUID().uuidString)")
+    let wrapped = SendableSecKey(raw)
+    let config = ServerConfig(baseURL: URL(string: "https://test.passwd-sso.example")!)
+    let coordinator = AuthCoordinator(serverConfig: config, keyLoader: { _ in wrapped.key })
+
+    let loaded = await coordinator.loadPersistedSigner()
+    XCTAssertTrue(loaded, "loadPersistedSigner must return true when the loader yields a key")
+
+    // currentSigner / currentJWK now succeed against the real coordinator.
+    let signer = try await coordinator.currentSigner()
+    let signature = try await signer.sign(input: Data("header.payload".utf8))
+    XCTAssertEqual(signature.count, 64)
+    let jwk = try await coordinator.currentJWK()
+    XCTAssertEqual(jwk["kty"], "EC")
+  }
+
+  func testLoadPersistedSigner_keyAbsent_returnsFalseAndSignerStillThrows() async {
+    let config = ServerConfig(baseURL: URL(string: "https://test.passwd-sso.example")!)
+    let coordinator = AuthCoordinator(
+      serverConfig: config,
+      keyLoader: { _ in throw SecureEnclaveKeyError.keyNotFound }
+    )
+
+    let loaded = await coordinator.loadPersistedSigner()
+    XCTAssertFalse(loaded, "loadPersistedSigner must return false when no key is found")
+
+    do {
+      _ = try await coordinator.currentSigner()
+      XCTFail("Expected keyGenerationFailed when no key is loaded")
+    } catch AuthError.keyGenerationFailed {
+      // Expected.
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
   // MARK: - Helpers
 
   /// Generate a software (non-SE) P-256 key for simulator testing.

--- a/ios/PasswdSSOTests/AutoLockServiceTests.swift
+++ b/ios/PasswdSSOTests/AutoLockServiceTests.swift
@@ -196,7 +196,7 @@ final class AutoLockServiceTests: XCTestCase {
     service.signOut()
 
     // Ends in .loggedOut (not .locked) so the app routes to sign-in.
-    XCTAssertEqual(service.state, .loggedOut)
+    XCTAssertEqual(service.state, .loggedOut(reason: .manual))
     // V2 bridge-key + bridge-meta items should be gone
     XCTAssertNil(keychain.store["com.passwd-sso.test.bridge-key-v2:blob"])
     XCTAssertNil(keychain.store["com.passwd-sso.test.bridge-meta-v2:blob"])
@@ -307,7 +307,7 @@ final class AutoLockServiceTests: XCTestCase {
     clock.advance(by: 15 * 60)
     service.tick()
 
-    XCTAssertEqual(service.state, .loggedOut)
+    XCTAssertEqual(service.state, .loggedOut(reason: .idleTimeout))
     XCTAssertNil(
       keychain.store["com.passwd-sso.test.bridge-key-v2:blob"],
       "bridge_key should be deleted on logout timeout"
@@ -362,7 +362,7 @@ final class AutoLockServiceTests: XCTestCase {
 
     XCTAssertTrue(spy.didClear,
       "signOut() must call teamDirectoryStore.clear() to wipe the team-directory blob (F2/S13 regression)")
-    XCTAssertEqual(service.state, .loggedOut)
+    XCTAssertEqual(service.state, .loggedOut(reason: .manual))
   }
 
   // MARK: - autoLockMinutes clamping

--- a/ios/PasswdSSOTests/MobileAPIClientTests.swift
+++ b/ios/PasswdSSOTests/MobileAPIClientTests.swift
@@ -1066,6 +1066,79 @@ final class TokenRefreshTests: XCTestCase {
     XCTAssertEqual(refreshCallCount, 1, "Refresh should be attempted exactly once")
   }
 
+  // MARK: - ensureValidSession (C2): launch-time session probe
+
+  func testEnsureValidSession_validToken_makesNoNetworkRequest() async throws {
+    let expiresAt = fixedNow.addingTimeInterval(3600)
+    try tokenStore.saveTokens(access: "acc_fresh", refresh: "ref_fresh", expiresAt: expiresAt)
+
+    MockURLProtocol.requestHandler = { [weak self] request in
+      self?.resourceCallCount += 1
+      return (Data(), httpResponse(status: 200, url: request.url!))
+    }
+
+    let client = makeClient()
+    try await client.ensureValidSession()
+
+    XCTAssertEqual(resourceCallCount, 0,
+                   "ensureValidSession must make no network call when the token is still valid")
+  }
+
+  func testEnsureValidSession_expiredToken_refreshesAndPersists() async throws {
+    let expiresAt = fixedNow.addingTimeInterval(-10)
+    try tokenStore.saveTokens(access: "acc_old", refresh: "ref_old", expiresAt: expiresAt)
+
+    let refreshURL = serverURL.appending(path: "/api/mobile/token/refresh", directoryHint: .notDirectory)
+    MockURLProtocol.requestHandler = { [weak self] request in
+      if request.url?.path == "/api/mobile/token/refresh" {
+        self?.refreshCallCount += 1
+        return (tokenResponseJSON(), httpResponse(status: 200, url: refreshURL))
+      }
+      return (Data(), httpResponse(status: 200, url: request.url!))
+    }
+
+    let client = makeClient()
+    try await client.ensureValidSession()
+
+    XCTAssertEqual(refreshCallCount, 1, "expired token must trigger exactly one refresh")
+    let stored = try XCTUnwrap(tokenStore.loadAccess())
+    XCTAssertEqual(stored.token, "acc_test", "rotated access token must be persisted")
+  }
+
+  func testEnsureValidSession_refresh401_throwsAuthenticationRequired() async throws {
+    let expiresAt = fixedNow.addingTimeInterval(-10)
+    try tokenStore.saveTokens(access: "acc_dead", refresh: "ref_dead", expiresAt: expiresAt)
+
+    let refreshURL = serverURL.appending(path: "/api/mobile/token/refresh", directoryHint: .notDirectory)
+    MockURLProtocol.requestHandler = { _ in (Data(), httpResponse(status: 401, url: refreshURL)) }
+
+    let client = makeClient()
+    do {
+      try await client.ensureValidSession()
+      XCTFail("Expected authenticationRequired (dead session)")
+    } catch MobileAPIError.authenticationRequired {
+      // Expected.
+    }
+  }
+
+  func testEnsureValidSession_transportError_throwsNetworkError() async throws {
+    let expiresAt = fixedNow.addingTimeInterval(-10)
+    try tokenStore.saveTokens(access: "acc_off", refresh: "ref_off", expiresAt: expiresAt)
+
+    // MUST be a concrete URLError — an NSError in NSURLErrorDomain would not
+    // match `as URLError` and would be remapped to authenticationRequired (T2f),
+    // silently validating the dead-session path instead of the offline path.
+    MockURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
+
+    let client = makeClient()
+    do {
+      try await client.ensureValidSession()
+      XCTFail("Expected networkError (offline)")
+    } catch MobileAPIError.networkError {
+      // Expected — distinct from a dead session.
+    }
+  }
+
   // MARK: - fetchEntries: 200 happy path
 
   func testFetchEntries_happyPath() async throws {

--- a/ios/PasswdSSOTests/SessionRestorerTests.swift
+++ b/ios/PasswdSSOTests/SessionRestorerTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+
+@testable import PasswdSSOApp
+@testable import Shared
+
+/// Routing-matrix tests for SessionRestorer (plan C3 / T1). The four seams are
+/// injected as closures so the routing is exercised without a real Secure
+/// Enclave or network.
+final class SessionRestorerTests: XCTestCase {
+  private let config = ServerConfig(baseURL: URL(string: "https://srv.example")!)
+
+  /// Counts validate() invocations across an async restore.
+  private actor CallCounter {
+    private(set) var count = 0
+    func bump() { count += 1 }
+  }
+
+  private func dummyClient() -> MobileAPIClient {
+    MobileAPIClient(
+      serverURL: URL(string: "https://dummy.example")!,
+      signer: FakeSigner(),
+      jwk: [:],
+      tokenStore: HostTokenStore(service: "com.test.session-restorer", keychain: FakeKeychain())
+    )
+  }
+
+  private func makeRestorer(
+    loadConfig: @escaping @Sendable () -> ServerConfig?,
+    hasTokens: @escaping @Sendable () -> Bool = { true },
+    makeSession: (@Sendable (ServerConfig) async -> MobileAPIClient?)? = nil,
+    validate: @escaping @Sendable (MobileAPIClient) async -> SessionValidation = { _ in .ok }
+  ) -> SessionRestorer {
+    let client = dummyClient()
+    return SessionRestorer(
+      loadConfig: loadConfig,
+      hasTokens: hasTokens,
+      makeSession: makeSession ?? { _ in client },
+      validate: validate
+    )
+  }
+
+  // MARK: - Routing matrix
+
+  func testRestore_noConfig_needsSetup() async {
+    let result = await makeRestorer(loadConfig: { nil }).restore()
+    guard case .needsSetup = result else { return XCTFail("expected .needsSetup, got \(result)") }
+  }
+
+  func testRestore_noTokens_needsSignIn() async {
+    let result = await makeRestorer(loadConfig: { [config] in config }, hasTokens: { false }).restore()
+    guard case .needsSignIn = result else { return XCTFail("expected .needsSignIn, got \(result)") }
+  }
+
+  func testRestore_makeSessionNil_keyGone_needsSignIn() async {
+    let result = await makeRestorer(
+      loadConfig: { [config] in config },
+      hasTokens: { true },
+      makeSession: { _ in nil }
+    ).restore()
+    guard case .needsSignIn = result else { return XCTFail("expected .needsSignIn, got \(result)") }
+  }
+
+  // Distinct fixture from the key-gone case (T1f2): a makeSession that returns
+  // nil for a different reason (e.g. signer/JWK export failure) routes the same.
+  func testRestore_makeSessionNil_signerExportFailed_needsSignIn() async {
+    let signerExportFailed: @Sendable (ServerConfig) async -> MobileAPIClient? = { _ in nil }
+    let result = await makeRestorer(
+      loadConfig: { [config] in config },
+      hasTokens: { true },
+      makeSession: signerExportFailed
+    ).restore()
+    guard case .needsSignIn = result else { return XCTFail("expected .needsSignIn, got \(result)") }
+  }
+
+  func testRestore_validateOk_needsUnlock() async {
+    let result = await makeRestorer(loadConfig: { [config] in config }, validate: { _ in .ok }).restore()
+    guard case .needsUnlock = result else { return XCTFail("expected .needsUnlock, got \(result)") }
+  }
+
+  func testRestore_validateOffline_needsUnlock() async {
+    let result = await makeRestorer(loadConfig: { [config] in config }, validate: { _ in .offline }).restore()
+    guard case .needsUnlock = result else { return XCTFail("expected .needsUnlock, got \(result)") }
+  }
+
+  func testRestore_validateDead_needsReauth() async {
+    let result = await makeRestorer(loadConfig: { [config] in config }, validate: { _ in .dead }).restore()
+    guard case .needsReauth = result else { return XCTFail("expected .needsReauth, got \(result)") }
+  }
+
+  // MARK: - validate is not invoked when a precondition fails
+
+  func testRestore_validateNotCalledWhenPreconditionsFail() async {
+    let spy = CallCounter()
+    let validate: @Sendable (MobileAPIClient) async -> SessionValidation = { _ in
+      await spy.bump()
+      return .ok
+    }
+
+    _ = await makeRestorer(loadConfig: { nil }, validate: validate).restore()
+    _ = await makeRestorer(
+      loadConfig: { [config] in config }, hasTokens: { false }, validate: validate
+    ).restore()
+    _ = await makeRestorer(
+      loadConfig: { [config] in config }, hasTokens: { true },
+      makeSession: { _ in nil }, validate: validate
+    ).restore()
+
+    let count = await spy.count
+    XCTAssertEqual(count, 0, "validate must not run when config/tokens/session preconditions fail")
+  }
+}

--- a/ios/PasswdSSOUITests/PasswdSSOUITests.swift
+++ b/ios/PasswdSSOUITests/PasswdSSOUITests.swift
@@ -14,8 +14,9 @@ final class PasswdSSOUITests: XCTestCase {
   /// accidentally removing or breaking hit-testing on the button. Buttons are
   /// matched by accessibility identifier, not localized title, so the test is
   /// locale-independent (the simulator may run in any language).
-  /// Launch routes to either ServerURLSetupView or, when a server config is
-  /// already persisted, SignInView.
+  /// Launch first shows a splash while SessionRestorer.restore() runs, then
+  /// routes to ServerURLSetupView (no persisted config — the clean UI-test
+  /// case) or, when a server config is already persisted, SignInView.
   func testPrimaryButtonIsHittable() {
     let app = XCUIApplication()
     app.launch()


### PR DESCRIPTION
## Summary
Returning users re-walked **URL → Sign-in → passphrase (with a flicker)** on every cold launch because `RootView` always started at `.setup` with no state restoration. This adds launch-time session restoration so a signed-in user goes straight to **(Face ID / passphrase) → list**, and surfaces the server URL where it's now needed.

## What changed
**Launch restoration** (`SessionRestorer`, C1–C5)
- New `.launching` splash runs `SessionRestorer.restore()` in `RootView.task` before anything renders (no URL-screen flash).
- Routing over injected seams: no config → `.setup`; no tokens/signer → `.signIn`; valid/offline → `.signedIn` (auto Face ID); refresh failed → `.vaultLocked` (local unlock **+** "Sign in again").
- `AuthCoordinator.loadPersistedSigner()` reloads the persisted Secure Enclave DPoP key at launch without OAuth (injectable \`keyLoader\` seam for simulator tests).
- `MobileAPIClient.ensureValidSession()` — offline-safe probe; distinguishes \`.networkError\` (offline) from \`.authenticationRequired\` (dead session).
- New \`.unlocking\` splash removes the post-unlock passphrase-screen flicker; \`.signedIn\` drops its unused \`tokens\` payload.

**No destructive cleanup at launch (S7)** — the refresh ladder collapses dead-session / 5xx / 429 into \`.authenticationRequired\`, so dead-vs-transient is ambiguous at launch. Restoration never wipes tenant policy / QuickType / tokens; that stays on the explicit Sign-Out path.

**DEBUG removal (C6)** — removed the "Load Test Vault" sign-in path; kept \`DebugVaultLoader\` + its test (sole CredentialResolver decrypt coverage).

**Server-URL confirmation** (follow-ups)
- Shown on the sign-in screen (before OAuth) and in Settings → Server (after sign-in), since the always-on URL screen is gone.

**Logout routing split**
- Idle-timeout logout now skips the URL screen → \`.signIn\` (server is known); manual Sign Out keeps → \`.setup\` (the deliberate change-server path). Encoded as \`AutoLockService.State.loggedOut(reason:)\`.

## Testing
- \`xcodebuild test\`: **525 unit + 2 UI tests pass** (iPhone 16 Pro sim, iOS 18).
- New: \`SessionRestorerTests\` (routing matrix), \`ensureValidSession\` (incl. offline \`URLError\`), \`loadPersistedSigner\`.

## Review
Built via \`/triangulate\`: plan reviewed 2 rounds + a security confirmation; code reviewed 1 round (functionality/security/testing) — **no Critical/Major**. Artifacts under \`docs/archive/review/ios-signin-flow-ux-*.md\`.

Base is \`main\` (the iOS integration branch). Does not touch server/extension/CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)