### PR TITLE
fix(vault): sync 3-pane detail header to edited entry overview

### DIFF
--- a/src/components/passwords/detail/entry-list-view.test.tsx
+++ b/src/components/passwords/detail/entry-list-view.test.tsx
@@ -132,12 +132,14 @@ vi.mock("./master-detail-shell", () => ({
 vi.mock("./password-detail-pane", () => ({
   PasswordDetailPane: ({
     entryId,
+    entry,
     readOnly,
     onRestore,
     onDeletePermanently,
     onDelete,
   }: {
     entryId: string | null;
+    entry?: { username?: string } | null;
     readOnly?: boolean;
     onRestore?: () => void;
     onDeletePermanently?: () => void;
@@ -146,10 +148,13 @@ vi.mock("./password-detail-pane", () => ({
     capturedPaneRestore = onRestore;
     capturedPaneDeletePermanently = onDeletePermanently;
     capturedPaneDelete = onDelete;
+    // Expose the overview username so a test can assert the header re-syncs to the
+    // refreshed list object after an edit (the real header reads entry.username).
     return (
       <div
         data-testid="detail-pane"
         data-entry-id={entryId ?? ""}
+        data-username={entry?.username ?? ""}
         data-readonly={String(readOnly ?? false)}
       />
     );
@@ -726,5 +731,58 @@ describe("EntryListView — accordion team PasswordCard wiring", () => {
     expect(typeof capturedCardProps?.getUrl).toBe("function");
     expect(capturedCardProps?.createdBy).toBe("createdBy:Alice");
     expect(await (capturedCardProps?.getPassword as () => Promise<string>)()).toBe("pw");
+  });
+});
+
+// ── Detail-pane header re-syncs to the refreshed list object after an edit ──────
+// Regression: in master-detail, editing an entry's username synced the list but the
+// detail-pane header kept the stale username — activeEntry held the old object and
+// was never re-pointed to the refreshed entries object. Fails before the resync
+// effect in entry-list-view.tsx; passes after.
+describe("EntryListView — detail-pane header re-sync after edit", () => {
+  beforeEach(() => {
+    mockFetchApi.mockReset();
+    mockDecryptData.mockReset();
+    mockBuildAAD.mockReset().mockReturnValue("aad-bytes");
+  });
+
+  it("updates the detail-pane header username when the active entry is refreshed", async () => {
+    // Initial fetch: entry-1 with username "alice".
+    mockFetchApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [makeServerEntry("entry-1", { deletedAt: null })],
+    });
+    mockDecryptData.mockResolvedValueOnce(
+      makeDecryptedOverview("GitHub", { username: "alice" }),
+    );
+
+    const { rerender } = render(
+      <PasswordList searchQuery="" tagId={null} refreshKey={0} />,
+    );
+
+    await waitFor(() => { expect(screen.getByText("GitHub")).toBeInTheDocument(); });
+
+    // Select entry-1 → header shows the original username.
+    act(() => { fireEvent.click(screen.getByTestId("row-entry-1")); });
+    expect(screen.getByTestId("detail-pane")).toHaveAttribute("data-username", "alice");
+
+    // Simulate edit + refresh: same id, new username "bob". Bumping refreshKey
+    // re-triggers the fetch effect, producing a NEW entry object (fresh decrypt).
+    mockFetchApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [makeServerEntry("entry-1", { deletedAt: null })],
+    });
+    mockDecryptData.mockResolvedValueOnce(
+      makeDecryptedOverview("GitHub", { username: "bob" }),
+    );
+
+    await act(async () => {
+      rerender(<PasswordList searchQuery="" tagId={null} refreshKey={1} />);
+    });
+
+    // Assert: the header reflects the new username (stale "alice" before the fix).
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-pane")).toHaveAttribute("data-username", "bob");
+    });
   });
 });

--- a/src/components/passwords/detail/entry-list-view.tsx
+++ b/src/components/passwords/detail/entry-list-view.tsx
@@ -133,8 +133,10 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
     assertDescriptorAdapterCompat(descriptor, adapter);
   }, [descriptor, adapter]);
 
-  // INV-F1 / INV-S5: activeEntry AND selectionMode — owned here, reset atomically on query/view change.
-  const [activeEntry, setActiveEntry] = useState<E | null>(null);
+  // INV-F1 / INV-S5: active selection AND selectionMode — owned here, reset atomically on query/view change.
+  // Store the id only; the entry is DERIVED from the live entries array below, so the
+  // detail pane always reflects the latest overview (no stale-snapshot drift on edit).
+  const [activeEntryId, setActiveEntryId] = useState<string | null>(null);
   const [selectionMode, setSelectionMode] = useState(false);
 
   // Soft-delete (move-to-trash) confirm dialog state. Mirrors the accordion
@@ -160,7 +162,7 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
   const [prevViewKey, setPrevViewKey] = useState(viewKey);
   if (prevViewKey !== viewKey) {
     setPrevViewKey(viewKey);
-    setActiveEntry(null);
+    setActiveEntryId(null);
     setSelectionMode(false);
   }
 
@@ -174,6 +176,15 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
     refreshKey,
     sort: descriptor.sort,
   });
+
+  // Derive the active entry from the live list by id. Storing the id (not the object)
+  // keeps the detail pane in sync with edits automatically — a refetch replaces the
+  // entry object and this re-derives, so the header never shows a stale snapshot.
+  // Resolves to null when the selected entry leaves the list (deleted/filtered out).
+  const activeEntry = useMemo(
+    () => (activeEntryId ? (entries.find((en) => en.id === activeEntryId) ?? null) : null),
+    [entries, activeEntryId],
+  );
 
   // INV-S3: derive vaultStatus from adapter.availability (S3 — same signal for list + pane).
   const vaultStatus = adapter.availability.ready ? VAULT_STATUS.UNLOCKED : VAULT_STATUS.LOADING;
@@ -252,7 +263,7 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
           ? Math.min(currentIdx + 1, entries.length - 1)
           : Math.max(currentIdx - 1, 0);
         const next = entries[nextIdx];
-        if (next) setActiveEntry(next);
+        if (next) setActiveEntryId(next.id);
       }, 150);
       return;
     }
@@ -291,7 +302,7 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
     () => ({
       enterSelectionMode: () => {
         setSelectionMode(true);
-        setActiveEntry(null);
+        setActiveEntryId(null);
       },
       exitSelectionMode: () => {
         setSelectionMode(false);
@@ -329,7 +340,7 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
     // INV-C1.4 + F8: for favorites view, unfavoriting removes the row.
     const removesRow = descriptor.removeOnUnfavorite && !next;
     if (removesRow) {
-      setActiveEntry((prev) => (prev?.id === entry.id ? null : prev));
+      setActiveEntryId((prev) => (prev === entry.id ? null : prev));
       onEntryRemoved?.(entry.id);
     }
     try {
@@ -343,7 +354,7 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
 
   const handleSetArchived = useCallback(async (entry: E, next: boolean) => {
     // Archive/unarchive always removes from the current view.
-    setActiveEntry((prev) => (prev?.id === entry.id ? null : prev));
+    setActiveEntryId((prev) => (prev === entry.id ? null : prev));
     onEntryRemoved?.(entry.id);
     try {
       await adapter.setArchived(entry, next);
@@ -355,7 +366,7 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
   }, [adapter, onDataChange, onEntryRemoved, reload]);
 
   const handleSoftDelete = useCallback(async (entry: E) => {
-    setActiveEntry((prev) => (prev?.id === entry.id ? null : prev));
+    setActiveEntryId((prev) => (prev === entry.id ? null : prev));
     onEntryRemoved?.(entry.id);
     try {
       await adapter.softDelete(entry);
@@ -369,7 +380,7 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
   // Share — decrypt the entry's detail (lazy, on demand), strip secret/internal
   // fields, then open the share dialog. Works for personal + team via the adapter.
   const handleShare = useCallback(async (entry: E) => {
-    setActiveEntry(entry);
+    setActiveEntryId(entry.id);
     try {
       const detail = await adapter.buildGetDetail(entry)();
       const { totp: _totp, passwordHistory: _ph, id: _id, requireReprompt: _rp, ...safe } = detail;
@@ -385,7 +396,7 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
 
   // C9 — restore (no confirm per INV-C9.2).
   const handleRestore = useCallback(async (entry: E) => {
-    setActiveEntry((prev) => (prev?.id === entry.id ? null : prev));
+    setActiveEntryId((prev) => (prev === entry.id ? null : prev));
     onEntryRemoved?.(entry.id);
     try {
       await adapter.restore(entry);
@@ -401,7 +412,7 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
     const entry = deletePermanentlyPending;
     if (!entry) return;
     setDeletePermanentlyPending(null);
-    setActiveEntry((prev) => (prev?.id === entry.id ? null : prev));
+    setActiveEntryId((prev) => (prev === entry.id ? null : prev));
     onEntryRemoved?.(entry.id);
     try {
       await adapter.deletePermanently(entry);
@@ -463,13 +474,8 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
   }, [entries]);
 
   const handleToggleExpand = useCallback((id: string) => {
-    const entry = entries.find((e) => e.id === id);
-    if (activeEntry?.id === id) {
-      setActiveEntry(null);
-    } else if (entry) {
-      setActiveEntry(entry);
-    }
-  }, [entries, activeEntry]);
+    setActiveEntryId((prev) => (prev === id ? null : id));
+  }, []);
 
   // ── Render helpers ──────────────────────────────────────────────────────────
 
@@ -713,13 +719,9 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
             return (
               <PasswordRow
                 entry={entry}
-                isActive={activeEntry?.id === entry.id}
+                isActive={activeEntryId === entry.id}
                 onActivate={() => {
-                  if (activeEntry?.id === entry.id) {
-                    setActiveEntry(null);
-                  } else {
-                    setActiveEntry(entry);
-                  }
+                  setActiveEntryId((prev) => (prev === entry.id ? null : entry.id));
                 }}
                 selectionMode={selectionMode}
                 showFavorite={descriptor.rowActions.favorite && adapter.supportsFavorite}


### PR DESCRIPTION
## Summary

In the master-detail (3-pane) layout, editing an entry's overview field — e.g. `username` — updated the list pane but left the **right detail-pane header** showing the stale value. The list synced because it re-fetched; the header did not because it read from a stale selection snapshot.

## Root cause

`EntryListView` stored the selected entry as a full object (`useState<E | null>`). After an edit, `refreshKey` bumped → the list re-fetched fresh objects, and `invalidateDetail()` re-decrypted the detail **body** — but nothing re-pointed the stored selection to the refreshed object, so the header (which reads overview fields like `username` directly from the selection) kept the old value.

## Fix

Store the selection as an **id** (`activeEntryId`) and **derive** the active entry from the live `entries` array via `useMemo`. The header now always reflects the latest overview, and the stale-snapshot drift is structurally impossible. All `setActiveEntry(obj)` call sites become id-based; the derived `activeEntry` is used unchanged everywhere it's read.

This also resolves a secondary edge case: when the selected entry is filtered out (search) or removed, the derived value cleanly becomes `null` instead of holding a stale object.

## Testing

- Added a regression test in `entry-list-view.test.tsx` that selects an entry, refetches with a changed `username`, and asserts the detail-pane header updates. Verified it fails on the pre-fix tree and passes after.
- Full suite: 11511 tests pass; lint 0 errors; production build succeeds; `scripts/pre-pr.sh` 37/37 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)