### PR TITLE
fix(api): enforce streaming body-size caps on form/raw/multipart routes

### DIFF
--- a/docs/archive/review/fix-attachment-delete-dialog-overflow-plan.md
+++ b/docs/archive/review/fix-attachment-delete-dialog-overflow-plan.md
@@ -1,0 +1,128 @@
+# Plan: Fix attachment delete dialog filename overflow
+
+## Project context
+
+- **Type**: web app (Next.js 16 App Router + React + Tailwind 4 + shadcn/ui)
+- **Test infrastructure**: unit + integration (vitest) + E2E (Playwright) + CI/CD
+- **Verification environment constraints**: none blocking. The change is a CSS/markup-only
+  fix in two client components; visually verifiable in local dev. No paid-tier APIs,
+  external services, or hardware paths involved.
+
+## Objective
+
+When an attachment with a long filename is deleted, the confirmation dialog
+("添付ファイルの削除") renders the filename without wrapping. Long unbroken tokens
+(e.g. a 64-char hex name `a4b76f1e34aa...1090a26.jpg`) overflow horizontally out of
+the dialog box. Constrain the filename so it wraps within the dialog bounds.
+
+## Root cause
+
+`AlertDialogDescription` (`src/components/ui/alert-dialog.tsx:118-129`) carries only
+`text-muted-foreground text-sm` — no overflow handling. The filename is interpolated
+into the i18n string as plain text:
+
+```tsx
+{t("confirmDeleteDescription", { filename: deleteTarget?.filename ?? "" })}
+```
+
+The default CSS `overflow-wrap: normal` only breaks at whitespace/hyphens. A continuous
+hex filename has no break opportunity, so it overflows the `max-w-[calc(100%-2rem)]`
+(mobile) / `sm:max-w-lg` (desktop) dialog content box.
+
+## Technical approach
+
+Scope the line-breaking to the **filename token only**, not the whole description.
+A blanket `break-all` on the shared `AlertDialogDescription` component would affect
+45 files / 116 call sites and force mid-word breaks on ordinary prose in unrelated
+dialogs — rejected.
+
+Use next-intl `t.rich` to render the filename inside a `<span className="break-all">`.
+This matches the established codebase pattern for user-controlled long strings
+(URLs, usernames) which already use `break-all`:
+- `src/components/passwords/detail/sections/login-section.tsx:105,141` (URL, field value)
+- `src/components/passwords/detail/password-detail-pane.tsx:260` (username)
+
+`t.rich` is already used in the codebase (`src/app/[locale]/privacy-policy/page.tsx:63`).
+
+## Contracts
+
+### C1 — i18n message converts `{filename}` placeholder to a `<filename>` rich tag
+
+Both locale files, key `confirmDeleteDescription` (`messages/ja/Attachments.json`,
+`messages/en/Attachments.json`).
+
+- ja: `「{filename}」を削除してもよろしいですか？この操作は元に戻せません。`
+  → `「<filename>{name}</filename>」を削除してもよろしいですか？この操作は元に戻せません。`
+- en: `Are you sure you want to delete "{filename}"? This action cannot be undone.`
+  → `Are you sure you want to delete "<filename>{name}</filename>"? This action cannot be undone.`
+
+- **Invariant** (app-enforced): the literal corner brackets `「」` (ja) and straight
+  quotes `"…"` (en) stay OUTSIDE the tag, exactly as today, so wrapping the inner
+  text does not change the punctuation rendering.
+- **Forbidden patterns**:
+  - pattern: `confirmDeleteDescription.*\{filename\}` — reason: old placeholder form must be fully replaced by the `<filename>` tag in both locales.
+- **Acceptance**: `t.rich("confirmDeleteDescription", { filename: (chunks) => <span className="break-all">{chunks}</span> })` renders the filename as a breakable span and the surrounding text unchanged.
+- **Consumer-flow walkthrough**: Consumer = the two attachment-section components
+  (`attachment-section.tsx`, `team-attachment-section.tsx`). Each reads
+  `deleteTarget.filename` and passes it as `{ name: deleteTarget?.filename ?? "" }`
+  plus the `filename` chunk renderer to `t.rich`. No other consumer reads this key
+  (grep `confirmDeleteDescription` → only these two files + locale files).
+
+### C2 — both attachment-section call sites switch `t(...)` → `t.rich(...)`
+
+Files:
+- `src/components/passwords/entry/attachment-section.tsx:457-459`
+- `src/components/team/forms/team-attachment-section.tsx:345-347`
+
+Replace:
+```tsx
+{t("confirmDeleteDescription", { filename: deleteTarget?.filename ?? "" })}
+```
+with:
+```tsx
+{t.rich("confirmDeleteDescription", {
+  name: deleteTarget?.filename ?? "",
+  filename: (chunks) => <span className="break-all">{chunks}</span>,
+})}
+```
+
+- **Invariant**: both call sites stay byte-identical to each other (parallel
+  personal/team implementations — see project memory on commonizing personal/team UI).
+- **Acceptance**: long hex filename wraps within the dialog; short filename renders
+  identically to before.
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | i18n `confirmDeleteDescription` → rich `<filename>` tag (ja+en) | locked |
+| C2 | both call sites use `t.rich` with `break-all` span | locked |
+
+## Testing strategy
+
+- Manual visual check in local dev (`:3001`): upload an attachment, rename/use a long
+  hex filename, open the delete dialog, confirm the filename wraps inside the box on
+  both narrow (mobile) and `sm` widths.
+- No new automated test: this is a presentational CSS fix; the project has no visual
+  regression harness and a unit test asserting a Tailwind class on interpolated markup
+  would be decorative (asserting implementation detail). Existing E2E attachment-delete
+  flows remain green (dialog text content unchanged; only markup structure differs).
+- `npx vitest run` + `npx next build` per CLAUDE.md mandatory checks.
+
+## Considerations & constraints
+
+- **SC1** (out of scope): the global `AlertDialogDescription` overflow gap across the
+  other 114 call sites — deliberately NOT touched here to avoid regressing prose
+  dialogs. If a future audit wants a global guard, it belongs in a separate PR that
+  reviews each call site. Owner: future issue.
+- `break-all` chosen over `break-words`/`overflow-wrap-anywhere` because the failing
+  input is a single unbroken token with no break opportunities; `break-words` does not
+  break inside such a token. `break-all` is already the codebase convention for
+  user-controlled long strings.
+
+## User operation scenarios
+
+1. Attachment with 64-char hex filename (the reported case) → wraps to 2-3 lines inside dialog.
+2. Attachment with normal filename `invoice.pdf` → single line, unchanged from today.
+3. Filename with mixed spaces and a long token → spaces break naturally, long token breaks via `break-all`.
+4. Narrow mobile viewport (`max-w-[calc(100%-2rem)]`) → wraps within the reduced width.

--- a/scripts/checks/check-raw-body-read.sh
+++ b/scripts/checks/check-raw-body-read.sh
@@ -26,7 +26,7 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 API_DIR="$REPO_ROOT/src/app/api"
 ALLOWLIST="$REPO_ROOT/scripts/checks/raw-body-read-allowlist.txt"
 

--- a/scripts/checks/check-raw-body-read.sh
+++ b/scripts/checks/check-raw-body-read.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# CI gate: API route handlers must not read the request body via the
+# unbounded primitives `req.text()` / `req.arrayBuffer()` / `req.formData()`
+# without a streaming byte cap. The App Router has no platform body-size cap,
+# so a chunked / no-Content-Length body would otherwise be buffered into memory
+# unbounded (availability DoS, worst on pre-auth/public OAuth endpoints).
+#
+# Canonical helpers (src/lib/http/parse-body.ts):
+#   readJsonWithCap / parseBody     — JSON bodies (authoritative streaming cap)
+#   readFormWithCap                 — application/x-www-form-urlencoded
+#   readBytesWithCap                — raw bytes (e.g. replay-vs-retry hash)
+#   rejectOversizedMultipart        — gate before req.formData() (multipart)
+#
+# Rules enforced (over src/app/api/**/route.ts, excluding *.test.ts):
+#   (1) req.text()       — FORBIDDEN. Use readFormWithCap / readBytesWithCap.
+#   (2) req.arrayBuffer()— FORBIDDEN. Use readBytesWithCap.
+#   (3) req.formData()   — ALLOWED only when the same file also calls
+#                          rejectOversizedMultipart(...). req.formData() cannot
+#                          be stream-capped (the parser owns the stream), so the
+#                          pre-parse Content-Length gate is mandatory.
+#
+# A genuinely-exempt route may be added to the allowlist file
+# scripts/checks/raw-body-read-allowlist.txt (one path per line, `#` comments).
+#
+# Fail: exits 1 with one RAW_BODY_READ line per offending route.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+API_DIR="$REPO_ROOT/src/app/api"
+ALLOWLIST="$REPO_ROOT/scripts/checks/raw-body-read-allowlist.txt"
+
+# Normalize allowlist into a newline-delimited list (bash 3.2: no assoc arrays).
+ALLOW_LIST=""
+if [ -f "$ALLOWLIST" ]; then
+  while IFS= read -r line; do
+    line="${line%$'\r'}"
+    line="${line## }"; line="${line%% }"
+    [ -z "$line" ] && continue
+    case "$line" in \#*) continue ;; esac
+    ALLOW_LIST="${ALLOW_LIST}${line}
+"
+  done < "$ALLOWLIST"
+fi
+
+is_allowed() {
+  printf '%s' "$ALLOW_LIST" | grep -qxF "$1"
+}
+
+fail=0
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  rel="${file#"$REPO_ROOT"/}"
+  is_allowed "$rel" && continue
+
+  # (1) + (2): text() / arrayBuffer() are never allowed in routes.
+  if grep -nE "\b(req|request)\.(text|arrayBuffer)\(\)" "$file" >/dev/null; then
+    hit=$(grep -nE "\b(req|request)\.(text|arrayBuffer)\(\)" "$file" | head -1)
+    echo "RAW_BODY_READ: $rel — req.text()/req.arrayBuffer() is forbidden (use readFormWithCap / readBytesWithCap): $hit"
+    fail=1
+  fi
+
+  # (3): formData() requires a rejectOversizedMultipart gate in the same file.
+  if grep -nE "\b(req|request)\.formData\(\)" "$file" >/dev/null; then
+    if ! grep -q "rejectOversizedMultipart(" "$file"; then
+      hit=$(grep -nE "\b(req|request)\.formData\(\)" "$file" | head -1)
+      echo "RAW_BODY_READ: $rel — req.formData() without rejectOversizedMultipart() gate: $hit"
+      fail=1
+    fi
+  fi
+done < <(
+  grep -rlE "\b(req|request)\.(text|arrayBuffer|formData)\(\)" "$API_DIR" \
+    --include="route.ts" 2>/dev/null \
+    | grep -v "\.test\.ts$" \
+    | sort
+)
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "Route handlers must cap the request body. Use the helpers in"
+  echo "src/lib/http/parse-body.ts, or add a justified entry to"
+  echo "scripts/checks/raw-body-read-allowlist.txt."
+  exit 1
+fi
+
+exit 0

--- a/scripts/checks/raw-body-read-allowlist.txt
+++ b/scripts/checks/raw-body-read-allowlist.txt
@@ -1,0 +1,8 @@
+# Allowlist for check-raw-body-read.sh — route files permitted to call
+# req.text() / req.arrayBuffer() / req.formData() without the standard
+# parse-body cap helpers. One repo-relative path per line; `#` lines are
+# comments.
+#
+# Add an entry ONLY with a justification comment explaining why the route
+# cannot use the streaming-cap helpers. Empty by default — all current routes
+# use the helpers (src/lib/http/parse-body.ts).

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -130,6 +130,7 @@ run_step "Static: settings-card-layout"  bash scripts/checks/check-settings-card
 run_step "Static: api-error-codes" bash scripts/checks/check-api-error-codes.sh
 run_step "Static: api-error-body-drift" bash scripts/checks/check-api-error-body-drift.sh
 run_step "Static: fail-closed-routes-have-test" bash scripts/checks/check-fail-closed-routes-have-test.sh
+run_step "Static: raw-body-read" bash scripts/checks/check-raw-body-read.sh
 run_step "Static: actions-sha-pinned" bash scripts/checks/check-actions-sha-pinned.sh
 run_step "Static: dockerfile-prisma-pin" bash scripts/checks/check-dockerfile-prisma-pin.sh
 run_step "Static: ios-no-diagnostic-logging" bash scripts/checks/check-ios-no-diagnostic-logging.sh

--- a/src/__tests__/api/passwords/attachments.test.ts
+++ b/src/__tests__/api/passwords/attachments.test.ts
@@ -116,7 +116,7 @@ vi.mock("@/lib/quota/resource-quotas", () => ({
   QuotaExceededError: class extends Error {},
 }));
 
-function createFormDataRequest(
+async function createFormDataRequest(
   fields: Record<string, string | Blob>,
   headers: Record<string, string> = {},
 ) {
@@ -124,10 +124,19 @@ function createFormDataRequest(
   for (const [key, value] of Object.entries(fields)) {
     formData.append(key, value);
   }
+  // Serialize once to set Content-Length, mirroring a real browser upload —
+  // the route gates on it via rejectOversizedMultipart (fail-closed if absent).
+  // An explicit `headers` override (e.g. a too-large content-length test) wins.
+  const encoded = new Request("http://localhost", { method: "POST", body: formData });
+  const bytes = new Uint8Array(await encoded.arrayBuffer());
   return new NextRequest("http://localhost/api/passwords/e1/attachments", {
     method: "POST",
-    body: formData,
-    headers,
+    body: bytes,
+    headers: {
+      "content-type": encoded.headers.get("content-type") ?? "multipart/form-data",
+      "content-length": String(bytes.length),
+      ...headers,
+    },
   });
 }
 
@@ -225,7 +234,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
 
   it("returns 401 when not authenticated", async () => {
     mockAuth.mockResolvedValue(null);
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, createParams("e1"));
     const { status } = await parseResponse(res);
     expect(status).toBe(401);
@@ -234,7 +243,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
   it("returns 404 when entry not found", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockEntryFindUnique.mockResolvedValue(null);
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, createParams("e1"));
     const { status } = await parseResponse(res);
     expect(status).toBe(404);
@@ -243,7 +252,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
   it("returns 404 when entry belongs to another user (A01-4: no existence oracle)", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockEntryFindUnique.mockResolvedValue({ userId: "other-user" });
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, createParams("e1"));
     const { status } = await parseResponse(res);
     expect(status).toBe(404);
@@ -253,7 +262,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockEntryFindUnique.mockResolvedValue({ userId: DEFAULT_SESSION.user.id });
     mockAttachmentCount.mockResolvedValue(20);
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -264,7 +273,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockEntryFindUnique.mockResolvedValue({ userId: DEFAULT_SESSION.user.id });
     mockAttachmentCount.mockResolvedValue(0);
-    const req = createFormDataRequest(validFormFields(), {
+    const req = await createFormDataRequest(validFormFields(), {
       "content-length": String(100 * 1024 * 1024),
     });
     const res = await POST(req, createParams("e1"));
@@ -277,10 +286,16 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockEntryFindUnique.mockResolvedValue({ userId: DEFAULT_SESSION.user.id });
     mockAttachmentCount.mockResolvedValue(0);
+    const body = "not form data";
     const req = new NextRequest("http://localhost/api/passwords/e1/attachments", {
       method: "POST",
-      body: "not form data",
-      headers: { "content-type": "text/plain" },
+      body,
+      // Valid content-length so the multipart size gate passes and we reach
+      // formData() — this test exercises the parse-failure path specifically.
+      headers: {
+        "content-type": "text/plain",
+        "content-length": String(Buffer.byteLength(body)),
+      },
     });
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
@@ -292,7 +307,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockEntryFindUnique.mockResolvedValue({ userId: DEFAULT_SESSION.user.id });
     mockAttachmentCount.mockResolvedValue(0);
-    const req = createFormDataRequest({ file: new Blob(["x"]) });
+    const req = await createFormDataRequest({ file: new Blob(["x"]) });
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -305,7 +320,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.iv = "bad-iv";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -318,7 +333,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.authTag = "bad-tag";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -331,7 +346,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.filename = "malware.exe";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -344,7 +359,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.contentType = "application/x-executable";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -357,7 +372,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.filename = "../etc/passwd.pdf";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -370,7 +385,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.filename = "test\r\n.pdf";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -383,7 +398,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.filename = "CON.pdf";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -403,7 +418,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
       createdAt: new Date(),
     };
     mockAttachmentCreate.mockResolvedValue(created);
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(201);
@@ -415,7 +430,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockEntryFindUnique.mockResolvedValue({ userId: DEFAULT_SESSION.user.id });
     mockAttachmentCount.mockResolvedValue(0);
     const fields = { ...validFormFields(), cekEncrypted: "Y2V-" };
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -438,7 +453,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     };
     mockAttachmentCreate.mockResolvedValue(created);
     const fields = { ...validFormFields(), id: uppercaseId };
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, createParams("e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(201);

--- a/src/__tests__/api/sends/file.test.ts
+++ b/src/__tests__/api/sends/file.test.ts
@@ -88,7 +88,7 @@ describe("POST /api/sends/file", () => {
   it("returns 401 when not authenticated", async () => {
     mockAuth.mockResolvedValue(null);
 
-    const req = createMultipartRequest(
+    const req = await createMultipartRequest(
       "http://localhost/api/sends/file",
       createFormData()
     );
@@ -103,7 +103,7 @@ describe("POST /api/sends/file", () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockCheck.mockResolvedValue({ allowed: false });
 
-    const req = createMultipartRequest(
+    const req = await createMultipartRequest(
       "http://localhost/api/sends/file",
       createFormData()
     );
@@ -118,12 +118,18 @@ describe("POST /api/sends/file", () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
 
     // Send non-FormData body that will cause req.formData() to throw
+    const body = JSON.stringify({ name: "test" });
     const req = new (await import("next/server")).NextRequest(
       "http://localhost/api/sends/file",
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: "test" }),
+        // Valid content-length so the multipart size gate passes and we reach
+        // formData() — this test exercises the parse-failure path specifically.
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": String(Buffer.byteLength(body)),
+        },
+        body,
       } as ConstructorParameters<typeof import("next/server").NextRequest>[1]
     );
     const res = await POST(req as never);
@@ -141,7 +147,7 @@ describe("POST /api/sends/file", () => {
     fd.append("expiresIn", "1d");
     // No file field appended
 
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
 
@@ -159,7 +165,7 @@ describe("POST /api/sends/file", () => {
       type: "application/octet-stream",
     });
 
-    const req = createMultipartRequest(
+    const req = await createMultipartRequest(
       "http://localhost/api/sends/file",
       createFormData({ file: exactFile })
     );
@@ -177,7 +183,7 @@ describe("POST /api/sends/file", () => {
       type: "application/octet-stream",
     });
 
-    const req = createMultipartRequest(
+    const req = await createMultipartRequest(
       "http://localhost/api/sends/file",
       createFormData({ file: bigFile })
     );
@@ -194,7 +200,7 @@ describe("POST /api/sends/file", () => {
     mockCreate.mockResolvedValue({ id: "share-1", expiresAt: new Date() });
 
     const fd = createFormData({ contentType: "image/png", filename: "test.png" });
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
 
     expect(res.status).toBe(201);
@@ -206,7 +212,7 @@ describe("POST /api/sends/file", () => {
     mockCreate.mockResolvedValue({ id: "share-1", expiresAt: new Date() });
 
     const fd = createFormData({ contentType: "application/octet-stream", filename: "test.bin" });
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
 
     expect(res.status).toBe(201);
@@ -218,7 +224,7 @@ describe("POST /api/sends/file", () => {
 
     const fd = createFormData({ contentType: "image/jpeg", filename: "test.jpg" });
 
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
 
@@ -231,7 +237,7 @@ describe("POST /api/sends/file", () => {
     mockFileTypeFromBuffer.mockResolvedValue(undefined);
     mockCreate.mockResolvedValue({ id: "share-1", expiresAt: new Date() });
 
-    const req = createMultipartRequest(
+    const req = await createMultipartRequest(
       "http://localhost/api/sends/file",
       createFormData()
     );
@@ -245,7 +251,7 @@ describe("POST /api/sends/file", () => {
 
     const fd = createFormData({ filename: "../etc/passwd" });
 
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
 
@@ -259,7 +265,7 @@ describe("POST /api/sends/file", () => {
 
     const fd = createFormData({ filename: "テスト文書.txt" });
 
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
 
     expect(res.status).toBe(201);
@@ -270,7 +276,7 @@ describe("POST /api/sends/file", () => {
 
     const fd = createFormData({ filename: "test😀.txt" });
 
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
 
@@ -284,7 +290,7 @@ describe("POST /api/sends/file", () => {
     const file = new File(["data"], "", { type: "text/plain" });
     const fd = createFormData({ file });
 
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
 
@@ -307,7 +313,7 @@ describe("POST /api/sends/file", () => {
     );
     const fdLarge = createFormData({ file: largeFile });
 
-    const req = createMultipartRequest(
+    const req = await createMultipartRequest(
       "http://localhost/api/sends/file",
       fdLarge
     );
@@ -323,7 +329,7 @@ describe("POST /api/sends/file", () => {
     const expiresAt = new Date(Date.now() + 86400_000);
     mockCreate.mockResolvedValue({ id: "share-1", expiresAt });
 
-    const req = createMultipartRequest(
+    const req = await createMultipartRequest(
       "http://localhost/api/sends/file",
       createFormData()
     );
@@ -364,7 +370,7 @@ describe("POST /api/sends/file", () => {
     const fd = createFormData();
     fd.append("requirePassword", "true");
 
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
     const { status } = await parseResponse(res);
 

--- a/src/__tests__/api/teams/team-attachments.test.ts
+++ b/src/__tests__/api/teams/team-attachments.test.ts
@@ -78,7 +78,7 @@ function createGetRequest() {
   });
 }
 
-function createFormDataRequest(
+async function createFormDataRequest(
   fields: Record<string, string | Blob>,
   headers: Record<string, string> = {},
 ) {
@@ -86,10 +86,19 @@ function createFormDataRequest(
   for (const [key, value] of Object.entries(fields)) {
     formData.append(key, value);
   }
+  // Serialize once to set Content-Length, mirroring a real browser upload —
+  // the route gates on it via rejectOversizedMultipart (fail-closed if absent).
+  // An explicit `headers` override (e.g. a too-large content-length test) wins.
+  const encoded = new Request("http://localhost", { method: "POST", body: formData });
+  const bytes = new Uint8Array(await encoded.arrayBuffer());
   return new NextRequest("http://localhost/api/teams/o1/passwords/e1/attachments", {
     method: "POST",
-    body: formData,
-    headers,
+    body: bytes,
+    headers: {
+      "content-type": encoded.headers.get("content-type") ?? "multipart/form-data",
+      "content-length": String(bytes.length),
+      ...headers,
+    },
   });
 }
 
@@ -169,7 +178,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
 
   it("returns 401 when not authenticated", async () => {
     mockAuth.mockResolvedValue(null);
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, makeParams("o1", "e1"));
     const { status } = await parseResponse(res);
     expect(status).toBe(401);
@@ -178,7 +187,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
   it("returns 403 when lacking permission", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockRequireTeamPermission.mockRejectedValue(new TeamAuthError("FORBIDDEN", 403));
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, makeParams("o1", "e1"));
     const { status } = await parseResponse(res);
     expect(status).toBe(403);
@@ -188,7 +197,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockRequireTeamPermission.mockResolvedValue(undefined);
     mockEntryFindUnique.mockResolvedValue(null);
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, makeParams("o1", "e1"));
     const { status } = await parseResponse(res);
     expect(status).toBe(404);
@@ -199,7 +208,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockRequireTeamPermission.mockResolvedValue(undefined);
     mockEntryFindUnique.mockResolvedValue(TEAM_ENTRY);
     mockAttachmentCount.mockResolvedValue(20);
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -211,7 +220,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockRequireTeamPermission.mockResolvedValue(undefined);
     mockEntryFindUnique.mockResolvedValue(TEAM_ENTRY);
     mockAttachmentCount.mockResolvedValue(0);
-    const req = createFormDataRequest(validFormFields(), {
+    const req = await createFormDataRequest(validFormFields(), {
       "content-length": String(100 * 1024 * 1024),
     });
     const res = await POST(req, makeParams("o1", "e1"));
@@ -225,7 +234,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockRequireTeamPermission.mockResolvedValue(undefined);
     mockEntryFindUnique.mockResolvedValue(TEAM_ENTRY);
     mockAttachmentCount.mockResolvedValue(0);
-    const req = createFormDataRequest({ file: new Blob(["x"]) });
+    const req = await createFormDataRequest({ file: new Blob(["x"]) });
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -239,7 +248,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.filename = "malware.exe";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -253,7 +262,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.contentType = "application/x-executable";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -266,7 +275,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockEntryFindUnique.mockResolvedValue(TEAM_ENTRY);
     mockAttachmentCount.mockResolvedValue(0);
     const fields = { ...validFormFields(), iv: "bad-iv" };
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -279,7 +288,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockEntryFindUnique.mockResolvedValue(TEAM_ENTRY);
     mockAttachmentCount.mockResolvedValue(0);
     const fields = { ...validFormFields(), authTag: "bad-tag" };
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -293,7 +302,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.filename = "../etc/passwd.pdf";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -307,7 +316,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.filename = "test\r\n.pdf";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -321,7 +330,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     fields.filename = "CON.pdf";
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -342,7 +351,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
       createdAt: new Date(),
     };
     mockAttachmentCreate.mockResolvedValue(created);
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(201);
@@ -365,7 +374,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockEntryFindUnique.mockResolvedValue(TEAM_ENTRY);
     mockAttachmentCount.mockResolvedValue(0);
     const fields = { ...validFormFields(), encryptionMode: "0" };
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -378,7 +387,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockEntryFindUnique.mockResolvedValue(TEAM_ENTRY);
     mockAttachmentCount.mockResolvedValue(0);
     const fields = { ...validFormFields(), encryptionMode: "2" };
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -392,7 +401,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockAttachmentCount.mockResolvedValue(0);
     const fields = validFormFields();
     delete fields.encryptionMode;
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -403,7 +412,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockRequireTeamPermission.mockResolvedValue(undefined);
     mockEntryFindUnique.mockResolvedValue({ ...TEAM_ENTRY, itemKeyVersion: 0 });
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -416,7 +425,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockEntryFindUnique.mockResolvedValue(TEAM_ENTRY);
     mockAttachmentCount.mockResolvedValue(0);
     const fields = { ...validFormFields(), id: "not-a-uuid" };
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -437,7 +446,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
       createdAt: new Date(),
     });
     const fields = { ...validFormFields(), id: "550e8400-e29b-41d4-a716-446655440000" };
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status } = await parseResponse(res);
     expect(status).toBe(201);
@@ -458,7 +467,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
       createdAt: new Date(),
     });
     const fields = { ...validFormFields(), id: uppercaseId };
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(201);
@@ -479,7 +488,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockEntryFindUnique.mockResolvedValue(TEAM_ENTRY);
     mockAttachmentCount.mockResolvedValue(0);
     const fields = { ...validFormFields(), aadVersion: "2" };
-    const req = createFormDataRequest(fields);
+    const req = await createFormDataRequest(fields);
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -491,7 +500,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     mockRequireTeamPermission.mockResolvedValue(undefined);
     const entryWithoutItemKey = { teamId: "o1", teamKeyVersion: 1, tenantId: "t1" };
     mockEntryFindUnique.mockResolvedValue(entryWithoutItemKey);
-    const req = createFormDataRequest(validFormFields());
+    const req = await createFormDataRequest(validFormFields());
     const res = await POST(req, makeParams("o1", "e1"));
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);

--- a/src/__tests__/helpers/request-builder.ts
+++ b/src/__tests__/helpers/request-builder.ts
@@ -39,17 +39,34 @@ export function createRequest(
 /**
  * Creates a NextRequest from FormData for multipart upload tests.
  * Note: Do NOT set Content-Type header manually — the boundary is auto-generated.
+ *
+ * A real browser sets Content-Length on form uploads, and route handlers gate
+ * on it (rejectOversizedMultipart fails closed when it is absent). undici does
+ * NOT set Content-Length for a streamed FormData body, so we serialize the body
+ * once to compute and set it — mirroring the browser wire shape. Pass
+ * `{ omitContentLength: true }` to exercise the fail-closed (no-header) path.
  */
-export function createMultipartRequest(
+export async function createMultipartRequest(
   url: string,
   formData: FormData,
-  options: { headers?: Record<string, string> } = {}
-): NextRequest {
-  const { headers = {} } = options;
+  options: { headers?: Record<string, string>; omitContentLength?: boolean } = {}
+): Promise<NextRequest> {
+  const { headers = {}, omitContentLength = false } = options;
+  // Serialize the multipart body once to capture its bytes + boundary header.
+  const encoded = new Request("http://localhost", { method: "POST", body: formData });
+  const bytes = new Uint8Array(await encoded.arrayBuffer());
+  const contentType = encoded.headers.get("content-type") ?? "multipart/form-data";
+
+  const finalHeaders: Record<string, string> = {
+    "content-type": contentType,
+    ...(omitContentLength ? {} : { "content-length": String(bytes.length) }),
+    ...headers,
+  };
+
   return new NextRequest(url, {
     method: "POST",
-    body: formData,
-    headers,
+    body: bytes,
+    headers: finalHeaders,
   } as ConstructorParameters<typeof NextRequest>[1]);
 }
 

--- a/src/app/api/mcp/authorize/consent/route.test.ts
+++ b/src/app/api/mcp/authorize/consent/route.test.ts
@@ -15,7 +15,7 @@ const {
   mockRequireRecentSession,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
-  mockWithBypassRls: vi.fn(async (p: unknown, fn: (tx: unknown) => unknown) => fn(p)),
+  mockWithBypassRls: vi.fn(),
   mockFindFirst: vi.fn(),
   mockFindUnique: vi.fn(),
   mockCreateAuthorizationCode: vi.fn(),
@@ -56,6 +56,34 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
+// withBypassRls runs its callback on a bypass-RLS transaction client. The route
+// uses that tx directly for both simple cross-tenant lookups (mcpClient.findFirst
+// / user.findUnique / mcpClient.findUnique) AND the DCR claim sequence (count →
+// exclusion findFirst → delete → CAS updateMany). This impl passes a tx mock
+// serving all of them. Defined as a named helper (re-applied in beforeEach
+// because vi.clearAllMocks() wipes mock implementations between tests).
+function bypassRlsImpl(_p: unknown, fn: (tx: unknown) => unknown) {
+  return fn({
+    mcpClient: {
+      // The route issues two distinct findFirst shapes on the bypass tx: the
+      // initial client lookup keys on `clientId`; the DCR claim-exclusion
+      // lookups key on `name`/`isDcr` (no clientId). Dispatch by shape so the
+      // claim path keeps using mockTxFindFirst while the client lookup uses
+      // mockFindFirst — preserving the per-call assertions in the tests.
+      findFirst: (args: { where?: Record<string, unknown> }) =>
+        args?.where && "clientId" in args.where
+          ? mockFindFirst(args)
+          : mockTxFindFirst(args),
+      findUnique: mockMcpClientFindUnique,
+      count: mockMcpClientCount,
+      updateMany: mockMcpClientUpdateMany,
+      deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+      delete: mockTxDelete,
+    },
+    user: { findUnique: mockFindUnique },
+  });
+}
+
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
   withBypassRls: mockWithBypassRls,
 }));
@@ -93,21 +121,23 @@ const VALID_USER = {
   tenantId: "tenant-uuid-123",
 };
 
-function buildFormData(fields: Record<string, string>): FormData {
-  const fd = new FormData();
+function buildFormBody(fields: Record<string, string>): string {
+  // The consent UI submits a hidden-input <form> POST, which the browser sends
+  // as application/x-www-form-urlencoded — match that wire shape here.
+  const params = new URLSearchParams();
   for (const [key, value] of Object.entries(fields)) {
-    fd.set(key, value);
+    params.set(key, value);
   }
-  return fd;
+  return params.toString();
 }
 
 function createFormRequest(url: string, fields: Record<string, string>, headers: Record<string, string> = {}) {
-  const fd = buildFormData(fields);
   const urlObj = new URL(url);
   return new Request(url, {
     method: "POST",
-    body: fd,
+    body: buildFormBody(fields),
     headers: {
+      "content-type": "application/x-www-form-urlencoded",
       origin: urlObj.origin,
       host: urlObj.host,
       ...headers,
@@ -128,8 +158,9 @@ describe("POST /api/mcp/authorize/consent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue(VALID_SESSION);
-    // withBypassRls: always execute callback (may be called 2+ times for claiming)
-    mockWithBypassRls.mockImplementation(async (p: unknown, fn: (tx: unknown) => unknown) => fn(p));
+    // withBypassRls: execute callback on the bypass tx mock (may be called 2+
+    // times for claiming). Re-applied each test because clearAllMocks wipes it.
+    mockWithBypassRls.mockImplementation(bypassRlsImpl);
     mockFindFirst.mockResolvedValue(VALID_CLIENT);
     mockFindUnique.mockResolvedValue(VALID_USER);
     mockTxFindFirst.mockResolvedValue(null); // default: no existing same-name client
@@ -572,14 +603,13 @@ describe("POST /api/mcp/authorize/consent", () => {
   // (c) P2002 unique-violation race maps to consent error (not a 500).
   it("C7(c): P2002 unique violation during claim maps to name_conflict consent error", async () => {
     mockFindFirst.mockResolvedValueOnce({ ...VALID_CLIENT, isDcr: true, tenantId: null });
-    // $transaction throws P2002 (concurrent foreign claim won the race)
+    // The claim CAS updateMany throws P2002 — a concurrent foreign claim won the
+    // race and tripped the (tenantId, name) unique constraint on the write.
     const p2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
       code: "P2002",
       clientVersion: "5.0.0",
     });
-    // Override $transaction to throw P2002
-    const { prisma: mockPrismaModule } = await import("@/lib/prisma");
-    vi.mocked(mockPrismaModule.$transaction).mockRejectedValueOnce(p2002);
+    mockMcpClientUpdateMany.mockRejectedValueOnce(p2002);
 
     const req = createFormRequest(
       "http://localhost/api/mcp/authorize/consent",

--- a/src/app/api/mcp/authorize/consent/route.ts
+++ b/src/app/api/mcp/authorize/consent/route.ts
@@ -9,7 +9,7 @@ import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION } from "@/lib/constants/audit/audit";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { errorResponse, unauthorized } from "@/lib/http/api-response";
-import { exceedsDeclaredContentLength } from "@/lib/http/parse-body";
+import { readFormWithCap } from "@/lib/http/parse-body";
 import { MAX_JSON_BODY_BYTES } from "@/lib/validations/common.server";
 import { requireRecentSession } from "@/lib/auth/session/step-up";
 
@@ -35,18 +35,18 @@ export async function POST(req: NextRequest) {
   const stepUpError = await requireRecentSession(req);
   if (stepUpError) return stepUpError;
 
-  // Cap the untrusted form body before parsing (content-length pre-check;
-  // session-authed so lower severity, but still untrusted input).
-  if (exceedsDeclaredContentLength(req, MAX_JSON_BODY_BYTES)) {
+  // Stream-read the consent form under the byte cap. The form is submitted as
+  // application/x-www-form-urlencoded (hidden-input form POST, no file upload),
+  // so the streaming text cap is authoritative against oversized/chunked bodies.
+  const read = await readFormWithCap(req, MAX_JSON_BODY_BYTES);
+  if (!read.ok) {
     return NextResponse.json({ error: "invalid_request" }, { status: 400 });
   }
-
-  // Parse form data submitted from the consent UI
-  const formData = await req.formData();
-  const clientId = formData.get("client_id") as string;
-  const redirectUri = formData.get("redirect_uri") as string;
-  const state = formData.get("state") as string;
-  const action = formData.get("action") as string;
+  const formData = new URLSearchParams(read.text);
+  const clientId = formData.get("client_id") ?? "";
+  const redirectUri = formData.get("redirect_uri") ?? "";
+  const state = formData.get("state") ?? "";
+  const action = formData.get("action") ?? "";
 
   if (!clientId || !redirectUri) {
     return NextResponse.json({ error: "invalid_request" }, { status: 400 });
@@ -93,9 +93,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.redirect(denyUrl.toString(), 302);
   }
 
-  const scope = formData.get("scope") as string;
-  const codeChallenge = formData.get("code_challenge") as string;
-  const codeChallengeMethod = (formData.get("code_challenge_method") as string) || "S256";
+  const scope = formData.get("scope") ?? "";
+  const codeChallenge = formData.get("code_challenge") ?? "";
+  const codeChallengeMethod = formData.get("code_challenge_method") || "S256";
 
   if (!scope || !codeChallenge) {
     return NextResponse.json({ error: "invalid_request" }, { status: 400 });
@@ -115,8 +115,14 @@ export async function POST(req: NextRequest) {
 
     let claimResult: { error: "tenant_cap" | "name_conflict" | "already_claimed" | null };
     try {
-      claimResult = await withBypassRls(prisma, async (tx) =>
-        prisma.$transaction(async (tx) => {
+      // withBypassRls already runs the callback inside a transaction with the
+      // RLS-bypass GUC set. The claim sequence (count → exclusion lookup → CAS
+      // update) runs directly on that tx — a nested prisma.$transaction would
+      // open a second connection WITHOUT the bypass config, so it must not be
+      // reintroduced here.
+      claimResult = await withBypassRls(
+        prisma,
+        async (tx) => {
           const tenantClientCount = await tx.mcpClient.count({
             where: { tenantId: userTenantId },
           });
@@ -165,8 +171,9 @@ export async function POST(req: NextRequest) {
             return { error: "already_claimed" as const };
           }
           return { error: null as null };
-        }),
-      BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+        },
+        BYPASS_PURPOSE.CROSS_TENANT_LOOKUP,
+      );
     } catch (err) {
       // C7: a concurrent foreign claim can win the race and cause a P2002 unique
       // violation on (tenantId, name). Map to the same consent error — not a 500.

--- a/src/app/api/mcp/revoke/route.ts
+++ b/src/app/api/mcp/revoke/route.ts
@@ -4,7 +4,7 @@ import { hashToken } from "@/lib/crypto/crypto-server";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { extractClientIp } from "@/lib/auth/policy/ip-access";
 import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
-import { readJsonWithCap, exceedsDeclaredContentLength } from "@/lib/http/parse-body";
+import { readJsonWithCap, readFormWithCap } from "@/lib/http/parse-body";
 import { MAX_JSON_BODY_BYTES } from "@/lib/validations/common.server";
 import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { MS_PER_MINUTE, MS_PER_SECOND } from "@/lib/constants/time";
@@ -57,17 +57,14 @@ export async function POST(req: NextRequest) {
   const contentType = req.headers.get("content-type") ?? "";
 
   if (contentType.includes("application/x-www-form-urlencoded")) {
-    // Cap the untrusted form body. readJsonWithCap is JSON-only, so guard the
-    // form branch with an explicit content-length pre-check (RFC 6749 envelope).
-    if (exceedsDeclaredContentLength(req, MAX_JSON_BODY_BYTES)) {
+    // Stream-read the untrusted form body under the byte cap. The streaming cap
+    // is authoritative — it defends against chunked bodies that omit
+    // Content-Length, which a bare header pre-check cannot.
+    const read = await readFormWithCap(req, MAX_JSON_BODY_BYTES);
+    if (!read.ok) {
       return NextResponse.json({ error: "invalid_request" }, { status: 400 });
     }
-    try {
-      const text = await req.text();
-      body = Object.fromEntries(new URLSearchParams(text));
-    } catch {
-      return NextResponse.json({ error: "invalid_request" }, { status: 400 });
-    }
+    body = Object.fromEntries(new URLSearchParams(read.text));
   } else {
     const read = await readJsonWithCap(req, MAX_JSON_BODY_BYTES);
     if (!read.ok) return NextResponse.json({ error: "invalid_request" }, { status: 400 });

--- a/src/app/api/mcp/token/route.test.ts
+++ b/src/app/api/mcp/token/route.test.ts
@@ -129,6 +129,59 @@ describe("POST /api/mcp/token", () => {
     expect(json.error).toBe("invalid_request");
   });
 
+  it("rejects an oversized urlencoded form body with no Content-Length (chunked-TE bypass guard)", async () => {
+    // If the streaming cap did NOT fire, this body parses into a complete,
+    // valid authorization_code grant and would reach exchangeCodeForToken —
+    // so `not.toHaveBeenCalled()` can only hold when the cap aborts the read.
+    // (Guards against a vacuous pass via the missing-required-fields branch.)
+    mockExchangeCodeForToken.mockResolvedValue({
+      ok: true,
+      data: {
+        accessToken: "mcp_access_token_should_not_be_issued",
+        tokenType: "Bearer",
+        expiresIn: 3600,
+        scope: "credentials:list",
+        tokenId: "token-id",
+        clientDbId: "client-uuid",
+        tenantId: "tenant-uuid",
+        userId: "user-uuid",
+        serviceAccountId: null,
+      },
+    });
+    const { NextRequest } = await import("next/server");
+    // 2 MB urlencoded body, streamed with NO Content-Length header — the
+    // streaming cap must abort the read and reject before parsing. The grant
+    // params come FIRST so the body is structurally complete up front; only the
+    // trailing padding pushes it over the cap.
+    const oversized =
+      "grant_type=authorization_code" +
+      "&code=test-code-abc" +
+      "&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback" +
+      "&client_id=mcpc_testclient" +
+      "&client_secret=secret-value" +
+      "&code_verifier=my-code-verifier" +
+      "&padding=" + "x".repeat(2_000_000);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(oversized));
+        controller.close();
+      },
+    });
+    const req = new NextRequest("http://localhost/api/mcp/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: stream,
+      duplex: "half",
+    } as ConstructorParameters<typeof NextRequest>[1]);
+    const res = await POST(req);
+    const { status, json } = await parseResponse(res);
+
+    expect(status).toBe(400);
+    expect(json.error).toBe("invalid_request");
+    // The cap must have aborted the read before the grant was exchanged.
+    expect(mockExchangeCodeForToken).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when exchange fails with invalid_grant", async () => {
     mockExchangeCodeForToken.mockResolvedValue({
       ok: false,

--- a/src/app/api/mcp/token/route.ts
+++ b/src/app/api/mcp/token/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { hashToken } from "@/lib/crypto/crypto-server";
-import { readJsonWithCap, exceedsDeclaredContentLength } from "@/lib/http/parse-body";
+import { readJsonWithCap, readFormWithCap } from "@/lib/http/parse-body";
 import { MAX_JSON_BODY_BYTES } from "@/lib/validations/common.server";
 import {
   createRefreshToken,
@@ -36,17 +36,14 @@ async function handlePOST(req: NextRequest) {
   const contentType = req.headers.get("content-type") ?? "";
 
   if (contentType.includes("application/x-www-form-urlencoded")) {
-    // Cap the untrusted form body. readJsonWithCap is JSON-only, so guard the
-    // form branch with an explicit content-length pre-check (RFC 6749 envelope).
-    if (exceedsDeclaredContentLength(req, MAX_JSON_BODY_BYTES)) {
+    // Stream-read the untrusted form body under the byte cap. The streaming cap
+    // is authoritative — it defends against chunked bodies that omit
+    // Content-Length, which a bare header pre-check cannot.
+    const read = await readFormWithCap(req, MAX_JSON_BODY_BYTES);
+    if (!read.ok) {
       return NextResponse.json({ error: "invalid_request" }, { status: 400 });
     }
-    try {
-      const text = await req.text();
-      body = Object.fromEntries(new URLSearchParams(text));
-    } catch {
-      return NextResponse.json({ error: "invalid_request" }, { status: 400 });
-    }
+    body = Object.fromEntries(new URLSearchParams(read.text));
   } else {
     const read = await readJsonWithCap(req, MAX_JSON_BODY_BYTES);
     if (!read.ok) return NextResponse.json({ error: "invalid_request" }, { status: 400 });

--- a/src/app/api/mobile/token/refresh/route.test.ts
+++ b/src/app/api/mobile/token/refresh/route.test.ts
@@ -174,6 +174,36 @@ describe("POST /api/mobile/token/refresh", () => {
     expect(res.headers.get("dpop-nonce")).toBeNull();
   });
 
+  it("rejects an oversized JSON body with no Content-Length before any token lookup (chunked-TE bypass guard)", async () => {
+    // 2 MB body streamed with NO Content-Length header. readBytesWithCap is the
+    // first thing handlePOST does, so the streaming cap must abort the read and
+    // return 413 before the token is looked up or rotated. (Guards the raw-body
+    // hash path against the chunked-body DoS that an after-read check missed.)
+    const oversized = JSON.stringify({ refresh_token: REFRESH_TOKEN, padding: "x".repeat(2_000_000) });
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(oversized));
+        controller.close();
+      },
+    });
+    const req = new NextRequest("https://example.test/api/mobile/token/refresh", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `DPoP ${REFRESH_TOKEN}`,
+        dpop: "fake.proof",
+      },
+      body: stream,
+      duplex: "half",
+    } as ConstructorParameters<typeof NextRequest>[1]);
+    const res = await POST(req);
+    const { status, json } = await parseJson(res);
+    expect(status).toBe(413);
+    expect(json.error).toBe("PAYLOAD_TOO_LARGE");
+    expect(mockExtensionTokenFindUnique).not.toHaveBeenCalled();
+    expect(mockRefreshIosToken).not.toHaveBeenCalled();
+  });
+
   it("returns 401 with REPLAY_DETECTED code when refreshIosToken signals replay", async () => {
     mockRefreshIosToken.mockResolvedValueOnce({
       ok: false,

--- a/src/app/api/mobile/token/refresh/route.ts
+++ b/src/app/api/mobile/token/refresh/route.ts
@@ -42,7 +42,7 @@ import {
 import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { enforceAccessRestriction } from "@/lib/auth/policy/access-restriction";
-import { exceedsDeclaredContentLength } from "@/lib/http/parse-body";
+import { readBytesWithCap } from "@/lib/http/parse-body";
 import { MAX_JSON_BODY_BYTES } from "@/lib/validations/common.server";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { getLogger } from "@/lib/logger";
@@ -90,18 +90,15 @@ function extractDpopBearer(req: NextRequest): string | null {
 }
 
 async function handlePOST(req: NextRequest): Promise<Response> {
-  // Cheap early reject before buffering the whole body (cap untrusted bytes).
-  if (exceedsDeclaredContentLength(req, MAX_JSON_BODY_BYTES)) {
-    return errorResponse(API_ERROR.PAYLOAD_TOO_LARGE);
-  }
-
   // We need raw body bytes for the replay-vs-retry hash AND a parsed copy
-  // for validation. Read once, then reparse from the buffer.
-  const rawBody = new Uint8Array(await req.arrayBuffer());
-  // Authoritative cap (defends against chunked TE that omits content-length).
-  if (rawBody.length > MAX_JSON_BODY_BYTES) {
+  // for validation. Stream-read once under the byte cap, then reparse from the
+  // buffer. The streaming cap is authoritative — it aborts mid-read on a
+  // chunked body that omits Content-Length, unlike an after-read length check.
+  const read = await readBytesWithCap(req, MAX_JSON_BODY_BYTES);
+  if (!read.ok) {
     return errorResponse(API_ERROR.PAYLOAD_TOO_LARGE);
   }
+  const rawBody = read.bytes;
   let parsedBody: unknown;
   try {
     parsedBody = rawBody.length === 0

--- a/src/app/api/passwords/[id]/attachments/route.test.ts
+++ b/src/app/api/passwords/[id]/attachments/route.test.ts
@@ -103,17 +103,25 @@ vi.mock("@/lib/quota/resource-quotas", () => ({
   QuotaExceededError: class extends Error {},
 }));
 
-function createFormDataRequest(
+async function createFormDataRequest(
   url: string,
   fields: Record<string, string | Blob>
-): NextRequest {
+): Promise<NextRequest> {
   const formData = new FormData();
   for (const [key, value] of Object.entries(fields)) {
     formData.append(key, value);
   }
+  // Serialize once to set Content-Length, mirroring a real browser upload —
+  // the route gates on it via rejectOversizedMultipart (fail-closed if absent).
+  const encoded = new Request("http://localhost", { method: "POST", body: formData });
+  const bytes = new Uint8Array(await encoded.arrayBuffer());
   return new NextRequest(url, {
     method: "POST",
-    body: formData,
+    body: bytes,
+    headers: {
+      "content-type": encoded.headers.get("content-type") ?? "multipart/form-data",
+      "content-length": String(bytes.length),
+    },
   });
 }
 
@@ -230,7 +238,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
   it("returns 401 when unauthenticated", async () => {
     mockAuth.mockResolvedValue(null);
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -247,7 +255,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
   it("returns 400 when attachment limit reached", async () => {
     mockPrismaAttachment.count.mockResolvedValue(20);
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -265,7 +273,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
 
   it("returns 400 for invalid extension (EXTENSION_NOT_ALLOWED)", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -283,7 +291,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
 
   it("returns 400 for file too large (FILE_TOO_LARGE)", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -301,7 +309,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
 
   it("returns 400 for invalid content type (CONTENT_TYPE_NOT_ALLOWED)", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -319,7 +327,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
 
   it("returns 400 for invalid iv format (INVALID_ENCRYPTION_FORMAT)", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["data"]),
         iv: "short",
         authTag: "b".repeat(32),
@@ -340,7 +348,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
   it("rejects upload missing cekEncrypted → 400 INVALID_REQUEST", async () => {
     // No CEK fields at all
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -364,7 +372,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     });
 
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         id: clientId,
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
@@ -404,7 +412,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         id: clientId,
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
@@ -443,7 +451,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     });
 
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         id: clientId,
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
@@ -470,7 +478,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
   it("returns 400 when actual file blob exceeds MAX_FILE_SIZE", async () => {
     const hugeBlob = new Blob([new Uint8Array(11 * 1024 * 1024)]); // 11MB
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: hugeBlob,
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -510,7 +518,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     });
 
     await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -533,7 +541,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
   it("returns 429 when rate limited", async () => {
     mockRateLimitCheck.mockResolvedValueOnce({ allowed: false, retryAfterMs: 30_000 });
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -561,7 +569,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     );
 
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         id: "../../../etc/passwd",
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
@@ -591,7 +599,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     });
 
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         id: clientId,
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
@@ -622,7 +630,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockPrismaUser.findUnique.mockResolvedValueOnce({ keyVersion: 2 });
 
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -647,7 +655,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     mockPrismaUser.findUnique.mockResolvedValueOnce(null);
 
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -685,7 +693,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     });
 
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -703,7 +711,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
   it("rejects upload with oversized cekEncrypted → 400 VALIDATION_ERROR", async () => {
     const longCek = "A".repeat(257);
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -722,7 +730,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
   it("rejects upload with malformed base64 in cekEncrypted (base64url chars) → 400 VALIDATION_ERROR", async () => {
     // base64url uses `-` / `_`; standard base64 regex must reject them.
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -743,7 +751,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
 
   it("rejects upload with cekEncrypted length not multiple of 4 → 400 VALIDATION_ERROR", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),
@@ -763,7 +771,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
 
   it("rejects upload with cekEncrypted containing the OTHER base64url char `_` → 400", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
         file: new Blob(["encrypted-data"]),
         iv: "a".repeat(24),
         authTag: "b".repeat(32),

--- a/src/app/api/passwords/[id]/attachments/route.ts
+++ b/src/app/api/passwords/[id]/attachments/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/validations";
 import { BASE64_RE, CEK_WRAP_BASE64_MAX } from "@/lib/validations/common";
 import { API_ERROR } from "@/lib/http/api-error-codes";
+import { rejectOversizedMultipart } from "@/lib/http/parse-body";
 import { assertQuotaAvailable, QuotaExceededError } from "@/lib/quota/resource-quotas";
 import { getAttachmentBlobStore } from "@/lib/blob-store";
 import { withRequestLog } from "@/lib/http/with-request-log";
@@ -115,14 +116,12 @@ async function handlePOST(
     return errorResponse(API_ERROR.ATTACHMENT_LIMIT_EXCEEDED);
   }
 
-  // Early rejection: check Content-Length before consuming body into memory
-  const contentLength = req.headers.get("content-length");
-  if (contentLength) {
-    const declaredSize = parseInt(contentLength, 10);
-    if (!Number.isNaN(declaredSize) && declaredSize > MAX_FILE_SIZE * 2) {
-      return errorResponse(API_ERROR.PAYLOAD_TOO_LARGE);
-    }
-  }
+  // Early rejection before buffering the multipart body into memory. Requires a
+  // declared Content-Length and caps it — fail-closed on a missing header so a
+  // chunked / no-Content-Length body cannot bypass the cap (req.formData() has
+  // no streaming cap of its own).
+  const oversized = rejectOversizedMultipart(req, MAX_FILE_SIZE * 2);
+  if (oversized) return oversized;
 
   // Parse FormData
   let formData: FormData;

--- a/src/app/api/sends/file/route.test.ts
+++ b/src/app/api/sends/file/route.test.ts
@@ -93,7 +93,7 @@ describe("POST /api/sends/file", () => {
 
   it("returns 401 when unauthenticated", async () => {
     mockAuth.mockResolvedValue(null);
-    const req = createMultipartRequest("http://localhost/api/sends/file", createFormData());
+    const req = await createMultipartRequest("http://localhost/api/sends/file", createFormData());
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
     expect(status).toBe(401);
@@ -103,10 +103,16 @@ describe("POST /api/sends/file", () => {
   it("returns 400 when FormData parsing fails", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     const { NextRequest } = await import("next/server");
+    const body = JSON.stringify({ name: "test" });
     const req = new NextRequest("http://localhost/api/sends/file", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: "test" }),
+      // Valid content-length so the multipart size gate passes and we reach
+      // formData() — this test exercises the parse-failure path specifically.
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(Buffer.byteLength(body)),
+      },
+      body,
     } as ConstructorParameters<typeof NextRequest>[1]);
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
@@ -119,7 +125,7 @@ describe("POST /api/sends/file", () => {
     const fd = new FormData();
     fd.append("name", "Test");
     fd.append("expiresIn", "1d");
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -131,11 +137,24 @@ describe("POST /api/sends/file", () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     const bigContent = new Uint8Array(10 * 1024 * 1024 + 1);
     const bigFile = new File([bigContent], "big.bin", { type: "application/octet-stream" });
-    const req = createMultipartRequest("http://localhost/api/sends/file", createFormData({ file: bigFile }));
+    const req = await createMultipartRequest("http://localhost/api/sends/file", createFormData({ file: bigFile }));
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
     expect(json.error).toBe("SEND_FILE_TOO_LARGE");
+  });
+
+  it("returns 413 (fail-closed) when Content-Length is absent (chunked-body DoS guard)", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    const req = await createMultipartRequest(
+      "http://localhost/api/sends/file",
+      createFormData(),
+      { omitContentLength: true },
+    );
+    const res = await POST(req as never);
+    const { status, json } = await parseResponse(res);
+    expect(status).toBe(413);
+    expect(json.error).toBe("PAYLOAD_TOO_LARGE");
   });
 
   it("returns 400 when storage limit exceeded (413 semantics)", async () => {
@@ -144,7 +163,7 @@ describe("POST /api/sends/file", () => {
     const largeFile = new File([new Uint8Array(2 * 1024 * 1024)], "medium.bin", {
       type: "application/octet-stream",
     });
-    const req = createMultipartRequest("http://localhost/api/sends/file", createFormData({ file: largeFile }));
+    const req = await createMultipartRequest("http://localhost/api/sends/file", createFormData({ file: largeFile }));
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
     expect(status).toBe(400);
@@ -156,7 +175,7 @@ describe("POST /api/sends/file", () => {
     const expiresAt = new Date(Date.now() + 86400_000);
     mockCreate.mockResolvedValue({ id: "share-1", expiresAt });
 
-    const req = createMultipartRequest("http://localhost/api/sends/file", createFormData());
+    const req = await createMultipartRequest("http://localhost/api/sends/file", createFormData());
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
 
@@ -193,7 +212,7 @@ describe("POST /api/sends/file", () => {
 
     const fd = createFormData();
     fd.append("requirePassword", "true");
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
 
@@ -206,7 +225,7 @@ describe("POST /api/sends/file", () => {
     const expiresAt = new Date(Date.now() + 86400_000);
     mockCreate.mockResolvedValue({ id: "share-3", expiresAt });
 
-    const req = createMultipartRequest("http://localhost/api/sends/file", createFormData());
+    const req = await createMultipartRequest("http://localhost/api/sends/file", createFormData());
     await POST(req as never);
 
     // Both aggregate and user.findUnique must be called
@@ -230,7 +249,7 @@ describe("POST /api/sends/file", () => {
       type: "application/octet-stream",
     });
     const fd = createFormData({ file });
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
 
@@ -247,7 +266,7 @@ describe("POST /api/sends/file", () => {
     const html = new TextEncoder().encode("<html><script>alert(1)</script></html>");
     const file = new File([html], "page.html", { type: "text/plain" });
     const fd = createFormData({ file });
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
 
@@ -265,7 +284,7 @@ describe("POST /api/sends/file", () => {
     const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
     const file = new File([png], "image.png", { type: "image/png" });
     const fd = createFormData({ file });
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     await POST(req as never);
 
     expect(mockCreate).toHaveBeenCalledWith(
@@ -284,7 +303,7 @@ describe("POST /api/sends/file", () => {
     // both to flag tampering and to avoid storing a misleading content-type.
     const file = new File([png], "image.png", { type: "image/jpeg" });
     const fd = createFormData({ file });
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     const res = await POST(req as never);
     const { status, json } = await parseResponse(res);
 
@@ -303,7 +322,7 @@ describe("POST /api/sends/file", () => {
 
     const file = new File(["hello"], "notes.txt", { type: "text/plain" });
     const fd = createFormData({ file });
-    const req = createMultipartRequest("http://localhost/api/sends/file", fd);
+    const req = await createMultipartRequest("http://localhost/api/sends/file", fd);
     await POST(req as never);
 
     expect(mockCreate).toHaveBeenCalledWith(

--- a/src/app/api/sends/file/route.ts
+++ b/src/app/api/sends/file/route.ts
@@ -27,6 +27,7 @@ import {
   SHARE_TYPE,
 } from "@/lib/constants";
 import { withUserTenantRls } from "@/lib/tenant-context";
+import { rejectOversizedMultipart } from "@/lib/http/parse-body";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 
@@ -43,6 +44,13 @@ async function handlePOST(req: NextRequest) {
   if (!rl.allowed) {
     return rateLimited(rl.retryAfterMs);
   }
+
+  // Early rejection before buffering the multipart body into memory. Requires a
+  // declared Content-Length and caps it — fail-closed on a missing header so a
+  // chunked / no-Content-Length body cannot bypass the cap (req.formData() has
+  // no streaming cap of its own). file.size is re-checked post-parse below.
+  const oversized = rejectOversizedMultipart(req, SEND_MAX_FILE_SIZE * 2);
+  if (oversized) return oversized;
 
   let formData: FormData;
   try {

--- a/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.test.ts
@@ -66,14 +66,27 @@ function createRequest(method: string, url: string) {
   return new NextRequest(url, { method });
 }
 
-function createFormDataRequest(
+async function createFormDataRequest(
   url: string,
   fields: Record<string, string | Blob>,
   headers?: Record<string, string>
-): NextRequest {
+): Promise<NextRequest> {
   const formData = new FormData();
   for (const [k, v] of Object.entries(fields)) formData.append(k, v);
-  return new NextRequest(url, { method: "POST", body: formData, headers });
+  // Serialize once to set Content-Length, mirroring a real browser upload —
+  // the route gates on it via rejectOversizedMultipart (fail-closed if absent).
+  // An explicit `headers` override (e.g. a too-large content-length test) wins.
+  const encoded = new Request("http://localhost", { method: "POST", body: formData });
+  const bytes = new Uint8Array(await encoded.arrayBuffer());
+  return new NextRequest(url, {
+    method: "POST",
+    body: bytes,
+    headers: {
+      "content-type": encoded.headers.get("content-type") ?? "multipart/form-data",
+      "content-length": String(bytes.length),
+      ...headers,
+    },
+  });
 }
 
 // Valid hex strings for client-encrypted fields
@@ -161,7 +174,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
   it("returns 401 when unauthenticated", async () => {
     mockAuth.mockResolvedValue(null);
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/pdf",
@@ -179,7 +192,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
       new MockTeamAuthError("FORBIDDEN", 403),
     );
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/pdf",
@@ -197,7 +210,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
   it("returns 404 when entry does not belong to team", async () => {
     mockPrismaTeamPasswordEntry.findUnique.mockResolvedValue({ teamId: "other-team" });
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/pdf",
@@ -212,7 +225,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
 
   it("returns 400 when required fields are missing", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         filename: "doc.pdf",
       }),
       createParams("team-1", "pw-1"),
@@ -224,7 +237,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
 
   it("returns 400 when content type is not allowed", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/zip",
@@ -242,7 +255,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
   it("returns 400 when attachment limit is exceeded", async () => {
     mockPrismaAttachment.count.mockResolvedValue(20);
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/pdf",
@@ -259,7 +272,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
 
   it("returns 413 when declared content-length is too large", async () => {
     const res = await POST(
-      createFormDataRequest(
+      await createFormDataRequest(
         "http://localhost/api/teams/team-1/passwords/pw-1/attachments",
         {
           file: new Blob(["abc"]),
@@ -281,7 +294,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
   it("returns 400 when actual file size exceeds max", async () => {
     const huge = new Blob([new Uint8Array(11 * 1024 * 1024)]);
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: huge,
         filename: "doc.pdf",
         contentType: "application/pdf",
@@ -298,7 +311,9 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
 
   it("returns 400 when formData parsing fails", async () => {
     const req = {
-      headers: new Headers(),
+      // Valid content-length so the multipart size gate passes and we reach
+      // formData() — this test exercises the parse-failure path specifically.
+      headers: new Headers({ "content-length": "100" }),
       formData: vi.fn().mockRejectedValue(new Error("bad form")),
     } as unknown as NextRequest;
     const res = await POST(req, createParams("team-1", "pw-1"));
@@ -309,7 +324,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
 
   it("returns 400 for invalid extension", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "bad.exe",
         contentType: "application/pdf",
@@ -324,7 +339,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
 
   it("returns 400 for invalid iv format", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/pdf",
@@ -341,7 +356,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
 
   it("returns 400 for invalid authTag format", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/pdf",
@@ -365,7 +380,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
       createdAt: new Date(),
     });
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/pdf",
@@ -394,7 +409,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
 
   it("returns 400 when encryptionMode is missing", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/pdf",
@@ -411,7 +426,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
 
   it("returns 400 when encryptionMode=0", async () => {
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/pdf",
@@ -430,7 +445,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
   it("returns 429 when rate limited", async () => {
     mockRateLimitCheck.mockResolvedValueOnce({ allowed: false, retryAfterMs: 30_000 });
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/pdf",
@@ -453,7 +468,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
       teamKeyVersion: 1,
     });
     const res = await POST(
-      createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
+      await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
         file: new Blob(["abc"]),
         filename: "doc.pdf",
         contentType: "application/pdf",

--- a/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.ts
@@ -16,6 +16,7 @@ import {
   isValidSendFilename,
 } from "@/lib/validations";
 import { withRequestLog } from "@/lib/http/with-request-log";
+import { rejectOversizedMultipart } from "@/lib/http/parse-body";
 import { errorResponse, handleAuthError, notFound, rateLimited, unauthorized, validationError } from "@/lib/http/api-response";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
@@ -122,14 +123,12 @@ async function handlePOST(
     return errorResponse(API_ERROR.ATTACHMENT_LIMIT_EXCEEDED);
   }
 
-  // Early rejection: check Content-Length before consuming body into memory
-  const contentLength = req.headers.get("content-length");
-  if (contentLength) {
-    const declaredSize = parseInt(contentLength, 10);
-    if (!Number.isNaN(declaredSize) && declaredSize > MAX_FILE_SIZE * 2) {
-      return errorResponse(API_ERROR.PAYLOAD_TOO_LARGE);
-    }
-  }
+  // Early rejection before buffering the multipart body into memory. Requires a
+  // declared Content-Length and caps it — fail-closed on a missing header so a
+  // chunked / no-Content-Length body cannot bypass the cap (req.formData() has
+  // no streaming cap of its own).
+  const oversized = rejectOversizedMultipart(req, MAX_FILE_SIZE * 2);
+  if (oversized) return oversized;
 
   // Parse FormData
   let formData: FormData;

--- a/src/lib/http/parse-body.test.ts
+++ b/src/lib/http/parse-body.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { NextRequest } from "next/server";
 import { z } from "zod";
-import { parseBody, readJsonWithCap, exceedsDeclaredContentLength } from "./parse-body";
+import {
+  parseBody,
+  readJsonWithCap,
+  readBytesWithCap,
+  readFormWithCap,
+  rejectOversizedMultipart,
+  exceedsDeclaredContentLength,
+} from "./parse-body";
 
 function jsonRequest(body: unknown): NextRequest {
   return new NextRequest("http://localhost:3000/api/test", {
@@ -237,6 +244,133 @@ describe("readJsonWithCap", () => {
     if (result.ok) {
       expect(result.body).toEqual({ foo: "bar" });
     }
+  });
+});
+
+describe("readBytesWithCap", () => {
+  it("returns the raw bytes when within the cap", async () => {
+    const req = new NextRequest("http://localhost:3000/api/test", {
+      method: "POST",
+      body: "hello",
+    });
+    const result = await readBytesWithCap(req, 1024);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(new TextDecoder().decode(result.bytes)).toBe("hello");
+    }
+  });
+
+  it("rejects via streaming cap when no content-length is present (chunked-TE bypass guard)", async () => {
+    const big = "x".repeat(2_000_000);
+    const req = new NextRequest("http://localhost:3000/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: big,
+    });
+    const result = await readBytesWithCap(req, 1_048_576);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.tooLarge).toBe(true);
+    }
+  });
+
+  it("rejects early when content-length declares over the cap", async () => {
+    const req = new NextRequest("http://localhost:3000/api/test", {
+      method: "POST",
+      headers: { "Content-Length": "2000" },
+      body: "small",
+    });
+    const result = await readBytesWithCap(req, 1000);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.tooLarge).toBe(true);
+    }
+  });
+
+  it("reports noStream (not tooLarge) when the body stream is absent", async () => {
+    const req = new NextRequest("http://localhost:3000/api/test", {
+      method: "POST",
+    });
+    const result = await readBytesWithCap(req, 1024);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.tooLarge).toBeUndefined();
+      expect(result.noStream).toBe(true);
+    }
+  });
+});
+
+describe("readFormWithCap", () => {
+  it("decodes a urlencoded body within the cap", async () => {
+    const req = new NextRequest("http://localhost:3000/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "a=1&b=two",
+    });
+    const result = await readFormWithCap(req, 1024);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const params = new URLSearchParams(result.text);
+      expect(params.get("a")).toBe("1");
+      expect(params.get("b")).toBe("two");
+    }
+  });
+
+  it("rejects an oversized form body via the streaming cap", async () => {
+    const big = "k=" + "v".repeat(2_000_000);
+    const req = new NextRequest("http://localhost:3000/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: big,
+    });
+    const result = await readFormWithCap(req, 1_048_576);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.tooLarge).toBe(true);
+    }
+  });
+});
+
+describe("rejectOversizedMultipart", () => {
+  function multipartReq(contentLength: string | null): NextRequest {
+    const headers: Record<string, string> = {
+      "Content-Type": "multipart/form-data; boundary=x",
+    };
+    if (contentLength !== null) headers["Content-Length"] = contentLength;
+    return new NextRequest("http://localhost:3000/api/test", {
+      method: "POST",
+      headers,
+      body: "--x--",
+    });
+  }
+
+  it("returns a 413 when content-length is absent (fail-closed)", () => {
+    const res = rejectOversizedMultipart(multipartReq(null), 1000);
+    expect(res?.status).toBe(413);
+  });
+
+  it("returns a 413 when content-length exceeds the cap", () => {
+    const res = rejectOversizedMultipart(multipartReq("2000"), 1000);
+    expect(res?.status).toBe(413);
+  });
+
+  it("returns a 413 for a non-numeric content-length", () => {
+    const res = rejectOversizedMultipart(multipartReq("not-a-number"), 1000);
+    expect(res?.status).toBe(413);
+  });
+
+  it("returns null (proceed) when content-length is within the cap", () => {
+    expect(rejectOversizedMultipart(multipartReq("500"), 1000)).toBeNull();
+  });
+
+  it("returns null when content-length equals the cap", () => {
+    expect(rejectOversizedMultipart(multipartReq("1000"), 1000)).toBeNull();
   });
 });
 

--- a/src/lib/http/parse-body.ts
+++ b/src/lib/http/parse-body.ts
@@ -53,13 +53,116 @@ export function exceedsDeclaredContentLength(
   return Number.isFinite(n) && n > maxBytes;
 }
 
+/**
+ * Gate a multipart/form-data upload on its declared Content-Length BEFORE
+ * calling req.formData(), which buffers the entire multipart body into memory
+ * with no platform cap. Unlike JSON/text bodies we cannot stream-cap formData()
+ * (the App Router parser owns the stream), so the only pre-parse defense is the
+ * declared length — and a body without one is rejected fail-closed.
+ *
+ * Browsers always set Content-Length on form uploads, so requiring it does not
+ * break the legitimate UI path; it closes the chunked / no-Content-Length DoS
+ * vector. Returns a 413 response when the header is missing, unparseable, or
+ * declares more than maxBytes; null when the request may proceed to formData().
+ */
+export function rejectOversizedMultipart(
+  req: NextRequest,
+  maxBytes: number,
+): NextResponse | null {
+  const contentLength = req.headers.get("content-length");
+  if (!contentLength) {
+    return errorResponse(API_ERROR.PAYLOAD_TOO_LARGE);
+  }
+  const declared = Number(contentLength);
+  if (!Number.isFinite(declared) || declared > maxBytes) {
+    return errorResponse(API_ERROR.PAYLOAD_TOO_LARGE);
+  }
+  return null;
+}
+
+type ReadBytesOk = { ok: true; bytes: Uint8Array };
+type ReadBytesFail = { ok: false; tooLarge?: true; noStream?: true };
+type ReadBytesResult = ReadBytesOk | ReadBytesFail;
+
+/**
+ * Read req.body as a stream, accumulating bytes, aborting the moment the running
+ * total exceeds `maxBytes`. This is the authoritative guard against the
+ * chunked-Transfer-Encoding bypass: the App Router has no platform body cap and
+ * a missing/lying Content-Length header makes the cheap pre-check useless, so
+ * the only durable defense is to stop reading once the cap is crossed.
+ *
+ * This is the byte-level primitive that readJsonWithCap / readFormWithCap build
+ * on. Use it directly only when a route needs the raw bytes (e.g. a
+ * replay-vs-retry body hash); otherwise reach for the typed helpers below.
+ */
+export async function readBytesWithCap(
+  req: NextRequest,
+  maxBytes: number,
+): Promise<ReadBytesResult> {
+  // Pre-check content-length when present (cheap early reject)
+  if (exceedsDeclaredContentLength(req, maxBytes)) {
+    return { ok: false, tooLarge: true };
+  }
+
+  const reader = req.body?.getReader();
+  if (!reader) {
+    // No body stream — reachable only when tests mock req.body=null or for
+    // GET/HEAD. In production App Router POST handlers req.body is always a
+    // ReadableStream. Without a stream we cannot enforce the byte cap, so we
+    // fail closed and let the caller decide how to surface it.
+    return { ok: false, noStream: true };
+  }
+
+  let total = 0;
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.length;
+      if (total > maxBytes) {
+        await reader.cancel();
+        return { ok: false, tooLarge: true };
+      }
+      chunks.push(value);
+    }
+  }
+
+  return { ok: true, bytes: Buffer.concat(chunks) };
+}
+
+type ReadTextOk = { ok: true; text: string };
+type ReadTextFail = { ok: false; tooLarge?: true };
+type ReadTextResult = ReadTextOk | ReadTextFail;
+
+/**
+ * Stream-read a request body as UTF-8 text under a byte cap. Used by routes that
+ * consume application/x-www-form-urlencoded bodies (OAuth token/revoke), which
+ * cannot use readJsonWithCap. The streaming cap is authoritative — unlike a bare
+ * exceedsDeclaredContentLength pre-check, it defends against chunked bodies that
+ * omit Content-Length.
+ *
+ * A noStream result (test-only req.body=null) is reported as ok:false; the form
+ * is then empty, which the caller rejects as invalid_request downstream.
+ */
+export async function readFormWithCap(
+  req: NextRequest,
+  maxBytes: number,
+): Promise<ReadTextResult> {
+  const read = await readBytesWithCap(req, maxBytes);
+  if (!read.ok) {
+    return read.tooLarge ? { ok: false, tooLarge: true } : { ok: false };
+  }
+  return { ok: true, text: new TextDecoder().decode(read.bytes) };
+}
+
 type ReadOk = { ok: true; body: unknown };
 type ReadFail = { ok: false; tooLarge?: true; invalidJson?: true };
 type ReadResult = ReadOk | ReadFail;
 
 /**
- * Read req.body as a stream, accumulating bytes, aborting if cap exceeded.
- * Authoritative guard against chunked-TE bypass (App Router has no platform cap).
+ * Read req.body as a stream, accumulating bytes, aborting if cap exceeded, then
+ * JSON-parse the result. Authoritative guard against chunked-TE bypass.
  *
  * Exported for routes that need body-size enforcement but cannot use parseBody
  * directly (e.g. mixed application/x-www-form-urlencoded + JSON endpoints).
@@ -68,50 +171,24 @@ export async function readJsonWithCap(
   req: NextRequest,
   maxBytes: number,
 ): Promise<ReadResult> {
-  // Pre-check content-length when present (cheap early reject)
-  if (exceedsDeclaredContentLength(req, maxBytes)) {
-    return { ok: false, tooLarge: true };
-  }
-
-  const reader = req.body?.getReader();
-  if (!reader) {
-    // No body stream — this path is reachable only in test environments that
-    // mock req.body=null or for GET/HEAD (no body). In production App Router
-    // POST handlers, req.body is always a ReadableStream. Without a stream we
-    // cannot enforce the byte cap, so a missing content-length header here is
-    // treated as invalid input (fail-closed). Tests that mock req.body=null
-    // MUST set content-length, or the request is rejected.
-    if (!req.headers.get("content-length")) {
-      return { ok: false, invalidJson: true };
-    }
-    try {
-      const body = await req.json();
-      return { ok: true, body };
-    } catch {
-      return { ok: false, invalidJson: true };
-    }
-  }
-
-  let total = 0;
-  const chunks: Uint8Array[] = [];
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (value) {
-        total += value.length;
-        if (total > maxBytes) {
-          await reader.cancel();
-          return { ok: false, tooLarge: true };
-        }
-        chunks.push(value);
+  const read = await readBytesWithCap(req, maxBytes);
+  if (!read.ok) {
+    if (read.tooLarge) return { ok: false, tooLarge: true };
+    // No body stream — reachable only in tests that hand-craft a req without a
+    // ReadableStream (production POST handlers always have one). If a
+    // content-length header is present we honor the cap pre-check (already run
+    // in readBytesWithCap) and fall back to req.json(); otherwise fail closed.
+    if (read.noStream && req.headers.get("content-length")) {
+      try {
+        return { ok: true, body: await req.json() };
+      } catch {
+        return { ok: false, invalidJson: true };
       }
     }
-  } catch {
     return { ok: false, invalidJson: true };
   }
 
-  const text = new TextDecoder().decode(Buffer.concat(chunks));
+  const text = new TextDecoder().decode(read.bytes);
   try {
     return { ok: true, body: JSON.parse(text) };
   } catch {


### PR DESCRIPTION
## Why

The App Router has no platform request-body size cap. Routes that read bodies via `req.text()` / `req.arrayBuffer()` / `req.formData()` buffered chunked or no-`Content-Length` bodies unbounded — an availability/DoS vector. The exposure was worst on the **pre-auth / public OAuth endpoints** (`/api/mcp/token`, `/api/mcp/revoke`, `/api/mcp/authorize/consent`) and `/api/mobile/token/refresh`, which relied only on a `Content-Length` pre-check that a chunked body trivially bypasses. The multipart upload routes had no effective pre-`formData()` cap at all.

## What

- **New streaming-cap helpers** in `src/lib/http/parse-body.ts`:
  - `readBytesWithCap` — streaming byte cap; authoritative against chunked / missing-`Content-Length` bodies.
  - `readFormWithCap` — `application/x-www-form-urlencoded` under cap.
  - `rejectOversizedMultipart` — pre-`formData()` gate; **fail-closed** (413) when `Content-Length` is absent, unparseable, or over cap. `formData()` cannot be stream-capped, so the declared length is the only pre-parse defense. Browsers always set it; the only clients of these multipart endpoints are the web UI.
  - `readJsonWithCap` refactored to build on `readBytesWithCap` (null-stream `req.json()` fallback for hand-crafted test mocks preserved).
- **Wired all 7 affected routes** through the helpers:
  - form/raw: `mcp/token`, `mcp/revoke`, `mcp/authorize/consent` (urlencoded form → `readFormWithCap`), `mobile/token/refresh` (`arrayBuffer` → `readBytesWithCap`).
  - multipart: `sends/file`, `passwords/[id]/attachments`, `teams/[teamId]/passwords/[id]/attachments`.
- **CI guard** `scripts/checks/check-raw-body-read.sh` (+ allowlist), wired into `scripts/pre-pr.sh`: forbids `req.text()` / `req.arrayBuffer()` in routes and requires `rejectOversizedMultipart` alongside any `req.formData()`.

## Incidental fix

Removed a redundant nested `prisma.$transaction` inside `withBypassRls` in the consent DCR-claim path. The nested transaction opened a second connection **without** the RLS-bypass GUC (which is transaction-local), so the claim queries ran without the intended bypass. The sequence now runs on the bypass `tx` directly. Owner-scoped `delete` and CAS scoping are unchanged.

## Testing

- New helper unit tests (`readBytesWithCap`, `readFormWithCap`, `rejectOversizedMultipart`).
- New route-level regression tests: chunked-TE bypass on `mcp/token` (mutation-verified non-vacuous — fails if the cap is removed), fail-closed 413 on `sends/file` with no `Content-Length`.
- Multipart test helpers now set `Content-Length` (mirroring browser behavior) with an `omitContentLength` option for the fail-closed path.
- Full suite: 11543 passed / 1 skipped. `tsc`, `eslint`, `next build`, and all 29 pre-PR static guards (incl. the new one) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)