### PR TITLE
feat(security): per-tenant retention for append-only logs (SC7)

### DIFF
--- a/docs/archive/review/retention-append-only-logs-code-review.md
+++ b/docs/archive/review/retention-append-only-logs-code-review.md
@@ -1,0 +1,29 @@
+# Code Review: retention-append-only-logs (SC7)
+Date: 2026-06-18
+Review rounds: plan (1) + code (1), converged.
+
+## Plan review — clean
+The #571 deferral note ("needs schema cutoff columns") was wrong — all 3 tables already have a timestamp + tenant_id + id PK, so SC7 reuses the SC3 PER_TENANT_AGE kind with no schema cutoff column. Plan OK; per-table individual retention fields (user-confirmed).
+
+## Code review — SC7 OK (no findings)
+All 8 focus areas verified clean:
+- auditAction parameterization: sweepPerTenantAge emits AUDIT_ACTION[entry.auditAction]; both SC3 history entries got HISTORY_RETENTION_PURGED, the 3 SC7 log entries use LOG_RETENTION_PURGED; unit test asserts both independently (non-vacuous).
+- `as unknown as` cast (tenant.findMany computed-select): sound — Prisma returns exactly { id, [col] }; the cast narrows the inference-widened ~50-model union; `col` is an ORM key only, never raw SQL.
+- S1: table + cutoffColumn allowlist-validated (boot + sweep); tenantRetentionColumn is a closed literal union (ORM key only). directory_sync_logs correctly uses started_at (no created_at).
+- R14: 3 leaf tables SELECT+DELETE, no inbound FK, no over-grant.
+- R12: LOG_RETENTION_PURGED in all sites + MAINTENANCE group + separate enum migration; coverage tests pass.
+- registry.test count → 5 PER_TENANT_AGE; DMMF block auto-covers the 3 new entries (created_at/started_at/created_at).
+- 3 additive nullable Tenant columns.
+
+One low note (no fix): T1 makeTx test-helper type widened to Record<string,...> (accepts any key) — acceptable given the integration test exercises the real DB path and the assertions catch wrong values.
+
+## Design note
+SC7 is the cleanest follow-up — it reuses SC3's PER_TENANT_AGE kind with zero new sweep logic. The only additions: 3 Tenant retention columns, a `tenantRetentionColumn` union widening, an `auditAction` field parameterizing the audit action (HISTORY vs LOG), a new LOG_RETENTION_PURGED action, 3 registry entries, and grants.
+
+## Verification
+- Unit: 91 worker tests (incl. auditAction parameterization for both HISTORY and LOG). tsc clean for SC7 files.
+- Integration (real DB, share_access_logs representative): trim-old/keep-recent; NULL-retention skip; worker-role least-privilege. directory_sync_logs/notifications share the identical codepath (DMMF + unit covered).
+- Full worker suite + audit coverage pass; lint clean; pre-pr.sh 36/36; migrations applied to dev DB, grants verified via information_schema.
+
+## Verdict
+Converged. Per-tenant per-table retention for share_access_logs / directory_sync_logs / notifications, reusing PER_TENANT_AGE. Policy API/UI for the 3 retention fields is a documented follow-up. Only SC6 remains.

--- a/docs/archive/review/retention-append-only-logs-plan.md
+++ b/docs/archive/review/retention-append-only-logs-plan.md
@@ -1,0 +1,74 @@
+# Plan: retention-append-only-logs (SC7)
+
+## Project context
+- Service (Next.js + Prisma 7 + PostgreSQL, multi-tenant RLS, least-privilege roles) + retention-GC worker (engine + SC5/SC4/SC2/SC3 merged/in-flight). SC3 added the generic `PER_TENANT_AGE` kind (plain per-tenant age-based DELETE).
+
+## Objective
+Add per-tenant retention to the three append-only log tables #571 deferred (SC7): `share_access_logs`, `directory_sync_logs`, `notifications`. The #571 note said these "need schema cutoff columns" — but verified: ALL THREE already have a timestamp column + `tenant_id` + `id` PK. So SC7 needs NO schema cutoff column; each is a straightforward `PER_TENANT_AGE` entry (the kind SC3 created).
+
+## Background facts (verified)
+| Table | timestamp (cutoff) | tenant_id | id PK | RLS |
+|-------|--------------------|-----------|-------|-----|
+| `share_access_logs` | `created_at` | yes | yes | yes |
+| `directory_sync_logs` | `started_at` | yes | yes | yes |
+| `notifications` | `created_at` | yes | yes | yes |
+
+## Policy decision (user-confirmed)
+- **Per-table individual retention fields** (consistent with prior SCs): add `Tenant.shareAccessLogRetentionDays`, `directorySyncLogRetentionDays`, `notificationRetentionDays` (all `Int?`, NULL = never auto-delete). This lets a tenant tune each independently (notifications short, audit-style logs longer).
+
+## Technical approach
+Reuse the SC3 `PER_TENANT_AGE` kind. Widen its `tenantRetentionColumn` type from the literal `"historyRetentionDays"` to a union of all per-tenant-age retention columns. Add 3 registry entries.
+
+### Type change
+```
+// registry.ts — widen PerTenantAgeEntry.tenantRetentionColumn:
+tenantRetentionColumn:
+  | "historyRetentionDays"
+  | "shareAccessLogRetentionDays"
+  | "directorySyncLogRetentionDays"
+  | "notificationRetentionDays";
+```
+sweepPerTenantAge already reads `tenant[entry.tenantRetentionColumn]` and `where: { [entry.tenantRetentionColumn]: { not: null } }` generically — no sweep logic change needed.
+
+## Contracts
+
+### C1 — schema + migration — locked
+- Add 3 `Int?` columns to Tenant: `shareAccessLogRetentionDays @map("share_access_log_retention_days")`, `directorySyncLogRetentionDays @map("directory_sync_log_retention_days")`, `notificationRetentionDays @map("notification_retention_days")`. One additive migration (3 ADD COLUMN IF NOT EXISTS). Policy API/UI out of scope (follow-up).
+
+### C2 — registry entries + type widening — locked
+- Widen `PerTenantAgeEntry.tenantRetentionColumn` union (C2 type above).
+- Add 3 PER_TENANT_AGE entries: share_access_logs/created_at/shareAccessLogRetentionDays; directory_sync_logs/started_at/directorySyncLogRetentionDays; notifications/created_at/notificationRetentionDays.
+- The validator's PER_TENANT_AGE branch (from SC3) already assertIdentifier's table+cutoffColumn — covers these. DMMF cross-check (from SC3) already iterates all PER_TENANT_AGE entries — covers these.
+
+### C3 — sweep — locked
+- NO change to sweepPerTenantAge (already generic over table/cutoffColumn/tenantRetentionColumn).
+
+### C4 — DB role grant — locked
+- Grant `passwd_retention_gc_worker` `SELECT, DELETE` on `share_access_logs`, `directory_sync_logs`, `notifications`. Verify leaf (no inbound FK) — directory_sync_logs may FK TO a sync config (outbound, fine); confirm nothing cascades INTO these. Verify against live DB.
+
+### C5 — audit action — locked
+- **Decision: reuse the SC3 `HISTORY_RETENTION_PURGED`? No — these aren't history.** Add a generic `AUDIT_ACTION.LOG_RETENTION_PURGED` (MAINTENANCE group) for append-only-log trims, OR emit per-table with a `table` metadata field under one action. **Decision: one new `LOG_RETENTION_PURGED` action** (const + VALUES + MAINTENANCE group + en/ja + Prisma enum + separate enum migration) — the metadata.table distinguishes which log. Keeps the audit-action set from exploding one-per-table.
+- **Sweep emit change**: sweepPerTenantAge currently hardcodes `action: HISTORY_RETENTION_PURGED`. Parameterize the audit action per entry: add an optional `auditAction` field to PerTenantAgeEntry (default HISTORY_RETENTION_PURGED for the SC3 history entries; LOG_RETENTION_PURGED for the SC7 log entries). This is a small, contained change to the existing sweepPerTenantAge.
+
+### C6 — tests — locked
+- registry.test: count assertion (+3 PER_TENANT_AGE → now 5 total); the existing DMMF PER_TENANT_AGE block auto-covers the 3 new entries (cutoffColumn varies: created_at/started_at/created_at).
+- Unit: extend sweep-per-tenant-age.test.ts to assert the auditAction parameterization (a LOG_RETENTION_PURGED entry emits that action, not HISTORY_RETENTION_PURGED).
+- Integration (real DB): one representative (share_access_logs) — old row trimmed, recent kept, NULL-retention skip, role-grant positive+negative. The other two share the identical PER_TENANT_AGE codepath (DMMF + unit cover them).
+
+## Go/No-Go Gate
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | 3 Tenant retention columns + migration | locked |
+| C2 | widen tenantRetentionColumn union + 3 entries | locked |
+| C3 | no sweep logic change (generic) | locked |
+| C4 | DB role grant (3 tables) | locked |
+| C5 | LOG_RETENTION_PURGED action + auditAction parameterization | locked |
+| C6 | tests | locked |
+
+## Considerations
+- **directory_sync_logs cutoff = started_at** (not created_at — it has no created_at; started_at is the run start). Correct age basis for a sync-run log.
+- **notifications**: user-facing, not an audit log — but auto-deleting old read/dismissed notifications past a tenant retention is reasonable cleanup. (The cutoff is created_at regardless of read state; a tenant that wants to keep notifications sets NULL.)
+- Out of scope: policy API/UI for the 3 new fields (follow-up); SC6.
+
+## Scope contract
+SC6 remains a separate follow-up. Policy API/UI for the 3 retention fields is a documented follow-up.

--- a/messages/en/AuditLog.json
+++ b/messages/en/AuditLog.json
@@ -254,6 +254,7 @@
   "CREDENTIAL_RETENTION_PURGED": "Expired credential purged after recording its provenance (system worker)",
   "TRASH_RETENTION_PURGED": "Expired trashed entries purged (system worker)",
   "HISTORY_RETENTION_PURGED": "Expired entry history trimmed (system worker)",
+  "LOG_RETENTION_PURGED": "Expired log entries purged (system worker)",
   "AUDIT_DELIVERY_FAILED": "Audit delivery failed",
   "AUDIT_DELIVERY_DEAD_LETTER": "Audit delivery dead-lettered",
   "AUDIT_ANCHOR_PUBLISHED": "Audit anchor manifest published",

--- a/messages/ja/AuditLog.json
+++ b/messages/ja/AuditLog.json
@@ -254,6 +254,7 @@
   "CREDENTIAL_RETENTION_PURGED": "期限切れ認証情報を証跡記録のうえ削除（システムワーカー）",
   "TRASH_RETENTION_PURGED": "ゴミ箱の期限切れエントリを削除（システムワーカー）",
   "HISTORY_RETENTION_PURGED": "期限切れの変更履歴を削除（システムワーカー）",
+  "LOG_RETENTION_PURGED": "期限切れのログを削除（システムワーカー）",
   "AUDIT_DELIVERY_FAILED": "監査配信失敗",
   "AUDIT_DELIVERY_DEAD_LETTER": "監査配信デッドレター化",
   "AUDIT_ANCHOR_PUBLISHED": "監査アンカーマニフェストを公開",

--- a/prisma/migrations/20260618210000_add_log_retention_purged_action/migration.sql
+++ b/prisma/migrations/20260618210000_add_log_retention_purged_action/migration.sql
@@ -1,0 +1,2 @@
+-- SC7: audit action for automatic append-only log deletion (system worker).
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'LOG_RETENTION_PURGED';

--- a/prisma/migrations/20260618220000_add_log_retention_days/migration.sql
+++ b/prisma/migrations/20260618220000_add_log_retention_days/migration.sql
@@ -1,0 +1,4 @@
+-- SC7: per-tenant append-only log auto-delete retention (per table). NULL = never.
+ALTER TABLE "tenants" ADD COLUMN IF NOT EXISTS "share_access_log_retention_days" INTEGER;
+ALTER TABLE "tenants" ADD COLUMN IF NOT EXISTS "directory_sync_log_retention_days" INTEGER;
+ALTER TABLE "tenants" ADD COLUMN IF NOT EXISTS "notification_retention_days" INTEGER;

--- a/prisma/migrations/20260618230000_retention_gc_log_grants/migration.sql
+++ b/prisma/migrations/20260618230000_retention_gc_log_grants/migration.sql
@@ -1,0 +1,11 @@
+-- SC7: grant the retention-gc worker SELECT + DELETE on the append-only log
+-- tables it trims. Leaf tables (no inbound FK) — plain batch DELETE by age.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'passwd_retention_gc_worker') THEN
+    GRANT SELECT, DELETE ON TABLE "share_access_logs" TO passwd_retention_gc_worker;
+    GRANT SELECT, DELETE ON TABLE "directory_sync_logs" TO passwd_retention_gc_worker;
+    GRANT SELECT, DELETE ON TABLE "notifications" TO passwd_retention_gc_worker;
+  END IF;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -595,6 +595,11 @@ model Tenant {
   // Password-entry history auto-trim retention. NULL = never auto-trim.
   historyRetentionDays Int? @map("history_retention_days")
 
+  // Append-only log auto-delete retention (per table). NULL = never auto-delete.
+  shareAccessLogRetentionDays   Int? @map("share_access_log_retention_days")
+  directorySyncLogRetentionDays Int? @map("directory_sync_log_retention_days")
+  notificationRetentionDays     Int? @map("notification_retention_days")
+
   // Tenant-wide password policy
   tenantMinPasswordLength Int     @default(0) @map("tenant_min_password_length")
   tenantRequireUppercase  Boolean @default(false) @map("tenant_require_uppercase")
@@ -935,6 +940,7 @@ enum AuditAction {
   CREDENTIAL_RETENTION_PURGED
   TRASH_RETENTION_PURGED
   HISTORY_RETENTION_PURGED
+  LOG_RETENTION_PURGED
   MASTER_KEY_ROTATION
   VERIFIER_PEPPER_ROTATE_BEGIN
   VERIFIER_PEPPER_ROTATE_COMPLETE

--- a/src/__tests__/db-integration/retention-gc-append-only-logs.integration.test.ts
+++ b/src/__tests__/db-integration/retention-gc-append-only-logs.integration.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Real-DB test for SC7 append-only log retention (PER_TENANT_AGE).
+ *
+ * Representative: share_access_logs (created_at age basis). directory_sync_logs
+ * and notifications share the identical PER_TENANT_AGE codepath (covered by the
+ * registry DMMF check + the sweep unit test); this exercises the live DB path.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { randomUUID } from "node:crypto";
+import {
+  createTestContext,
+  setBypassRlsGucs,
+  type TestContext,
+} from "./helpers";
+import { sweepPerTenantAge } from "@/workers/retention-gc-worker/sweep";
+import { RETENTION_REGISTRY } from "@/workers/retention-gc-worker/registry";
+
+const shareLogEntry = RETENTION_REGISTRY.find(
+  (e) => e.kind === "PER_TENANT_AGE" && e.table === "share_access_logs",
+)! as Extract<(typeof RETENTION_REGISTRY)[number], { kind: "PER_TENANT_AGE" }>;
+
+describe("retention-gc append-only log retention (SC7)", () => {
+  let ctx: TestContext;
+  let tenantId: string;
+  let userId: string;
+  let shareId: string;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+  });
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+  beforeEach(async () => {
+    tenantId = await ctx.createTenant();
+    userId = await ctx.createUser(tenantId);
+    shareId = randomUUID();
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO password_shares (id, token_hash, encrypted_data, data_iv, data_auth_tag, expires_at, created_by_id, tenant_id, created_at)
+         VALUES ($1::uuid, $2, '\\x00', 'iv', 'tag', now() + interval '7 days', $3::uuid, $4::uuid, now())`,
+        shareId,
+        `sh-${shareId.slice(0, 16)}`,
+        userId,
+        tenantId,
+      );
+    });
+  });
+  afterEach(async () => {
+    await ctx.deleteTestData(tenantId);
+  });
+
+  async function setRetention(days: number | null): Promise<void> {
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `UPDATE tenants SET share_access_log_retention_days = ${days === null ? "NULL" : "$2"} WHERE id = $1::uuid`,
+        ...(days === null ? [tenantId] : [tenantId, days]),
+      );
+    });
+  }
+
+  async function insertAccessLog(ageExpr: string): Promise<string> {
+    const id = randomUUID();
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO share_access_logs (id, share_id, tenant_id, created_at)
+         VALUES ($1::uuid, $2::uuid, $3::uuid, ${ageExpr})`,
+        id,
+        shareId,
+        tenantId,
+      );
+    });
+    return id;
+  }
+
+  async function logExists(id: string): Promise<boolean> {
+    const rows = await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      return tx.$queryRawUnsafe<{ id: string }[]>(
+        `SELECT id FROM share_access_logs WHERE id = $1::uuid`,
+        id,
+      );
+    });
+    return rows.length > 0;
+  }
+
+  it("deletes access logs older than the tenant retention, keeps recent", async () => {
+    await setRetention(30);
+    const old = await insertAccessLog("now() - interval '31 days'");
+    const recent = await insertAccessLog("now() - interval '5 days'");
+
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await sweepPerTenantAge(tx, shareLogEntry, 100);
+    });
+
+    expect(await logExists(old)).toBe(false);
+    expect(await logExists(recent)).toBe(true);
+  });
+
+  it("does NOT delete when the tenant retention is NULL", async () => {
+    await setRetention(null);
+    const old = await insertAccessLog("now() - interval '400 days'");
+
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await sweepPerTenantAge(tx, shareLogEntry, 100);
+    });
+
+    expect(await logExists(old)).toBe(true);
+  });
+
+  it("worker role CAN delete logs but CANNOT delete audit_logs (least privilege)", async () => {
+    await setRetention(30);
+    const old = await insertAccessLog("now() - interval '31 days'");
+
+    await ctx.retentionWorker.prisma.$transaction(async (tx) => {
+      await sweepPerTenantAge(tx, shareLogEntry, 100);
+    });
+    expect(await logExists(old)).toBe(false);
+
+    await expect(
+      ctx.retentionWorker.prisma.$transaction(async (tx) => {
+        await tx.$executeRaw`SELECT set_config('app.bypass_rls', 'on', true)`;
+        await tx.$executeRawUnsafe(
+          `DELETE FROM audit_logs WHERE tenant_id = $1::uuid`,
+          tenantId,
+        );
+      }),
+    ).rejects.toThrow(/permission denied/);
+  });
+});

--- a/src/lib/constants/audit/audit.ts
+++ b/src/lib/constants/audit/audit.ts
@@ -87,6 +87,8 @@ export const AUDIT_ACTION = {
   TRASH_RETENTION_PURGED: "TRASH_RETENTION_PURGED",
   // Password-entry history auto-trim past per-tenant retention (system worker).
   HISTORY_RETENTION_PURGED: "HISTORY_RETENTION_PURGED",
+  // Append-only log auto-delete past per-tenant retention (system worker).
+  LOG_RETENTION_PURGED: "LOG_RETENTION_PURGED",
   // MASTER_KEY_ROTATION: legacy single-action key — retained for old audit rows
   // and for the share-only rotation path (A04-4 keeps emit-site removed and
   // routes the four phase actions below). Do NOT add new emit sites for this
@@ -280,6 +282,7 @@ export const AUDIT_ACTION_VALUES = [
   AUDIT_ACTION.CREDENTIAL_RETENTION_PURGED,
   AUDIT_ACTION.TRASH_RETENTION_PURGED,
   AUDIT_ACTION.HISTORY_RETENTION_PURGED,
+  AUDIT_ACTION.LOG_RETENTION_PURGED,
   AUDIT_ACTION.SEND_CREATE,
   AUDIT_ACTION.SEND_REVOKE,
   AUDIT_ACTION.SHARE_ACCESS_VERIFY_SUCCESS,
@@ -736,6 +739,7 @@ export const AUDIT_ACTION_GROUPS_TENANT: Record<string, AuditAction[]> = {
     AUDIT_ACTION.CREDENTIAL_RETENTION_PURGED,
     AUDIT_ACTION.TRASH_RETENTION_PURGED,
     AUDIT_ACTION.HISTORY_RETENTION_PURGED,
+    AUDIT_ACTION.LOG_RETENTION_PURGED,
     AUDIT_ACTION.AUDIT_DELIVERY_FAILED,
     AUDIT_ACTION.AUDIT_DELIVERY_DEAD_LETTER,
     AUDIT_ACTION.AUDIT_ANCHOR_PUBLISHED,

--- a/src/workers/retention-gc-worker/__tests__/registry.test.ts
+++ b/src/workers/retention-gc-worker/__tests__/registry.test.ts
@@ -33,7 +33,7 @@ for (const model of Prisma.dmmf.datamodel.models) {
 }
 
 describe("RETENTION_REGISTRY — schema cross-check (INV-C1a)", () => {
-  it("contains exactly 6 EXPIRY + 1 EXPIRY_GUARDED + 4 EXPIRY_AUDIT_PROVENANCE + 1 PER_TENANT_FN + 2 PER_TENANT_TRASH + 2 PER_TENANT_AGE entries", () => {
+  it("contains exactly 6 EXPIRY + 1 EXPIRY_GUARDED + 4 EXPIRY_AUDIT_PROVENANCE + 1 PER_TENANT_FN + 2 PER_TENANT_TRASH + 5 PER_TENANT_AGE entries", () => {
     const expiry = RETENTION_REGISTRY.filter((e) => e.kind === "EXPIRY");
     const guarded = RETENTION_REGISTRY.filter(
       (e) => e.kind === "EXPIRY_GUARDED",
@@ -55,7 +55,7 @@ describe("RETENTION_REGISTRY — schema cross-check (INV-C1a)", () => {
     expect(provenance).toHaveLength(4);
     expect(perTenant).toHaveLength(1);
     expect(perTenantTrash).toHaveLength(2);
-    expect(perTenantAge).toHaveLength(2);
+    expect(perTenantAge).toHaveLength(5);
   });
 
   it("has no duplicate table entries (INV-C1d)", () => {

--- a/src/workers/retention-gc-worker/__tests__/sweep-per-tenant-age.test.ts
+++ b/src/workers/retention-gc-worker/__tests__/sweep-per-tenant-age.test.ts
@@ -14,10 +14,19 @@ const ENTRY: PerTenantAgeEntry = {
   table: "password_entry_histories",
   cutoffColumn: "changed_at",
   tenantRetentionColumn: "historyRetentionDays",
+  auditAction: "HISTORY_RETENTION_PURGED",
+};
+
+const LOG_ENTRY: PerTenantAgeEntry = {
+  kind: "PER_TENANT_AGE",
+  table: "share_access_logs",
+  cutoffColumn: "created_at",
+  tenantRetentionColumn: "shareAccessLogRetentionDays",
+  auditAction: "LOG_RETENTION_PURGED",
 };
 
 function makeTx(
-  tenants: Array<{ id: string; historyRetentionDays: number | null }>,
+  tenants: Array<Record<string, string | number | null>>,
   deletedPerTenant: number,
 ) {
   const executeRaw = vi.fn().mockResolvedValue(undefined); // set_config
@@ -100,5 +109,18 @@ describe("sweepPerTenantAge (SC3)", () => {
     const total = await sweepPerTenantAge(tx, ENTRY, 100);
     expect(total).toBe(0);
     expect(auditOutbox.create).not.toHaveBeenCalled();
+  });
+
+  it("emits the entry's auditAction (LOG_RETENTION_PURGED for append-only logs, SC7)", async () => {
+    const tenantId = "44444444-4444-4444-8444-444444444444";
+    const { tx, auditOutbox } = makeTx(
+      [{ id: tenantId, shareAccessLogRetentionDays: 60 }],
+      2,
+    );
+    await sweepPerTenantAge(tx, LOG_ENTRY, 100);
+    expect(auditOutbox.create).toHaveBeenCalledTimes(1);
+    const payload = auditOutbox.create.mock.calls[0][0].data.payload;
+    expect(payload.action).toBe("LOG_RETENTION_PURGED");
+    expect(payload.metadata.table).toBe("share_access_logs");
   });
 });

--- a/src/workers/retention-gc-worker/registry.ts
+++ b/src/workers/retention-gc-worker/registry.ts
@@ -132,7 +132,7 @@ export interface PerTenantTrashEntry {
  * retention. Unlike PER_TENANT_FN (audit_logs, which routes through a SECURITY
  * DEFINER fn because audit_logs DELETE is revoked for immutability), these tables
  * are trimmable with a direct batch-bounded DELETE. Used for password-entry
- * history (SC3).
+ * history (SC3) and append-only logs (SC7).
  */
 export interface PerTenantAgeEntry {
   kind: "PER_TENANT_AGE";
@@ -140,7 +140,16 @@ export interface PerTenantAgeEntry {
   /** Age column compared to now() - retention (^[a-z_]+$), e.g. "changed_at". */
   cutoffColumn: string;
   /** Prisma model field holding per-tenant retention days (null = skip). */
-  tenantRetentionColumn: "historyRetentionDays";
+  tenantRetentionColumn:
+    | "historyRetentionDays"
+    | "shareAccessLogRetentionDays"
+    | "directorySyncLogRetentionDays"
+    | "notificationRetentionDays";
+  /**
+   * Audit action emitted per tenant when rows are trimmed. HISTORY_RETENTION_PURGED
+   * for entry history (SC3); LOG_RETENTION_PURGED for append-only logs (SC7).
+   */
+  auditAction: "HISTORY_RETENTION_PURGED" | "LOG_RETENTION_PURGED";
 }
 
 export type RetentionEntry =
@@ -335,6 +344,7 @@ export const RETENTION_REGISTRY: readonly RetentionEntry[] = [
     table: "password_entry_histories",
     cutoffColumn: "changed_at",
     tenantRetentionColumn: "historyRetentionDays",
+    auditAction: "HISTORY_RETENTION_PURGED",
   },
   {
     // Team password-entry history auto-trim past the per-tenant retention (SC3).
@@ -342,5 +352,30 @@ export const RETENTION_REGISTRY: readonly RetentionEntry[] = [
     table: "team_password_entry_histories",
     cutoffColumn: "changed_at",
     tenantRetentionColumn: "historyRetentionDays",
+    auditAction: "HISTORY_RETENTION_PURGED",
+  },
+  {
+    // Share-link access logs (SC7) — created_at age basis.
+    kind: "PER_TENANT_AGE",
+    table: "share_access_logs",
+    cutoffColumn: "created_at",
+    tenantRetentionColumn: "shareAccessLogRetentionDays",
+    auditAction: "LOG_RETENTION_PURGED",
+  },
+  {
+    // Directory-sync run logs (SC7) — started_at age basis (no created_at column).
+    kind: "PER_TENANT_AGE",
+    table: "directory_sync_logs",
+    cutoffColumn: "started_at",
+    tenantRetentionColumn: "directorySyncLogRetentionDays",
+    auditAction: "LOG_RETENTION_PURGED",
+  },
+  {
+    // User notifications (SC7) — created_at age basis; tenant opts in via retention.
+    kind: "PER_TENANT_AGE",
+    table: "notifications",
+    cutoffColumn: "created_at",
+    tenantRetentionColumn: "notificationRetentionDays",
+    auditAction: "LOG_RETENTION_PURGED",
   },
 ] as const;

--- a/src/workers/retention-gc-worker/sweep.ts
+++ b/src/workers/retention-gc-worker/sweep.ts
@@ -353,7 +353,7 @@ export async function sweepAuditLogs(
  * Takes a `tx` (dispatched via workerPrisma.$transaction, like sweepAuditLogs).
  * Sets bypass_rls first; enumerates tenants with the retention column NOT NULL;
  * per tenant deletes `<table>` rows where `<cutoffColumn> < now() - retention`.
- * Emits a per-tenant HISTORY_RETENTION_PURGED audit when a tenant has rows trimmed.
+ * Emits a per-tenant audit (entry.auditAction) when a tenant has rows trimmed.
  *
  * @returns Total rows deleted across all enumerated tenants.
  */
@@ -368,14 +368,19 @@ export async function sweepPerTenantAge(
   await tx.$executeRaw`SELECT set_config('app.bypass_rls', 'on', true)`;
 
   // Enumerate only tenants with the retention column configured (NULL → skip).
-  const tenants = await tx.tenant.findMany({
-    where: { [entry.tenantRetentionColumn]: { not: null } },
-    select: { id: true, [entry.tenantRetentionColumn]: true },
-  });
+  // The retention column is a dynamic (but closed-union) Prisma field name, so
+  // type the rows explicitly — a computed `select` key defeats Prisma inference.
+  const col = entry.tenantRetentionColumn;
+  // A computed `select` key defeats Prisma's row-type inference (the return type
+  // widens to a 50-model union), so narrow explicitly through `unknown`.
+  const tenants = (await tx.tenant.findMany({
+    where: { [col]: { not: null } },
+    select: { id: true, [col]: true },
+  })) as unknown as Array<{ id: string } & Record<typeof col, number | null>>;
 
   let total = 0;
   for (const tenant of tenants) {
-    const retention = tenant[entry.tenantRetentionColumn] as number;
+    const retention = tenant[col] as number;
     const cutoff = new Date(Date.now() - retention * MS_PER_DAY);
 
     // Batch-bounded (id) IN (SELECT id ... LIMIT) — table/cutoffColumn are
@@ -396,7 +401,7 @@ export async function sweepPerTenantAge(
     if (deleted > 0) {
       await enqueueAuditInWorkerTx(tx, tenant.id, {
         scope: AUDIT_SCOPE.TENANT,
-        action: AUDIT_ACTION.HISTORY_RETENTION_PURGED,
+        action: AUDIT_ACTION[entry.auditAction],
         userId: SYSTEM_ACTOR_ID,
         actorType: ACTOR_TYPE.SYSTEM,
         serviceAccountId: null,


### PR DESCRIPTION
## Summary

Follow-up to the retention-GC worker (#571; SC5 #576; SC4 #577; SC2 #578; SC3 #579). Implements **SC7**: per-tenant retention for the three append-only log tables deferred in #571 — `share_access_logs`, `directory_sync_logs`, `notifications`.

The #571 deferral note said these "need schema cutoff columns" — but all three already have a timestamp column + `tenant_id` + `id` PK, so SC7 reuses the SC3 `PER_TENANT_AGE` kind with **no new sweep logic**.

## Design
- **Per-table retention fields**: `Tenant.shareAccessLogRetentionDays` / `directorySyncLogRetentionDays` / `notificationRetentionDays` (all `Int?`, NULL = never auto-delete), so a tenant can tune each independently (notifications short, audit-style logs longer).
- **Generic reuse**: widened `PerTenantAgeEntry.tenantRetentionColumn` to a 4-value union and added an `auditAction` field that parameterizes the emitted audit action — `HISTORY_RETENTION_PURGED` for the SC3 history entries, a new `LOG_RETENTION_PURGED` for the SC7 log entries. `sweepPerTenantAge` is otherwise unchanged.
- Cutoff columns: `created_at` (share-access, notifications), `started_at` (directory-sync run logs — no `created_at`).
- **Least-privilege**: `SELECT+DELETE` on the three leaf log tables only.

## Testing
- Unit: auditAction parameterization (HISTORY vs LOG emitted correctly), tenant enumeration, cutoff math, SQL shape.
- Integration (real DB, `share_access_logs` representative): trim-old/keep-recent; NULL-retention skip; worker-role least-privilege. `directory_sync_logs` / `notifications` share the identical `PER_TENANT_AGE` codepath (covered by the registry DMMF check + the sweep unit test).
- Full suite passes; `tsc --noEmit` clean (SC7 files); lint clean; `next build` green; `pre-pr.sh` 36/36; migrations applied to dev DB, grants verified via `information_schema`.

Policy API/UI for the 3 retention fields is a documented follow-up. **SC6** (security-record retention) is the last remaining scope contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)