### PR TITLE
feat(security): tenant-configurable password-history auto-trim (SC3)

### DIFF
--- a/docs/archive/review/retention-history-trim-code-review.md
+++ b/docs/archive/review/retention-history-trim-code-review.md
@@ -1,0 +1,26 @@
+# Code Review: retention-history-trim (SC3)
+Date: 2026-06-18
+Review rounds: plan (1) + code (1), converged.
+
+## Plan review — 4 findings, all fixed pre-implementation
+- **F4 (functional)**: validateRegistry would silent-skip PER_TENANT_AGE — added an explicit branch (assertIdentifier table+cutoffColumn).
+- **F1 (test)**: registry.test DMMF loop didn't cover PER_TENANT_AGE — added a block asserting table+cutoffColumn(changed_at)+tenant_id resolve.
+- **F2 (test)**: count assertion updated (+2 PER_TENANT_AGE).
+- **F3 (consistency)**: do NOT reuse HISTORY_PURGE (operator-manual, ADMIN group). Added a dedicated `HISTORY_RETENTION_PURGED` in the MAINTENANCE group, consistent with SC4's CREDENTIAL_RETENTION_PURGED / SC2's TRASH_RETENTION_PURGED.
+
+## Code review — SC3 OK (no findings)
+All 10 focus areas verified clean: S1 SQL containment (table/cutoffColumn allowlist-validated boot+sweep; tenant.id/cutoff/batch bound; batch-bounded (id) IN); validator branch present; bypass_rls set first; R14 grant (2 leaf tables SELECT+DELETE, no over-grant); R12 audit coverage complete in MAINTENANCE group; dispatch correct (tx, per-entry isolation); registry DMMF cross-check non-vacuous; audit emitted only when deleted>0.
+
+Two non-blocking observations (no fix): T-OBS1 (team_password_entry_histories DMMF-tested + unit-tested but not separately integration-tested — identical abstracted codepath to the personal table which IS integration-tested; accepted); T-OBS2 (test-helper NULL literal, test-internal only).
+
+## Design note: PER_TENANT_AGE vs PER_TENANT_FN
+audit_logs (PER_TENANT_FN) routes deletion through a SECURITY DEFINER function because audit_logs DELETE is revoked from the app role for immutability. History is mutable/trimmable, so PER_TENANT_AGE does a plain direct batch-bounded DELETE with a normal grant — simpler and correct. This is the generic plain-per-tenant-age-delete kind.
+
+## Verification
+- Unit: 4 sweep-per-tenant-age tests (enumeration NULL-skip, cutoff math, SQL shape, audit-only-when-deleted>0) + registry DMMF/count. tsc clean for SC3 files.
+- Integration (real DB): trim-old/keep-recent; NULL-retention skip; worker-role least-privilege (can trim history, cannot delete audit_logs).
+- Full worker suite + audit coverage pass; lint clean; pre-pr.sh 36/36; migrations applied to dev DB, grants verified via information_schema.
+- Pre-existing unrelated tsc errors (tenant-admin-ttl / team-login / empty-trash test files, 40 on base) confirmed NOT in this diff and NOT a CI gate.
+
+## Verdict
+Converged. Tenant-configurable history auto-trim (`historyRetentionDays`, NULL = never), plain per-tenant age DELETE, least privilege, dedicated MAINTENANCE-group audit. Policy API/UI for historyRetentionDays is a documented follow-up. Age-based trim only (keep-last-N per-entry is out of scope).

--- a/docs/archive/review/retention-history-trim-plan.md
+++ b/docs/archive/review/retention-history-trim-plan.md
@@ -1,0 +1,83 @@
+# Plan: retention-history-trim (SC3)
+
+## Project context
+- Service (Next.js + Prisma 7 + PostgreSQL, multi-tenant RLS, least-privilege roles) + retention-GC worker (engine + SC5/SC4/SC2 merged or in-flight).
+- Test infra: unit + integration (real-DB) + CI.
+
+## Objective
+Auto-trim old password-entry history rows past a tenant-configured retention — `password_entry_histories` and `team_password_entry_histories` (column `changed_at`) — which #571 deferred (SC3). History accumulates as live entries are edited; the existing manual `purge-history` route is age-based per-tenant (`changed_at < now() - retentionDays`, default 90) but requires an operator to invoke it. This adds automatic per-tenant trimming.
+
+(History of a *deleted* entry is already removed by the FK cascade — `*_histories.entry_id → entry ON DELETE CASCADE` — so SC2's trash purge handles that. SC3 trims history of LIVE entries.)
+
+## Background facts (verified)
+- `password_entry_histories.changed_at` / `team_password_entry_histories.changed_at` — the age column. Both have `tenant_id`, RLS-enabled, indexed `@@index([entryId, changedAt])` + `@@index([tenantId])`.
+- Existing manual `purge-history` route: `changedAt < now() - retentionDays days`, scoped to the operator's tenant, default 90, min 1 max 3650 (src/app/api/maintenance/purge-history/route.ts).
+- This is the SAME age-based per-tenant shape as `audit_logs` (PER_TENANT_FN), but history needs NO SECURITY DEFINER function — a plain DELETE suffices (history is not immutable like audit_logs).
+
+## Policy decision
+- **Tenant-configurable retention** (consistent with SC2 trashRetentionDays / audit auditLogRetentionDays): add `Tenant.historyRetentionDays Int?` (NULL = never auto-trim). Cutoff: `changed_at < now() - historyRetentionDays days`.
+
+## Technical approach
+Add a generic registry kind **`PER_TENANT_AGE`**: deletes rows older than a per-tenant retention, parameterized by `table` + `cutoffColumn` + `tenantRetentionColumn`. Unlike PER_TENANT_FN (audit_logs, which routes through a definer fn for immutability), PER_TENANT_AGE does a plain batch-bounded DELETE. Two entries (one per history table).
+
+### Registry entry
+```
+interface PerTenantAgeEntry {
+  kind: "PER_TENANT_AGE";
+  table: string;                 // ^[a-z_]+$
+  cutoffColumn: string;          // ^[a-z_]+$, e.g. "changed_at"
+  tenantRetentionColumn: "historyRetentionDays";
+}
+```
+
+## Contracts
+
+### C1 — schema + migration — locked
+- Add `Tenant.historyRetentionDays Int? @map("history_retention_days")` (mirror auditLogRetentionDays/trashRetentionDays). Additive nullable migration. Policy API/UI out of scope (follow-up).
+
+### C2 — registry kind + entries + validator — locked
+- Extend `RetentionEntryKind` with `"PER_TENANT_AGE"`; add `PerTenantAgeEntry`; add 2 entries (password_entry_histories, team_password_entry_histories with cutoffColumn "changed_at").
+- **Validator (review F4 — MUST NOT FORGET)**: add an explicit `else if (entry.kind === "PER_TENANT_AGE")` branch to `validateRegistry` in index.ts running `assertIdentifier(entry.table)` + `assertIdentifier(entry.cutoffColumn)`. Without this branch the entry is silently skipped (no boot-time S1 check). No globalDelete field (the sweeper sets bypass_rls).
+- **DMMF cross-check (review F1 — MUST NOT FORGET)**: the registry.test.ts DMMF loop currently only processes EXPIRY/EXPIRY_GUARDED/EXPIRY_AUDIT_PROVENANCE/PER_TENANT_TRASH — add a `PER_TENANT_AGE` block asserting table + cutoffColumn (changed_at) + tenant_id resolve to real physical columns. Update the registry count assertion (+2 PER_TENANT_AGE) (review F2).
+
+### C3 — sweepPerTenantAge — locked
+- `sweepPerTenantAge(tx, entry, batchSize): Promise<number>` (takes a `tx`, dispatched via workerPrisma.$transaction like sweepAuditLogs):
+  - bypass_rls set first.
+  - Enumerate tenants with `<tenantRetentionColumn> NOT NULL` (one query: `tenant.findMany`).
+  - Per tenant: cutoff = now() - retention days; batch-bounded DELETE: `DELETE FROM <table> WHERE (id) IN (SELECT id FROM <table> WHERE tenant_id = $tenant AND <cutoffColumn> < $cutoff LIMIT $batch)`. (Both history tables have an `id` PK — verify.)
+  - Sum deleted across tenants. Return total.
+- Identifiers (table/cutoffColumn) allowlist-validated; tenant.id/cutoff/batch bound, not interpolated.
+- **Decision (corrected per review F3): emit a per-tenant `HISTORY_RETENTION_PURGED` audit** — a NEW action, NOT the existing `HISTORY_PURGE`. Reason: `HISTORY_PURGE` lives in the tenant ADMIN audit group, but the worker's auto-trim is a maintenance operation; SC4/SC2 put their worker actions in the MAINTENANCE group (`CREDENTIAL_RETENTION_PURGED`, `TRASH_RETENTION_PURGED`). A dedicated `HISTORY_RETENTION_PURGED` in MAINTENANCE keeps the worker actions consistent AND distinguishes operator-triggered manual purge (HISTORY_PURGE) from automatic retention trim. Emit when count>0, under the tenant, with metadata { table, purgedCount, triggeredBy: "retention-gc-worker" }.
+
+### C4 — sweepOnce dispatch — locked
+- Add explicit `else if (entry.kind === "PER_TENANT_AGE")` → `workerPrisma.$transaction(tx => sweepPerTenantAge(tx, entry, batchSize))` (same shape as PER_TENANT_FN — it takes a tx).
+
+### C5 — audit action — locked (corrected per review F3)
+- Add a NEW `AUDIT_ACTION.HISTORY_RETENTION_PURGED` — const + AUDIT_ACTION_VALUES + **MAINTENANCE** group (consistent with TRASH_RETENTION_PURGED / CREDENTIAL_RETENTION_PURGED) + en/ja AuditLog.json (ja non-katakana) + Prisma AuditAction enum + a SEPARATE enum migration (R24). Do NOT reuse HISTORY_PURGE (that is the operator-manual action, in the ADMIN group).
+
+### C6 — DB role grant — locked
+- Grant `passwd_retention_gc_worker`: `SELECT, DELETE` on `password_entry_histories`, `team_password_entry_histories`. `SELECT` on tenants (already granted). No cascade concern (history rows are leaves — verify no inbound FK). Verify against live DB.
+
+### C7 — tests — locked
+- registry.test.ts: count assertion +2 PER_TENANT_AGE; DMMF cross-check covers the new kind.
+- Unit (sweep-per-tenant-age.test.ts): tenant enumeration (NULL skipped), cutoff math, SQL shape (batch-bounded (id) IN, bound params), audit emit only when count>0.
+- Integration (real DB): tenant historyRetentionDays=90 → history row with changed_at = now()-91d deleted, recent (now()-5d) kept; NULL-retention tenant untouched; role-grant positive + cannot-delete-other-table negative.
+
+## Go/No-Go Gate
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | Tenant.historyRetentionDays + migration | locked |
+| C2 | PER_TENANT_AGE kind + 2 entries + validator | locked |
+| C3 | sweepPerTenantAge (per-tenant batch DELETE) | locked |
+| C4 | sweepOnce dispatch | locked |
+| C5 | reuse HISTORY_PURGE audit | locked |
+| C6 | DB role grant | locked |
+| C7 | unit + integration tests | locked |
+
+## Considerations
+- **Why PER_TENANT_AGE not PER_TENANT_FN?** audit_logs uses a SECURITY DEFINER fn because audit_logs DELETE is revoked from the app role (immutability). History is mutable/trimmable — a plain DELETE with a direct grant is correct and simpler. PER_TENANT_AGE is the generic plain-DELETE-by-age kind.
+- **Keep-last-N vs age**: this PR does age-based trim only (matches the existing manual route). A per-entry "keep last N versions" trim is a separate concern (not deferred here — out of scope, age-based covers the accumulation problem).
+- Out of scope: policy API/UI for historyRetentionDays (follow-up); SC6/SC7.
+
+## Scope contract
+SC6/SC7 remain separate follow-ups. Policy API/UI for historyRetentionDays is a documented follow-up.

--- a/messages/en/AuditLog.json
+++ b/messages/en/AuditLog.json
@@ -253,6 +253,7 @@
   "RETENTION_GC_SWEEP": "Retention GC sweep executed (system worker)",
   "CREDENTIAL_RETENTION_PURGED": "Expired credential purged after recording its provenance (system worker)",
   "TRASH_RETENTION_PURGED": "Expired trashed entries purged (system worker)",
+  "HISTORY_RETENTION_PURGED": "Expired entry history trimmed (system worker)",
   "AUDIT_DELIVERY_FAILED": "Audit delivery failed",
   "AUDIT_DELIVERY_DEAD_LETTER": "Audit delivery dead-lettered",
   "AUDIT_ANCHOR_PUBLISHED": "Audit anchor manifest published",

--- a/messages/ja/AuditLog.json
+++ b/messages/ja/AuditLog.json
@@ -253,6 +253,7 @@
   "RETENTION_GC_SWEEP": "保持期限切れデータの定期削除を実行（システムワーカー）",
   "CREDENTIAL_RETENTION_PURGED": "期限切れ認証情報を証跡記録のうえ削除（システムワーカー）",
   "TRASH_RETENTION_PURGED": "ゴミ箱の期限切れエントリを削除（システムワーカー）",
+  "HISTORY_RETENTION_PURGED": "期限切れの変更履歴を削除（システムワーカー）",
   "AUDIT_DELIVERY_FAILED": "監査配信失敗",
   "AUDIT_DELIVERY_DEAD_LETTER": "監査配信デッドレター化",
   "AUDIT_ANCHOR_PUBLISHED": "監査アンカーマニフェストを公開",

--- a/prisma/migrations/20260618180000_add_history_retention_purged_action/migration.sql
+++ b/prisma/migrations/20260618180000_add_history_retention_purged_action/migration.sql
@@ -1,0 +1,3 @@
+-- SC3: audit action for automatic password-entry history trimming (system worker).
+-- Separate migration so the enum value is committed before any usage.
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'HISTORY_RETENTION_PURGED';

--- a/prisma/migrations/20260618190000_add_history_retention_days/migration.sql
+++ b/prisma/migrations/20260618190000_add_history_retention_days/migration.sql
@@ -1,0 +1,2 @@
+-- SC3: per-tenant password-entry history auto-trim retention. NULL = never auto-trim.
+ALTER TABLE "tenants" ADD COLUMN IF NOT EXISTS "history_retention_days" INTEGER;

--- a/prisma/migrations/20260618200000_retention_gc_history_grants/migration.sql
+++ b/prisma/migrations/20260618200000_retention_gc_history_grants/migration.sql
@@ -1,0 +1,11 @@
+-- SC3: grant the retention-gc worker SELECT + DELETE on the entry-history tables
+-- it trims. Both are leaf tables (no inbound FK) — a plain batch DELETE; no
+-- cascade or definer function needed (history is mutable, unlike audit_logs).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'passwd_retention_gc_worker') THEN
+    GRANT SELECT, DELETE ON TABLE "password_entry_histories" TO passwd_retention_gc_worker;
+    GRANT SELECT, DELETE ON TABLE "team_password_entry_histories" TO passwd_retention_gc_worker;
+  END IF;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -592,6 +592,9 @@ model Tenant {
   // Trash (soft-deleted entry) auto-purge retention. NULL = never auto-purge.
   trashRetentionDays Int? @map("trash_retention_days")
 
+  // Password-entry history auto-trim retention. NULL = never auto-trim.
+  historyRetentionDays Int? @map("history_retention_days")
+
   // Tenant-wide password policy
   tenantMinPasswordLength Int     @default(0) @map("tenant_min_password_length")
   tenantRequireUppercase  Boolean @default(false) @map("tenant_require_uppercase")
@@ -931,6 +934,7 @@ enum AuditAction {
   RETENTION_GC_SWEEP
   CREDENTIAL_RETENTION_PURGED
   TRASH_RETENTION_PURGED
+  HISTORY_RETENTION_PURGED
   MASTER_KEY_ROTATION
   VERIFIER_PEPPER_ROTATE_BEGIN
   VERIFIER_PEPPER_ROTATE_COMPLETE

--- a/src/__tests__/db-integration/retention-gc-history-trim.integration.test.ts
+++ b/src/__tests__/db-integration/retention-gc-history-trim.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Real-DB tests for PER_TENANT_AGE history auto-trim (SC3).
+ *
+ * Trims password_entry_histories rows whose changed_at is past the tenant's
+ * historyRetentionDays. NULL retention = skip. Mirrors the audit_logs per-tenant
+ * pattern but with a plain DELETE (history is mutable, no definer fn).
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { randomUUID } from "node:crypto";
+import {
+  createTestContext,
+  setBypassRlsGucs,
+  type TestContext,
+} from "./helpers";
+import { sweepPerTenantAge } from "@/workers/retention-gc-worker/sweep";
+import { RETENTION_REGISTRY } from "@/workers/retention-gc-worker/registry";
+
+const historyEntry = RETENTION_REGISTRY.find(
+  (e) =>
+    e.kind === "PER_TENANT_AGE" && e.table === "password_entry_histories",
+)! as Extract<
+  (typeof RETENTION_REGISTRY)[number],
+  { kind: "PER_TENANT_AGE" }
+>;
+
+describe("retention-gc history auto-trim (SC3)", () => {
+  let ctx: TestContext;
+  let tenantId: string;
+  let userId: string;
+  let entryId: string;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+  });
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+  beforeEach(async () => {
+    tenantId = await ctx.createTenant();
+    userId = await ctx.createUser(tenantId);
+    entryId = randomUUID();
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO password_entries (id, user_id, tenant_id, encrypted_blob, blob_iv, blob_auth_tag, encrypted_overview, overview_iv, overview_auth_tag, key_version, created_at, updated_at)
+         VALUES ($1::uuid, $2::uuid, $3::uuid, '\\x00', 'iv', 'tag', '\\x00', 'oiv', 'otag', 1, now(), now())`,
+        entryId,
+        userId,
+        tenantId,
+      );
+    });
+  });
+  afterEach(async () => {
+    await ctx.deleteTestData(tenantId);
+  });
+
+  async function setRetention(days: number | null): Promise<void> {
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `UPDATE tenants SET history_retention_days = ${days === null ? "NULL" : "$2"} WHERE id = $1::uuid`,
+        ...(days === null ? [tenantId] : [tenantId, days]),
+      );
+    });
+  }
+
+  async function insertHistory(ageExpr: string): Promise<string> {
+    const id = randomUUID();
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO password_entry_histories (id, entry_id, tenant_id, encrypted_blob, blob_iv, blob_auth_tag, key_version, changed_at)
+         VALUES ($1::uuid, $2::uuid, $3::uuid, '\\x00', 'iv', 'tag', 1, ${ageExpr})`,
+        id,
+        entryId,
+        tenantId,
+      );
+    });
+    return id;
+  }
+
+  async function historyExists(id: string): Promise<boolean> {
+    const rows = await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      return tx.$queryRawUnsafe<{ id: string }[]>(
+        `SELECT id FROM password_entry_histories WHERE id = $1::uuid`,
+        id,
+      );
+    });
+    return rows.length > 0;
+  }
+
+  it("trims history older than the tenant's retention, keeps recent history", async () => {
+    await setRetention(90);
+    const old = await insertHistory("now() - interval '91 days'");
+    const recent = await insertHistory("now() - interval '5 days'");
+
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await sweepPerTenantAge(tx, historyEntry, 100);
+    });
+
+    expect(await historyExists(old)).toBe(false);
+    expect(await historyExists(recent)).toBe(true);
+  });
+
+  it("does NOT trim any history when the tenant's retention is NULL", async () => {
+    await setRetention(null);
+    const old = await insertHistory("now() - interval '400 days'");
+
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await sweepPerTenantAge(tx, historyEntry, 100);
+    });
+
+    expect(await historyExists(old)).toBe(true);
+  });
+
+  it("worker role CAN trim history but CANNOT delete audit_logs (least privilege)", async () => {
+    await setRetention(30);
+    const old = await insertHistory("now() - interval '31 days'");
+
+    await ctx.retentionWorker.prisma.$transaction(async (tx) => {
+      await sweepPerTenantAge(tx, historyEntry, 100);
+    });
+    expect(await historyExists(old)).toBe(false);
+
+    await expect(
+      ctx.retentionWorker.prisma.$transaction(async (tx) => {
+        await tx.$executeRaw`SELECT set_config('app.bypass_rls', 'on', true)`;
+        await tx.$executeRawUnsafe(
+          `DELETE FROM audit_logs WHERE tenant_id = $1::uuid`,
+          tenantId,
+        );
+      }),
+    ).rejects.toThrow(/permission denied/);
+  });
+});

--- a/src/lib/constants/audit/audit.ts
+++ b/src/lib/constants/audit/audit.ts
@@ -85,6 +85,8 @@ export const AUDIT_ACTION = {
   // Per-tenant trash auto-purge: the retention-gc-worker deletes soft-deleted
   // vault entries past the tenant's trashRetentionDays grace period (SC2).
   TRASH_RETENTION_PURGED: "TRASH_RETENTION_PURGED",
+  // Password-entry history auto-trim past per-tenant retention (system worker).
+  HISTORY_RETENTION_PURGED: "HISTORY_RETENTION_PURGED",
   // MASTER_KEY_ROTATION: legacy single-action key — retained for old audit rows
   // and for the share-only rotation path (A04-4 keeps emit-site removed and
   // routes the four phase actions below). Do NOT add new emit sites for this
@@ -277,6 +279,7 @@ export const AUDIT_ACTION_VALUES = [
   AUDIT_ACTION.RETENTION_GC_SWEEP,
   AUDIT_ACTION.CREDENTIAL_RETENTION_PURGED,
   AUDIT_ACTION.TRASH_RETENTION_PURGED,
+  AUDIT_ACTION.HISTORY_RETENTION_PURGED,
   AUDIT_ACTION.SEND_CREATE,
   AUDIT_ACTION.SEND_REVOKE,
   AUDIT_ACTION.SHARE_ACCESS_VERIFY_SUCCESS,
@@ -732,6 +735,7 @@ export const AUDIT_ACTION_GROUPS_TENANT: Record<string, AuditAction[]> = {
     AUDIT_ACTION.RETENTION_GC_SWEEP,
     AUDIT_ACTION.CREDENTIAL_RETENTION_PURGED,
     AUDIT_ACTION.TRASH_RETENTION_PURGED,
+    AUDIT_ACTION.HISTORY_RETENTION_PURGED,
     AUDIT_ACTION.AUDIT_DELIVERY_FAILED,
     AUDIT_ACTION.AUDIT_DELIVERY_DEAD_LETTER,
     AUDIT_ACTION.AUDIT_ANCHOR_PUBLISHED,

--- a/src/workers/retention-gc-worker/__tests__/registry.test.ts
+++ b/src/workers/retention-gc-worker/__tests__/registry.test.ts
@@ -33,7 +33,7 @@ for (const model of Prisma.dmmf.datamodel.models) {
 }
 
 describe("RETENTION_REGISTRY — schema cross-check (INV-C1a)", () => {
-  it("contains exactly 6 EXPIRY + 1 EXPIRY_GUARDED + 4 EXPIRY_AUDIT_PROVENANCE + 1 PER_TENANT_FN + 2 PER_TENANT_TRASH entries", () => {
+  it("contains exactly 6 EXPIRY + 1 EXPIRY_GUARDED + 4 EXPIRY_AUDIT_PROVENANCE + 1 PER_TENANT_FN + 2 PER_TENANT_TRASH + 2 PER_TENANT_AGE entries", () => {
     const expiry = RETENTION_REGISTRY.filter((e) => e.kind === "EXPIRY");
     const guarded = RETENTION_REGISTRY.filter(
       (e) => e.kind === "EXPIRY_GUARDED",
@@ -47,11 +47,15 @@ describe("RETENTION_REGISTRY — schema cross-check (INV-C1a)", () => {
     const perTenantTrash = RETENTION_REGISTRY.filter(
       (e) => e.kind === "PER_TENANT_TRASH",
     );
+    const perTenantAge = RETENTION_REGISTRY.filter(
+      (e) => e.kind === "PER_TENANT_AGE",
+    );
     expect(expiry).toHaveLength(6);
     expect(guarded).toHaveLength(1);
     expect(provenance).toHaveLength(4);
     expect(perTenant).toHaveLength(1);
     expect(perTenantTrash).toHaveLength(2);
+    expect(perTenantAge).toHaveLength(2);
   });
 
   it("has no duplicate table entries (INV-C1d)", () => {
@@ -120,6 +124,21 @@ describe("RETENTION_REGISTRY — schema cross-check (INV-C1a)", () => {
       const model = modelsByPhysicalName.get(entry.table);
       expect(model, `model "${entry.table}" not found`).toBeDefined();
       expect(model!.fields.has("deleted_at")).toBe(true);
+      expect(model!.fields.has("tenant_id")).toBe(true);
+    });
+  }
+
+  // PER_TENANT_AGE: table must resolve and carry the cutoffColumn + tenant_id.
+  for (const entry of RETENTION_REGISTRY) {
+    if (entry.kind !== "PER_TENANT_AGE") continue;
+
+    it(`age entry "${entry.table}" resolves and carries cutoffColumn "${entry.cutoffColumn}" + tenant_id`, () => {
+      const model = modelsByPhysicalName.get(entry.table);
+      expect(model, `model "${entry.table}" not found`).toBeDefined();
+      expect(
+        model!.fields.has(entry.cutoffColumn),
+        `cutoffColumn "${entry.cutoffColumn}" missing on "${entry.table}"`,
+      ).toBe(true);
       expect(model!.fields.has("tenant_id")).toBe(true);
     });
   }

--- a/src/workers/retention-gc-worker/__tests__/sweep-per-tenant-age.test.ts
+++ b/src/workers/retention-gc-worker/__tests__/sweep-per-tenant-age.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for sweepPerTenantAge (SC3): tenant enumeration (NULL skipped),
+ * cutoff math, batch-bounded DELETE SQL shape (bound params, allowlisted
+ * identifiers), and per-tenant audit emitted only when rows are trimmed.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { Prisma } from "@prisma/client";
+import { sweepPerTenantAge } from "../sweep";
+import type { PerTenantAgeEntry } from "../registry";
+
+const ENTRY: PerTenantAgeEntry = {
+  kind: "PER_TENANT_AGE",
+  table: "password_entry_histories",
+  cutoffColumn: "changed_at",
+  tenantRetentionColumn: "historyRetentionDays",
+};
+
+function makeTx(
+  tenants: Array<{ id: string; historyRetentionDays: number | null }>,
+  deletedPerTenant: number,
+) {
+  const executeRaw = vi.fn().mockResolvedValue(undefined); // set_config
+  const executeRawUnsafe = vi.fn().mockResolvedValue(deletedPerTenant); // DELETE
+  const findMany = vi.fn().mockResolvedValue(tenants);
+  const auditOutbox = { create: vi.fn().mockResolvedValue(undefined) };
+  const queryRaw = vi
+    .fn()
+    .mockResolvedValueOnce([{ bypass_rls: "on", tenant_id: "" }])
+    .mockResolvedValue([{ ok: true }]);
+  const tx = {
+    $executeRaw: executeRaw,
+    $executeRawUnsafe: executeRawUnsafe,
+    $queryRaw: queryRaw,
+    tenant: { findMany },
+    auditOutbox,
+  } as unknown as Prisma.TransactionClient;
+  return { tx, executeRawUnsafe, findMany, auditOutbox };
+}
+
+describe("sweepPerTenantAge (SC3)", () => {
+  it("enumerates only tenants with the retention column NOT NULL", async () => {
+    const { tx, findMany } = makeTx([], 0);
+    await sweepPerTenantAge(tx, ENTRY, 100);
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { historyRetentionDays: { not: null } },
+      }),
+    );
+  });
+
+  it("DELETEs with batch-bounded (id) IN (SELECT ... LIMIT) and bound params (tenant, cutoff, batch)", async () => {
+    const tenantId = "11111111-1111-4111-8111-111111111111";
+    const { tx, executeRawUnsafe } = makeTx(
+      [{ id: tenantId, historyRetentionDays: 90 }],
+      5,
+    );
+
+    const before = Date.now();
+    const total = await sweepPerTenantAge(tx, ENTRY, 200);
+    const after = Date.now();
+
+    expect(total).toBe(5);
+    const [sql, ...params] = executeRawUnsafe.mock.calls[0];
+    expect(sql).toMatch(
+      /DELETE FROM password_entry_histories\s+WHERE \(id\) IN \(\s*SELECT id FROM password_entry_histories\s+WHERE tenant_id = \$1::uuid\s+AND changed_at < \$2::timestamptz\s+LIMIT \$3\s*\)/,
+    );
+    expect(sql).not.toContain("${");
+    // params: [tenantId, cutoffDate, batchSize]
+    expect(params[0]).toBe(tenantId);
+    expect(params[2]).toBe(200);
+    const cutoff = params[1] as Date;
+    const expectedMs = 90 * 24 * 60 * 60 * 1000;
+    // cutoff ≈ now - 90d (within the test window)
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(before - expectedMs - 1000);
+    expect(cutoff.getTime()).toBeLessThanOrEqual(after - expectedMs + 1000);
+  });
+
+  it("emits a per-tenant HISTORY_RETENTION_PURGED audit only when rows were trimmed", async () => {
+    const tenantId = "22222222-2222-4222-8222-222222222222";
+    const { tx, auditOutbox } = makeTx(
+      [{ id: tenantId, historyRetentionDays: 30 }],
+      3,
+    );
+    await sweepPerTenantAge(tx, ENTRY, 100);
+    expect(auditOutbox.create).toHaveBeenCalledTimes(1);
+    const emitted = auditOutbox.create.mock.calls[0][0];
+    expect(emitted.data.tenantId).toBe(tenantId);
+    const payload = emitted.data.payload;
+    expect(payload.action).toBe("HISTORY_RETENTION_PURGED");
+    expect(payload.metadata.purgedCount).toBe(3);
+    expect(payload.metadata.table).toBe("password_entry_histories");
+  });
+
+  it("emits NO audit when a tenant has zero rows to trim", async () => {
+    const { tx, auditOutbox } = makeTx(
+      [{ id: "33333333-3333-4333-8333-333333333333", historyRetentionDays: 30 }],
+      0,
+    );
+    const total = await sweepPerTenantAge(tx, ENTRY, 100);
+    expect(total).toBe(0);
+    expect(auditOutbox.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/workers/retention-gc-worker/index.ts
+++ b/src/workers/retention-gc-worker/index.ts
@@ -119,6 +119,12 @@ export function validateRegistry(
       // are literal-union types. The sweeper sets bypass_rls explicitly (like
       // sweepAuditLogs), so there is no globalDelete flag to enforce.
       assertIdentifier(entry.table);
+    } else if (entry.kind === "PER_TENANT_AGE") {
+      // table + cutoffColumn are interpolated into the DELETE SQL → allowlist
+      // both at boot (S1). tenantRetentionColumn is a literal-union type. The
+      // sweeper sets bypass_rls explicitly, so no globalDelete flag to enforce.
+      assertIdentifier(entry.table);
+      assertIdentifier(entry.cutoffColumn);
     }
     // PER_TENANT_FN entries have no free identifiers to validate — the table,
     // fn, and tenantRetentionColumn fields are literal union types.

--- a/src/workers/retention-gc-worker/registry.ts
+++ b/src/workers/retention-gc-worker/registry.ts
@@ -16,7 +16,8 @@ export type RetentionEntryKind =
   | "EXPIRY_GUARDED"
   | "EXPIRY_AUDIT_PROVENANCE"
   | "PER_TENANT_FN"
-  | "PER_TENANT_TRASH";
+  | "PER_TENANT_TRASH"
+  | "PER_TENANT_AGE";
 
 /**
  * Closed set of "no live dependents" guards. Each maps to a fixed SQL fragment
@@ -126,12 +127,29 @@ export interface PerTenantTrashEntry {
   tenantRetentionColumn: "trashRetentionDays";
 }
 
+/**
+ * A plain per-tenant age-based DELETE: removes rows older than a per-tenant
+ * retention. Unlike PER_TENANT_FN (audit_logs, which routes through a SECURITY
+ * DEFINER fn because audit_logs DELETE is revoked for immutability), these tables
+ * are trimmable with a direct batch-bounded DELETE. Used for password-entry
+ * history (SC3).
+ */
+export interface PerTenantAgeEntry {
+  kind: "PER_TENANT_AGE";
+  table: string;
+  /** Age column compared to now() - retention (^[a-z_]+$), e.g. "changed_at". */
+  cutoffColumn: string;
+  /** Prisma model field holding per-tenant retention days (null = skip). */
+  tenantRetentionColumn: "historyRetentionDays";
+}
+
 export type RetentionEntry =
   | ExpiryEntry
   | GuardedExpiryEntry
   | AuditProvenanceEntry
   | PerTenantFnEntry
-  | PerTenantTrashEntry;
+  | PerTenantTrashEntry
+  | PerTenantAgeEntry;
 
 /**
  * EXPIRY tables that are intentionally RLS-free (no RLS policy, no tenant_id),
@@ -310,5 +328,19 @@ export const RETENTION_REGISTRY: readonly RetentionEntry[] = [
     table: "team_password_entries",
     scopeKind: "team",
     tenantRetentionColumn: "trashRetentionDays",
+  },
+  {
+    // Personal password-entry history auto-trim past the per-tenant retention (SC3).
+    kind: "PER_TENANT_AGE",
+    table: "password_entry_histories",
+    cutoffColumn: "changed_at",
+    tenantRetentionColumn: "historyRetentionDays",
+  },
+  {
+    // Team password-entry history auto-trim past the per-tenant retention (SC3).
+    kind: "PER_TENANT_AGE",
+    table: "team_password_entry_histories",
+    cutoffColumn: "changed_at",
+    tenantRetentionColumn: "historyRetentionDays",
   },
 ] as const;

--- a/src/workers/retention-gc-worker/sweep.ts
+++ b/src/workers/retention-gc-worker/sweep.ts
@@ -35,6 +35,7 @@ import {
   type AuditProvenanceEntry,
   type PerTenantFnEntry,
   type PerTenantTrashEntry,
+  type PerTenantAgeEntry,
 } from "./registry";
 import { USER_AGENT_MAX_LENGTH } from "@/lib/validations/common.server";
 import {
@@ -345,6 +346,80 @@ export async function sweepAuditLogs(
 }
 
 /**
+ * Plain per-tenant age-based DELETE (SC3): trims rows older than each tenant's
+ * configured retention. Unlike sweepAuditLogs (definer fn for immutability),
+ * these tables (entry history) are trimmed with a direct batch-bounded DELETE.
+ *
+ * Takes a `tx` (dispatched via workerPrisma.$transaction, like sweepAuditLogs).
+ * Sets bypass_rls first; enumerates tenants with the retention column NOT NULL;
+ * per tenant deletes `<table>` rows where `<cutoffColumn> < now() - retention`.
+ * Emits a per-tenant HISTORY_RETENTION_PURGED audit when a tenant has rows trimmed.
+ *
+ * @returns Total rows deleted across all enumerated tenants.
+ */
+export async function sweepPerTenantAge(
+  tx: Prisma.TransactionClient,
+  entry: PerTenantAgeEntry,
+  batchSize: number,
+): Promise<number> {
+  assertIdentifier(entry.table);
+  assertIdentifier(entry.cutoffColumn);
+
+  await tx.$executeRaw`SELECT set_config('app.bypass_rls', 'on', true)`;
+
+  // Enumerate only tenants with the retention column configured (NULL → skip).
+  const tenants = await tx.tenant.findMany({
+    where: { [entry.tenantRetentionColumn]: { not: null } },
+    select: { id: true, [entry.tenantRetentionColumn]: true },
+  });
+
+  let total = 0;
+  for (const tenant of tenants) {
+    const retention = tenant[entry.tenantRetentionColumn] as number;
+    const cutoff = new Date(Date.now() - retention * MS_PER_DAY);
+
+    // Batch-bounded (id) IN (SELECT id ... LIMIT) — table/cutoffColumn are
+    // allowlist-validated; tenant id, cutoff, batchSize are bound params.
+    const deleted = await tx.$executeRawUnsafe<number>(
+      `DELETE FROM ${entry.table}
+         WHERE (id) IN (
+           SELECT id FROM ${entry.table}
+           WHERE tenant_id = $1::uuid
+             AND ${entry.cutoffColumn} < $2::timestamptz
+           LIMIT $3
+         )`,
+      tenant.id,
+      cutoff,
+      batchSize,
+    );
+
+    if (deleted > 0) {
+      await enqueueAuditInWorkerTx(tx, tenant.id, {
+        scope: AUDIT_SCOPE.TENANT,
+        action: AUDIT_ACTION.HISTORY_RETENTION_PURGED,
+        userId: SYSTEM_ACTOR_ID,
+        actorType: ACTOR_TYPE.SYSTEM,
+        serviceAccountId: null,
+        teamId: null,
+        targetType: entry.table,
+        targetId: null,
+        metadata: {
+          table: entry.table,
+          purgedCount: deleted,
+          triggeredBy: "retention-gc-worker",
+        },
+        ip: null,
+        userAgent: "retention-gc-worker",
+      });
+    }
+
+    total += deleted;
+  }
+
+  return total;
+}
+
+/**
  * Auto-purge soft-deleted (trashed) vault entries past each tenant's configured
  * grace period (SC2). One PER_TENANT_TRASH entry per entry table.
  *
@@ -521,6 +596,10 @@ export async function sweepOnce(
         // (no outer $transaction): it owns its own per-tenant transactions
         // because the external blob delete must run after each DB tx commits.
         counts[tableName] = await sweepTrashEntry(workerPrisma, entry, batchSize);
+      } else if (entry.kind === "PER_TENANT_AGE") {
+        counts[tableName] = await workerPrisma.$transaction(async (tx) =>
+          sweepPerTenantAge(tx, entry, batchSize),
+        );
       }
     } catch (err) {
       // Per-entry error isolation (INV-C4b): log {table, code} — authoritative error record (F7).


### PR DESCRIPTION
## Summary

Follow-up to the retention-GC worker (#571; SC5 #576; SC4 #577; SC2 #578). Implements **SC3**: automatic trimming of old password-entry history (`password_entry_histories`, `team_password_entry_histories`) past a tenant-configured retention, deferred in #571. History accumulates as live entries are edited; the existing manual `purge-history` route is age-based per-tenant but requires an operator to invoke it.

(History of a *deleted* entry is already removed by the FK cascade — SC2's trash purge handles that. SC3 trims history of LIVE entries.)

## Design
New `PER_TENANT_AGE` registry kind + `sweepPerTenantAge`: per tenant with `historyRetentionDays` set, a plain batch-bounded `DELETE` of rows where `changed_at < now() - retention`. Unlike `audit_logs` (`PER_TENANT_FN`, which routes through a SECURITY DEFINER function because audit_logs DELETE is revoked for immutability), history is mutable — a direct grant + plain DELETE is correct and simpler.

- **Tenant-configurable**: `Tenant.historyRetentionDays Int?` (NULL = never auto-trim; mirrors `auditLogRetentionDays` / `trashRetentionDays`). Policy API/UI is a documented follow-up — this PR adds the column + worker only.
- **S1 containment**: `table` + `cutoffColumn` allowlist-validated (`^[a-z_]+$`) at boot and sweep; tenant id / cutoff / batch size are bound parameters; batch-bounded `(id) IN (SELECT id ... LIMIT $3)`.
- **Least-privilege**: `SELECT+DELETE` on the two leaf history tables only.
- **Dedicated audit**: a new `HISTORY_RETENTION_PURGED` action in the MAINTENANCE group (consistent with SC4/SC2 worker actions), distinct from the operator-manual `HISTORY_PURGE` (ADMIN group). Emitted per tenant only when rows are trimmed.

## Testing
- Unit: tenant enumeration (NULL skipped), cutoff math, SQL shape (batch-bounded, bound params), audit-only-when-trimmed.
- Integration (real DB): trim-old/keep-recent; NULL-retention skip; worker-role least-privilege (can trim history, cannot delete audit_logs).
- Full suite passes; `tsc --noEmit` clean (SC3 files); lint clean; `next build` green; `pre-pr.sh` 36/36; migrations applied to dev DB, grants verified via `information_schema`.

Age-based trim only (per-entry keep-last-N is out of scope). Remaining scope contracts (SC6, SC7) are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)