### PR TITLE
fix(ios): decode SSH keySize as number to fix undecryptable SSH entries

### DIFF
--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		9B43CD74FC38538B051314BD /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 296B0035C443158058EA4866 /* Shared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9CADAC4F619993DF6DBF1F0B /* PasskeySignCountStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E38F8248BD5540CEF7680AD /* PasskeySignCountStoreTests.swift */; };
 		A3CEA13B7C87135CC54039D6 /* TeamContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8901EA2724A715ACFBEEDBEF /* TeamContext.swift */; };
+		A3D18ECBB5D9A2871B328CF7 /* EntryBlobGoldenPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F520C6A793A73EED943FBC /* EntryBlobGoldenPayloadTests.swift */; };
 		A457C9391F7E1E8164C97A46 /* AutoLockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C68DCFC79DBA6600F27E36 /* AutoLockService.swift */; };
 		A4619E1EAF28B7B5566B72CD /* CryptoParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4362A04B3AF6AD6D6C510D00 /* CryptoParamsTests.swift */; };
 		A49DCEFF5ABDE722BF33C324 /* SPKIEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FBC66A0BFC38B393757852 /* SPKIEncoder.swift */; };
@@ -234,6 +235,7 @@
 		00C68DCFC79DBA6600F27E36 /* AutoLockService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLockService.swift; sourceTree = "<group>"; };
 		0333F38BE2751CE94BF0F47D /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		06E4377840A9A939A6B88D9A /* VaultEntrySummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultEntrySummary.swift; sourceTree = "<group>"; };
+		07F520C6A793A73EED943FBC /* EntryBlobGoldenPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryBlobGoldenPayloadTests.swift; sourceTree = "<group>"; };
 		093A4C680F943C38DC91C965 /* AutofillTokenRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillTokenRefresherTests.swift; sourceTree = "<group>"; };
 		0B5A5914A5C31DC30D3F8BB7 /* HTTPConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPConstants.swift; sourceTree = "<group>"; };
 		0BDD66BD3FF47585E7183FC8 /* fixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; name = fixtures; path = ../extension/test/fixtures; sourceTree = SOURCE_ROOT; };
@@ -434,6 +436,7 @@
 				3FED91E37F4E8005AEF7E9B6 /* DebugVaultLoaderTests.swift */,
 				EBF559B979642506D203C806 /* DPoPProofBuilderTests.swift */,
 				80BC3E2908650479CBBE6D07 /* EntryBlobDecoderTests.swift */,
+				07F520C6A793A73EED943FBC /* EntryBlobGoldenPayloadTests.swift */,
 				24CD914CFF8AD6DD6DAB0129 /* EntryCacheFileTests.swift */,
 				628885DD1B6E8E32503A7DD9 /* EntryEncrypterTests.swift */,
 				28A274ABCE6A2833F3A66EF5 /* EntryFetcherTests.swift */,
@@ -1056,6 +1059,7 @@
 				0A36948197E80ACA5ED17F22 /* DPoPProofBuilderTests.swift in Sources */,
 				E1FA345EE6BF6D38163AD937 /* DebugVaultLoaderTests.swift in Sources */,
 				1633001879A14FC075CBC4A3 /* EntryBlobDecoderTests.swift in Sources */,
+				A3D18ECBB5D9A2871B328CF7 /* EntryBlobGoldenPayloadTests.swift in Sources */,
 				EF9407000E17ADEB5E667D88 /* EntryCacheFileTests.swift in Sources */,
 				96A710A8F83E4FEB146E39D4 /* EntryEncrypterTests.swift in Sources */,
 				53BABB8B7A6B12FE9A269D87 /* EntryFetcherTests.swift in Sources */,

--- a/ios/PasswdSSO.xcodeproj/project.pbxproj
+++ b/ios/PasswdSSO.xcodeproj/project.pbxproj
@@ -1215,7 +1215,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.58;
+				MARKETING_VERSION = 0.4.59;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOUITests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1235,7 +1235,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.4.58;
+				MARKETING_VERSION = 0.4.59;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOAutofillExtension";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1258,7 +1258,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.58;
+				MARKETING_VERSION = 0.4.59;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.Shared";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1347,7 +1347,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.4.58;
+				MARKETING_VERSION = 0.4.59;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOAutofillExtension";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1366,7 +1366,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.58;
+				MARKETING_VERSION = 0.4.59;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOTests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1385,7 +1385,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.58;
+				MARKETING_VERSION = 0.4.59;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOUITests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1466,7 +1466,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.58;
+				MARKETING_VERSION = 0.4.59;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1485,7 +1485,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.58;
+				MARKETING_VERSION = 0.4.59;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1504,7 +1504,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.58;
+				MARKETING_VERSION = 0.4.59;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.PasswdSSOTests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1528,7 +1528,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.58;
+				MARKETING_VERSION = 0.4.59;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.jpng.passwd-sso.Shared";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
+++ b/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
@@ -239,11 +239,14 @@ final class EntryBlobDecoderTests: XCTestCase {
   }
 
   func testDetailDecodesSshKeyBlobUsesPassphraseAndCommentKeys() throws {
-    // Blob keys are `passphrase`/`comment` (NOT sshPassphrase/sshComment), and
-    // `keySize` is a free-text string ("2048"), not an Int.
+    // Blob keys are `passphrase`/`comment` (NOT sshPassphrase/sshComment).
+    // The web client writes `keySize` as a JSON NUMBER (the SSH parser yields an
+    // Int bit-length); decoding it as a bare String previously threw a
+    // typeMismatch that failed the whole blob decode and left SSH entries stuck
+    // on "decrypting". This mirrors the real server payload (numeric keySize).
     let json = #"""
     {"title":"deploy key","privateKey":"-----BEGIN-----","publicKey":"ssh-ed25519 AAA",
-     "keyType":"ed25519","keySize":"256","fingerprint":"SHA256:abc",
+     "keyType":"ed25519","keySize":256,"fingerprint":"SHA256:abc",
      "passphrase":"hunter2","comment":"deploy@host"}
     """#
     let d = try XCTUnwrap(
@@ -260,6 +263,79 @@ final class EntryBlobDecoderTests: XCTestCase {
     XCTAssertNil(d.bankAccount)
     XCTAssertEqual(d.url, "")
     XCTAssertEqual(d.password, "")
+  }
+
+  func testDetailDecodesSshKeyBlobToleratesStringKeySize() throws {
+    // Defensive: a blob that carries `keySize` as a string (legacy/hand-edited
+    // data) must still decode rather than throwing the whole blob away.
+    let json = #"""
+    {"title":"legacy key","privateKey":"-----BEGIN-----","keyType":"rsa",
+     "keySize":"2048","fingerprint":"SHA256:xyz"}
+    """#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "ssh2", teamId: nil, entryType: "SSH_KEY")
+    )
+    let key = try XCTUnwrap(d.sshKey)
+    XCTAssertEqual(key.keySize, "2048")
+    XCTAssertEqual(key.keyType, "rsa")
+  }
+
+  func testDetailDecodesSshKeyBlobWithNullKeySize() throws {
+    // `keySize || null` → JSON null when the parser could not estimate a size.
+    let json = #"""
+    {"title":"sizeless key","privateKey":"-----BEGIN-----","keyType":"ed25519",
+     "keySize":null,"fingerprint":"SHA256:zzz"}
+    """#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "ssh3", teamId: nil, entryType: "SSH_KEY")
+    )
+    let key = try XCTUnwrap(d.sshKey)
+    XCTAssertNil(key.keySize)
+    XCTAssertEqual(key.keyType, "ed25519")
+  }
+
+  func testDetailDecodesSshKeyBlobWithMissingKeySize() throws {
+    // keySize key omitted entirely (different decode path from explicit null).
+    let json = #"""
+    {"title":"k","privateKey":"-----BEGIN-----","keyType":"rsa","fingerprint":"SHA256:m"}
+    """#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "ssh4", teamId: nil, entryType: "SSH_KEY")
+    )
+    let key = try XCTUnwrap(d.sshKey)
+    XCTAssertNil(key.keySize)
+    XCTAssertEqual(key.keyType, "rsa")
+  }
+
+  func testDetailDecodesSshKeyBlobNormalizesWholeNumberDoubleKeySize() throws {
+    // A whole-number double (256.0) normalizes to "256", not "256.0".
+    let json = #"""
+    {"title":"k","privateKey":"-----BEGIN-----","keyType":"rsa","keySize":256.0}
+    """#
+    let d = try XCTUnwrap(
+      EntryBlobDecoder.detail(plaintext: data(json), entryId: "ssh5", teamId: nil, entryType: "SSH_KEY")
+    )
+    let key = try XCTUnwrap(d.sshKey)
+    XCTAssertEqual(key.keySize, "256")
+  }
+
+  func testDetailToleratesNonScalarKeySizeWithoutFailingWholeBlob() throws {
+    // Regression guard for the exact failure class this fix targets: an
+    // unexpected JSON shape for ONE field must not throw the whole blob decode.
+    // bool/array keySize → keySize nil, but the SSH entry still decodes.
+    for badKeySize in ["true", "[2048]", #"{"bits":2048}"#] {
+      let json = """
+      {"title":"weird","privateKey":"-----BEGIN-----","keyType":"rsa",
+       "keySize":\(badKeySize),"fingerprint":"SHA256:q"}
+      """
+      let d = try XCTUnwrap(
+        EntryBlobDecoder.detail(plaintext: data(json), entryId: "ssh6", teamId: nil, entryType: "SSH_KEY"),
+        "blob with keySize=\(badKeySize) should still decode"
+      )
+      let key = try XCTUnwrap(d.sshKey)
+      XCTAssertNil(key.keySize, "non-scalar keySize=\(badKeySize) should decode to nil")
+      XCTAssertEqual(key.keyType, "rsa")
+    }
   }
 
   func testDetailDecodesSoftwareLicenseBlob() throws {

--- a/ios/PasswdSSOTests/EntryBlobGoldenPayloadTests.swift
+++ b/ios/PasswdSSOTests/EntryBlobGoldenPayloadTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import XCTest
+@testable import Shared
+
+/// Golden-payload regression tests guarding against the bug class behind the SSH
+/// `keySize` failure: a single blob field whose iOS decode type disagrees with
+/// the web client's write-side type throws a `typeMismatch` that fails the WHOLE
+/// blob decode, leaving the entry stuck on "decrypting".
+///
+/// Each fixture below MIRRORS the JSON the web client's per-type form actually
+/// writes (see `src/components/passwords/personal/personal-*-form.tsx` in the
+/// server repo) — including the field VALUE TYPES (numbers as numbers, bools as
+/// bools, nulls as nulls). If the web write-side type drifts and iOS does not
+/// follow, the matching test here turns a silent runtime "stuck on decrypting"
+/// into a build-time test failure.
+///
+/// When adding a new entry type, add its golden payload here in lockstep with
+/// the new web form — that is the whole point of this file.
+final class EntryBlobGoldenPayloadTests: XCTestCase {
+
+  private func data(_ json: String) -> Data { Data(json.utf8) }
+
+  private func decode(_ json: String, _ entryType: String) throws -> VaultEntryDetail {
+    try XCTUnwrap(
+      EntryBlobDecoder.detail(
+        plaintext: data(json), entryId: "golden", teamId: nil, entryType: entryType),
+      "\(entryType) golden payload failed to decode — likely an iOS↔web blob type drift"
+    )
+  }
+
+  // MARK: - One golden payload per entry type (value types mirror the web forms)
+
+  func testGoldenSshKey() throws {
+    // personal-ssh-key-form.tsx: keySize is a NUMBER.
+    let json = #"""
+    {"title":"deploy","privateKey":"-----BEGIN-----","publicKey":"ssh-ed25519 AAA",
+     "keyType":"ed25519","keySize":256,"fingerprint":"SHA256:abc",
+     "passphrase":"hunter2","comment":"a@b","notes":null,"tags":[],"travelSafe":true}
+    """#
+    let key = try XCTUnwrap(try decode(json, "SSH_KEY").sshKey)
+    XCTAssertEqual(key.keySize, "256")
+    XCTAssertEqual(key.privateKey, "-----BEGIN-----")
+  }
+
+  func testGoldenCreditCard() throws {
+    // personal-credit-card-form.tsx: all fields are strings (expiryMonth/Year too).
+    let json = #"""
+    {"title":"Visa","cardholderName":"Alice","cardNumber":"4111111111111111",
+     "brand":"visa","expiryMonth":"12","expiryYear":"2030","cvv":"123",
+     "notes":null,"tags":[],"travelSafe":true}
+    """#
+    let card = try XCTUnwrap(try decode(json, "CREDIT_CARD").creditCard)
+    XCTAssertEqual(card.expiryMonth, "12")
+    XCTAssertEqual(card.cardNumber, "4111111111111111")
+  }
+
+  func testGoldenIdentity() throws {
+    let json = #"""
+    {"title":"Me","fullName":"Alice A","givenName":"Alice","familyName":"A",
+     "email":"a@b.example","phone":"+81-3-0000-0000","dateOfBirth":"1990-01-01",
+     "notes":null,"tags":[],"travelSafe":true}
+    """#
+    let id = try XCTUnwrap(try decode(json, "IDENTITY").identity)
+    XCTAssertEqual(id.fullName, "Alice A")
+  }
+
+  func testGoldenBankAccount() throws {
+    let json = #"""
+    {"title":"Main","bankName":"Bank","accountType":"checking",
+     "accountHolderName":"Alice","accountNumber":"12345678","routingNumber":"021",
+     "swiftBic":"BOFAUS3N","iban":"DE00","branchName":"HQ","notes":null,
+     "tags":[],"travelSafe":true}
+    """#
+    let bank = try XCTUnwrap(try decode(json, "BANK_ACCOUNT").bankAccount)
+    XCTAssertEqual(bank.accountNumber, "12345678")
+  }
+
+  func testGoldenSecureNote() throws {
+    // personal-secure-note-form.tsx: isMarkdown is a BOOL.
+    let json = #"""
+    {"title":"Note","content":"hello","tags":[],"isMarkdown":true,"travelSafe":true}
+    """#
+    let note = try XCTUnwrap(try decode(json, "SECURE_NOTE").secureNote)
+    XCTAssertEqual(note.content, "hello")
+    XCTAssertEqual(note.isMarkdown, true)
+  }
+
+  func testGoldenSoftwareLicense() throws {
+    let json = #"""
+    {"title":"IDE","softwareName":"CoolIDE","licenseKey":"ABCD-EFGH","version":"3.2",
+     "licensee":"Alice","email":"a@b.example","purchaseDate":"2024-01-01",
+     "expirationDate":"2025-01-01","notes":null,"tags":[],"travelSafe":true}
+    """#
+    let lic = try XCTUnwrap(try decode(json, "SOFTWARE_LICENSE").softwareLicense)
+    XCTAssertEqual(lic.licenseKey, "ABCD-EFGH")
+  }
+
+  func testGoldenPasskey() throws {
+    // personal-passkey-form.tsx: display fields + provider fields (passkeySignCount
+    // is a NUMBER, decoded only by PasskeyFullBlobPayload, not the display path).
+    let json = #"""
+    {"title":"GitHub","relyingPartyId":"github.com","relyingPartyName":"GitHub",
+     "username":"alice","credentialId":"Y3JlZA","creationDate":"2024-01-01",
+     "deviceInfo":"iPhone","notes":null,"tags":[],"travelSafe":true,
+     "passkeyPrivateKeyJwk":"{\"kty\":\"EC\"}","passkeyUserHandle":"dWg",
+     "passkeySignCount":5}
+    """#
+    let pk = try XCTUnwrap(try decode(json, "PASSKEY").passkey)
+    XCTAssertEqual(pk.relyingPartyId, "github.com")
+    // The numeric passkeySignCount must not break the display-path blob decode.
+  }
+
+  func testGoldenLogin() throws {
+    // personal-login-form path (buildPersonalEntryPayload): password present,
+    // totp.digits/period are NUMBERS.
+    let json = #"""
+    {"title":"Login","username":"alice","password":"s3cr3t","url":"https://b.example",
+     "notes":null,"tags":[],"totp":{"secret":"JBSWY","algorithm":"SHA1","digits":6,"period":30},
+     "travelSafe":true}
+    """#
+    let d = try decode(json, "LOGIN")
+    XCTAssertEqual(d.password, "s3cr3t")
+    XCTAssertEqual(d.totpDigits, 6)
+    XCTAssertEqual(d.totpPeriod, 30)
+  }
+
+  func testLoginToleratesStringTotpDigitsWithoutFailingWholeBlob() throws {
+    // Defense for the same bug class on the LOGIN path: a TOTP digits/period that
+    // drifts to a string must not throw the whole blob decode.
+    let json = #"""
+    {"title":"Login","username":"alice","password":"s3cr3t",
+     "totp":{"secret":"JBSWY","digits":"8","period":"60"}}
+    """#
+    let d = try decode(json, "LOGIN")
+    XCTAssertEqual(d.password, "s3cr3t")
+    XCTAssertEqual(d.totpDigits, 8)
+    XCTAssertEqual(d.totpPeriod, 60)
+  }
+
+  func testLoginToleratesNonNumericTotpDigitsWithoutFailingWholeBlob() throws {
+    // A garbage digits value → totpDigits nil, but the entry still decodes.
+    let json = #"""
+    {"title":"Login","username":"alice","password":"s3cr3t",
+     "totp":{"secret":"JBSWY","digits":true,"period":[30]}}
+    """#
+    let d = try decode(json, "LOGIN")
+    XCTAssertEqual(d.password, "s3cr3t")
+    XCTAssertNil(d.totpDigits)
+    XCTAssertNil(d.totpPeriod)
+    XCTAssertEqual(d.totpSecret, "JBSWY")
+  }
+}

--- a/ios/Shared/Models/EntryBlobDecoder.swift
+++ b/ios/Shared/Models/EntryBlobDecoder.swift
@@ -93,16 +93,21 @@ public enum EntryBlobDecoder {
     let swiftBic: String?
     let iban: String?
     let branchName: String?
-    // SSH_KEY (blob keys are `passphrase`/`comment`, NOT sshPassphrase/sshComment;
-    // `keySize` is free-text so decode as String). `publicKey`/`keyType`/
-    // `fingerprint` reuse identifiers above where not already declared.
+    // SSH_KEY (blob keys are `passphrase`/`comment`, NOT sshPassphrase/sshComment).
+    // `publicKey`/`keyType`/`fingerprint` reuse identifiers above where not
+    // already declared. `keySize` is written by the web client as a JSON number
+    // (`keySize || null`, where the parser yields an Int bit-length), so it must
+    // tolerate a numeric value — decoding it as a bare `String?` throws a
+    // typeMismatch that fails the WHOLE blob decode and leaves SSH entries stuck
+    // on "decrypting". `FlexibleString` accepts a number or a string and
+    // normalizes to a display string.
     let privateKey: String?
     let publicKey: String?
     let keyType: String?
     let fingerprint: String?
     let passphrase: String?
     let comment: String?
-    let keySize: String?
+    let keySize: FlexibleString?
     // SOFTWARE_LICENSE
     let softwareName: String?
     let licenseKey: String?
@@ -130,6 +135,36 @@ public enum EntryBlobDecoder {
     // Monotonic signature counter the extension increments + persists per
     // assertion. The RP enforces monotonicity; the assertion emits this + 1.
     let passkeySignCount: Int?
+  }
+
+  /// Decodes a JSON value that may be a number or a string into a display string.
+  /// Used for blob fields whose write-side type has drifted across clients (e.g.
+  /// SSH `keySize`, written as a number by the web client). This NEVER throws:
+  /// any unexpected shape (bool, array, object) decodes to `value == nil` rather
+  /// than failing — so a single drifted field can never throw the whole blob
+  /// decode (the exact failure that left SSH entries stuck on "decrypting").
+  /// A whole-number `Double` (e.g. `256.0`) is normalized to an integer string.
+  private struct FlexibleString: Decodable {
+    let value: String?
+
+    init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      if let s = try? container.decode(String.self) {
+        value = s
+      } else if let i = try? container.decode(Int.self) {
+        value = String(i)
+      } else if let d = try? container.decode(Double.self) {
+        // Normalize whole-number doubles (256.0 → "256"); guard the Int cast
+        // against out-of-range/non-finite values that would trap.
+        if d.isFinite, d == d.rounded(), d >= -9.007e15, d <= 9.007e15 {
+          value = String(Int(d))
+        } else {
+          value = String(d)
+        }
+      } else {
+        value = nil
+      }
+    }
   }
 
   private struct TagPayload: Decodable {
@@ -267,7 +302,7 @@ public enum EntryBlobDecoder {
         ? .init(
           privateKey: p.privateKey, publicKey: p.publicKey, keyType: p.keyType,
           fingerprint: p.fingerprint, passphrase: p.passphrase, comment: p.comment,
-          keySize: p.keySize) : nil,
+          keySize: p.keySize.flatMap { $0.value }) : nil,
       softwareLicense: entryType == "SOFTWARE_LICENSE"
         ? .init(
           softwareName: p.softwareName, licenseKey: p.licenseKey, version: p.version,

--- a/ios/Shared/Models/EntryBlobDecoder.swift
+++ b/ios/Shared/Models/EntryBlobDecoder.swift
@@ -167,6 +167,25 @@ public enum EntryBlobDecoder {
     }
   }
 
+  /// Decodes a JSON value that may be an integer or a numeric string into an Int.
+  /// Same defense as `FlexibleString` but for integer-typed blob fields (TOTP
+  /// `digits`/`period`): a write-side drift to a string (e.g. `"6"`) must not
+  /// throw the whole blob decode. Non-numeric shapes decode to `value == nil`.
+  private struct FlexibleInt: Decodable {
+    let value: Int?
+
+    init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      if let i = try? container.decode(Int.self) {
+        value = i
+      } else if let s = try? container.decode(String.self), let i = Int(s) {
+        value = i
+      } else {
+        value = nil
+      }
+    }
+  }
+
   private struct TagPayload: Decodable {
     let name: String
     let color: String?
@@ -175,8 +194,10 @@ public enum EntryBlobDecoder {
   private struct TotpPayload: Decodable {
     let secret: String
     let algorithm: String?
-    let digits: Int?
-    let period: Int?
+    // Tolerant: web writes these as numbers, but a string drift must not throw
+    // the whole blob decode (which would make the LOGIN detail undecryptable).
+    let digits: FlexibleInt?
+    let period: FlexibleInt?
   }
 
   /// Reconstruct a list-view summary from an overview-blob plaintext. `id` and
@@ -275,8 +296,8 @@ public enum EntryBlobDecoder {
       notes: p.notes ?? "",
       totpSecret: p.totp?.secret,
       totpAlgorithm: p.totp?.algorithm,
-      totpDigits: p.totp?.digits,
-      totpPeriod: p.totp?.period,
+      totpDigits: p.totp?.digits.flatMap { $0.value },
+      totpPeriod: p.totp?.period.flatMap { $0.value },
       generatorSettings: nil,
       entryType: entryType,
       secureNote: entryType == "SECURE_NOTE"

--- a/ios/Shared/Models/VaultEntryDetail.swift
+++ b/ios/Shared/Models/VaultEntryDetail.swift
@@ -147,8 +147,9 @@ public struct VaultEntryDetail: Codable, Sendable, Equatable, Identifiable {
     public let fingerprint: String?
     public let passphrase: String?
     public let comment: String?
-    // Free-text input on the web form (written as `keySize || null`), so the
-    // blob value may be a string like "2048" — decode as String, not Int.
+    // Auto-detected bit length. The web client writes it as a JSON number;
+    // EntryBlobDecoder tolerantly decodes number-or-string and normalizes to a
+    // display string here (see FlexibleString in EntryBlobDecoder).
     public let keySize: String?
     public init(
       privateKey: String? = nil, publicKey: String? = nil, keyType: String? = nil,


### PR DESCRIPTION
### Summary

SSH key entries failed to decrypt on iOS — the detail view stayed stuck on "decrypting" while every other entry type worked. The AES-GCM decryption actually succeeded; the failure was in the JSON decode of the decrypted blob.

The web client writes SSH `keySize` as a JSON **number** (the SSH parser yields an Int bit-length), but iOS decoded it as `String?`. The resulting `typeMismatch` threw the **entire** `FullBlobPayload` decode, so `detail()` returned `nil` and the entry appeared undecryptable. The existing test masked this by encoding `keySize` as a string (`"256"`) — a shape the server never produces (write-read consistency violation).

### Fix
- Introduce a tolerant `FlexibleString` decode for `keySize` that accepts a number, string, or null and **never throws** — any unexpected shape decodes to `nil` so a single drifted field can no longer fail the whole blob.

### Horizontal rollout (same bug class)
- **Detection:** `EntryBlobGoldenPayloadTests.swift` — one golden payload per entry type (SSH / CARD / IDENTITY / BANK / NOTE / LICENSE / PASSKEY / LOGIN), mirroring the exact value types each web form writes. A future iOS↔web type drift becomes a build-time test failure instead of a silent "stuck on decrypting".
- **Defense:** TOTP `digits` / `period` (the other numeric blob fields) now decode via a tolerant `FlexibleInt`, so a string/garbage drift can't throw the LOGIN blob decode.

### Testing
- All **553 unit + UI tests** pass (`xcodebuild test -scheme PasswdSSOApp`).
- Reviewed via `/triangulate` (functionality / security / testing), converged in 2 rounds.
- **Manual device verification: OK** (confirmed by reporter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)