### PR TITLE
docs: document the retention-GC worker; fix stale dcr-cleanup references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ MIGRATION_DATABASE_URL=<privileged-url> npm run migrate:account-tokens          
 Audit outbox worker (separate process):
 ```bash
 npm run worker:audit-outbox    # Run the outbox worker (requires OUTBOX_WORKER_DATABASE_URL)
-npm run worker:dcr-cleanup     # Run the DCR cleanup worker (requires DCR_CLEANUP_DATABASE_URL)
+npm run worker:retention-gc    # Run the retention GC worker (requires RETENTION_GC_DATABASE_URL)
 npm run test:integration       # Run real-DB integration tests (requires running Postgres)
 ```
 
@@ -418,7 +418,7 @@ All password data is encrypted **client-side** before reaching the server. The s
 | `/api/admin/rotate-master-key` | POST | Rotate server master key (admin-only, bearer token) |
 | `/api/maintenance/purge-history` | POST | System-wide history purge (admin-only, bearer token) |
 | `/api/maintenance/purge-audit-logs` | POST | System-wide audit log purge (admin-only, bearer token) |
-| `/api/maintenance/dcr-cleanup` | POST | **DEPRECATED — returns 410 Gone.** DCR cleanup now runs in the `dcr-cleanup-worker` process. Stub emits audit event for stale-cron detection; removed next minor. |
+| `/api/maintenance/dcr-cleanup` | POST | **DEPRECATED — returns 410 Gone.** DCR cleanup now runs in the `retention-gc-worker` process (the generic retention GC absorbed the former DCR-cleanup worker). Stub emits audit event for stale-cron detection; removed next minor. |
 
 ### i18n
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -194,7 +194,7 @@ npm run docker:down
 
 > **古いクローンからの移行**: 過去の運用で `.env.local` のみ作成しているリポジトリは、`mv .env.local .env` を実行して Docker Compose が自動読込できる canonical なファイルに移してください。`npm run init:env` は legacy `.env.local` を検出すると 1 度だけ NOTE で同じことを案内します。
 
-`.env.example` の末尾には **External / Build-time** セクションがあり、Next.js アプリは読まないが docker-compose / 本番ビルド / プロビジョニングスクリプトが必要とする変数 (`JACKSON_API_KEY` (Jackson コンテナ用), `PASSWD_SUPERUSER_PASSWORD` / `PASSWD_APP_PASSWORD` / `PASSWD_OUTBOX_WORKER_PASSWORD` / `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` (DB ロール用), `SENTRY_AUTH_TOKEN` (ソースマップアップロード用), `NEXT_DEV_ALLOWED_ORIGINS` (dev サーバ用)) が並びます。`npm run init:env` は Zod 宣言済み変数と並んで、これらも同一の `.env` に書き出します。
+`.env.example` の末尾には **External / Build-time** セクションがあり、Next.js アプリは読まないが docker-compose / 本番ビルド / プロビジョニングスクリプトが必要とする変数 (`JACKSON_API_KEY` (Jackson コンテナ用), `PASSWD_SUPERUSER_PASSWORD` / `PASSWD_APP_PASSWORD` / `PASSWD_OUTBOX_WORKER_PASSWORD` / `PASSWD_RETENTION_GC_WORKER_PASSWORD` (DB ロール用), `SENTRY_AUTH_TOKEN` (ソースマップアップロード用), `NEXT_DEV_ALLOWED_ORIGINS` (dev サーバ用)) が並びます。`npm run init:env` は Zod 宣言済み変数と並んで、これらも同一の `.env` に書き出します。
 
 主要な変数:
 
@@ -255,7 +255,7 @@ npm run docker:down
 | `PASSWD_SUPERUSER_PASSWORD` | （`docker compose` 必須）`passwd_user` SUPERUSER ロールのパスワード。未設定だと docker-compose が起動失敗。アップグレード手順は [Docker Setup](docs/setup/docker/en.md) 参照 |
 | `PASSWD_APP_PASSWORD` | （`docker compose` 必須）`passwd_app` ランタイムロールのパスワード。未設定だと docker-compose が起動失敗 |
 | `PASSWD_OUTBOX_WORKER_PASSWORD` | （`docker compose` 必須）`passwd_outbox_worker` DB ロールのパスワード。initdb 初回起動時に使用。既存クラスタでは `scripts/set-outbox-worker-password.sh` を使用 |
-| `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` | （`docker compose` 必須）`passwd_dcr_cleanup_worker` DB ロールのパスワード。initdb 初回起動時に使用。既存クラスタでは `scripts/set-dcr-cleanup-worker-password.sh` を使用 |
+| `PASSWD_RETENTION_GC_WORKER_PASSWORD` | （`docker compose` 必須）`passwd_retention_gc_worker` DB ロールのパスワード。initdb 初回起動時に使用。既存クラスタでは `scripts/set-retention-gc-worker-password.sh` を使用 |
 | `OUTBOX_BATCH_SIZE`, `OUTBOX_*` | （任意）監査アウトボックスワーカーの調整。詳細は `.env.example` 参照 |
 | `NEXT_DEV_ALLOWED_ORIGINS` | （任意）dev サーバー向け許可オリジン（例: Tailscale ホスト名） |
 | `NEXT_PUBLIC_CHROME_STORE_URL` | （任意）ブラウザ拡張配布用 Chrome Web Store URL |

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ npm run docker:down   # stops and tears down
 
 > **Migration from older clones**: if your repo predates this change you may have a `.env.local` and no `.env`. Run `mv .env.local .env` so Docker Compose can find it without `--env-file`. Re-running `npm run init:env` warns when both files exist.
 
-The bottom of `.env.example` has a dedicated **External / Build-time** section listing variables that are NOT read by the Next.js app but ARE required by docker-compose, provisioning scripts, or the production build (`JACKSON_API_KEY` for the Jackson container, `PASSWD_SUPERUSER_PASSWORD` / `PASSWD_APP_PASSWORD` / `PASSWD_OUTBOX_WORKER_PASSWORD` / `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` for the DB roles, `SENTRY_AUTH_TOKEN` for source-map upload, `NEXT_DEV_ALLOWED_ORIGINS` for the dev server). `npm run init:env` prompts for these alongside the Zod-declared vars and writes them into the same `.env`.
+The bottom of `.env.example` has a dedicated **External / Build-time** section listing variables that are NOT read by the Next.js app but ARE required by docker-compose, provisioning scripts, or the production build (`JACKSON_API_KEY` for the Jackson container, `PASSWD_SUPERUSER_PASSWORD` / `PASSWD_APP_PASSWORD` / `PASSWD_OUTBOX_WORKER_PASSWORD` / `PASSWD_RETENTION_GC_WORKER_PASSWORD` for the DB roles, `SENTRY_AUTH_TOKEN` for source-map upload, `NEXT_DEV_ALLOWED_ORIGINS` for the dev server). `npm run init:env` prompts for these alongside the Zod-declared vars and writes them into the same `.env`.
 
 Key variables:
 
@@ -256,7 +256,7 @@ Key variables:
 | `PASSWD_SUPERUSER_PASSWORD` | (Required for `docker compose`) Password for the `passwd_user` SUPERUSER DB role. docker-compose fails to start if unset. See [Docker Setup](docs/setup/docker/en.md) for upgrade notes. |
 | `PASSWD_APP_PASSWORD` | (Required for `docker compose`) Password for the `passwd_app` runtime DB role. docker-compose fails to start if unset. |
 | `PASSWD_OUTBOX_WORKER_PASSWORD` | (Required for `docker compose`) Password for the `passwd_outbox_worker` DB role. Used by initdb on first boot; for existing clusters use `scripts/set-outbox-worker-password.sh` |
-| `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` | (Required for `docker compose`) Password for the `passwd_dcr_cleanup_worker` DB role. Used by initdb on first boot; for existing clusters use `scripts/set-dcr-cleanup-worker-password.sh` |
+| `PASSWD_RETENTION_GC_WORKER_PASSWORD` | (Required for `docker compose`) Password for the `passwd_retention_gc_worker` DB role. Used by initdb on first boot; for existing clusters use `scripts/set-retention-gc-worker-password.sh` |
 | `OUTBOX_BATCH_SIZE`, `OUTBOX_*` | (Optional) Audit outbox worker tuning. See `.env.example` for all options |
 | `NEXT_DEV_ALLOWED_ORIGINS` | (Optional) Allowed origins for dev server (e.g., Tailscale hostname) |
 | `NEXT_PUBLIC_CHROME_STORE_URL` | (Optional) Chrome Web Store URL for extension distribution |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,3 +16,4 @@ Language policy: English-only (Class B). See [../operations/language-policy.md](
 | [extension-token-bridge.md](extension-token-bridge.md) | Browser extension token bridge & session encryption |
 | [extension-passkey-provider.md](extension-passkey-provider.md) | Browser extension passkey provider: get/create flows, security properties, known limitations |
 | [ios-app.md](ios-app.md) | iOS app & AutoFill extension: OAuth/DPoP sign-in, vault crypto, app↔extension bridge, cache rollback protection, AutoFill/passkey provider |
+| [retention-gc-worker.md](retention-gc-worker.md) | Retention GC worker: declarative registry, per-tenant retention, least-privilege role, RLS bypass, SQL-injection containment |

--- a/docs/architecture/retention-gc-worker.md
+++ b/docs/architecture/retention-gc-worker.md
@@ -1,0 +1,86 @@
+# Retention GC Worker
+
+The retention garbage-collection worker physically deletes expired and
+past-retention rows across the database. It is a single generic process driven
+by a declarative registry — one row per managed table — rather than per-table
+bespoke jobs. It generalizes (and absorbed) the former DCR-cleanup worker.
+
+- Worker entry: `scripts/retention-gc-worker.ts`
+- Implementation: `src/workers/retention-gc-worker/` (`registry.ts`, `sweep.ts`, `index.ts`, `predicate.ts`)
+- Run: `npm run worker:retention-gc` (dev) or the `retention-gc-worker` Docker service
+- Full design rationale / inclusion-exclusion notes: `docs/archive/review/retention-gc-worker-plan.md`
+
+## Why a single generic worker
+
+The 18 managed tables do not need bespoke deletion logic — they differ only in
+the table name, the cutoff column, and the SELECT predicate. So each is a
+**declarative registry entry**, and the worker dispatches on the entry `kind`.
+Adding a table is a registry row, not new code.
+
+## Entry kinds
+
+| Kind | Deletes when | Audit | Notes |
+|------|-------------|-------|-------|
+| `EXPIRY` | `cutoffColumn < now()` | none | Pure ephemeral rows (sessions, bridge/authorization codes, unclaimed DCR clients). |
+| `EXPIRY_GUARDED` | expired **and** a "no live dependents" guard holds | none | Guard is a fixed SQL fragment keyed by a closed `GuardName` enum (e.g. `MCP_TOKEN_FAMILY_DEAD`). |
+| `EXPIRY_AUDIT_PROVENANCE` | expired (optionally also guard) | **per-row provenance → audit, then delete, atomically** | For rows that carry forensic value (credentials, security records, grants). Captures provenance, emits the entry's `auditAction`, then deletes — in one transaction. An optional status-aware `guard` prevents deleting still-live rows (e.g. `EMERGENCY_GRANT_DEAD` keeps an ACCEPTED grant whose invite window has passed). |
+| `PER_TENANT_FN` | per-tenant age via a `SECURITY DEFINER` function | function-emitted | `audit_logs` only — deletion goes through a privileged function so the worker role never holds direct DELETE on `audit_logs`. ≥30-day floor enforced. |
+| `PER_TENANT_TRASH` | soft-deleted longer than the tenant's `trashRetentionDays` | `TRASH_RETENTION_PURGED` | `password_entries` / `team_password_entries`; the worker also deletes the external attachment blobs (best-effort, post-commit). |
+| `PER_TENANT_AGE` | `cutoffColumn` older than the tenant's retention column | `HISTORY_*` / `LOG_RETENTION_PURGED` | Plain per-tenant age delete (history, share-access / directory-sync logs, notifications). |
+
+## Per-tenant retention
+
+Six nullable `Tenant` columns let an admin opt into automatic cleanup.
+**`NULL` = never auto-delete** — the worker enumerates only tenants
+`WHERE <column> IS NOT NULL`. Configured in the tenant policy API
+(`/api/tenant/policy` GET/PATCH) and the retention settings card.
+
+| Column | Governs | Floor |
+|--------|---------|-------|
+| `auditLogRetentionDays` | `audit_logs` (via the SECURITY DEFINER function) | ≥ 30 days (forensic) |
+| `trashRetentionDays` | soft-deleted vault entries (personal + team) + attachment blobs | 1 day |
+| `historyRetentionDays` | password-entry history (personal + team) | 1 day |
+| `shareAccessLogRetentionDays` | `share_access_logs` | 1 day |
+| `directorySyncLogRetentionDays` | `directory_sync_logs` (age basis: `started_at`) | 1 day |
+| `notificationRetentionDays` | `notifications` | 1 day |
+
+Bounds for the five non-audit columns: `RETENTION_DAYS_MIN=1` /
+`RETENTION_DAYS_MAX=10*DAYS_PER_YEAR` (`src/lib/validations/common.ts`). The
+audit-log floor of 30 days is its own stricter constant.
+
+## Least privilege & RLS
+
+The worker connects as **`passwd_retention_gc_worker`** (NOSUPERUSER,
+NOBYPASSRLS), granted only the SELECT/DELETE it needs per table — never direct
+DELETE on `audit_logs` (that goes through the SECURITY DEFINER function).
+
+Because the role is NOBYPASSRLS, deleting across all tenants on an RLS-enabled
+table requires setting `app.bypass_rls = on` in-transaction. Every RLS-enabled
+registry entry must therefore declare **`globalDelete: true`**; the worker
+boot-validates this (an RLS-enabled entry missing `globalDelete`, and not in
+`RLS_FREE_EXPIRY_TABLES`, throws at startup) so a silent "0 rows deleted" cannot
+slip through. `ON DELETE CASCADE` runs internally under the table owner, so the
+role needs no DELETE grant on cascade children.
+
+## SQL-injection containment (S1)
+
+Registry-supplied identifiers (table, cutoff column, key/provenance columns) are
+allowlist-validated against `^[a-z_]+$` via `assertIdentifier` before
+interpolation. Predicates are structured (`PredicateClause[]`), not free-form
+SQL. Guard fragments are compile-time literals keyed by the closed `GuardName`
+enum — never registry data. Only `batchSize` and id lists are bound as
+parameters.
+
+## Operation
+
+| Env var | Purpose | Default |
+|---------|---------|---------|
+| `RETENTION_GC_DATABASE_URL` | DB URL for the `passwd_retention_gc_worker` role (falls back to `DATABASE_URL`) | — |
+| `RETENTION_GC_INTERVAL_MS` | sweep loop interval | (see `env-schema.ts`) |
+| `RETENTION_GC_BATCH_SIZE` | rows per delete batch (1–10000) | 1000 |
+| `RETENTION_GC_EMIT_HEARTBEAT_AUDIT` | emit a `RETENTION_GC_SWEEP` heartbeat audit event each cycle | — |
+
+For Docker, set `PASSWD_RETENTION_GC_WORKER_PASSWORD` (initdb wires it on first
+boot); for existing clusters rotate with
+`scripts/set-retention-gc-worker-password.sh`. Without the worker running,
+expired/past-retention rows simply accumulate — the app keeps functioning.

--- a/docs/operations/admin-tokens.md
+++ b/docs/operations/admin-tokens.md
@@ -37,9 +37,10 @@ not silently scoped. `audit-outbox-metrics` returns aggregates only for the
 token's own tenant — queue depth and failure counts of other tenants are not
 exposed.
 
-DCR cleanup (`dcr-cleanup`) is now system-internal: it runs as the
-`dcr-cleanup-worker` background process with its own least-privilege DB role and
-emits `SYSTEM`-attributed audit events. It is no longer triggered by an op_*
+DCR cleanup is now system-internal: it runs inside the generic
+`retention-gc-worker` background process (which absorbed the former dedicated
+DCR-cleanup worker) with its own least-privilege DB role and emits
+`SYSTEM`-attributed audit events. It is no longer triggered by an op_*
 token. The deprecated `POST /api/maintenance/dcr-cleanup` endpoint returns
 410 Gone and emits a `MCP_CLIENT_DCR_CLEANUP_DEPRECATED_CALL` audit event to
 surface stale cron jobs; the stub will be removed in the next minor release.
@@ -81,7 +82,7 @@ The token's subject is bound at mint time, so no separate `OPERATOR_ID` env var 
 For routes without a dedicated script (`audit-outbox-metrics`, `audit-outbox-purge-failed`, `audit-chain-verify`), curl directly:
 
 ```bash
-# DCR cleanup is now automatic — runs in the dcr-cleanup-worker process.
+# DCR cleanup is now automatic — runs in the retention-gc-worker process.
 # The deprecated POST endpoint returns 410 Gone for one minor version
 # to surface stale cron jobs via audit logs.
 

--- a/docs/security/owasp-top10-2026-05.md
+++ b/docs/security/owasp-top10-2026-05.md
@@ -35,6 +35,9 @@ Fixes applied (followup branch `fix/owasp-pr465-followup`):
   `PASSWD_OUTBOX_WORKER_PASSWORD` + `PASSWD_DCR_CLEANUP_WORKER_PASSWORD`
   to initdb so operator overrides actually take effect; env-allowlist
   + docs + CI workflows updated to match.
+  (As of this snapshot the role was `passwd_dcr_cleanup_worker`; it was
+  later generalized to `passwd_retention_gc_worker` /
+  `PASSWD_RETENTION_GC_WORKER_PASSWORD`.)
 
 Items NOT taken from PR #465 (assessed and dropped):
 - A02 CLI TLS guard (NODE_ENV-based): the guard rarely fires on
@@ -161,7 +164,7 @@ Items NOT taken from PR #465 (assessed and dropped):
 ### 強み
 
 - **CSP 'strict-dynamic' + nonce**: 信頼されたスクリプトのみ実行。XSS による改ざん耐性。
-- **DCR 未クレームクライアント期限切れ**: 24 時間で自動削除 (`dcr-cleanup-worker.ts`)。
+- **DCR 未クレームクライアント期限切れ**: 自動削除 (現在は汎用 `retention-gc-worker` に統合)。
 - **リフレッシュトークンローテーション + リプレイ検出**: ファミリー単位の失効。
 - **audit anchor publisher**: 監査ログハッシュチェーンによる改ざん検出 + 外部 WORM ストレージ連携インターフェース。
 - **Imports/Object.assign の代わりに NextResponse のクローン**: `applyCorsHeaders()` では response object を直接変更せず、ヘッダー設定のみ行うため既存レスポンスの改変ミスを防止。

--- a/docs/setup/docker/en.md
+++ b/docs/setup/docker/en.md
@@ -126,7 +126,7 @@ Set the following values:
 | `PASSWD_SUPERUSER_PASSWORD` | Password for the `passwd_user` SUPERUSER DB role. Used by `docker-compose` (POSTGRES_PASSWORD bootstrap, jackson DB_URL, migrate URL). Container fails to start if unset. | `openssl rand -hex 24` |
 | `PASSWD_APP_PASSWORD` | Password for the `passwd_app` NOSUPERUSER DB role (Next.js runtime). Used by `docker-compose` for `DATABASE_URL` AND forwarded to `initdb` for role creation. Container fails to start if unset. | `openssl rand -hex 24` |
 | `PASSWD_OUTBOX_WORKER_PASSWORD` | Password for the `passwd_outbox_worker` DB role (set during `initdb`). Used by `docker-compose` to wire `OUTBOX_WORKER_DATABASE_URL`. Required when running the audit-outbox-worker. Use `scripts/set-outbox-worker-password.sh` to rotate on existing clusters. | `openssl rand -hex 24` |
-| `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` | Password for the `passwd_dcr_cleanup_worker` DB role (set during `initdb`). Used by `docker-compose` to wire `DCR_CLEANUP_DATABASE_URL`. Required when running the dcr-cleanup-worker. Use `scripts/set-dcr-cleanup-worker-password.sh` to rotate on existing clusters. | `openssl rand -hex 24` |
+| `PASSWD_RETENTION_GC_WORKER_PASSWORD` | Password for the `passwd_retention_gc_worker` DB role (set during `initdb`). Used by `docker-compose` to wire `RETENTION_GC_DATABASE_URL`. Required when running the retention-gc-worker. Use `scripts/set-retention-gc-worker-password.sh` to rotate on existing clusters. | `openssl rand -hex 24` |
 
 > **Upgrading from a pre-2026-05-16 deployment**: `docker-compose.yml` and
 > `docker-compose.override.yml` previously fell back to the public default
@@ -143,13 +143,13 @@ Set the following values:
 >    PASSWD_SUPERUSER_PASSWORD=passwd_pass
 >    PASSWD_APP_PASSWORD=passwd_app_pass
 >    PASSWD_OUTBOX_WORKER_PASSWORD=passwd_outbox_pass
->    PASSWD_DCR_CLEANUP_WORKER_PASSWORD=passwd_dcr_pass
+>    PASSWD_RETENTION_GC_WORKER_PASSWORD=passwd_dcr_pass
 >    ```
 > 2. **Rotate to new passwords** (recommended): generate fresh values with
 >    `openssl rand -hex 24`, write them to `.env`, then `ALTER ROLE` each
 >    role to match. For the worker roles use the dedicated rotation scripts
 >    `scripts/set-outbox-worker-password.sh` and
->    `scripts/set-dcr-cleanup-worker-password.sh`.
+>    `scripts/set-retention-gc-worker-password.sh`.
 >
 | `BLOB_BACKEND` | Attachment storage backend | `db`, `s3`, `azure`, or `gcs` |
 | `AWS_REGION`, `S3_ATTACHMENTS_BUCKET` | Required if `BLOB_BACKEND=s3` | e.g., `ap-northeast-1`, bucket name |


### PR DESCRIPTION
## Summary

The retention-GC worker series renamed and generalized the former DCR-cleanup worker into a single registry-driven process, but the **user-facing docs were never updated**. They still referenced `dcr-cleanup-worker` / `PASSWD_DCR_CLEANUP_WORKER_PASSWORD` / `DCR_CLEANUP_DATABASE_URL` / `passwd_dcr_cleanup_worker` / `set-dcr-cleanup-worker-password.sh` — none of which exist in the codebase anymore. An operator following the docs would hit a missing DB role and a missing rotation script.

This also adds the architecture doc that the worker never had.

## Changes

- **New** `docs/architecture/retention-gc-worker.md` (indexed in `docs/architecture/README.md`): the full design —
  - why one generic registry-driven worker instead of per-table jobs;
  - the six entry kinds (`EXPIRY`, `EXPIRY_GUARDED`, `EXPIRY_AUDIT_PROVENANCE`, `PER_TENANT_FN`, `PER_TENANT_TRASH`, `PER_TENANT_AGE`);
  - the six per-tenant retention columns (NULL = never auto-delete) + bounds + the audit-log ≥30-day floor;
  - least-privilege `passwd_retention_gc_worker` role, the NOBYPASSRLS / `globalDelete` boot-validation, cascade behavior;
  - S1 SQL-injection containment (identifier allowlist, structured predicates, closed `GuardName` guard fragments);
  - operation: env knobs, role-password rotation, "no worker → rows just accumulate".
- **Stale-name fixes** to the current `retention-gc-worker` / `RETENTION_GC_*` / `passwd_retention_gc_worker` across `README.md`, `README.ja.md`, `CLAUDE.md`, `docs/operations/admin-tokens.md`, `docs/setup/docker/en.md`.
- The dated **OWASP snapshot** (`owasp-top10-2026-05.md`, "Reviewed commit: main (2026-05-15)") keeps its as-of name in the change-history line, annotated with the later rename so the reference still resolves without rewriting history.

## Verification

Docs only — no code change. All cross-links (plan doc, registry, worker script, rotation script, validation constants) and all four `RETENTION_GC_*` env vars verified to resolve against the codebase. Static pre-pr checks (incl. `check:env-docs` drift) pass 28/28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)