### PR TITLE
fix(security): patch HIGH CVEs (hono 4.12.25, OpenSSL 3.5.7-r0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Install dependencies
 # Pin base image to digest for reproducible builds (update with: docker pull node:20-alpine)
-FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS deps
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS deps
 # deps/builder are intermediate — only the runner stage ships. Patching here
 # would be discarded. apk upgrade only happens in the runner stage.
 RUN apk add --no-cache libc6-compat
@@ -23,7 +23,7 @@ COPY prisma.config.ts ./prisma.config.ts
 RUN DATABASE_URL="$DATABASE_URL" npx prisma generate
 
 # Stage 2: Build the application
-FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS builder
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
 WORKDIR /app
 # DATABASE_URL is needed only for `prisma generate` to satisfy env("DATABASE_URL")
 # in prisma.config.ts — no actual DB connection is opened at build time. A dummy
@@ -50,7 +50,7 @@ RUN npx esbuild scripts/dcr-cleanup-worker.ts \
       --alias:@=./src
 
 # Stage 3: Production image
-FROM node:20-alpine@sha256:b88333c42c23fbd91596ebd7fd10de239cedab9617de04142dde7315e3bc0afa AS runner
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS runner
 WORKDIR /app
 RUN apk upgrade --no-cache zlib libcrypto3 libssl3 musl musl-utils
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11920,9 +11920,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
   },
   "overrides": {
     "qs": "6.15.2",
-    "hono": "4.12.21",
+    "hono": "4.12.25",
     "@hono/node-server": "1.19.13",
     "lodash": "4.17.23",
     "cross-spawn": "7.0.6",


### PR DESCRIPTION
## Summary

The Trivy container image scan started flagging 3 fixed **HIGH** CVEs after a vuln-DB update. None are tied to feature work — surfaced on the next re-scan. This dependency/base-image security update clears them independently so feature PRs can rebase onto a green base.

## CVEs fixed
- **CVE-2026-54290** — `hono` CORS middleware reflects any Origin with credentials when `origin` defaults. Bump the `hono` override `4.12.21` → `4.12.25`.
- **CVE-2026-45447** — OpenSSL heap use-after-free in `PKCS7_verify()` (`libcrypto3`/`libssl3`). The runner stage already runs `apk upgrade --no-cache libcrypto3 libssl3`, but the old pinned `node:20-alpine` digest's cached layer served `3.5.6-r0`. Bumping the base digest busts that layer so `apk upgrade` re-runs against the live Alpine repo and pulls the fixed `3.5.7-r0`.

## Verification
- Rebuilt the production image: `libcrypto3`/`libssl3` = `3.5.7-r0`, `hono` = `4.12.25`.
- `trivy image --severity CRITICAL,HIGH --ignore-unfixed` (CI-equivalent) → **0 findings** (was 2 Alpine + 1 node-pkg).
- `pre-pr.sh` → 36/36 checks pass.

Diff is deps-only: `Dockerfile` (3 base digests), `package.json` (hono override), `package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)