### PR TITLE
feat(ios): render type-specific fields in entry detail view

### DIFF
--- a/docs/archive/review/ios-entry-detail-type-specific-fields-code-review.md
+++ b/docs/archive/review/ios-entry-detail-type-specific-fields-code-review.md
@@ -1,0 +1,51 @@
+# Code Review: ios-entry-detail-type-specific-fields
+
+Date: 2026-06-19
+Review round: 1 (terminated — tightening-only)
+
+## Changes from Previous Round
+Initial code review of the Phase 2 implementation (`git diff origin/main..HEAD`, iOS-only).
+
+## Functionality Findings
+**No findings.** All 8 verification checks passed:
+- Blob-key fidelity: every decoded key byte-exact vs the web `fullBlob` literals (`src/components/passwords/personal/personal-*-form.tsx`) for all 7 non-login types — incl. SSH `passphrase`/`comment` + `keySize: String?`, secure-note `content`, identity's 20 keys.
+- entryType gating: correct sub-struct per type, siblings nil, LOGIN/nil/unknown builds none; all type strings match server `ENTRY_TYPE`.
+- C7 Edit gate: no path lets a non-login entry reach `EntryForm.edit`.
+- C8 clear-on-lock: `.onChange(of: autoLockService.state)` clears on `.locked` and `.loggedOut`, not on unlock; no race.
+- SecretRow: per-row reveal isolation correct; composes in List/Section; @ViewBuilder optionals correct.
+- D1 deviation sensible; switch exhaustive (no `default`); no consumer broken (AutoFill/AutoCopyTOTP/DebugVaultLoader).
+
+## Security Findings
+**No findings.** Masked-field set matches the web `SENSITIVE_FIELDS` SSoT (`src/lib/constants/auth/share-permission.ts`) exactly for every type (card number/cvv; identity address/addressLine1/addressLine2/postalCode/idNumber; bank accountNumber/routingNumber/iban; ssh privateKey/passphrase; licenseKey; passkey credentialId; secure-note content `.privacySensitive()`). All copies route through `SecureClipboard` (localOnly + auto-clear); no raw `UIPasteboard`. Reveal/copy call `recordActivity()`. Passkey provider-private material (`passkeyPrivateKeyJwk`/`userHandle`/`signCount`) is NOT decoded into the display struct (isolated to the assertion-only `PasskeyFullBlobPayload`). No value logging. AutoFill keeps `entryType` nil (no new extension secret decode).
+
+## Testing Findings
+- **T1 (Low) — RESOLVED**: LOGIN-scalar-empty assertions (`url`/`password == ""`) added to the bank/ssh/software-license/passkey decode tests (previously only on card/identity).
+- **T2 (Low) — RESOLVED**: sibling-sub-struct-nil assertions added to the same four tests.
+- **T5 (Low) — ACCEPTED**: a dedicated minimal-fixture (absent→nil) test exists for credit card only.
+  - **Anti-Deferral check**: acceptable risk.
+  - Worst case: a non-card sub-struct field wired to the wrong key but still decoding to nil on a minimal fixture ships undetected. Likelihood: low — all sub-struct fields are uniform `String?` and every full-fixture test uses distinct non-default values per field, which catches cross-key swaps. Cost to fix: ~6 small tests. Accepted: the full per-field tests already guard the realistic regression (cross-key swap); the absent→nil edge is covered representatively by the credit-card minimal test.
+  - **Orchestrator sign-off**: accepted as a representative reading of C5's "per-sub-struct minimal fixture".
+- **T9 (Info) — ACCEPTED**: the C8 clear-on-lock decision is inlined (`newState != .unlocked`) rather than extracted into a unit-tested predicate.
+  - **Anti-Deferral check**: acceptable risk. The decision is a single-token enum comparison; extracting a named `shouldClear(state:)` + test is over-engineering (YAGNI) for a comparison the compiler already type-checks. The `isEditableOnIOS` seam (genuine branching logic) WAS extracted + tested. Clear-on-lock is covered by the manual Debug-fixture checklist (C8 acceptance). Cost-to-fix trivial but value near-zero.
+  - **Orchestrator sign-off**: accepted; inlined trivial comparison, manual-checklist covered.
+
+## Adjacent Findings
+None.
+
+## Recurring Issue Check
+### Functionality expert
+- R2/R12 (exhaustive switch, no default): PASS. R3 (key fidelity across boundary): PASS. R19 (optional defaults/back-compat): PASS. R25 (consumer breakage): PASS. R39 (secret residency): PASS (C8). Others N/A.
+### Security expert
+- R39: addressed (C8). RS1 (clipboard auto-clear): PASS. RS2 (unmasked secret): PASS (SSoT parity). RS3 (passkey private leak): PASS. RS4 (secret logging): PASS. RS5 (AutoFill regression): PASS.
+### Testing expert
+- RT1 (vacuous assertions): none. RT2 (default expected values): PASS (distinct literals). RT3 (T10 shared-key over-assertion): PASS (username/email not over-asserted). RT4 (coverage gaps): T1/T2 resolved, T5 accepted. RT5 (shared state/async): none. RT6 (regression pins): intact (addition-only). RT7 (cheap pure seam): T9 accepted.
+
+## Environment Verification Report
+Per Phase 1 `Verification environment constraints`:
+- `verifiable-local` (full test suite): **verified-local** — `xcodebuild test -scheme PasswdSSOApp` on sim 5EC37BD5, 538 unit tests + UI tests pass.
+- Per-type visual parity on device (`blocked-deferred` in Phase 1): **blocked-deferred** — requires seeded vault entries of all 8 types on a device; mitigated by the byte-exact decoder unit tests (C5) and the DebugVaultLoader manual checklist. Links to Phase 1 constraint entry (Verification environment constraints, bullet 2). No Anti-Deferral cost beyond the manual-checklist mitigation already planned.
+
+## Resolution Status
+- T1, T2: assertions added to `ios/PasswdSSOTests/EntryBlobDecoderTests.swift` (bank/ssh/license/passkey tests); 538 tests pass.
+- T5, T9: accepted per Anti-Deferral justifications above.
+- No Critical/Major findings in any perspective. Review loop terminated after Round 1 (tightening-only: all new findings test-only, inline-minor, within prior fix scope, no security boundary).

--- a/docs/archive/review/ios-entry-detail-type-specific-fields-deviation.md
+++ b/docs/archive/review/ios-entry-detail-type-specific-fields-deviation.md
@@ -1,0 +1,23 @@
+# Coding Deviation Log: ios-entry-detail-type-specific-fields
+
+## D1 — Non-login type sections render only populated fields (skip empty)
+
+**Plan reference**: Requirements → "Empty/absent fields render the existing muted 'Not set' placeholder (consistent with current LOGIN behavior)."
+
+**Deviation**: For the 7 non-login type-specific sections, a field row is rendered ONLY when the field has a value (`optionalFieldRow` / `optionalSecretRow` skip empty/nil). LOGIN is unchanged — it still shows its fixed username/password/url/notes/TOTP rows with "Not set" for empties.
+
+**Rationale**: IDENTITY has 20 fields and most are typically empty; rendering 15 "Not set" rows is poor UX and diverges from the web app, which renders type-specific fields conditionally. The "show all with Not set" idiom exists for LOGIN because LOGIN is editable on iOS and the rows mirror the edit form; non-login entries are read-only on iOS (C7), so empty rows carry no affordance. SECURE_NOTE keeps a single "Not set" when its body is empty (the note body is the entry's whole point, so its absence is worth showing).
+
+**Impact**: Display-only; no contract/security change. Masking (SecretRow) and copy (copySecurely) behavior is identical to plan.
+
+## D2 — Non-login footer caption
+
+**Plan reference**: C7/F11 — scope the LOGIN edit-preservation footer to `.login`; "(optionally a neutral 'Edit this entry in the web app')" for non-login.
+
+**Deviation**: Implemented the optional path — non-login entries show a neutral "Edit this entry in the web app." caption; LOGIN keeps its original edit-preservation caption. Within plan latitude.
+
+## D3 — Decoder type-gating uses raw string comparison, not EntryTypeCategory
+
+**Plan reference**: C2 — "When `entryType` resolves (via `EntryTypeCategory.from`) to a non-login type…"
+
+**Deviation**: `EntryBlobDecoder` lives in the `Shared` target; `EntryTypeCategory` lives in the app target and is not importable from Shared. The decoder therefore gates sub-struct construction on the raw `entryType` string (`entryType == "CREDIT_CARD"` etc.) directly. Same behavior; the raw strings are the same server constants `EntryTypeCategory` maps. The view layer still uses `EntryTypeCategory.from` for dispatch.

--- a/docs/archive/review/ios-entry-detail-type-specific-fields-plan.md
+++ b/docs/archive/review/ios-entry-detail-type-specific-fields-plan.md
@@ -1,0 +1,229 @@
+# Plan: iOS Entry Detail — Type-Specific Field Rendering
+
+## Project context
+
+- **Type**: iOS app (SwiftUI) within a mixed monorepo. This change is iOS-only (`ios/` tree). No web/server/CLI changes.
+- **Test infrastructure**: unit tests (XCTest) via `xcodebuild test -scheme PasswdSSOApp`. No iOS E2E. SwiftUI view rendering is not unit-testable in this repo; decoder logic is.
+- **Verification environment constraints**:
+  - `xcodebuild` (Xcode 26.4.1) is runnable in this environment (see memory `ios-build-env-available`). Full suite (~526 tests) runs against a simulator destination. → `verifiable-local`.
+  - Manual visual confirmation of each type's detail layout on a device/simulator with real encrypted entries of every type is **not** fully reproducible here (requires seeded vault entries of all 8 types). The Debug fixture loader (`DebugVaultLoader.swift`) can stand in for visual checks. → per-type visual parity = `blocked-deferred` for device verification, mitigated by decoder unit tests + Debug fixtures (see Testing strategy).
+
+## Objective
+
+Make the iOS read-only entry **detail** view render the correct field set for each of the 8 entry types (LOGIN, SECURE_NOTE, CREDIT_CARD, IDENTITY, BANK_ACCOUNT, SSH_KEY, SOFTWARE_LICENSE, PASSKEY), matching the web app's per-type sections. Today the detail view is hard-wired to a single LOGIN template (username / password / url / notes / TOTP) and ignores `entryType` entirely; type-specific fields (card number, IBAN, SSH private key, …) are dropped at decode time.
+
+## Requirements
+
+### Functional
+- The detail view displays, per type, the same fields the web app shows (field lists locked in Contracts below — sourced byte-for-byte from the web `fullBlob` assembly).
+- LOGIN behavior is unchanged (regression-free): username, password (reveal+copy), url, notes, TOTP.
+- SECURE_NOTE shows its note `content` (the note body lives under the `content` key, NOT `notes`).
+- Sensitive fields (card number, CVV, account/routing/IBAN, SSH private key & passphrase, license key, identity ID number, passkey credential id) are masked by default with a reveal+copy affordance, mirroring the password row.
+- Empty/absent fields render the existing muted "Not set" placeholder (consistent with current LOGIN behavior).
+- AutoFill extension behavior is unchanged.
+
+### Non-functional
+- No change to the on-the-wire / on-disk encrypted blob format (read-only consumer).
+- New source files auto-included by xcodegen directory globbing; `xcodegen generate` run and regenerated `project.pbxproj` committed.
+- All new user-facing labels localized in the String Catalog (EN + JA), per memory `ios-string-catalog-notes` (xcodebuild does not write back extraction — entries added by hand).
+- Per global rules: files < 300 lines, functions < 40 lines. The per-type sections go in a NEW file to keep `EntryDetailView.swift` under budget.
+
+## Technical approach
+
+### Decode strategy: flat blob, type-gated sub-structs
+The web stores a **single flat JSON object** per entry (no per-type nesting). Field names are disjoint across types except for shared keys (`title`, `notes`, `tags`, `username`, `email`). Therefore:
+
+- `EntryBlobDecoder.detail(...)` gains an `entryType: String? = nil` parameter. LOGIN fields are decoded **unconditionally** (back-compat: AutoFill passes nil → treated as LOGIN, identical to today). When `entryType` matches a non-login type, the decoder additionally constructs that type's sub-struct from the same flat payload.
+- `VaultEntryDetail` gains `entryType: String?` plus **optional per-type sub-structs** (`creditCard`, `identity`, `bankAccount`, `sshKey`, `softwareLicense`, `passkey`, `secureNote`). Grouping into sub-structs (vs ~45 flat optionals) keeps the model readable and the view's dispatch clean. Exactly one sub-struct is non-nil for a non-login entry; all are nil for LOGIN.
+
+Rationale for `entryType`-gating (vs decode-everything-always): avoids populating a `CreditCardDetail` with all-nil fields for a LOGIN entry, and gives the view a single authoritative `category` without consulting the summary. The decoder already receives the cache row at every call site, so `entry.entryType` is in scope.
+
+### View dispatch
+`EntryDetailView.detailContent` switches on `EntryTypeCategory.from(rawType: detail.entryType)` and delegates to a per-type section builder. Reuses existing row helpers (`fieldRow`, `passwordRow`, `notSetText`, `copySecurely`, `TOTPCodeView`) plus one new standalone `SecretRow` subview (reveal+copy with its OWN per-row `@State`; `passwordRow` is left untouched — see C3). Per-type sections live in a new file `EntryDetailTypeSections.swift`.
+
+### Call-site threading of `entryType`
+Three decoder `.detail(...)` call sites pass `entryType`:
+- `VaultViewModel.decryptBlob` → `entry.entryType`
+- `TeamEntryDecryptor.decryptTeamDetail` → `entry.entryType`
+- `CredentialResolver.decryptEntryDetail` (AutoFill) → **leave defaulted (nil)**; AutoFill only needs username/password/totp, and nil keeps its behavior byte-identical. (Recorded as deliberate, not an omission.)
+
+## Contracts
+
+### C1 — `VaultEntryDetail` gains `entryType` + per-type sub-structs
+**File**: `ios/Shared/Models/VaultEntryDetail.swift`
+
+Signature (additive; existing fields and `init` parameters preserved, new params appended with defaults so existing constructors compile):
+```
+public struct VaultEntryDetail {
+  // ... all existing fields unchanged ...
+  public let entryType: String?                 // new; nil ⇒ treat as LOGIN
+  public let secureNote: SecureNoteDetail?      // new
+  public let creditCard: CreditCardDetail?      // new
+  public let identity: IdentityDetail?          // new
+  public let bankAccount: BankAccountDetail?    // new
+  public let sshKey: SshKeyDetail?              // new
+  public let softwareLicense: SoftwareLicenseDetail? // new
+  public let passkey: PasskeyDetail?            // new
+}
+```
+Sub-struct field names (Codable, Sendable, Equatable) — **must match these blob keys verbatim**. **Every field is optional** (decode-defensive: a missing key must never fail the sub-struct decode — mirrors the existing `FullBlobPayload` contract that all variant-shape fields are optional):
+- `SecureNoteDetail { content: String?; isMarkdown: Bool? }` (F2: `isMarkdown` MUST be optional — legacy notes omit it; a non-optional `Bool` makes the whole sub-struct fail to decode. `content` optional too, rendered `?? ""`.)
+- `CreditCardDetail { cardholderName, cardNumber, brand, expiryMonth, expiryYear, cvv: String? }`
+- `IdentityDetail { fullName, address, givenName, familyName, middleName, familyNameKana, givenNameKana, addressLine1, addressLine2, city, state, postalCode, country, phone, email, dateOfBirth, nationality, idNumber, issueDate, expiryDate: String? }`
+- `BankAccountDetail { bankName, accountType, accountHolderName, accountNumber, routingNumber, swiftBic, iban, branchName: String? }`
+- `SshKeyDetail { privateKey, publicKey, keyType, fingerprint, passphrase, comment, keySize: String? }` (blob keys are `passphrase`/`comment`, NOT `sshPassphrase`/`sshComment`. F6: `keySize` is typed `String?` not `Int?` — the web ssh form's `keySize` is a free text `<Input>` written as `keySize || null`, so the JSON value may be a string like `"2048"`; an `Int?` decode would fail on string-valued blobs.)
+- `SoftwareLicenseDetail { softwareName, licenseKey, version, licensee, email, purchaseDate, expirationDate: String? }`
+- `PasskeyDetail { relyingPartyId, relyingPartyName, username, credentialId, creationDate, deviceInfo: String? }` (provider-private fields `passkeyPrivateKeyJwk`, `passkeyUserHandle`, `passkeySignCount` etc. are NOT displayed and NOT decoded here)
+
+All date-ish fields (`dateOfBirth`, `issueDate`, `expiryDate`, `purchaseDate`, `expirationDate`, `creationDate`) are ISO date **strings** rendered **verbatim** — no `Date` parsing (the blob stores raw text-input strings; a `Date` decode would nil-out non-ISO values).
+
+**Invariants** (app-enforced):
+- For non-login entries exactly one of the 7 sub-structs is non-nil; for LOGIN all 7 are nil.
+- `notes` (top-level) continues to hold the note for all types EXCEPT SECURE_NOTE, whose body is `secureNote.content` (top-level `notes` is absent/empty for secure notes).
+
+**Acceptance**: struct compiles; the appended init params are defaulted so the actual existing constructors still build. (Correction per F3/T5: `VaultEntryDetail(...)` is constructed only in `EntryBlobDecoder.detail` and ~15 test sites in `CredentialResolverTests.swift`/`AutoCopyTOTPTests.swift` — all use labeled args. `DebugVaultLoader.swift` does NOT construct `VaultEntryDetail`; it JSON-encodes a private LOGIN-shaped `FullBlob` struct — see C5 DebugVaultLoader scope.)
+
+**Consumer-flow walkthrough**:
+- Consumer `EntryDetailView.detailContent` (path: `ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift`) reads `{ entryType, username, password, url, notes, totp*, secureNote, creditCard, identity, bankAccount, sshKey, softwareLicense, passkey }` and uses `entryType` to pick which sub-struct's fields to render.
+- Consumer `AutoCopyTOTP.totpToCopy` (path: `ios/Shared/TOTP/AutoCopyTOTP.swift`) reads `{ totpSecret, totpAlgorithm, totpDigits, totpPeriod }` only — unaffected by new fields.
+- Consumer `CredentialProviderViewController.autoCopyTotpIfEnabled` (path: AutoFill ext) reads `{ totpSecret, ... }` only — unaffected.
+
+### C2 — `EntryBlobDecoder.detail` decodes type-specific fields
+**File**: `ios/Shared/Models/EntryBlobDecoder.swift`
+
+Signature:
+```
+public static func detail(plaintext: Data, entryId: String, teamId: String?,
+                          entryType: String? = nil) -> VaultEntryDetail?
+```
+- `FullBlobPayload` extended with all optional type fields above (all `Decodable` optionals; absent → nil).
+- LOGIN fields decoded as today regardless of `entryType` (back-compat).
+- When `entryType` resolves (via `EntryTypeCategory.from`) to a non-login type, construct the matching sub-struct from the decoded payload and pass it to `VaultEntryDetail`; other sub-structs nil. `entryType` stored on the result.
+- A non-login blob with absent `password` still decodes (existing behavior preserved — `password ?? ""`).
+- **`entryType` source (F4)**: `entryType` comes from `CacheEntry.entryType` (the param threaded by the caller), **never** from the blob. Personal forms omit `entryType` from `fullBlob`; team writes it but we ignore the blob copy. Do NOT add an `entryType` decode key to `FullBlobPayload` (it would be nil for every personal entry and misclassify).
+
+**Invariants**:
+- Decode never throws on a well-formed blob of any type; returns nil only on JSON parse failure (unchanged contract).
+- Unknown/legacy `entryType` (or nil) ⇒ LOGIN sub-struct selection (all sub-structs nil), login fields populated.
+
+**Forbidden patterns** (grep keys for Phase 2/3 conformance):
+- `pattern: sshPassphrase|sshComment` in `EntryBlobDecoder.swift` decode keys — reason: blob keys are `passphrase`/`comment`; using the web display-aliases would silently decode nil.
+- `pattern: "content"` must appear in the secure-note decode path — reason: note body key is `content`, not `notes`.
+
+**Acceptance**: new XCTest cases (C5) decode one fixture per type and assert every locked field.
+
+### C3 — Detail view renders per-type sections
+**Files**: `ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift` (dispatch only; `passwordRow`/`fieldRow`/`notSetText`/`copySecurely` left untouched), new `ios/PasswdSSOApp/Views/Vault/EntryDetailTypeSections.swift` (per-type section builders as `extension EntryDetailView` + a standalone `SecretRow` subview).
+
+- `detailContent(_ d:)` computes `let category = EntryTypeCategory.from(rawType: d.entryType)` and switches:
+  - `.login` → existing rows (username, password, url, notes, TOTP) — **unchanged output** (calls the same `passwordRow`/`fieldRow` as today; T6).
+  - `.secureNote` → note content section; render `secureNote.content` as `Text(...).privacySensitive()` (S2: web classifies `content` as sensitive; existing LOGIN `notes` already uses `.privacySensitive()`), "Not set" when empty (accept divergence from web's empty-area per F5).
+  - `.creditCard` → cardholderName, brand, **cardNumber (SecretRow)**, expiryMonth/expiryYear, **cvv (SecretRow)**, notes.
+  - `.identity` → name group, **address / addressLine1 / addressLine2 / postalCode (SecretRow)** (S1: web SSoT `SENSITIVE_FIELDS` masks these PII fields), city/state/country/phone/email/nationality/dateOfBirth/issueDate/expiryDate (plain), **idNumber (SecretRow)**, notes.
+  - `.bankAccount` → bankName, accountType, accountHolderName, **accountNumber/routingNumber/iban (SecretRow)**, swiftBic (plain — public institution id), branchName, notes.
+  - `.sshKey` → keyType, keySize, fingerprint (plain — public), publicKey (plain — public), **privateKey/passphrase (SecretRow)**, comment, notes.
+  - `.softwareLicense` → softwareName, **licenseKey (SecretRow)**, version, licensee, email, purchaseDate, expirationDate, notes.
+  - `.passkey` → relyingPartyId, relyingPartyName, username, **credentialId (SecretRow)**, creationDate, deviceInfo (plain), notes.
+- **`SecretRow` subview (F7, F8, S3, S4)**: a standalone SwiftUI `View` struct (NOT a generalization of `passwordRow`, which stays as-is per T6) owning its OWN `@State private var isRevealed = false`, so revealing one secret does NOT reveal sibling secrets in multi-secret types (credit card = cardNumber + cvv; bank = accountNumber + routingNumber + iban; ssh = privateKey + passphrase). It takes `label`, `value`, and an `onCopy: (String) -> Void` closure (wired to the view's `copySecurely`) plus an `onActivity: () -> Void` (wired to `autoLockService.recordActivity()`). Both reveal-toggle and copy buttons call `onActivity`. Masked value uses the same `SecureField`/monospaced pattern as `passwordRow` and is `.privacySensitive()` when revealed.
+- Per-type section builders live in `extension EntryDetailView { }` (F8) so they reach `fieldRow`, `notSetText`, `copySecurely`, `autoLockService`. Section ordering and labels mirror the web sections for parity.
+- **Access-control prerequisite (F9 — compile blocker)**: `fieldRow`, `notSetText`, `copySecurely` (and any helper the new extension calls) are currently `private` in `EntryDetailView.swift`. Swift `private` is file-scoped — a same-type `extension` in a SEPARATE file cannot see them and will NOT compile. Relax these helpers from `private` to `internal` (drop the modifier) as part of C3. `autoLockService` is already an internal `let` (fine). `passwordRow`/`isPasswordVisible` stay `private` (only the `.login` branch in the same file uses them; T6).
+- **`customFields` deliberately not decoded/rendered (S8)**: iOS does not surface custom fields (consistent with the existing footer "custom fields … edit those in the web app"). A future contributor adding custom-field display MUST route any password-type custom value through `SecretRow`.
+
+**Invariants**:
+- LOGIN rendering is structurally unchanged — `detailContent`'s `.login` branch calls the existing helpers with no row added/removed/reordered, and `passwordRow` is not refactored (T6).
+- Every copy affordance (SecretRow AND fieldRow) routes through `copySecurely` → `SecureClipboard.copy(clearAfter:)`; NO direct `UIPasteboard` write anywhere in the new file (S3).
+- Every reveal/copy on a SecretRow calls `autoLockService.recordActivity()` (S4 — parity with `passwordRow`; no new biometric gate, no weaker gate).
+- Sensitive-field masking matches the web `SENSITIVE_FIELDS` SSoT (S1/S2): masked = cardNumber, cvv, accountNumber, routingNumber, iban, privateKey, passphrase, licenseKey, idNumber, credentialId, identity address/addressLine1/addressLine2/postalCode, secure-note content (`.privacySensitive()` at minimum).
+- Every label string is a `LocalizedStringKey` backed by a String Catalog entry (C4).
+
+**Forbidden patterns**:
+- `pattern: UIPasteboard` — reason: must not appear in `EntryDetailTypeSections.swift`; all copy goes through `copySecurely`/`SecureClipboard` (S3).
+- `pattern: passkeyPrivateKeyJwk|passkeyUserHandle|passkeySignCount` — reason: must not appear in `EntryDetailTypeSections.swift` or the `PasskeyDetail` decode path; passkey provider-private material is never surfaced (S6).
+- `pattern: sshPassphrase|sshComment` — reason: blob keys are `passphrase`/`comment` (see C2).
+- `detailContent` switch over `EntryTypeCategory` must be exhaustive with NO `default` clause (compiler-checked coverage; R2/R12).
+
+**Acceptance**: build succeeds; manual/Debug-fixture check shows each type's field set with the masked fields above behind reveal. `EntryDetailView.swift` stays < 300 lines (sections extracted to the new file).
+
+### C7 — Gate Edit button to LOGIN-only (prevent type-specific data corruption)
+**File**: `ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift` (toolbar Edit button + footer caption); `ios/PasswdSSOApp/Views/Vault/EntryTypeCategory.swift` (testable predicate).
+
+**Problem (F1, corrected per F12)**: the toolbar shows an unconditional Edit button opening `EntryForm(mode: .edit(...))`, which is LOGIN-shaped (`title/username/password/url/notes/totpSecret` only). The iOS save path (`PersonalEntryBlobBuilder.applyEdits`) is a documented preserve-unknown round-trip, so it does NOT literally drop every type-specific key. The real corruption (verified): the LOGIN form pre-populates from a `VaultEntryDetail` that now has `password==""`/`url==""` for a non-login entry, and on save `applyMutation` unconditionally writes `password`, sets `url`/`username`/`notes` to NSNull, and injects a login-shaped `urlHost`/`hasTOTP` overview — polluting a card/SSH entry with empty login scalars and a login-shaped overview. Today the detail view looks login-shaped so the hazard is latent; this change makes non-login entries look first-class and editable, surfacing it. In-scope.
+
+**Fix**:
+- Add a pure, testable predicate on `EntryTypeCategory` (T11): `static func isEditableOnIOS(rawType: String?) -> Bool { from(rawType: rawType) == .login }`. The toolbar consults it.
+- Gate the Edit button: render it only when `EntryTypeCategory.isEditableOnIOS(rawType: detail?.entryType)`. Nil-state (F10): `detail` is async-optional; `from(nil) == .login` so the button shows during load then hides once a non-login entry resolves — acceptable (the edit sheet body is itself `if let detail`-guarded; button-only gating suffices). Prefer hiding over disabling.
+- Footer caption (F11): the existing footer "Tags, custom fields, generator settings, and password history are kept when you save an edit here — edit those in the web app" is LOGIN-edit-specific and misleading for non-login types. Scope it to the `.login` branch; for non-login show no edit-preservation caption (optionally a neutral "Edit this entry in the web app").
+
+**Invariants**: no non-login entry can reach `EntryForm.edit` from iOS.
+
+**Acceptance**: `isEditableOnIOS` unit-tested (C5) — true for LOGIN/nil/unknown, false for the 7 non-login types; opening a non-login entry shows no Edit affordance; LOGIN entry still shows Edit and its footer caption.
+
+### C8 — Clear `detail` on auto-lock (broadened secret surface)
+**File**: `ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift`.
+
+**Problem (S5/S9, R39)**: `detail` (`@State VaultEntryDetail?`) is cleared only on `.onDisappear`. `lock()` does NOT unmount the view, so an idle-timeout lock while an `EntryDetailView` is foregrounded leaves decrypted secrets resident — now a materially larger surface (SSH private key, passphrase, card number, CVV, IBAN, license key) than today's password+TOTP. Promoted from a testing-strategy note to a binding contract because the expanded surface makes clear-on-lock a correctness requirement.
+
+**Fix**: observe `autoLockService.state`; on transition to a locked/logged-out state set `detail = nil`. Factor the "should clear" decision into a testable function where practical (T13). Swift `String` non-zeroization remains an accepted limitation (now covering more secret types) — out of scope to fully wipe backing bytes.
+
+**Acceptance**: with an `EntryDetailView` (non-login) foregrounded, triggering lock clears `detail` (no decrypted secret retained in `@State`); verified via the extracted decision function unit test and/or a manual lock-while-foregrounded check.
+
+### C4 — Localization (String Catalog)
+**File**: `ios/PasswdSSOApp/.../Localizable.xcstrings` (the catalog already backing the view; confirm path during Phase 2).
+- Add EN + JA entries for every new field label (cardholderName, cardNumber, brand, expiry, cvv, IBAN, routing number, SWIFT/BIC, private key, fingerprint, passphrase, license key, software name, version, licensee, purchase/expiration date, relying party, credential ID, identity name/address/contact/date fields, etc.).
+- Reuse existing keys where present (Username, URL, Notes already exist).
+- Follow memory `ios-string-catalog-notes`: add entries by hand (xcodebuild won't extract); `String` interpolation pitfalls N/A (static labels).
+
+**Acceptance**: no missing-key fallbacks; JA strings present for all new labels.
+
+### C5 — Decoder tests (one per type)
+**File**: `ios/PasswdSSOTests/EntryBlobDecoderTests.swift`
+- Add `testDetailDecodes<Type>Blob` for each of: secureNote, creditCard, identity, bankAccount, sshKey, softwareLicense, passkey. Each builds a plaintext JSON fixture using the **exact locked blob keys** (SSH fixture MUST use `passphrase`/`comment`, not the web display-aliases — T9) and asserts:
+  - every field on the resulting sub-struct (non-default expected values so a dropped/mis-keyed mapping flips the assertion — T7);
+  - sibling sub-structs are nil;
+  - **unconsumed LOGIN scalars are empty for non-login types** (T1), with per-type precision (T10): `url` and `password` are non-login-absent for ALL 7 types → assert `== ""`. But `username`/`email` are SHARED keys decoded unconditionally and legitimately populate for some types (PASSKEY has `username`; IDENTITY/BANK_ACCOUNT/SOFTWARE_LICENSE/PASSKEY have `email`). Do NOT blanket-assert `username == ""`/`email == ""`; assert empty only for types whose locked blob omits that key. This catches a stray "URL/Password" row regression without producing a false assertion for identity/passkey.
+- Add a **per-sub-struct minimal fixture** test (only a couple of keys present) asserting the omitted fields decode to `nil` (T2) — catches a field silently mapped to the wrong key.
+- Add a regression test: LOGIN blob with `entryType: "LOGIN"` and with `entryType: nil` both yield identical login fields and all-nil sub-structs.
+- Add: SECURE_NOTE asserts body comes from `content`, AND that it did NOT leak into `detail.notes` — pin the content-vs-notes split in both directions (T1).
+- Add a **team-path** test (T8): `EntryBlobDecoder.detail(plaintext:, entryId:, teamId: "t1", entryType: "CREDIT_CARD")` populates `creditCard` and carries `teamId` — pins that the `TeamEntryDecryptor.decryptTeamDetail` call site's `entryType` argument is honored.
+- Add an **`isEditableOnIOS` test** (T11, in `EntryTypeCategoryTests.swift`): true for `"LOGIN"`, nil, and unknown raw types (fallback-to-login); false for all 7 non-login raw types. This is the committed regression guard for the C7 data-corruption gate — the only automated coverage of that guard.
+
+**Acceptance**: `xcodebuild test -scheme PasswdSSOApp` green. The durable guard is the per-field `XCTAssertEqual` on non-default values (T7); "temporarily breaking a key" is a one-time sanity check, not the committed safety net.
+
+**Manual checklist additions** (Debug fixtures, T12/T13): on a credit-card / bank / SSH fixture, reveal one secret and confirm sibling secrets stay masked (SecretRow per-row `@State` isolation); with a non-login entry foregrounded, trigger lock and confirm the detail clears (C8).
+
+### C6 — Build config / xcodegen
+- Run `xcodegen generate` after adding `EntryDetailTypeSections.swift`; commit regenerated `ios/PasswdSSOApp.xcodeproj/project.pbxproj`. (Directory globbing auto-includes the file; the committed pbxproj must reflect it — see memory `ios-xcodegen-build-settings`.)
+
+## Testing strategy
+- **Unit (primary)**: C5 decoder tests — the type-gated decode is the logic surface and is fully unit-testable with plaintext fixtures (existing pattern in `EntryBlobDecoderTests.swift`).
+- **Build**: `xcodegen generate` then `xcodebuild build`/`test` for `PasswdSSOApp` on a simulator destination (env supports it).
+- **Manual/visual (mitigated)**: extend `DebugVaultLoader.swift` fixtures with one entry per non-login type so the detail layout can be eyeballed in the Debug build. **Non-trivial (T3)**: `DebugVaultLoader`'s `FullBlob`/`OverviewBlob` structs are LOGIN-shaped and its `CacheEntry` rows are built with `entryType` defaulted nil — realizing per-type fixtures requires adding type-specific Encodable blob shapes AND threading `entryType:` onto the debug `CacheEntry`. Scope this as a real checklist item, not a one-liner. Full device verification across all types recorded as `blocked-deferred` (see Verification environment constraints); the per-type field set + order is enumerated in C3 so the manual pass is a checklist, not a vibe check (T4).
+- **Lock-state verification (S5/R39)**: confirm the navigation stack collapses (or `detail` is cleared) on auto-lock while an `EntryDetailView` is foregrounded — `detail` now holds more secret material (private key, CVV, IBAN…). Today `detail` is cleared only on `.onDisappear`. If `lock()` can leave the detail view mounted, add a lock-state observer that sets `detail = nil`. Record R39's Swift-`String` non-zeroization as a known, accepted limitation now covering a broader secret surface.
+
+## Considerations & constraints
+- **SC1** — Create/Edit form remains LOGIN-only (user-confirmed scope). Non-login entries are read-only on iOS; editing happens in the web app. Owned by a future feature if iOS edit parity is ever pursued. (Matches existing `EntryEditForm.swift` design comment.)
+- **SC2** — Team entries: `TeamEntryDecryptor.decryptTeamDetail` is threaded with `entry.entryType` so team non-login entries render correctly too; no team key-pipeline change (orthogonal to memory's team QuickType gap).
+- **SC3** — Markdown rendering of SECURE_NOTE `content` is out of scope; render as plain `Text`. `isMarkdown` is decoded but not acted upon (parity deferred).
+- **SC4** — AutoFill `CredentialResolver.decryptEntryDetail` intentionally keeps `entryType` defaulted nil (no behavior change). Tracked here, not an omission.
+- Risk: mis-spelled blob key ⇒ silent nil field. Mitigated by C5 byte-exact fixtures + forbidden-pattern greps (C2).
+- Risk: `VaultEntryDetail` is `Codable` but never used over the wire (confirmed) — adding fields cannot break a decode contract.
+
+## User operation scenarios
+1. User taps a **credit card** entry in the category grid → detail shows cardholder, brand, masked card number (tap eye to reveal, copy), expiry, masked CVV, notes — not a blank password row.
+2. User taps an **SSH key** entry → public key + fingerprint visible, private key & passphrase masked with reveal; no spurious "Username/Password/URL" rows.
+3. User taps a **secure note** → note body shown (from `content`), no password/url rows.
+4. User taps a **login** entry → identical to today (regression check).
+5. User taps a **team** non-login entry → same per-type rendering as personal.
+6. AutoFill fills a login → unchanged.
+
+## Go/No-Go Gate
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | `VaultEntryDetail` + per-type sub-structs | pending |
+| C2 | `EntryBlobDecoder.detail` type-specific decode + `entryType` param | pending |
+| C3 | Detail view per-type section dispatch + `SecretRow` (+ `private`→`internal` helper relax) | pending |
+| C4 | String Catalog labels (EN+JA) | pending |
+| C5 | Decoder tests per type (+ team path, content/notes split, LOGIN-scalar isolation, `isEditableOnIOS`) | pending |
+| C6 | xcodegen regenerate + pbxproj commit | pending |
+| C7 | Gate Edit button to LOGIN-only via `isEditableOnIOS` predicate (data-corruption guard) | pending |
+| C8 | Clear `detail` on auto-lock (broadened secret surface) | pending |

--- a/docs/archive/review/ios-entry-detail-type-specific-fields-review.md
+++ b/docs/archive/review/ios-entry-detail-type-specific-fields-review.md
@@ -1,0 +1,67 @@
+# Plan Review: ios-entry-detail-type-specific-fields
+
+Date: 2026-06-19
+Review rounds: 2 (triangulate: Functionality / Security / Testing)
+
+## Root cause (investigation)
+
+The iOS entry detail view does not branch on entry type at all. `EntryDetailView.detailContent` unconditionally renders LOGIN fields (username/password/url/notes/TOTP); `VaultEntryDetail` carries only login fields and no `entryType`; `EntryBlobDecoder.detail` decodes only the login blob shape. Type-specific fields (card number, IBAN, SSH key, identity, etc.) are dropped at decode time. Web (`password-detail-inline.tsx`) branches per type with dedicated sections — iOS never did.
+
+Scope (user-confirmed): all 7 non-login types; read-only detail rendering only (edit form stays login-only).
+
+## Round 1 — findings & resolutions
+
+### Functionality
+- **F1 (Major)** Edit button unguarded → non-login save corrupts entry → **C7** (gate Edit to login-only).
+- **F2 (Major)** `isMarkdown: Bool` non-optional fails decode on absent key → **C1** all sub-struct fields optional.
+- **F3 (Minor)** DebugVaultLoader does not construct `VaultEntryDetail` → C1 acceptance corrected.
+- **F4 (Minor)** `entryType` not in personal blob → **C2** sources it from `CacheEntry.entryType`.
+- **F6 (Minor)** `keySize` may be a string in blob → **C1** `keySize: String?`; dates verbatim strings.
+- **F7 (Minor)** shared reveal state leaks all secrets → **C3** `SecretRow` standalone subview, own `@State`.
+- **F8 (Minor)** free functions can't reach view state → **C3** `extension EntryDetailView`.
+
+### Security
+- **S1 (High)** identity address/addressLine1/addressLine2/postalCode rendered plain (web masks them) → **C3** routed through SecretRow.
+- **S2 (Med)** secure-note `content` not privacy-sensitive → **C3** `.privacySensitive()`.
+- **S3 (Low)** copy must use `copySecurely`/`SecureClipboard` → **C3** invariant + `UIPasteboard` forbidden-pattern.
+- **S4 (Low)** reveal/copy must call `recordActivity()` → **C3** invariant.
+- **S5 (Low)** broadened secret surface held at lock → testing-strategy item (promoted in round 2 → **C8**).
+- **S6/S7** passkey provider-private excluded; no secret logging → confirmed clean, forbidden-pattern grep added.
+
+### Testing
+- **T1 (Med)** assert LOGIN scalars empty for non-login + content/notes both directions → **C5**.
+- **T2 (Low)** per-sub-struct absent→nil test → **C5**.
+- **T3 (Med)** DebugVaultLoader non-trivial → testing-strategy scoped.
+- **T6 (Med)** keep `passwordRow` untouched for LOGIN regression → **C3** structural invariant.
+- **T7 (Low)** non-default expected values are the committed guard → **C5** acceptance.
+- **T8 (Med)** team non-login decoder test → **C5**.
+- **T9 (Low)** SSH fixture uses `passphrase`/`comment` → **C5** + grep.
+
+## Round 2 — findings & resolutions
+
+### Functionality
+- **F9 (Compile blocker)** `private` helpers are file-scoped; cross-file `extension` cannot see them → **C3** relax `fieldRow`/`notSetText`/`copySecurely` to `internal`.
+- **F10 (Minor)** C7 nil-state (`detail` async-optional) → **C7** nil → `.login`, button shows during load then hides (acceptable).
+- **F11 (Minor)** login-edit footer caption misleading for non-login → **C7** scope footer to `.login`.
+- **F12 (prose)** edit path `applyEdits` preserves unknown keys — the "silently drops every field" rationale was wrong; real corruption is empty-login-scalar + login-shaped overview pollution → **C7** rationale corrected (fix unchanged).
+
+### Security
+- **S8 (Low/doc)** `customFields` not decoded/rendered on iOS → **C3** note (future custom-field display must use SecretRow).
+- **S9 (Med)** promote S5 lock-clear from prose to binding contract (`lock()` does leave view mounted; surface expanded) → **C8**.
+
+### Testing
+- **T10 (Minor)** LOGIN-scalar-isolation must be per-type precise — `username`/`email` are shared keys → **C5** precision note.
+- **T11 (Med, high value)** extract C7 gate as pure `EntryTypeCategory.isEditableOnIOS(rawType:)` predicate + unit test (only automated coverage of the data-corruption guard) → **C7** + **C5**.
+- **T12 (Low)** SecretRow per-row reveal isolation → manual Debug-fixture checklist.
+- **T13 (Low)** lock-clear decision → testable function / manual checklist.
+
+## Status
+
+All round-1 and round-2 findings resolved in the plan (8 contracts C1–C8, Go/No-Go all `pending` → to be locked at implementation start). The one compile blocker (F9) and the factually-wrong rationale (F12) are corrected. No unresolved Critical/Major.
+
+## Recurring Issue Check (consolidated)
+- R2/R12 (enum/switch exhaustiveness): OK — `EntryTypeCategory` 8 cases, no-`default` switch, web parity verified byte-for-byte.
+- R3 (propagation): all 3 `.detail` call sites accounted for; AutoFill deliberately nil (SC4).
+- R19/R5 (test/constructor alignment): additive defaulted params keep all constructors/tests compiling.
+- R25 (persist/hydrate): N/A — read-only consumer; `VaultEntryDetail` Codable never used over wire.
+- R39 (lifecycle zeroization): addressed by C8 (clear on lock); Swift String non-zeroization accepted limitation.

--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		F7972AB668F0D8073EBA5172 /* EntryFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBBBBBE5688A781ED154534 /* EntryFormTests.swift */; };
 		FC74F7D953B2978FE27D3B85 /* EntryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD65567EDF5CDCFB425499EA /* EntryDetailView.swift */; };
 		FD86EB17606A4DC5301497AA /* TOTPCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D235AC82775464BDF11F292F /* TOTPCodeView.swift */; };
+		FDCF81FEBE1BAA45EF9FF36A /* EntryDetailTypeSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329772DC684FA8AA0E0D8B06 /* EntryDetailTypeSections.swift */; };
 		FEC853759999A05E6F0867F4 /* EntryUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D696B8B99CFDB4FFFDC090E1 /* EntryUploader.swift */; };
 		FF47A8B760D1DCE2230121A3 /* PasskeyRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0A9545A79418E5DCAF4109 /* PasskeyRegistration.swift */; };
 		FFA7B60616C41F7692F7271C /* SPKIEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160063572DE97E6E16AE7A3D /* SPKIEncoderTests.swift */; };
@@ -255,6 +256,7 @@
 		3000F818C09142AEC4837294 /* PasskeyAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAssertion.swift; sourceTree = "<group>"; };
 		3073F23D803A683034FF5D44 /* VaultCategoryLanding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultCategoryLanding.swift; sourceTree = "<group>"; };
 		327A83D67306CD99E0CB3270 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		329772DC684FA8AA0E0D8B06 /* EntryDetailTypeSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDetailTypeSections.swift; sourceTree = "<group>"; };
 		32E806A6C00D78F85B1ABC89 /* PersonalEntryBlobBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalEntryBlobBuilder.swift; sourceTree = "<group>"; };
 		345F9CF0FA1F40F81B8D6074 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		36DABD88C20A969FBE8AA7BA /* HostTokenStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostTokenStoreTests.swift; sourceTree = "<group>"; };
@@ -620,6 +622,7 @@
 		831DA2A399A896ABE739ED44 /* Vault */ = {
 			isa = PBXGroup;
 			children = (
+				329772DC684FA8AA0E0D8B06 /* EntryDetailTypeSections.swift */,
 				FD65567EDF5CDCFB425499EA /* EntryDetailView.swift */,
 				2A3E40BD15B72CC7D2465FA1 /* EntryEditForm.swift */,
 				7158BC25C5EA94F9F042EEEE /* EntryTypeCategory.swift */,
@@ -985,6 +988,7 @@
 				D8EA7B209BAE0D68AB7DB5D5 /* ContentView.swift in Sources */,
 				EEDC524C6F56E4E378F8DB16 /* DebugVaultLoader.swift in Sources */,
 				028ADBEDD93783F5080BA973 /* DeviceIdentifier.swift in Sources */,
+				FDCF81FEBE1BAA45EF9FF36A /* EntryDetailTypeSections.swift in Sources */,
 				FC74F7D953B2978FE27D3B85 /* EntryDetailView.swift in Sources */,
 				B0974C58F65B8B4CBE7FB084 /* EntryEditForm.swift in Sources */,
 				B083185D5D570CC65E2C2624 /* EntryFetcher.swift in Sources */,

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -83,6 +83,102 @@
         }
       }
     },
+    "Account Holder Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account Holder Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "口座名義人"
+          }
+        }
+      }
+    },
+    "Account Number" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account Number"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "口座番号"
+          }
+        }
+      }
+    },
+    "Account Type" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account Type"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "口座種別"
+          }
+        }
+      }
+    },
+    "Address" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "住所"
+          }
+        }
+      }
+    },
+    "Address Line 1" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address Line 1"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "住所1"
+          }
+        }
+      }
+    },
+    "Address Line 2" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address Line 2"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "住所2"
+          }
+        }
+      }
+    },
     "All" : {
       "extractionState" : "translated",
       "localizations" : {
@@ -185,6 +281,22 @@
         }
       }
     },
+    "Bank Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bank Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "銀行名"
+          }
+        }
+      }
+    },
     "biometrics" : {
       "comment" : "Fallback biometry name when neither Face ID nor Touch ID is detected.",
       "extractionState" : "stale",
@@ -203,6 +315,38 @@
         }
       }
     },
+    "Branch Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Branch Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支店名"
+          }
+        }
+      }
+    },
+    "Brand" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brand"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ブランド"
+          }
+        }
+      }
+    },
     "Cancel" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -216,6 +360,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "キャンセル"
+          }
+        }
+      }
+    },
+    "Card Number" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Card Number"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カード番号"
+          }
+        }
+      }
+    },
+    "Cardholder Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cardholder Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カード名義人"
+          }
+        }
+      }
+    },
+    "City" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "City"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "市区町村"
           }
         }
       }
@@ -266,6 +458,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "コード"
+          }
+        }
+      }
+    },
+    "Comment" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comment"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コメント"
           }
         }
       }
@@ -387,6 +595,22 @@
         }
       }
     },
+    "Country" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Country"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "国"
+          }
+        }
+      }
+    },
     "Create entry" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -400,6 +624,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "エントリを作成"
+          }
+        }
+      }
+    },
+    "Creation Date" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creation Date"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作成日"
+          }
+        }
+      }
+    },
+    "Credential ID" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credential ID"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クレデンシャルID"
           }
         }
       }
@@ -421,6 +677,22 @@
         }
       }
     },
+    "CVV" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CVV"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュリティコード"
+          }
+        }
+      }
+    },
     "Dark" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -438,6 +710,22 @@
         }
       }
     },
+    "Date of Birth" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date of Birth"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生年月日"
+          }
+        }
+      }
+    },
     "Decrypting…" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -451,6 +739,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "復号しています…"
+          }
+        }
+      }
+    },
+    "Device Info" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Device Info"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバイス情報"
           }
         }
       }
@@ -506,6 +810,38 @@
         }
       }
     },
+    "Edit this entry in the web app." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit this entry in the web app."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この項目の編集はWebアプリで行ってください。"
+          }
+        }
+      }
+    },
+    "Email" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メールアドレス"
+          }
+        }
+      }
+    },
     "Enter a valid https:// URL (http:// allowed for localhost)." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -555,6 +891,102 @@
         }
       }
     },
+    "Expiration Date" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiration Date"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限"
+          }
+        }
+      }
+    },
+    "Expiry Date" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiry Date"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限"
+          }
+        }
+      }
+    },
+    "Expiry Month" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiry Month"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限(月)"
+          }
+        }
+      }
+    },
+    "Expiry Year" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiry Year"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限(年)"
+          }
+        }
+      }
+    },
+    "Family Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Family Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "姓"
+          }
+        }
+      }
+    },
+    "Family Name (Kana)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Family Name (Kana)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "姓(カナ)"
+          }
+        }
+      }
+    },
     "Favorites" : {
       "extractionState" : "translated",
       "localizations" : {
@@ -568,6 +1000,102 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "お気に入り"
+          }
+        }
+      }
+    },
+    "Fingerprint" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fingerprint"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィンガープリント"
+          }
+        }
+      }
+    },
+    "Full Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Full Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "氏名"
+          }
+        }
+      }
+    },
+    "Given Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Given Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名"
+          }
+        }
+      }
+    },
+    "Given Name (Kana)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Given Name (Kana)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名(カナ)"
+          }
+        }
+      }
+    },
+    "IBAN" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IBAN"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IBAN"
+          }
+        }
+      }
+    },
+    "ID Number" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID Number"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID番号"
           }
         }
       }
@@ -602,6 +1130,86 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "パスフレーズが正しくありません。もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "Issue Date" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Issue Date"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "発行日"
+          }
+        }
+      }
+    },
+    "Key Size" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Key Size"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵サイズ"
+          }
+        }
+      }
+    },
+    "Key Type" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Key Type"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵タイプ"
+          }
+        }
+      }
+    },
+    "License Key" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "License Key"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライセンスキー"
+          }
+        }
+      }
+    },
+    "Licensee" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Licensee"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライセンシー"
           }
         }
       }
@@ -689,6 +1297,22 @@
         }
       }
     },
+    "Middle Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Middle Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ミドルネーム"
+          }
+        }
+      }
+    },
     "More" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -702,6 +1326,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "その他"
+          }
+        }
+      }
+    },
+    "Nationality" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nationality"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "国籍"
           }
         }
       }
@@ -784,6 +1424,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未設定"
+          }
+        }
+      }
+    },
+    "Note" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ノート"
           }
         }
       }
@@ -873,6 +1529,22 @@
         }
       }
     },
+    "Passphrase" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passphrase"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスフレーズ"
+          }
+        }
+      }
+    },
     "passwd-sso" : {
       "comment" : "Brand name — never translated.",
       "shouldTranslate" : false
@@ -911,6 +1583,86 @@
         }
       }
     },
+    "Phone" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phone"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電話番号"
+          }
+        }
+      }
+    },
+    "Postal Code" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postal Code"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "郵便番号"
+          }
+        }
+      }
+    },
+    "Private Key" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Private Key"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "秘密鍵"
+          }
+        }
+      }
+    },
+    "Public Key" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Public Key"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公開鍵"
+          }
+        }
+      }
+    },
+    "Purchase Date" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purchase Date"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購入日"
+          }
+        }
+      }
+    },
     "Recording — content hidden" : {
       "localizations" : {
         "en" : {
@@ -923,6 +1675,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "録画中 — 内容を非表示にしています"
+          }
+        }
+      }
+    },
+    "Relying Party ID" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relying Party ID"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リライングパーティID"
+          }
+        }
+      }
+    },
+    "Relying Party Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relying Party Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リライングパーティ名"
           }
         }
       }
@@ -940,6 +1724,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "再試行"
+          }
+        }
+      }
+    },
+    "Routing Number" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Routing Number"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ルーティング番号"
           }
         }
       }
@@ -1182,6 +1982,22 @@
         }
       }
     },
+    "Software Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Software Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソフトウェア名"
+          }
+        }
+      }
+    },
     "SSH Keys" : {
       "extractionState" : "translated",
       "localizations" : {
@@ -1195,6 +2011,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSHキー"
+          }
+        }
+      }
+    },
+    "State" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "State"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "都道府県"
+          }
+        }
+      }
+    },
+    "SWIFT / BIC" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SWIFT / BIC"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SWIFT / BIC"
           }
         }
       }
@@ -1532,6 +2380,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保管庫"
+          }
+        }
+      }
+    },
+    "Version" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バージョン"
           }
         }
       }

--- a/ios/PasswdSSOApp/Views/Vault/EntryDetailTypeSections.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryDetailTypeSections.swift
@@ -1,0 +1,192 @@
+import Shared
+import SwiftUI
+
+/// A masked field row with a per-row reveal toggle and a secure copy button.
+/// Standalone (not a generalization of EntryDetailView.passwordRow, which stays
+/// untouched) so each secret owns its OWN reveal state — revealing one secret in
+/// a multi-secret entry (card number + CVV, account + routing + IBAN, private
+/// key + passphrase) does not reveal its siblings.
+struct SecretRow: View {
+  let label: LocalizedStringKey
+  let value: String
+  let onCopy: (String) -> Void
+  let onActivity: () -> Void
+
+  @State private var isRevealed = false
+
+  var body: some View {
+    Section(label) {
+      HStack {
+        if isRevealed {
+          Text(value)
+            .font(.body.monospaced())
+            .privacySensitive()
+        } else {
+          SecureField("", text: .constant(value))
+            .disabled(true)
+        }
+        Spacer()
+        Button {
+          isRevealed.toggle()
+          onActivity()
+        } label: {
+          Image(systemName: isRevealed ? "eye.slash" : "eye")
+            .frame(minWidth: 44, minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+
+        Button {
+          onCopy(value)
+          onActivity()
+        } label: {
+          Image(systemName: "doc.on.doc")
+            .frame(minWidth: 44, minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .tint(.accentColor)
+      }
+    }
+  }
+}
+
+// MARK: - Per-type detail sections
+//
+// Non-login types render only the fields that carry a value (cleaner than the
+// LOGIN show-all-with-"Not set" idiom, and matches the web app's conditional
+// rendering). Secrets are masked per the web SENSITIVE_FIELDS classification.
+extension EntryDetailView {
+  // Plain copyable row, rendered only when the value is present.
+  @ViewBuilder
+  func optionalFieldRow(_ label: LocalizedStringKey, _ value: String?) -> some View {
+    if let value, !value.isEmpty {
+      fieldRow(label: label, value: value)
+    }
+  }
+
+  // Masked reveal+copy row, rendered only when the value is present.
+  @ViewBuilder
+  func optionalSecretRow(_ label: LocalizedStringKey, _ value: String?) -> some View {
+    if let value, !value.isEmpty {
+      SecretRow(
+        label: label,
+        value: value,
+        onCopy: { copySecurely(value: $0) },
+        onActivity: { autoLockService.recordActivity() }
+      )
+    }
+  }
+
+  @ViewBuilder
+  func notesSection(_ notes: String) -> some View {
+    if !notes.isEmpty {
+      Section("Notes") {
+        Text(notes)
+          .font(.caption)
+          .privacySensitive()
+      }
+    }
+  }
+
+  @ViewBuilder
+  func secureNoteSection(_ note: VaultEntryDetail.SecureNoteDetail?) -> some View {
+    Section("Note") {
+      let content = note?.content ?? ""
+      if content.isEmpty {
+        notSetText
+      } else {
+        Text(content)
+          .font(.body)
+          .privacySensitive()
+      }
+    }
+  }
+
+  @ViewBuilder
+  func creditCardSection(_ card: VaultEntryDetail.CreditCardDetail?, notes: String) -> some View {
+    optionalFieldRow("Cardholder Name", card?.cardholderName)
+    optionalFieldRow("Brand", card?.brand)
+    optionalSecretRow("Card Number", card?.cardNumber)
+    optionalFieldRow("Expiry Month", card?.expiryMonth)
+    optionalFieldRow("Expiry Year", card?.expiryYear)
+    optionalSecretRow("CVV", card?.cvv)
+    notesSection(notes)
+  }
+
+  @ViewBuilder
+  func identitySection(_ id: VaultEntryDetail.IdentityDetail?, notes: String) -> some View {
+    optionalFieldRow("Full Name", id?.fullName)
+    optionalFieldRow("Given Name", id?.givenName)
+    optionalFieldRow("Family Name", id?.familyName)
+    optionalFieldRow("Middle Name", id?.middleName)
+    optionalFieldRow("Given Name (Kana)", id?.givenNameKana)
+    optionalFieldRow("Family Name (Kana)", id?.familyNameKana)
+    // Address PII is masked per the web SENSITIVE_FIELDS classification.
+    optionalSecretRow("Address", id?.address)
+    optionalSecretRow("Address Line 1", id?.addressLine1)
+    optionalSecretRow("Address Line 2", id?.addressLine2)
+    optionalFieldRow("City", id?.city)
+    optionalFieldRow("State", id?.state)
+    optionalSecretRow("Postal Code", id?.postalCode)
+    optionalFieldRow("Country", id?.country)
+    optionalFieldRow("Phone", id?.phone)
+    optionalFieldRow("Email", id?.email)
+    optionalFieldRow("Date of Birth", id?.dateOfBirth)
+    optionalFieldRow("Nationality", id?.nationality)
+    optionalSecretRow("ID Number", id?.idNumber)
+    optionalFieldRow("Issue Date", id?.issueDate)
+    optionalFieldRow("Expiry Date", id?.expiryDate)
+    notesSection(notes)
+  }
+
+  @ViewBuilder
+  func bankAccountSection(_ bank: VaultEntryDetail.BankAccountDetail?, notes: String) -> some View {
+    optionalFieldRow("Bank Name", bank?.bankName)
+    optionalFieldRow("Account Type", bank?.accountType)
+    optionalFieldRow("Account Holder Name", bank?.accountHolderName)
+    optionalSecretRow("Account Number", bank?.accountNumber)
+    optionalSecretRow("Routing Number", bank?.routingNumber)
+    optionalFieldRow("SWIFT / BIC", bank?.swiftBic)
+    optionalSecretRow("IBAN", bank?.iban)
+    optionalFieldRow("Branch Name", bank?.branchName)
+    notesSection(notes)
+  }
+
+  @ViewBuilder
+  func sshKeySection(_ key: VaultEntryDetail.SshKeyDetail?, notes: String) -> some View {
+    optionalFieldRow("Key Type", key?.keyType)
+    optionalFieldRow("Key Size", key?.keySize)
+    optionalFieldRow("Fingerprint", key?.fingerprint)
+    optionalFieldRow("Public Key", key?.publicKey)
+    optionalSecretRow("Private Key", key?.privateKey)
+    optionalSecretRow("Passphrase", key?.passphrase)
+    optionalFieldRow("Comment", key?.comment)
+    notesSection(notes)
+  }
+
+  @ViewBuilder
+  func softwareLicenseSection(
+    _ lic: VaultEntryDetail.SoftwareLicenseDetail?, notes: String
+  ) -> some View {
+    optionalFieldRow("Software Name", lic?.softwareName)
+    optionalSecretRow("License Key", lic?.licenseKey)
+    optionalFieldRow("Version", lic?.version)
+    optionalFieldRow("Licensee", lic?.licensee)
+    optionalFieldRow("Email", lic?.email)
+    optionalFieldRow("Purchase Date", lic?.purchaseDate)
+    optionalFieldRow("Expiration Date", lic?.expirationDate)
+    notesSection(notes)
+  }
+
+  @ViewBuilder
+  func passkeySection(_ pk: VaultEntryDetail.PasskeyDetail?, notes: String) -> some View {
+    optionalFieldRow("Relying Party ID", pk?.relyingPartyId)
+    optionalFieldRow("Relying Party Name", pk?.relyingPartyName)
+    optionalFieldRow("Username", pk?.username)
+    optionalSecretRow("Credential ID", pk?.credentialId)
+    optionalFieldRow("Creation Date", pk?.creationDate)
+    optionalFieldRow("Device Info", pk?.deviceInfo)
+    notesSection(notes)
+  }
+}

--- a/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
@@ -55,9 +55,15 @@ struct EntryDetailView: View {
     .navigationTitle(summary.title)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
-      ToolbarItem(placement: .topBarTrailing) {
-        Button("Edit") {
-          isShowingEditForm = true
+      // Edit is LOGIN-only on iOS: the edit form is login-shaped and would
+      // corrupt a non-login entry on save (empty login scalars + login-shaped
+      // overview). Non-login entries are edited in the web app. nil/unknown
+      // entryType falls back to LOGIN, so the button shows during load.
+      if EntryTypeCategory.isEditableOnIOS(rawType: detail?.entryType) {
+        ToolbarItem(placement: .topBarTrailing) {
+          Button("Edit") {
+            isShowingEditForm = true
+          }
         }
       }
     }
@@ -90,40 +96,34 @@ struct EntryDetailView: View {
     .onDisappear {
       detail = nil
     }
+    // Clear decrypted secrets the moment the vault locks/logs out while this
+    // view stays foregrounded (lock() does not unmount it). The detail now
+    // holds SSH private keys, card numbers, IBANs — a larger surface than the
+    // password+TOTP it once carried, so don't leave it resident past lock.
+    .onChange(of: autoLockService.state) { _, newState in
+      if newState != .unlocked {
+        detail = nil
+      }
+    }
   }
 
   // MARK: - Detail content
 
+  @ViewBuilder
   private func detailContent(_ d: VaultEntryDetail) -> some View {
     List {
-      // Show the same fields as the edit form (even when empty) so opening Edit
-      // doesn't surprise the user with rows that weren't there. Empty fields
-      // render a muted "Not set" rather than being hidden.
-      fieldRow(label: "Username", value: d.username)
-      passwordRow(d.password)
-      fieldRow(label: "URL", value: d.url)
-
-      Section("Notes") {
-        if d.notes.isEmpty {
-          notSetText
-        } else {
-          Text(d.notes)
-            .font(.caption)
-            .privacySensitive()
-        }
-      }
-
-      Section("One-Time Code") {
-        if let totpSecret = d.totpSecret, !totpSecret.isEmpty {
-          TOTPCodeView(params: TOTPParams(
-            secret: totpSecret,
-            algorithm: d.totpAlgorithm,
-            digits: d.totpDigits,
-            period: d.totpPeriod
-          ))
-        } else {
-          notSetText
-        }
+      // Render the field set for the entry's type. Each per-type section lives
+      // in EntryDetailTypeSections.swift; LOGIN keeps its original rows so its
+      // rendering is structurally unchanged.
+      switch EntryTypeCategory.from(rawType: d.entryType) {
+      case .login: loginSections(d)
+      case .secureNote: secureNoteSection(d.secureNote)
+      case .creditCard: creditCardSection(d.creditCard, notes: d.notes)
+      case .identity: identitySection(d.identity, notes: d.notes)
+      case .bankAccount: bankAccountSection(d.bankAccount, notes: d.notes)
+      case .sshKey: sshKeySection(d.sshKey, notes: d.notes)
+      case .softwareLicense: softwareLicenseSection(d.softwareLicense, notes: d.notes)
+      case .passkey: passkeySection(d.passkey, notes: d.notes)
       }
 
       // Read-only display of preserved-but-not-iOS-editable data, so the user
@@ -135,16 +135,60 @@ struct EntryDetailView: View {
         }
       }
 
-      Section {
-        Text("Tags, custom fields, generator settings, and password history are kept when you save an edit here — edit those in the web app.")
-          .font(.caption)
-          .foregroundStyle(.secondary)
+      // The edit-preservation note only applies to LOGIN (the one type editable
+      // on iOS). For non-login types editing happens in the web app entirely.
+      if EntryTypeCategory.isEditableOnIOS(rawType: d.entryType) {
+        Section {
+          Text("Tags, custom fields, generator settings, and password history are kept when you save an edit here — edit those in the web app.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      } else {
+        Section {
+          Text("Edit this entry in the web app.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
       }
     }
     .listStyle(.insetGrouped)
   }
 
-  private var notSetText: some View {
+  // LOGIN field set — unchanged from the original detail layout.
+  @ViewBuilder
+  private func loginSections(_ d: VaultEntryDetail) -> some View {
+    // Show the same fields as the edit form (even when empty) so opening Edit
+    // doesn't surprise the user with rows that weren't there. Empty fields
+    // render a muted "Not set" rather than being hidden.
+    fieldRow(label: "Username", value: d.username)
+    passwordRow(d.password)
+    fieldRow(label: "URL", value: d.url)
+
+    Section("Notes") {
+      if d.notes.isEmpty {
+        notSetText
+      } else {
+        Text(d.notes)
+          .font(.caption)
+          .privacySensitive()
+      }
+    }
+
+    Section("One-Time Code") {
+      if let totpSecret = d.totpSecret, !totpSecret.isEmpty {
+        TOTPCodeView(params: TOTPParams(
+          secret: totpSecret,
+          algorithm: d.totpAlgorithm,
+          digits: d.totpDigits,
+          period: d.totpPeriod
+        ))
+      } else {
+        notSetText
+      }
+    }
+  }
+
+  var notSetText: some View {
     Text("Not set")
       .font(.body)
       .foregroundStyle(.secondary)
@@ -152,7 +196,7 @@ struct EntryDetailView: View {
 
   // LocalizedStringKey (not String) so `Section(_:)` binds the localizing
   // overload — callers pass literals ("Username"/"URL") that must translate.
-  private func fieldRow(label: LocalizedStringKey, value: String) -> some View {
+  func fieldRow(label: LocalizedStringKey, value: String) -> some View {
     Section(label) {
       if value.isEmpty {
         notSetText
@@ -232,7 +276,7 @@ struct EntryDetailView: View {
 
   /// Copy to pasteboard with localOnly + a configurable auto-clear expiration
   /// (AppSettingsStore.clipboardClearSeconds) per plan §"Side-Channel Controls".
-  private func copySecurely(value: String) {
+  func copySecurely(value: String) {
     SecureClipboard.copy(value, clearAfter: AppSettingsStore().clipboardClearSeconds)
   }
 }

--- a/ios/PasswdSSOApp/Views/Vault/EntryTypeCategory.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryTypeCategory.swift
@@ -19,6 +19,14 @@ enum EntryTypeCategory: String, CaseIterable {
     return category
   }
 
+  /// The iOS edit form is LOGIN-shaped only. Editing a non-login entry through it
+  /// re-encrypts a login blob and pollutes the entry with empty login scalars +
+  /// a login-shaped overview. Only LOGIN (and unknown/nil, which falls back to
+  /// LOGIN) is editable on iOS; everything else is edited in the web app.
+  static func isEditableOnIOS(rawType: String?) -> Bool {
+    from(rawType: rawType) == .login
+  }
+
   var sfSymbol: String {
     switch self {
     case .login: "person.text.rectangle"

--- a/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
@@ -204,7 +204,9 @@ public enum VaultScope: Hashable, Sendable {
         key: vaultKey,
         aad: aad
       )
-      return EntryBlobDecoder.detail(plaintext: plaintext, entryId: entry.id, teamId: entry.teamId)
+      return EntryBlobDecoder.detail(
+        plaintext: plaintext, entryId: entry.id, teamId: entry.teamId,
+        entryType: entry.entryType)
     } catch {
       return nil
     }

--- a/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
+++ b/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
@@ -161,6 +161,197 @@ final class EntryBlobDecoderTests: XCTestCase {
     )
   }
 
+  // MARK: - detail() type-specific sub-structs
+
+  func testDetailDecodesCreditCardBlob() throws {
+    let json = #"""
+    {"title":"Visa","cardholderName":"Alice A","cardNumber":"4111111111111111",
+     "brand":"visa","expiryMonth":"12","expiryYear":"2030","cvv":"123","notes":"n"}
+    """#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "cc1", teamId: nil, entryType: "CREDIT_CARD")
+    )
+    let cc = try XCTUnwrap(d.creditCard)
+    XCTAssertEqual(cc.cardholderName, "Alice A")
+    XCTAssertEqual(cc.cardNumber, "4111111111111111")
+    XCTAssertEqual(cc.brand, "visa")
+    XCTAssertEqual(cc.expiryMonth, "12")
+    XCTAssertEqual(cc.expiryYear, "2030")
+    XCTAssertEqual(cc.cvv, "123")
+    XCTAssertEqual(d.notes, "n")
+    // Sibling sub-structs are nil; unconsumed LOGIN scalars are empty.
+    XCTAssertNil(d.identity)
+    XCTAssertNil(d.bankAccount)
+    XCTAssertNil(d.secureNote)
+    XCTAssertEqual(d.password, "")
+    XCTAssertEqual(d.url, "")
+  }
+
+  func testDetailDecodesIdentityBlob() throws {
+    let json = #"""
+    {"title":"Me","fullName":"Alice Anderson","givenName":"Alice","familyName":"Anderson",
+     "address":"1 Main St","addressLine1":"Apt 2","postalCode":"94016","city":"SF",
+     "country":"US","email":"a@example.com","dateOfBirth":"1990-01-01","idNumber":"X12345",
+     "issueDate":"2020-01-01","expiryDate":"2030-01-01"}
+    """#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "id1", teamId: nil, entryType: "IDENTITY")
+    )
+    let id = try XCTUnwrap(d.identity)
+    XCTAssertEqual(id.fullName, "Alice Anderson")
+    XCTAssertEqual(id.address, "1 Main St")
+    XCTAssertEqual(id.addressLine1, "Apt 2")
+    XCTAssertEqual(id.postalCode, "94016")
+    XCTAssertEqual(id.city, "SF")
+    XCTAssertEqual(id.country, "US")
+    XCTAssertEqual(id.email, "a@example.com")
+    XCTAssertEqual(id.dateOfBirth, "1990-01-01")
+    XCTAssertEqual(id.idNumber, "X12345")
+    XCTAssertEqual(id.expiryDate, "2030-01-01")
+    XCTAssertNil(id.middleName)  // absent → nil
+    XCTAssertNil(d.creditCard)
+    XCTAssertEqual(d.password, "")
+  }
+
+  func testDetailDecodesBankAccountBlob() throws {
+    let json = #"""
+    {"title":"Checking","bankName":"Acme Bank","accountType":"checking",
+     "accountHolderName":"Alice","accountNumber":"000123456","routingNumber":"110000000",
+     "swiftBic":"ACMEUS33","iban":"US00ACME0001","branchName":"Downtown"}
+    """#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "ba1", teamId: nil, entryType: "BANK_ACCOUNT")
+    )
+    let ba = try XCTUnwrap(d.bankAccount)
+    XCTAssertEqual(ba.bankName, "Acme Bank")
+    XCTAssertEqual(ba.accountType, "checking")
+    XCTAssertEqual(ba.accountHolderName, "Alice")
+    XCTAssertEqual(ba.accountNumber, "000123456")
+    XCTAssertEqual(ba.routingNumber, "110000000")
+    XCTAssertEqual(ba.swiftBic, "ACMEUS33")
+    XCTAssertEqual(ba.iban, "US00ACME0001")
+    XCTAssertEqual(ba.branchName, "Downtown")
+    XCTAssertNil(d.sshKey)
+  }
+
+  func testDetailDecodesSshKeyBlobUsesPassphraseAndCommentKeys() throws {
+    // Blob keys are `passphrase`/`comment` (NOT sshPassphrase/sshComment), and
+    // `keySize` is a free-text string ("2048"), not an Int.
+    let json = #"""
+    {"title":"deploy key","privateKey":"-----BEGIN-----","publicKey":"ssh-ed25519 AAA",
+     "keyType":"ed25519","keySize":"256","fingerprint":"SHA256:abc",
+     "passphrase":"hunter2","comment":"deploy@host"}
+    """#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "ssh1", teamId: nil, entryType: "SSH_KEY")
+    )
+    let key = try XCTUnwrap(d.sshKey)
+    XCTAssertEqual(key.privateKey, "-----BEGIN-----")
+    XCTAssertEqual(key.publicKey, "ssh-ed25519 AAA")
+    XCTAssertEqual(key.keyType, "ed25519")
+    XCTAssertEqual(key.keySize, "256")
+    XCTAssertEqual(key.fingerprint, "SHA256:abc")
+    XCTAssertEqual(key.passphrase, "hunter2")
+    XCTAssertEqual(key.comment, "deploy@host")
+  }
+
+  func testDetailDecodesSoftwareLicenseBlob() throws {
+    let json = #"""
+    {"title":"IDE","softwareName":"CoolIDE","licenseKey":"ABCD-EFGH","version":"3.2",
+     "licensee":"Alice","email":"a@example.com","purchaseDate":"2024-01-01",
+     "expirationDate":"2025-01-01"}
+    """#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "sl1", teamId: nil, entryType: "SOFTWARE_LICENSE")
+    )
+    let lic = try XCTUnwrap(d.softwareLicense)
+    XCTAssertEqual(lic.softwareName, "CoolIDE")
+    XCTAssertEqual(lic.licenseKey, "ABCD-EFGH")
+    XCTAssertEqual(lic.version, "3.2")
+    XCTAssertEqual(lic.licensee, "Alice")
+    XCTAssertEqual(lic.email, "a@example.com")
+    XCTAssertEqual(lic.purchaseDate, "2024-01-01")
+    XCTAssertEqual(lic.expirationDate, "2025-01-01")
+  }
+
+  func testDetailDecodesPasskeyDisplayBlobExcludesPrivateMaterial() throws {
+    // Provider-private passkey* keys must never surface in the display struct.
+    let json = #"""
+    {"title":"GitHub","relyingPartyId":"github.com","relyingPartyName":"GitHub",
+     "username":"alice","credentialId":"AQIDBA","creationDate":"2024-05-01",
+     "deviceInfo":"iPhone","passkeyPrivateKeyJwk":"{\"d\":\"secret\"}","passkeyUserHandle":"dXNlcg"}
+    """#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "pk1", teamId: nil, entryType: "PASSKEY")
+    )
+    let pk = try XCTUnwrap(d.passkey)
+    XCTAssertEqual(pk.relyingPartyId, "github.com")
+    XCTAssertEqual(pk.relyingPartyName, "GitHub")
+    XCTAssertEqual(pk.username, "alice")
+    XCTAssertEqual(pk.credentialId, "AQIDBA")
+    XCTAssertEqual(pk.creationDate, "2024-05-01")
+    XCTAssertEqual(pk.deviceInfo, "iPhone")
+  }
+
+  func testDetailSecureNoteBodyComesFromContentNotNotes() throws {
+    // The note body lives under `content`, never `notes` — pin both directions.
+    let json = #"{"title":"Note","content":"the secret body","tags":[]}"#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "sn1", teamId: nil, entryType: "SECURE_NOTE")
+    )
+    let note = try XCTUnwrap(d.secureNote)
+    XCTAssertEqual(note.content, "the secret body")
+    XCTAssertEqual(d.notes, "")  // body did NOT leak into top-level notes
+  }
+
+  func testDetailMinimalSubStructLeavesAbsentFieldsNil() throws {
+    // Only one key present; every other credit-card field decodes to nil.
+    let json = #"{"title":"Card","cardNumber":"4111"}"#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "cc2", teamId: nil, entryType: "CREDIT_CARD")
+    )
+    let cc = try XCTUnwrap(d.creditCard)
+    XCTAssertEqual(cc.cardNumber, "4111")
+    XCTAssertNil(cc.cardholderName)
+    XCTAssertNil(cc.brand)
+    XCTAssertNil(cc.expiryMonth)
+    XCTAssertNil(cc.cvv)
+  }
+
+  func testDetailLoginEntryTypeNilAndLoginAreEquivalent() throws {
+    let json = #"{"title":"L","username":"a","password":"p","url":"https://x"}"#
+    let nilType = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "l1", teamId: nil)
+    )
+    let loginType = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "l1", teamId: nil, entryType: "LOGIN")
+    )
+    XCTAssertEqual(nilType.username, loginType.username)
+    XCTAssertEqual(nilType.password, loginType.password)
+    XCTAssertEqual(nilType.url, loginType.url)
+    // No sub-struct is populated for LOGIN under either form.
+    for d in [nilType, loginType] {
+      XCTAssertNil(d.secureNote)
+      XCTAssertNil(d.creditCard)
+      XCTAssertNil(d.identity)
+      XCTAssertNil(d.bankAccount)
+      XCTAssertNil(d.sshKey)
+      XCTAssertNil(d.softwareLicense)
+      XCTAssertNil(d.passkey)
+    }
+  }
+
+  func testDetailTeamPathHonorsEntryTypeAndCarriesTeamId() throws {
+    // Pins that the TeamEntryDecryptor call site's entryType + teamId reach the
+    // sub-struct selection.
+    let json = #"{"title":"Team Card","cardNumber":"4111111111111111","brand":"visa"}"#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "tc1", teamId: "t1", entryType: "CREDIT_CARD")
+    )
+    XCTAssertEqual(d.teamId, "t1")
+    XCTAssertEqual(d.creditCard?.cardNumber, "4111111111111111")
+  }
+
   // MARK: - passkey overview / material (C3)
 
   func testSummarySurfacesPasskeyOverviewFields() throws {

--- a/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
+++ b/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
@@ -232,6 +232,10 @@ final class EntryBlobDecoderTests: XCTestCase {
     XCTAssertEqual(ba.iban, "US00ACME0001")
     XCTAssertEqual(ba.branchName, "Downtown")
     XCTAssertNil(d.sshKey)
+    XCTAssertNil(d.creditCard)
+    // Unconsumed LOGIN scalars stay empty — no stray URL/Password row.
+    XCTAssertEqual(d.url, "")
+    XCTAssertEqual(d.password, "")
   }
 
   func testDetailDecodesSshKeyBlobUsesPassphraseAndCommentKeys() throws {
@@ -253,6 +257,9 @@ final class EntryBlobDecoderTests: XCTestCase {
     XCTAssertEqual(key.fingerprint, "SHA256:abc")
     XCTAssertEqual(key.passphrase, "hunter2")
     XCTAssertEqual(key.comment, "deploy@host")
+    XCTAssertNil(d.bankAccount)
+    XCTAssertEqual(d.url, "")
+    XCTAssertEqual(d.password, "")
   }
 
   func testDetailDecodesSoftwareLicenseBlob() throws {
@@ -272,6 +279,9 @@ final class EntryBlobDecoderTests: XCTestCase {
     XCTAssertEqual(lic.email, "a@example.com")
     XCTAssertEqual(lic.purchaseDate, "2024-01-01")
     XCTAssertEqual(lic.expirationDate, "2025-01-01")
+    XCTAssertNil(d.passkey)
+    XCTAssertEqual(d.url, "")
+    XCTAssertEqual(d.password, "")
   }
 
   func testDetailDecodesPasskeyDisplayBlobExcludesPrivateMaterial() throws {
@@ -291,6 +301,11 @@ final class EntryBlobDecoderTests: XCTestCase {
     XCTAssertEqual(pk.credentialId, "AQIDBA")
     XCTAssertEqual(pk.creationDate, "2024-05-01")
     XCTAssertEqual(pk.deviceInfo, "iPhone")
+    XCTAssertNil(d.softwareLicense)
+    // url/password absent → empty. `username` legitimately carries "alice"
+    // (shared key decoded unconditionally), so it is NOT asserted empty (T10).
+    XCTAssertEqual(d.url, "")
+    XCTAssertEqual(d.password, "")
   }
 
   func testDetailSecureNoteBodyComesFromContentNotNotes() throws {

--- a/ios/PasswdSSOTests/EntryTypeCategoryTests.swift
+++ b/ios/PasswdSSOTests/EntryTypeCategoryTests.swift
@@ -30,4 +30,24 @@ final class EntryTypeCategoryTests: XCTestCase {
   func testAllCasesCountIsEight() {
     XCTAssertEqual(EntryTypeCategory.allCases.count, 8)
   }
+
+  // MARK: - isEditableOnIOS (C7 data-corruption guard)
+
+  func testIsEditableOnIOSTrueForLoginNilAndUnknown() {
+    // LOGIN, plus nil/unknown which fall back to LOGIN, are the only editable cases.
+    XCTAssertTrue(EntryTypeCategory.isEditableOnIOS(rawType: "LOGIN"))
+    XCTAssertTrue(EntryTypeCategory.isEditableOnIOS(rawType: nil))
+    XCTAssertTrue(EntryTypeCategory.isEditableOnIOS(rawType: "FUTURE_TYPE"))
+  }
+
+  func testIsEditableOnIOSFalseForAllNonLoginTypes() {
+    for raw in [
+      "SECURE_NOTE", "CREDIT_CARD", "IDENTITY", "BANK_ACCOUNT",
+      "SSH_KEY", "SOFTWARE_LICENSE", "PASSKEY",
+    ] {
+      XCTAssertFalse(
+        EntryTypeCategory.isEditableOnIOS(rawType: raw),
+        "\(raw) must not be editable on iOS")
+    }
+  }
 }

--- a/ios/Shared/AutoFill/TeamEntryDecryptor.swift
+++ b/ios/Shared/AutoFill/TeamEntryDecryptor.swift
@@ -141,6 +141,7 @@ public enum TeamEntryDecryptor {
       let tag = try? hexDecode(entry.encryptedBlob.authTag),
       let plaintext = try? decryptAESGCM(ciphertext: cipher, iv: iv, tag: tag, key: entryKey, aad: aad)
     else { return nil }
-    return EntryBlobDecoder.detail(plaintext: plaintext, entryId: entry.id, teamId: teamId)
+    return EntryBlobDecoder.detail(
+      plaintext: plaintext, entryId: entry.id, teamId: teamId, entryType: entry.entryType)
   }
 }

--- a/ios/Shared/Models/EntryBlobDecoder.swift
+++ b/ios/Shared/Models/EntryBlobDecoder.swift
@@ -48,6 +48,75 @@ public enum EntryBlobDecoder {
     let notes: String?
     let tags: [TagPayload]?
     let totp: TotpPayload?
+
+    // Type-specific fields. The blob is a single flat JSON object; field names
+    // are disjoint across types (except shared title/notes/username/email), so
+    // every key is decoded as an optional and is nil for types that omit it.
+    // Sub-structs are built only for the matching entryType (see `detail`).
+    // SECURE_NOTE
+    let content: String?
+    let isMarkdown: Bool?
+    // CREDIT_CARD
+    let cardholderName: String?
+    let cardNumber: String?
+    let brand: String?
+    let expiryMonth: String?
+    let expiryYear: String?
+    let cvv: String?
+    // IDENTITY
+    let fullName: String?
+    let address: String?
+    let givenName: String?
+    let familyName: String?
+    let middleName: String?
+    let familyNameKana: String?
+    let givenNameKana: String?
+    let addressLine1: String?
+    let addressLine2: String?
+    let city: String?
+    let state: String?
+    let postalCode: String?
+    let country: String?
+    let phone: String?
+    let email: String?
+    let dateOfBirth: String?
+    let nationality: String?
+    let idNumber: String?
+    let issueDate: String?
+    let expiryDate: String?
+    // BANK_ACCOUNT
+    let bankName: String?
+    let accountType: String?
+    let accountHolderName: String?
+    let accountNumber: String?
+    let routingNumber: String?
+    let swiftBic: String?
+    let iban: String?
+    let branchName: String?
+    // SSH_KEY (blob keys are `passphrase`/`comment`, NOT sshPassphrase/sshComment;
+    // `keySize` is free-text so decode as String). `publicKey`/`keyType`/
+    // `fingerprint` reuse identifiers above where not already declared.
+    let privateKey: String?
+    let publicKey: String?
+    let keyType: String?
+    let fingerprint: String?
+    let passphrase: String?
+    let comment: String?
+    let keySize: String?
+    // SOFTWARE_LICENSE
+    let softwareName: String?
+    let licenseKey: String?
+    let version: String?
+    let licensee: String?
+    let purchaseDate: String?
+    let expirationDate: String?
+    // PASSKEY (display fields only — provider-private passkey* keys are never
+    // decoded here; see PasskeyFullBlobPayload for the assertion path).
+    let relyingPartyId: String?
+    let relyingPartyName: String?
+    let credentialId: String?
+    let creationDate: String?
+    let deviceInfo: String?
   }
 
   /// Full-blob fields needed to build a passkey assertion. Decoded separately
@@ -143,12 +212,16 @@ public enum EntryBlobDecoder {
     )
   }
 
-  /// Reconstruct a detail view from a full-blob plaintext. `id`/`teamId` come
-  /// from the cache row; `totpSecret` is derived from the `totp` object.
+  /// Reconstruct a detail view from a full-blob plaintext. `id`/`teamId`/
+  /// `entryType` come from the cache row, never the blob. LOGIN fields are
+  /// decoded unconditionally (so AutoFill, which passes `entryType: nil`, is
+  /// unchanged); the type-specific sub-struct is built only for a matching
+  /// non-login `entryType`.
   public static func detail(
     plaintext: Data,
     entryId: String,
-    teamId: String?
+    teamId: String?,
+    entryType: String? = nil
   ) -> VaultEntryDetail? {
     guard let p = try? JSONDecoder().decode(FullBlobPayload.self, from: plaintext) else {
       return nil
@@ -169,7 +242,42 @@ public enum EntryBlobDecoder {
       totpAlgorithm: p.totp?.algorithm,
       totpDigits: p.totp?.digits,
       totpPeriod: p.totp?.period,
-      generatorSettings: nil
+      generatorSettings: nil,
+      entryType: entryType,
+      secureNote: entryType == "SECURE_NOTE"
+        ? .init(content: p.content, isMarkdown: p.isMarkdown) : nil,
+      creditCard: entryType == "CREDIT_CARD"
+        ? .init(
+          cardholderName: p.cardholderName, cardNumber: p.cardNumber, brand: p.brand,
+          expiryMonth: p.expiryMonth, expiryYear: p.expiryYear, cvv: p.cvv) : nil,
+      identity: entryType == "IDENTITY"
+        ? .init(
+          fullName: p.fullName, address: p.address, givenName: p.givenName,
+          familyName: p.familyName, middleName: p.middleName, familyNameKana: p.familyNameKana,
+          givenNameKana: p.givenNameKana, addressLine1: p.addressLine1, addressLine2: p.addressLine2,
+          city: p.city, state: p.state, postalCode: p.postalCode, country: p.country,
+          phone: p.phone, email: p.email, dateOfBirth: p.dateOfBirth, nationality: p.nationality,
+          idNumber: p.idNumber, issueDate: p.issueDate, expiryDate: p.expiryDate) : nil,
+      bankAccount: entryType == "BANK_ACCOUNT"
+        ? .init(
+          bankName: p.bankName, accountType: p.accountType, accountHolderName: p.accountHolderName,
+          accountNumber: p.accountNumber, routingNumber: p.routingNumber, swiftBic: p.swiftBic,
+          iban: p.iban, branchName: p.branchName) : nil,
+      sshKey: entryType == "SSH_KEY"
+        ? .init(
+          privateKey: p.privateKey, publicKey: p.publicKey, keyType: p.keyType,
+          fingerprint: p.fingerprint, passphrase: p.passphrase, comment: p.comment,
+          keySize: p.keySize) : nil,
+      softwareLicense: entryType == "SOFTWARE_LICENSE"
+        ? .init(
+          softwareName: p.softwareName, licenseKey: p.licenseKey, version: p.version,
+          licensee: p.licensee, email: p.email, purchaseDate: p.purchaseDate,
+          expirationDate: p.expirationDate) : nil,
+      passkey: entryType == "PASSKEY"
+        ? .init(
+          relyingPartyId: p.relyingPartyId, relyingPartyName: p.relyingPartyName,
+          username: p.username, credentialId: p.credentialId, creationDate: p.creationDate,
+          deviceInfo: p.deviceInfo) : nil
     )
   }
 }

--- a/ios/Shared/Models/VaultEntryDetail.swift
+++ b/ios/Shared/Models/VaultEntryDetail.swift
@@ -19,6 +19,195 @@ public struct VaultEntryDetail: Codable, Sendable, Equatable, Identifiable {
   public let totpPeriod: Int?
   public let generatorSettings: GeneratorSettings?
 
+  /// Server entry-type string ("LOGIN", "CREDIT_CARD", …); nil ⇒ treat as LOGIN.
+  /// Sourced from the cache row (CacheEntry.entryType), never the blob — personal
+  /// blobs omit it. Drives which sub-struct the detail view renders.
+  public let entryType: String?
+  /// Exactly one of these is non-nil for a non-login entry; all nil for LOGIN.
+  /// Every field is optional so a missing blob key never fails the sub-struct decode.
+  public let secureNote: SecureNoteDetail?
+  public let creditCard: CreditCardDetail?
+  public let identity: IdentityDetail?
+  public let bankAccount: BankAccountDetail?
+  public let sshKey: SshKeyDetail?
+  public let softwareLicense: SoftwareLicenseDetail?
+  public let passkey: PasskeyDetail?
+
+  public struct SecureNoteDetail: Codable, Sendable, Equatable {
+    public let content: String?
+    public let isMarkdown: Bool?
+    public init(content: String? = nil, isMarkdown: Bool? = nil) {
+      self.content = content
+      self.isMarkdown = isMarkdown
+    }
+  }
+
+  public struct CreditCardDetail: Codable, Sendable, Equatable {
+    public let cardholderName: String?
+    public let cardNumber: String?
+    public let brand: String?
+    public let expiryMonth: String?
+    public let expiryYear: String?
+    public let cvv: String?
+    public init(
+      cardholderName: String? = nil, cardNumber: String? = nil, brand: String? = nil,
+      expiryMonth: String? = nil, expiryYear: String? = nil, cvv: String? = nil
+    ) {
+      self.cardholderName = cardholderName
+      self.cardNumber = cardNumber
+      self.brand = brand
+      self.expiryMonth = expiryMonth
+      self.expiryYear = expiryYear
+      self.cvv = cvv
+    }
+  }
+
+  public struct IdentityDetail: Codable, Sendable, Equatable {
+    public let fullName: String?
+    public let address: String?
+    public let givenName: String?
+    public let familyName: String?
+    public let middleName: String?
+    public let familyNameKana: String?
+    public let givenNameKana: String?
+    public let addressLine1: String?
+    public let addressLine2: String?
+    public let city: String?
+    public let state: String?
+    public let postalCode: String?
+    public let country: String?
+    public let phone: String?
+    public let email: String?
+    public let dateOfBirth: String?
+    public let nationality: String?
+    public let idNumber: String?
+    public let issueDate: String?
+    public let expiryDate: String?
+    public init(
+      fullName: String? = nil, address: String? = nil, givenName: String? = nil,
+      familyName: String? = nil, middleName: String? = nil, familyNameKana: String? = nil,
+      givenNameKana: String? = nil, addressLine1: String? = nil, addressLine2: String? = nil,
+      city: String? = nil, state: String? = nil, postalCode: String? = nil,
+      country: String? = nil, phone: String? = nil, email: String? = nil,
+      dateOfBirth: String? = nil, nationality: String? = nil, idNumber: String? = nil,
+      issueDate: String? = nil, expiryDate: String? = nil
+    ) {
+      self.fullName = fullName
+      self.address = address
+      self.givenName = givenName
+      self.familyName = familyName
+      self.middleName = middleName
+      self.familyNameKana = familyNameKana
+      self.givenNameKana = givenNameKana
+      self.addressLine1 = addressLine1
+      self.addressLine2 = addressLine2
+      self.city = city
+      self.state = state
+      self.postalCode = postalCode
+      self.country = country
+      self.phone = phone
+      self.email = email
+      self.dateOfBirth = dateOfBirth
+      self.nationality = nationality
+      self.idNumber = idNumber
+      self.issueDate = issueDate
+      self.expiryDate = expiryDate
+    }
+  }
+
+  public struct BankAccountDetail: Codable, Sendable, Equatable {
+    public let bankName: String?
+    public let accountType: String?
+    public let accountHolderName: String?
+    public let accountNumber: String?
+    public let routingNumber: String?
+    public let swiftBic: String?
+    public let iban: String?
+    public let branchName: String?
+    public init(
+      bankName: String? = nil, accountType: String? = nil, accountHolderName: String? = nil,
+      accountNumber: String? = nil, routingNumber: String? = nil, swiftBic: String? = nil,
+      iban: String? = nil, branchName: String? = nil
+    ) {
+      self.bankName = bankName
+      self.accountType = accountType
+      self.accountHolderName = accountHolderName
+      self.accountNumber = accountNumber
+      self.routingNumber = routingNumber
+      self.swiftBic = swiftBic
+      self.iban = iban
+      self.branchName = branchName
+    }
+  }
+
+  public struct SshKeyDetail: Codable, Sendable, Equatable {
+    public let privateKey: String?
+    public let publicKey: String?
+    public let keyType: String?
+    public let fingerprint: String?
+    public let passphrase: String?
+    public let comment: String?
+    // Free-text input on the web form (written as `keySize || null`), so the
+    // blob value may be a string like "2048" — decode as String, not Int.
+    public let keySize: String?
+    public init(
+      privateKey: String? = nil, publicKey: String? = nil, keyType: String? = nil,
+      fingerprint: String? = nil, passphrase: String? = nil, comment: String? = nil,
+      keySize: String? = nil
+    ) {
+      self.privateKey = privateKey
+      self.publicKey = publicKey
+      self.keyType = keyType
+      self.fingerprint = fingerprint
+      self.passphrase = passphrase
+      self.comment = comment
+      self.keySize = keySize
+    }
+  }
+
+  public struct SoftwareLicenseDetail: Codable, Sendable, Equatable {
+    public let softwareName: String?
+    public let licenseKey: String?
+    public let version: String?
+    public let licensee: String?
+    public let email: String?
+    public let purchaseDate: String?
+    public let expirationDate: String?
+    public init(
+      softwareName: String? = nil, licenseKey: String? = nil, version: String? = nil,
+      licensee: String? = nil, email: String? = nil, purchaseDate: String? = nil,
+      expirationDate: String? = nil
+    ) {
+      self.softwareName = softwareName
+      self.licenseKey = licenseKey
+      self.version = version
+      self.licensee = licensee
+      self.email = email
+      self.purchaseDate = purchaseDate
+      self.expirationDate = expirationDate
+    }
+  }
+
+  public struct PasskeyDetail: Codable, Sendable, Equatable {
+    public let relyingPartyId: String?
+    public let relyingPartyName: String?
+    public let username: String?
+    public let credentialId: String?
+    public let creationDate: String?
+    public let deviceInfo: String?
+    public init(
+      relyingPartyId: String? = nil, relyingPartyName: String? = nil, username: String? = nil,
+      credentialId: String? = nil, creationDate: String? = nil, deviceInfo: String? = nil
+    ) {
+      self.relyingPartyId = relyingPartyId
+      self.relyingPartyName = relyingPartyName
+      self.username = username
+      self.credentialId = credentialId
+      self.creationDate = creationDate
+      self.deviceInfo = deviceInfo
+    }
+  }
+
   public struct GeneratorSettings: Codable, Sendable, Equatable {
     public let length: Int
     public let useUppercase: Bool
@@ -57,7 +246,15 @@ public struct VaultEntryDetail: Codable, Sendable, Equatable, Identifiable {
     totpAlgorithm: String? = nil,
     totpDigits: Int? = nil,
     totpPeriod: Int? = nil,
-    generatorSettings: GeneratorSettings? = nil
+    generatorSettings: GeneratorSettings? = nil,
+    entryType: String? = nil,
+    secureNote: SecureNoteDetail? = nil,
+    creditCard: CreditCardDetail? = nil,
+    identity: IdentityDetail? = nil,
+    bankAccount: BankAccountDetail? = nil,
+    sshKey: SshKeyDetail? = nil,
+    softwareLicense: SoftwareLicenseDetail? = nil,
+    passkey: PasskeyDetail? = nil
   ) {
     self.id = id
     self.title = title
@@ -75,5 +272,13 @@ public struct VaultEntryDetail: Codable, Sendable, Equatable, Identifiable {
     self.totpDigits = totpDigits
     self.totpPeriod = totpPeriod
     self.generatorSettings = generatorSettings
+    self.entryType = entryType
+    self.secureNote = secureNote
+    self.creditCard = creditCard
+    self.identity = identity
+    self.bankAccount = bankAccount
+    self.sshKey = sshKey
+    self.softwareLicense = softwareLicense
+    self.passkey = passkey
   }
 }


### PR DESCRIPTION
## Problem

The iOS entry detail view rendered a fixed LOGIN template (username / password / URL / notes / TOTP) for **every** entry type. Type-specific fields — card number, IBAN, SSH private key, identity, software license, passkey metadata — were dropped at decode time, so opening a non-login entry showed an empty login-shaped screen. The web app branches per type; iOS never did.

## What changed

Read-only per-type rendering for all 8 entry types (LOGIN, SECURE_NOTE, CREDIT_CARD, IDENTITY, BANK_ACCOUNT, SSH_KEY, SOFTWARE_LICENSE, PASSKEY):

- **Model** (`VaultEntryDetail`): adds `entryType` + 7 optional per-type sub-structs.
- **Decoder** (`EntryBlobDecoder.detail(entryType:)`): decodes the type-specific fields from the flat blob, gated by `entryType` (sourced from the cache row). Blob keys verified byte-for-byte against the web `fullBlob` (SSH uses `passphrase`/`comment`; secure-note body is `content`). LOGIN decode is unchanged — AutoFill (which passes `entryType: nil`) is unaffected.
- **View** (`EntryDetailView` + new `EntryDetailTypeSections`): exhaustive switch over `EntryTypeCategory`; per-type sections reuse the existing row helpers plus a new `SecretRow` (per-row reveal toggle + secure copy).
- **Localization**: 54 new field labels (EN + JA).

## Security

- Sensitive fields are masked behind `SecretRow`, matching the web `SENSITIVE_FIELDS` SSoT exactly (card number/CVV, account/routing/IBAN, SSH private key/passphrase, license key, identity address/postal code/ID number, passkey credential ID; secure-note content is `.privacySensitive()`).
- All copies route through `SecureClipboard` (localOnly + auto-clear); no raw `UIPasteboard`. Passkey provider-private material is never decoded into the display struct.
- **Edit gate**: the LOGIN-only edit form is hidden for non-login entries — editing one through it would re-encrypt a login blob and corrupt the entry.
- **Clear-on-lock**: decrypted detail is cleared when the vault locks/logs out while the view is foregrounded (broadened secret surface).

## Scope

Read-only. The create/edit form stays LOGIN-only (edit other types in the web app).

## Testing

- `xcodebuild test -scheme PasswdSSOApp`: **538 unit tests + UI tests pass**, build clean.
- New decoder tests: one per type, content-vs-notes split, LOGIN-scalar isolation, team-path entryType, nil-vs-LOGIN equivalence, `isEditableOnIOS` (8 cases).
- Per-type on-device visual parity deferred (requires seeded entries of all types); mitigated by byte-exact decoder tests + Debug fixtures.

Built via /triangulate (plan + 2 review rounds, implementation, code review — functionality & security clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)