### PR TITLE
refactor(ios): replace hardcoded values with shared constants

### DIFF
--- a/docs/archive/review/ios-hardcoded-values-to-constants-code-review.md
+++ b/docs/archive/review/ios-hardcoded-values-to-constants-code-review.md
@@ -45,10 +45,10 @@ None — all observations carried file:line evidence.
 - RT1 (mock desync): PASS. RT2 (no non-unit-testable demands): PASS. RT3 (fixture inline correct): PASS. RT5 (no CI demands): PASS. RT6 (new exports covered): PASS. RT7 (tests can go red on drift): PASS. RT4 + R-series (impl/sec): N/A.
 
 ## Environment Verification Report
-Phase 1 declared VE1 (Xcode/macOS build not runnable in the authoring environment) and VE2 (xcodegen folder-glob auto-discovery).
+Phase 1 declared VE1 (Xcode/macOS build assumed not runnable in the authoring environment) and VE2 (xcodegen folder-glob auto-discovery).
 - All contract acceptance **grep gates**: `verified-local` — run by the orchestrator, all return 0 in production code (see Functionality findings).
-- `xcodebuild test` (full XCTest suite incl. crypto vectors + new `CryptoParamsTests`): `blocked-deferred` — predicted by Phase 1 VE1 (no macOS toolchain). Cost-to-fix: user/CI runs one `xcodebuild test` command; worst case a missed adoption is a compile error caught immediately by that build; likelihood low (edits are mechanical literal→constant swaps, grep-verified, byte-identity confirmed by review). No code path requires runtime verification beyond what the existing suite + value-pins cover.
-- VE2: confirmed — `Shared/` and `PasswdSSOTests/` use folder globs in `project.yml`; the 4 new files are auto-included, no manifest edit.
+- `xcodebuild test` (full suite incl. crypto vectors + new `CryptoParamsTests`): **`verified-local`** — VE1 was incorrect; Xcode 26.4.1 IS available. After `xcodegen generate` (to register the 4 new files in the tracked `project.pbxproj`), ran `xcodebuild test -project PasswdSSO.xcodeproj -scheme PasswdSSOApp -destination 'platform=iOS Simulator,id=iPhone 15 Pro'`: **`** TEST SUCCEEDED **`, EXIT=0, Executed 526 unit tests + UITests, 0 failures** (2026-06-16). The new `CryptoParamsTests` and all crypto vector/parity suites pass. VE1 is hereby retracted.
+- VE2: confirmed — `Shared/` and `PasswdSSOTests/` use folder globs in `project.yml`; `xcodegen generate` auto-discovered all 4 new files (pbxproj diff: +26/-10, only the new file registrations, no churn). The regenerated `project.pbxproj` is committed.
 
 ## Resolution Status
 No findings to resolve. Plan review (2 functionality rounds + 1 security + 1 testing) and Phase 2 verification (contract greps + crypto byte-identity spot-check) front-loaded the issues; the code-review round confirmed clean. Awaiting `xcodebuild test` by the user/CI (VE1) as the final gate before PR.

--- a/docs/archive/review/ios-hardcoded-values-to-constants-code-review.md
+++ b/docs/archive/review/ios-hardcoded-values-to-constants-code-review.md
@@ -1,0 +1,54 @@
+# Code Review: ios-hardcoded-values-to-constants
+Date: 2026-06-16
+Review round: 1 (converged — all three experts "No findings")
+
+## Changes from Previous Round
+Initial code review of the Phase 2 implementation (commit 8c669cd7). Diff: 25 files (21 modified + 4 new), 210 insertions / 119 deletions under `ios/`.
+
+## Functionality Findings (Senior Software Engineer)
+**No findings.** Behavior-preserving refactor verified end-to-end by value-identity reasoning + the plan's forbidden-pattern greps (all return 0 in production code).
+- C1: every replaced crypto literal byte/numerically identical; `CryptoParams`/`P256Params` correct; `uncompressedPointByteCount = 1 + coordinateByteCount + coordinateByteCount` = 65 (static-let-references-static-let is valid Swift, `+` binds tighter than `..<`); SecureEnclaveKey slices reduce to `1..<33` / `33..<65`; `data[0] == uncompressedPointPrefix` types match (`UInt8`); BridgeKeyStore unified on `bridgeKeyV2Size` (Int, fits C API at alloc + `SecRandomCopyBytes`).
+- C2: all `/api/` literals removed from production; builders reproduce exact interpolation; F4 fused literal handled (`"\(APIPath.passwords)?include=blob"`).
+- C3: `htm:` and `httpMethod` use the SAME `HTTPMethod` constant at every site (htm==method now structural); `"DPoP"` header vs `"DPoP "` scheme preserved; residual `"DPoP"` at RootView.swift:449 is an error-message string, correctly inline.
+- C4: 6 sites adopt `AppGroupContainer.loggerSubsystem`; literal gone.
+- R10: 3 new Shared files import Foundation only — no cycle. No cross-batch duplicate symbols. VE2 confirmed (folder globs auto-discover new files).
+
+## Security Findings (Security Engineer)
+**No findings.** No Critical; no escalation.
+- Crypto value-identity byte-identical for all touched constants (12/16/32/65/0x04/256).
+- Domain-separation / versioned strings confirmed NOT in the diff: HKDF info strings (`passwd-sso-*-v1`, `rollback-flag-mac`, ecdh/team/item wrap infos), AAD scopes (PV/OV/AT/IK/OK/LW), `aadVersion`, AAD cap `0xFFFF`, `pbkdf2Iterations = 600_000`.
+- Semantic separation holds: `credentialIdByteCount`, `ecdsaComponentByteCount`, `pkceRandomByteCount`, `bridgeKeyV2Size` kept distinct/file-local; every `symmetricKeyByteCount` mapping is genuine 256-bit key material.
+- RS5: `VaultUnlocker.swift` KDF-iteration floor (`>= pbkdf2Iterations`) not in diff, not weakened.
+- F3 (security angle): DPoP `htm` == request method preserved (same constant); `htu` still derived from the byte-identical APIPath. No secrets turned into source constants (only public protocol strings + diagnostic logger subsystem).
+
+## Testing Findings (QA Engineer)
+**No blocking findings** (T1–T5 are Info-level confirmations).
+- T1: `CryptoParamsTests.swift` pins `keySizeBits==256`, `uncompressedPointByteCount==65`, `uncompressedPointPrefix==0x04` (+ the AES/symmetric counts) against independent literals — non-tautological (RT7), `@testable import Shared` matches existing tests. `keySizeBits` is the only changed constant with no prior catch (SE-only `generateDPoPKey` path, not unit-testable) — pinning it is the correct substitute (RT2).
+- T2: every other changed constant is caught transitively by existing golden-vector suites (KDFTests PBKDF2 hex, TeamKeyCryptoTests ECDH/HKDF/AES-GCM round-trips, AESGCMTests).
+- T3/T4 (RT1): no test modified except the additive new file; inline path/header/method fixture literals correctly stayed inline (SC-iOS-6) and now double as a drift cross-check; no mock desync, nothing made vacuous.
+- T5: file-local distinct-meaning constants correctly NOT promoted; RT6 satisfied (the only new *exported* enums `CryptoParams`/`P256Params` are covered).
+
+## Adjacent Findings
+None requiring cross-routing.
+
+## Quality Warnings
+None — all observations carried file:line evidence.
+
+## Recurring Issue Check
+### Functionality expert
+- R2 (constants): PASS — semantic separation honored. R3 (propagation): PASS — all planned sites in diff, all forbidden greps 0. R10 (circular import): PASS — Foundation-only. R1, R4–R9, R11–R41: N/A (pure literal→constant refactor).
+
+### Security expert
+- RS1 (auth comparison unchanged): PASS. RS5 (KDF floor preserved): PASS. R3 (crypto propagation, no divergent literal): PASS. R1–R41 / RS2–RS4: N/A.
+
+### Testing expert
+- RT1 (mock desync): PASS. RT2 (no non-unit-testable demands): PASS. RT3 (fixture inline correct): PASS. RT5 (no CI demands): PASS. RT6 (new exports covered): PASS. RT7 (tests can go red on drift): PASS. RT4 + R-series (impl/sec): N/A.
+
+## Environment Verification Report
+Phase 1 declared VE1 (Xcode/macOS build not runnable in the authoring environment) and VE2 (xcodegen folder-glob auto-discovery).
+- All contract acceptance **grep gates**: `verified-local` — run by the orchestrator, all return 0 in production code (see Functionality findings).
+- `xcodebuild test` (full XCTest suite incl. crypto vectors + new `CryptoParamsTests`): `blocked-deferred` — predicted by Phase 1 VE1 (no macOS toolchain). Cost-to-fix: user/CI runs one `xcodebuild test` command; worst case a missed adoption is a compile error caught immediately by that build; likelihood low (edits are mechanical literal→constant swaps, grep-verified, byte-identity confirmed by review). No code path requires runtime verification beyond what the existing suite + value-pins cover.
+- VE2: confirmed — `Shared/` and `PasswdSSOTests/` use folder globs in `project.yml`; the 4 new files are auto-included, no manifest edit.
+
+## Resolution Status
+No findings to resolve. Plan review (2 functionality rounds + 1 security + 1 testing) and Phase 2 verification (contract greps + crypto byte-identity spot-check) front-loaded the issues; the code-review round confirmed clean. Awaiting `xcodebuild test` by the user/CI (VE1) as the final gate before PR.

--- a/docs/archive/review/ios-hardcoded-values-to-constants-plan.md
+++ b/docs/archive/review/ios-hardcoded-values-to-constants-plan.md
@@ -1,0 +1,213 @@
+# Plan: ios-hardcoded-values-to-constants
+
+Branch: `refactor/ios-hardcoded-values-to-constants`
+Type: refactor (behavior-preserving)
+
+Reference: web/extension/cli sweep `refactor: replace hardcoded values with shared constants (#561)`
+(`docs/archive/review/hardcoded-values-to-constants-plan.md`), which explicitly deferred
+the iOS app under SC1 (`TODO(hardcoded-values-to-constants): iOS constant sweep not planned`).
+This plan executes that deferred iOS-side sweep, following the same conventions:
+value-identity (zero runtime behavior change), semantic separation (never fold
+semantically-distinct values that happen to share a number), and forbidden-pattern greps
+as the mechanical completeness gate.
+
+## Project context
+
+- Type: native iOS app (Swift / SwiftUI) — 3 product targets sharing one framework:
+  - `Shared` (framework, `APPLICATION_EXTENSION_API_ONLY: YES`) — compiled into BOTH the app and the AutoFill extension.
+  - `PasswdSSOApp` (application) — embeds `Shared`, embeds the extension.
+  - `PasswdSSOAutofillExtension` (credential-provider app extension) — links `Shared` only.
+  - Test targets: `PasswdSSOTests` (unit), `PasswdSSOUITests`.
+- Import boundaries (hard constraints):
+  - Constants used by code in BOTH the app and the extension (or by `Shared/` code) MUST live in `Shared/`.
+  - The extension CANNOT import `PasswdSSOApp/`; the app CANNOT import the extension.
+  - `Shared/` builds with extension-only API (`APPLICATION_EXTENSION_API_ONLY`) — new constant files must not pull in app-only APIs.
+- Test infrastructure: unit tests only (XCTest), no CI-runnable macOS in this environment (see VE1). Crypto behavior is guarded by parity/vector tests: `KDFTests`, `TeamKeyCryptoTests`, `AADParityTests`, `PasskeyRegistrationTests`, `TOTPVectorTests`, `CredentialResolverTests`, `EntryCacheFileTests`.
+- Verification environment constraints:
+  - VE1: building/testing requires Xcode/macOS; the orchestrator's shell cannot run `xcodebuild`/`swift test`. All contracts are pure refactors verifiable by **value-identity reasoning + forbidden-pattern greps**; the user (or CI) runs `xcodebuild test` to confirm. Every contract's acceptance therefore lists both the grep gate (runnable here) and the test gate (`blocked-deferred` to the user/CI — Anti-Deferral cost-justification: cost-to-fix is "user runs one xcodebuild command"; worst case a missed adoption causes a compile error caught immediately by that build; likelihood low because edits are mechanical literal→constant swaps with grep verification).
+  - VE2: `xcodegen` regenerates `PasswdSSO.xcodeproj` from `ios/project.yml`. New `.swift` files under already-globbed source folders (`Shared/Crypto`, `Shared/Network`) are auto-discovered by the folder globs — no `project.yml` edit needed (confirm the target `sources:` use folder globs, not explicit file lists).
+
+## Objective
+
+Eliminate magic numbers and repeated hardcoded string literals in the iOS Swift code that
+bypass (or should become) shared constants, with **zero runtime behavior change**. Every
+replaced literal keeps its exact current value/bytes. Scope is the genuine duplication that
+creates drift risk; idiomatic single-use values (SwiftUI layout numbers, RFC-default TOTP
+params, per-store keychain identifiers) stay inline.
+
+## Requirements
+
+- Functional: no observable behavior change. All constant values byte/numerically identical pre/post. Crypto wire formats unchanged (golden/parity tests prove it).
+- Non-functional: single definition per shared value within the iOS build boundary. Constants live in `Shared/` so app + extension share one definition.
+- Convention (match the codebase's existing patterns): namespace via caseless `enum` with `static let` members (precedent: `AutoLockLimits` in `Shared/Models/LockState.swift`, `VaultType` in `Shared/Crypto/AAD.swift`). Do NOT introduce free global `let`s for new groups (the existing `pbkdf2Iterations` global stays as-is — already centralized, not in scope to move).
+- Semantic separation: the literal `32` appears with ≥6 distinct meanings (256-bit symmetric key length, HKDF/PBKDF2 output length, P-256 coordinate length, HKDF zero-salt length, PKCE/credential-ID random length, ECDSA component length). Each meaning gets its own named constant even when the number coincides — mirroring the reference PR's `VERIFIER_BITS` vs `AES_KEY_LENGTH` separation. Folding all `32`s into one constant is a forbidden anti-pattern.
+
+## Technical approach
+
+Investigation (3 parallel codebase sweeps, 2026-06-16) produced a verified inventory.
+Fix clusters become contracts C1–C4. Each new constant file is a caseless-enum namespace
+under `Shared/` so both product targets resolve one definition.
+
+## Contracts
+
+> No contract changes any wire format, persisted-state shape, network payload, or on-disk
+> cache format — all VALUES (bytes, strings, numbers) are identical pre/post; only the
+> source spelling moves from literal to constant. Consumer-flow walkthroughs are N/A for
+> every contract (no shape is created or modified).
+
+### C1 — Crypto params namespace + adoption (Shared/Crypto)
+
+New file `ios/Shared/Crypto/CryptoParams.swift`, a caseless-enum namespace (no imports beyond `Foundation`), with **semantically-named** members. Numbers that coincide stay separate constants:
+
+```swift
+public enum CryptoParams {
+  // AES-256-GCM wire parameters (match crypto-client.ts / AESGCM.swift wire format)
+  public static let aesGCMNonceByteCount = 12   // IV length
+  public static let aesGCMTagByteCount = 16     // auth tag length
+  // 256-bit symmetric key material expressed in bytes (AES-256 key, HKDF/PBKDF2 output)
+  public static let symmetricKeyByteCount = 32
+}
+
+public enum P256Params {
+  public static let coordinateByteCount = 32                 // JWK x / y length, scalar length
+  public static let keySizeBits = 256                        // SecKey kSecAttrKeySizeInBits
+  // uncompressed EC point: 0x04 ‖ x(32) ‖ y(32)
+  public static let uncompressedPointPrefix: UInt8 = 0x04
+  public static let uncompressedPointByteCount = 1 + coordinateByteCount + coordinateByteCount  // 65
+}
+```
+
+Adoption (verified sites from investigation; exact line numbers re-confirmed at edit time):
+- `Shared/Crypto/AESGCM.swift:26,54` (`== 12`) → `CryptoParams.aesGCMNonceByteCount`; `:55` (`== 16`) → `CryptoParams.aesGCMTagByteCount`.
+- `Shared/Crypto/KDF.swift`: `hkdfZeroSalt = Data(repeating: 0, count: 32)` (:10), `derivedKey = Data(repeating: 0, count: 32)` (:28), `derivedKeyPtr ... 32` (:38), `outputByteCount: 32` (:59,73,87) → `CryptoParams.symmetricKeyByteCount`. (The zero-salt length and key length both equal 32; both are "256-bit material in bytes" here, so one constant is correct — but keep the explanatory comments on each site.)
+- `Shared/Crypto/TeamKeyCrypto.swift`: zero-salt `count: 32` (:12) and HKDF `outputByteCount: 32` (:30,96,118,131) → `symmetricKeyByteCount`; JWK x/y validation `count == 32` (:65-66) → `P256Params.coordinateByteCount`; `:68` `Data([0x04])` x963 uncompressed-point marker → `Data([P256Params.uncompressedPointPrefix])` (same value/meaning as the SecureEnclaveKey prefix; **F5** — fold it, do not leave raw).
+- `Shared/Crypto/PasskeyAssertion.swift:73` (P-256 scalar `32`) → `P256Params.coordinateByteCount`.
+- `Shared/Crypto/PasskeyRegistration.swift:54-55,125-126` (x/y `prefix(32)`/`suffix(32)` and JWK encode) → `P256Params.coordinateByteCount`; `:159` random credential-ID `32` → **file-local** `private let credentialIdByteCount = 32` (semantically a random-ID length, NOT a coordinate; named locally with a comment that it coincides with the coordinate size).
+- `Shared/Crypto/SecureEnclaveKey.swift:32` (`kSecAttrKeySizeInBits: 256`) → `P256Params.keySizeBits`; `:106` uncompressed-point `65` and `0x04` prefix → `P256Params.uncompressedPointByteCount` / `.uncompressedPointPrefix`; `:109-110` x slice `1..<33` and y slice `33..<65` → expressed from `P256Params.coordinateByteCount` (`1 ..< (1 + coordinateByteCount)`, `(1 + coordinateByteCount) ..< uncompressedPointByteCount`); `:170-173` ECDSA component padding `32` → **file-local** `private let ecdsaComponentByteCount = 32` (ASN.1/raw signature component length — semantically distinct from key/coordinate; named locally).
+  - **NOTE (T1)**: `:32` `keySizeBits` lives in `generateDPoPKey`, a Secure-Enclave path NOT runnable in the simulator and NOT exercised by any unit test. Its correctness rests on compile-check + value-identity + the C1 value-pin test (see Testing strategy), NOT on the crypto vector suites. Do not count it under the test-guarded invariant.
+- `Shared/Crypto/SPKIEncoder.swift:31-32` (**F1** — `guard uncompressedPoint.count == 65, uncompressedPoint[startIdx] == 0x04`) → `P256Params.uncompressedPointByteCount` / `.uncompressedPointPrefix`. This file was missed by the initial inventory; it is the same uncompressed-point validation as `SecureEnclaveKey.swift:106` and MUST be migrated or the duplication survives the refactor.
+- `Shared/Storage/BridgeKeyStore.swift` (**F2**): the bridge-key length `32` appears THREE ways in this file — the existing `internal let bridgeKeyV2Size = 32` (:22, the value `readBlob` validates against at :237), the allocation `count: 32` (:129), and the random-fill `32` (:134). Reconcile to ONE: adopt the **existing** `bridgeKeyV2Size` at both :129 and :134 (it is the file's canonical storage-layout size and the read path already uses it). Do NOT introduce `CryptoParams.symmetricKeyByteCount` here — `bridgeKeyV2Size`/`bridgeMetaV2Size`/`legacyBridgeKeyBlobSize` are storage-layout sizes kept file-local by design (add to the file-local exclusion note below).
+- `Shared/AutoFill/RollbackFlagWriter.swift:37` (zero-salt `32`), `:42` (HKDF `outputByteCount: 32`) → `CryptoParams.symmetricKeyByteCount`.
+- `PasswdSSOApp/Auth/AuthCoordinator.swift:224-225` (PKCE verifier + state random `32`) → **file-local** `private let pkceRandomByteCount = 32` (random entropy length, distinct meaning).
+- **Deliberately NOT folded** (semantic-separation / SC-iOS list): the various `32`s named as file-local constants above (`credentialIdByteCount`, `ecdsaComponentByteCount`, `pkceRandomByteCount`); `BridgeKeyStore.swift` storage-layout sizes (`bridgeKeyV2Size`, `bridgeMetaV2Size`, `legacyBridgeKeyBlobSize` — kept file-local; the bridge-key length is unified on the existing `bridgeKeyV2Size`, see F2 above); `Shared/Crypto/SecureEnclaveKey.swift` DER tag bytes (`0x30`,`0x02`,`0x10` etc.) and other ASN.1/encoding bytes; AAD field-length caps (`0xFFFF`); `EntryCacheFile.swift` header byte offsets (file-format layout, single-file, already named `fileHeaderSize`); `Debug/DebugVaultLoader.swift:93` `.bits256` (CryptoKit idiom, not a bare literal); `pbkdf2Iterations` (already a centralized public constant — leave in `KDF.swift`).
+- Invariants:
+  - (test-guarded, app-enforced) `KDFTests`, `TeamKeyCryptoTests`, `AADParityTests`, `PasskeyRegistrationTests`, `EntryCacheFileTests`, `CredentialResolverTests` pass unchanged — proves byte-identical crypto. This is the strongest available guard (no schema-enforced equivalent for in-code constants).
+  - `CryptoParams.swift` imports only `Foundation` → safe in the `APPLICATION_EXTENSION_API_ONLY` framework and both targets.
+- Forbidden patterns (acceptance greps, run from `ios/`):
+  - pattern: `count == 12` / `count == 16` in `Shared/Crypto/AESGCM.swift` — reason: bare AES-GCM nonce/tag length. After edit, grep returns 0 in that file.
+  - pattern: `outputByteCount: 32` in `Shared/Crypto/` — reason: bare HKDF output length. Returns 0 after edit.
+  - pattern: bare `count == 32` in `Shared/Crypto/TeamKeyCrypto.swift` for JWK x/y — replaced by `P256Params.coordinateByteCount`.
+  - pattern (F1, broadened): bare `65` and `0x04` in **`Shared/Crypto/`** (NOT just `SecureEnclaveKey.swift`) at uncompressed-point parse/build sites — replaced. Covers `SecureEnclaveKey.swift:106`, `SPKIEncoder.swift:31-32`, `TeamKeyCrypto.swift:68`. After edit, grep `grep -rn '== 65\|\[0x04\]\|== 0x04' Shared/Crypto` returns only sites that reference `P256Params`.
+  - NOTE: a blanket `grep '\b32\b'` will still match the deliberately-retained file-local `32` named-constant declarations (`= 32`) — those are the named exclusions above and are NOT failures; the greps target the literal-at-use-site forms only.
+- Acceptance: forbidden greps above return 0 at the named use sites; the file-local named constants exist (grep `credentialIdByteCount`, `ecdsaComponentByteCount`, `pkceRandomByteCount` each return ≥1); `xcodebuild test` (incl. all crypto/parity suites) passes (VE1 → user/CI).
+
+### C2 — API path constants (Shared/Network)
+
+New file `ios/Shared/Network/APIPath.swift` (caseless-enum namespace, `Foundation` only). Centralize every `/api/...` path literal used by network code; the API surface belongs in one place even for currently-single-use endpoints (an API client's endpoint list is a legitimate cohesive surface, not premature DRY).
+
+```swift
+public enum APIPath {
+  public static let mobileToken = "/api/mobile/token"
+  public static let mobileTokenRefresh = "/api/mobile/token/refresh"
+  public static let mobileAutofillToken = "/api/mobile/autofill-token"
+  public static let mobileAuthorize = "/api/mobile/authorize"
+  public static let mobileCacheRollbackReport = "/api/mobile/cache-rollback-report"
+  public static let vaultUnlockData = "/api/vault/unlock/data"
+  public static let passwords = "/api/passwords"
+  public static let healthLive = "/api/health/live"
+  public static let teams = "/api/teams"
+  // Interpolated paths keep a builder so the {id}/{teamId} interpolation stays at the call site:
+  public static func password(id: String) -> String { "\(passwords)/\(id)" }
+  public static func teamPasswords(teamId: String) -> String { "\(teams)/\(teamId)/passwords" }
+  public static func teamMemberKey(teamId: String) -> String { "\(teams)/\(teamId)/member-key" }
+}
+```
+
+Adoption: replace literals at the verified sites (`MobileAPIClient.swift` ~200,254,304,312,323,349,398,448,497; `Shared/Network/EntryUploader.swift`; `PasswdSSOApp/Auth/AuthCoordinator.swift:243`; `PasswdSSOApp/Views/ServerURLSetupView.swift:80`; `PasswdSSOApp/Vault/HostSyncService.swift:240`; `PasswdSSOApp/Vault/EntryFetcher.swift:157`). Interpolated team/password paths use the builder funcs. The `include=blob` query param stays inline (single-use query string, not a path).
+- **F4 — fused path+query literal**: `EntryFetcher.swift:157` passes `"/api/passwords?include=blob"` as one string (not a `.appending(path:)` site). Adopt as `"\(APIPath.passwords)?include=blob"` so the `/api/` part comes from the constant and only the query stays inline.
+- Invariant (app-enforced): concatenated request URLs are byte-identical to today — the builder funcs reproduce the exact `"\(base)/\(id)"` interpolation currently inline. Verify each builder against its current call-site interpolation before adopting.
+- Forbidden pattern: `"/api/` outside `Shared/Network/APIPath.swift` — reason: bypasses APIPath.
+- Acceptance: `grep -rn '"/api/' Shared PasswdSSOApp PasswdSSOAutofillExtension --include='*.swift'` returns only `APIPath.swift` (T6: the test target lives under `PasswdSSOTests/`, outside the three grepped dirs, so its legitimate `/api/` fixture literals do not appear — and intentionally stay, per SC-iOS-6); URLs unchanged (spot-check each builder, incl. the F4 fused literal); `xcodebuild test` passes (VE1).
+
+### C3 — HTTP header / method / content-type / scheme constants (Shared/Network)
+
+New file `ios/Shared/Network/HTTPConstants.swift`:
+
+```swift
+public enum HTTPHeader {
+  public static let contentType = "Content-Type"
+  public static let authorization = "Authorization"
+  public static let dpop = "DPoP"
+  public static let dpopNonce = "DPoP-Nonce"
+}
+public enum HTTPMethod {
+  public static let get = "GET"
+  public static let post = "POST"
+  public static let put = "PUT"
+}
+public enum HTTPContentType {
+  public static let json = "application/json"
+}
+public enum HTTPAuthScheme {
+  public static let bearerPrefix = "Bearer "
+  public static let dpopPrefix = "DPoP "
+}
+```
+
+Adoption: `MobileAPIClient.swift` (header set/get sites ~224-226,277-281,369-372,418-421,468-471,517-520,626,632,676-687,746-797) and `Shared/Network/EntryUploader.swift`. `"Bearer "` / `"DPoP "` prefixes adopted at the `Authorization` value-construction sites.
+- **F3 — `htm:` DPoP-proof method argument**: every request passes the SAME method string twice — `request.httpMethod = "POST"` AND `htm: "POST"` to `buildDPoPProof` (MobileAPIClient.swift `htm:` sites ~209,231,265,286,359,377,408,426,458,476,507,525,621; EntryUploader.swift:114). These MUST stay equal (the DPoP proof's `htm` claim is validated server-side against the actual method). Adopt `HTTPMethod.*` at BOTH the `httpMethod =` assignment AND the paired `htm:` argument so the invariant `htm == httpMethod` is structurally guaranteed.
+- Invariant (app-enforced): header names/values byte-identical — wire requests unchanged. Note: `"DPoP"` (header name) and `"DPoP "` (auth-scheme prefix, trailing space) are DISTINCT constants — do not conflate. `htm:` value == `httpMethod` value at every call site.
+- Forbidden patterns:
+  - pattern: `"Authorization"` / `"Content-Type"` / `"DPoP-Nonce"` outside `HTTPConstants.swift` — reason: bypasses HTTPHeader.
+  - pattern: `httpMethod = "POST"|"GET"|"PUT"` — reason: bypasses HTTPMethod.
+  - pattern (F3): `htm: "(POST|GET|PUT)"` — reason: bypasses HTTPMethod at the DPoP-proof site (the literal-method form the `httpMethod =` grep cannot see).
+  - pattern: `"Bearer "` outside `HTTPConstants.swift` — reason: bypasses HTTPAuthScheme.
+- Acceptance: greps return 0 in production code (excluding `HTTPConstants.swift` and tests); `xcodebuild test` passes (VE1).
+
+### C4 — Logger subsystem constant (Shared)
+
+`"jp.jpng.passwd-sso"` is passed as `subsystem:` to `Logger`/`os.Logger` in 6 files across all three targets. Add a single shared constant and adopt it.
+- Home: extend `Shared/Storage/AppGroupContainer.swift` (already the canonical home for the related App Group identifier `"group.jp.jpng.passwd-sso.shared"`) with `public static let loggerSubsystem = "jp.jpng.passwd-sso"`, OR a new tiny `Shared/AppIdentifiers.swift` namespace if AppGroupContainer is not a fitting home (decide at edit time; prefer co-locating with the App Group id for cohesion).
+- Adoption: `Shared/AutoFill/CredentialIdentityRegistrar.swift`, `Shared/AutoFill/CredentialResolver.swift`, `Shared/Storage/BridgeKeyStore.swift`, `PasswdSSOApp/Auth/AutofillTokenRefresher.swift`, `PasswdSSOApp/Views/RootView.swift`, `PasswdSSOAutofillExtension/CredentialProviderViewController.swift`.
+- Invariant (app-enforced): subsystem string unchanged → Console/log filtering by subsystem unaffected.
+- Forbidden pattern: `subsystem: "jp.jpng.passwd-sso"` (literal) outside the constant's home — reason: bypasses the shared constant.
+- Acceptance: grep returns only the definition site; `xcodebuild test` passes (VE1).
+
+## Go/No-Go Gate
+
+| ID | Subject                                              | Status |
+|----|------------------------------------------------------|--------|
+| C1 | Crypto params namespace + adoption (Shared/Crypto)   | locked |
+| C2 | API path constants (Shared/Network)                  | locked |
+| C3 | HTTP header/method/content-type/scheme constants     | locked |
+| C4 | Logger subsystem constant (Shared)                   | locked |
+
+(Locked after plan review closed: 2 functionality rounds + 1 security + 1 testing; all findings resolved.)
+
+## Testing strategy
+
+- `xcodebuild test -scheme PasswdSSO ...` (or `swift test` where applicable) — full XCTest suite. Crypto parity/vector suites (`KDFTests`, `TeamKeyCryptoTests`, `AADParityTests`, `PasskeyRegistrationTests`, `TOTPVectorTests`, `EntryCacheFileTests`, `CredentialResolverTests`) are the primary behavior guard for C1. Run by the user/CI (VE1).
+- Forbidden-pattern greps (runnable in this environment) are the migration-completeness gate per contract.
+- Value-pin tests (T5 — **required for the vector-uncovered constants, optional for the rest**): add a small `PasswdSSOTests/CryptoParamsTests.swift`. The AES-GCM / symmetric-key constants are already transitively pinned by the known-vector suites (a wrong `aesGCMTagByteCount` makes `decryptAESGCM` throw → `AADParityTests`/`TeamKeyCryptoTests` fail end-to-end), so pinning them is decorative/optional. The constants **NO existing vector pins** — `P256Params.keySizeBits == 256` (the SE-only `:32` site from T1), `P256Params.uncompressedPointByteCount == 65`, `P256Params.uncompressedPointPrefix == 0x04` — MUST be pinned here; this is the only test-time guard for the Secure-Enclave path that the simulator cannot run. (These pins are non-tautological per RT7: they compare the symbol against an independent literal.)
+- No new behavior to test (pure refactor); existing suites + value-identity reasoning cover correctness.
+
+## Considerations & constraints
+
+- **Crypto is the highest-risk surface.** Mitigation: value-identity (no value changes), semantic separation (file-local constants for distinct-meaning `32`s), parity/vector tests, no HKDF/AAD info strings touched (those are versioned protocol strings and stay where they are).
+- **Import boundary**: all new constant files live in `Shared/` and import only `Foundation` → safe under `APPLICATION_EXTENSION_API_ONLY` and resolvable from both product targets.
+- **xcodegen**: confirm `Shared/Crypto` and `Shared/Network` are folder-globbed in `project.yml` so new files are picked up without a manifest edit (VE2).
+
+### Scope contract
+
+- **SC-iOS-1 — Time/duration normalization**: out of scope. Unlike the web PR's `MS_PER_*` work, Swift time literals are mostly single-use or already centralized (`AutoLockLimits`, `TeamEntryDecryptor.teamKeyMaxAge`, `SecureClipboard.min/maxClearSeconds`, `MobileAPIClient.refreshSkewSeconds`). `15 * 60` for seconds is idiomatic and readable. Introducing `SEC_PER_*` base constants is churn without dedup benefit. `TODO(ios-hardcoded-values-to-constants): time-base constants not planned — values are single-use or already named`.
+- **SC-iOS-2 — Keychain/service identifiers** (`"com.passwd-sso.host-tokens"`, `.bridge-key`, `.dpop.host`, `.deviceId`, `.cache-sync`, …): out of scope. Each is a DISTINCT identifier already assigned to a single named constant in its store; they share only the `"com.passwd-sso."` reverse-DNS vendor prefix. Splitting the prefix reduces readability without removing duplication (mirrors reference PR SC4 "per-route key prefixes"). Not duplication → not in scope.
+- **SC-iOS-3 — Enumerated domain strings** (entry types, cache-rejection reasons, TOTP algorithms, AAD scopes, vault-timeout actions, team roles): out of scope — already centralized as Swift enums (`EntryTypeCategory`, `CacheRejectionKind`, `TOTPHashAlgorithm`, `AADScope`, `VaultTimeoutAction`, `TeamRole`). The "not done" gap this plan addresses does not include these.
+- **SC-iOS-4 — UI layout magic numbers** (SwiftUI spacing/padding/frame sizes): out of scope — single-use, idiomatic; investigation found no value repeated ≥3× across files.
+- **SC-iOS-5 — RFC-default protocol numbers** (TOTP digits=6, period=30 per RFC 6238; DER/ASN.1 tag bytes; AAD field-length caps): out of scope — spec-mandated idiom, not arbitrary magic.
+- **SC-iOS-6 — Test-fixture literals** (`expiresIn: 3600/86400`, `600000` in `MobileAPIClientTests`): leave ALL of them as inline fixture data. Testing review (T3) confirmed per-site that the iOS suite has **zero** tests asserting a production-owned numeric constant: `expiresIn`/`addingTimeInterval` durations are arbitrary inputs chosen to straddle the 60s refresh skew, and `kdfIterations: 600000` in the mock unlock-data JSON is a **server-response field** the client reads (never compares to `pbkdf2Iterations`) — coupling it to the iOS constant would be incorrect. Net: no test literal adopts a production constant. Bonus (T4): the tests' hardcoded `"Authorization"`/`"/api/..."` literals act as an independent drift cross-check against C2/C3 constants (test goes red if a constant's value drifts), which is another reason to keep them inline.
+
+## User operation scenarios
+
+- A user unlocks the vault (PBKDF2 + HKDF), views/edits entries (AES-GCM decrypt/encrypt with AAD), uses AutoFill (team-key ECDH unwrap), registers/uses a passkey (P-256 key parsing) — all crypto paths must produce/accept byte-identical bytes (parity/vector tests + manual smoke).
+- The app and the AutoFill extension both make network requests (token refresh, fetch entries, upload) — header names, methods, and URL paths must be byte-identical so the server contract is unchanged.
+- Console.app log filtering by subsystem `jp.jpng.passwd-sso` continues to surface all three targets' logs.

--- a/docs/archive/review/ios-hardcoded-values-to-constants-review.md
+++ b/docs/archive/review/ios-hardcoded-values-to-constants-review.md
@@ -1,0 +1,56 @@
+# Plan Review: ios-hardcoded-values-to-constants
+Date: 2026-06-16
+Review rounds: Functionality ×2, Security ×1, Testing ×1
+
+## Changes from Previous Round
+Initial review (R1) for all three experts; Functionality R2 confirmed all R1 Major findings resolved with no new findings.
+
+## Functionality Findings (Senior Software Engineer)
+
+- **F1 [Major] — SPKIEncoder.swift uncompressed-point duplication missed.** `Shared/Crypto/SPKIEncoder.swift:31-32` validates `count == 65` / `== 0x04` — the same uncompressed EC-point values C1 centralizes (`P256Params.uncompressedPointByteCount` / `.uncompressedPointPrefix`) — but was absent from the inventory and the acceptance grep was file-scoped to `SecureEnclaveKey.swift`. **Resolved**: added to C1 adoption; the `65`/`0x04` forbidden grep broadened to `Shared/Crypto/` (`== 65\|\[0x04\]\|== 0x04`), which matches the 3 real EC-point sites and correctly excludes the WebAuthn UV-flag `= 0x04` declarations.
+- **F2 [Major] — BridgeKeyStore bridge-key length spelled 3 ways.** `bridgeKeyV2Size = 32` (:22, the read-path validator at :237), allocation `count: 32` (:129), random-fill `32` (:134). **Resolved**: unify create-path (:129, :134) onto the existing `bridgeKeyV2Size`; keep storage-layout sizes (`bridgeKeyV2Size`/`bridgeMetaV2Size`/`legacyBridgeKeyBlobSize`) file-local (NOT `CryptoParams.symmetricKeyByteCount`). R2 confirmed `bridgeKeyV2Size` is the read-path validator, so create/read symmetry is preserved.
+- **F3 [Major] — `htm:` DPoP-proof method literals missed by the method grep.** Each request passes the method twice: `httpMethod = "POST"` AND `htm: "POST"` to `buildDPoPProof`; the two MUST stay equal (server validates the DPoP `htm` claim). The `httpMethod =` grep cannot see `htm: "POST"`. **Resolved**: C3 adoption now covers both sites (13 in MobileAPIClient + EntryUploader:114), states the `htm == httpMethod` invariant, and adds a `htm: "(POST|GET|PUT)"` forbidden grep.
+- **F4 [Minor] — fused path+query literal.** `EntryFetcher.swift:157` `"/api/passwords?include=blob"`. **Resolved**: adopt `"\(APIPath.passwords)?include=blob"`.
+- **F5 [Minor] — TeamKeyCrypto x963 prefix.** `:68` `Data([0x04])` is the same uncompressed-point marker. **Resolved**: fold to `Data([P256Params.uncompressedPointPrefix])` (covered by the F1 grep).
+
+Verified-correct (no finding): EC slice arithmetic reproduces `1..<33`/`33..<65`; C1 semantic separation of the distinct `32`s is correct; full C2 path inventory + builder interpolation byte-identical; C3 `"DPoP"` vs `"DPoP "` distinction; C4 exactly 6 subsystem sites; VE2 xcodegen folder-glob confirmed (no project.yml edit needed); no module cycles in the new Shared files.
+
+R2 result: **No findings** — all F1–F5 closed, no residue, completeness re-sweep of `Shared/Crypto` + network files found nothing new.
+
+## Security Findings (Security Engineer)
+
+**No findings.** Value-identity verified byte-identical for every security-relevant constant (AES-GCM nonce 12 / tag 16, key length 32, P-256 coordinate 32, uncompressed point 65 / 0x04, key-size bits 256; `pbkdf2Iterations` left in place). Domain-separation / versioned strings (HKDF info strings, AAD scope strings `PV/OV/AT/IK/OK/LW`, `aadVersion`, AAD field cap `0xFFFF`) confirmed EXCLUDED. RS5 anti-downgrade floor `kdfIterations >= pbkdf2Iterations` (`VaultUnlocker.swift:99`) not in scope, not weakened. No secret/key/token VALUES turned into source constants. Import boundary unchanged (new files `Foundation`-only in `Shared/`). Endorsement (adopted via T5): pin the vector-uncovered crypto constants in a test.
+
+## Testing Findings (QA Engineer)
+
+All Minor; incorporated:
+- **T1** — `SecureEnclaveKey.swift:32 keySizeBits` is in a Secure-Enclave path not runnable in the simulator / not exercised by any unit test. Plan now notes it as compile-only + value-pin guard, not "test-guarded".
+- **T3 / SC-iOS-6** — per-site verdict: the iOS suite has ZERO tests asserting a production-owned numeric constant (`expiresIn`/`addingTimeInterval` are arbitrary inputs; mock `kdfIterations: 600000` is a server-response field the client reads, never compares). SC-iOS-6 reworded to "leave all test literals inline."
+- **T4 / RT1** — mock response shapes stay in sync; the tests' hardcoded `"Authorization"`/`"/api/..."` literals double as an independent C2/C3 drift cross-check (reason to keep inline).
+- **T5 / RT7** — value-pin test made **required** for the 3 vector-uncovered constants (`P256Params.keySizeBits`, `.uncompressedPointByteCount`, `.uncompressedPointPrefix`); optional/decorative for AES/symmetric constants (already pinned transitively by `KDFTests`/`AADParityTests`/`TeamKeyCryptoTests`).
+- **T6** — C2 grep prose fixed (test target is outside the grepped dirs).
+- **T2, T7** — no plan change (grep-gate routing acknowledged; spot-check `EntryFetcherTests`/`HostSyncServiceTests` during Phase 2).
+
+## Adjacent Findings
+None requiring cross-routing (F-series stayed within functionality scope; T-series within testing).
+
+## Quality Warnings
+None (all findings carried file:line evidence and concrete fixes).
+
+## Recurring Issue Check
+
+### Functionality expert
+- R2 (constants centralization): R1 PARTIAL (F1/F2/F3/F5 missed sites) → R2 CLEAN after fixes.
+- R3 (propagation / all call sites): R1 PARTIAL (file-scoped greps under-covered) → R2 CLEAN (greps broadened to `Shared/Crypto/`, htm: + fused-literal sites added).
+- R10 (circular dependency, new Shared files): OK — `Foundation`-only.
+- R25 (persist/hydrate symmetry): OK — no storage-key string values moved; values byte-identical.
+- R1, R4–R9, R11–R24, R26–R41: N/A (Swift constant-extraction refactor; no DB/events/migrations/i18n/UI-state).
+
+### Security expert
+- R3 (propagation): PASS. R4 (no secret values): PASS. R5 (input validation guards unchanged): PASS.
+- RS1 (authn/authz untouched): PASS. RS3 (crypto misuse — no algo/mode change): PASS. RS4 (no key-material logging): PASS. RS5 (server-param floor preserved): PASS.
+- RS2, R1–R2, R6–R41 (excl. above): N/A.
+
+### Testing expert
+- RT1 (mock consistency): PASS. RT2 (no non-unit-testable test demands): honored. RT3/SC-iOS-6 (fixture vs constant): PASS. RT5 (test path includes primitive): PASS except SE-only site, routed to compile+pin. RT7 (value-pins can go red): PASS.
+- RT4, RT6, R-rules not listed: N/A.

--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		3D23FF146F64052F0EC31277 /* WrappedKeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19D6A107E63BFA725F2C0F3 /* WrappedKeyStoreTests.swift */; };
 		3E108ED6C538686316A3B694 /* AutoCopyTOTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5663016688BE4902C4F1E41 /* AutoCopyTOTP.swift */; };
 		4372EB553FD8B0AE2BF33972 /* StaleBlobRecoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B088B96E6D37D767B517A837 /* StaleBlobRecoveryService.swift */; };
+		4BB5CCEA7BC170BA864CE2A4 /* HTTPConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5A5914A5C31DC30D3F8BB7 /* HTTPConstants.swift */; };
 		4C643AAE37D9DA7E0DCC0DAA /* fixtures in Resources */ = {isa = PBXBuildFile; fileRef = 0BDD66BD3FF47585E7183FC8 /* fixtures */; };
 		4D0A43663B1F311CD3A16903 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 327A83D67306CD99E0CB3270 /* Localizable.xcstrings */; };
 		4E56AE164F22FCD21F81770B /* SecureClipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23842E34485154B227229627 /* SecureClipboard.swift */; };
@@ -93,6 +94,7 @@
 		9CADAC4F619993DF6DBF1F0B /* PasskeySignCountStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E38F8248BD5540CEF7680AD /* PasskeySignCountStoreTests.swift */; };
 		A3CEA13B7C87135CC54039D6 /* TeamContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8901EA2724A715ACFBEEDBEF /* TeamContext.swift */; };
 		A457C9391F7E1E8164C97A46 /* AutoLockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C68DCFC79DBA6600F27E36 /* AutoLockService.swift */; };
+		A4619E1EAF28B7B5566B72CD /* CryptoParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4362A04B3AF6AD6D6C510D00 /* CryptoParamsTests.swift */; };
 		A49DCEFF5ABDE722BF33C324 /* SPKIEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FBC66A0BFC38B393757852 /* SPKIEncoder.swift */; };
 		A593FD25556BA7A6EB040FAE /* team-key-fixture.json in Resources */ = {isa = PBXBuildFile; fileRef = B8AE8A147DAB81877B408F77 /* team-key-fixture.json */; };
 		A5FA7118BBC2D9CE7C30901E /* MobileAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7D6EC824EE87139CFBABE4 /* MobileAPIClient.swift */; };
@@ -121,10 +123,12 @@
 		D5D219073C574D1919EE94D6 /* AutofillTokenRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093A4C680F943C38DC91C965 /* AutofillTokenRefresherTests.swift */; };
 		D818CC3D8994859EC9B470F2 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F670E8B421F3D4CB3734A6 /* RootView.swift */; };
 		D8EA7B209BAE0D68AB7DB5D5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2BB90663584E9586FF0945C /* ContentView.swift */; };
+		DBB29BDC22F36FCF2C0E17BC /* APIPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FC6A9ACA49A08723A4C1B0 /* APIPath.swift */; };
 		DBFB20A7E48448D3D840FDE7 /* RollbackFlagWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C6B815B59EF7FAADB00EB /* RollbackFlagWriterTests.swift */; };
 		DC4BEF76059ED0111E834689 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CC4B0DD9996CF6B29E2CEA6A /* Assets.xcassets */; };
 		DCA4385D86B0CEEFBE1492CB /* CacheEntryPropagationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F64F52EEBB1CEEBF012664 /* CacheEntryPropagationTests.swift */; };
 		E0832EF8431014E47A2A4636 /* ServerTrustServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662E445816ED2184809324A5 /* ServerTrustServiceTests.swift */; };
+		E0962DA0EAD8AD7DF3448384 /* CryptoParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104B83F63713CEDACF886F9 /* CryptoParams.swift */; };
 		E0E33F33FBEB6BBA6CC22D06 /* KDFTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A24C3EFD4C6BA4ACDA40380 /* KDFTests.swift */; };
 		E1FA345EE6BF6D38163AD937 /* DebugVaultLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FED91E37F4E8005AEF7E9B6 /* DebugVaultLoaderTests.swift */; };
 		E300850EF22C24B05B82D25B /* SecureEnclaveKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120E0D108C572BDFE0A5E79E /* SecureEnclaveKey.swift */; };
@@ -226,8 +230,10 @@
 		00C68DCFC79DBA6600F27E36 /* AutoLockService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLockService.swift; sourceTree = "<group>"; };
 		06E4377840A9A939A6B88D9A /* VaultEntrySummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultEntrySummary.swift; sourceTree = "<group>"; };
 		093A4C680F943C38DC91C965 /* AutofillTokenRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillTokenRefresherTests.swift; sourceTree = "<group>"; };
+		0B5A5914A5C31DC30D3F8BB7 /* HTTPConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPConstants.swift; sourceTree = "<group>"; };
 		0BDD66BD3FF47585E7183FC8 /* fixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; name = fixtures; path = ../extension/test/fixtures; sourceTree = SOURCE_ROOT; };
 		0CB624E102C09D08D7B9BB8D /* TOTPVectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPVectorTests.swift; sourceTree = "<group>"; };
+		1104B83F63713CEDACF886F9 /* CryptoParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoParams.swift; sourceTree = "<group>"; };
 		120E0D108C572BDFE0A5E79E /* SecureEnclaveKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureEnclaveKey.swift; sourceTree = "<group>"; };
 		123297FA521C8B4A2D71A5A3 /* TeamKeyCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamKeyCrypto.swift; sourceTree = "<group>"; };
 		13E66C8E3793F0F33D64AAB4 /* VaultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultViewModel.swift; sourceTree = "<group>"; };
@@ -258,6 +264,7 @@
 		3FED91E37F4E8005AEF7E9B6 /* DebugVaultLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugVaultLoaderTests.swift; sourceTree = "<group>"; };
 		404B7404ADFE4D340E600931 /* PasswdSSOTests.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PasswdSSOTests.entitlements; sourceTree = "<group>"; };
 		430B7C32D3A606C25EDA8568 /* AppSettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStoreTests.swift; sourceTree = "<group>"; };
+		4362A04B3AF6AD6D6C510D00 /* CryptoParamsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoParamsTests.swift; sourceTree = "<group>"; };
 		469C94A411CE66C4D3EAB9AA /* PasskeySignCountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeySignCountStore.swift; sourceTree = "<group>"; };
 		49247874A1D0207489D6F624 /* PasswdSSOApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = PasswdSSOApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		493B2BB02D23F64F52EF0DAA /* PasskeyAssertionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAssertionTests.swift; sourceTree = "<group>"; };
@@ -284,6 +291,7 @@
 		720107D734C7B5EBBBFCB91E /* AppGroupContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupContainer.swift; sourceTree = "<group>"; };
 		72F670E8B421F3D4CB3734A6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		7546B006E2E44B4AB2F80A42 /* RollbackFlagWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollbackFlagWriter.swift; sourceTree = "<group>"; };
+		75FC6A9ACA49A08723A4C1B0 /* APIPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPath.swift; sourceTree = "<group>"; };
 		775C6B815B59EF7FAADB00EB /* RollbackFlagWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollbackFlagWriterTests.swift; sourceTree = "<group>"; };
 		77B346160EEA436AAF564277 /* EntryFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryFetcher.swift; sourceTree = "<group>"; };
 		77C0E5B05F04FC285CE89519 /* BackgroundSyncCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSyncCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -414,6 +422,7 @@
 				C8F64F52EEBB1CEEBF012664 /* CacheEntryPropagationTests.swift */,
 				1C62D90660DD31E8DCA4CD77 /* CredentialIdentityRegistrarTests.swift */,
 				8AC8C547AA2FF81B4A670924 /* CredentialResolverTests.swift */,
+				4362A04B3AF6AD6D6C510D00 /* CryptoParamsTests.swift */,
 				3FED91E37F4E8005AEF7E9B6 /* DebugVaultLoaderTests.swift */,
 				EBF559B979642506D203C806 /* DPoPProofBuilderTests.swift */,
 				80BC3E2908650479CBBE6D07 /* EntryBlobDecoderTests.swift */,
@@ -601,7 +610,9 @@
 		7E5F29FABDA0803348E14E75 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				75FC6A9ACA49A08723A4C1B0 /* APIPath.swift */,
 				D696B8B99CFDB4FFFDC090E1 /* EntryUploader.swift */,
+				0B5A5914A5C31DC30D3F8BB7 /* HTTPConstants.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -645,6 +656,7 @@
 			children = (
 				00886F462BDA31731FCC1B2A /* AAD.swift */,
 				D86EB7DC9441141057919E49 /* AESGCM.swift */,
+				1104B83F63713CEDACF886F9 /* CryptoParams.swift */,
 				FC38F9BDA78209BF77E16CC7 /* CryptoUtils.swift */,
 				C02778E2A8EE7B7A09B671C4 /* KDF.swift */,
 				3000F818C09142AEC4837294 /* PasskeyAssertion.swift */,
@@ -1016,6 +1028,7 @@
 				DCA4385D86B0CEEFBE1492CB /* CacheEntryPropagationTests.swift in Sources */,
 				275CA45AE18A3AD75D9EDA8C /* CredentialIdentityRegistrarTests.swift in Sources */,
 				B8E8B10956121151C6DF7F9C /* CredentialResolverTests.swift in Sources */,
+				A4619E1EAF28B7B5566B72CD /* CryptoParamsTests.swift in Sources */,
 				0A36948197E80ACA5ED17F22 /* DPoPProofBuilderTests.swift in Sources */,
 				E1FA345EE6BF6D38163AD937 /* DebugVaultLoaderTests.swift in Sources */,
 				1633001879A14FC075CBC4A3 /* EntryBlobDecoderTests.swift in Sources */,
@@ -1063,6 +1076,7 @@
 			files = (
 				B51FF4981CF7716A4F01CF18 /* AAD.swift in Sources */,
 				60AD9C0835A9502C54C79E90 /* AESGCM.swift in Sources */,
+				DBB29BDC22F36FCF2C0E17BC /* APIPath.swift in Sources */,
 				34E13CBD9ED4C6D8D72D6EFE /* AppGroupContainer.swift in Sources */,
 				D034CB85FCE2181F6E9490EE /* AppSettingsStore.swift in Sources */,
 				3E108ED6C538686316A3B694 /* AutoCopyTOTP.swift in Sources */,
@@ -1071,12 +1085,14 @@
 				1ACA702DAFCBA5F5EDD82475 /* BridgeKeyStore.swift in Sources */,
 				8065245BE0FB70308D802C22 /* CredentialIdentityRegistrar.swift in Sources */,
 				CCF7AB22A048CA0D633DC740 /* CredentialResolver.swift in Sources */,
+				E0962DA0EAD8AD7DF3448384 /* CryptoParams.swift in Sources */,
 				65B588E2DB548D9142568179 /* CryptoUtils.swift in Sources */,
 				72BD7556CC6BAD53BD1F093D /* DPoPProofBuilder.swift in Sources */,
 				E3E4F08803D9E1580F7BE6CD /* EntryBlobDecoder.swift in Sources */,
 				89EF5EABFE7C000262E67616 /* EntryCacheFile.swift in Sources */,
 				0F7754D416476CE6B1AE0C81 /* EntryEncrypter.swift in Sources */,
 				FEC853759999A05E6F0867F4 /* EntryUploader.swift in Sources */,
+				4BB5CCEA7BC170BA864CE2A4 /* HTTPConstants.swift in Sources */,
 				3582DA3CD5414790F589E168 /* HostTokenStore.swift in Sources */,
 				542B8D1BD03A73706A98778B /* KDF.swift in Sources */,
 				2F1B42C2B8566A94C6155FEE /* LockState.swift in Sources */,
@@ -1175,7 +1191,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.57;
+				MARKETING_VERSION = 0.4.58;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOUITests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1195,7 +1211,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.4.57;
+				MARKETING_VERSION = 0.4.58;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOAutofillExtension";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1218,7 +1234,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.57;
+				MARKETING_VERSION = 0.4.58;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.Shared";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1307,7 +1323,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.4.57;
+				MARKETING_VERSION = 0.4.58;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOAutofillExtension";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1326,7 +1342,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.57;
+				MARKETING_VERSION = 0.4.58;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOTests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1345,7 +1361,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.57;
+				MARKETING_VERSION = 0.4.58;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOUITests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1426,7 +1442,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.57;
+				MARKETING_VERSION = 0.4.58;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1445,7 +1461,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.57;
+				MARKETING_VERSION = 0.4.58;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1464,7 +1480,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.57;
+				MARKETING_VERSION = 0.4.58;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOTests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1488,7 +1504,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.57;
+				MARKETING_VERSION = 0.4.58;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.Shared";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/ios/PasswdSSOApp/Auth/AuthCoordinator.swift
+++ b/ios/PasswdSSOApp/Auth/AuthCoordinator.swift
@@ -35,6 +35,8 @@ public enum AuthError: Error, Equatable {
 public actor AuthCoordinator {
   private let serverConfig: ServerConfig
   let tokenStore: HostTokenStore
+  /// PKCE verifier/state entropy length
+  private let pkceRandomByteCount = 32
   private let dpopKeyLabel: String
   /// Seam for loading the persisted SE key. Defaults to `loadDPoPKey`, which
   /// filters on `kSecAttrTokenIDSecureEnclave` — invisible to the simulator
@@ -221,8 +223,8 @@ public actor AuthCoordinator {
 
   /// Generate PKCE code_verifier (43-char base64url), code_challenge (S256), and state.
   private func generatePKCEAndState() throws -> (verifier: String, challenge: String, state: String) {
-    let verifierBytes = try secureRandom(count: 32)
-    let stateBytes = try secureRandom(count: 32)
+    let verifierBytes = try secureRandom(count: pkceRandomByteCount)
+    let stateBytes = try secureRandom(count: pkceRandomByteCount)
 
     let verifier = base64URLEncode(verifierBytes)
     let state = base64URLEncode(stateBytes)
@@ -240,7 +242,7 @@ public actor AuthCoordinator {
   ) throws -> URL {
     var components = URLComponents(
       url: serverConfig.baseURL.appending(
-        path: "/api/mobile/authorize",
+        path: APIPath.mobileAuthorize,
         directoryHint: .notDirectory
       ),
       resolvingAgainstBaseURL: false

--- a/ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift
+++ b/ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift
@@ -11,7 +11,7 @@ import Shared
 /// missing/expired token as a clean cancel (fall-through to iCloud Keychain),
 /// not a lockout.
 public struct AutofillTokenRefresher: Sendable {
-  private static let log = Logger(subsystem: "jp.jpng.passwd-sso", category: "autofill-token")
+  private static let log = Logger(subsystem: AppGroupContainer.loggerSubsystem, category: "autofill-token")
 
   private let apiClient: MobileAPIClient
   private let uploadTokenStore: UploadTokenStore

--- a/ios/PasswdSSOApp/Network/MobileAPIClient.swift
+++ b/ios/PasswdSSOApp/Network/MobileAPIClient.swift
@@ -197,7 +197,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     codeVerifier: String,
     deviceJkt: String
   ) async throws -> TokenExchangeResponse {
-    let tokenURL = serverURL.appending(path: "/api/mobile/token", directoryHint: .notDirectory)
+    let tokenURL = serverURL.appending(path: APIPath.mobileToken, directoryHint: .notDirectory)
     let htu = canonicalHTU(url: tokenURL)
 
     // Capture values before crossing into async context so retry closure doesn't need await.
@@ -206,7 +206,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
 
     let nonce = try? tokenStore.loadNonce()
     let proof = try await buildDPoPProof(
-      htm: "POST",
+      htm: HTTPMethod.post,
       htu: htu,
       jwk: localJWK,
       nonce: nonce,
@@ -221,21 +221,21 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let bodyData = try JSONEncoder().encode(body)
 
     var request = URLRequest(url: tokenURL)
-    request.httpMethod = "POST"
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue(proof.jws, forHTTPHeaderField: "DPoP")
+    request.httpMethod = HTTPMethod.post
+    request.setValue(HTTPContentType.json, forHTTPHeaderField: HTTPHeader.contentType)
+    request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
     request.httpBody = bodyData
 
     return try await performTokenRequest(request) { newNonce in
       let retryProof = try await buildDPoPProof(
-        htm: "POST",
+        htm: HTTPMethod.post,
         htu: htu,
         jwk: localJWK,
         nonce: newNonce,
         signer: localSigner
       )
       var retryRequest = request
-      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: "DPoP")
+      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       return retryRequest
     }
   }
@@ -251,7 +251,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     }
 
     let refreshURL = serverURL.appending(
-      path: "/api/mobile/token/refresh",
+      path: APIPath.mobileTokenRefresh,
       directoryHint: .notDirectory
     )
     let htu = canonicalHTU(url: refreshURL)
@@ -262,7 +262,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
 
     let nonce = try? tokenStore.loadNonce()
     let proof = try await buildDPoPProof(
-      htm: "POST",
+      htm: HTTPMethod.post,
       htu: htu,
       jwk: localJWK,
       ath: ath,
@@ -274,16 +274,16 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let bodyData = try JSONEncoder().encode(body)
 
     var request = URLRequest(url: refreshURL)
-    request.httpMethod = "POST"
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpMethod = HTTPMethod.post
+    request.setValue(HTTPContentType.json, forHTTPHeaderField: HTTPHeader.contentType)
     // SECURITY: never log this request or its headers — Authorization carries the refresh token.
-    request.setValue("DPoP \(refreshToken)", forHTTPHeaderField: "Authorization")
-    request.setValue(proof.jws, forHTTPHeaderField: "DPoP")
+    request.setValue("\(HTTPAuthScheme.dpopPrefix)\(refreshToken)", forHTTPHeaderField: HTTPHeader.authorization)
+    request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
     request.httpBody = bodyData
 
     return try await performTokenRequest(request) { newNonce in
       let retryProof = try await buildDPoPProof(
-        htm: "POST",
+        htm: HTTPMethod.post,
         htu: htu,
         jwk: localJWK,
         ath: ath,
@@ -291,7 +291,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
         signer: localSigner
       )
       var retryRequest = request
-      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: "DPoP")
+      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       return retryRequest
     }
   }
@@ -301,7 +301,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
   /// Fetch vault unlock data from GET /api/vault/unlock/data.
   /// Requires a valid access token (DPoP-signed). Applies the full C3 retry ladder.
   public func fetchVaultUnlockData() async throws -> VaultUnlockData {
-    let url = serverURL.appending(path: "/api/vault/unlock/data", directoryHint: .notDirectory)
+    let url = serverURL.appending(path: APIPath.vaultUnlockData, directoryHint: .notDirectory)
     let data = try await performAuthedGET(url: url)
     return try JSONDecoder().decode(VaultUnlockData.self, from: data)
   }
@@ -309,7 +309,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
   /// Fetch encrypted team entries (flat response format) for a given team.
   /// Requires a valid access token (DPoP-signed). Applies the full C3 retry ladder.
   public func fetchTeamEntries(teamId: String) async throws -> [TeamEncryptedEntry] {
-    guard let endpointURL = resourceURL(path: "/api/teams/\(teamId)/passwords", query: "include=blob") else {
+    guard let endpointURL = resourceURL(path: APIPath.teamPasswords(teamId: teamId), query: "include=blob") else {
       throw MobileAPIError.serverError(status: 400)
     }
     let data = try await performAuthedGET(url: endpointURL)
@@ -320,7 +320,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
   /// 403 (KEY_NOT_DISTRIBUTED) / 404 (MEMBER_KEY_NOT_FOUND) → `teamKeyNotDistributed`
   /// so the sync caller skips the team rather than failing the whole sync.
   public func fetchTeamMemberKey(teamId: String) async throws -> TeamMemberKeyResponse {
-    let url = serverURL.appending(path: "/api/teams/\(teamId)/member-key", directoryHint: .notDirectory)
+    let url = serverURL.appending(path: APIPath.teamMemberKey(teamId: teamId), directoryHint: .notDirectory)
     do {
       let data = try await performAuthedGET(url: url)
       return try JSONDecoder().decode(TeamMemberKeyResponse.self, from: data)
@@ -346,7 +346,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let accessToken = try await validAccessToken()
 
     let endpoint = serverURL.appending(
-      path: "/api/mobile/cache-rollback-report",
+      path: APIPath.mobileCacheRollbackReport,
       directoryHint: .notDirectory
     )
     let htu = canonicalHTU(url: endpoint)
@@ -356,7 +356,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let localSigner = signer
     let nonce = try? tokenStore.loadNonce()
     let proof = try await buildDPoPProof(
-      htm: "POST",
+      htm: HTTPMethod.post,
       htu: htu,
       jwk: localJWK,
       ath: ath,
@@ -366,15 +366,15 @@ public actor MobileAPIClient: VaultUnlockDataSource {
 
     let bodyData = try JSONEncoder().encode(body)
     var request = URLRequest(url: endpoint)
-    request.httpMethod = "POST"
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-    request.setValue(proof.jws, forHTTPHeaderField: "DPoP")
+    request.httpMethod = HTTPMethod.post
+    request.setValue(HTTPContentType.json, forHTTPHeaderField: HTTPHeader.contentType)
+    request.setValue("\(HTTPAuthScheme.bearerPrefix)\(accessToken)", forHTTPHeaderField: HTTPHeader.authorization)
+    request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
     request.httpBody = bodyData
 
     try await performVoidHTTP(request) { newNonce in
       let retryProof = try await buildDPoPProof(
-        htm: "POST",
+        htm: HTTPMethod.post,
         htu: htu,
         jwk: localJWK,
         ath: ath,
@@ -382,7 +382,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
         signer: localSigner
       )
       var retryRequest = request
-      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: "DPoP")
+      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       return retryRequest
     }
   }
@@ -395,7 +395,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let accessToken = try await validAccessToken()
 
     let endpoint = serverURL.appending(
-      path: "/api/passwords",
+      path: APIPath.passwords,
       directoryHint: .notDirectory
     )
     let htu = canonicalHTU(url: endpoint)
@@ -405,7 +405,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let localSigner = signer
     let nonce = try? tokenStore.loadNonce()
     let proof = try await buildDPoPProof(
-      htm: "POST",
+      htm: HTTPMethod.post,
       htu: htu,
       jwk: localJWK,
       ath: ath,
@@ -415,15 +415,15 @@ public actor MobileAPIClient: VaultUnlockDataSource {
 
     let bodyData = try JSONEncoder().encode(body)
     var request = URLRequest(url: endpoint)
-    request.httpMethod = "POST"
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-    request.setValue(proof.jws, forHTTPHeaderField: "DPoP")
+    request.httpMethod = HTTPMethod.post
+    request.setValue(HTTPContentType.json, forHTTPHeaderField: HTTPHeader.contentType)
+    request.setValue("\(HTTPAuthScheme.bearerPrefix)\(accessToken)", forHTTPHeaderField: HTTPHeader.authorization)
+    request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
     request.httpBody = bodyData
 
     return try await performCreateHTTP(request) { newNonce in
       let retryProof = try await buildDPoPProof(
-        htm: "POST",
+        htm: HTTPMethod.post,
         htu: htu,
         jwk: localJWK,
         ath: ath,
@@ -431,7 +431,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
         signer: localSigner
       )
       var retryRequest = request
-      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: "DPoP")
+      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       return retryRequest
     }
   }
@@ -445,7 +445,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let accessToken = try await validAccessToken()
 
     let endpoint = serverURL.appending(
-      path: "/api/mobile/autofill-token",
+      path: APIPath.mobileAutofillToken,
       directoryHint: .notDirectory
     )
     let htu = canonicalHTU(url: endpoint)
@@ -455,7 +455,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let localSigner = signer
     let nonce = try? tokenStore.loadNonce()
     let proof = try await buildDPoPProof(
-      htm: "POST",
+      htm: HTTPMethod.post,
       htu: htu,
       jwk: localJWK,
       ath: ath,
@@ -465,15 +465,15 @@ public actor MobileAPIClient: VaultUnlockDataSource {
 
     let bodyData = try JSONEncoder().encode(["jwk": extensionJWK])
     var request = URLRequest(url: endpoint)
-    request.httpMethod = "POST"
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-    request.setValue(proof.jws, forHTTPHeaderField: "DPoP")
+    request.httpMethod = HTTPMethod.post
+    request.setValue(HTTPContentType.json, forHTTPHeaderField: HTTPHeader.contentType)
+    request.setValue("\(HTTPAuthScheme.bearerPrefix)\(accessToken)", forHTTPHeaderField: HTTPHeader.authorization)
+    request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
     request.httpBody = bodyData
 
     let data = try await performBodyHTTP(request) { newNonce in
       let retryProof = try await buildDPoPProof(
-        htm: "POST",
+        htm: HTTPMethod.post,
         htu: htu,
         jwk: localJWK,
         ath: ath,
@@ -481,7 +481,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
         signer: localSigner
       )
       var retryRequest = request
-      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: "DPoP")
+      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       return retryRequest
     }
     return try JSONDecoder().decode(AutofillTokenResponse.self, from: data)
@@ -494,7 +494,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let accessToken = try await validAccessToken()
 
     let endpoint = serverURL.appending(
-      path: "/api/passwords/\(entryId)",
+      path: APIPath.password(id: entryId),
       directoryHint: .notDirectory
     )
     let htu = canonicalHTU(url: endpoint)
@@ -504,7 +504,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let localSigner = signer
     let nonce = try? tokenStore.loadNonce()
     let proof = try await buildDPoPProof(
-      htm: "PUT",
+      htm: HTTPMethod.put,
       htu: htu,
       jwk: localJWK,
       ath: ath,
@@ -514,15 +514,15 @@ public actor MobileAPIClient: VaultUnlockDataSource {
 
     let bodyData = try JSONEncoder().encode(body)
     var request = URLRequest(url: endpoint)
-    request.httpMethod = "PUT"
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-    request.setValue(proof.jws, forHTTPHeaderField: "DPoP")
+    request.httpMethod = HTTPMethod.put
+    request.setValue(HTTPContentType.json, forHTTPHeaderField: HTTPHeader.contentType)
+    request.setValue("\(HTTPAuthScheme.bearerPrefix)\(accessToken)", forHTTPHeaderField: HTTPHeader.authorization)
+    request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
     request.httpBody = bodyData
 
     try await performVoidHTTP(request) { newNonce in
       let retryProof = try await buildDPoPProof(
-        htm: "PUT",
+        htm: HTTPMethod.put,
         htu: htu,
         jwk: localJWK,
         ath: ath,
@@ -530,7 +530,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
         signer: localSigner
       )
       var retryRequest = request
-      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: "DPoP")
+      retryRequest.setValue(retryProof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       return retryRequest
     }
   }
@@ -618,18 +618,18 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     var didNonceRetry = false, didRefreshRetry = false
     while true {
       let proof = try await buildDPoPProof(
-        htm: "GET", htu: htu, jwk: localJWK, ath: sha256Base64URL(token),
+        htm: HTTPMethod.get, htu: htu, jwk: localJWK, ath: sha256Base64URL(token),
         nonce: nonce, signer: localSigner
       )
       var request = URLRequest(url: url)
-      request.httpMethod = "GET"
-      request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-      request.setValue(proof.jws, forHTTPHeaderField: "DPoP")
+      request.httpMethod = HTTPMethod.get
+      request.setValue("\(HTTPAuthScheme.bearerPrefix)\(token)", forHTTPHeaderField: HTTPHeader.authorization)
+      request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       let (data, response) = try await performHTTP(request)
       let http = response as! HTTPURLResponse
       // A nonce in THIS response is the actual challenge signal; a stale stored
       // nonce must NOT trigger a nonce-retry (keeps the ladder bounded at ≤3).
-      let freshNonce = http.value(forHTTPHeaderField: "DPoP-Nonce")
+      let freshNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce)
       if let n = freshNonce {
         try? tokenStore.saveNonce(n)
         nonce = n
@@ -673,18 +673,18 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let http = response as! HTTPURLResponse
 
     // Persist nonce from any response (RFC 9449 §8).
-    if let newNonce = http.value(forHTTPHeaderField: "DPoP-Nonce") {
+    if let newNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
       try? tokenStore.saveNonce(newNonce)
     }
 
     // On 401 with a new nonce and a retry closure, retry once.
     if http.statusCode == 401,
        let makeRetry,
-       let newNonce = http.value(forHTTPHeaderField: "DPoP-Nonce") {
+       let newNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
       let retryRequest = try await makeRetry(newNonce)
       let (retryData, retryResponse) = try await performHTTP(retryRequest)
       let retryHTTP = retryResponse as! HTTPURLResponse
-      if let retryNonce = retryHTTP.value(forHTTPHeaderField: "DPoP-Nonce") {
+      if let retryNonce = retryHTTP.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
         try? tokenStore.saveNonce(retryNonce)
       }
       return try decodeResponse(retryData, status: retryHTTP.statusCode)
@@ -743,17 +743,17 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let (_, response) = try await performHTTP(request)
     let http = response as! HTTPURLResponse
 
-    if let newNonce = http.value(forHTTPHeaderField: "DPoP-Nonce") {
+    if let newNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
       try? tokenStore.saveNonce(newNonce)
     }
 
     if http.statusCode == 401,
        let makeRetry,
-       let newNonce = http.value(forHTTPHeaderField: "DPoP-Nonce") {
+       let newNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
       let retryRequest = try await makeRetry(newNonce)
       let (_, retryResponse) = try await performHTTP(retryRequest)
       let retryHTTP = retryResponse as! HTTPURLResponse
-      if let retryNonce = retryHTTP.value(forHTTPHeaderField: "DPoP-Nonce") {
+      if let retryNonce = retryHTTP.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
         try? tokenStore.saveNonce(retryNonce)
       }
       try decodeVoidResponse(status: retryHTTP.statusCode)
@@ -784,17 +784,17 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     let (data, response) = try await performHTTP(request)
     let http = response as! HTTPURLResponse
 
-    if let newNonce = http.value(forHTTPHeaderField: "DPoP-Nonce") {
+    if let newNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
       try? tokenStore.saveNonce(newNonce)
     }
 
     if http.statusCode == 401,
        let makeRetry,
-       let newNonce = http.value(forHTTPHeaderField: "DPoP-Nonce") {
+       let newNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
       let retryRequest = try await makeRetry(newNonce)
       let (retryData, retryResponse) = try await performHTTP(retryRequest)
       let retryHTTP = retryResponse as! HTTPURLResponse
-      if let retryNonce = retryHTTP.value(forHTTPHeaderField: "DPoP-Nonce") {
+      if let retryNonce = retryHTTP.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
         try? tokenStore.saveNonce(retryNonce)
       }
       return try decodeBodyResponse(retryData, status: retryHTTP.statusCode)

--- a/ios/PasswdSSOApp/Vault/EntryFetcher.swift
+++ b/ios/PasswdSSOApp/Vault/EntryFetcher.swift
@@ -154,7 +154,7 @@ public actor EntryFetcher {
   /// Fetch personal vault entries with `?include=blob`.
   /// Returns entries as `CacheEntry` (with AAD input fields populated).
   public func fetchPersonal() async throws -> [EncryptedEntry] {
-    try await apiClient.fetchEntries(endpoint: "/api/passwords?include=blob")
+    try await apiClient.fetchEntries(endpoint: "\(APIPath.passwords)?include=blob")
   }
 
   /// Fetch team-vault entries for a single team.

--- a/ios/PasswdSSOApp/Vault/HostSyncService.swift
+++ b/ios/PasswdSSOApp/Vault/HostSyncService.swift
@@ -237,7 +237,7 @@ extension MobileAPIClient {
   /// Fetch team memberships from GET /api/teams.
   /// Uses performAuthedGET for the full C3 retry ladder (nonce→refresh, fixes F3).
   func fetchTeamMemberships() async throws -> [TeamMembership] {
-    let endpoint = serverURL.appending(path: "/api/teams", directoryHint: .notDirectory)
+    let endpoint = serverURL.appending(path: APIPath.teams, directoryHint: .notDirectory)
     let data = try await performAuthedGET(url: endpoint)
     return try JSONDecoder().decode([TeamMembership].self, from: data)
   }

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -317,7 +317,7 @@ struct RootView: View {
       // token surfaces as stale data, recoverable by an explicit manual Sign Out.
       // Diagnostic only (no secrets — MobileAPIError cases carry no token data):
       // captures WHY an unlock-time sync failed so a stale-data report is debuggable.
-      Logger(subsystem: "jp.jpng.passwd-sso", category: "sync")
+      Logger(subsystem: AppGroupContainer.loggerSubsystem, category: "sync")
         .error("unlock-time runSync failed: \(String(describing: error), privacy: .public)")
       syncReport = nil
     }

--- a/ios/PasswdSSOApp/Views/ServerURLSetupView.swift
+++ b/ios/PasswdSSOApp/Views/ServerURLSetupView.swift
@@ -77,7 +77,7 @@ final class ServerURLSetupViewModel: @unchecked Sendable {
     let aasaURL = aasaRootURL(for: base)
     async let aasaCheck: Void = fetchURL(aasaURL)
     async let healthCheck: Void = fetchURL(
-      base.appending(path: "/api/health/live", directoryHint: .notDirectory)
+      base.appending(path: APIPath.healthLive, directoryHint: .notDirectory)
     )
     _ = try await (aasaCheck, healthCheck)
   }

--- a/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
+++ b/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
@@ -8,7 +8,7 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
 
   // Diagnostic only — confirms the extension is invoked and which branch runs,
   // so the AutoFill "vault locked" symptom is traceable in Console.app.
-  private static let log = Logger(subsystem: "jp.jpng.passwd-sso", category: "autofill")
+  private static let log = Logger(subsystem: AppGroupContainer.loggerSubsystem, category: "autofill")
 
   // Work deferred until the extension view is foreground (viewDidAppear) — the
   // reliable point for the biometric keychain read (`evaluateAccessControl`),

--- a/ios/PasswdSSOTests/CryptoParamsTests.swift
+++ b/ios/PasswdSSOTests/CryptoParamsTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import Shared
+
+final class CryptoParamsTests: XCTestCase {
+
+  /// Value-pin the crypto parameters not already covered by the byte-level
+  /// vector suites (KDFTests, TeamKeyCryptoTests, etc.). A wrong value here
+  /// silently breaks encryption / key derivation, so the literals are frozen.
+  func testCryptoParamConstantsArePinnedToExpectedValues() {
+    XCTAssertEqual(P256Params.keySizeBits, 256)
+    XCTAssertEqual(P256Params.uncompressedPointByteCount, 65)
+    XCTAssertEqual(P256Params.uncompressedPointPrefix, 0x04)
+    XCTAssertEqual(P256Params.coordinateByteCount, 32)
+
+    XCTAssertEqual(CryptoParams.aesGCMNonceByteCount, 12)
+    XCTAssertEqual(CryptoParams.aesGCMTagByteCount, 16)
+    XCTAssertEqual(CryptoParams.symmetricKeyByteCount, 32)
+  }
+}

--- a/ios/Shared/AutoFill/CredentialIdentityRegistrar.swift
+++ b/ios/Shared/AutoFill/CredentialIdentityRegistrar.swift
@@ -6,7 +6,7 @@ import OSLog
 // Diagnostic only — traces the QuickType passkey registration lifecycle
 // (detection counts + register/clear timing) so a "passkey not offered in the
 // system sheet" symptom is debuggable in Console.app. No secrets logged.
-private let identityLog = Logger(subsystem: "jp.jpng.passwd-sso", category: "autofill")
+private let identityLog = Logger(subsystem: AppGroupContainer.loggerSubsystem, category: "autofill")
 
 // MARK: - Personal overview decryption (for registration)
 

--- a/ios/Shared/AutoFill/CredentialResolver.swift
+++ b/ios/Shared/AutoFill/CredentialResolver.swift
@@ -79,7 +79,7 @@ public actor CredentialResolver {
   // Diagnostic only — records WHICH of the three vault-locked sub-causes fired
   // (bridge_key read, wrapped-key absent, or unwrap failure) so the AutoFill
   // "vault locked" symptom is traceable in Console.app. No key material logged.
-  private static let log = Logger(subsystem: "jp.jpng.passwd-sso", category: "autofill")
+  private static let log = Logger(subsystem: AppGroupContainer.loggerSubsystem, category: "autofill")
 
   // MARK: - Error
 

--- a/ios/Shared/AutoFill/RollbackFlagWriter.swift
+++ b/ios/Shared/AutoFill/RollbackFlagWriter.swift
@@ -34,12 +34,12 @@ public struct RollbackFlagPayload: Sendable, Codable, Equatable {
 /// either side would silently reject every flag as forged.
 private func deriveRollbackFlagMacKey(from vaultKey: SymmetricKey) -> SymmetricKey {
   let info = "rollback-flag-mac".data(using: .utf8)!
-  let salt = Data(repeating: 0, count: 32)
+  let salt = Data(repeating: 0, count: CryptoParams.symmetricKeyByteCount)
   return HKDF<SHA256>.deriveKey(
     inputKeyMaterial: vaultKey,
     salt: salt,
     info: info,
-    outputByteCount: 32
+    outputByteCount: CryptoParams.symmetricKeyByteCount
   )
 }
 

--- a/ios/Shared/Crypto/AESGCM.swift
+++ b/ios/Shared/Crypto/AESGCM.swift
@@ -23,7 +23,7 @@ public func encryptAESGCM(
 ) throws -> (ciphertext: Data, iv: Data, tag: Data) {
   let nonce = AES.GCM.Nonce()
   let nonceData = Data(nonce)
-  guard nonceData.count == 12 else {
+  guard nonceData.count == CryptoParams.aesGCMNonceByteCount else {
     throw AESGCMError.unexpectedNonceLength
   }
 
@@ -51,8 +51,8 @@ public func decryptAESGCM(
   key: SymmetricKey,
   aad: Data? = nil
 ) throws -> Data {
-  guard iv.count == 12 else { throw AESGCMError.invalidIVLength }
-  guard tag.count == 16 else { throw AESGCMError.invalidTagLength }
+  guard iv.count == CryptoParams.aesGCMNonceByteCount else { throw AESGCMError.invalidIVLength }
+  guard tag.count == CryptoParams.aesGCMTagByteCount else { throw AESGCMError.invalidTagLength }
 
   let nonce = try AES.GCM.Nonce(data: iv)
   let sealedBox = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ciphertext, tag: tag)

--- a/ios/Shared/Crypto/CryptoParams.swift
+++ b/ios/Shared/Crypto/CryptoParams.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// AES-256-GCM wire and key parameters. Values match crypto-client.ts /
+/// AESGCM.swift wire format and MUST stay byte-identical with the parent server.
+public enum CryptoParams {
+  // AES-256-GCM wire parameters (match crypto-client.ts / AESGCM.swift wire format)
+  public static let aesGCMNonceByteCount = 12   // IV length
+  public static let aesGCMTagByteCount = 16     // auth tag length
+  // 256-bit symmetric key material expressed in bytes (AES-256 key, HKDF/PBKDF2 output)
+  public static let symmetricKeyByteCount = 32
+}
+
+/// P-256 (secp256r1) point and key parameters.
+public enum P256Params {
+  public static let coordinateByteCount = 32                 // JWK x / y length, scalar length
+  public static let keySizeBits = 256                        // SecKey kSecAttrKeySizeInBits
+  // uncompressed EC point: 0x04 ‖ x(32) ‖ y(32)
+  public static let uncompressedPointPrefix: UInt8 = 0x04
+  public static let uncompressedPointByteCount = 1 + coordinateByteCount + coordinateByteCount  // 65
+}

--- a/ios/Shared/Crypto/KDF.swift
+++ b/ios/Shared/Crypto/KDF.swift
@@ -7,7 +7,7 @@ private let hkdfEncInfo = "passwd-sso-enc-v1"
 private let hkdfAuthInfo = "passwd-sso-auth-v1"
 // Cache vault key — used only on iOS device (no server-side equivalent).
 private let hkdfCacheInfo = "passwd-sso-cache-v1"
-private let hkdfZeroSalt = Data(repeating: 0, count: 32)
+private let hkdfZeroSalt = Data(repeating: 0, count: CryptoParams.symmetricKeyByteCount)
 
 /// PBKDF2 iteration count pinned by the parent server (crypto-client.ts).
 /// Doubles as the minimum a client accepts from a server-supplied unlock
@@ -25,7 +25,7 @@ public func deriveWrappingKeyPBKDF2(
     throw KDFError.invalidPassphrase
   }
 
-  var derivedKey = Data(repeating: 0, count: 32)
+  var derivedKey = Data(repeating: 0, count: CryptoParams.symmetricKeyByteCount)
   let status = derivedKey.withUnsafeMutableBytes { derivedKeyPtr in
     passphraseData.withUnsafeBytes { passphrasePtr in
       salt.withUnsafeBytes { saltPtr in
@@ -35,7 +35,7 @@ public func deriveWrappingKeyPBKDF2(
           saltPtr.baseAddress, salt.count,
           CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
           UInt32(iterations),
-          derivedKeyPtr.baseAddress, 32
+          derivedKeyPtr.baseAddress, CryptoParams.symmetricKeyByteCount
         )
       }
     }
@@ -55,7 +55,7 @@ public func deriveEncryptionKey(secretKey: Data) throws -> SymmetricKey {
     inputKeyMaterial: inputKey,
     salt: hkdfZeroSalt,
     info: info,
-    outputByteCount: 32
+    outputByteCount: CryptoParams.symmetricKeyByteCount
   )
 }
 
@@ -69,7 +69,7 @@ public func deriveAuthKey(secretKey: Data) throws -> Data {
     inputKeyMaterial: inputKey,
     salt: hkdfZeroSalt,
     info: info,
-    outputByteCount: 32
+    outputByteCount: CryptoParams.symmetricKeyByteCount
   )
   return derived.withUnsafeBytes { Data($0) }
 }
@@ -83,7 +83,7 @@ public func deriveCacheVaultKey(bridgeKey: Data) throws -> SymmetricKey {
     inputKeyMaterial: inputKey,
     salt: hkdfZeroSalt,
     info: info,
-    outputByteCount: 32
+    outputByteCount: CryptoParams.symmetricKeyByteCount
   )
 }
 

--- a/ios/Shared/Crypto/PasskeyAssertion.swift
+++ b/ios/Shared/Crypto/PasskeyAssertion.swift
@@ -70,7 +70,7 @@ public func decodeP256PrivateKeyJWK(_ jwkJSON: Data) throws -> P256.Signing.Priv
   guard jwk.kty == "EC", jwk.crv == "P-256" else {
     throw PasskeyCryptoError.unsupportedKeyType
   }
-  guard var scalar = try? base64URLDecode(jwk.d), scalar.count == 32 else {
+  guard var scalar = try? base64URLDecode(jwk.d), scalar.count == P256Params.coordinateByteCount else {
     throw PasskeyCryptoError.malformedPrivateScalar
   }
   // Zero the raw private scalar once the key is constructed (the inner JSON

--- a/ios/Shared/Crypto/PasskeyRegistration.swift
+++ b/ios/Shared/Crypto/PasskeyRegistration.swift
@@ -51,8 +51,8 @@ enum CBOR {
 /// -1:1(P-256), -2:x(32), -3:y(32)} in canonical key order.
 public func coseEC2PublicKey(_ pub: P256.Signing.PublicKey) -> Data {
   let raw = pub.rawRepresentation  // 64 bytes: x ‖ y (no 0x04 prefix)
-  let x = raw.prefix(32)
-  let y = raw.suffix(32)
+  let x = raw.prefix(P256Params.coordinateByteCount)
+  let y = raw.suffix(P256Params.coordinateByteCount)
   var out = Data()
   CBOR.writeHead(5, 5, into: &out)  // map, 5 entries
   CBOR.int(1, into: &out); CBOR.int(2, into: &out)    // kty: EC2
@@ -122,11 +122,14 @@ public func buildNoneAttestationObject(authData: Data) -> Data {
 public func ecPrivateKeyJWKString(_ key: P256.Signing.PrivateKey) -> String {
   let d = key.rawRepresentation                 // 32 bytes (private scalar)
   let pub = key.publicKey.rawRepresentation     // 64 bytes: x ‖ y
-  let x = base64URLEncode(Data(pub.prefix(32)))
-  let y = base64URLEncode(Data(pub.suffix(32)))
+  let x = base64URLEncode(Data(pub.prefix(P256Params.coordinateByteCount)))
+  let y = base64URLEncode(Data(pub.suffix(P256Params.coordinateByteCount)))
   let dStr = base64URLEncode(d)
   return "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"\(x)\",\"y\":\"\(y)\",\"d\":\"\(dStr)\"}"
 }
+
+// random ID length; coincides with the P-256 coordinate size but semantically distinct
+private let credentialIdByteCount = 32
 
 // MARK: - Generated passkey
 
@@ -156,6 +159,6 @@ public func makePasskey(privateKey: P256.Signing.PrivateKey, credentialId: Data)
 /// `SystemRandomNumberGenerator` is cryptographically secure on Apple platforms.
 public func generatePasskey() -> GeneratedPasskey {
   var rng = SystemRandomNumberGenerator()
-  let credentialId = Data((0..<32).map { _ in UInt8.random(in: 0...255, using: &rng) })
+  let credentialId = Data((0..<credentialIdByteCount).map { _ in UInt8.random(in: 0...255, using: &rng) })
   return GeneratedPasskey(credentialId: credentialId, privateKey: P256.Signing.PrivateKey())
 }

--- a/ios/Shared/Crypto/SPKIEncoder.swift
+++ b/ios/Shared/Crypto/SPKIEncoder.swift
@@ -28,8 +28,8 @@ private let p256SPKIPrefix: [UInt8] = [
 public func encodeP256SPKI(uncompressedPoint: Data) throws -> Data {
   // Expect 0x04 || X(32) || Y(32) = 65 bytes.
   let startIdx = uncompressedPoint.startIndex
-  guard uncompressedPoint.count == 65,
-        uncompressedPoint[startIdx] == 0x04
+  guard uncompressedPoint.count == P256Params.uncompressedPointByteCount,
+        uncompressedPoint[startIdx] == P256Params.uncompressedPointPrefix
   else {
     throw SPKIEncoderError.invalidPoint
   }

--- a/ios/Shared/Crypto/SecureEnclaveKey.swift
+++ b/ios/Shared/Crypto/SecureEnclaveKey.swift
@@ -29,7 +29,7 @@ public func generateDPoPKey(label: String) throws -> SecKey {
 
   let attributes: [String: Any] = [
     kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
-    kSecAttrKeySizeInBits as String: 256,
+    kSecAttrKeySizeInBits as String: P256Params.keySizeBits,
     kSecAttrTokenID as String: kSecAttrTokenIDSecureEnclave,
     kSecPrivateKeyAttrs as String: [
       kSecAttrIsPermanent as String: true,
@@ -103,11 +103,12 @@ public func exportPublicKeyJWK(key: SecKey) throws -> [String: String] {
     throw SecureEnclaveKeyError.publicKeyExportFailed
   }
   // Uncompressed EC point: 0x04 || x(32) || y(32)
-  guard data.count == 65, data[0] == 0x04 else {
+  guard data.count == P256Params.uncompressedPointByteCount,
+        data[0] == P256Params.uncompressedPointPrefix else {
     throw SecureEnclaveKeyError.publicKeyExportFailed
   }
-  let x = data[1..<33]
-  let y = data[33..<65]
+  let x = data[1 ..< (1 + P256Params.coordinateByteCount)]
+  let y = data[(1 + P256Params.coordinateByteCount) ..< P256Params.uncompressedPointByteCount]
   return [
     "kty": "EC",
     "crv": "P-256",
@@ -140,6 +141,9 @@ public func computeJWKThumbprint(jwk: [String: String]) throws -> String {
 
 // MARK: - DER → raw r||s conversion
 
+// raw ECDSA r/s component length; distinct from key/coordinate
+private let ecdsaComponentByteCount = 32
+
 /// Convert X9.62 DER-encoded ECDSA signature to raw 64-byte r||s for JWS.
 private func derToRawECDSA(_ der: Data) throws -> Data {
   var idx = 0
@@ -167,10 +171,10 @@ private func derToRawECDSA(_ der: Data) throws -> Data {
     defer { idx += len }
     var intBytes = Data(bytes[idx..<(idx + len)])
     // Strip leading zero padding for sign-extension
-    while intBytes.count > 32, intBytes.first == 0x00 { intBytes = intBytes.dropFirst() }
+    while intBytes.count > ecdsaComponentByteCount, intBytes.first == 0x00 { intBytes = intBytes.dropFirst() }
     // Left-pad to 32 bytes
-    while intBytes.count < 32 { intBytes.insert(0x00, at: intBytes.startIndex) }
-    guard intBytes.count == 32 else { throw SecureEnclaveKeyError.derConversionFailed }
+    while intBytes.count < ecdsaComponentByteCount { intBytes.insert(0x00, at: intBytes.startIndex) }
+    guard intBytes.count == ecdsaComponentByteCount else { throw SecureEnclaveKeyError.derConversionFailed }
     return intBytes
   }
 

--- a/ios/Shared/Crypto/TeamKeyCrypto.swift
+++ b/ios/Shared/Crypto/TeamKeyCrypto.swift
@@ -9,7 +9,7 @@ import Foundation
 ///   ECDH(member, ephemeral) → HKDF("passwd-sso-team-v1", salt=memberKey.hkdfSalt) → AES-GCM(AAD "OK") → rawTeamKey
 ///   rawTeamKey → HKDF("passwd-sso-team-enc-v1", salt=zero32) → teamEncKey (entry decryption key)
 public enum TeamKeyCrypto {
-  private static let zeroSalt = Data(repeating: 0, count: 32)
+  private static let zeroSalt = Data(repeating: 0, count: CryptoParams.symmetricKeyByteCount)
   private static let ecdhWrapInfo = "passwd-sso-ecdh-v1"
   private static let teamWrapInfo = "passwd-sso-team-v1"
   private static let teamEncInfo = "passwd-sso-team-enc-v1"
@@ -27,7 +27,7 @@ public enum TeamKeyCrypto {
       inputKeyMaterial: secretKey,
       salt: zeroSalt,
       info: Data(ecdhWrapInfo.utf8),
-      outputByteCount: 32
+      outputByteCount: CryptoParams.symmetricKeyByteCount
     )
   }
 
@@ -62,10 +62,10 @@ public enum TeamKeyCrypto {
     guard key.kty == "EC", key.crv == "P-256" else {
       throw TeamKeyCryptoError.unsupportedKeyType
     }
-    guard let x = base64URLDecode(key.x), x.count == 32,
-          let y = base64URLDecode(key.y), y.count == 32
+    guard let x = base64URLDecode(key.x), x.count == P256Params.coordinateByteCount,
+          let y = base64URLDecode(key.y), y.count == P256Params.coordinateByteCount
     else { throw TeamKeyCryptoError.malformedPublicKey }
-    var x963 = Data([0x04])
+    var x963 = Data([P256Params.uncompressedPointPrefix])
     x963.append(x)
     x963.append(y)
     return try P256.KeyAgreement.PublicKey(x963Representation: x963)
@@ -93,7 +93,7 @@ public enum TeamKeyCrypto {
       inputKeyMaterial: SymmetricKey(data: sharedBytes),
       salt: try hexDecode(hkdfSalt),
       info: Data(teamWrapInfo.utf8),
-      outputByteCount: 32
+      outputByteCount: CryptoParams.symmetricKeyByteCount
     )
     let aad = try buildTeamKeyWrapAAD(
       teamId: teamId, toUserId: toUserId, keyVersion: keyVersion, wrapVersion: wrapVersion
@@ -115,7 +115,7 @@ public enum TeamKeyCrypto {
       inputKeyMaterial: rawTeamKey,
       salt: zeroSalt,
       info: Data(teamEncInfo.utf8),
-      outputByteCount: 32
+      outputByteCount: CryptoParams.symmetricKeyByteCount
     )
   }
 
@@ -128,7 +128,7 @@ public enum TeamKeyCrypto {
       inputKeyMaterial: itemKey,
       salt: zeroSalt,
       info: Data(itemEncInfo.utf8),
-      outputByteCount: 32
+      outputByteCount: CryptoParams.symmetricKeyByteCount
     )
   }
 

--- a/ios/Shared/Network/APIPath.swift
+++ b/ios/Shared/Network/APIPath.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum APIPath {
+  public static let mobileToken = "/api/mobile/token"
+  public static let mobileTokenRefresh = "/api/mobile/token/refresh"
+  public static let mobileAutofillToken = "/api/mobile/autofill-token"
+  public static let mobileAuthorize = "/api/mobile/authorize"
+  public static let mobileCacheRollbackReport = "/api/mobile/cache-rollback-report"
+  public static let vaultUnlockData = "/api/vault/unlock/data"
+  public static let passwords = "/api/passwords"
+  public static let healthLive = "/api/health/live"
+  public static let teams = "/api/teams"
+  // Interpolated paths keep a builder so the {id}/{teamId} interpolation stays at the call site:
+  public static func password(id: String) -> String { "\(passwords)/\(id)" }
+  public static func teamPasswords(teamId: String) -> String { "\(teams)/\(teamId)/passwords" }
+  public static func teamMemberKey(teamId: String) -> String { "\(teams)/\(teamId)/member-key" }
+}

--- a/ios/Shared/Network/EntryUploader.swift
+++ b/ios/Shared/Network/EntryUploader.swift
@@ -102,7 +102,7 @@ public struct EntryUploader: Sendable {
   /// the caller (registration outcome gate) verifies it equals the
   /// client-generated id before completing the ceremony.
   public func createEntry(body: CreateEntryRequest) async throws -> String {
-    let endpoint = serverURL.appending(path: "/api/passwords", directoryHint: .notDirectory)
+    let endpoint = serverURL.appending(path: APIPath.passwords, directoryHint: .notDirectory)
     let htu = canonicalHTU(url: endpoint)
     let ath = sha256Base64URL(accessToken)
     let bodyData = try JSONEncoder().encode(body)
@@ -111,13 +111,13 @@ public struct EntryUploader: Sendable {
     var didNonceRetry = false
     while true {
       let proof = try await buildDPoPProof(
-        htm: "POST", htu: htu, jwk: jwk, ath: ath, nonce: nonce, signer: signer
+        htm: HTTPMethod.post, htu: htu, jwk: jwk, ath: ath, nonce: nonce, signer: signer
       )
       var request = URLRequest(url: endpoint)
-      request.httpMethod = "POST"
-      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-      request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-      request.setValue(proof.jws, forHTTPHeaderField: "DPoP")
+      request.httpMethod = HTTPMethod.post
+      request.setValue(HTTPContentType.json, forHTTPHeaderField: HTTPHeader.contentType)
+      request.setValue("\(HTTPAuthScheme.bearerPrefix)\(accessToken)", forHTTPHeaderField: HTTPHeader.authorization)
+      request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       request.httpBody = bodyData
 
       let data: Data
@@ -133,7 +133,7 @@ public struct EntryUploader: Sendable {
 
       // A nonce in THIS response is the actual challenge signal; persist it
       // for future proofs either way (RFC 9449 §8).
-      let freshNonce = http.value(forHTTPHeaderField: "DPoP-Nonce")
+      let freshNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce)
       if let n = freshNonce {
         onNonceUpdate?(n)
         nonce = n

--- a/ios/Shared/Network/HTTPConstants.swift
+++ b/ios/Shared/Network/HTTPConstants.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public enum HTTPHeader {
+  public static let contentType = "Content-Type"
+  public static let authorization = "Authorization"
+  public static let dpop = "DPoP"
+  public static let dpopNonce = "DPoP-Nonce"
+}
+
+public enum HTTPMethod {
+  public static let get = "GET"
+  public static let post = "POST"
+  public static let put = "PUT"
+}
+
+public enum HTTPContentType {
+  public static let json = "application/json"
+}
+
+public enum HTTPAuthScheme {
+  public static let bearerPrefix = "Bearer "
+  public static let dpopPrefix = "DPoP "
+}

--- a/ios/Shared/Storage/AppGroupContainer.swift
+++ b/ios/Shared/Storage/AppGroupContainer.swift
@@ -10,6 +10,9 @@ public enum AppGroupContainerError: Error, Equatable {
 public struct AppGroupContainer: Sendable {
   public static let identifier = "group.jp.jpng.passwd-sso.shared"
 
+  /// Logger subsystem shared by all three targets (host app, AutoFill extension, Shared framework).
+  public static let loggerSubsystem = "jp.jpng.passwd-sso"
+
   /// Returns the root URL of the shared App Group container.
   public static func url() throws -> URL {
     guard let containerURL = FileManager.default.containerURL(

--- a/ios/Shared/Storage/BridgeKeyStore.swift
+++ b/ios/Shared/Storage/BridgeKeyStore.swift
@@ -59,7 +59,7 @@ public final class BridgeKeyStore: Sendable {
   // AutoFill "vault locked" symptom can be traced to its true cause (item
   // missing vs. biometry failure vs. interaction-not-allowed/entitlement) via
   // Console.app. No key material is ever logged.
-  private static let log = Logger(subsystem: "jp.jpng.passwd-sso", category: "autofill")
+  private static let log = Logger(subsystem: AppGroupContainer.loggerSubsystem, category: "autofill")
 
   /// Logical bundle of bridge-key + counter/uuid. After the V2 split, the
   /// two Keychain items back this struct: `bridgeKey` comes from
@@ -126,12 +126,12 @@ public final class BridgeKeyStore: Sendable {
   /// Writes BOTH v2 items in this order: meta first, then key. On failure
   /// of the second write, deletes the first to avoid orphaned state.
   public func create() throws -> Blob {
-    var bridgeKeyBytes = Data(repeating: 0, count: 32)
+    var bridgeKeyBytes = Data(repeating: 0, count: bridgeKeyV2Size)
     var counterBytes = Data(repeating: 0, count: 8)
     var uuidBytes = Data(repeating: 0, count: 16)
 
     let r1 = bridgeKeyBytes.withUnsafeMutableBytes {
-      SecRandomCopyBytes(kSecRandomDefault, 32, $0.baseAddress!)
+      SecRandomCopyBytes(kSecRandomDefault, bridgeKeyV2Size, $0.baseAddress!)
     }
     let r2 = counterBytes.withUnsafeMutableBytes {
       SecRandomCopyBytes(kSecRandomDefault, 8, $0.baseAddress!)

--- a/scripts/checks/check-fail-closed-routes-have-test.sh
+++ b/scripts/checks/check-fail-closed-routes-have-test.sh
@@ -28,8 +28,10 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 DEBT_FILE="$REPO_ROOT/scripts/checks/fail-closed-test-debt.txt"
 
-# Build allowlist set (paths only, no comments, no blanks)
-declare -A DEBT
+# Build allowlist (paths only, no comments, no blanks). bash 3.2 has no
+# associative arrays (`declare -A`), so keep a newline-delimited list and
+# test membership with `grep -qxF`.
+DEBT_LIST=""
 if [ -f "$DEBT_FILE" ]; then
   while IFS= read -r line; do
     # Strip CR (Windows line endings) and surrounding whitespace
@@ -37,19 +39,31 @@ if [ -f "$DEBT_FILE" ]; then
     line="${line## }"; line="${line%% }"
     [ -z "$line" ] && continue
     case "$line" in \#*) continue ;; esac
-    DEBT["$line"]=1
+    DEBT_LIST="${DEBT_LIST}${line}
+"
   done < "$DEBT_FILE"
 fi
 
-# Enumerate opt-in routes
+is_debt() {
+  # exact whole-line match against the normalized debt list
+  printf '%s' "$DEBT_LIST" | grep -qxF "$1"
+}
+
+# Enumerate opt-in routes. bash 3.2 has no `mapfile`; read into an indexed
+# array with a while-loop.
 fail=0
-mapfile -t routes < <(
+routes=()
+while IFS= read -r route_line; do
+  [ -n "$route_line" ] && routes+=("$route_line")
+done < <(
   grep -rln 'failClosedOnRedisError: true' "$REPO_ROOT/src/app/api" 2>/dev/null \
     | sed "s|^$REPO_ROOT/||" \
     | sort
 )
 
-for route in "${routes[@]}"; do
+# Guard against an empty array under `set -u` (bash 3.2 errors on "${a[@]}"
+# when the array is empty).
+for route in ${routes[@]+"${routes[@]}"}; do
   # Adjacent test path
   dir="$(dirname "$route")"
   adjacent_test="$dir/route.test.ts"
@@ -65,7 +79,7 @@ for route in "${routes[@]}"; do
   if grep -q "redisErrored" "$REPO_ROOT/$alt_test" 2>/dev/null; then
     continue
   fi
-  if [ -n "${DEBT[$route]:-}" ]; then
+  if is_debt "$route"; then
     continue # documented debt
   fi
 


### PR DESCRIPTION
## Summary

Execute the iOS-side constant sweep that the web/extension/cli PR "replace hardcoded values with shared constants" (#561) deliberately deferred under SC1, following the same conventions — value-identity (zero runtime change) and semantic separation (numbers that coincide stay distinct constants). Also fixes the `pre-pr.sh` incompatibility with macOS's system bash (3.2).

Behavior-preserving: every replaced literal keeps its exact value/bytes — no runtime behavior change.

## Changes

### iOS constants (`Shared/`, shared by app + AutoFill extension)
- **C1 `CryptoParams` / `P256Params`** (`Shared/Crypto/CryptoParams.swift`): AES-GCM nonce(12)/tag(16), 256-bit key length(32), P-256 coordinate(32)/uncompressed-point(65)/`0x04`/key-size-bits(256), adopted across the crypto files. The `32` literal has 6+ distinct meanings — distinct ones (`credentialIdByteCount`, `ecdsaComponentByteCount`, `pkceRandomByteCount`) are kept file-local rather than folded into the shared key-length constant. HKDF info strings / AAD / `pbkdf2Iterations` are untouched.
- **C2 `APIPath`** (`Shared/Network/APIPath.swift`): every `/api` path + interpolation builders.
- **C3 `HTTPConstants`**: header names, methods, content-type, auth-scheme prefixes. The DPoP-proof `htm` claim now shares the same `HTTPMethod` constant as `httpMethod`, so `htm == method` is structurally guaranteed.
- **C4 `loggerSubsystem`** (`AppGroupContainer`): consolidates the 6 `Logger(subsystem:)` call sites.
- `BridgeKeyStore` key-generation path unified onto the existing `bridgeKeyV2Size`.
- `CryptoParamsTests`: value-pins the constants no existing crypto vector covers (e.g. `keySizeBits`, the Secure-Enclave-only path).

### CI
- Make `check-fail-closed-routes-have-test.sh` bash 3.2 compatible (drop `declare -A` and `mapfile`), so `pre-pr.sh` runs to completion on macOS.

## Verification
- `xcodebuild test` (iPhone 15 Pro simulator): **526 unit tests + UITests, 0 failures** — including the new `CryptoParamsTests` and all crypto vector/parity suites.
- `pre-pr.sh` full run (macOS bash 3.2): **35 checks, all pass**.

## Review process
triangulate (functionality / security / testing perspectives): plan review = 2 functionality rounds + 1 security + 1 testing; code review = all three perspectives "No findings". Artifacts: `docs/archive/review/ios-hardcoded-values-to-constants-{plan,review,code-review}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)