### PR TITLE
fix(extension): enforce user-presence on WebAuthn bridge sign/create

### DIFF
--- a/extension/src/__tests__/content/ui/passkey-dropdown.test.ts
+++ b/extension/src/__tests__/content/ui/passkey-dropdown.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { PasskeyMatchEntry } from "../../../types/messages";
+
+// Override navigator.language for consistent i18n
+Object.defineProperty(navigator, "language", { value: "en-US", configurable: true });
+
+// Mock shadow-host so the test can reach the (otherwise closed) shadow root.
+// mockRoot is attached to document.body so keydown events dispatched on
+// document reach the capture-phase handler the dropdown registers.
+const mockRoot = document.createElement("div");
+vi.mock("../../../content/ui/shadow-host", () => ({
+  getShadowHost: vi.fn(() => ({ host: document.createElement("div"), root: mockRoot })),
+  removeShadowHost: vi.fn(),
+}));
+
+import { showPasskeyDropdown, hidePasskeyDropdown } from "../../../content/ui/passkey-dropdown";
+
+// jsdom sets Event.isTrusted as a non-configurable own property that is always
+// false for scripted events and cannot be redefined on the instance or faked via
+// the prototype. Real dispatch hands the listener that native (untrusted) event.
+// So for the POSITIVE (trusted) path we capture the registered listener and invoke
+// it directly with a Proxy that reports isTrusted=true — the same technique the
+// suggestion-dropdown test uses for its exported keydown handler. The NEGATIVE
+// (untrusted) path uses real dispatch, which is genuinely isTrusted=false.
+function trusted<E extends Event>(e: E): E {
+  return new Proxy(e, {
+    get(target, prop, receiver) {
+      if (prop === "isTrusted") return true;
+      const val = Reflect.get(target, prop, receiver);
+      return typeof val === "function" ? (val as (...a: unknown[]) => unknown).bind(target) : val;
+    },
+  }) as E;
+}
+
+// Capture every (target, type, listener) registered while `fn` runs, so a test
+// can invoke a specific listener directly with a trusted-event Proxy.
+interface Registered { target: EventTarget; type: string; listener: EventListener }
+function captureListeners(fn: () => void): Registered[] {
+  const registered: Registered[] = [];
+  const targets = [EventTarget.prototype];
+  const originals = targets.map((t) => t.addEventListener);
+  targets.forEach((t) => {
+    t.addEventListener = function (type: string, listener: EventListenerOrEventListenerObject | null, opts?: unknown) {
+      if (typeof listener === "function") registered.push({ target: this, type, listener: listener as EventListener });
+      return (originals[0] as typeof t.addEventListener).call(this, type, listener as EventListener, opts as boolean);
+    } as typeof t.addEventListener;
+  });
+  try {
+    fn();
+  } finally {
+    targets.forEach((t, i) => { t.addEventListener = originals[i]; });
+  }
+  return registered;
+}
+
+// Invoke the click listener registered on `el` directly with a trusted Proxy event.
+function trustedClick(registered: Registered[], el: EventTarget): void {
+  const reg = registered.find((r) => r.target === el && r.type === "click");
+  if (!reg) throw new Error("no click listener registered on element");
+  reg.listener.call(el, trusted(new MouseEvent("click")));
+}
+
+// Invoke the document keydown listener directly with a trusted Proxy event.
+function trustedKeydown(registered: Registered[], key: string): void {
+  const reg = registered.find((r) => r.target === document && r.type === "keydown");
+  if (!reg) throw new Error("no keydown listener registered on document");
+  reg.listener.call(document, trusted(new KeyboardEvent("keydown", { key, cancelable: true })));
+}
+
+function makeEntries(): PasskeyMatchEntry[] {
+  return [
+    { id: "entry-1", title: "Example", username: "alice", relyingPartyId: "example.com", credentialId: "cred-1" },
+  ];
+}
+
+function makeOptions(overrides?: Partial<Parameters<typeof showPasskeyDropdown>[0]>) {
+  return {
+    entries: makeEntries(),
+    rpId: "example.com",
+    onSelect: vi.fn(),
+    onPlatform: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+}
+
+function getItem(): HTMLDivElement {
+  const item = mockRoot.querySelector<HTMLDivElement>('.psso-pk-item[data-entry-id="entry-1"]');
+  if (!item) throw new Error("passkey item not rendered");
+  return item;
+}
+
+function getPlatformItem(): HTMLDivElement {
+  const item = mockRoot.querySelector<HTMLDivElement>(".psso-pk-platform");
+  if (!item) throw new Error("platform item not rendered");
+  return item;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.body.appendChild(mockRoot);
+  mockRoot.innerHTML = "";
+});
+
+afterEach(() => {
+  hidePasskeyDropdown();
+  vi.restoreAllMocks();
+});
+
+describe("passkey-dropdown user-presence gate", () => {
+  it("renders an item per entry plus the platform row", () => {
+    showPasskeyDropdown(makeOptions());
+    expect(getItem()).toBeTruthy();
+    expect(getPlatformItem()).toBeTruthy();
+  });
+
+  // ── Mouse ──────────────────────────────────────────────────────
+
+  it("calls onSelect on a trusted item click", () => {
+    const opts = makeOptions();
+    const registered = captureListeners(() => showPasskeyDropdown(opts));
+    trustedClick(registered, getItem());
+    expect(opts.onSelect).toHaveBeenCalledTimes(1);
+    expect(opts.onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "entry-1" }));
+  });
+
+  it("does NOT call onSelect on a synthetic (untrusted) item click — blocks scripted assertion", () => {
+    const opts = makeOptions();
+    showPasskeyDropdown(opts);
+    getItem().dispatchEvent(new MouseEvent("click", { bubbles: true })); // isTrusted=false
+    expect(opts.onSelect).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onPlatform on a synthetic (untrusted) platform click", () => {
+    const opts = makeOptions();
+    showPasskeyDropdown(opts);
+    getPlatformItem().dispatchEvent(new MouseEvent("click", { bubbles: true })); // isTrusted=false
+    expect(opts.onPlatform).not.toHaveBeenCalled();
+  });
+
+  it("calls onPlatform on a trusted platform click", () => {
+    const opts = makeOptions();
+    const registered = captureListeners(() => showPasskeyDropdown(opts));
+    trustedClick(registered, getPlatformItem());
+    expect(opts.onPlatform).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Keyboard ───────────────────────────────────────────────────
+
+  it("selects the active item on a trusted Enter", () => {
+    const opts = makeOptions();
+    const registered = captureListeners(() => showPasskeyDropdown(opts));
+    // ArrowDown is navigation only (no guard) — moves active to the first item.
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", cancelable: true }));
+    trustedKeydown(registered, "Enter");
+    expect(opts.onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "entry-1" }));
+  });
+
+  it("does NOT select on a synthetic (untrusted) Enter — blocks scripted ArrowDown+Enter exfiltration", () => {
+    const opts = makeOptions();
+    showPasskeyDropdown(opts);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", cancelable: true }));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", cancelable: true })); // isTrusted=false
+    expect(opts.onSelect).not.toHaveBeenCalled();
+    expect(opts.onPlatform).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/__tests__/content/ui/passkey-save-banner.test.ts
+++ b/extension/src/__tests__/content/ui/passkey-save-banner.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Override navigator.language for consistent i18n
+Object.defineProperty(navigator, "language", { value: "en-US", configurable: true });
+
+// Mock shadow-host so the test can reach the (otherwise closed) shadow root.
+const mockRoot = document.createElement("div");
+vi.mock("../../../content/ui/shadow-host", () => ({
+  getShadowHost: vi.fn(() => ({ host: document.createElement("div"), root: mockRoot })),
+  removeShadowHost: vi.fn(),
+}));
+
+import { showPasskeySaveBanner, hidePasskeySaveBanner } from "../../../content/ui/passkey-save-banner";
+
+// jsdom marks scripted events isTrusted=false (non-configurable), and real
+// dispatch hands the listener the native event. For the POSITIVE (trusted) path
+// we capture the registered listener and invoke it with a Proxy reporting
+// isTrusted=true; the NEGATIVE path uses real dispatch (genuinely untrusted).
+function trusted<E extends Event>(e: E): E {
+  return new Proxy(e, {
+    get(target, prop, receiver) {
+      if (prop === "isTrusted") return true;
+      const val = Reflect.get(target, prop, receiver);
+      return typeof val === "function" ? (val as (...a: unknown[]) => unknown).bind(target) : val;
+    },
+  }) as E;
+}
+
+interface Registered { target: EventTarget; type: string; listener: EventListener }
+function captureListeners(fn: () => void): Registered[] {
+  const registered: Registered[] = [];
+  const original = EventTarget.prototype.addEventListener;
+  EventTarget.prototype.addEventListener = function (type: string, listener: EventListenerOrEventListenerObject | null, opts?: unknown) {
+    if (typeof listener === "function") registered.push({ target: this, type, listener: listener as EventListener });
+    return original.call(this, type, listener as EventListener, opts as boolean);
+  } as typeof EventTarget.prototype.addEventListener;
+  try {
+    fn();
+  } finally {
+    EventTarget.prototype.addEventListener = original;
+  }
+  return registered;
+}
+
+function trustedClick(registered: Registered[], el: EventTarget): void {
+  const reg = registered.find((r) => r.target === el && r.type === "click");
+  if (!reg) throw new Error("no click listener registered on element");
+  reg.listener.call(el, trusted(new MouseEvent("click")));
+}
+
+function makeOptions(overrides?: Partial<Parameters<typeof showPasskeySaveBanner>[0]>) {
+  return {
+    rpName: "Example",
+    userName: "alice",
+    onSave: vi.fn(),
+    onDismiss: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+}
+
+function saveButton(): HTMLButtonElement {
+  const btn = mockRoot.querySelector<HTMLButtonElement>(".psso-btn-primary");
+  if (!btn) throw new Error("save button not rendered");
+  return btn;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  document.body.innerHTML = "";
+  document.body.appendChild(mockRoot);
+  mockRoot.innerHTML = "";
+});
+
+afterEach(() => {
+  hidePasskeySaveBanner();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("passkey-save-banner user-presence gate", () => {
+  it("calls onSave on a trusted save click", () => {
+    const opts = makeOptions();
+    const registered = captureListeners(() => showPasskeySaveBanner(opts));
+    trustedClick(registered, saveButton());
+    expect(opts.onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call onSave on a synthetic (untrusted) save click — blocks scripted credential creation", () => {
+    const opts = makeOptions();
+    showPasskeySaveBanner(opts);
+    saveButton().dispatchEvent(new MouseEvent("click", { bubbles: true })); // isTrusted=false
+    expect(opts.onSave).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/__tests__/webauthn-bridge-lib.test.ts
+++ b/extension/src/__tests__/webauthn-bridge-lib.test.ts
@@ -188,10 +188,14 @@ describe("webauthn-bridge-lib handleWebAuthnMessage", () => {
     );
   });
 
-  it("forwards PASSKEY_SIGN_ASSERTION to chrome.runtime.sendMessage", () => {
-    sendMessageMock.mockImplementation((_msg: unknown, cb: (r: unknown) => void) => {
-      cb({ ok: true });
-    });
+  // ── User-presence gate (SIGN_ASSERTION / CREATE_CREDENTIAL) ───────
+  // The terminal actions must originate from a trusted in-bridge selection,
+  // never directly from a page postMessage. A page script skipping the
+  // dropdown/banner has no approval and is rejected before reaching background.
+
+  it("REJECTS a page-direct PASSKEY_SIGN_ASSERTION with no prior trusted selection", () => {
+    const postedMessages: unknown[] = [];
+    vi.spyOn(window, "postMessage").mockImplementation((data) => { postedMessages.push(data); });
 
     const event = makeEvent({
       data: {
@@ -206,6 +210,49 @@ describe("webauthn-bridge-lib handleWebAuthnMessage", () => {
     });
     handleWebAuthnMessage(event);
 
+    // Background must never be asked to sign.
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(postedMessages).toContainEqual(
+      expect.objectContaining({
+        type: WEBAUTHN_BRIDGE_RESP,
+        requestId: "req-sign",
+        response: { ok: false, error: "USER_PRESENCE_REQUIRED" },
+      }),
+    );
+  });
+
+  it("forwards PASSKEY_SIGN_ASSERTION only after a trusted dropdown selection authorizes that entry", async () => {
+    const { showPasskeyDropdown } = await import("../content/ui/passkey-dropdown");
+    sendMessageMock.mockImplementation((_msg: unknown, cb: (r: unknown) => void) => {
+      cb({ ok: true });
+    });
+
+    // Step 1: SELECT shows the dropdown; simulate the user picking entry-1
+    // (the dropdown only invokes onSelect from a trusted event).
+    handleWebAuthnMessage(makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-select",
+        action: "PASSKEY_SELECT",
+        payload: { entries: [{ id: "entry-1" }], rpId: "example.com" },
+      },
+    }));
+    const dropdownOptions = (showPasskeyDropdown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    dropdownOptions.onSelect({ id: "entry-1" });
+
+    // Step 2: the interceptor now posts SIGN_ASSERTION for the selected entry.
+    handleWebAuthnMessage(makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-sign",
+        action: "PASSKEY_SIGN_ASSERTION",
+        payload: {
+          entryId: "entry-1",
+          clientDataJSON: JSON.stringify({ type: "webauthn.get", challenge: "abc" }),
+        },
+      },
+    }));
+
     expect(sendMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         type: EXT_MSG.PASSKEY_SIGN_ASSERTION,
@@ -215,10 +262,76 @@ describe("webauthn-bridge-lib handleWebAuthnMessage", () => {
     );
   });
 
-  it("forwards PASSKEY_CREATE_CREDENTIAL to chrome.runtime.sendMessage", () => {
-    sendMessageMock.mockImplementation((_msg: unknown, cb: (r: unknown) => void) => {
-      cb({ ok: true });
+  it("REJECTS PASSKEY_SIGN_ASSERTION whose entryId differs from the trusted selection", async () => {
+    const { showPasskeyDropdown } = await import("../content/ui/passkey-dropdown");
+    const postedMessages: unknown[] = [];
+    vi.spyOn(window, "postMessage").mockImplementation((data) => { postedMessages.push(data); });
+
+    handleWebAuthnMessage(makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-select",
+        action: "PASSKEY_SELECT",
+        payload: { entries: [{ id: "entry-1" }], rpId: "example.com" },
+      },
+    }));
+    const dropdownOptions = (showPasskeyDropdown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    dropdownOptions.onSelect({ id: "entry-1" });
+
+    // Page tries to sign a DIFFERENT entry than the user selected.
+    handleWebAuthnMessage(makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-sign",
+        action: "PASSKEY_SIGN_ASSERTION",
+        payload: {
+          entryId: "entry-evil",
+          clientDataJSON: JSON.stringify({ type: "webauthn.get", challenge: "abc" }),
+        },
+      },
+    }));
+
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(postedMessages).toContainEqual(
+      expect.objectContaining({
+        type: WEBAUTHN_BRIDGE_RESP,
+        requestId: "req-sign",
+        response: { ok: false, error: "USER_PRESENCE_REQUIRED" },
+      }),
+    );
+  });
+
+  it("consumes the sign approval once — a replayed PASSKEY_SIGN_ASSERTION is rejected", async () => {
+    const { showPasskeyDropdown } = await import("../content/ui/passkey-dropdown");
+    sendMessageMock.mockImplementation((_msg: unknown, cb: (r: unknown) => void) => { cb({ ok: true }); });
+
+    handleWebAuthnMessage(makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-select",
+        action: "PASSKEY_SELECT",
+        payload: { entries: [{ id: "entry-1" }], rpId: "example.com" },
+      },
+    }));
+    (showPasskeyDropdown as ReturnType<typeof vi.fn>).mock.calls[0][0].onSelect({ id: "entry-1" });
+
+    const signEvent = makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-sign",
+        action: "PASSKEY_SIGN_ASSERTION",
+        payload: { entryId: "entry-1", clientDataJSON: "{}" },
+      },
     });
+    handleWebAuthnMessage(signEvent); // first use — allowed
+    handleWebAuthnMessage(signEvent); // replay — must be rejected
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("REJECTS a page-direct PASSKEY_CREATE_CREDENTIAL with no prior trusted save", () => {
+    const postedMessages: unknown[] = [];
+    vi.spyOn(window, "postMessage").mockImplementation((data) => { postedMessages.push(data); });
 
     const event = makeEvent({
       data: {
@@ -237,6 +350,53 @@ describe("webauthn-bridge-lib handleWebAuthnMessage", () => {
       },
     });
     handleWebAuthnMessage(event);
+
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(postedMessages).toContainEqual(
+      expect.objectContaining({
+        type: WEBAUTHN_BRIDGE_RESP,
+        requestId: "req-create",
+        response: { ok: false, error: "USER_PRESENCE_REQUIRED" },
+      }),
+    );
+  });
+
+  it("forwards PASSKEY_CREATE_CREDENTIAL only after a trusted save-banner press authorizes that rpId", async () => {
+    const { showPasskeySaveBanner } = await import("../content/ui/passkey-save-banner");
+    // First CONFIRM_CREATE → CHECK_DUPLICATE returns entries → banner shown.
+    sendMessageMock.mockImplementationOnce((_msg: unknown, cb: (r: unknown) => void) => {
+      cb({ entries: [] });
+    });
+    handleWebAuthnMessage(makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-confirm",
+        action: "PASSKEY_CONFIRM_CREATE",
+        payload: { rpId: "example.com", rpName: "Example", userName: "alice", userDisplayName: "Alice" },
+      },
+    }));
+    // Simulate the user pressing Save (banner only fires onSave from a trusted event).
+    const bannerOptions = (showPasskeySaveBanner as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    bannerOptions.onSave();
+
+    // Now CREATE_CREDENTIAL for the same rpId is authorized.
+    sendMessageMock.mockImplementation((_msg: unknown, cb: (r: unknown) => void) => { cb({ ok: true }); });
+    handleWebAuthnMessage(makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-create",
+        action: "PASSKEY_CREATE_CREDENTIAL",
+        payload: {
+          rpId: "example.com",
+          rpName: "Example",
+          userId: "user-handle",
+          userName: "alice",
+          userDisplayName: "Alice",
+          excludeCredentialIds: [],
+          clientDataJSON: JSON.stringify({ type: "webauthn.create", challenge: "xyz" }),
+        },
+      },
+    }));
 
     expect(sendMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/extension/src/__tests__/webauthn-bridge-lib.test.ts
+++ b/extension/src/__tests__/webauthn-bridge-lib.test.ts
@@ -372,14 +372,14 @@ describe("webauthn-bridge-lib handleWebAuthnMessage", () => {
         type: WEBAUTHN_BRIDGE_MSG,
         requestId: "req-confirm",
         action: "PASSKEY_CONFIRM_CREATE",
-        payload: { rpId: "example.com", rpName: "Example", userName: "alice", userDisplayName: "Alice" },
+        payload: { rpId: "example.com", rpName: "Example", userId: "user-handle", userName: "alice", userDisplayName: "Alice" },
       },
     }));
     // Simulate the user pressing Save (banner only fires onSave from a trusted event).
     const bannerOptions = (showPasskeySaveBanner as ReturnType<typeof vi.fn>).mock.calls[0][0];
     bannerOptions.onSave();
 
-    // Now CREATE_CREDENTIAL for the same rpId is authorized.
+    // Now CREATE_CREDENTIAL for the same identity (rpId + userId + userName) is authorized.
     sendMessageMock.mockImplementation((_msg: unknown, cb: (r: unknown) => void) => { cb({ ok: true }); });
     handleWebAuthnMessage(makeEvent({
       data: {
@@ -405,6 +405,94 @@ describe("webauthn-bridge-lib handleWebAuthnMessage", () => {
       }),
       expect.any(Function),
     );
+  });
+
+  it("REJECTS PASSKEY_CREATE_CREDENTIAL whose identity differs from the trusted save", async () => {
+    const { showPasskeySaveBanner } = await import("../content/ui/passkey-save-banner");
+    const postedMessages: unknown[] = [];
+    vi.spyOn(window, "postMessage").mockImplementation((data) => { postedMessages.push(data); });
+    sendMessageMock.mockImplementationOnce((_msg: unknown, cb: (r: unknown) => void) => { cb({ entries: [] }); });
+
+    handleWebAuthnMessage(makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-confirm",
+        action: "PASSKEY_CONFIRM_CREATE",
+        payload: { rpId: "example.com", rpName: "Example", userId: "user-handle", userName: "alice", userDisplayName: "Alice" },
+      },
+    }));
+    (showPasskeySaveBanner as ReturnType<typeof vi.fn>).mock.calls[0][0].onSave();
+    // Drop the CONFIRM_CREATE's own CHECK_DUPLICATE call so the assertion below
+    // measures only whether the terminal CREATE_CREDENTIAL reached background.
+    sendMessageMock.mockClear();
+
+    // Page tries to create a credential for a DIFFERENT user than the banner showed.
+    handleWebAuthnMessage(makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-create",
+        action: "PASSKEY_CREATE_CREDENTIAL",
+        payload: {
+          rpId: "example.com",
+          rpName: "Example",
+          userId: "user-evil",
+          userName: "mallory",
+          userDisplayName: "Alice",
+          excludeCredentialIds: [],
+          clientDataJSON: "{}",
+        },
+      },
+    }));
+
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(postedMessages).toContainEqual(
+      expect.objectContaining({
+        type: WEBAUTHN_BRIDGE_RESP,
+        requestId: "req-create",
+        response: { ok: false, error: "USER_PRESENCE_REQUIRED" },
+      }),
+    );
+  });
+
+  it("REJECTS PASSKEY_SIGN_ASSERTION after the approval TTL has elapsed", async () => {
+    const { showPasskeyDropdown } = await import("../content/ui/passkey-dropdown");
+    const postedMessages: unknown[] = [];
+    vi.spyOn(window, "postMessage").mockImplementation((data) => { postedMessages.push(data); });
+
+    // Freeze time so we can advance past the 30s TTL deterministically.
+    const base = 1_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(base);
+
+    handleWebAuthnMessage(makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-select",
+        action: "PASSKEY_SELECT",
+        payload: { entries: [{ id: "entry-1" }], rpId: "example.com" },
+      },
+    }));
+    (showPasskeyDropdown as ReturnType<typeof vi.fn>).mock.calls[0][0].onSelect({ id: "entry-1" });
+
+    // 31s later — past the 30s approval TTL.
+    nowSpy.mockReturnValue(base + 31_000);
+    handleWebAuthnMessage(makeEvent({
+      data: {
+        type: WEBAUTHN_BRIDGE_MSG,
+        requestId: "req-sign",
+        action: "PASSKEY_SIGN_ASSERTION",
+        payload: { entryId: "entry-1", clientDataJSON: "{}" },
+      },
+    }));
+
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(postedMessages).toContainEqual(
+      expect.objectContaining({
+        type: WEBAUTHN_BRIDGE_RESP,
+        requestId: "req-sign",
+        response: { ok: false, error: "USER_PRESENCE_REQUIRED" },
+      }),
+    );
+    nowSpy.mockRestore();
   });
 
   // ── PASSKEY_CONFIRM_CREATE ────────────────────────────────────

--- a/extension/src/content/ui/passkey-dropdown.ts
+++ b/extension/src/content/ui/passkey-dropdown.ts
@@ -97,7 +97,13 @@ export function showPasskeyDropdown(opts: PasskeyDropdownOptions): void {
     item.appendChild(icon);
     item.appendChild(text);
 
-    item.addEventListener("click", () => opts.onSelect(entry));
+    // Selecting a passkey authorizes a credential assertion — only a trusted
+    // (real) click may trigger it. Blocks a page script dispatching a synthetic
+    // click to auto-select without a human gesture (mirrors suggestion-dropdown).
+    item.addEventListener("click", (e) => {
+      if (!e.isTrusted) return;
+      opts.onSelect(entry);
+    });
     dropdown.appendChild(item);
     itemElements.push(item);
   }
@@ -125,7 +131,10 @@ export function showPasskeyDropdown(opts: PasskeyDropdownOptions): void {
 
   platformItem.appendChild(platformIcon);
   platformItem.appendChild(platformText);
-  platformItem.addEventListener("click", () => opts.onPlatform());
+  platformItem.addEventListener("click", (e) => {
+    if (!e.isTrusted) return;
+    opts.onPlatform();
+  });
   dropdown.appendChild(platformItem);
   itemElements.push(platformItem);
 
@@ -154,8 +163,20 @@ export function showPasskeyDropdown(opts: PasskeyDropdownOptions): void {
       activeIndex = Math.max(activeIndex - 1, 0);
       updateActive();
     } else if (e.key === "Enter" && activeIndex >= 0) {
+      // Confirming a passkey authorizes a credential assertion — only a trusted
+      // (real) keypress may trigger it. Invoke the callback directly rather than
+      // synthesizing a click (which the click guards above would reject anyway).
+      if (!e.isTrusted) return;
       e.preventDefault();
-      itemElements[activeIndex].click();
+      const active = itemElements[activeIndex];
+      const entryId = active.getAttribute("data-entry-id");
+      if (entryId) {
+        const entry = opts.entries.find((x) => x.id === entryId);
+        if (entry) opts.onSelect(entry);
+      } else {
+        // The only item without a data-entry-id is the platform authenticator row.
+        opts.onPlatform();
+      }
     }
   };
   document.addEventListener("keydown", keyHandler, true);

--- a/extension/src/content/ui/passkey-save-banner.ts
+++ b/extension/src/content/ui/passkey-save-banner.ts
@@ -66,7 +66,10 @@ export function showPasskeySaveBanner(options: PasskeySaveBannerOptions): void {
       const keepBothBtn = document.createElement("button");
       keepBothBtn.textContent = t("passkeySaveBanner.keepBoth");
       keepBothBtn.className = "psso-btn-primary";
-      keepBothBtn.addEventListener("click", () => {
+      // Saving authorizes a credential creation — only a trusted (real) click
+      // may trigger it (mirrors the passkey dropdown / suggestion dropdown).
+      keepBothBtn.addEventListener("click", (e) => {
+        if (!e.isTrusted) return;
         options.onSave();
         hidePasskeySaveBanner();
       });
@@ -75,7 +78,8 @@ export function showPasskeySaveBanner(options: PasskeySaveBannerOptions): void {
       const replaceBtn = document.createElement("button");
       replaceBtn.textContent = t("passkeySaveBanner.replace");
       replaceBtn.className = "psso-btn-secondary";
-      replaceBtn.addEventListener("click", () => {
+      replaceBtn.addEventListener("click", (e) => {
+        if (!e.isTrusted) return;
         options.onSave(existing[0].id);
         hidePasskeySaveBanner();
       });
@@ -85,7 +89,8 @@ export function showPasskeySaveBanner(options: PasskeySaveBannerOptions): void {
       const addNewBtn = document.createElement("button");
       addNewBtn.textContent = t("passkeySaveBanner.addNew");
       addNewBtn.className = "psso-btn-primary";
-      addNewBtn.addEventListener("click", () => {
+      addNewBtn.addEventListener("click", (e) => {
+        if (!e.isTrusted) return;
         options.onSave();
         hidePasskeySaveBanner();
       });
@@ -95,7 +100,8 @@ export function showPasskeySaveBanner(options: PasskeySaveBannerOptions): void {
     const saveBtn = document.createElement("button");
     saveBtn.textContent = t("passkeySaveBanner.save");
     saveBtn.className = "psso-btn-primary";
-    saveBtn.addEventListener("click", () => {
+    saveBtn.addEventListener("click", (e) => {
+      if (!e.isTrusted) return;
       options.onSave();
       hidePasskeySaveBanner();
     });

--- a/extension/src/content/webauthn-bridge-lib.ts
+++ b/extension/src/content/webauthn-bridge-lib.ts
@@ -4,6 +4,7 @@
 // Typed version for testing; entry point in webauthn-bridge.ts.
 
 import { WEBAUTHN_BRIDGE_MSG, WEBAUTHN_BRIDGE_RESP, PASSKEY_BRIDGE_ACTION, EXT_MSG } from "../lib/constants";
+import { MS_PER_SECOND } from "../lib/time";
 import type { PasskeyMatchEntry } from "../types/messages";
 import { showPasskeyDropdown, hidePasskeyDropdown } from "./ui/passkey-dropdown";
 import { showPasskeySaveBanner } from "./ui/passkey-save-banner";
@@ -20,11 +21,23 @@ import { showPasskeySaveBanner } from "./ui/passkey-save-banner";
 // and the entry's rpId are bound to the sender tab URL). This gate closes the
 // remaining same-origin gap: a page script (e.g. via stored XSS) skipping the
 // dropdown to mint an assertion with no human gesture.
+// Approvals are single-use AND short-lived. The TTL is a defense-in-depth
+// backstop: in the normal flow the terminal action arrives immediately after
+// the trusted selection, but if the MAIN-world interceptor goes silent after
+// SELECT/CONFIRM_CREATE, an unconsumed approval must not linger indefinitely.
+const APPROVAL_TTL_MS = 30 * MS_PER_SECOND;
 interface SignApproval {
   entryId: string;
+  expiresAt: number;
 }
+// Bind the create approval to the full identity shown in the save banner
+// (rpId + userId + userName) so the credential actually created matches what
+// the user consented to, not merely the same rpId.
 interface CreateApproval {
   rpId: string;
+  userId: string;
+  userName: string;
+  expiresAt: number;
 }
 let pendingSignApproval: SignApproval | null = null;
 let pendingCreateApproval: CreateApproval | null = null;
@@ -101,7 +114,7 @@ function handleSelect(
       hidePasskeyDropdown();
       // Authorize the subsequent SIGN_ASSERTION for exactly this entry.
       // The dropdown only invokes onSelect from a trusted (isTrusted) event.
-      pendingSignApproval = { entryId: entry.id };
+      pendingSignApproval = { entryId: entry.id, expiresAt: Date.now() + APPROVAL_TTL_MS };
       respond(requestId, { action: "select", entry });
     },
     onPlatform: () => {
@@ -124,7 +137,7 @@ function handleSignAssertion(
   // has no approval and is rejected here, before reaching the background.
   const approval = pendingSignApproval;
   pendingSignApproval = null; // single-use
-  if (!approval || approval.entryId !== payload.entryId) {
+  if (!approval || approval.entryId !== payload.entryId || approval.expiresAt < Date.now()) {
     respond(requestId, { ok: false, error: "USER_PRESENCE_REQUIRED" });
     return;
   }
@@ -159,9 +172,14 @@ function handleConfirmCreate(
       userName: payload.userName,
       existingEntries,
       onSave: (replaceEntryId?: string) => {
-        // Authorize the subsequent CREATE_CREDENTIAL for this rpId. The save
-        // banner only invokes onSave from a trusted (isTrusted) press.
-        pendingCreateApproval = { rpId: payload.rpId };
+        // Authorize the subsequent CREATE_CREDENTIAL for this exact identity.
+        // The save banner only invokes onSave from a trusted (isTrusted) press.
+        pendingCreateApproval = {
+          rpId: payload.rpId,
+          userId: payload.userId ?? "",
+          userName: payload.userName,
+          expiresAt: Date.now() + APPROVAL_TTL_MS,
+        };
         respond(requestId, { action: "save", replaceEntryId });
       },
       onDismiss: () => {
@@ -214,7 +232,13 @@ function handleCreateCredential(
   // Fail closed unless a trusted save-banner press authorized this rpId.
   const approval = pendingCreateApproval;
   pendingCreateApproval = null; // single-use
-  if (!approval || approval.rpId !== payload.rpId) {
+  if (
+    !approval ||
+    approval.rpId !== payload.rpId ||
+    approval.userId !== payload.userId ||
+    approval.userName !== payload.userName ||
+    approval.expiresAt < Date.now()
+  ) {
     respond(requestId, { ok: false, error: "USER_PRESENCE_REQUIRED" });
     return;
   }

--- a/extension/src/content/webauthn-bridge-lib.ts
+++ b/extension/src/content/webauthn-bridge-lib.ts
@@ -8,6 +8,27 @@ import type { PasskeyMatchEntry } from "../types/messages";
 import { showPasskeyDropdown, hidePasskeyDropdown } from "./ui/passkey-dropdown";
 import { showPasskeySaveBanner } from "./ui/passkey-save-banner";
 
+// User-presence gate: the terminal SIGN_ASSERTION / CREATE_CREDENTIAL actions
+// must originate from a trusted in-bridge selection (a real dropdown click or
+// save-banner press), NOT directly from a page postMessage. WebAuthn's
+// user-presence guarantee is otherwise only enforced by convention in the
+// MAIN-world interceptor, which page JS can bypass by posting the terminal
+// action itself. We record a one-time authorization here on the trusted
+// selection and require the terminal action to match it.
+//
+// Cross-origin theft is already blocked in the background (clientDataJSON.origin
+// and the entry's rpId are bound to the sender tab URL). This gate closes the
+// remaining same-origin gap: a page script (e.g. via stored XSS) skipping the
+// dropdown to mint an assertion with no human gesture.
+interface SignApproval {
+  entryId: string;
+}
+interface CreateApproval {
+  rpId: string;
+}
+let pendingSignApproval: SignApproval | null = null;
+let pendingCreateApproval: CreateApproval | null = null;
+
 function isContextValid(): boolean {
   try {
     return !!chrome.runtime && !!chrome.runtime.id;
@@ -65,6 +86,9 @@ function handleSelect(
   requestId: string,
   payload: { entries: PasskeyMatchEntry[]; rpId: string },
 ): void {
+  // A new selection round invalidates any prior unconsumed approval.
+  pendingSignApproval = null;
+
   if (!payload.entries || payload.entries.length === 0) {
     respond(requestId, { action: "platform" });
     return;
@@ -75,6 +99,9 @@ function handleSelect(
     rpId: payload.rpId,
     onSelect: (entry) => {
       hidePasskeyDropdown();
+      // Authorize the subsequent SIGN_ASSERTION for exactly this entry.
+      // The dropdown only invokes onSelect from a trusted (isTrusted) event.
+      pendingSignApproval = { entryId: entry.id };
       respond(requestId, { action: "select", entry });
     },
     onPlatform: () => {
@@ -92,6 +119,16 @@ function handleSignAssertion(
   requestId: string,
   payload: { entryId: string; clientDataJSON: string; teamId?: string },
 ): void {
+  // Fail closed unless a trusted selection authorized exactly this entry.
+  // A page script that skips the dropdown and posts SIGN_ASSERTION directly
+  // has no approval and is rejected here, before reaching the background.
+  const approval = pendingSignApproval;
+  pendingSignApproval = null; // single-use
+  if (!approval || approval.entryId !== payload.entryId) {
+    respond(requestId, { ok: false, error: "USER_PRESENCE_REQUIRED" });
+    return;
+  }
+
   chrome.runtime.sendMessage(
     {
       type: EXT_MSG.PASSKEY_SIGN_ASSERTION,
@@ -110,6 +147,9 @@ function handleConfirmCreate(
   requestId: string,
   payload: { rpId: string; rpName: string; userName: string; userDisplayName: string; userId?: string },
 ): void {
+  // A new create round invalidates any prior unconsumed approval.
+  pendingCreateApproval = null;
+
   let resolved = false;
   const show = (existingEntries: PasskeyMatchEntry[]) => {
     if (resolved) return;
@@ -119,6 +159,9 @@ function handleConfirmCreate(
       userName: payload.userName,
       existingEntries,
       onSave: (replaceEntryId?: string) => {
+        // Authorize the subsequent CREATE_CREDENTIAL for this rpId. The save
+        // banner only invokes onSave from a trusted (isTrusted) press.
+        pendingCreateApproval = { rpId: payload.rpId };
         respond(requestId, { action: "save", replaceEntryId });
       },
       onDismiss: () => {
@@ -168,6 +211,14 @@ function handleCreateCredential(
     replaceEntryId?: string;
   },
 ): void {
+  // Fail closed unless a trusted save-banner press authorized this rpId.
+  const approval = pendingCreateApproval;
+  pendingCreateApproval = null; // single-use
+  if (!approval || approval.rpId !== payload.rpId) {
+    respond(requestId, { ok: false, error: "USER_PRESENCE_REQUIRED" });
+    return;
+  }
+
   chrome.runtime.sendMessage(
     {
       type: EXT_MSG.PASSKEY_CREATE_CREDENTIAL,


### PR DESCRIPTION
## Summary

Closes a same-origin user-presence gap in the browser-extension WebAuthn bridge. The ISOLATED-world bridge accepted the terminal `SIGN_ASSERTION` / `CREATE_CREDENTIAL` actions directly from page `postMessage`, so same-origin page script — e.g. via stored XSS on the relying party, or a malicious RP itself — could mint a passkey assertion or create a credential with **no human gesture**, defeating WebAuthn's user-presence guarantee for that origin.

Cross-origin theft was already blocked: the background binds `clientDataJSON.origin` and the entry's `rpId` to the sender tab URL (`isSenderAuthorizedForRpId` / `validateClientDataJSON`), so `evil.com` cannot sign for another origin's passkey. This change closes the remaining **same-origin** gap. Severity: Major (no cross-origin bypass, no key exposure).

This is pre-existing code (not introduced by the recent favicon / no-store / step-up PRs); it is tracked and fixed here as a security hardening follow-up.

## What changed

Make user presence **structural**, not conventional:

- `webauthn-bridge-lib.ts` — the bridge records a **single-use approval** set only inside the trusted in-bridge dropdown `onSelect` / save-banner `onSave` callback, and rejects (`USER_PRESENCE_REQUIRED`) any terminal action that does not match. A page posting the terminal action directly — or replaying it, or substituting a different entry — never reaches the background. The approval additionally carries:
  - a short **TTL** (30s, well under the interceptor's 120s timeout) so an unconsumed approval cannot linger if the MAIN-world interceptor goes silent;
  - for create, the **full consented identity** (`rpId` + `userId` + `userName`) shown in the save banner, so the credential actually created matches what the user saw — not merely the same `rpId` (consent integrity).
- `passkey-dropdown.ts` — add `isTrusted` guards to the item/platform click and Enter handlers (mirroring `suggestion-dropdown.ts`). Enter now invokes the callback directly instead of synthesizing a click.
- `passkey-save-banner.ts` — mirror the `isTrusted` guard onto the credential-authorizing buttons (Save / Keep-both / Replace / Add-new). Non-disclosing paths (cancel / dismiss / Escape / overlay) are left unguarded by design.

The MAIN-world interceptor (`webauthn-interceptor.js`) is unchanged; the legitimate `get()` / `create()` flow still works end-to-end.

## Tests

- Invert the bridge "forwards terminal action" tests to assert page-direct `SIGN_ASSERTION` / `CREATE_CREDENTIAL` are **rejected**, not forwarded.
- Positive trusted-flow coverage; single-use replay rejection; entry/identity-mismatch rejection; TTL-expiry rejection.
- New `passkey-dropdown.test.ts` and `passkey-save-banner.test.ts` prove synthetic (untrusted) clicks/Enter do not select or authorize.
- Every new guard was verified able to go **red** by reverting it.

## Verification

- Extension suite: 784 tests pass; `tsc && vite build` clean.
- `scripts/pre-pr.sh`: all 38 checks pass.
- Manual: verified the live passkey get/create flow on webauthn.io — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)