### PR TITLE
feat(security): tenant-configurable trash auto-purge with blob cleanup (SC2)

### DIFF
--- a/docs/archive/review/retention-trash-purge-code-review.md
+++ b/docs/archive/review/retention-trash-purge-code-review.md
@@ -1,0 +1,35 @@
+# Code Review: retention-trash-purge (SC2)
+Date: 2026-06-18
+Review rounds: plan (1) + code (1), converged.
+
+## Plan review — 5 findings, all fixed pre-implementation
+- **F1 (high)**: my C4 dispatch claim was backwards (PER_TENANT_FN gets a `tx`, not workerPrisma). Corrected: PER_TENANT_TRASH is the *first* kind to take workerPrisma directly (post-commit blob delete owns its own tx).
+- **F3 (high)**: C6 cascade-reach enumeration incomplete. Corrected: deleting an entry cascades to attachments + history + favorites + tag-join-tables + SetNull on password_shares — all pure-cascade → NO grant (R14 lesson); only entry tables need DELETE, attachments SELECT-only.
+- **F4 (high)**: team-scope mismatch — `collectEntryAttachmentRefs` needs ONE teamId but per-tenant enumeration spans many teams. Corrected: group entry ids by team_id, call once per team.
+- **S1 (verified not an issue)**: password_shares SetNull under auto-purge — confirmed the share-content route serves the share's OWN encryptedData snapshot (not via passwordEntryId) and is independently gated, so SetNull doesn't change access. No guard needed.
+- **T1**: external-blob test must assert the F4 multi-team partition.
+
+## Code review — SC2 OK (no findings)
+All 9 focus areas verified clean against the staged diff:
+- F4 multi-team grouping correct; unit test non-vacuous (2 interleaved teams → 2 partitioned calls).
+- Blob-delete ordering: refs collected BEFORE the deleteMany cascade; deleteAttachmentBlobs AFTER tx commit.
+- SQL: parameterized `$queryRaw` tagged templates (tenant.id/cutoff/batchSize bound); bypass_rls set first.
+- Dispatch: sweepTrashEntry called directly with workerPrisma (no outer tx); per-entry error isolation preserved.
+- R14: attachments SELECT-only, no over-grant; T2 integration test proves cascade works without child DELETE grant.
+- R12: TRASH_RETENTION_PURGED in all sites + coverage tests pass.
+- sweep-isolation.test.ts updated correctly for the non-$transaction trash dispatch — isolation still genuinely proven.
+- Audit emitted only when count>0 (no noise).
+
+Two non-blocking minor notes (no fix): N1 deletedCount = ids.length (equal under bypass_rls same-tx); N2 SetNull path untested but verified safe (S1).
+
+## Verification
+- Unit: 81 worker tests (incl. F4 multi-team partition). `tsc --noEmit` clean for SC2 files.
+- Integration (real DB, DB backend): past-grace purge + cascade attachment removal; within-grace kept; non-trashed kept; NULL-retention tenant skipped; T2 worker-role negative grant (cannot direct-DELETE attachments, cascade works).
+- Full suite 11395 pass; lint clean; `next build` green; `pre-pr.sh` 36/36; migrations applied to dev DB, grants verified via information_schema.
+- Pre-existing tsc error in teams/.../empty-trash/route.test.ts:161 confirmed on the branch base, NOT in this diff, NOT a CI gate (pre-pr passes) — out of SC2 scope.
+
+## Verification environment constraint
+- **VC-blob (blocked-deferred)**: the real external-blob delete (S3/Azure/GCS) cannot run in CI (no bucket). Covered by the F4 multi-team unit test (mocked blob store, asserts the right refs/partition reach deleteAttachmentBlobs). The DB-backend cascade is integration-tested on the live DB.
+
+## Verdict
+Converged. Tenant-configurable trash retention (`trashRetentionDays`, NULL = never auto-purge) + worker-driven external-blob cleanup (reusing the empty-trash helpers), under least privilege. Policy API/UI for trashRetentionDays is a documented follow-up (this PR adds the column + worker only).

--- a/docs/archive/review/retention-trash-purge-plan.md
+++ b/docs/archive/review/retention-trash-purge-plan.md
@@ -1,0 +1,95 @@
+# Plan: retention-trash-purge (SC2)
+
+## Project context
+- Service (Next.js + Prisma 7 + PostgreSQL 16, multi-tenant RLS, least-privilege roles) + retention-GC worker (engine + SC5 + SC4 merged).
+- Test infra: unit + integration (real-DB) + CI.
+
+## Objective
+Auto-purge soft-deleted (trashed) vault entries past a tenant-configured grace period — `password_entries` and `team_password_entries` with `deleted_at` set — which #571 deferred (SC2) because deleting them must also clean up encrypted `Attachment` blobs, and when an external blob backend (S3/Azure/GCS) is configured a raw DB cascade DELETE would orphan the external objects (R6).
+
+## Background facts (verified)
+- `password_entries.deleted_at` / `team_password_entries.deleted_at` — soft-delete tombstone (nullable). RLS-enabled, tenant-scoped.
+- `Attachment` rows FK `password_entry_id` / `team_password_entry_id` → entry `ON DELETE CASCADE`; the blob lives in `Attachment.encrypted_data` (Bytes) for the **DB** backend, OR externally (S3/Azure/GCS) with `encrypted_data` holding the object ref.
+- Existing reusable helpers (`src/lib/blob-store/cleanup.ts`): `collectEntryAttachmentRefs(client, scope)` returns `[]` for the DB backend (cascade handles it) and the external object refs otherwise; `deleteAttachmentBlobs(refs)` removes external objects. `getAttachmentBlobStore()` is env-driven (`BLOB_BACKEND`) and works in the worker process (Prisma-based, no Next.js runtime dependency).
+- `Tenant.auditLogRetentionDays` (schema:589) is the per-tenant-retention pattern to mirror.
+
+## Policy decisions (user-confirmed)
+- **Grace period: tenant-configurable** — add `Tenant.trashRetentionDays Int?` (NULL = never auto-purge, mirrors auditLogRetentionDays NULL-skip). Cutoff: `deleted_at < now() - trashRetentionDays days`.
+- **External blobs: the worker deletes them** — reuse `collectEntryAttachmentRefs` → `deleteAttachmentBlobs` before deleting DB rows.
+
+## Technical approach
+Add a registry kind **`PER_TENANT_TRASH`** (per-tenant, with blob side effect). For each entry (one per entry-table: password_entries, team_password_entries), per sweep:
+1. Enumerate tenants with `trashRetentionDays IS NOT NULL`.
+2. Per tenant: compute cutoff; SELECT trashed entry ids past cutoff (LIMIT batchSize) under bypass_rls.
+3. `collectEntryAttachmentRefs(tx, scope)` → external blob refs (empty for DB backend).
+4. **Delete external blobs FIRST** (`deleteAttachmentBlobs(refs)`) — outside or before the DB delete so an orphaned external object never outlives the DB row. (Ordering: collect refs in tx → delete DB rows in tx → on commit, delete external blobs. If external-blob delete is best-effort like empty-trash's `Promise.allSettled`, a failed external delete leaves an orphan but the DB row is gone — matches the existing empty-trash contract. **Decision: mirror empty-trash exactly** — collect refs, delete DB rows (cascade attachments), then best-effort external-blob delete after commit. This is the established app behavior; consistency over a stricter guarantee.)
+5. `deleteMany` the entry ids (cascade removes Attachment DB rows + DB-backend blobs).
+
+### Registry entry
+```
+interface PerTenantTrashEntry {
+  kind: "PER_TENANT_TRASH";
+  table: "password_entries" | "team_password_entries";
+  scopeKind: "personal" | "team";
+  tenantRetentionColumn: "trashRetentionDays";
+}
+```
+
+## Contracts
+
+### C1 — schema + migration — locked
+- Add `Tenant.trashRetentionDays Int?` (mirror auditLogRetentionDays). Migration: additive nullable column (no backfill needed — NULL = current behavior, no auto-purge). Add a validation min/max constant (mirror AUDIT_LOG_RETENTION_MIN; e.g. min 1, max 3650) if exposed via policy API — **policy API/UI is OUT OF SCOPE for this PR** (the column + worker only; UI wiring is a follow-up). Document that.
+- Invariant: additive-only migration (R24 — nullable, no strict constraint).
+
+### C2 — registry kind + entries + validator — locked
+- Extend `RetentionEntryKind` with `"PER_TENANT_TRASH"`; add `PerTenantTrashEntry`; add 2 entries. Validator: assertIdentifier on table; no globalDelete field needed (the sweeper sets bypass_rls explicitly like sweepAuditLogs). DMMF cross-check: table + that deleted_at exists.
+
+### C3 — sweepTrashEntry — locked
+- `sweepTrashEntry(workerPrisma, entry, batchSize): Promise<number>`:
+  - Enumerate tenants with trashRetentionDays NOT NULL (mirror sweepAuditLogs tenant enumeration).
+  - Per tenant, in a tx: set bypass_rls FIRST (before any SELECT — both entry tables AND attachments are RLS-enabled); SELECT trashed entries past `now() - retention days` (LIMIT batchSize) — for `team_password_entries` SELECT `(id, team_id)`, for `password_entries` SELECT `id`.
+  - **Team multi-team grouping (review F4)**: `collectEntryAttachmentRefs`'s team scope requires a SINGLE `teamId`, but a tenant spans many teams. For `team_password_entries`, GROUP the selected entry ids BY `team_id` and call `collectEntryAttachmentRefs(tx, { kind: "team", teamId, entryIds })` once per team-id group. For `password_entries` call once with `{ kind: "personal", entryIds }`. Accumulate all refs.
+  - `deleteMany` entries by id (cascade removes attachments + history + favorites + tag links; SetNull on password_shares).
+  - After the tx commits: `deleteAttachmentBlobs(allRefs)` (best-effort `Promise.allSettled`, mirrors empty-trash).
+  - Emit a CREDENTIAL-style audit? Optional — a TRASH_RETENTION_PURGED audit action per tenant with the count (mirrors RETENTION_GC_SWEEP heartbeat, under the tenant). **Decision: include a per-tenant TRASH_RETENTION_PURGED audit** so the tenant sees the auto-purge in their log (consistency with SC4's per-tenant forensic record).
+  - Return total deleted across tenants.
+- Invariant: blob refs collected BEFORE the DB delete (the cascade destroys the Attachment rows; we need their refs first). External blob delete is best-effort post-commit (matches empty-trash).
+
+### C4 — sweepOnce dispatch — locked (corrected per review F1)
+- **Reality check**: ALL existing kinds (incl. PER_TENANT_FN/sweepAuditLogs) are dispatched as `workerPrisma.$transaction(tx => sweepX(tx, entry, ...))` — they receive a `tx`, NOT workerPrisma. (The earlier plan claim was wrong.)
+- `PER_TENANT_TRASH` is the **first** kind that legitimately needs `workerPrisma` directly (not a tx): the external-blob delete must happen AFTER the DB tx commits, so `sweepTrashEntry` must own its inner transaction(s). The dispatch branch calls `sweepTrashEntry(workerPrisma, entry, batchSize)` directly — NO outer `$transaction` wrapper. State this as a new pattern.
+
+### C5 — audit action — locked
+- Add `AUDIT_ACTION.TRASH_RETENTION_PURGED` (const + VALUES + MAINTENANCE group + en/ja + Prisma enum + separate enum migration).
+
+### C6 — DB role grant — locked (corrected per review F3)
+- Grant `passwd_retention_gc_worker`: `SELECT, DELETE` on `password_entries`, `team_password_entries`; `SELECT` on `attachments` (for `collectEntryAttachmentRefs`). `SELECT` on `tenants` (already granted).
+- **Full cascade reach (R14, must be confirmed intentional)** — deleting a trashed entry cascades to ALL of: `attachments` (Cascade), `password_entry_histories` / `team_password_entry_histories` (Cascade), `team_password_favorites` (Cascade), `_PasswordEntryToTag` / `_TeamPasswordEntryToTeamTag` join tables (Cascade), and SetNull on `password_shares`. **All pure-cascade/SetNull → NO grant needed** (the RI trigger runs internally, doesn't re-check invoking-role privileges; RLS satisfied by bypass_rls — the SC5 lesson). The worker needs DELETE only on the two entry tables and SELECT on attachments. Purging a trashed entry removing its history/favorites/tag-links is the intended semantics. Verify the grant set + cascade against live DB; the integration test proves the cascade works with attachments SELECT-only (no child DELETE grant).
+
+### C7 — tests — locked
+- Unit: sweepTrashEntry tenant enumeration + cutoff math; the blob-ref-before-delete ordering.
+- Integration (real DB, DB backend): trashed entry past grace → deleted + its attachment (DB blob) gone via cascade; trashed entry within grace → kept; non-trashed (deletedAt NULL) → kept; NULL retention tenant → skipped; role-grant positive+negative.
+- External-blob path: unit-test `collectEntryAttachmentRefs`→`deleteAttachmentBlobs` with a mocked blob store — the real S3/Azure/GCS delete is not exercisable in CI (no bucket), blocked-deferred.
+  - **T1 (multi-team partition)**: the external-blob unit test MUST exercise a tenant with trashed `team_password_entries` across ≥2 teams, asserting `collectEntryAttachmentRefs` is called once per team-id group with correctly partitioned ids + the right `teamId` in each context (this is where F4's grouping bug would surface — a single-team test would pass with the bug).
+  - **T2 (negative grant)**: integration test that the worker role canNOT directly `DELETE FROM attachments` (only via cascade) — mirrors the SC5 positive+negative role pattern.
+
+## Go/No-Go Gate
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | Tenant.trashRetentionDays column + migration | locked |
+| C2 | PER_TENANT_TRASH kind + 2 entries + validator | locked |
+| C3 | sweepTrashEntry (enumerate→collect refs→delete→blob cleanup) | locked |
+| C4 | sweepOnce dispatch (workerPrisma, own tx) | locked |
+| C5 | TRASH_RETENTION_PURGED audit action | locked |
+| C6 | DB role grant | locked |
+| C7 | unit + integration tests | locked |
+
+## Considerations
+- **Blob-delete ordering**: refs MUST be collected before the cascade destroys the Attachment rows. External blob delete is best-effort post-commit (mirrors empty-trash; a failed external delete orphans an object but never leaves a dangling DB row). For the DB backend, `collectEntryAttachmentRefs` returns `[]` and the cascade removes the blob with the row — no external step.
+- **Verification constraint (VC-blob)**: the real external-blob delete (S3/Azure/GCS) cannot run in CI (no bucket). Classification: blocked-deferred — the external path is unit-tested via a mocked blob store (assert the right refs are passed to deleteAttachmentBlobs); the DB-backend cascade is integration-tested on the live DB.
+- **S1 (password_shares SetNull under auto-purge) — VERIFIED NOT A SECURITY ISSUE**: purging a trashed entry SetNulls `password_shares.password_entry_id` (pre-existing FK, shared with empty-trash). Confirmed the share-content route (`/api/share-links/[id]/content/route.ts:74-107`) serves the share's OWN `encryptedData` snapshot (NOT fetched via passwordEntryId) and is independently gated by `revokedAt`/`expiresAt`/`maxViews`. So SetNulling the entry link does not change content access — the share remains exactly as functional (or revoked/expired) as it was before the purge, identical to today's empty-trash behavior. No new guard needed; the entry link is provenance-only.
+- **F2 (env not in worker .pick())**: `BLOB_BACKEND` + cloud config vars are read raw from `process.env` (after `loadEnv()`) by `getAttachmentBlobStore()`, not validated in the worker's env `.pick()`. Functionally fine; the worker fails at first sweep via `validateConfig()` rather than at boot. Acceptable — note it.
+- Out of scope: policy API/UI for trashRetentionDays (column + worker only — follow-up); SC3/SC6/SC7.
+
+## Scope contract
+SC3/SC6/SC7 remain separate follow-ups. Policy API/UI for trashRetentionDays is a documented follow-up (this PR adds the column + the GC worker only).

--- a/messages/en/AuditLog.json
+++ b/messages/en/AuditLog.json
@@ -252,6 +252,7 @@
   "AUDIT_OUTBOX_PURGE_EXECUTED": "Outbox failed rows purged",
   "RETENTION_GC_SWEEP": "Retention GC sweep executed (system worker)",
   "CREDENTIAL_RETENTION_PURGED": "Expired credential purged after recording its provenance (system worker)",
+  "TRASH_RETENTION_PURGED": "Expired trashed entries purged (system worker)",
   "AUDIT_DELIVERY_FAILED": "Audit delivery failed",
   "AUDIT_DELIVERY_DEAD_LETTER": "Audit delivery dead-lettered",
   "AUDIT_ANCHOR_PUBLISHED": "Audit anchor manifest published",

--- a/messages/ja/AuditLog.json
+++ b/messages/ja/AuditLog.json
@@ -252,6 +252,7 @@
   "AUDIT_OUTBOX_PURGE_EXECUTED": "送信キュー失敗行をパージ",
   "RETENTION_GC_SWEEP": "保持期限切れデータの定期削除を実行（システムワーカー）",
   "CREDENTIAL_RETENTION_PURGED": "期限切れ認証情報を証跡記録のうえ削除（システムワーカー）",
+  "TRASH_RETENTION_PURGED": "ゴミ箱の期限切れエントリを削除（システムワーカー）",
   "AUDIT_DELIVERY_FAILED": "監査配信失敗",
   "AUDIT_DELIVERY_DEAD_LETTER": "監査配信デッドレター化",
   "AUDIT_ANCHOR_PUBLISHED": "監査アンカーマニフェストを公開",

--- a/prisma/migrations/20260618150000_add_trash_retention_purged_action/migration.sql
+++ b/prisma/migrations/20260618150000_add_trash_retention_purged_action/migration.sql
@@ -1,0 +1,4 @@
+-- SC2: add TRASH_RETENTION_PURGED to the AuditAction enum so the retention-gc
+-- worker's per-tenant trash auto-purge is distinguishable from credential and
+-- audit-log retention purges in the audit log.
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'TRASH_RETENTION_PURGED';

--- a/prisma/migrations/20260618160000_add_trash_retention_days/migration.sql
+++ b/prisma/migrations/20260618160000_add_trash_retention_days/migration.sql
@@ -1,0 +1,3 @@
+-- SC2: per-tenant trash auto-purge grace period. Additive nullable column;
+-- NULL = never auto-purge (mirrors audit_log_retention_days). No backfill.
+ALTER TABLE "tenants" ADD COLUMN IF NOT EXISTS "trash_retention_days" INTEGER;

--- a/prisma/migrations/20260618170000_retention_gc_trash_grants/migration.sql
+++ b/prisma/migrations/20260618170000_retention_gc_trash_grants/migration.sql
@@ -1,0 +1,16 @@
+-- SC2: grant the retention-gc worker the privileges needed to auto-purge
+-- soft-deleted vault entries. It SELECTs + DELETEs the two entry tables; the
+-- ON DELETE CASCADE then removes attachments, history, favorites, and tag
+-- links internally (the RI trigger runs without re-checking invoking-role
+-- privileges), so no DELETE grant on those child tables is needed. SELECT on
+-- attachments is required only so collectEntryAttachmentRefs can read external
+-- blob refs before the cascade destroys the rows.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'passwd_retention_gc_worker') THEN
+    GRANT SELECT, DELETE ON TABLE "password_entries" TO passwd_retention_gc_worker;
+    GRANT SELECT, DELETE ON TABLE "team_password_entries" TO passwd_retention_gc_worker;
+    GRANT SELECT ON TABLE "attachments" TO passwd_retention_gc_worker;
+  END IF;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -589,6 +589,9 @@ model Tenant {
   auditLogRetentionDays Int?    @map("audit_log_retention_days")
   auditChainEnabled     Boolean @default(false) @map("audit_chain_enabled")
 
+  // Trash (soft-deleted entry) auto-purge retention. NULL = never auto-purge.
+  trashRetentionDays Int? @map("trash_retention_days")
+
   // Tenant-wide password policy
   tenantMinPasswordLength Int     @default(0) @map("tenant_min_password_length")
   tenantRequireUppercase  Boolean @default(false) @map("tenant_require_uppercase")
@@ -927,6 +930,7 @@ enum AuditAction {
   AUDIT_LOG_PURGE
   RETENTION_GC_SWEEP
   CREDENTIAL_RETENTION_PURGED
+  TRASH_RETENTION_PURGED
   MASTER_KEY_ROTATION
   VERIFIER_PEPPER_ROTATE_BEGIN
   VERIFIER_PEPPER_ROTATE_COMPLETE

--- a/src/__tests__/db-integration/retention-gc-trash-purge.integration.test.ts
+++ b/src/__tests__/db-integration/retention-gc-trash-purge.integration.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Real-DB integration tests for sweepTrashEntry (SC2 / C3 / C6 / C7 / T2).
+ *
+ * DB blob backend (the CI default): collectEntryAttachmentRefs returns [] and
+ * the FK cascade removes the Attachment rows with the entry. Covers:
+ *   - trashed entry past grace (deleted_at = now()-31d) → deleted + its
+ *     attachment row gone via cascade.
+ *   - within-grace trashed entry (deleted_at = now()-5d) → kept.
+ *   - non-trashed entry (deleted_at NULL) → kept.
+ *   - NULL-retention tenant's trashed entry → untouched.
+ *   - T2 negative grant: the worker role CANNOT directly DELETE FROM attachments
+ *     (permission denied) but CAN delete password_entries (cascade removes the
+ *     attachment).
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { randomUUID } from "node:crypto";
+import {
+  createTestContext,
+  setBypassRlsGucs,
+  type TestContext,
+} from "./helpers";
+import { sweepTrashEntry } from "@/workers/retention-gc-worker/sweep";
+import type { PerTenantTrashEntry } from "@/workers/retention-gc-worker/registry";
+import { SYSTEM_TENANT_ID } from "@/lib/constants/app";
+
+const PERSONAL_ENTRY: PerTenantTrashEntry = {
+  kind: "PER_TENANT_TRASH",
+  table: "password_entries",
+  scopeKind: "personal",
+  tenantRetentionColumn: "trashRetentionDays",
+};
+
+describe("retention-gc sweepTrashEntry: personal trash purge (SC2/C3/C7)", () => {
+  let ctx: TestContext;
+  let tenantId: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+  });
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+  beforeEach(async () => {
+    tenantId = await ctx.createTenant();
+    userId = await ctx.createUser(tenantId);
+  });
+  afterEach(async () => {
+    // Drain the SYSTEM-tenant heartbeat/per-tenant audit rows this sweep enqueued.
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `UPDATE audit_outbox SET status = 'FAILED'::"AuditOutboxStatus"
+         WHERE tenant_id IN ($1::uuid, $2::uuid) AND status IN ('PENDING', 'PROCESSING')`,
+        tenantId,
+        SYSTEM_TENANT_ID,
+      );
+      await tx.$executeRawUnsafe(
+        `DELETE FROM audit_outbox WHERE tenant_id IN ($1::uuid, $2::uuid)`,
+        tenantId,
+        SYSTEM_TENANT_ID,
+      );
+    });
+    await ctx.deleteTestData(tenantId);
+  });
+
+  async function setTrashRetention(
+    targetTenantId: string,
+    days: number | null,
+  ): Promise<void> {
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `UPDATE tenants SET trash_retention_days = $2 WHERE id = $1::uuid`,
+        targetTenantId,
+        days,
+      );
+    });
+  }
+
+  async function insertEntry(opts: {
+    ownerTenantId: string;
+    ownerUserId: string;
+    deletedAt: string; // SQL expression or 'NULL'
+  }): Promise<string> {
+    const id = randomUUID();
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO password_entries
+           (id, encrypted_blob, blob_iv, blob_auth_tag,
+            encrypted_overview, overview_iv, overview_auth_tag,
+            key_version, user_id, tenant_id, deleted_at, created_at, updated_at)
+         VALUES ($1::uuid, 'blob', 'iv0', 'tag0',
+                 'ov', 'oviv', 'ovtag',
+                 1, $2::uuid, $3::uuid, ${opts.deletedAt}, now(), now())`,
+        id,
+        opts.ownerUserId,
+        opts.ownerTenantId,
+      );
+    });
+    return id;
+  }
+
+  async function insertAttachment(
+    entryId: string,
+    ownerTenantId: string,
+    ownerUserId: string,
+  ): Promise<string> {
+    const id = randomUUID();
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO attachments
+           (id, filename, content_type, size_bytes, encrypted_data, iv, auth_tag,
+            tenant_id, password_entry_id, created_by_id, created_at)
+         VALUES ($1::uuid, 'f.txt', 'text/plain', 3, '\\x010203'::bytea, 'aiv', 'atag',
+                 $2::uuid, $3::uuid, $4::uuid, now())`,
+        id,
+        ownerTenantId,
+        entryId,
+        ownerUserId,
+      );
+    });
+    return id;
+  }
+
+  async function entryExists(id: string): Promise<boolean> {
+    const rows = await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      return tx.$queryRawUnsafe<{ id: string }[]>(
+        `SELECT id FROM password_entries WHERE id = $1::uuid`,
+        id,
+      );
+    });
+    return rows.length === 1;
+  }
+
+  async function attachmentExists(id: string): Promise<boolean> {
+    const rows = await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      return tx.$queryRawUnsafe<{ id: string }[]>(
+        `SELECT id FROM attachments WHERE id = $1::uuid`,
+        id,
+      );
+    });
+    return rows.length === 1;
+  }
+
+  it("purges a past-grace trashed entry and cascade-removes its attachment; keeps within-grace + non-trashed", async () => {
+    await setTrashRetention(tenantId, 30);
+
+    // Past grace (31d) — should be purged, with its attachment.
+    const pastId = await insertEntry({
+      ownerTenantId: tenantId,
+      ownerUserId: userId,
+      deletedAt: "now() - interval '31 days'",
+    });
+    const attachmentId = await insertAttachment(pastId, tenantId, userId);
+
+    // Within grace (5d) — should be kept.
+    const withinGraceId = await insertEntry({
+      ownerTenantId: tenantId,
+      ownerUserId: userId,
+      deletedAt: "now() - interval '5 days'",
+    });
+
+    // Non-trashed (deleted_at NULL) — should be kept.
+    const liveId = await insertEntry({
+      ownerTenantId: tenantId,
+      ownerUserId: userId,
+      deletedAt: "NULL",
+    });
+
+    const deleted = await sweepTrashEntry(ctx.su.prisma, PERSONAL_ENTRY, 100);
+
+    // Only the configured tenant's past-grace entry is deleted.
+    expect(deleted).toBe(1);
+    expect(await entryExists(pastId)).toBe(false);
+    expect(await attachmentExists(attachmentId)).toBe(false); // cascade
+    expect(await entryExists(withinGraceId)).toBe(true);
+    expect(await entryExists(liveId)).toBe(true);
+  });
+
+  it("does not touch a NULL-retention tenant's past-grace trashed entry", async () => {
+    // tenantId keeps its default NULL trash_retention_days.
+    const pastId = await insertEntry({
+      ownerTenantId: tenantId,
+      ownerUserId: userId,
+      deletedAt: "now() - interval '90 days'",
+    });
+
+    const deleted = await sweepTrashEntry(ctx.su.prisma, PERSONAL_ENTRY, 100);
+
+    expect(deleted).toBe(0);
+    expect(await entryExists(pastId)).toBe(true);
+  });
+
+  // ─── T2: negative grant — worker role can't directly DELETE attachments ──────
+
+  it("T2: worker role CANNOT directly DELETE FROM attachments, but CAN delete password_entries (cascade removes the attachment)", async () => {
+    await setTrashRetention(tenantId, 30);
+    const entryId = await insertEntry({
+      ownerTenantId: tenantId,
+      ownerUserId: userId,
+      deletedAt: "now() - interval '31 days'",
+    });
+    const attachmentId = await insertAttachment(entryId, tenantId, userId);
+
+    // Direct DELETE FROM attachments is denied for the worker role.
+    await expect(
+      ctx.retentionWorker.prisma.$transaction(async (tx) => {
+        await tx.$executeRaw`SELECT set_config('app.bypass_rls', 'on', true)`;
+        await tx.$executeRawUnsafe(
+          `DELETE FROM attachments WHERE id = $1::uuid`,
+          attachmentId,
+        );
+      }),
+    ).rejects.toThrow(/permission denied/);
+
+    // Attachment still present (the denied DELETE rolled back).
+    expect(await attachmentExists(attachmentId)).toBe(true);
+
+    // But deleting the parent entry via the worker role cascades the attachment.
+    await ctx.retentionWorker.prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`SELECT set_config('app.bypass_rls', 'on', true)`;
+      await tx.$executeRawUnsafe(
+        `DELETE FROM password_entries WHERE id = $1::uuid`,
+        entryId,
+      );
+    });
+
+    expect(await entryExists(entryId)).toBe(false);
+    expect(await attachmentExists(attachmentId)).toBe(false);
+  });
+});

--- a/src/lib/constants/audit/audit.ts
+++ b/src/lib/constants/audit/audit.ts
@@ -82,6 +82,9 @@ export const AUDIT_ACTION = {
   // Forensic provenance of an expired credential, recorded just before the
   // retention-gc-worker deletes it (SC4) — preserves incident-investigation evidence.
   CREDENTIAL_RETENTION_PURGED: "CREDENTIAL_RETENTION_PURGED",
+  // Per-tenant trash auto-purge: the retention-gc-worker deletes soft-deleted
+  // vault entries past the tenant's trashRetentionDays grace period (SC2).
+  TRASH_RETENTION_PURGED: "TRASH_RETENTION_PURGED",
   // MASTER_KEY_ROTATION: legacy single-action key — retained for old audit rows
   // and for the share-only rotation path (A04-4 keeps emit-site removed and
   // routes the four phase actions below). Do NOT add new emit sites for this
@@ -273,6 +276,7 @@ export const AUDIT_ACTION_VALUES = [
   AUDIT_ACTION.AUDIT_LOG_PURGE,
   AUDIT_ACTION.RETENTION_GC_SWEEP,
   AUDIT_ACTION.CREDENTIAL_RETENTION_PURGED,
+  AUDIT_ACTION.TRASH_RETENTION_PURGED,
   AUDIT_ACTION.SEND_CREATE,
   AUDIT_ACTION.SEND_REVOKE,
   AUDIT_ACTION.SHARE_ACCESS_VERIFY_SUCCESS,
@@ -727,6 +731,7 @@ export const AUDIT_ACTION_GROUPS_TENANT: Record<string, AuditAction[]> = {
     AUDIT_ACTION.AUDIT_OUTBOX_PURGE_EXECUTED,
     AUDIT_ACTION.RETENTION_GC_SWEEP,
     AUDIT_ACTION.CREDENTIAL_RETENTION_PURGED,
+    AUDIT_ACTION.TRASH_RETENTION_PURGED,
     AUDIT_ACTION.AUDIT_DELIVERY_FAILED,
     AUDIT_ACTION.AUDIT_DELIVERY_DEAD_LETTER,
     AUDIT_ACTION.AUDIT_ANCHOR_PUBLISHED,

--- a/src/workers/retention-gc-worker/__tests__/registry.test.ts
+++ b/src/workers/retention-gc-worker/__tests__/registry.test.ts
@@ -33,7 +33,7 @@ for (const model of Prisma.dmmf.datamodel.models) {
 }
 
 describe("RETENTION_REGISTRY — schema cross-check (INV-C1a)", () => {
-  it("contains exactly 6 EXPIRY + 1 EXPIRY_GUARDED + 4 EXPIRY_AUDIT_PROVENANCE + 1 PER_TENANT_FN entries", () => {
+  it("contains exactly 6 EXPIRY + 1 EXPIRY_GUARDED + 4 EXPIRY_AUDIT_PROVENANCE + 1 PER_TENANT_FN + 2 PER_TENANT_TRASH entries", () => {
     const expiry = RETENTION_REGISTRY.filter((e) => e.kind === "EXPIRY");
     const guarded = RETENTION_REGISTRY.filter(
       (e) => e.kind === "EXPIRY_GUARDED",
@@ -44,10 +44,14 @@ describe("RETENTION_REGISTRY — schema cross-check (INV-C1a)", () => {
     const perTenant = RETENTION_REGISTRY.filter(
       (e) => e.kind === "PER_TENANT_FN",
     );
+    const perTenantTrash = RETENTION_REGISTRY.filter(
+      (e) => e.kind === "PER_TENANT_TRASH",
+    );
     expect(expiry).toHaveLength(6);
     expect(guarded).toHaveLength(1);
     expect(provenance).toHaveLength(4);
     expect(perTenant).toHaveLength(1);
+    expect(perTenantTrash).toHaveLength(2);
   });
 
   it("has no duplicate table entries (INV-C1d)", () => {
@@ -104,6 +108,19 @@ describe("RETENTION_REGISTRY — schema cross-check (INV-C1a)", () => {
         expect(model!.fields.has(col), `column "${col}" missing on "${entry.table}"`).toBe(true);
       }
       expect(entry.provenanceColumns).toContain("tenant_id");
+    });
+  }
+
+  // PER_TENANT_TRASH: table must resolve and must carry deleted_at (the
+  // soft-delete tombstone the sweeper filters on) + tenant_id (per-tenant scope).
+  for (const entry of RETENTION_REGISTRY) {
+    if (entry.kind !== "PER_TENANT_TRASH") continue;
+
+    it(`trash entry "${entry.table}" resolves and carries deleted_at + tenant_id`, () => {
+      const model = modelsByPhysicalName.get(entry.table);
+      expect(model, `model "${entry.table}" not found`).toBeDefined();
+      expect(model!.fields.has("deleted_at")).toBe(true);
+      expect(model!.fields.has("tenant_id")).toBe(true);
     });
   }
 });

--- a/src/workers/retention-gc-worker/__tests__/sweep-isolation.test.ts
+++ b/src/workers/retention-gc-worker/__tests__/sweep-isolation.test.ts
@@ -25,23 +25,35 @@ describe("sweepOnce per-entry error isolation (C4/INV-C4b/RT7)", () => {
       (e) => e.kind === "EXPIRY",
     )!.table;
 
+    // PER_TENANT_TRASH entries dispatch through sweepTrashEntry (not an outer
+    // $transaction), which first calls workerPrisma.tenant.findMany. Returning
+    // [] makes those entries report 0 with no inner tx — keeping the $transaction
+    // call sequence aligned 1:1 with the non-trash entries.
+    const txEntryOrder = RETENTION_REGISTRY.filter(
+      (e) => e.kind !== "PER_TENANT_TRASH",
+    ).map((e) => e.table);
+    const trashTables = RETENTION_REGISTRY.filter(
+      (e) => e.kind === "PER_TENANT_TRASH",
+    ).map((e) => e.table);
+    const entryOrder = RETENTION_REGISTRY.map((e) => e.table);
+
     let callIndex = 0;
-    // Each registry entry triggers one $transaction call, in registry order.
-    // sweepOnce ALSO fires one EXTRA $transaction for the heartbeat after the
-    // entries (because a sibling deleted >0 → anyDeleted). That extra call has
-    // callIndex === entryOrder.length; we return 0 for it (entryOrder[i] is
-    // undefined there) and the mock ignores the callback, so the heartbeat
+    // Each non-trash registry entry triggers one $transaction call, in registry
+    // order. sweepOnce ALSO fires one EXTRA $transaction for the heartbeat after
+    // the entries (because a sibling deleted >0 → anyDeleted). That extra call
+    // has callIndex === txEntryOrder.length; we return 0 for it (txEntryOrder[i]
+    // is undefined there) and the mock ignores the callback, so the heartbeat
     // emit never runs and its result is discarded by sweepOnce — invisible to
     // the assertions below. Guard it explicitly so a future mock that DOES
     // invoke the callback can't silently misalign the per-entry mapping.
-    const entryOrder = RETENTION_REGISTRY.map((e) => e.table);
     const mockPrisma = {
+      tenant: { findMany: vi.fn(async () => []) },
       $transaction: vi.fn(async () => {
-        if (callIndex >= entryOrder.length) {
+        if (callIndex >= txEntryOrder.length) {
           callIndex += 1;
           return 0; // heartbeat tx — result discarded by sweepOnce
         }
-        const table = entryOrder[callIndex];
+        const table = txEntryOrder[callIndex];
         callIndex += 1;
         if (table === failingTable) {
           throw Object.assign(new Error("boom"), { code: "XX000" });
@@ -58,10 +70,14 @@ describe("sweepOnce per-entry error isolation (C4/INV-C4b/RT7)", () => {
     // The failing entry is flagged -1; the sweep did NOT abort.
     expect(counts[failingTable]).toBe(-1);
 
-    // Every sibling entry still ran and reported its count (3), proving isolation.
-    for (const table of entryOrder) {
+    // Every non-trash sibling still ran and reported its count (3) — isolation.
+    for (const table of txEntryOrder) {
       if (table === failingTable) continue;
       expect(counts[table]).toBe(3);
+    }
+    // Trash entries (no tenants enumerated) report 0 and don't abort the sweep.
+    for (const table of trashTables) {
+      expect(counts[table]).toBe(0);
     }
 
     // sweepOnce visited every registry entry despite the mid-loop failure.

--- a/src/workers/retention-gc-worker/__tests__/sweep-trash.test.ts
+++ b/src/workers/retention-gc-worker/__tests__/sweep-trash.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for sweepTrashEntry (SC2 / C3 / T1).
+ *
+ * workerPrisma + the attachment blob store are mocked. Asserts:
+ *   - tenant enumeration skips NULL trashRetentionDays (only configured tenants).
+ *   - cutoff math: deleted_at < now() - retention days is passed to the SELECT.
+ *   - F4 multi-team grouping: a tenant with trashed team entries across 2 teams
+ *     calls collectEntryAttachmentRefs once per team with correctly partitioned
+ *     ids + the right teamId (this is where a single-team test would mask the
+ *     grouping bug).
+ *
+ * getAttachmentBlobStore is mocked to a NON-DB backend so
+ * collectEntryAttachmentRefs does not early-return [] — otherwise the per-team
+ * findMany calls (which carry the partition evidence) would be skipped.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MS_PER_DAY } from "@/lib/constants/time";
+import { BLOB_STORAGE } from "@/lib/blob-store/types";
+
+const deleteObject = vi.fn(async () => {});
+const getAttachmentBlobStore = vi.fn(() => ({
+  backend: BLOB_STORAGE.S3,
+  deleteObject,
+}));
+
+vi.mock("@/lib/blob-store", () => ({
+  get BLOB_STORAGE() {
+    return BLOB_STORAGE;
+  },
+  getAttachmentBlobStore: () => getAttachmentBlobStore(),
+}));
+
+import { sweepTrashEntry } from "../sweep";
+import type { PerTenantTrashEntry } from "../registry";
+
+/** The subset of the attachment.findMany arg the sweeper passes (via collectEntryAttachmentRefs). */
+interface AttachmentFindManyArg {
+  where: {
+    teamPasswordEntryId?: { in: string[] };
+    passwordEntryId?: { in: string[] };
+  };
+}
+
+type AttachmentFindManyMock = ReturnType<
+  typeof vi.fn<(arg: AttachmentFindManyArg) => Promise<unknown[]>>
+>;
+
+const PERSONAL_ENTRY: PerTenantTrashEntry = {
+  kind: "PER_TENANT_TRASH",
+  table: "password_entries",
+  scopeKind: "personal",
+  tenantRetentionColumn: "trashRetentionDays",
+};
+
+const TEAM_ENTRY: PerTenantTrashEntry = {
+  kind: "PER_TENANT_TRASH",
+  table: "team_password_entries",
+  scopeKind: "team",
+  tenantRetentionColumn: "trashRetentionDays",
+};
+
+/**
+ * Build a mock workerPrisma. `selectRows` is what the trashed-entry SELECT
+ * returns; the audit-emit $queryRaw calls (bypass_rls check, tenant existence)
+ * are distinguished from the SELECT by the query text.
+ */
+function buildMockPrisma(opts: {
+  tenants: Array<{ id: string; trashRetentionDays: number | null }>;
+  selectRows: Record<string, unknown>[];
+  attachmentFindMany: AttachmentFindManyMock;
+}) {
+  const teamDeleteMany = vi.fn(async () => ({ count: 0 }));
+  const personalDeleteMany = vi.fn(async () => ({ count: 0 }));
+  const auditCreate = vi.fn(async () => ({}));
+
+  const queryRaw = vi.fn(async (strings: TemplateStringsArray) => {
+    const text = strings.join("");
+    if (text.includes("current_setting")) {
+      return [{ bypass_rls: "on", tenant_id: "" }];
+    }
+    if (text.includes("SELECT EXISTS")) {
+      return [{ ok: true }];
+    }
+    // The trashed-entry SELECT.
+    return opts.selectRows;
+  });
+
+  const tx = {
+    $executeRaw: vi.fn(async () => 0),
+    $queryRaw: queryRaw,
+    teamPasswordEntry: { deleteMany: teamDeleteMany },
+    passwordEntry: { deleteMany: personalDeleteMany },
+    attachment: { findMany: opts.attachmentFindMany },
+    auditOutbox: { create: auditCreate },
+  };
+
+  const workerPrisma = {
+    tenant: {
+      findMany: vi.fn(async () =>
+        opts.tenants.filter((t) => t.trashRetentionDays !== null),
+      ),
+    },
+    $transaction: vi.fn(async (cb: (t: typeof tx) => Promise<unknown>) =>
+      cb(tx),
+    ),
+  };
+
+  return {
+    workerPrisma,
+    tx,
+    teamDeleteMany,
+    personalDeleteMany,
+    auditCreate,
+    queryRaw,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAttachmentBlobStore.mockReturnValue({
+    backend: BLOB_STORAGE.S3,
+    deleteObject,
+  });
+});
+
+describe("sweepTrashEntry — tenant enumeration (C3)", () => {
+  it("enumerates only tenants with trashRetentionDays NOT NULL", async () => {
+    const attachmentFindMany: AttachmentFindManyMock = vi.fn(
+      async () => [],
+    );
+    const { workerPrisma } = buildMockPrisma({
+      tenants: [
+        { id: "11111111-1111-4111-8111-111111111111", trashRetentionDays: 30 },
+        { id: "22222222-2222-4222-8222-222222222222", trashRetentionDays: null },
+      ],
+      selectRows: [],
+      attachmentFindMany,
+    });
+
+    await sweepTrashEntry(
+      workerPrisma as unknown as Parameters<typeof sweepTrashEntry>[0],
+      PERSONAL_ENTRY,
+      100,
+    );
+
+    expect(workerPrisma.tenant.findMany).toHaveBeenCalledWith({
+      where: { trashRetentionDays: { not: null } },
+      select: { id: true, trashRetentionDays: true },
+    });
+    // The NULL-retention tenant is filtered out → only one tenant tx opened.
+    expect(workerPrisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("sweepTrashEntry — cutoff math (C3)", () => {
+  it("passes deleted_at < (now - retention days) as the SELECT bind", async () => {
+    const retention = 30;
+    const before = Date.now();
+    const attachmentFindMany: AttachmentFindManyMock = vi.fn(
+      async () => [],
+    );
+    const { workerPrisma, queryRaw } = buildMockPrisma({
+      tenants: [
+        { id: "11111111-1111-4111-8111-111111111111", trashRetentionDays: retention },
+      ],
+      selectRows: [],
+      attachmentFindMany,
+    });
+
+    await sweepTrashEntry(
+      workerPrisma as unknown as Parameters<typeof sweepTrashEntry>[0],
+      PERSONAL_ENTRY,
+      100,
+    );
+    const after = Date.now();
+
+    // Find the SELECT call (the one whose text references deleted_at) and read
+    // its cutoff bind (the Date interpolated after the template strings).
+    const selectCall = queryRaw.mock.calls.find((c) =>
+      (c[0] as TemplateStringsArray).join("").includes("deleted_at"),
+    );
+    expect(selectCall).toBeDefined();
+    const cutoff = selectCall!.find((arg) => arg instanceof Date) as Date;
+    expect(cutoff).toBeInstanceOf(Date);
+
+    const expectedMin = before - retention * MS_PER_DAY;
+    const expectedMax = after - retention * MS_PER_DAY;
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(expectedMin);
+    expect(cutoff.getTime()).toBeLessThanOrEqual(expectedMax);
+  });
+});
+
+describe("sweepTrashEntry — F4 multi-team grouping (T1)", () => {
+  it("calls collectEntryAttachmentRefs once per team with partitioned ids + right teamId", async () => {
+    const TEAM_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const TEAM_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    // Two entries in team A, one in team B (interleaved to prove grouping, not order).
+    const selectRows = [
+      { id: "entry-a1", team_id: TEAM_A },
+      { id: "entry-b1", team_id: TEAM_B },
+      { id: "entry-a2", team_id: TEAM_A },
+    ];
+    // attachment.findMany is the observable surface of collectEntryAttachmentRefs.
+    const attachmentFindMany: AttachmentFindManyMock = vi.fn(
+      async () => [],
+    );
+    const { workerPrisma, teamDeleteMany } = buildMockPrisma({
+      tenants: [
+        { id: "11111111-1111-4111-8111-111111111111", trashRetentionDays: 30 },
+      ],
+      selectRows,
+      attachmentFindMany,
+    });
+
+    await sweepTrashEntry(
+      workerPrisma as unknown as Parameters<typeof sweepTrashEntry>[0],
+      TEAM_ENTRY,
+      100,
+    );
+
+    // One findMany per team group (2 teams → 2 calls).
+    expect(attachmentFindMany).toHaveBeenCalledTimes(2);
+
+    // Extract the partitioned id lists each call received.
+    const idLists = attachmentFindMany.mock.calls.map(
+      (c) => c[0].where.teamPasswordEntryId?.in ?? [],
+    );
+    const teamAList = idLists.find((ids) => ids.includes("entry-a1"));
+    const teamBList = idLists.find((ids) => ids.includes("entry-b1"));
+
+    // Team A group: exactly its two ids, partitioned away from team B.
+    expect(teamAList).toBeDefined();
+    expect([...teamAList!].sort()).toEqual(["entry-a1", "entry-a2"]);
+    // Team B group: exactly its one id.
+    expect(teamBList).toEqual(["entry-b1"]);
+
+    // All three ids are deleted in a single deleteMany.
+    expect(teamDeleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["entry-a1", "entry-b1", "entry-a2"] } },
+    });
+  });
+});

--- a/src/workers/retention-gc-worker/index.ts
+++ b/src/workers/retention-gc-worker/index.ts
@@ -114,6 +114,11 @@ export function validateRegistry(
             `All RLS-enabled tables require globalDelete to acknowledge the all-tenant blast radius.`,
         );
       }
+    } else if (entry.kind === "PER_TENANT_TRASH") {
+      // `table` is the only free identifier; scopeKind and tenantRetentionColumn
+      // are literal-union types. The sweeper sets bypass_rls explicitly (like
+      // sweepAuditLogs), so there is no globalDelete flag to enforce.
+      assertIdentifier(entry.table);
     }
     // PER_TENANT_FN entries have no free identifiers to validate — the table,
     // fn, and tenantRetentionColumn fields are literal union types.

--- a/src/workers/retention-gc-worker/registry.ts
+++ b/src/workers/retention-gc-worker/registry.ts
@@ -15,7 +15,8 @@ export type RetentionEntryKind =
   | "EXPIRY"
   | "EXPIRY_GUARDED"
   | "EXPIRY_AUDIT_PROVENANCE"
-  | "PER_TENANT_FN";
+  | "PER_TENANT_FN"
+  | "PER_TENANT_TRASH";
 
 /**
  * Closed set of "no live dependents" guards. Each maps to a fixed SQL fragment
@@ -106,11 +107,31 @@ export interface AuditProvenanceEntry {
   globalDelete?: true;
 }
 
+/**
+ * Per-tenant auto-purge of soft-deleted (trashed) vault entries with an
+ * attachment-blob side effect (SC2). Deleting a trashed entry cascades to its
+ * attachments/history/favorites/tag-links and SetNulls password_shares; when an
+ * external blob backend is configured the worker first collects the external
+ * object refs (collectEntryAttachmentRefs) and deletes them post-commit
+ * (deleteAttachmentBlobs), mirroring empty-trash. NULL trashRetentionDays →
+ * tenant skipped (no implicit deletion).
+ */
+export interface PerTenantTrashEntry {
+  kind: "PER_TENANT_TRASH";
+  /** Physical entry table whose deleted_at tombstones are auto-purged. */
+  table: "password_entries" | "team_password_entries";
+  /** Selects the collectEntryAttachmentRefs scope shape (personal vs team). */
+  scopeKind: "personal" | "team";
+  /** Prisma model field holding per-tenant trash retention days (null = skip). */
+  tenantRetentionColumn: "trashRetentionDays";
+}
+
 export type RetentionEntry =
   | ExpiryEntry
   | GuardedExpiryEntry
   | AuditProvenanceEntry
-  | PerTenantFnEntry;
+  | PerTenantFnEntry
+  | PerTenantTrashEntry;
 
 /**
  * EXPIRY tables that are intentionally RLS-free (no RLS policy, no tenant_id),
@@ -271,5 +292,23 @@ export const RETENTION_REGISTRY: readonly RetentionEntry[] = [
     table: "audit_logs",
     fn: "audit_log_purge",
     tenantRetentionColumn: "auditLogRetentionDays",
+  },
+  {
+    // Personal-vault trash auto-purge (SC2). NULL trashRetentionDays → tenant
+    // skipped. The cascade removes attachments/history/favorites/tag-links;
+    // external blobs are deleted post-commit by sweepTrashEntry.
+    kind: "PER_TENANT_TRASH",
+    table: "password_entries",
+    scopeKind: "personal",
+    tenantRetentionColumn: "trashRetentionDays",
+  },
+  {
+    // Team-vault trash auto-purge (SC2). Selected ids are grouped by team_id so
+    // collectEntryAttachmentRefs is called once per team (its team scope takes a
+    // single teamId).
+    kind: "PER_TENANT_TRASH",
+    table: "team_password_entries",
+    scopeKind: "team",
+    tenantRetentionColumn: "trashRetentionDays",
   },
 ] as const;

--- a/src/workers/retention-gc-worker/sweep.ts
+++ b/src/workers/retention-gc-worker/sweep.ts
@@ -34,8 +34,14 @@ import {
   type GuardName,
   type AuditProvenanceEntry,
   type PerTenantFnEntry,
+  type PerTenantTrashEntry,
 } from "./registry";
 import { USER_AGENT_MAX_LENGTH } from "@/lib/validations/common.server";
+import {
+  collectEntryAttachmentRefs,
+  deleteAttachmentBlobs,
+  type AttachmentBlobRef,
+} from "@/lib/blob-store/cleanup";
 
 /**
  * Fixed "no live dependents" guard SQL fragments, keyed by GuardName.
@@ -339,6 +345,134 @@ export async function sweepAuditLogs(
 }
 
 /**
+ * Auto-purge soft-deleted (trashed) vault entries past each tenant's configured
+ * grace period (SC2). One PER_TENANT_TRASH entry per entry table.
+ *
+ * Per tenant, in its own transaction:
+ *   1. set bypass_rls FIRST (entry tables AND attachments are RLS-enabled).
+ *   2. SELECT trashed entry ids past `now() - trashRetentionDays days` (LIMIT
+ *      batchSize). For team_password_entries also select team_id.
+ *   3. Collect external blob refs BEFORE the cascade destroys the Attachment
+ *      rows. For team scope the ids are grouped by team_id and
+ *      collectEntryAttachmentRefs is called once per team group (F4) — its team
+ *      scope takes a single teamId. Refs are [] on the DB backend.
+ *   4. deleteMany the entries by id (cascade removes attachments/history/
+ *      favorites/tag-links; SetNull on password_shares).
+ *   5. Emit a per-tenant TRASH_RETENTION_PURGED audit (only if rows deleted).
+ *
+ * AFTER the tx commits, the collected external blobs are deleted best-effort
+ * (deleteAttachmentBlobs uses Promise.allSettled) — mirrors empty-trash: a
+ * failed external delete orphans an object but never leaves a dangling DB row.
+ *
+ * Unlike the other sweepers this takes workerPrisma (not a tx): the external
+ * blob delete must run after the DB tx commits, so this owns its own
+ * transactions.
+ *
+ * @returns Total entries deleted across all enumerated tenants.
+ */
+export async function sweepTrashEntry(
+  workerPrisma: PrismaClient,
+  entry: PerTenantTrashEntry,
+  batchSize: number,
+): Promise<number> {
+  assertIdentifier(entry.table);
+
+  // Enumerate only tenants with explicit trash retention configured (NULL → skip).
+  const tenants = await workerPrisma.tenant.findMany({
+    where: { trashRetentionDays: { not: null } },
+    select: { id: true, trashRetentionDays: true },
+  });
+
+  let total = 0;
+  for (const tenant of tenants) {
+    const retention = tenant.trashRetentionDays!;
+    const cutoff = new Date(Date.now() - retention * MS_PER_DAY);
+
+    const { deletedCount, refs } = await workerPrisma.$transaction(
+      async (tx) => {
+        // bypass_rls FIRST — both entry tables and attachments are RLS-enabled.
+        await tx.$executeRaw`SELECT set_config('app.bypass_rls', 'on', true)`;
+
+        // Select trashed entries past the cutoff. team scope also needs team_id
+        // so the refs can be partitioned by team (F4).
+        const rows =
+          entry.scopeKind === "team"
+            ? await tx.$queryRaw<Array<{ id: string; team_id: string }>>`
+                SELECT id, team_id FROM team_password_entries
+                WHERE tenant_id = ${tenant.id}::uuid
+                  AND deleted_at IS NOT NULL
+                  AND deleted_at < ${cutoff}
+                LIMIT ${batchSize}`
+            : await tx.$queryRaw<Array<{ id: string }>>`
+                SELECT id FROM password_entries
+                WHERE tenant_id = ${tenant.id}::uuid
+                  AND deleted_at IS NOT NULL
+                  AND deleted_at < ${cutoff}
+                LIMIT ${batchSize}`;
+
+        if (rows.length === 0) {
+          return { deletedCount: 0, refs: [] as AttachmentBlobRef[] };
+        }
+
+        const ids = rows.map((r) => r.id);
+
+        // Collect external blob refs BEFORE the cascade delete.
+        const collected: AttachmentBlobRef[] = [];
+        if (entry.scopeKind === "team") {
+          // Group ids by team_id; one collectEntryAttachmentRefs call per team.
+          const idsByTeam = new Map<string, string[]>();
+          for (const row of rows as Array<{ id: string; team_id: string }>) {
+            const list = idsByTeam.get(row.team_id) ?? [];
+            list.push(row.id);
+            idsByTeam.set(row.team_id, list);
+          }
+          for (const [teamId, teamEntryIds] of idsByTeam) {
+            collected.push(
+              ...(await collectEntryAttachmentRefs(tx, {
+                kind: "team",
+                teamId,
+                entryIds: teamEntryIds,
+              })),
+            );
+          }
+          await tx.teamPasswordEntry.deleteMany({ where: { id: { in: ids } } });
+        } else {
+          collected.push(
+            ...(await collectEntryAttachmentRefs(tx, {
+              kind: "personal",
+              entryIds: ids,
+            })),
+          );
+          await tx.passwordEntry.deleteMany({ where: { id: { in: ids } } });
+        }
+
+        await enqueueAuditInWorkerTx(tx, tenant.id, {
+          scope: AUDIT_SCOPE.TENANT,
+          action: AUDIT_ACTION.TRASH_RETENTION_PURGED,
+          userId: SYSTEM_ACTOR_ID,
+          actorType: ACTOR_TYPE.SYSTEM,
+          serviceAccountId: null,
+          teamId: null,
+          targetType: entry.table,
+          targetId: null,
+          metadata: { table: entry.table, purgedCount: ids.length },
+          ip: null,
+          userAgent: "retention-gc-worker",
+        });
+
+        return { deletedCount: ids.length, refs: collected };
+      },
+    );
+
+    // Best-effort external blob delete AFTER the tx commits (mirrors empty-trash).
+    await deleteAttachmentBlobs(refs);
+    total += deletedCount;
+  }
+
+  return total;
+}
+
+/**
  * Run one full sweep across the RETENTION_REGISTRY.
  *
  * Each EXPIRY entry runs in its own $transaction (INV-C4a). A per-entry error
@@ -382,6 +516,11 @@ export async function sweepOnce(
         counts[tableName] = await workerPrisma.$transaction(async (tx) =>
           sweepAuditLogs(tx, entry),
         );
+      } else if (entry.kind === "PER_TENANT_TRASH") {
+        // Unlike other kinds, call sweepTrashEntry with workerPrisma DIRECTLY
+        // (no outer $transaction): it owns its own per-tenant transactions
+        // because the external blob delete must run after each DB tx commits.
+        counts[tableName] = await sweepTrashEntry(workerPrisma, entry, batchSize);
       }
     } catch (err) {
       // Per-entry error isolation (INV-C4b): log {table, code} — authoritative error record (F7).


### PR DESCRIPTION
## Summary

Follow-up to the retention-GC worker (#571; SC5 #576; SC4 #577). Implements **SC2**: auto-purge of soft-deleted (trashed) vault entries past a tenant-configured grace period, deferred in #571 because deleting them must also clean up encrypted `Attachment` blobs — and when an external blob backend (S3/Azure/GCS) is configured, a raw DB cascade DELETE would orphan the external objects.

## Design
New `PER_TENANT_TRASH` registry kind + `sweepTrashEntry`. Per tenant with `trashRetentionDays` set, the worker deletes `password_entries` / `team_password_entries` whose `deleted_at` is older than the grace period. Attachment blobs:
- **DB backend**: removed by the FK `ON DELETE CASCADE` (the blob is the inline `encrypted_data` column).
- **External backend**: the worker collects object refs via `collectEntryAttachmentRefs` **before** the cascade destroys the attachment rows, then best-effort deletes the external objects via `deleteAttachmentBlobs` **after** the DB transaction commits — mirroring the existing `empty-trash` flow.

Key points:
- **Tenant-configurable**: `Tenant.trashRetentionDays Int?` (NULL = never auto-purge; mirrors `auditLogRetentionDays`). Policy API/UI is a documented follow-up — this PR adds the column + worker only.
- **Multi-team grouping**: `collectEntryAttachmentRefs`'s team scope needs a single `teamId`, so the worker groups a tenant's trashed team entries by `team_id` and calls it once per team.
- **Least-privilege**: entry tables `SELECT+DELETE`, `attachments` `SELECT`-only. The RI cascade needs no child DELETE grant — proven by an integration test running the cascade as the worker role; history/favorites/tag-links/`password_shares` (SetNull) cascade with zero grants.
- Per-tenant `TRASH_RETENTION_PURGED` audit (only when a tenant has rows purged).

## Testing
- Unit: tenant enumeration (NULL skipped), cutoff math, and the **multi-team partition** (a tenant with trashed entries across ≥2 teams → `collectEntryAttachmentRefs` called once per team with correctly-partitioned ids).
- Integration (real DB, DB backend): past-grace purge + cascade attachment removal; within-grace kept; non-trashed kept; NULL-retention tenant skipped; worker-role cannot directly `DELETE attachments` (cascade works regardless).
- Full suite passes; `tsc --noEmit` clean (SC2 files); lint clean; `next build` green; `pre-pr.sh` 36/36; migrations applied to dev DB, grants verified via `information_schema`.

The real external-blob delete (S3/Azure/GCS) is not runnable in CI (no bucket) — covered by the mocked-blob-store multi-team unit test.

Remaining scope contracts (SC3, SC6, SC7) are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)