### PR TITLE
fix(extension): override undici >=7.28.0 to clear transitive CVEs

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "passwd-sso-extension",
-  "version": "0.4.57",
+  "version": "0.4.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "passwd-sso-extension",
-      "version": "0.4.57",
+      "version": "0.4.58",
       "dependencies": {
         "otpauth": "^9.5.0",
         "react": "^19.1.0",
@@ -3436,9 +3436,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.2.tgz",
-      "integrity": "sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -19,7 +19,8 @@
     "rollup": "$rollup",
     "@crxjs/vite-plugin": {
       "rollup": "^2.80.0"
-    }
+    },
+    "undici": ">=7.28.0 <8"
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.3.0",


### PR DESCRIPTION
## Summary

Closes the last two open Dependabot alerts. After #589 fixed the app's `undici`, two alerts remained — and they turned out to be against **`extension/package-lock.json`**, a separate lockfile #589 didn't touch:

- `GHSA-vmh5-mc38-953g` (high)
- `GHSA-pr7r-676h-xcf6` (moderate)

The extension pulls `undici` purely transitively as a build-time dev dependency: `@crxjs/vite-plugin` → `cheerio` → `undici@7.24.2`. It's not imported by extension code and not shipped in the extension bundle.

## Change

Add `undici: >=7.28.0 <8` to the extension's `overrides` (kept on the 7.x line — 8.x is a major). Resolves to `undici@7.28.0`.

## Verification

- extension `npm audit`: **0 vulnerabilities**.
- extension build: OK. Tests: **769 pass**.
- `pre-pr.sh`: **37/37**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)