### PR TITLE
feat(security): emergency-access-grant GC with status-aware guard (SC6b)

### DIFF
--- a/docs/archive/review/retention-emergency-access-code-review.md
+++ b/docs/archive/review/retention-emergency-access-code-review.md
@@ -1,0 +1,32 @@
+# Code Review: retention-emergency-access (SC6b)
+Date: 2026-06-18
+Review rounds: plan (1) + code (1), converged.
+
+## Plan review — PLAN OK
+The review thoroughly verified the security-critical death model against the emergency-access lifecycle + state MATRIX:
+- Post-accept liveness gates on status/wait_expires_at, NEVER token_expires_at — so an ACCEPTED/IDLE/ACTIVATED grant is live past the invite window.
+- The guard (`status IN (REVOKED,REJECTED) OR (status=PENDING AND token_expires_at<now())`) deletes only dead grants. STALE is recoverable (STALE→IDLE transition exists) — correctly EXCLUDED; IDLE recoverable — EXCLUDED. Expired-PENDING is non-revivable (accept route rejects expired invites) — correctly included.
+- Recommended hardening: RT7 should assert the cascade child's fate (added).
+
+## Code review — SC6b OK (no findings)
+Security-critical review verified clean:
+- Guard SQL correct: deletes only REVOKED/REJECTED/expired-PENDING; KEEPS live (ACCEPTED/ACTIVATED/REQUESTED) and recoverable (STALE/IDLE) even past token_expires_at.
+- RT7 critical test non-vacuous: inserts created_at=now() so cutoffColumn is always-true; without the guard ALL grants delete → the ACCEPTED/ACTIVATED-kept assertions go red. Proven.
+- S1: guard fragment is compile-time-literal status strings in GUARD_SQL; parent=entry.table assertIdentifier-validated; only batchSize bound. Same posture as MCP_TOKEN_FAMILY_DEAD.
+- guard applied to SELECT only; DELETE targets captured id list → SELECT/DELETE consistent; unguarded path (SC4/SC6 entries) byte-identical (dedicated unit test).
+- Provenance: 8 real @map columns incl. status (enum) — DMMF registry test covers enum columns (the SC6 builder fix).
+- R6 cascade: dead grant → emergency_access_key_pairs cascade (integration test proves it under the worker role); no child grant needed.
+- R14: SELECT+DELETE on emergency_access_grants only; no over-grant; worker still cannot delete audit_logs.
+- enum cast (status IN ('REVOKED',...)): Postgres implicit cast, proven by real-DB integration tests.
+
+One cosmetic nit fixed: registry.test count-title 10→11.
+
+## Verification
+- Unit: 10 sweep-sql tests (incl. guard-appended both-OR-branches + unguarded-unchanged); registry DMMF (count 11).
+- Integration (real DB, 7 tests): REVOKED/REJECTED deleted; expired-PENDING deleted; live-PENDING kept; **CRITICAL: ACCEPTED/ACTIVATED past-window KEPT**; STALE/IDLE kept; cascade child removed; worker-role least-privilege.
+- Full worker suite + audit coverage pass; lint clean; pre-pr.sh 36/36; migration applied to dev DB, grant verified.
+
+## Verdict
+Converged. The deferred-from-SC6 table is now GC'd safely with a status-aware guard reusing the SC5 GUARD_SQL mechanism on the provenance path — no live emergency-access grant can be deleted. This completes retention GC for ALL expiry/security tables.
+
+Remaining follow-up: policy API/UI for the per-tenant retention fields (SC2/SC3/SC7) — the worker + columns exist, UI wiring only.

--- a/docs/archive/review/retention-emergency-access-plan.md
+++ b/docs/archive/review/retention-emergency-access-plan.md
@@ -1,0 +1,77 @@
+# Plan: retention-emergency-access (SC6b)
+
+## Project context
+- Service (Next.js + Prisma 7 + PostgreSQL, multi-tenant RLS, least-privilege roles) + retention-GC worker with all SC2-SC7 kinds merged (EXPIRY, EXPIRY_GUARDED w/ GUARD_SQL, EXPIRY_AUDIT_PROVENANCE, PER_TENANT_FN, PER_TENANT_TRASH, PER_TENANT_AGE).
+
+## Objective
+GC `emergency_access_grants` — deferred from SC6 because its `token_expires_at` is the 7-day INVITATION-acceptance window, NOT a "record is dead" signal: an ACCEPTED/IDLE/ACTIVATED grant stays live with `token_expires_at` long past (verified: the post-accept lifecycle in `[id]/vault`, `[id]/request`, `[id]/approve` never re-checks token_expires_at; the live window is governed by `wait_expires_at`/`waitDays`). GCing by token_expires_at would delete LIVE grants.
+
+A grant is GC-eligible only when **terminal**: `status IN ('REVOKED','REJECTED')`, OR a **never-accepted expired invite**: `status = 'PENDING' AND token_expires_at < now()`. This is an OR of two conditions — the AND-joined PredicateClause[] cannot express it.
+
+These records carry forensic value (who granted emergency access to whom), so — consistent with SC6 — capture provenance to audit before delete.
+
+## Background facts (verified)
+- `emergency_access_grants`: status enum {PENDING, ACCEPTED, IDLE, STALE, REQUESTED, ACTIVATED, REVOKED, REJECTED}; columns tenant_id, owner_id, grantee_id (nullable), status, token_expires_at, wait_expires_at, revoked_at, created_at; RLS-enabled; id PK.
+- Cascade child: `emergency_access_key_pairs.grant_id → emergency_access_grants ON DELETE CASCADE` (deleting a dead grant removes its key pairs — intended).
+- The SC5 `EXPIRY_GUARDED` kind already has a `GUARD_SQL` map of compile-time-literal SQL fragments keyed by a closed `GuardName` enum (S1-safe). SC6b reuses that mechanism for the provenance path.
+
+## Technical approach
+Extend `EXPIRY_AUDIT_PROVENANCE` with an optional `guard` field (the same `GuardName` enum used by EXPIRY_GUARDED). Add a new guard `EMERGENCY_GRANT_DEAD` to GUARD_SQL whose fragment is the OR-condition above. `sweepAuditProvenanceEntry` appends the guard SQL (when present) to its SELECT WHERE, exactly like sweepGuardedExpiryEntry does.
+
+The cutoff for this entry: since the death condition is status-based (not a single timestamp), use `created_at` as the cutoffColumn for a forensic grace (delete dead grants older than... actually the guard already restricts to dead rows; the cutoffColumn still applies as `created_at < now()` which is always true). **Decision**: keep `cutoffColumn: created_at` (the engine requires a cutoffColumn; `created_at < now()` is a tautology that lets the guard be the real filter). The guard is the death predicate; no separate age grace (a REVOKED/REJECTED grant or an expired-unaccepted invite is already dead — no value in keeping it, and its provenance is captured to audit). If a grace is wanted later, tighten the cutoff.
+
+### Guard SQL (compile-time literal in sweep.ts GUARD_SQL)
+```
+EMERGENCY_GRANT_DEAD: (parent) =>
+  `AND (
+     ${parent}.status IN ('REVOKED', 'REJECTED')
+     OR (${parent}.status = 'PENDING' AND ${parent}.token_expires_at < now())
+   )`
+```
+(parent = entry.table, assertIdentifier-validated. The status literals are compile-time constants in this file — S1-safe, no registry/user data.)
+
+## Contracts
+
+### C1 — guard field on AuditProvenanceEntry + new guard — locked
+- Add optional `guard?: GuardName` to `AuditProvenanceEntry` (import GuardName from registry — it's already exported for EXPIRY_GUARDED).
+- Add `EMERGENCY_GRANT_DEAD` to the `GuardName` union and to GUARD_SQL (sweep.ts).
+- Add 1 EXPIRY_AUDIT_PROVENANCE entry: emergency_access_grants / cutoffColumn created_at / provenanceColumns [tenant_id, owner_id, grantee_id, status, token_expires_at, wait_expires_at, revoked_at, created_at] / auditAction SECURITY_RECORD_RETENTION_PURGED / guard EMERGENCY_GRANT_DEAD / globalDelete true.
+
+### C2 — sweepAuditProvenanceEntry guard application — locked
+- When entry.guard is set, append `GUARD_SQL[entry.guard](entry.table)` to the SELECT WHERE (after `cutoffColumn < now()`), mirroring sweepGuardedExpiryEntry. No guard → unchanged (SC4/SC6 entries).
+- Invariant: guard SQL is a compile-time literal (GUARD_SQL), never registry data — S1 boundary preserved.
+
+### C3 — validator — locked
+- The EXPIRY_AUDIT_PROVENANCE validator branch needs no change for `guard` (it's a closed GuardName enum, compile-time checked, like EXPIRY_GUARDED). Confirm.
+
+### C4 — DB role grant — locked
+- Grant `passwd_retention_gc_worker` SELECT, DELETE on `emergency_access_grants`. Cascade child emergency_access_key_pairs needs no grant (RI internal). Verify live DB.
+
+### C5 — tests — locked
+- registry.test: count (+1 EXPIRY_AUDIT_PROVENANCE → 11); DMMF covers the new entry's columns (incl. enum `status`).
+- Unit: sweep-sql provenance test — assert the guard SQL is appended for the emergency entry (both OR-branches present: status IN (...) and PENDING+token_expires_at).
+- Integration (real DB): seed grants in each state:
+  - REVOKED (any age) → deleted + provenance emitted
+  - REJECTED → deleted
+  - PENDING + token_expires_at < now() (expired unaccepted invite) → deleted
+  - PENDING + token_expires_at > now() (live pending invite) → KEPT (guard holds)
+  - ACCEPTED / ACTIVATED with token_expires_at < now() (LIVE grant past its invite window) → **KEPT** (the critical case — guard must NOT delete it; RT7: removing the guard would delete this live grant)
+  - cascade: a deleted grant's emergency_access_key_pairs child removed
+  - role-grant positive + cannot-delete-audit_logs negative
+
+## Go/No-Go Gate
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | guard field + EMERGENCY_GRANT_DEAD + entry | locked |
+| C2 | sweepAuditProvenanceEntry guard application | locked |
+| C3 | validator (no change needed) | locked |
+| C4 | DB role grant | locked |
+| C5 | tests incl. the live-grant-KEPT critical case | locked |
+
+## Considerations
+- **The critical test (RT7)**: ACCEPTED/ACTIVATED grant with token_expires_at in the past must be KEPT. This is the exact bug SC6 deferral avoided. The test must assert this row survives; removing the guard makes it delete-eligible → test goes red.
+- **No age grace**: a terminal (REVOKED/REJECTED) grant or expired-unaccepted invite is already dead; provenance is captured to audit, so immediate GC is fine. (A future grace could tighten cutoffColumn.)
+- Out of scope: policy field for emergency-grant retention (uses the status guard, not a tenant retention field).
+
+## Scope contract
+This completes the retention-GC series for all expiry/security tables. Only the policy API/UI follow-up remains (per-tenant retention fields from SC2/SC3/SC7).

--- a/prisma/migrations/20260619100000_retention_gc_emergency_access_grant/migration.sql
+++ b/prisma/migrations/20260619100000_retention_gc_emergency_access_grant/migration.sql
@@ -1,0 +1,11 @@
+-- SC6b: grant the retention-gc worker SELECT + DELETE on emergency_access_grants.
+-- The worker GCs only DEAD grants (terminal or expired-unaccepted, via the
+-- EMERGENCY_GRANT_DEAD guard). The cascade to emergency_access_key_pairs needs
+-- no child grant (RI runs internally).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'passwd_retention_gc_worker') THEN
+    GRANT SELECT, DELETE ON TABLE "emergency_access_grants" TO passwd_retention_gc_worker;
+  END IF;
+END
+$$;

--- a/src/__tests__/db-integration/retention-gc-emergency-access.integration.test.ts
+++ b/src/__tests__/db-integration/retention-gc-emergency-access.integration.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Real-DB tests for SC6b emergency-access-grant GC (EMERGENCY_GRANT_DEAD guard).
+ *
+ * The guard deletes ONLY dead grants: terminal (REVOKED/REJECTED) or never-accepted
+ * expired invites (PENDING + token_expires_at past). The CRITICAL case (RT7): an
+ * ACCEPTED/ACTIVATED grant whose token_expires_at is in the past is STILL LIVE
+ * (token_expires_at is the invite window, not a death signal) and MUST be KEPT —
+ * removing the guard would delete it (data loss). The test asserts it survives.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { randomUUID } from "node:crypto";
+import {
+  createTestContext,
+  setBypassRlsGucs,
+  type TestContext,
+} from "./helpers";
+import { sweepAuditProvenanceEntry } from "@/workers/retention-gc-worker/sweep";
+import { RETENTION_REGISTRY } from "@/workers/retention-gc-worker/registry";
+
+const grantEntry = RETENTION_REGISTRY.find(
+  (e) =>
+    e.kind === "EXPIRY_AUDIT_PROVENANCE" &&
+    e.table === "emergency_access_grants",
+)! as Extract<
+  (typeof RETENTION_REGISTRY)[number],
+  { kind: "EXPIRY_AUDIT_PROVENANCE" }
+>;
+
+describe("retention-gc emergency-access-grant GC (SC6b)", () => {
+  let ctx: TestContext;
+  let tenantId: string;
+  let ownerId: string;
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+  });
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+  beforeEach(async () => {
+    tenantId = await ctx.createTenant();
+    ownerId = await ctx.createUser(tenantId);
+  });
+  afterEach(async () => {
+    await ctx.deleteTestData(tenantId);
+  });
+
+  async function insertGrant(opts: {
+    status: string;
+    tokenExpiresAt: string; // SQL expr
+  }): Promise<string> {
+    const id = randomUUID();
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO emergency_access_grants
+           (id, owner_id, grantee_email, wait_days, token_hash, token_expires_at, status, tenant_id, created_at, updated_at)
+         VALUES ($1::uuid, $2::uuid, $3, 3, $4, ${opts.tokenExpiresAt}, $5::"EmergencyAccessStatus", $6::uuid, now(), now())`,
+        id,
+        ownerId,
+        `grantee-${id.slice(0, 8)}@example.com`,
+        `tok-${id.slice(0, 16)}`,
+        opts.status,
+        tenantId,
+      );
+    });
+    return id;
+  }
+
+  async function insertKeyPair(grantId: string): Promise<string> {
+    const id = randomUUID();
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO emergency_access_key_pairs
+           (id, grant_id, encrypted_private_key, private_key_iv, private_key_auth_tag, tenant_id)
+         VALUES ($1::uuid, $2::uuid, '\\x00', 'iv', 'tag', $3::uuid)`,
+        id,
+        grantId,
+        tenantId,
+      );
+    });
+    return id;
+  }
+
+  async function grantExists(id: string): Promise<boolean> {
+    const rows = await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      return tx.$queryRawUnsafe<{ id: string }[]>(
+        `SELECT id FROM emergency_access_grants WHERE id = $1::uuid`,
+        id,
+      );
+    });
+    return rows.length > 0;
+  }
+
+  async function keyPairExists(id: string): Promise<boolean> {
+    const rows = await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      return tx.$queryRawUnsafe<{ id: string }[]>(
+        `SELECT id FROM emergency_access_key_pairs WHERE id = $1::uuid`,
+        id,
+      );
+    });
+    return rows.length > 0;
+  }
+
+  async function sweep() {
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await setBypassRlsGucs(tx);
+      await sweepAuditProvenanceEntry(tx, grantEntry, 100);
+    });
+  }
+
+  it("deletes REVOKED and REJECTED grants (terminal)", async () => {
+    const revoked = await insertGrant({
+      status: "REVOKED",
+      tokenExpiresAt: "now() + interval '1 day'",
+    });
+    const rejected = await insertGrant({
+      status: "REJECTED",
+      tokenExpiresAt: "now() + interval '1 day'",
+    });
+
+    await sweep();
+
+    expect(await grantExists(revoked)).toBe(false);
+    expect(await grantExists(rejected)).toBe(false);
+  });
+
+  it("deletes a never-accepted EXPIRED invite (PENDING + token_expires_at past)", async () => {
+    const expiredInvite = await insertGrant({
+      status: "PENDING",
+      tokenExpiresAt: "now() - interval '1 hour'",
+    });
+    await sweep();
+    expect(await grantExists(expiredInvite)).toBe(false);
+  });
+
+  it("KEEPS a still-pending live invite (PENDING + token_expires_at future)", async () => {
+    const liveInvite = await insertGrant({
+      status: "PENDING",
+      tokenExpiresAt: "now() + interval '6 days'",
+    });
+    await sweep();
+    expect(await grantExists(liveInvite)).toBe(true);
+  });
+
+  it("CRITICAL (RT7): KEEPS an ACCEPTED grant whose token_expires_at is in the past (still live)", async () => {
+    // token_expires_at is the invite window; an ACCEPTED grant is live past it.
+    // Removing the EMERGENCY_GRANT_DEAD guard would delete this — data loss.
+    const liveAccepted = await insertGrant({
+      status: "ACCEPTED",
+      tokenExpiresAt: "now() - interval '30 days'",
+    });
+    const activated = await insertGrant({
+      status: "ACTIVATED",
+      tokenExpiresAt: "now() - interval '30 days'",
+    });
+    await sweep();
+    expect(await grantExists(liveAccepted)).toBe(true);
+    expect(await grantExists(activated)).toBe(true);
+  });
+
+  it("KEEPS recoverable STALE/IDLE grants even with token_expires_at past", async () => {
+    const stale = await insertGrant({
+      status: "STALE",
+      tokenExpiresAt: "now() - interval '30 days'",
+    });
+    const idle = await insertGrant({
+      status: "IDLE",
+      tokenExpiresAt: "now() - interval '30 days'",
+    });
+    await sweep();
+    expect(await grantExists(stale)).toBe(true);
+    expect(await grantExists(idle)).toBe(true);
+  });
+
+  it("cascade-removes a dead grant's emergency_access_key_pairs child", async () => {
+    const revoked = await insertGrant({
+      status: "REVOKED",
+      tokenExpiresAt: "now() + interval '1 day'",
+    });
+    const keyPair = await insertKeyPair(revoked);
+
+    await sweep();
+
+    expect(await grantExists(revoked)).toBe(false);
+    expect(await keyPairExists(keyPair)).toBe(false); // cascade
+  });
+
+  it("worker role CAN delete dead grants but CANNOT delete audit_logs (least privilege)", async () => {
+    const revoked = await insertGrant({
+      status: "REVOKED",
+      tokenExpiresAt: "now() + interval '1 day'",
+    });
+
+    await ctx.retentionWorker.prisma.$transaction(async (tx) => {
+      await sweepAuditProvenanceEntry(tx, grantEntry, 100);
+    });
+    expect(await grantExists(revoked)).toBe(false);
+
+    await expect(
+      ctx.retentionWorker.prisma.$transaction(async (tx) => {
+        await tx.$executeRaw`SELECT set_config('app.bypass_rls', 'on', true)`;
+        await tx.$executeRawUnsafe(
+          `DELETE FROM audit_logs WHERE tenant_id = $1::uuid`,
+          tenantId,
+        );
+      }),
+    ).rejects.toThrow(/permission denied/);
+  });
+});

--- a/src/workers/retention-gc-worker/__tests__/registry.test.ts
+++ b/src/workers/retention-gc-worker/__tests__/registry.test.ts
@@ -36,7 +36,7 @@ for (const model of Prisma.dmmf.datamodel.models) {
 }
 
 describe("RETENTION_REGISTRY — schema cross-check (INV-C1a)", () => {
-  it("contains exactly 6 EXPIRY + 1 EXPIRY_GUARDED + 10 EXPIRY_AUDIT_PROVENANCE + 1 PER_TENANT_FN + 2 PER_TENANT_TRASH + 5 PER_TENANT_AGE entries", () => {
+  it("contains exactly 6 EXPIRY + 1 EXPIRY_GUARDED + 11 EXPIRY_AUDIT_PROVENANCE + 1 PER_TENANT_FN + 2 PER_TENANT_TRASH + 5 PER_TENANT_AGE entries", () => {
     const expiry = RETENTION_REGISTRY.filter((e) => e.kind === "EXPIRY");
     const guarded = RETENTION_REGISTRY.filter(
       (e) => e.kind === "EXPIRY_GUARDED",
@@ -55,7 +55,7 @@ describe("RETENTION_REGISTRY — schema cross-check (INV-C1a)", () => {
     );
     expect(expiry).toHaveLength(6);
     expect(guarded).toHaveLength(1);
-    expect(provenance).toHaveLength(10);
+    expect(provenance).toHaveLength(11);
     expect(perTenant).toHaveLength(1);
     expect(perTenantTrash).toHaveLength(2);
     expect(perTenantAge).toHaveLength(5);

--- a/src/workers/retention-gc-worker/__tests__/sweep-sql.test.ts
+++ b/src/workers/retention-gc-worker/__tests__/sweep-sql.test.ts
@@ -277,4 +277,46 @@ describe("sweepAuditProvenanceEntry generated SQL (SC4 C2/RT7)", () => {
     const emitted = auditOutbox.create.mock.calls[0][0];
     expect(emitted.data.payload.action).toBe("SECURITY_RECORD_RETENTION_PURGED");
   });
+
+  it("SC6b emergency-grant entry appends the EMERGENCY_GRANT_DEAD guard (both OR-branches) to the SELECT", async () => {
+    const entry: AuditProvenanceEntry = {
+      kind: "EXPIRY_AUDIT_PROVENANCE",
+      table: "emergency_access_grants",
+      cutoffColumn: "created_at",
+      provenanceColumns: ["tenant_id", "owner_id", "status", "token_expires_at"],
+      auditAction: "SECURITY_RECORD_RETENTION_PURGED",
+      guard: "EMERGENCY_GRANT_DEAD",
+      globalDelete: true,
+    };
+    const { tx, queryRawUnsafe } = makeProvenanceTx([]);
+
+    await sweepAuditProvenanceEntry(tx, entry, 100);
+
+    const [selectSql] = queryRawUnsafe.mock.calls[0];
+    // The guard restricts to DEAD grants only — both OR-branches present so a
+    // live ACCEPTED/ACTIVATED grant (past its invite window) is never selected.
+    expect(selectSql).toContain("status IN ('REVOKED', 'REJECTED')");
+    expect(selectSql).toMatch(
+      /status = 'PENDING' AND emergency_access_grants\.token_expires_at < now\(\)/,
+    );
+    // Guard is appended after the cutoff, still batch-bounded.
+    expect(selectSql).toMatch(/WHERE created_at < now\(\)\s+AND \(/);
+    expect(selectSql).toMatch(/LIMIT \$1/);
+  });
+
+  it("entries WITHOUT a guard append no guard SQL (SC4/SC6 unguarded path unchanged)", async () => {
+    const entry: AuditProvenanceEntry = {
+      kind: "EXPIRY_AUDIT_PROVENANCE",
+      table: "api_keys",
+      cutoffColumn: "expires_at",
+      provenanceColumns: ["tenant_id", "user_id"],
+      auditAction: "CREDENTIAL_RETENTION_PURGED",
+      globalDelete: true,
+    };
+    const { tx, queryRawUnsafe } = makeProvenanceTx([]);
+    await sweepAuditProvenanceEntry(tx, entry, 100);
+    const [selectSql] = queryRawUnsafe.mock.calls[0];
+    expect(selectSql).not.toContain("status IN");
+    expect(selectSql).toMatch(/WHERE expires_at < now\(\)\s+LIMIT \$1/);
+  });
 });

--- a/src/workers/retention-gc-worker/registry.ts
+++ b/src/workers/retention-gc-worker/registry.ts
@@ -25,7 +25,7 @@ export type RetentionEntryKind =
  * NOT EXISTS subqueries stay compile-time literals and never widen the S1
  * SQL-injection containment boundary.
  */
-export type GuardName = "MCP_TOKEN_FAMILY_DEAD";
+export type GuardName = "MCP_TOKEN_FAMILY_DEAD" | "EMERGENCY_GRANT_DEAD";
 
 export interface ExpiryEntry {
   kind: "EXPIRY";
@@ -113,6 +113,14 @@ export interface AuditProvenanceEntry {
   auditAction:
     | "CREDENTIAL_RETENTION_PURGED"
     | "SECURITY_RECORD_RETENTION_PURGED";
+  /**
+   * Optional "this row is dead" guard (closed GuardName enum → compile-time-literal
+   * SQL in GUARD_SQL, never registry data). Used when a single cutoffColumn cannot
+   * express GC-eligibility — e.g. emergency_access_grants, whose token_expires_at is
+   * an invitation window, not a death signal, so the guard restricts to terminal /
+   * expired-unaccepted rows (SC6b).
+   */
+  guard?: GuardName;
   globalDelete?: true;
 }
 
@@ -428,6 +436,30 @@ export const RETENTION_REGISTRY: readonly RetentionEntry[] = [
       "created_at",
     ],
     auditAction: "SECURITY_RECORD_RETENTION_PURGED",
+    globalDelete: true,
+  },
+  {
+    // Emergency-access grants (SC6b) — GC only DEAD grants: terminal
+    // (REVOKED/REJECTED) or never-accepted expired invites. The
+    // EMERGENCY_GRANT_DEAD guard is the real filter (token_expires_at is the
+    // invite window, not a death signal — an ACCEPTED/ACTIVATED grant past it is
+    // still live). cutoffColumn created_at < now() is a tautology so the guard
+    // governs. Cascade removes the grant's emergency_access_key_pairs.
+    kind: "EXPIRY_AUDIT_PROVENANCE",
+    table: "emergency_access_grants",
+    cutoffColumn: "created_at",
+    provenanceColumns: [
+      "tenant_id",
+      "owner_id",
+      "grantee_id",
+      "status",
+      "token_expires_at",
+      "wait_expires_at",
+      "revoked_at",
+      "created_at",
+    ],
+    auditAction: "SECURITY_RECORD_RETENTION_PURGED",
+    guard: "EMERGENCY_GRANT_DEAD",
     globalDelete: true,
   },
   {

--- a/src/workers/retention-gc-worker/sweep.ts
+++ b/src/workers/retention-gc-worker/sweep.ts
@@ -69,6 +69,16 @@ const GUARD_SQL: Record<GuardName, (parent: string) => string> = {
        WHERE d.mcp_token_id = ${parent}.id
          AND d.revoked_at IS NULL AND d.expires_at > now()
      )`,
+  // emergency_access_grants: token_expires_at is the 7-day INVITATION window, NOT
+  // a death signal — an ACCEPTED/IDLE/ACTIVATED grant stays live past it. A grant
+  // is dead only when terminal (REVOKED/REJECTED) or a never-accepted expired
+  // invite (PENDING + token_expires_at past). STALE/IDLE are recoverable, NOT
+  // included. Status literals are compile-time constants here (S1-safe).
+  EMERGENCY_GRANT_DEAD: (parent) =>
+    `AND (
+       ${parent}.status IN ('REVOKED', 'REJECTED')
+       OR (${parent}.status = 'PENDING' AND ${parent}.token_expires_at < now())
+     )`,
 };
 
 // Re-export EmitFn and enqueueAuditInWorkerTx so integration tests can target them.
@@ -254,10 +264,15 @@ export async function sweepAuditProvenanceEntry(
   // over-privilege it (it never updates these rows). The capture targets only
   // already-expired rows, which the app never deletes (only this worker does),
   // so there is no SELECT→DELETE race to lock against — the id list is stable.
+  // Optional "this row is dead" guard (SC6b) — a compile-time-literal SQL fragment
+  // from GUARD_SQL, appended to the WHERE. Used when cutoffColumn alone cannot
+  // express GC-eligibility (e.g. emergency_access_grants). The DELETE below targets
+  // the captured id list, so the guard only needs to filter the SELECT.
+  const guardSql = entry.guard ? ` ${GUARD_SQL[entry.guard](entry.table)}` : "";
   const projection = ["id", ...entry.provenanceColumns].join(", ");
   const rows = await tx.$queryRawUnsafe<Record<string, unknown>[]>(
     `SELECT ${projection} FROM ${entry.table}
-       WHERE ${entry.cutoffColumn} < now()
+       WHERE ${entry.cutoffColumn} < now()${guardSql}
        LIMIT $1`,
     batchSize,
   );


### PR DESCRIPTION
## Summary

Completes the SC6 work (#581 shipped 6 of 7 security-record tables). GCs `emergency_access_grants`, which was deferred because its `token_expires_at` is the **7-day invitation-acceptance window, NOT a "record is dead" signal** — an ACCEPTED/ACTIVATED grant stays live with `token_expires_at` long past (the post-accept lifecycle gates on status/`wait_expires_at`, never `token_expires_at`). GCing by `token_expires_at` would have **deleted live emergency-access grants** (data loss).

## Design
Extends the SC4 `EXPIRY_AUDIT_PROVENANCE` kind with an optional `guard` field, reusing the SC5 `GUARD_SQL` mechanism (compile-time-literal SQL fragments keyed by a closed `GuardName` enum — S1-safe). The new `EMERGENCY_GRANT_DEAD` guard restricts deletion to genuinely dead grants:

```sql
status IN ('REVOKED', 'REJECTED')
OR (status = 'PENDING' AND token_expires_at < now())
```

- **STALE / IDLE are excluded** — they are recoverable states (STALE→IDLE is a valid transition), not terminal. Including them would be a data-loss bug.
- **ACCEPTED / ACTIVATED / REQUESTED are excluded** — live, even past the invite window.
- The guard is appended to the provenance SELECT only; the DELETE targets the captured id list, so SELECT/DELETE stay consistent. Records' provenance (owner/grantee/status) is emitted to `audit_logs` before deletion (`SECURITY_RECORD_RETENTION_PURGED`).
- **Least-privilege**: `SELECT+DELETE` on `emergency_access_grants`; the `emergency_access_key_pairs` cascade needs no child grant.

## Testing
- Unit: guard SQL appended with both OR-branches; the unguarded path (SC4/SC6 entries) is byte-identical.
- Integration (real DB, 7 tests): REVOKED/REJECTED deleted; expired-PENDING invite deleted; live-PENDING invite kept; **CRITICAL — an ACCEPTED/ACTIVATED grant whose `token_expires_at` is 30 days past is KEPT** (the exact data-loss case the deferral avoided; removing the guard makes the test go red); STALE/IDLE kept; cascade child removed with a dead grant; worker-role least-privilege.
- Full suite passes; `tsc --noEmit` clean (SC6b files); lint clean; `next build` green; `pre-pr.sh` 36/36; migration applied to dev DB, grant verified.

This completes retention GC for ALL expiry/security tables. The only remaining follow-up is the policy API/UI for the per-tenant retention fields added across SC2/SC3/SC7 (the worker + columns exist; UI wiring only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)