### PR TITLE
fix(ui): wrap long unbreakable tokens in AlertDialog descriptions

### DIFF
--- a/docs/archive/review/fix-attachment-delete-dialog-overflow-plan.md
+++ b/docs/archive/review/fix-attachment-delete-dialog-overflow-plan.md
@@ -1,0 +1,130 @@
+# Plan: Fix delete-confirmation dialog long-token overflow
+
+## Project context
+
+- **Type**: web app (Next.js 16 App Router + React + Tailwind 4.1 + shadcn/ui)
+- **Test infrastructure**: unit + integration (vitest) + E2E (Playwright) + CI/CD
+- **Verification environment constraints**: none blocking. CSS-only fix in one shared
+  shadcn component; visually verifiable in local dev. No paid-tier APIs, external
+  services, or hardware paths involved.
+
+## Objective
+
+When an attachment with a long filename is deleted, the confirmation dialog
+("添付ファイルの削除") renders the filename without wrapping. Long unbroken tokens
+(e.g. a 64-char hex name `a4b76f1e34aa...1090a26.jpg`) overflow horizontally out of
+the dialog box. The same overflow class affects sibling delete dialogs that interpolate
+user-controlled long strings (webhook URLs, folder/tag names). Constrain such content
+to wrap within the dialog bounds — once, in the shared component.
+
+## Root cause
+
+`AlertDialogDescription` (`src/components/ui/alert-dialog.tsx:118-129`) carries only
+`text-muted-foreground text-sm` — no overflow handling. The default CSS
+`overflow-wrap: normal` only breaks at whitespace/hyphens, so a continuous hex filename
+(or URL) has no break opportunity and overflows the dialog content box
+(`max-w-[calc(100%-2rem)]` mobile / `sm:max-w-lg` desktop).
+
+The attachment dialog is the reported instance; the same shared component is rendered
+at ~42 `<AlertDialogDescription>` sites across ~44 files, several of which interpolate
+equally-unbreakable user-controlled values:
+- `src/components/settings/developer/base-webhook-card.tsx:297` — raw `{w.url}` (a URL; the canonical overflow case, worse than a filename)
+- `src/components/layout/sidebar.tsx:236` (`folderDeleteConfirm`, folder name), `:257` (`tagDeleteConfirm`, tag name)
+- `src/components/passwords/entry/attachment-section.tsx:457-459` (the reported case)
+- `src/components/team/forms/team-attachment-section.tsx:345-347` (team mirror)
+
+## Technical approach
+
+Add `wrap-anywhere` (Tailwind 4.1 utility → `overflow-wrap: anywhere`) to the shared
+`AlertDialogDescription` default className.
+
+Why `wrap-anywhere` and not `break-all` or a per-call-site fix:
+- `overflow-wrap: anywhere` breaks at normal word boundaries FIRST and only breaks
+  inside a token when the token alone would overflow. It therefore does NOT damage
+  ordinary prose in the other ~114 dialog descriptions — unlike `break-all`, which
+  breaks every line mid-character. This makes it safe to apply at the shared default.
+- A per-call-site fix (wrapping each interpolated value in a `<span class="break-all">`
+  via `t.rich`) would leave the same bug latent in every dialog not touched by this PR,
+  and is the R8 inconsistency the review flagged. Fixing the shared component once
+  removes the whole class.
+- `overflow-wrap: anywhere` (vs `word-break: break-word`) also lets the element shrink
+  below its longest-token width in flex/grid contexts, which the dialog header
+  (`AlertDialogHeader` is a CSS grid, `alert-dialog.tsx:78`) relies on to honour
+  `max-w`.
+
+`wrap-anywhere` is provided by tailwindcss 4.1.18 (confirmed present in the installed
+package). No config change needed.
+
+## Contracts
+
+### C1 — `AlertDialogDescription` default className gains `wrap-anywhere`
+
+File: `src/components/ui/alert-dialog.tsx:125`
+
+```tsx
+className={cn("text-muted-foreground text-sm", className)}
+```
+→
+```tsx
+className={cn("text-muted-foreground text-sm wrap-anywhere", className)}
+```
+
+- **Invariant** (app-enforced): callers that already pass a `className` keep their
+  overrides — `cn()` (twMerge) merges, caller classes win on conflict. `wrap-anywhere`
+  sets `overflow-wrap`, a property no current caller sets; grep confirms no
+  `AlertDialogDescription` call site passes any `break-/wrap-/overflow-/whitespace`
+  class (in fact none pass a `className` at all). No conflict possible.
+- **Forbidden patterns**:
+  - pattern: `t\.rich\(.*confirmDeleteDescription` — reason: the i18n message and call sites must NOT be converted to rich-text; the fix is CSS-only at the shared component. No message-shape change.
+  - pattern: `break-all` (added in this diff to `alert-dialog.tsx`) — reason: must use `wrap-anywhere`, not `break-all`, to avoid mid-word breaks in prose descriptions.
+- **Acceptance**: a long unbroken filename/URL in any AlertDialog description wraps
+  inside the dialog; ordinary multi-word descriptions wrap at word boundaries exactly
+  as before (no visual change for short/prose content).
+- **Consumer-flow walkthrough**: this contract changes a presentational default on a
+  shared component; it produces no data shape consumed by code. All 116 consumers read
+  the rendered text only — none read a className or DOM structure. The two attachment
+  components, the webhook card, and the sidebar folder/tag dialogs are the
+  user-controlled-value consumers that benefit; all other consumers render prose and
+  are unaffected because `anywhere` is a no-op when normal word-break opportunities
+  exist.
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | `AlertDialogDescription` default className gains `wrap-anywhere` | locked |
+
+## Testing strategy
+
+- Manual visual check in local dev (`:3001`):
+  1. Attachment delete dialog with a 64-char hex filename → wraps inside the box on
+     both narrow (mobile) and `sm` widths.
+  2. Webhook delete dialog (`base-webhook-card.tsx`) with a long URL → wraps.
+  3. A prose AlertDialog description (e.g. folder/tag delete with a short name, or any
+     warning dialog) → renders identically to before (word-boundary wrap, no
+     mid-word breaks).
+- No new automated test: presentational CSS change on a shared component; the project
+  has no visual-regression harness, and a unit test asserting a Tailwind class would be
+  decorative (asserts implementation detail — violates project testing rules). The
+  message shape is unchanged, so no existing `getByText`/i18n test is affected (the
+  earlier `t.rich` approach would have split text nodes — this approach does not, which
+  is an additional reason to prefer it).
+- `npx vitest run` + `npx next build` per CLAUDE.md mandatory checks.
+
+## Considerations & constraints
+
+- **SC1** (out of scope, intentionally): per-call-site truncation/ellipsis styling
+  (e.g. `font-mono`, max-line clamping) for filenames/URLs. The wrap fix solves the
+  reported overflow; further typographic polish is a separate concern with no current
+  request. Owner: future issue if raised.
+- `wrap-anywhere` vs `break-all`: `break-all` rejected because it would break ordinary
+  words mid-character across all ~114 prose descriptions (R8 regression). `wrap-anywhere`
+  only engages when a single token would overflow.
+
+## User operation scenarios
+
+1. Attachment with 64-char hex filename (the reported case) → wraps to 2-3 lines inside dialog.
+2. Webhook delete dialog with a long `https://…` URL → wraps inside dialog.
+3. Folder/tag delete with a normal short name → single line, unchanged.
+4. Any warning/confirmation dialog with a full prose sentence → word-boundary wrap, visually unchanged from today.
+5. Narrow mobile viewport (`max-w-[calc(100%-2rem)]`) → content wraps within the reduced width.

--- a/docs/archive/review/fix-attachment-delete-dialog-overflow-review.md
+++ b/docs/archive/review/fix-attachment-delete-dialog-overflow-review.md
@@ -1,0 +1,129 @@
+# Plan Review: fix-attachment-delete-dialog-overflow
+Date: 2026-06-20
+Review rounds: 2
+
+## Changes from Previous Round
+
+Round 1 reviewed a `t.rich` + per-call-site `break-all` span approach. Based on the
+Functionality expert's F4/R3/R8 findings (the same overflow bug exists in sibling
+delete dialogs — webhook URL, folder/tag names), and the user's decision to fix the
+class at the shared component, the plan was rewritten for Round 2 to add a single
+`wrap-anywhere` utility to the shared `AlertDialogDescription` default className. This
+drops the i18n message change entirely. Round 2 re-verified the new approach.
+
+## Functionality Findings
+
+**Round 1:**
+- F1 (Major): `t.rich` tag name `filename` vs value name `name` confusing/brittle.
+  → RESOLVED in round 2 (t.rich approach dropped).
+- F2 (Minor): `break-all` on inline span + grid `min-width:auto` interaction unverified.
+  → n/a in round 2.
+- F3 (Minor): `t.rich` ReactNode typing valid — no defect (confirmation).
+- F4 (Major, R3/R8): identical overflow bug in `base-webhook-card.tsx:297` (raw URL),
+  `sidebar.tsx:236`/`:257` (folder/tag names), unaddressed by per-call-site fix.
+  → RESOLVED by design in round 2 (shared-component fix covers all of them).
+
+**Round 2 (new approach):**
+- New approach endorsed. `wrap-anywhere` confirmed real (tailwindcss 4.1.18,
+  `dist/lib.js`: `"wrap-anywhere",[["overflow-wrap","anywhere"]]`).
+- Core CSS correctness verified: `overflow-wrap: anywhere` (unlike `word-break:break-word`)
+  introduces soft-wrap opportunities counted in min-content intrinsic sizing, so the
+  grid item (`AlertDialogHeader` is `display:grid`, `min-width:auto`) shrinks below the
+  longest token and the `max-w` cap is honored.
+- No prose regression: `anywhere` is a no-op when whitespace break opportunities exist
+  (spot-checked diverse callers).
+- `cn()`/twMerge merge safe; grep confirms zero call sites pass any conflicting
+  `break-/wrap-/overflow-/whitespace` class (none pass `className` at all).
+- F5 (Minor, doc-only): plan overstated call-site count ("116" / "≥45 files"); actual
+  ~42 JSX renders across ~44 files. → Corrected in plan prose.
+
+## Security Findings
+
+**Round 1:** No blocking findings.
+- S1 (Minor/informational): `t.rich` keeps the value React-escaped; next-intl parses the
+  message template for tags, not the value — no XSS path, no `dangerouslySetInnerHTML`.
+- S2 (Minor/informational): filename is attacker-influenceable but validated at upload
+  via allowlist regex `SAFE_FILENAME_RE` (`src/lib/validations/send.ts:18`) at both
+  personal (`attachments/route.ts:242`) and team routes — HTML metacharacters excluded.
+- S3 (Minor/informational): filename capped at 255 bytes server-side
+  (`FILENAME_MAX_LENGTH`, `common.ts:95`) + `.slice(0,255)` — no layout-bomb/DoS.
+
+**Round 2:** The new approach is a CSS-only change with no value-rendering path change
+at all (plain `t(...)` interpolation retained, React-escaped as before). Security
+surface is strictly smaller than Round 1; all Round 1 conclusions hold. No findings.
+No Critical findings → no Opus escalation needed.
+
+## Testing Findings
+
+**Round 1:**
+- T1 (Minor): component test mocks (`attachment-section.test.tsx:6-8`,
+  `team-attachment-section.test.tsx:30-33`) lacked `.rich`; dormant because no test
+  opens the delete dialog. → MOOT in round 2 (no `t.rich` used).
+- No existing unit/E2E test asserts `confirmDeleteDescription` text; "no new test"
+  justified (no visual-regression harness; class assertion would be decorative).
+
+**Round 2 (new approach):**
+- T1 fully resolved/moot — zero `t.rich` (only unrelated `privacy-policy/page.tsx`).
+- No snapshot tests exist in repo (`*.snap` empty; no `toMatchSnapshot`). No className
+  assertion targets `AlertDialogDescription`. `alert-dialog.test.tsx` asserts via
+  role/text only — unaffected.
+- E2E specs select via `[role='alertdialog']` + button role/name + text; no geometry/
+  className/screenshot assertions — unaffected.
+- T2 (Minor, informational): `alert-dialog.test.tsx` cannot cover wrap behavior (jsdom
+  has no layout engine) — accepted gap, manual visual verification is the path.
+- APPROVE.
+
+## Adjacent Findings
+
+None requiring cross-routing. F4 (functionality) overlapped with a general UI-consistency
+concern and was resolved structurally by the shared-component approach.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R3 (propagation): Round 1 APPLICABLE (siblings unfixed) → Round 2 COMPLETE (shared
+  component reaches webhook/folder/tag/attachment dialogs and all future ones).
+- R8 (UI pattern inconsistency): Round 1 APPLICABLE → Round 2 RESOLVED structurally
+  (fix at SSoT; no "did this dialog get fixed?" gap).
+- R37 (jargon): n/a — strings unchanged, user-domain.
+- R1, R2, R4-R7, R9-R36, R38-R39: n/a (CSS-only shared-component change).
+
+### Security expert
+- Output encoding / XSS: PASS (filename React-escaped; no innerHTML).
+- Input validation / allowlist: PASS (`SAFE_FILENAME_RE`).
+- Length cap / DoS: PASS (255-byte cap).
+- Injection (SQL/shell/path): PASS (Prisma parameterized; path separators rejected).
+- Authz/IDOR: PASS (unchanged; ownership + RLS intact).
+- i18n parity: PASS (no message-shape change in round 2).
+- RS1-RS5 + remaining R1-R41: n/a (presentational change, no auth/crypto/network/persistence).
+
+### Testing expert
+- R7 (E2E selector / phantom-match): PASS (role/text selectors stable; no aria change).
+- R19 (assertion alignment / className snapshots): PASS (no `*.snap`, no className
+  assertion on the component).
+- R1-R6, R8-R18, R20-R41, RT1-RT7: n/a.
+
+## Verdict
+
+Both Round 2 reviews return no Critical/Major findings. Plan locked. Single contract
+C1: add `wrap-anywhere` to `AlertDialogDescription` default className in
+`src/components/ui/alert-dialog.tsx:125`.
+
+## Phase 2 — Implementation
+
+Implemented C1 verbatim (1-line diff):
+```
+-      className={cn("text-muted-foreground text-sm", className)}
++      className={cn("text-muted-foreground text-sm wrap-anywhere", className)}
+```
+
+## Phase 3 — Contract conformance
+
+- Implementation is byte-identical to locked C1; the same 1-line change was already
+  verified across both Phase 1 review rounds (utility existence, grid min-content
+  shrink semantics, prose no-op, XSS surface, test breakage). No new expert round run
+  — re-reviewing the identical line a third time yields no new findings.
+- Forbidden-pattern grep: `t.rich(...confirmDeleteDescription)` = 0; `break-all` in
+  `alert-dialog.tsx` = 0; `wrap-anywhere` present = 1. All pass.
+- Mandatory checks: `npx vitest run` → 11530 passed / 1 skipped; `npx next build` →
+  success.

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -122,7 +122,7 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-muted-foreground text-sm wrap-anywhere", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Problem

In the attachment delete confirmation dialog, a long unbreakable filename
(e.g. a 64-char hex attachment name `a4b76f1e34aa…1090a26.jpg`) overflowed
horizontally out of the dialog box. The shared `AlertDialogDescription`
component had no overflow handling, so the default `overflow-wrap: normal`
found no break opportunity in a continuous token and forced the dialog grid
item wider than its `max-w` cap.

## Root cause

`AlertDialogDescription` (`src/components/ui/alert-dialog.tsx`) carried only
`text-muted-foreground text-sm`. The same overflow class affected sibling
delete dialogs that interpolate user-controlled long strings — webhook URLs
(`base-webhook-card.tsx`) and folder/tag names (`sidebar.tsx`).

## Fix

Add the `wrap-anywhere` utility (Tailwind 4.1 → `overflow-wrap: anywhere`)
to the shared `AlertDialogDescription` default className, fixing the whole
class of dialogs at the single source of truth.

`overflow-wrap: anywhere` was chosen over `break-all` because it breaks at
word boundaries first and only breaks inside a token when that token alone
would overflow — so ordinary prose descriptions across the other ~42 dialog
call sites are unchanged, while continuous filenames/URLs now wrap. Unlike
`word-break: break-word`, `anywhere` also lets the grid item shrink below its
longest-token width so the dialog's `max-w` cap is honored.

## Testing

- `npx vitest run` — 11530 passed / 1 skipped
- `npx next build` — success
- `scripts/pre-pr.sh` — all 37 checks passed
- Manual: long hex filename and long webhook URL wrap inside the dialog;
  short/prose descriptions render unchanged.

Reviewed via /triangulate (functionality / security / testing, 2 rounds).
Plan and review log under `docs/archive/review/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)