### PR TITLE
test(security): cover directory_sync_logs + notifications retention GC against real DB

### DIFF
--- a/src/__tests__/db-integration/retention-gc-directory-sync-logs.integration.test.ts
+++ b/src/__tests__/db-integration/retention-gc-directory-sync-logs.integration.test.ts
@@ -1,10 +1,10 @@
 /**
- * Real-DB test for SC7 append-only log retention (PER_TENANT_AGE).
+ * Real-DB test for SC7 directory-sync-log retention (PER_TENANT_AGE).
  *
- * share_access_logs (created_at age basis). directory_sync_logs (started_at) and
- * notifications (created_at) share the identical PER_TENANT_AGE codepath and have
- * their own live-DB companions (retention-gc-directory-sync-logs,
- * retention-gc-notifications).
+ * Companion to retention-gc-append-only-logs (share_access_logs). This exercises
+ * the directory_sync_logs table specifically: started_at age basis (no created_at
+ * column), child of directory_sync_configs. Verifies the live worker DELETE path,
+ * NULL = never, and worker least-privilege.
  */
 
 import {
@@ -25,15 +25,14 @@ import {
 import { sweepPerTenantAge } from "@/workers/retention-gc-worker/sweep";
 import { RETENTION_REGISTRY } from "@/workers/retention-gc-worker/registry";
 
-const shareLogEntry = RETENTION_REGISTRY.find(
-  (e) => e.kind === "PER_TENANT_AGE" && e.table === "share_access_logs",
+const syncLogEntry = RETENTION_REGISTRY.find(
+  (e) => e.kind === "PER_TENANT_AGE" && e.table === "directory_sync_logs",
 )! as Extract<(typeof RETENTION_REGISTRY)[number], { kind: "PER_TENANT_AGE" }>;
 
-describe("retention-gc append-only log retention (SC7)", () => {
+describe("retention-gc directory-sync-log retention (SC7)", () => {
   let ctx: TestContext;
   let tenantId: string;
-  let userId: string;
-  let shareId: string;
+  let configId: string;
 
   beforeAll(async () => {
     ctx = await createTestContext();
@@ -43,16 +42,16 @@ describe("retention-gc append-only log retention (SC7)", () => {
   });
   beforeEach(async () => {
     tenantId = await ctx.createTenant();
-    userId = await ctx.createUser(tenantId);
-    shareId = randomUUID();
+    configId = randomUUID();
     await ctx.su.prisma.$transaction(async (tx) => {
       await setBypassRlsGucs(tx);
       await tx.$executeRawUnsafe(
-        `INSERT INTO password_shares (id, token_hash, encrypted_data, data_iv, data_auth_tag, expires_at, created_by_id, tenant_id, created_at)
-         VALUES ($1::uuid, $2, '\\x00', 'iv', 'tag', now() + interval '7 days', $3::uuid, $4::uuid, now())`,
-        shareId,
-        `sh-${shareId.slice(0, 16)}`,
-        userId,
+        `INSERT INTO directory_sync_configs
+           (id, tenant_id, provider, display_name, enabled, sync_interval_minutes,
+            encrypted_credentials, credentials_iv, credentials_auth_tag, status, created_at, updated_at)
+         VALUES ($1::uuid, $2::uuid, 'OKTA'::"DirectorySyncProvider", 'test-config', true, 60,
+            '\\x00', 'iv', 'tag', 'IDLE'::"DirectorySyncStatus", now(), now())`,
+        configId,
         tenantId,
       );
     });
@@ -65,21 +64,23 @@ describe("retention-gc append-only log retention (SC7)", () => {
     await ctx.su.prisma.$transaction(async (tx) => {
       await setBypassRlsGucs(tx);
       await tx.$executeRawUnsafe(
-        `UPDATE tenants SET share_access_log_retention_days = ${days === null ? "NULL" : "$2"} WHERE id = $1::uuid`,
+        `UPDATE tenants SET directory_sync_log_retention_days = ${days === null ? "NULL" : "$2"} WHERE id = $1::uuid`,
         ...(days === null ? [tenantId] : [tenantId, days]),
       );
     });
   }
 
-  async function insertAccessLog(ageExpr: string): Promise<string> {
+  async function insertSyncLog(ageExpr: string): Promise<string> {
     const id = randomUUID();
     await ctx.su.prisma.$transaction(async (tx) => {
       await setBypassRlsGucs(tx);
       await tx.$executeRawUnsafe(
-        `INSERT INTO share_access_logs (id, share_id, tenant_id, created_at)
-         VALUES ($1::uuid, $2::uuid, $3::uuid, ${ageExpr})`,
+        `INSERT INTO directory_sync_logs
+           (id, config_id, tenant_id, status, started_at, dry_run,
+            users_created, users_updated, users_deactivated, groups_updated)
+         VALUES ($1::uuid, $2::uuid, $3::uuid, 'SUCCESS'::"DirectorySyncStatus", ${ageExpr}, false, 0, 0, 0, 0)`,
         id,
-        shareId,
+        configId,
         tenantId,
       );
     });
@@ -90,21 +91,21 @@ describe("retention-gc append-only log retention (SC7)", () => {
     const rows = await ctx.su.prisma.$transaction(async (tx) => {
       await setBypassRlsGucs(tx);
       return tx.$queryRawUnsafe<{ id: string }[]>(
-        `SELECT id FROM share_access_logs WHERE id = $1::uuid`,
+        `SELECT id FROM directory_sync_logs WHERE id = $1::uuid`,
         id,
       );
     });
     return rows.length > 0;
   }
 
-  it("deletes access logs older than the tenant retention, keeps recent", async () => {
+  it("deletes sync logs older than the tenant retention, keeps recent", async () => {
     await setRetention(30);
-    const old = await insertAccessLog("now() - interval '31 days'");
-    const recent = await insertAccessLog("now() - interval '5 days'");
+    const old = await insertSyncLog("now() - interval '31 days'");
+    const recent = await insertSyncLog("now() - interval '5 days'");
 
     await ctx.su.prisma.$transaction(async (tx) => {
       await setBypassRlsGucs(tx);
-      await sweepPerTenantAge(tx, shareLogEntry, 100);
+      await sweepPerTenantAge(tx, syncLogEntry, 100);
     });
 
     expect(await logExists(old)).toBe(false);
@@ -113,11 +114,11 @@ describe("retention-gc append-only log retention (SC7)", () => {
 
   it("does NOT delete when the tenant retention is NULL", async () => {
     await setRetention(null);
-    const old = await insertAccessLog("now() - interval '400 days'");
+    const old = await insertSyncLog("now() - interval '400 days'");
 
     await ctx.su.prisma.$transaction(async (tx) => {
       await setBypassRlsGucs(tx);
-      await sweepPerTenantAge(tx, shareLogEntry, 100);
+      await sweepPerTenantAge(tx, syncLogEntry, 100);
     });
 
     expect(await logExists(old)).toBe(true);
@@ -125,10 +126,10 @@ describe("retention-gc append-only log retention (SC7)", () => {
 
   it("worker role CAN delete logs but CANNOT delete audit_logs (least privilege)", async () => {
     await setRetention(30);
-    const old = await insertAccessLog("now() - interval '31 days'");
+    const old = await insertSyncLog("now() - interval '31 days'");
 
     await ctx.retentionWorker.prisma.$transaction(async (tx) => {
-      await sweepPerTenantAge(tx, shareLogEntry, 100);
+      await sweepPerTenantAge(tx, syncLogEntry, 100);
     });
     expect(await logExists(old)).toBe(false);
 

--- a/src/__tests__/db-integration/retention-gc-notifications.integration.test.ts
+++ b/src/__tests__/db-integration/retention-gc-notifications.integration.test.ts
@@ -1,10 +1,9 @@
 /**
- * Real-DB test for SC7 append-only log retention (PER_TENANT_AGE).
+ * Real-DB test for SC7 notification retention (PER_TENANT_AGE).
  *
- * share_access_logs (created_at age basis). directory_sync_logs (started_at) and
- * notifications (created_at) share the identical PER_TENANT_AGE codepath and have
- * their own live-DB companions (retention-gc-directory-sync-logs,
- * retention-gc-notifications).
+ * Companion to retention-gc-append-only-logs (share_access_logs). This exercises
+ * the notifications table specifically: created_at age basis, child of users.
+ * Verifies the live worker DELETE path, NULL = never, and worker least-privilege.
  */
 
 import {
@@ -25,15 +24,14 @@ import {
 import { sweepPerTenantAge } from "@/workers/retention-gc-worker/sweep";
 import { RETENTION_REGISTRY } from "@/workers/retention-gc-worker/registry";
 
-const shareLogEntry = RETENTION_REGISTRY.find(
-  (e) => e.kind === "PER_TENANT_AGE" && e.table === "share_access_logs",
+const notificationEntry = RETENTION_REGISTRY.find(
+  (e) => e.kind === "PER_TENANT_AGE" && e.table === "notifications",
 )! as Extract<(typeof RETENTION_REGISTRY)[number], { kind: "PER_TENANT_AGE" }>;
 
-describe("retention-gc append-only log retention (SC7)", () => {
+describe("retention-gc notification retention (SC7)", () => {
   let ctx: TestContext;
   let tenantId: string;
   let userId: string;
-  let shareId: string;
 
   beforeAll(async () => {
     ctx = await createTestContext();
@@ -44,18 +42,6 @@ describe("retention-gc append-only log retention (SC7)", () => {
   beforeEach(async () => {
     tenantId = await ctx.createTenant();
     userId = await ctx.createUser(tenantId);
-    shareId = randomUUID();
-    await ctx.su.prisma.$transaction(async (tx) => {
-      await setBypassRlsGucs(tx);
-      await tx.$executeRawUnsafe(
-        `INSERT INTO password_shares (id, token_hash, encrypted_data, data_iv, data_auth_tag, expires_at, created_by_id, tenant_id, created_at)
-         VALUES ($1::uuid, $2, '\\x00', 'iv', 'tag', now() + interval '7 days', $3::uuid, $4::uuid, now())`,
-        shareId,
-        `sh-${shareId.slice(0, 16)}`,
-        userId,
-        tenantId,
-      );
-    });
   });
   afterEach(async () => {
     await ctx.deleteTestData(tenantId);
@@ -65,72 +51,73 @@ describe("retention-gc append-only log retention (SC7)", () => {
     await ctx.su.prisma.$transaction(async (tx) => {
       await setBypassRlsGucs(tx);
       await tx.$executeRawUnsafe(
-        `UPDATE tenants SET share_access_log_retention_days = ${days === null ? "NULL" : "$2"} WHERE id = $1::uuid`,
+        `UPDATE tenants SET notification_retention_days = ${days === null ? "NULL" : "$2"} WHERE id = $1::uuid`,
         ...(days === null ? [tenantId] : [tenantId, days]),
       );
     });
   }
 
-  async function insertAccessLog(ageExpr: string): Promise<string> {
+  async function insertNotification(ageExpr: string): Promise<string> {
     const id = randomUUID();
     await ctx.su.prisma.$transaction(async (tx) => {
       await setBypassRlsGucs(tx);
       await tx.$executeRawUnsafe(
-        `INSERT INTO share_access_logs (id, share_id, tenant_id, created_at)
-         VALUES ($1::uuid, $2::uuid, $3::uuid, ${ageExpr})`,
+        `INSERT INTO notifications
+           (id, user_id, tenant_id, type, title, body, is_read, created_at)
+         VALUES ($1::uuid, $2::uuid, $3::uuid, 'SECURITY_ALERT'::"NotificationType", 'title', 'body', false, ${ageExpr})`,
         id,
-        shareId,
+        userId,
         tenantId,
       );
     });
     return id;
   }
 
-  async function logExists(id: string): Promise<boolean> {
+  async function notificationExists(id: string): Promise<boolean> {
     const rows = await ctx.su.prisma.$transaction(async (tx) => {
       await setBypassRlsGucs(tx);
       return tx.$queryRawUnsafe<{ id: string }[]>(
-        `SELECT id FROM share_access_logs WHERE id = $1::uuid`,
+        `SELECT id FROM notifications WHERE id = $1::uuid`,
         id,
       );
     });
     return rows.length > 0;
   }
 
-  it("deletes access logs older than the tenant retention, keeps recent", async () => {
+  it("deletes notifications older than the tenant retention, keeps recent", async () => {
     await setRetention(30);
-    const old = await insertAccessLog("now() - interval '31 days'");
-    const recent = await insertAccessLog("now() - interval '5 days'");
+    const old = await insertNotification("now() - interval '31 days'");
+    const recent = await insertNotification("now() - interval '5 days'");
 
     await ctx.su.prisma.$transaction(async (tx) => {
       await setBypassRlsGucs(tx);
-      await sweepPerTenantAge(tx, shareLogEntry, 100);
+      await sweepPerTenantAge(tx, notificationEntry, 100);
     });
 
-    expect(await logExists(old)).toBe(false);
-    expect(await logExists(recent)).toBe(true);
+    expect(await notificationExists(old)).toBe(false);
+    expect(await notificationExists(recent)).toBe(true);
   });
 
   it("does NOT delete when the tenant retention is NULL", async () => {
     await setRetention(null);
-    const old = await insertAccessLog("now() - interval '400 days'");
+    const old = await insertNotification("now() - interval '400 days'");
 
     await ctx.su.prisma.$transaction(async (tx) => {
       await setBypassRlsGucs(tx);
-      await sweepPerTenantAge(tx, shareLogEntry, 100);
+      await sweepPerTenantAge(tx, notificationEntry, 100);
     });
 
-    expect(await logExists(old)).toBe(true);
+    expect(await notificationExists(old)).toBe(true);
   });
 
-  it("worker role CAN delete logs but CANNOT delete audit_logs (least privilege)", async () => {
+  it("worker role CAN delete notifications but CANNOT delete audit_logs (least privilege)", async () => {
     await setRetention(30);
-    const old = await insertAccessLog("now() - interval '31 days'");
+    const old = await insertNotification("now() - interval '31 days'");
 
     await ctx.retentionWorker.prisma.$transaction(async (tx) => {
-      await sweepPerTenantAge(tx, shareLogEntry, 100);
+      await sweepPerTenantAge(tx, notificationEntry, 100);
     });
-    expect(await logExists(old)).toBe(false);
+    expect(await notificationExists(old)).toBe(false);
 
     await expect(
       ctx.retentionWorker.prisma.$transaction(async (tx) => {


### PR DESCRIPTION
## Summary

Follow-up to the retention-GC series. The SC7 append-only-log integration test (`retention-gc-append-only-logs`) exercised `share_access_logs` as the *representative* `PER_TENANT_AGE` table and left `directory_sync_logs` and `notifications` to the registry DMMF check + sweep unit test. This PR adds live-DB companions so **every** per-tenant-retention table is proven, through the actual worker codepath, to delete expired rows.

Prompted by the question: "did we actually test that data gets deleted via the worker?" — the answer is yes for `trashRetentionDays` / `historyRetentionDays` / `shareAccessLogRetentionDays`, but `directorySyncLogRetentionDays` and `notificationRetentionDays` were only covered transitively. This closes that gap.

## Changes

- `retention-gc-directory-sync-logs.integration.test.ts` — `directory_sync_logs` (started_at age basis, child of `directory_sync_configs`).
- `retention-gc-notifications.integration.test.ts` — `notifications` (created_at age basis, child of `users`).
- Updated the `retention-gc-append-only-logs` header comment to point at the new companions instead of claiming the two tables are unit-test-only.

Each new test asserts the same three properties as the existing per-tenant-age tests, calling the real `sweepPerTenantAge` worker function in a live DB transaction (not a mock):
1. deletes rows older than the tenant retention, keeps recent ones;
2. `NULL` retention → never deletes (matches the worker's skip-on-null enumeration);
3. worker role CAN delete the target table but CANNOT delete `audit_logs` (least privilege).

The two tables differ from `share_access_logs` in age basis (`started_at` vs `created_at`) and parent FK, which is what makes exercising the per-table path directly worthwhile rather than relying on the shared codepath alone.

## Tests

Test-only change. `npm run test:integration -- retention-gc-append-only-logs retention-gc-directory-sync-logs retention-gc-notifications` → 9/9 pass. `pre-pr.sh` 36/36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)