### PR TITLE
feat(ios): demo mode for App Store review (read-only, isolated)

### DIFF
--- a/docs/archive/review/ios-demo-mode-code-review.md
+++ b/docs/archive/review/ios-demo-mode-code-review.md
@@ -1,0 +1,57 @@
+# Code Review: ios-demo-mode
+Date: 2026-06-26
+Review round: 1 (all findings resolved)
+
+## Changes from Previous Round
+Initial code review of the Phase 2 implementation (commit c7ddf9ba).
+
+## Functionality Findings
+- **[F1] Minor** — Grep-gate tests pass vacuously if the source file is unreadable (`guard let source = try? ... else { return }`). Same root as T1 below; resolved by T1's fix.
+- **[F2] Minor** — `testDemoPresentationFlags_allFalse` asserts the value type but not that `DemoVaultView` consumes the flags. Wiring verified correct in source (`DemoVaultView` reads `presentation.showsFavicons`/`exitLabel`, no parallel hardcoded copy). No snapshot harness exists to assert rendered output (RT2). Accepted: the now-non-vacuous grep gate (T1 fixed) proves `DemoVaultView` constructs no `FaviconLoader`, which structurally backs `showsFavicons=false`. Documented, not separately fixed.
+- All 6 functionality focus areas verified PASS: read-only seam preserves live behavior (live call sites pass all 3 deps explicitly), `.onChange(of: autoLockService?.state)` correct for nil/non-nil, edit sheet appears in live only, DemoVaultView renders 9 entries via shared `categoryCounts`/`VaultCategory`, `try? makeDemoVault()` acceptable (throws only on deterministic fixture errors), checklist fully covered.
+
+## Security Findings
+- **No findings.** NFR1 (isolation) and NFR2 (no network) hold structurally: `DemoVaultFactory` writes nothing; `DemoVaultView` holds no apiClient/hostSyncService/autoLockService/FaviconLoader. Favicon path dead (showFavicons=false → EntryIconView builds no FaviconImageView). No QuickType seeding (CredentialIdentityRegistrar only on live `.vaultUnlocked`). NFR3 sample data all fake (RFC 2606 domains, published TOTP seed, placeholder SSH key, fake passkey credentialId). `docs/assets/passwd-sso.json` not in any Copy-Resources phase. `AppSettingsStore().clipboardClearSeconds` read in the reused detail copy path is a fail-closed READ, not a write — no contamination (accepted, plan §C3 F8/S8). No PII in diff/plan (RS4). Demo exit never calls `DebugVaultLoader.reset()` (R31).
+
+## Testing Findings
+- **[T1] Critical (RESOLVED)** — The three source-reading gate tests (`testForbiddenPatternsAbsent_inDemoVaultFactory`, `…_inDemoVaultView`, `testSampleDataUsesReservedDomainsOnly`) passed VACUOUSLY under Swift 6. Empirically verified: `swiftc -swift-version 6` makes `#file` the concise `<module>/<basename>` form (not absolute), so `URL(fileURLWithPath: #file)` + two `deletingLastPathComponent()` resolved to a non-existent path; `try? ... else { return }` swallowed the failed read and the test passed with ZERO assertions. The isolation grep gates — the plan's central falsifiable NFR1 proof — were decorative. Fix: switch to `#filePath` (always absolute) + non-swallowing `try String(contentsOf:)`, mirroring the codebase's own `LocalizationCatalogTests` idiom; added a `matches.count > 0` guard to the domain test. **Prove-red executed**: injecting `FaviconLoader` into `DemoVaultFactory.swift` now makes the gate FAIL (`** TEST FAILED **`), reverted clean. The gate is now genuinely falsifiable.
+- **[T2] Minor (accepted)** — Second LOGIN fixture (GitHub, non-TOTP) has no dedicated detail assertion; covered transitively by `count==9`. Per-type matrix otherwise complete. Not worth a dedicated test.
+- **[T7] Major (RESOLVED)** — The promised manual-test artifact `ios-demo-mode-manual-test.md` (R35 Tier-1 UI surface) was missing — the only runtime verification of the NFR1 residue invariant against a REAL shared container. Created `docs/archive/review/ios-demo-mode-manual-test.md` with Pre-conditions / Steps (discoverability + iPad-compat render + all-8-type browse + TOTP + the cache-mtime/favicon-dir/QuickType-count residue check) / Expected / Rollback.
+- RT1 confirmed: C1 tests drive the REAL decrypt path (`loadFromCache`/`loadDetail`), not the bare plaintext decoder — AAD/key/userId drift would be caught.
+
+## Adjacent Findings
+- F1 (functionality) ↔ T1 (testing): same root cause (#file + swallowed read). Routed to testing, fixed once.
+
+## Quality Warnings
+None.
+
+## Recurring Issue Check
+### Functionality expert
+R3 (gate propagation): PASS — showFavicons:false reaches EntryIconView in detail + search-row + category-row. R25/R39 (residue/ephemeral key): PASS — ARC-freed, no disk/Keychain write. R41 (capability backing): PARTIAL → F2 (flags drive the view in source; test gap accepted, grep gate backs it). Others N/A.
+
+### Security expert
+R31 (destructive on exit): PASS — no DebugVaultLoader.reset(). R39 (zeroization): PASS. RS4 (PII): PASS. RS1-RS3/RS5: N/A (no credential compare, no routes, no external crypto params). Others N/A.
+
+### Testing expert
+RT1: PASS (real decrypt path). RT2: PASS (DemoVaultView left to predicate + grep, no untestable snapshot demanded). RT6: PARTIAL → resolved via T1 (grep gate now real) + accepted F2. RT7: was FAIL (T1) → now PASS, prove-red executed. RT4: N/A.
+
+## Environment Verification Report
+Per the plan's Phase-1 `Verification environment constraints`:
+- **VEC1 (iPad-compat render)**: `verified-local` pending — the manual-test artifact (now present) step A covers it; to be executed by operator on an iPad simulator. Recorded in `ios-demo-mode-manual-test.md`.
+- **VEC2 (real App Store review outcome)**: `blocked-deferred` — predicted in Phase 1; only re-submission confirms. Anti-Deferral justification recorded in the plan.
+- **VEC3 (QuickType positive path)**: `blocked-deferred` — simulator cannot select a third-party AutoFill provider. The NEGATIVE invariant (demo registers no identities) is `verified-local` via the now-non-vacuous grep gate + manual residue step 8.
+
+## Resolution Status
+### T1 Critical — vacuous grep gates under Swift 6
+- Action: `#file` → `#filePath`; `try? … else { return }` → `try String(contentsOf:)`; added `matches.count > 0` guard. Prove-red executed (gate fails on injected `FaviconLoader`, reverted).
+- Modified: ios/PasswdSSOTests/DemoModeStateTests.swift:57-99, ios/PasswdSSOTests/DemoVaultFactoryTests.swift:182-203
+
+### T7 Major — missing manual-test artifact
+- Action: created the R35 Tier-1 manual test plan.
+- Modified: docs/archive/review/ios-demo-mode-manual-test.md (new)
+
+### F1 Minor — folded into T1.
+### F2 Minor — accepted (grep gate backs the favicon-severance; no snapshot harness for view-consumes-flag).
+### T2 Minor — accepted (non-TOTP login covered transitively).
+
+All Critical/Major resolved. Full suite: 631 tests pass.

--- a/docs/archive/review/ios-demo-mode-code-review.md
+++ b/docs/archive/review/ios-demo-mode-code-review.md
@@ -1,6 +1,15 @@
 # Code Review: ios-demo-mode
 Date: 2026-06-26
-Review round: 1 (all findings resolved)
+Review rounds: 2 (all findings resolved)
+
+## Round 2 (incremental verification)
+Reviewed the Round-1 fix commit (4eec0a42). **No findings.** Verified: all three
+source-reading gate tests switched to `#filePath` + non-swallowing `try` (no
+remaining `#file`/`try?`-swallow in the test dir); no sibling bug-class
+recurrence (the only other source-reading gate, `LocalizationCatalogTests`, was
+already correct); the manual-test artifact is present and complete with the NFR1
+residue check; prove-red capability confirmed (path resolves to real files, the
+`source.contains` assertion can now fail). Review loop terminates.
 
 ## Changes from Previous Round
 Initial code review of the Phase 2 implementation (commit c7ddf9ba).

--- a/docs/archive/review/ios-demo-mode-manual-test.md
+++ b/docs/archive/review/ios-demo-mode-manual-test.md
@@ -1,0 +1,83 @@
+# Manual Test Plan: iOS Demo Mode (R35 Tier-1 — UI surface)
+
+Covers the paths automated tests cannot exercise (per the plan's two-filter rule):
+the on-device UI walkthrough, the iPad-compatibility render (VEC1), and the NFR1
+runtime residue invariant against a REAL shared App Group container (the unit
+grep gate proves the demo *source* references no shared-state symbol; only this
+manual check proves the running app leaves a real user's vault untouched).
+
+Automated coverage already verifies (excluded here per Filter A): the 9-entry
+decrypt, per-type detail decode, TOTP secret, NFR3 reserved domains, ephemeral
+key, and the source-level forbidden-symbol grep gate (`DemoVaultFactoryTests`,
+`DemoModeStateTests`).
+
+## Pre-conditions
+- A simulator or device with the app installed from this branch.
+- For the residue check (steps 6-8): a SECOND, real (non-demo) vault already set
+  up and synced on the same simulator/device — sign in to the demo server
+  (`https://www.jpng.jp/passwd-sso`) with the review account, unlock the vault so
+  the shared cache file + QuickType identities exist, then sign out to `.setup`.
+  (Operator-supplied credentials — substitute locally; do not commit.)
+
+## Steps & Expected results
+
+### A. Discoverability + render (VEC1 — run on an iPad simulator in iPhone-compat mode)
+1. Cold-launch the app → lands on the server-URL screen (`.setup`).
+   - **Expected**: a "Try Demo Mode" button is visible without entering a URL.
+2. Tap "Try Demo Mode".
+   - **Expected**: the demo vault opens; a "Demo Mode" chip is visible; the
+     category grid shows "All" + one card per present type (Logins, Credit Cards,
+     Identities, Passkeys, Secure Notes, Bank Accounts, Software Licenses, SSH Keys).
+3. (iPad) Confirm the layout renders correctly in iPhone-compatibility (scaled)
+   mode — no clipped/blank screen.
+   - **Expected**: usable layout; the grid and rows render.
+
+### B. Browse all 8 types + TOTP (FR2)
+4. Open one entry of EACH type and confirm type-correct fields:
+   - Logins → "AWS Console (IAM)": username, password (reveal), URL, One-Time Code.
+   - Credit Cards → "Corporate VISA": brand/number/expiry/CVV.
+   - Identities → "Alice Identity": full name / contact fields.
+   - Passkeys → "GitHub Passkey": relying party.
+   - Secure Notes → "VPN Recovery Notes": note content.
+   - Bank Accounts → "Acme Savings": bank/account fields.
+   - Software Licenses → "Adobe License": license key.
+   - SSH Keys → "Deploy Key": public key + fingerprint.
+   - **Expected**: each shows its own field set (NOT a login layout); no "Edit"
+     button (read-only); no decrypt error.
+5. On "AWS Console (IAM)", tap the One-Time Code copy and confirm a rotating
+   6-digit code displays; search "ssh" and confirm "Deploy Key" appears.
+   - **Expected**: TOTP code renders/copies; search filters live.
+
+### C. Exit + NFR1 residue (the invariant only this plan can verify at runtime)
+6. Before entering demo (or from the real-vault baseline in Pre-conditions),
+   record: (a) the shared cache file mtime + size, (b) the favicon cache dir
+   state, (c) the OS QuickType identity count. On a simulator:
+   - cache: `~/Library/Developer/CoreSimulator/Devices/<UDID>/data/Containers/Shared/AppGroup/<group-UDID>/vault/encryptedEntries.cache`
+   - favicon dir: `…/vault/favicon-cache/`
+   - QuickType: Settings → Passwords → AutoFill (or `ASCredentialIdentityStore` count via a debug build).
+   - **Destructive — operator-only**: none; this step is read-only inspection.
+7. Enter demo, browse several entries (steps 2-5), then tap "Exit Demo".
+   - **Expected**: returns to the server-URL screen (`.setup`).
+8. Re-inspect the three values from step 6.
+   - **Expected (NFR1)**: cache file mtime + size UNCHANGED; favicon-cache dir
+     UNCHANGED (no new demo-host favicons); QuickType identity count UNCHANGED
+     (demo entries did NOT register as OS suggestions).
+9. Sign back into the real vault.
+   - **Expected**: the real vault unlocks unchanged; entry count + settings
+     (auto-lock, language, favicon opt-in) unchanged.
+
+## Rollback
+No persistent changes are made by demo. If any residue is observed in step 8,
+that is a NFR1 failure — file a bug; no rollback needed (the demo wrote nothing
+it can roll back). To clear an unrelated dirty simulator state, erase the
+simulator (`xcrun simctl erase <UDID>`) — operator-only, destroys all sim data.
+
+## Notes
+- VEC2 (real App Store review acceptance): blocked-deferred — verifiable only by
+  re-submission. See plan §Verification environment constraints.
+- VEC3 (QuickType positive path): blocked-deferred — simulator Settings cannot
+  select a third-party AutoFill provider. The negative invariant (demo registers
+  NO identities) is covered by step 8 + the source grep gate.
+
+## Execution record
+_Append actual results inline after running (date / device / pass-fail per step)._

--- a/docs/archive/review/ios-demo-mode-plan.md
+++ b/docs/archive/review/ios-demo-mode-plan.md
@@ -1,0 +1,159 @@
+# Plan: iOS Demo Mode (App Store Guideline 2.1 remediation)
+
+> Round 2 (post plan-review). Core change: demo no longer reuses the live
+> `VaultListView`; it renders a **dedicated `DemoVaultView`** that wires only the
+> pure rendering subviews over an in-memory cache. This makes NFR1 (no
+> shared-state writes) a **structural** property — the demo view has no
+> `apiClient`/`hostSyncService`/`FaviconLoader`/Settings code path to gate — rather
+> than a "remembered to guard every site" property. Resolves F1, S1, S2, S3, T4, T5.
+
+## Project context
+
+- **Type**: mixed — iOS SwiftUI app (host + AutoFill extension) in a monorepo that also holds the Next.js web/server. This plan touches **only** the iOS host app target.
+- **Test infrastructure**: pure XCTest under `ios/PasswdSSOTests` (no Swift Testing, no snapshot library, empty `PasswdSSOUITests` target), runnable via `xcodebuild test -scheme PasswdSSOApp -destination 'id=<sim udid>'` (~526 tests). Established isolation idiom: **inject a temp dir / `MockKeychainAccessor`** — tests never touch the real App Group container (confirmed: zero tests reference `AppGroupContainer.cacheFileURL()`).
+- **Verification environment constraints**:
+  - **VEC1 — App Store reviewer device**: review happens on iPad Air (M3) despite `TARGETED_DEVICE_FAMILY=1` (iPhone-only). Demo Mode UI must render correctly in iPhone-compatibility (scaled) mode. Classify: `verifiable-local` (run the iPhone scheme on an iPad simulator).
+  - **VEC2 — Real App Store review outcome**: cannot be verified locally; only re-submission confirms. Classify: `blocked-deferred`. Anti-Deferral: worst case = second 2.1 rejection (cost: ~24-48h review cycle); likelihood = low (Apple explicitly recommends demo mode); cost to fully de-risk locally = impossible (no reviewer access). Mitigation: maximize feature visibility + reviewer note.
+  - **VEC3 — AutoFill QuickType interaction**: cannot exercise the *positive* path on a simulator (third-party AutoFill provider is unselectable in simulator Settings — memory `ios-autofill-host-entitlement`). Classify: `blocked-deferred` for the positive path. The *negative* invariant this plan needs (demo MUST NOT register QuickType identities) is `verifiable-local` — `DemoVaultView` structurally contains no `CredentialIdentityRegistrar` reference (grep gate, C2).
+
+## Objective
+
+Add a user-facing **Demo Mode** to the iOS host app so an App Store reviewer (or any prospective user) can explore the vault UI with realistic sample data **without** a server, account, OAuth sign-in, or master passphrase. Remediates the Guideline 2.1 rejection (reviewer could not sign in via SSO).
+
+## Requirements
+
+### Functional
+- FR1: The sign-in screen (and the first-launch server-URL screen) shows a persistent **"Try Demo Mode"** affordance. Tapping it enters a demo vault populated with bundled sample data, with **zero** network calls and **zero** credentials.
+- FR2: The demo vault shows all 8 entry types (login×2, credit card, identity, passkey, secure note, bank account, software license, SSH key), each **correctly classified** (browsable in the category grid + entry list + search), each opening a **type-correct** detail (card fields for cards, public key/fingerprint for SSH, etc.). TOTP code display/copy works for entries carrying a TOTP secret.
+- FR3: An **"Exit Demo"** affordance returns to the sign-in/setup screen and leaves **no** residual demo state anywhere the real app or AutoFill extension can observe it.
+- FR4: Demo Mode is reachable and renders on the App-Store-review device (iPad-compatibility rendering of the iPhone-only app).
+
+### Non-functional
+- NFR1 (**isolation, paramount — now structural**): Demo Mode MUST NOT write to, and `DemoVaultView` MUST NOT even *reference*, the shared App Group cache file (`AppGroupContainer.cacheFileURL()` / `writeCacheFile`), the shared Keychain bridge key (`BridgeKeyStore`), the shared wrapped-key store (`AppGroupWrappedKeyStore` / `saveVaultKey`), the host token store (`HostTokenStore`), the favicon cache + fetch (`FaviconLoader`), the OS QuickType store (`CredentialIdentityRegistrar`), or `HostSyncService` (`runSync`). A real user with a real vault and/or the AutoFill extension enabled must see no change to data, suggestions, or settings from anyone using Demo Mode.
+- NFR2: Demo Mode MUST make **no** network request. (Structurally guaranteed: `DemoVaultView` holds no `apiClient`.)
+- NFR3: Sample data is bundled in code (no download). Sample secrets are obviously fake — usernames use RFC 2606 reserved domains (`example.com`/`.org`/`.net`); the only "working" secret is the universally-published TOTP test seed `JBSWY3DPEHPK3PXP` (intentional, so TOTP display demos correctly). The Bitwarden-compat export `docs/assets/passwd-sso.json` is **not** consumed at runtime and **not** added to the app bundle's Copy-Resources phase.
+
+## Technical approach
+
+### Why a dedicated DemoVaultView, not a reused VaultListView
+
+The live `VaultListView` (~400 lines) unconditionally wires server/shared-state collaborators that demo must never touch:
+- `let apiClient: MobileAPIClient`, `let hostSyncService: HostSyncService`, `let autoLockService: AutoLockService` — all non-optional (VaultListView.swift:19-24).
+- `sync()` → `hostSyncService.runSync` writes the **shared** cache file + hits the network; triggered by the "Sync now" menu, **both** `.refreshable` blocks (VaultListView.swift:323,356), and `onChange(of: scenePhase == .active)` (VaultListView.swift:120-125).
+- `onAppear` → `FaviconLoader.configure(apiClient:serverURL:)` + `resolveShowFavicons()` reading the **shared** `AppSettingsStore().fetchFaviconsCached`; favicon rows fetch over the network and cache to the **shared** `<AppGroup>/vault/favicon-cache/` (FaviconLoader.swift:117-129).
+- A toolbar menu exposing **Settings** (writes the shared app-group `UserDefaults`), **Lock**, and **Sign Out** (autoLockService).
+- `createEntry`/`saveEntry`/delete → `apiClient` + `runSync` + `refreshCredentialIdentities` (QuickType).
+
+Gating ~10+ sites with `mode == .live` leaves NFR1/NFR2 as a "no missed guard" property — one slip writes a real user's encrypted vault. Instead, **`DemoVaultView` reuses only the pure rendering subviews** (the category grid, the entry-summary list, and the entry detail) over an in-memory `CacheData`, decrypting via the existing `VaultViewModel.loadFromCache`/`loadDetail` (which read **only** the in-memory `cacheData` value — confirmed VaultViewModel.swift:98-101 — never the file, never the network). `DemoVaultView` holds **no** `apiClient`, `hostSyncService`, `autoLockService`, or `FaviconLoader`; those code paths do not exist in it, so the isolation invariant is structural and grep-provable.
+
+### Data injection (extends the DebugVaultLoader pattern, in-memory + production)
+
+`DebugVaultLoader` (`#if DEBUG`) proves the core: synthetic vault `SymmetricKey` → build server-shaped `OverviewBlobPayload`/`FullBlobPayload` blobs → `encryptAESGCMEncoded` with `buildPersonalEntryAAD(userId:, entryId:, vaultType:)` → assemble `CacheData`. **But** `DebugVaultLoader` also writes the shared cache file + bridge key + wrapped key (it is a DEBUG fixture, not isolation-safe) — `DemoVaultFactory` must NOT copy those write steps.
+
+The export JSON (`docs/assets/passwd-sso.json`) is the **Bitwarden-compat import format, NOT the decoder's blob shape**; demo entries are authored as `EntryBlobDecoder`-shaped fixtures in code, one per type, **in lockstep with the per-type shapes already pinned in `EntryBlobGoldenPayloadTests.swift`** (single source of blob-shape truth — T6).
+
+`DemoVaultFactory.makeDemoVault()` (production, `Shared` target) returns an in-memory `CacheData` + ephemeral `SymmetricKey` **as values**; it writes nothing to disk/Keychain/UserDefaults/network. Each fixture `CacheEntry` sets `entryType` to its type string (`"LOGIN"`/`"CREDIT_CARD"`/`"IDENTITY"`/`"BANK_ACCOUNT"`/`"SSH_KEY"`/`"SOFTWARE_LICENSE"`/`"PASSKEY"`/`"SECURE_NOTE"`) — without this every entry classifies as a login (F2).
+
+### State machine wiring (RootView)
+
+New terminal case `AppState.demo(demo: DemoVault)`. RootView renders `DemoVaultView(demo:onExit:)`. Entry: a "Try Demo Mode" closure in `SignInView`/`ServerURLSetupView` sets `appState = .demo(DemoVaultFactory.makeDemoVault())`. Exit: `DemoVaultView`'s "Exit Demo" → `appState = .setup`, dropping the in-memory cache (ARC frees the key). Entering `.demo` runs no `SessionRestorer`/`VaultUnlocker`/`AutofillTokenRefresher`/`onVaultReady`; exiting runs no token/cache cleanup (there is none) and never calls `CredentialIdentityRegistrar`.
+
+## Contracts
+
+### C1 — `DemoVaultFactory.makeDemoVault()`
+- **Signature**: `enum DemoVaultFactory { public static func makeDemoVault() -> DemoVault }` where `public struct DemoVault: Sendable { public let cacheData: CacheData; public let vaultKey: SymmetricKey; public let userId: String }`
+- **Invariants**:
+  - **app-enforced**: returns a `CacheData` whose `entries` decode to exactly 9 `CacheEntry` records (8 types; login×2); `header.entryCount == 9`; `header.userId == userId`.
+  - **app-enforced**: every fixture `CacheEntry` sets `entryType` to its type string, so `EntryTypeCategory.from(rawType:)` classifies each correctly and `EntryBlobDecoder.detail` builds the type-specific sub-struct (F2).
+  - **app-enforced**: every blob is encrypted under the returned `vaultKey` with `buildPersonalEntryAAD(userId:, entryId:, vaultType:)` such that the **real decrypt path** (`VaultViewModel.loadFromCache` → public `filteredSummaries`, then `loadDetail`) — not the bare plaintext decoder — succeeds for all 9 (T3). (Note: `decryptOverview` is the private worker `loadFromCache` calls; tests drive the public `loadFromCache`/`loadDetail`, not a private symbol — T9.)
+  - **app-enforced (isolation)**: performs no Keychain, file, UserDefaults, or network I/O. (No Swift compile-time effect system exists for "no I/O"; enforced by the Forbidden-patterns grep below + the structural test, NOT by an unreliable real-container assertion — T1/T2.)
+- **Forbidden patterns** (must NOT appear in `DemoVaultFactory.swift`):
+  - `pattern: BridgeKeyStore` — reason: no shared Keychain bridge key
+  - `pattern: AppGroupWrappedKeyStore` — reason: no persisted wrapped keys
+  - `pattern: saveVaultKey` — reason: ephemeral key only
+  - `pattern: cacheFileURL` — reason: no shared cache file
+  - `pattern: writeCacheFile` — reason: in-memory cache only
+  - `pattern: HostTokenStore` — reason: no token
+  - `pattern: FaviconLoader` — reason: no favicon fetch/cache (S1)
+- **Acceptance**:
+  - `makeDemoVault()` returns; the **real decrypt path** yields 9 summaries (`loadFromCache` → `viewModel.filteredSummaries.count == 9`, scope defaults to `.personal`; assert the public surface, not internal `allSummaries` — T10) and `header.entryCount == 9`.
+  - Per-type detail assertions via `loadDetail`: each non-login type confirms a type-specific field (CREDIT_CARD `brand`, IDENTITY `fullName`, BANK_ACCOUNT `bankName`, SSH_KEY `publicKey`, SOFTWARE_LICENSE `licenseKey`, PASSKEY `relyingPartyId`, SECURE_NOTE `content`) — proving correct classification (F2/F6).
+  - The login fixture carrying a TOTP decrypts to `totpSecret == "JBSWY3DPEHPK3PXP"` (T7).
+  - Forbidden-patterns grep over `DemoVaultFactory.swift` returns no match (the falsifiable isolation gate). Prove-red: temporarily add a `cacheFileURL` reference → grep must fail (T1/RT7).
+- **Consumer-flow walkthrough**:
+  - Consumer `RootView` (path: `ios/PasswdSSOApp/Views/RootView.swift`) reads `{ cacheData, vaultKey, userId }` and passes them into `DemoVaultView(demo:onExit:)`. All three present in `DemoVault`.
+  - Consumer `VaultViewModel.loadFromCache` (path: `ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift`) reads `{ cacheData, vaultKey, userId }` and decrypts overviews; demo calls it with `cacheKey: nil`, `teamDirectory: []` (the actual signature is `teamDirectory: [TeamDirectoryEntry] = []`, not optional — F5). `cacheKey: nil` means `loadTeamKeys` is skipped → no shared wrapped-key read (S6).
+
+### C2 — `AppState.demo` terminal state + entry/exit
+- **Signature**: add `case demo(DemoVault)` to `enum AppState` (`RootView.swift`). Entry: `SignInView`/`ServerURLSetupView` "Try Demo Mode" closure → `appState = .demo(DemoVaultFactory.makeDemoVault())`. Exit: `DemoVaultView` `onExit` → `appState = .setup`.
+- **Invariants**:
+  - **app-enforced**: `.demo` carries only `DemoVault`; no `apiClient`/`hostSyncService`/`autoLockService`/`cacheKey`.
+  - **app-enforced**: entering `.demo` does not run `SessionRestorer`/`VaultUnlocker`/`AutofillTokenRefresher`/`onVaultReady`; exiting calls no cleanup and never `CredentialIdentityRegistrar`.
+  - **app-enforced**: the `RootView` `switch appState` is exhaustive with `.demo`; the `onChange(of: autoLockService.state)` block stays attached to `.vaultUnlocked` only (no `autoLockService` reference dangles into `.demo`).
+- **Forbidden patterns** (must NOT appear in `DemoVaultView.swift` or the `.demo` entry/exit code):
+  - `pattern: onVaultReady` — reason: demo wires no sync/drain/token-refresh
+  - `pattern: refreshCredentialIdentities` — reason: demo must not seed QuickType
+  - `pattern: CredentialIdentityRegistrar` — reason: same
+  - `pattern: HostSyncService` / `pattern: runSync` — reason: no sync (S2)
+  - `pattern: MobileAPIClient` — reason: no network (NFR2)
+  - `pattern: FaviconLoader` — reason: no favicon fetch/cache (S1)
+  - `pattern: AppSettingsStore` — reason: demo must not write shared settings (S3)
+- **Acceptance**: a state-machine unit test drives `.setup → .demo → .setup` and asserts the transition is reachable + reversible. **Structural (grep) gate** over `DemoVaultView.swift` + the `.demo` wiring asserts none of the Forbidden patterns appear — this is the falsifiable isolation proof (NOT a runtime spy, which would be vacuous because the demo path constructs none of these collaborators — T5). Prove-red: temporarily add a `refreshCredentialIdentities` call to `DemoVaultView` → grep must fail (RT7).
+
+### C3 — `DemoVaultView` (read-only renderer over the in-memory cache)
+- **Signature**: `struct DemoVaultView: View { let demo: DemoVault; let onExit: () -> Void }`. Owns a `@State private var viewModel = VaultViewModel()`; on appear calls `viewModel.loadFromCache(cacheData: demo.cacheData, vaultKey: demo.vaultKey, userId: demo.userId, cacheKey: nil, teamDirectory: [])`. Renders the **pure** rendering subviews: the category grid, the entry-summary list, search, and `EntryDetailView` — **without** the live toolbar (no Sync/Settings/Lock/Sign Out), without create/edit/delete, without favicons, without `scenePhase` sync, without `autoLockService`.
+- **Invariants**:
+  - **app-enforced**: `DemoVaultView` constructs no `MobileAPIClient`/`HostSyncService`/`FaviconLoader`/`AutoLockService`/`CredentialIdentityRegistrar` (grep gate, C2).
+  - **app-enforced**: the only navigation control out of demo is "Exit Demo" → `onExit()`; there is no path from `.demo` into a real unlock (scenario 3).
+  - **app-enforced**: a persistent "Demo Mode" banner is shown.
+  - **app-enforced**: reused subviews (`EntryDetailView`, the category/list rows, `EntrySummaryRow`) are passed `showFavicons: false` so their favicon branch is dead in demo (S1/R3 — the gate propagates to every reused subview, not just the top view).
+- **Forbidden patterns**: C2's list applies to `DemoVaultView.swift` **and to every file the read-only seam extracts** (see Mandatory read-only seam). The grep gate is scoped by glob `Demo*.swift` **plus** any extracted read-only file (`*ReadOnly*.swift` or whatever the implementer names it) — NOT a hardcoded two-file list (F7/S7/T8).
+- **Mandatory read-only seam (was "reuse note" — now required, not optional)**: `categoryGrid`/`entryList` are `private` computed properties of `VaultListView` (VaultListView.swift:293,335) closing over the live deps, so `DemoVaultView` **must reimplement** the grid/list navigation regardless. More binding: BOTH `VaultCategoryListView` (VaultCategoryLanding.swift:75-78) AND `EntryDetailView` (EntryDetailView.swift:15-18) declare **non-optional** `apiClient: MobileAPIClient` / `hostSyncService: HostSyncService` / `autoLockService` — and `MobileAPIClient.init` drags in the forbidden `HostTokenStore`. Reusing either verbatim therefore **contradicts the grep gate**. The implementer MUST extract a read-only rendering seam covering **both** views — either an `isReadOnly`/`mode` parameter that makes those three collaborators optional-and-unused, or trimmed standalone views (`EntryDetailReadOnlyView` + a read-only category list) that take none of them. The per-type detail section renderers (`creditCardSection`/`sshKeySection`/… in EntryDetailTypeSections.swift) are currently `private` to `EntryDetailView` and must be extracted into a standalone view as part of this seam. The seam file(s) are added to the Forbidden-patterns grep scope (above). (F7/S7)
+  - **Accepted reads in the extracted seam (F8/S8)**: the reused copy helpers call `autoLockService.recordActivity()` and `SecureClipboard.copy(clearAfter: AppSettingsStore().clipboardClearSeconds)`. In the read-only seam: drop the `autoLockService` activity calls (demo has no idle lock); the `AppSettingsStore().clipboardClearSeconds` **read** (not a write — fail-closed to a secure default, no contamination) is accepted. Because `AppSettingsStore` is a C2-forbidden literal, the seam either inlines a constant clipboard-clear OR records a one-line grep-gate exception noting this is a read-only access. State which in Phase 2.
+- **Acceptance**: a pure predicate test — extract `DemoVaultView`'s capability flags into a `DemoVaultPresentation` value type the view actually reads (`showsMutationAffordances == false`, `showsSyncControls == false`, `showsFavicons == false`, `exitLabel`) and unit-test those (no snapshot harness exists — T4). The test must assert the VIEW consumes the same constants (not a parallel value the view ignores — T8/R41). **Prove-red (RT7)**: flip a flag default (e.g. `showsMutationAffordances = true`) and confirm the predicate test goes red. Plus the C2 grep gate over `DemoVaultView.swift` + the extracted seam file(s). The live `VaultListView` is **untouched**, so all existing VaultListView tests pass unchanged.
+
+### C4 — "Try Demo Mode" affordance on entry screens
+- **Signature**: a button in `SignInView` body and `ServerURLSetupView` body; both call an injected `onEnterDemo: () -> Void` wired in `RootView` to `appState = .demo(DemoVaultFactory.makeDemoVault())`.
+- **Invariants**:
+  - **app-enforced**: always visible (not behind a hidden gesture or a specific server URL) — Apple-recommended, reviewer-discoverable.
+  - **app-enforced**: tapping it needs no server URL or token.
+- **Acceptance**: button visible on first launch (`.setup`) and on `.signIn`; tap transitions to `.demo`; localized label present in `Localizable.xcstrings` (en + ja).
+
+## Go/No-Go Gate
+
+| ID  | Subject                                              | Status |
+|-----|-----------------------------------------------------|--------|
+| C1  | `DemoVaultFactory.makeDemoVault()` in-memory builder | locked |
+| C2  | `AppState.demo` terminal state + entry/exit          | locked |
+| C3  | `DemoVaultView` read-only renderer + read-only seam   | locked |
+| C4  | "Try Demo Mode" affordance on entry screens          | locked |
+
+## Testing strategy
+
+- **Unit (C1)** `DemoVaultFactoryTests`: call `makeDemoVault()`, drive the **real decrypt path** (`VaultViewModel.loadFromCache`) — assert `allSummaries.count == 9`, `header.entryCount == 9`, one per-type field via `loadDetail` for each of the 7 non-login types (F2), and `totpSecret == "JBSWY3DPEHPK3PXP"` for the TOTP login (T7). NFR3 grep: source contains no email domain outside `example.{com,org,net}`. Follow the existing `DebugVaultLoaderTests`/`EntryBlobGoldenPayloadTests` idioms (T3/T6).
+- **Unit (C2)** state-machine test `.setup → .demo → .setup`. **Isolation gate (grep)**: a test (or a pre-PR check script) greps **all `Demo*.swift` files PLUS any extracted read-only seam file** (`*ReadOnly*.swift` or as named in C3) for the Forbidden patterns and fails on any match — a glob, not a hardcoded file list (T8). Documented prove-red step per gate (T1/T5/RT7). No real-container/real-keychain runtime assertion (unreliable — T1/T2).
+- **Unit (C3)** pure-predicate test on the demo presentation flags (no snapshot harness — T4), with a prove-red step (flip a flag default → test goes red — RT7). The extracted read-only seam is a new production export and ships with its own test in this PR (RT6).
+- **Manual (R35 Tier-1 — UI surface)** `ios-demo-mode-manual-test.md`: fresh-install → Try Demo Mode → browse all 8 types (confirm card/SSH/identity/etc. render type-correct) → copy a TOTP → search → Exit Demo → back at sign-in. Run on an **iPad simulator in iPhone-compatibility mode** (VEC1). Residue check: with a separately set-up real vault on the same simulator, run a demo session, exit, and assert the real cache file mtime + entry count are unchanged, the favicon cache dir is unchanged, and the `ASCredentialIdentityStore` identity count is unchanged (NFR1/S4).
+
+## Considerations & constraints
+
+### Scope contract
+- **SC1 — Local-only create/edit/delete in demo**: deferred. Owner: a follow-up PR if Apple/users request mutation. Reason: read-only browse satisfies Guideline 2.1 (reviewer must *see* the app work); local-write would require intercepting the concrete `MobileAPIClient` actor + `runSync`, materially higher-risk. Re-scope trigger: a second rejection citing "cannot exercise features".
+- **SC2 — AutoFill extension demo**: out of scope permanently (the extension has no sign-in screen; demo is a host-app concept). The extension is untouched.
+- **SC3 — Team/shared-vault entries in demo**: deferred to SC1's follow-up. Demo shows personal entries only (`cacheKey: nil`), matching the existing debug path.
+
+### Known risks
+- Fixture drift vs. real server blobs. Mitigation: C1 exercises the **real** decrypt+decode path and the fixtures track `EntryBlobGoldenPayloadTests` (memory `ios-blob-type-drift-bug-class`).
+- `EntryDetailView` reuse may require a read-only seam (C3 reuse note). If too invasive, `DemoVaultView` renders a trimmed detail.
+- App-switcher snapshot will capture the demo vault list on backgrounding. Accepted: demo data is fake (NFR3); documented rather than mitigated (the live screen-recording overlay keys on `UIScreen.isCaptured`, a separate concern).
+
+### Out of scope
+- Web/server changes (none).
+- Changing `TARGETED_DEVICE_FAMILY` (the app stays iPhone-only; demo just renders in compatibility mode).
+- `DebugVaultLoader` removal/refactor — left as-is (`#if DEBUG`). Possible future DRY (have it call `DemoVaultFactory`) is out of scope to avoid changing a working debug path.
+
+## User operation scenarios
+
+1. **Reviewer, fresh install, iPad**: launch → `.setup` (server URL screen) → "Try Demo Mode" (no URL entered) → demo vault, 9 entries → category "Logins" → open "AWS Console (IAM)" → reveal password + copy TOTP → back → search "ssh" → open "Deploy Key" → see public key/fingerprint → "Exit Demo" → back at server URL screen.
+2. **Real user with existing vault, curious**: has a real unlocked vault; signs out to `.setup`; tries demo; exits; signs back in → real vault unlocks unchanged, AutoFill suggestions unchanged, settings unchanged.
+3. **Edge — demo then real sign-in without exit**: from `.demo` the only forward control is "Exit Demo" → `.setup`; no path from `.demo` into a real unlock, so demo state cannot bleed into a real session.

--- a/docs/archive/review/ios-demo-mode-plan.md
+++ b/docs/archive/review/ios-demo-mode-plan.md
@@ -157,3 +157,37 @@ New terminal case `AppState.demo(demo: DemoVault)`. RootView renders `DemoVaultV
 1. **Reviewer, fresh install, iPad**: launch → `.setup` (server URL screen) → "Try Demo Mode" (no URL entered) → demo vault, 9 entries → category "Logins" → open "AWS Console (IAM)" → reveal password + copy TOTP → back → search "ssh" → open "Deploy Key" → see public key/fingerprint → "Exit Demo" → back at server URL screen.
 2. **Real user with existing vault, curious**: has a real unlocked vault; signs out to `.setup`; tries demo; exits; signs back in → real vault unlocks unchanged, AutoFill suggestions unchanged, settings unchanged.
 3. **Edge — demo then real sign-in without exit**: from `.demo` the only forward control is "Exit Demo" → `.setup`; no path from `.demo` into a real unlock, so demo state cannot bleed into a real session.
+
+## Implementation Checklist
+
+### New files
+- `ios/Shared/Demo/DemoVaultFactory.swift` (Shared target) — `enum DemoVaultFactory` + `struct DemoVault` (C1). Builds 9 in-memory `CacheEntry` fixtures (8 types; login×2), each with `entryType` set + blobs encrypted under a fresh `SymmetricKey(size:.bits256)` + `aadVersion: 1` + `buildPersonalEntryAAD`. Mirrors `DebugVaultLoader.buildFixtureCacheEntries` blob-building ONLY (NOT its file/keychain writes). Per-type `FullBlobPayload`/`OverviewBlobPayload` shapes tracked against `EntryBlobGoldenPayloadTests.swift`.
+- `ios/PasswdSSOApp/Views/Vault/DemoVaultView.swift` (app target) — `struct DemoVaultView: View { let demo: DemoVault; let onExit: () -> Void }` (C3). Owns `@State viewModel = VaultViewModel()`; `.onAppear` → `viewModel.loadFromCache(cacheData: demo.cacheData, vaultKey: demo.vaultKey, userId: demo.userId, cacheKey: nil, teamDirectory: [])`. Renders: a "Demo Mode" banner, an "Exit Demo" toolbar button → `onExit()`, a category grid (`CategoryCard` over `EntryTypeCategory.allCases` present in the demo set + an "All" card) pushing `VaultCategoryListView(isReadOnly: true, …)`, a search field filtering `viewModel.filteredSummaries` into `EntrySummaryRow` → `EntryDetailView(isReadOnly: true, …)`. Passes `showFavicons: false` everywhere. Holds NO apiClient/hostSyncService/autoLockService/FaviconLoader.
+- `ios/Shared/Demo/DemoVaultPresentation.swift` (or nested) — small value type exposing `showsMutationAffordances=false`/`showsSyncControls=false`/`showsFavicons=false`/`exitLabel` that `DemoVaultView` actually reads (C3 acceptance / RT7).
+- `ios/PasswdSSOTests/DemoVaultFactoryTests.swift` — C1 unit tests (real decrypt path via `loadFromCache`→`filteredSummaries.count==9`; per-type `loadDetail` field; TOTP secret; NFR3 domain grep). Mirror `DebugVaultLoaderTests` idiom.
+- `ios/PasswdSSOTests/DemoModeStateTests.swift` — C2/C3 state-machine + presentation-flag tests + the grep-gate prove-red note.
+
+### Modified files (read-only seam — make 3 live deps optional)
+- `ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift` — add `var isReadOnly: Bool = false`; change `autoLockService: AutoLockService` → `AutoLockService?`, `apiClient: MobileAPIClient?`, `hostSyncService: HostSyncService?` (all optional, default nil). Gate Edit toolbar + edit sheet on `!isReadOnly`. Replace `autoLockService.recordActivity()` → `autoLockService?.recordActivity()`; guard `.onChange(of: autoLockService.state)` so it is attached only when a service exists (e.g. via an optional-bound modifier). Live call sites pass the same args (defaults preserve behavior). **All existing live call sites keep working unchanged** (params default).
+- `ios/PasswdSSOApp/Views/Vault/EntryDetailTypeSections.swift` — the `extension EntryDetailView` section funcs call `autoLockService.recordActivity()` (line ~76) → `autoLockService?.recordActivity()`.
+- `ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift` — `VaultCategoryListView`: same optional-dep + `isReadOnly` treatment; forward `isReadOnly` into the `EntryDetailView` it pushes.
+- `ios/PasswdSSOApp/Views/RootView.swift` — add `case demo(DemoVault)` to `AppState`; render `DemoVaultView(demo:onExit: { appState = .setup })`; wire `onEnterDemo` into the sign-in/setup factories. Keep the `.onChange(of: autoLockService.state)` attached to `.vaultUnlocked` only.
+- `ios/PasswdSSOApp/Views/SignInView.swift` — add `onEnterDemo: () -> Void` + a "Try Demo Mode" button (C4).
+- `ios/PasswdSSOApp/Views/ServerURLSetupView.swift` — add `onEnterDemo` + a "Try Demo Mode" button (C4).
+- `ios/PasswdSSOApp/Localizable.xcstrings` — add "Try Demo Mode" / "Exit Demo" / "Demo Mode" (en + ja). Regenerate via xcodegen if needed.
+
+### Reused (do NOT reimplement — R1)
+- `CategoryCard`, `EntrySummaryRow`, `ScreenRecordingOverlay`, `SecretRow`, `EntryIconView` (VaultCategoryLanding.swift / EntryDetailTypeSections.swift / EntryIconView.swift) — standalone structs, reuse as-is.
+- `VaultViewModel.loadFromCache`/`loadDetail`/`filteredSummaries` — the existing decrypt + filter path; no changes.
+- `encryptAESGCMEncoded`, `buildPersonalEntryAAD`, `VaultType.blob/.overview`, `CacheEntry`, `CacheData`/`CacheHeader` — crypto + model primitives.
+- The per-type detail section funcs (`creditCardSection`/`sshKeySection`/…) — reused via `EntryDetailView(isReadOnly:true)`.
+
+### Forbidden-pattern grep gate (CI/pre-PR) — scope = `Demo*.swift` (NOT a hardcoded file list)
+- In `DemoVaultFactory.swift`: no `BridgeKeyStore`/`AppGroupWrappedKeyStore`/`saveVaultKey`/`cacheFileURL`/`writeCacheFile`/`HostTokenStore`/`FaviconLoader`.
+- In `DemoVaultView.swift`: no `MobileAPIClient`/`HostSyncService`/`runSync`/`FaviconLoader`/`CredentialIdentityRegistrar`/`refreshCredentialIdentities`/`onVaultReady`/`AppSettingsStore`. (Demo passes `nil` to the now-optional params, so it never names these symbols.)
+- Prove-red: temporarily add a forbidden symbol → gate fails.
+
+### Build/test verification
+- `xcodegen generate` (regenerate pbxproj for new files), commit pbxproj.
+- `xcodebuild test -scheme PasswdSSOApp -destination 'id=<sim udid>'` — all tests pass.
+- Pre-PR gate runs (ios-only docs/code change; SKIP_PRE_PR_GATE only for docs-only).

--- a/docs/archive/review/ios-demo-mode-review.md
+++ b/docs/archive/review/ios-demo-mode-review.md
@@ -1,0 +1,78 @@
+# Plan Review: ios-demo-mode
+Date: 2026-06-25
+Review rounds: 2 (all findings resolved)
+
+---
+
+# Round 2 (incremental)
+
+## Changes from Previous Round
+Core architecture pivot: demo no longer reuses the live `VaultListView` (which wires `apiClient`/`hostSyncService`/`autoLockService`/favicon/Settings unconditionally). Demo now renders a **dedicated `DemoVaultView`** over an in-memory cache, making NFR1/NFR2 a structural property enforced by a grep gate rather than per-site guards. C1 test now drives the real decrypt path; C2 isolation is a grep gate (not a vacuous spy); C3 uses a pure predicate (no snapshot harness).
+
+## Round-1 dispositions (all verified against source)
+F1→Resolved (dedicated view; `categoryGrid`/`entryList` confirmed private, reimplemented; `EntrySummaryRow`/`CategoryCard` reusable). F2→Resolved (entryType strings match `EntryTypeCategory` raw values + decoder literals exactly, incl. `SECURE_NOTE`). F3/F4→Resolved structurally + verified the favicon gate is dead at `EntryIconView.decision` when `showFavicons:false`, and `FaviconLoader.shared` stays nil without `configure`. F5→Resolved. S1/S2/S3/S6→Resolved structurally (verified residual-singleton vector does not survive; no `URLCache.shared`; no `DebugVaultLoader.reset()` on exit). S4/S5→Resolved. T1-T7→Resolved (grep gate replaces unreliable real-container/keychain assertions; real decrypt path; golden-payload lockstep; TOTP unit assertion).
+
+## Round-2 new findings (resolved in plan)
+- **[F7/S7/T8] High — the recurring root**: `EntryDetailView` AND `VaultCategoryListView` declare non-optional `apiClient: MobileAPIClient`/`hostSyncService`/`autoLockService` (EntryDetailView.swift:15-18, VaultCategoryLanding.swift:75-78); `MobileAPIClient.init` drags in the forbidden `HostTokenStore`. Reusing either verbatim contradicts the grep gate. The C3 "reuse note" treated the read-only seam as optional and omitted `VaultCategoryListView`; the grep scope was a hardcoded two-file list that wouldn't cover the extracted seam (RT6). **Fixed**: C3 now makes the read-only seam **mandatory** for both views (extract `isReadOnly`/trimmed views taking none of the three collaborators; per-type section renderers extracted from `EntryDetailTypeSections.swift`), and the grep gate is now a glob (`Demo*.swift` + `*ReadOnly*.swift`).
+- **[F8/S8] Low**: extracted copy helpers reference `autoLockService` + read `AppSettingsStore().clipboardClearSeconds`. **Fixed**: C3 drops the autoLock activity calls in the seam and documents the clipboard read as an accepted read-only access (fail-closed default; not a write → no contamination).
+- **[T9] Low**: C1 cited non-existent `decryptPersonalOverviews`. **Fixed**: replaced with `loadFromCache`/`loadDetail` (real public path); noted `decryptOverview` is the private worker.
+- **[T10] Low**: C1 asserted internal `allSummaries`. **Fixed**: assert public `filteredSummaries.count == 9`.
+- **[RT7 gap] Low**: C3 predicate test lacked a prove-red step. **Fixed**: C3 acceptance now requires flipping a flag default → test goes red, and requires the view to consume the same constants the test asserts.
+
+## Round-2 escalation
+No Critical findings. F7/S7 is High but a plan-completeness gap (the grep gate would fail the build rather than ship contamination) — `escalate: false`. All four contracts now `locked`.
+
+---
+
+# Round 1
+
+## Changes from Previous Round
+Initial review.
+
+## Functionality Findings
+
+- **[F1] Critical**: `.demo` cannot construct `VaultListView` without `autoLockService`/`apiClient`/`hostSyncService`/`keyVersion` — all non-optional (`VaultListView.swift:15-24`). The terminal-state "carries nothing" design (C2) contradicts the view signature. Fix: thread `mode` AND make those deps optional + gate every use, OR build a dedicated `DemoVaultView` reusing the rendering subviews. Enumerate ~10 references at VaultListView.swift:69,75,98,101,108,143,156-157,233,308,344,379,386.
+- **[F2] Critical**: Demo `CacheEntry` omits `entryType` → all 8 types collapse to "Login" (`EntryTypeCategory.from(rawType:nil)=.login`; decoder builds type sub-struct only when entryType matches, EntryBlobDecoder.swift:303-336; the DebugVaultLoader template never sets it). Defeats FR2. Fix: C1 sets `entryType` per fixture; assert per-type classification.
+- **[F3] Major**: Favicon auto-fetch on browse path = network call in demo (NFR2). VaultListView.swift:150-160 → FaviconLoader.configure; image(forHost:) → apiClient.fetchFavicon. Fix: force `showFavicons=false` in demo, skip configure; add to C3.
+- **[F4] Major**: `.refreshable` + `scenePhase==.active` still wired to `sync()` (VaultListView.swift:120-125,323,356). Fix: gate both behind `mode==.live`.
+- **[F5] Minor**: C1 says `teamDirectory: nil` but signature is `[TeamDirectoryEntry] = []`. Fix: reword to `[]`.
+- **[F6] Minor**: count arithmetic OK (8 types, login×2 = 9 entries); C1 test must enumerate each of 9 by type (folds into F2).
+
+## Security Findings
+
+- **[S1] Critical (escalate:true)**: Favicon path writes the **shared** App Group cache (`FaviconLoader.swift:117-129` → `<AppGroup>/vault/favicon-cache/`) AND makes network calls; omitted from NFR1 + every forbidden-pattern list. Falls back to `loadServerConfig()?.baseURL`. Fix: force `showFavicons=false` (don't read shared store), gate `FaviconLoader.configure` behind `mode==.live`, add `FaviconLoader`/`faviconCacheDirectory` to C1+C3 forbidden + NFR1 surface; test favicon dir absent + `fetchFavicon` never called.
+- **[S2] Critical (escalate:true)**: `VaultListView` needs live `apiClient`/`hostSyncService` and unconditionally runs `sync()` (shared-cache write + network) on scenePhase/refresh (VaultListView.swift:120-125,323,356,375-402 → `hostSyncService.runSync`). Direct path to the central contamination threat. Fix: make deps optional/mode-gated; `sync()` first stmt `guard mode==.live else return`; gate scenePhase + both `.refreshable`; add `hostSyncService`/`runSync` to C3 forbidden; extend C2 spy to `runSync`.
+- **[S3] Major**: Demo menu exposes Settings (writes shared app-group UserDefaults), Lock, Sign Out (VaultListView.swift:70-99). Plan known-risk note ("no settings UI reachable") contradicts the code. Fix: C3 hides Settings/Lock/Sign Out in demo; resolve `autoLockService` absence.
+- **[S4] Major**: Residue-on-exit not provably empty — favicon disk cache + QuickType identity clears are wired to `AutoLockService`/sign-out, which don't run on demo exit. Fix: if favicons disabled (S1), collapses to "verify no favicon dir"; add post-exit asserts (favicon dir + `ASCredentialIdentityStore` count unchanged); document the app-switcher snapshot of (fake) demo data as accepted.
+- **[S5] Major**: NFR3 fakeness asserted but fixtures not in plan; mirrored DebugVaultLoader carries the published test TOTP seed `JBSWY3DPEHPK3PXP` (acceptable, but call it out) + `example.com` (RFC 2606, OK). Fix: NFR3 sub-assertion (all usernames RFC 2606 reserved domains; secrets fake/published-test); grep test for non-`example.*` domains; confirm `docs/assets/passwd-sso.json` is NOT in the app bundle Copy Resources phase.
+- **[S6] Minor**: Inverse contamination (demo reads real vault) NOT possible via `loadFromCache` (reads in-memory param, VaultViewModel.swift:98-101); only vector is `sync()` (covered by S2). `loadTeamKeys` runs only when `cacheKey!=nil`; demo passes nil → no shared wrapped-key read. Good.
+
+## Testing Findings
+
+- **[T1] Critical**: C1 isolation assertion `fileExists(cacheFileURL())==false` unreliable — the shared container is polluted by prior runs/DebugVaultLoader; can't distinguish demo's write. Zero existing tests touch the real `AppGroupContainer`; all inject a temp dir (DebugVaultLoaderTests.swift:23). Fix: drop absolute non-existence; rely on the Forbidden-patterns grep (the real, falsifiable gate) + optional before/after mtime-unchanged.
+- **[T2] Major**: "no Keychain item written" has no injection seam (C1 sig takes no params → hits real polluted keychain). Idiom injects `MockKeychainAccessor`. Fix: rely on the Forbidden grep for `BridgeKeyStore`/`HostTokenStore`/`saveVaultKey`; don't author a real-keychain query.
+- **[T3] Major**: C1 names the wrong API — `EntryBlobDecoder.summary/.detail` take **plaintext**, not encrypted blobs (EntryBlobDecoder.swift:212,276); decrypt is `decryptOverview`/`decryptEntryDetail`. Bare-decoder test bypasses the encrypt+AAD wiring (wrong AAD/key/userId uncaught). Fix: C1 test drives the real path — `vm.loadFromCache` then assert `allSummaries.count==9` + per-type via `loadDetail`, OR `decryptPersonalOverviews(from:vaultKey:userId:)`. (RT1)
+- **[T4] Major**: C3 "snapshot/structural test" untestable — no snapshot lib, empty UITest target, no SwiftUI body inspection in the codebase. Fix: extract a pure predicate (`VaultMode.showsMutationAffordances`/`.showsSyncControls`/`.signOutLabel`) and unit-test the enum. (RT2/RT7)
+- **[T5] Major**: C2/C3 negative invariants ("runSync/registrar never called") have no spy seam — `.demo` constructs none of them (RootView.swift:101,119,393 inline). "Spy + assert zero" is vacuous. Fix: make the invariant compile-time/structural (Forbidden grep — already lists `onVaultReady`/`refreshCredentialIdentities`/`CredentialIdentityRegistrar`); prove-red by injecting the call. Drop the "injected spy" wording, OR inject the registrar into `VaultListView` (a `FakeIdentityStore` spy already exists). (RT7)
+- **[T6] Minor**: C1 fixtures duplicate the existing `EntryBlobGoldenPayloadTests.swift` (per-type golden payloads, all 8 types, with a "add new type in lockstep" comment). Fix: `DemoVaultFactory` builds from / asserts against the same shapes; C1 test asserts only factory-specific concerns. (R1/RT3)
+- **[T7] Minor**: TOTP-copy (FR2) only in the manual plan but unit-testable. Fix: C1 sub-assertion — decrypt the demo login detail, assert `totpSecret == known`.
+
+## Adjacent Findings
+- F1 [Adjacent → security]: ephemeral-key zeroization relies on ARC; security pass noted (S4 covers residue).
+- S3/S1 [Adjacent → functionality]: the mode gate must propagate to `EntryDetailView`/`VaultCategoryListView`/`EntrySummaryRow`, not only `VaultListView` (R3).
+
+## Quality Warnings
+None — all findings carry file:line evidence and concrete fixes.
+
+## Recurring Issue Check
+### Functionality expert
+R3=F1/F5; R7=F2/F5; R8=F1; R25=N/A (demo persists nothing, by design); R39=ephemeral key freed by ARC, no Keychain/disk → OK; R41=F2/F3/F4. R1,R2,R4-R6,R9-R24,R26-R38,R40 = N/A or Checked-no-issue.
+
+### Security expert
+R3=S1/S3 (propagate gate to EntryDetailView/VaultCategoryListView/EntrySummaryRow); R31=DebugVaultLoader.reset() deletes real shared state — demo exit must NOT call it (plan OK, exit is appState=.setup only); R34=favicon/sync pre-existing but in-scope; R39=S4; R40=fixture vs decoder shape OK by design; RS4=plan PII clean (Alice Example/example.com), confirm passwd-sso.json not bundled. RS1-RS3,RS5 = N/A. Others Checked/N/A.
+
+### Testing expert
+RT1=T3/T6; RT2=T1/T2/T4; RT5=T3/T5 (adjacent); RT6=DemoVaultFactory/DemoVault/VaultMode new exports — tests in same PR; RT7=T1/T4/T5 (each needs an explicit prove-red step). R1=T6. RT3=T6. RT4 = N/A (no race tests).
+
+## Security escalation
+S1 and S2 flagged `escalate: true` (NFR1/NFR2 — the plan's paramount invariants — failing on surfaces the plan never enumerated, touching shared App-Group disk + network). Orchestrator assessment: the Sonnet security findings are concrete, evidenced, and already actionable; the root cause (reuse of `VaultListView` wires favicon/sync/settings to shared state) is the SAME root as F1/S2/S3 and is fully understood. Re-running on Opus would not change the fix. **Escalation declined** — proceeding to plan revision with the findings as-is.

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -761,6 +761,57 @@
         }
       }
     },
+    "Demo Mode" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Demo Mode"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デモモード"
+          }
+        }
+      }
+    },
+    "Exit Demo" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exit Demo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デモを終了"
+          }
+        }
+      }
+    },
+    "Try Demo Mode" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try Demo Mode"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デモを試す"
+          }
+        }
+      }
+    },
     "Device Info" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -31,6 +31,7 @@ enum AppState {
   // server config + token (no OAuth re-sign-in). Carries serverConfig/apiClient
   // so the passphrase screen can call /api/vault/unlock/data again.
   case vaultLocked(serverConfig: ServerConfig, apiClient: MobileAPIClient)
+  case demo(DemoVault)
 }
 
 // MARK: - Root view
@@ -67,11 +68,18 @@ struct RootView: View {
         launchSplash
 
       case .setup:
-        ServerURLSetupView { config in
-          let tokenStore = HostTokenStore()
-          let coordinator = AuthCoordinator(serverConfig: config, tokenStore: tokenStore)
-          appState = .signIn(serverConfig: config, coordinator: coordinator)
-        }
+        ServerURLSetupView(
+          onReady: { config in
+            let tokenStore = HostTokenStore()
+            let coordinator = AuthCoordinator(serverConfig: config, tokenStore: tokenStore)
+            appState = .signIn(serverConfig: config, coordinator: coordinator)
+          },
+          onEnterDemo: {
+            if let demo = try? DemoVaultFactory.makeDemoVault() {
+              appState = .demo(demo)
+            }
+          }
+        )
 
       case .signIn(let config, let coordinator):
         makeSignInView(config: config, coordinator: coordinator)
@@ -142,6 +150,9 @@ struct RootView: View {
           .controlSize(.large)
           .padding(.bottom)
         }
+
+      case .demo(let demo):
+        DemoVaultView(demo: demo, onExit: { appState = .setup })
       }
     }
     // Re-evaluate content bodies in place on a language change so already-rendered
@@ -200,6 +211,11 @@ struct RootView: View {
             coordinator: coordinator
           )
           appState = .signedIn(serverConfig: config, apiClient: apiClient)
+        }
+      },
+      onEnterDemo: {
+        if let demo = try? DemoVaultFactory.makeDemoVault() {
+          appState = .demo(demo)
         }
       }
     )

--- a/ios/PasswdSSOApp/Views/ServerURLSetupView.swift
+++ b/ios/PasswdSSOApp/Views/ServerURLSetupView.swift
@@ -120,6 +120,7 @@ private enum ProbeError: LocalizedError {
 struct ServerURLSetupView: View {
   @State private var viewModel = ServerURLSetupViewModel()
   let onReady: (ServerConfig) -> Void
+  var onEnterDemo: (() -> Void)? = nil
 
   var body: some View {
     NavigationStack {
@@ -170,6 +171,18 @@ struct ServerURLSetupView: View {
           if case .probing = viewModel.state { return true }
           return false
         }())
+
+        if let onEnterDemo {
+          Button {
+            onEnterDemo()
+          } label: {
+            Text("Try Demo Mode")
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(.bordered)
+          .controlSize(.large)
+          .accessibilityIdentifier("server-setup-demo-button")
+        }
 
         Spacer()
         Spacer()

--- a/ios/PasswdSSOApp/Views/SignInView.swift
+++ b/ios/PasswdSSOApp/Views/SignInView.swift
@@ -34,6 +34,7 @@ struct SignInView: View {
   /// before authenticating (the URL setup screen is skipped on a known server).
   let serverURL: URL
   let onSignedIn: (TokenPair) -> Void
+  var onEnterDemo: (() -> Void)? = nil
 
   @State private var state: SignInViewState = .idle
   @State private var windowProvider = WindowProvider()
@@ -75,6 +76,18 @@ struct SignInView: View {
       .controlSize(.large)
       .accessibilityIdentifier("sign-in-primary-button")
       .disabled(state == .signingIn)
+
+      if let onEnterDemo {
+        Button {
+          onEnterDemo()
+        } label: {
+          Text("Try Demo Mode")
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.large)
+        .accessibilityIdentifier("sign-in-demo-button")
+      }
 
       Spacer()
       Spacer()

--- a/ios/PasswdSSOApp/Views/Vault/DemoVaultView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/DemoVaultView.swift
@@ -1,0 +1,171 @@
+import CryptoKit
+import Foundation
+import Shared
+import SwiftUI
+import UIKit
+
+// MARK: - DemoLandingItem
+
+/// A single entry in the demo category grid. Identifiable for ForEach.
+private struct DemoLandingItem: Identifiable {
+  let id: String
+  let category: VaultCategory
+  let symbol: String
+  let label: String
+  let count: Int
+}
+
+// MARK: - DemoVaultView
+
+/// Read-only vault browser for Demo Mode. Hydrates from an in-memory DemoVault
+/// produced by DemoVaultFactory. Holds no live-service dependencies — no network,
+/// no Keychain, no shared-state writes. See DemoModeStateTests grep gate.
+@MainActor
+struct DemoVaultView: View {
+  let demo: DemoVault
+  let onExit: () -> Void
+
+  @State private var viewModel = VaultViewModel()
+  @State private var isScreenRecording: Bool = UIScreen.main.isCaptured
+
+  private let presentation = DemoVaultPresentation()
+
+  var body: some View {
+    NavigationStack {
+      Group {
+        if isScreenRecording {
+          ScreenRecordingOverlay()
+        } else if viewModel.searchQuery.isEmpty {
+          categoryGrid
+        } else {
+          searchResultsList
+        }
+      }
+      .navigationTitle("passwd-sso")
+      .searchable(text: $viewModel.searchQuery, prompt: Text("Search"))
+      .toolbar {
+        ToolbarItem(placement: .topBarLeading) {
+          demoBanner
+        }
+        ToolbarItem(placement: .topBarTrailing) {
+          Button(presentation.exitLabel) { onExit() }
+        }
+      }
+    }
+    .onAppear {
+      viewModel.loadFromCache(
+        cacheData: demo.cacheData,
+        vaultKey: demo.vaultKey,
+        userId: demo.userId,
+        cacheKey: nil,
+        teamDirectory: []
+      )
+      isScreenRecording = UIScreen.main.isCaptured
+    }
+    .onReceive(
+      NotificationCenter.default.publisher(for: UIScreen.capturedDidChangeNotification)
+    ) { _ in
+      isScreenRecording = UIScreen.main.isCaptured
+    }
+  }
+
+  // MARK: - Demo mode banner
+
+  private var demoBanner: some View {
+    Text("Demo Mode")
+      .font(.caption.bold())
+      .padding(.horizontal, 8)
+      .padding(.vertical, 4)
+      .background(Color.accentColor.opacity(0.15))
+      .foregroundStyle(Color.accentColor)
+      .clipShape(Capsule())
+  }
+
+  // MARK: - Category grid
+
+  private var landingItems: [DemoLandingItem] {
+    let summaries = viewModel.filteredSummaries
+    let counts = categoryCounts(summaries)
+    var items: [DemoLandingItem] = [
+      DemoLandingItem(
+        id: "all", category: .all, symbol: "tray.full",
+        label: L10n.string("All"), count: counts[.all] ?? 0
+      ),
+    ]
+    for type in EntryTypeCategory.allCases {
+      let count = counts[.type(type)] ?? 0
+      if count > 0 {
+        items.append(DemoLandingItem(
+          id: "type-\(type.rawValue)", category: .type(type),
+          symbol: type.sfSymbol, label: type.localizedLabel, count: count
+        ))
+      }
+    }
+    return items
+  }
+
+  private var categoryGrid: some View {
+    ScrollView {
+      LazyVGrid(
+        columns: [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)],
+        spacing: 12
+      ) {
+        ForEach(landingItems) { item in
+          NavigationLink {
+            VaultCategoryListView(
+              category: item.category,
+              navigationTitle: item.label,
+              cacheData: demo.cacheData,
+              vaultKey: demo.vaultKey,
+              userId: demo.userId,
+              keyVersion: 1,
+              viewModel: viewModel,
+              isReadOnly: true,
+              showFavicons: presentation.showsFavicons
+            )
+          } label: {
+            CategoryCard(symbol: item.symbol, label: item.label, count: item.count)
+          }
+          .buttonStyle(.plain)
+        }
+      }
+      .padding()
+    }
+    .overlay {
+      if viewModel.filteredSummaries.isEmpty {
+        Text("No entries")
+          .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+  }
+
+  // MARK: - Search results list
+
+  private var searchResultsList: some View {
+    List(viewModel.filteredSummaries) { summary in
+      NavigationLink {
+        EntryDetailView(
+          summary: summary,
+          cacheData: demo.cacheData,
+          vaultKey: demo.vaultKey,
+          userId: demo.userId,
+          keyVersion: 1,
+          viewModel: viewModel,
+          isReadOnly: true,
+          showFavicons: presentation.showsFavicons
+        )
+      } label: {
+        EntrySummaryRow(summary: summary, showFavicons: presentation.showsFavicons)
+      }
+    }
+    .listStyle(.plain)
+    .overlay {
+      if viewModel.filteredSummaries.isEmpty {
+        Text("No matches")
+          .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+  }
+}

--- a/ios/PasswdSSOApp/Views/Vault/EntryDetailTypeSections.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryDetailTypeSections.swift
@@ -73,7 +73,7 @@ extension EntryDetailView {
         label: label,
         value: value,
         onCopy: { copySecurely(value: $0) },
-        onActivity: { autoLockService.recordActivity() }
+        onActivity: { autoLockService?.recordActivity() }
       )
     }
   }

--- a/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/EntryDetailView.swift
@@ -12,11 +12,13 @@ struct EntryDetailView: View {
   let vaultKey: SymmetricKey
   let userId: String
   let keyVersion: Int
-  let autoLockService: AutoLockService
+  var autoLockService: AutoLockService? = nil
   @Bindable var viewModel: VaultViewModel
-  let apiClient: MobileAPIClient
-  let hostSyncService: HostSyncService
+  var apiClient: MobileAPIClient? = nil
+  var hostSyncService: HostSyncService? = nil
   var cacheKey: SymmetricKey? = nil
+  /// When true, hides Edit controls and disables mutation. Used by DemoVaultView.
+  var isReadOnly: Bool = false
   /// Resolved server favicon opt-in, threaded from the list (C7) so the detail
   /// icon stays consistent with the rows rather than re-reading the store (F-3).
   var showFavicons: Bool = false
@@ -62,7 +64,7 @@ struct EntryDetailView: View {
       // corrupt a non-login entry on save (empty login scalars + login-shaped
       // overview). Non-login entries are edited in the web app. nil/unknown
       // entryType falls back to LOGIN, so the button shows during load.
-      if EntryTypeCategory.isEditableOnIOS(rawType: detail?.entryType) {
+      if !isReadOnly && EntryTypeCategory.isEditableOnIOS(rawType: detail?.entryType) {
         ToolbarItem(placement: .topBarTrailing) {
           Button("Edit") {
             isShowingEditForm = true
@@ -74,7 +76,7 @@ struct EntryDetailView: View {
     // just-saved edit is reflected immediately (the VM refreshes cacheData after
     // the PUT+sync; without this trigger the view keeps showing pre-edit values).
     .sheet(isPresented: $isShowingEditForm, onDismiss: { loadDetail() }) {
-      if let detail {
+      if let detail, let apiClient, let hostSyncService {
         EntryForm(
           mode: .edit(summary: summary, initial: detail),
           vaultKey: vaultKey,
@@ -103,8 +105,8 @@ struct EntryDetailView: View {
     // view stays foregrounded (lock() does not unmount it). The detail now
     // holds SSH private keys, card numbers, IBANs — a larger surface than the
     // password+TOTP it once carried, so don't leave it resident past lock.
-    .onChange(of: autoLockService.state) { _, newState in
-      if newState != .unlocked {
+    .onChange(of: autoLockService?.state) { _, newState in
+      if let newState, newState != .unlocked {
         detail = nil
       }
     }
@@ -223,7 +225,7 @@ struct EntryDetailView: View {
           Spacer()
           Button {
             copySecurely(value: value)
-            autoLockService.recordActivity()
+            autoLockService?.recordActivity()
           } label: {
             Image(systemName: "doc.on.doc")
               .frame(minWidth: 44, minHeight: 44)
@@ -250,7 +252,7 @@ struct EntryDetailView: View {
         Spacer()
         Button {
           isPasswordVisible.toggle()
-          autoLockService.recordActivity()
+          autoLockService?.recordActivity()
         } label: {
           Image(systemName: isPasswordVisible ? "eye.slash" : "eye")
             .frame(minWidth: 44, minHeight: 44)
@@ -260,7 +262,7 @@ struct EntryDetailView: View {
 
         Button {
           copySecurely(value: password)
-          autoLockService.recordActivity()
+          autoLockService?.recordActivity()
         } label: {
           Image(systemName: "doc.on.doc")
             .frame(minWidth: 44, minHeight: 44)

--- a/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
@@ -72,11 +72,12 @@ struct VaultCategoryListView: View {
   let vaultKey: SymmetricKey
   let userId: String
   let keyVersion: Int
-  let autoLockService: AutoLockService
+  var autoLockService: AutoLockService? = nil
   @Bindable var viewModel: VaultViewModel
-  let apiClient: MobileAPIClient
-  let hostSyncService: HostSyncService
+  var apiClient: MobileAPIClient? = nil
+  var hostSyncService: HostSyncService? = nil
   var cacheKey: SymmetricKey? = nil
+  var isReadOnly: Bool = false
   var showFavicons: Bool = false
 
   // Seed synchronously so an already-active recording never shows a frame of
@@ -106,6 +107,7 @@ struct VaultCategoryListView: View {
               apiClient: apiClient,
               hostSyncService: hostSyncService,
               cacheKey: cacheKey,
+              isReadOnly: isReadOnly,
               showFavicons: showFavicons
             )
           } label: {

--- a/ios/PasswdSSOTests/DemoModeStateTests.swift
+++ b/ios/PasswdSSOTests/DemoModeStateTests.swift
@@ -54,15 +54,17 @@ final class DemoModeStateTests: XCTestCase {
   // MARK: - Grep gate: forbidden patterns in DemoVaultFactory.swift
 
   /// Prove-red (RT7): temporarily add `BridgeKeyStore` to DemoVaultFactory.swift → test fails.
+  // Uses #filePath (absolute) not #file: under Swift 6 language mode #file is the
+  // concise <module>/<basename> form, which would make the URL relative and the
+  // read fail — silently greenwashing the gate. A non-swallowing `try` makes an
+  // unreadable file fail the test loudly. Mirrors LocalizationCatalogTests.
   func testForbiddenPatternsAbsent_inDemoVaultFactory() throws {
-    let fileURL = URL(fileURLWithPath: #file)
+    let fileURL = URL(filePath: #filePath)
       .deletingLastPathComponent()   // PasswdSSOTests/
       .deletingLastPathComponent()   // ios/
       .appendingPathComponent("Shared/Demo/DemoVaultFactory.swift")
 
-    guard let source = try? String(contentsOf: fileURL, encoding: .utf8) else {
-      return
-    }
+    let source = try String(contentsOf: fileURL, encoding: .utf8)
     let forbidden = [
       "BridgeKeyStore", "AppGroupWrappedKeyStore", "saveVaultKey",
       "cacheFileURL", "writeCacheFile", "HostTokenStore", "FaviconLoader",
@@ -76,15 +78,14 @@ final class DemoModeStateTests: XCTestCase {
   }
 
   /// Prove-red (RT7): temporarily add `MobileAPIClient` to DemoVaultView.swift → test fails.
+  // See the #filePath rationale on testForbiddenPatternsAbsent_inDemoVaultFactory.
   func testForbiddenPatternsAbsent_inDemoVaultView() throws {
-    let fileURL = URL(fileURLWithPath: #file)
+    let fileURL = URL(filePath: #filePath)
       .deletingLastPathComponent()   // PasswdSSOTests/
       .deletingLastPathComponent()   // ios/
       .appendingPathComponent("PasswdSSOApp/Views/Vault/DemoVaultView.swift")
 
-    guard let source = try? String(contentsOf: fileURL, encoding: .utf8) else {
-      return
-    }
+    let source = try String(contentsOf: fileURL, encoding: .utf8)
     let forbidden = [
       "MobileAPIClient", "HostSyncService", "runSync", "FaviconLoader",
       "CredentialIdentityRegistrar", "refreshCredentialIdentities",

--- a/ios/PasswdSSOTests/DemoModeStateTests.swift
+++ b/ios/PasswdSSOTests/DemoModeStateTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import XCTest
+@testable import PasswdSSOApp
+@testable import Shared
+
+/// Tests for Demo Mode state machine (C2) and presentation flags (C3).
+///
+/// Structural isolation proof: the grep gate below verifies that the Forbidden
+/// patterns from the plan do NOT appear in DemoVaultFactory.swift or
+/// DemoVaultView.swift. Each test has a documented prove-red step (RT7) in its
+/// comment.
+@MainActor
+final class DemoModeStateTests: XCTestCase {
+
+  // MARK: - C3: DemoVaultPresentation flags
+
+  /// Prove-red (RT7): flip showsMutationAffordances default to true → test fails.
+  func testDemoPresentationFlags_allFalse() {
+    let p = DemoVaultPresentation()
+    XCTAssertFalse(p.showsMutationAffordances, "Demo must never show mutation affordances")
+    XCTAssertFalse(p.showsSyncControls, "Demo must never show sync controls")
+    XCTAssertFalse(p.showsFavicons, "Demo must never fetch/show favicons")
+  }
+
+  func testDemoPresentation_exitLabel() {
+    let p = DemoVaultPresentation()
+    XCTAssertEqual(p.exitLabel, "Exit Demo")
+  }
+
+  // MARK: - C2: AppState.demo pattern-match
+
+  /// Verifies .demo is a valid AppState case and carries DemoVault.
+  func testAppStateDemo_patternMatchable() throws {
+    let demo = try DemoVaultFactory.makeDemoVault()
+    let state = AppState.demo(demo)
+    if case .demo(let d) = state {
+      XCTAssertFalse(d.userId.isEmpty)
+      XCTAssertEqual(d.cacheData.header.entryCount, 9)
+    } else {
+      XCTFail("AppState.demo did not pattern-match")
+    }
+  }
+
+  /// State machine: .setup → .demo → .setup is representable (structural).
+  func testAppStateTransition_setupToDemoToSetup() throws {
+    let demo = try DemoVaultFactory.makeDemoVault()
+    var state = AppState.setup
+    state = .demo(demo)
+    guard case .demo = state else { XCTFail("Expected .demo"); return }
+    state = .setup
+    guard case .setup = state else { XCTFail("Expected .setup after exit"); return }
+  }
+
+  // MARK: - Grep gate: forbidden patterns in DemoVaultFactory.swift
+
+  /// Prove-red (RT7): temporarily add `BridgeKeyStore` to DemoVaultFactory.swift → test fails.
+  func testForbiddenPatternsAbsent_inDemoVaultFactory() throws {
+    let fileURL = URL(fileURLWithPath: #file)
+      .deletingLastPathComponent()   // PasswdSSOTests/
+      .deletingLastPathComponent()   // ios/
+      .appendingPathComponent("Shared/Demo/DemoVaultFactory.swift")
+
+    guard let source = try? String(contentsOf: fileURL, encoding: .utf8) else {
+      return
+    }
+    let forbidden = [
+      "BridgeKeyStore", "AppGroupWrappedKeyStore", "saveVaultKey",
+      "cacheFileURL", "writeCacheFile", "HostTokenStore", "FaviconLoader",
+    ]
+    for pattern in forbidden {
+      XCTAssertFalse(
+        source.contains(pattern),
+        "DemoVaultFactory.swift must not reference '\(pattern)' (isolation contract)"
+      )
+    }
+  }
+
+  /// Prove-red (RT7): temporarily add `MobileAPIClient` to DemoVaultView.swift → test fails.
+  func testForbiddenPatternsAbsent_inDemoVaultView() throws {
+    let fileURL = URL(fileURLWithPath: #file)
+      .deletingLastPathComponent()   // PasswdSSOTests/
+      .deletingLastPathComponent()   // ios/
+      .appendingPathComponent("PasswdSSOApp/Views/Vault/DemoVaultView.swift")
+
+    guard let source = try? String(contentsOf: fileURL, encoding: .utf8) else {
+      return
+    }
+    let forbidden = [
+      "MobileAPIClient", "HostSyncService", "runSync", "FaviconLoader",
+      "CredentialIdentityRegistrar", "refreshCredentialIdentities",
+      "onVaultReady", "AppSettingsStore",
+    ]
+    for pattern in forbidden {
+      XCTAssertFalse(
+        source.contains(pattern),
+        "DemoVaultView.swift must not reference '\(pattern)' (isolation contract)"
+      )
+    }
+  }
+}

--- a/ios/PasswdSSOTests/DemoVaultFactoryTests.swift
+++ b/ios/PasswdSSOTests/DemoVaultFactoryTests.swift
@@ -1,0 +1,213 @@
+import CryptoKit
+import Foundation
+import XCTest
+@testable import PasswdSSOApp
+@testable import Shared
+
+/// Tests for DemoVaultFactory (C1). Drives the real decrypt path via
+/// VaultViewModel.loadFromCache / loadDetail — not a bare plaintext decoder —
+/// to catch any AAD mismatch or blob-shape drift before ship.
+///
+/// Mirrors the DebugVaultLoaderTests idiom (no real App Group container,
+/// no Keychain — pure in-memory ephemeral key).
+@MainActor
+final class DemoVaultFactoryTests: XCTestCase {
+
+  // MARK: - Helpers
+
+  private func makeDemoAndVM() throws -> (DemoVault, VaultViewModel) {
+    let demo = try DemoVaultFactory.makeDemoVault()
+    let vm = VaultViewModel()
+    vm.loadFromCache(
+      cacheData: demo.cacheData,
+      vaultKey: demo.vaultKey,
+      userId: demo.userId,
+      cacheKey: nil,
+      teamDirectory: []
+    )
+    return (demo, vm)
+  }
+
+  // MARK: - C1: real decrypt path yields 9 summaries
+
+  func testMakeDemoVault_yields9SummariesViaRealDecryptPath() throws {
+    let (demo, vm) = try makeDemoAndVM()
+    XCTAssertEqual(demo.cacheData.header.entryCount, 9, "header.entryCount must be 9")
+    XCTAssertEqual(vm.filteredSummaries.count, 9, "filteredSummaries must have 9 entries")
+  }
+
+  // MARK: - C1: header.userId matches
+
+  func testDemoVault_headerUserIdMatchesDemoUserId() throws {
+    let demo = try DemoVaultFactory.makeDemoVault()
+    XCTAssertEqual(demo.cacheData.header.userId, demo.userId)
+  }
+
+  // MARK: - C1: each non-login type has a type-specific sub-struct
+
+  func testCreditCard_decodesWithBrandField() throws {
+    let (demo, vm) = try makeDemoAndVM()
+    let summary = try XCTUnwrap(
+      vm.filteredSummaries.first { $0.entryType == "CREDIT_CARD" },
+      "No CREDIT_CARD summary"
+    )
+    let detail = try XCTUnwrap(
+      vm.loadDetail(
+        for: summary.id, cacheData: demo.cacheData,
+        vaultKey: demo.vaultKey, userId: demo.userId),
+      "CREDIT_CARD loadDetail returned nil"
+    )
+    XCTAssertNotNil(detail.creditCard, "creditCard sub-struct must be present")
+    XCTAssertEqual(detail.creditCard?.brand, "Visa")
+  }
+
+  func testIdentity_decodesWithFullName() throws {
+    let (demo, vm) = try makeDemoAndVM()
+    let summary = try XCTUnwrap(
+      vm.filteredSummaries.first { $0.entryType == "IDENTITY" },
+      "No IDENTITY summary"
+    )
+    let detail = try XCTUnwrap(
+      vm.loadDetail(
+        for: summary.id, cacheData: demo.cacheData,
+        vaultKey: demo.vaultKey, userId: demo.userId),
+      "IDENTITY loadDetail returned nil"
+    )
+    XCTAssertNotNil(detail.identity)
+    XCTAssertEqual(detail.identity?.fullName, "Alice Example")
+  }
+
+  func testBankAccount_decodesWithBankName() throws {
+    let (demo, vm) = try makeDemoAndVM()
+    let summary = try XCTUnwrap(
+      vm.filteredSummaries.first { $0.entryType == "BANK_ACCOUNT" },
+      "No BANK_ACCOUNT summary"
+    )
+    let detail = try XCTUnwrap(
+      vm.loadDetail(
+        for: summary.id, cacheData: demo.cacheData,
+        vaultKey: demo.vaultKey, userId: demo.userId),
+      "BANK_ACCOUNT loadDetail returned nil"
+    )
+    XCTAssertNotNil(detail.bankAccount)
+    XCTAssertEqual(detail.bankAccount?.bankName, "Acme Bank")
+  }
+
+  func testSshKey_decodesWithPublicKeyAndNumericKeySize() throws {
+    let (demo, vm) = try makeDemoAndVM()
+    let summary = try XCTUnwrap(
+      vm.filteredSummaries.first { $0.entryType == "SSH_KEY" },
+      "No SSH_KEY summary"
+    )
+    let detail = try XCTUnwrap(
+      vm.loadDetail(
+        for: summary.id, cacheData: demo.cacheData,
+        vaultKey: demo.vaultKey, userId: demo.userId),
+      "SSH_KEY loadDetail returned nil"
+    )
+    XCTAssertNotNil(detail.sshKey)
+    XCTAssertNotNil(detail.sshKey?.publicKey)
+    // keySize is written as a JSON number; FlexibleString must decode it to "256"
+    XCTAssertEqual(detail.sshKey?.keySize, "256", "keySize must decode JSON number 256 to String '256'")
+  }
+
+  func testSoftwareLicense_decodesWithLicenseKey() throws {
+    let (demo, vm) = try makeDemoAndVM()
+    let summary = try XCTUnwrap(
+      vm.filteredSummaries.first { $0.entryType == "SOFTWARE_LICENSE" },
+      "No SOFTWARE_LICENSE summary"
+    )
+    let detail = try XCTUnwrap(
+      vm.loadDetail(
+        for: summary.id, cacheData: demo.cacheData,
+        vaultKey: demo.vaultKey, userId: demo.userId),
+      "SOFTWARE_LICENSE loadDetail returned nil"
+    )
+    XCTAssertNotNil(detail.softwareLicense)
+    XCTAssertEqual(detail.softwareLicense?.licenseKey, "EXAMPLE-1234-5678-9ABC")
+  }
+
+  func testPasskey_decodesWithRelyingPartyId() throws {
+    let (demo, vm) = try makeDemoAndVM()
+    let summary = try XCTUnwrap(
+      vm.filteredSummaries.first { $0.entryType == "PASSKEY" },
+      "No PASSKEY summary"
+    )
+    let detail = try XCTUnwrap(
+      vm.loadDetail(
+        for: summary.id, cacheData: demo.cacheData,
+        vaultKey: demo.vaultKey, userId: demo.userId),
+      "PASSKEY loadDetail returned nil"
+    )
+    XCTAssertNotNil(detail.passkey)
+    XCTAssertEqual(detail.passkey?.relyingPartyId, "github.com")
+  }
+
+  func testSecureNote_decodesWithContent() throws {
+    let (demo, vm) = try makeDemoAndVM()
+    let summary = try XCTUnwrap(
+      vm.filteredSummaries.first { $0.entryType == "SECURE_NOTE" },
+      "No SECURE_NOTE summary"
+    )
+    let detail = try XCTUnwrap(
+      vm.loadDetail(
+        for: summary.id, cacheData: demo.cacheData,
+        vaultKey: demo.vaultKey, userId: demo.userId),
+      "SECURE_NOTE loadDetail returned nil"
+    )
+    XCTAssertNotNil(detail.secureNote)
+    XCTAssertEqual(detail.secureNote?.content, "Sample secure note for demo.")
+  }
+
+  // MARK: - C1: TOTP login decodes correct secret (T7)
+
+  func testTotpLogin_decodesSecret() throws {
+    let (demo, vm) = try makeDemoAndVM()
+    // The AWS Console entry carries the TOTP seed and isFavorite=true
+    let summary = try XCTUnwrap(
+      vm.filteredSummaries.first { $0.isFavorite && $0.entryType == "LOGIN" },
+      "No favorite LOGIN (AWS Console) summary"
+    )
+    let detail = try XCTUnwrap(
+      vm.loadDetail(
+        for: summary.id, cacheData: demo.cacheData,
+        vaultKey: demo.vaultKey, userId: demo.userId),
+      "AWS login loadDetail returned nil"
+    )
+    XCTAssertEqual(detail.totpSecret, "JBSWY3DPEHPK3PXP")
+  }
+
+  // MARK: - NFR3: sample data uses only reserved/example domains
+
+  func testSampleDataUsesReservedDomainsOnly() throws {
+    let factoryURL = URL(fileURLWithPath: #file)
+      .deletingLastPathComponent()   // PasswdSSOTests/
+      .deletingLastPathComponent()   // ios/
+      .appendingPathComponent("Shared/Demo/DemoVaultFactory.swift")
+
+    guard let source = try? String(contentsOf: factoryURL, encoding: .utf8) else {
+      return
+    }
+
+    let emailPattern = try NSRegularExpression(pattern: #"[A-Za-z0-9._%+\-]+@([A-Za-z0-9.\-]+)"#)
+    let range = NSRange(source.startIndex..., in: source)
+    let matches = emailPattern.matches(in: source, range: range)
+    for match in matches {
+      guard let domainRange = Range(match.range(at: 1), in: source) else { continue }
+      let domain = String(source[domainRange])
+      let ok = domain.hasSuffix("example.com") || domain.hasSuffix("example.org")
+        || domain.hasSuffix("example.net")
+      XCTAssertTrue(ok, "Non-reserved email domain in DemoVaultFactory: \(domain)")
+    }
+  }
+
+  // MARK: - Vaults from successive calls have different keys (ephemeral)
+
+  func testSuccessiveCalls_produceDifferentVaultKeys() throws {
+    let d1 = try DemoVaultFactory.makeDemoVault()
+    let d2 = try DemoVaultFactory.makeDemoVault()
+    let k1 = d1.vaultKey.withUnsafeBytes { Data($0) }
+    let k2 = d2.vaultKey.withUnsafeBytes { Data($0) }
+    XCTAssertNotEqual(k1, k2, "Each call must produce a fresh ephemeral key")
+  }
+}

--- a/ios/PasswdSSOTests/DemoVaultFactoryTests.swift
+++ b/ios/PasswdSSOTests/DemoVaultFactoryTests.swift
@@ -180,18 +180,22 @@ final class DemoVaultFactoryTests: XCTestCase {
   // MARK: - NFR3: sample data uses only reserved/example domains
 
   func testSampleDataUsesReservedDomainsOnly() throws {
-    let factoryURL = URL(fileURLWithPath: #file)
+    // #filePath (absolute) not #file: under Swift 6 #file is concise
+    // (<module>/<basename>) → relative URL → read fails. A non-swallowing `try`
+    // fails loudly instead of greenwashing. See LocalizationCatalogTests.
+    let factoryURL = URL(filePath: #filePath)
       .deletingLastPathComponent()   // PasswdSSOTests/
       .deletingLastPathComponent()   // ios/
       .appendingPathComponent("Shared/Demo/DemoVaultFactory.swift")
 
-    guard let source = try? String(contentsOf: factoryURL, encoding: .utf8) else {
-      return
-    }
+    let source = try String(contentsOf: factoryURL, encoding: .utf8)
 
     let emailPattern = try NSRegularExpression(pattern: #"[A-Za-z0-9._%+\-]+@([A-Za-z0-9.\-]+)"#)
     let range = NSRange(source.startIndex..., in: source)
     let matches = emailPattern.matches(in: source, range: range)
+    // Guard against a vacuous pass: the fixtures DO contain emails, so a zero
+    // match count means the regex or the read silently broke.
+    XCTAssertGreaterThan(matches.count, 0, "Expected at least one email in the fixtures")
     for match in matches {
       guard let domainRange = Range(match.range(at: 1), in: source) else { continue }
       let domain = String(source[domainRange])

--- a/ios/Shared/Demo/DemoVaultFactory.swift
+++ b/ios/Shared/Demo/DemoVaultFactory.swift
@@ -1,0 +1,464 @@
+import CryptoKit
+import Foundation
+
+// MARK: - DemoVault
+
+/// In-memory demo vault returned by DemoVaultFactory. Carries only the three
+/// values needed to hydrate a VaultViewModel — no file, no Keychain, no network.
+public struct DemoVault: Sendable {
+  public let cacheData: CacheData
+  public let vaultKey: SymmetricKey
+  public let userId: String
+}
+
+// MARK: - DemoVaultFactory
+
+/// Builds a fully-encrypted in-memory vault for Demo Mode.
+///
+/// Contains 9 fixture entries (8 types; LOGIN appears twice). Every blob is
+/// encrypted with a fresh ephemeral SymmetricKey using the same
+/// encryptAESGCMEncoded + buildPersonalEntryAAD path the real app uses, so the
+/// real VaultViewModel.loadFromCache / loadDetail decrypt path exercises them
+/// end-to-end in tests.
+///
+/// ISOLATION CONTRACT: no shared Keychain, no cache file, no wrapped-key
+/// store, no host token store, no favicon loader. All state stays in-memory.
+/// See DemoModeStateTests.testForbiddenPatternsAbsent_inDemoVaultFactory for
+/// the grep gate that enforces this.
+public enum DemoVaultFactory {
+
+  // MARK: - Public API
+
+  public static func makeDemoVault() throws -> DemoVault {
+    let userId = "demo-user-fixture-id"
+    let vaultKey = SymmetricKey(size: .bits256)
+
+    let cacheEntries = try buildDemoEntries(vaultKey: vaultKey, userId: userId)
+    let now = Date()
+    let header = CacheHeader(
+      cacheVersionCounter: 0,
+      cacheIssuedAt: now,
+      lastSuccessfulRefreshAt: now,
+      entryCount: UInt32(cacheEntries.count),
+      hostInstallUUID: Data(repeating: 0, count: 16),
+      userId: userId
+    )
+    let entriesJSON = try JSONEncoder().encode(cacheEntries)
+    let cacheData = CacheData(header: header, entries: entriesJSON)
+    return DemoVault(cacheData: cacheData, vaultKey: vaultKey, userId: userId)
+  }
+
+  // MARK: - Blob payload encodable types
+
+  // Shape mirrors OverviewBlobPayload in EntryBlobDecoder (the server JSON shape).
+  private struct OverviewBlob: Encodable {
+    let title: String
+    let username: String?
+    let urlHost: String?
+    let tags: [TagBlob]
+    let hasTOTP: Bool?
+    let relyingPartyId: String?
+    let credentialId: String?
+  }
+
+  // Shape mirrors FullBlobPayload in EntryBlobDecoder.
+  // All type-specific fields are flat at the top level.
+  private struct FullBlob: Encodable {
+    let title: String
+    let username: String?
+    let password: String?
+    let url: String?
+    let notes: String?
+    let tags: [TagBlob]
+    let totp: TotpBlob?
+    // SECURE_NOTE
+    let content: String?
+    let isMarkdown: Bool?
+    // CREDIT_CARD
+    let cardholderName: String?
+    let cardNumber: String?
+    let brand: String?
+    let expiryMonth: String?
+    let expiryYear: String?
+    let cvv: String?
+    // IDENTITY
+    let fullName: String?
+    let givenName: String?
+    let familyName: String?
+    let email: String?
+    let phone: String?
+    // BANK_ACCOUNT
+    let bankName: String?
+    let accountType: String?
+    let accountHolderName: String?
+    let accountNumber: String?
+    let routingNumber: String?
+    // SSH_KEY — keySize encoded as Int (web client writes a JSON number)
+    let privateKey: String?
+    let publicKey: String?
+    let keyType: String?
+    let fingerprint: String?
+    let comment: String?
+    let keySize: Int?
+    // SOFTWARE_LICENSE
+    let softwareName: String?
+    let licenseKey: String?
+    let version: String?
+    let licensee: String?
+    // PASSKEY (display fields only)
+    let relyingPartyId: String?
+    let relyingPartyName: String?
+    let credentialId: String?
+    let creationDate: String?
+    let deviceInfo: String?
+  }
+
+  private struct TagBlob: Encodable {
+    let name: String
+    let color: String?
+  }
+
+  private struct TotpBlob: Encodable {
+    let secret: String
+    let algorithm: String?
+    let digits: Int?
+    let period: Int?
+  }
+
+  // MARK: - Fixture definitions
+
+  private struct FixtureEntry {
+    let id: String
+    let entryType: String
+    let isFavorite: Bool
+    let overview: OverviewBlob
+    let full: FullBlob
+  }
+
+  // swiftlint:disable function_body_length
+  private static func fixtures() -> [FixtureEntry] {
+    [
+      // 1. LOGIN with TOTP — AWS Console
+      FixtureEntry(
+        id: "a1000000-0000-0000-0000-000000000001",
+        entryType: "LOGIN",
+        isFavorite: true,
+        overview: OverviewBlob(
+          title: "AWS Console (IAM)",
+          username: "alice@example.com",
+          urlHost: "signin.aws.amazon.com",
+          tags: [],
+          hasTOTP: true,
+          relyingPartyId: nil,
+          credentialId: nil
+        ),
+        full: FullBlob(
+          title: "AWS Console (IAM)",
+          username: "alice@example.com",
+          password: "ChangeMe-Example-123!",
+          url: "https://signin.aws.amazon.com/console",
+          notes: nil,
+          tags: [],
+          totp: TotpBlob(secret: "JBSWY3DPEHPK3PXP", algorithm: "SHA1", digits: 6, period: 30),
+          content: nil, isMarkdown: nil,
+          cardholderName: nil, cardNumber: nil, brand: nil,
+          expiryMonth: nil, expiryYear: nil, cvv: nil,
+          fullName: nil, givenName: nil, familyName: nil,
+          email: nil, phone: nil,
+          bankName: nil, accountType: nil, accountHolderName: nil,
+          accountNumber: nil, routingNumber: nil,
+          privateKey: nil, publicKey: nil, keyType: nil,
+          fingerprint: nil, comment: nil, keySize: nil,
+          softwareName: nil, licenseKey: nil, version: nil, licensee: nil,
+          relyingPartyId: nil, relyingPartyName: nil,
+          credentialId: nil, creationDate: nil, deviceInfo: nil
+        )
+      ),
+      // 2. LOGIN without TOTP — GitHub
+      FixtureEntry(
+        id: "a2000000-0000-0000-0000-000000000002",
+        entryType: "LOGIN",
+        isFavorite: false,
+        overview: OverviewBlob(
+          title: "GitHub",
+          username: "alice@example.com",
+          urlHost: "github.com",
+          tags: [],
+          hasTOTP: nil,
+          relyingPartyId: nil,
+          credentialId: nil
+        ),
+        full: FullBlob(
+          title: "GitHub",
+          username: "alice@example.com",
+          password: "Example-Pass-456!",
+          url: "https://github.com/login",
+          notes: nil,
+          tags: [],
+          totp: nil,
+          content: nil, isMarkdown: nil,
+          cardholderName: nil, cardNumber: nil, brand: nil,
+          expiryMonth: nil, expiryYear: nil, cvv: nil,
+          fullName: nil, givenName: nil, familyName: nil,
+          email: nil, phone: nil,
+          bankName: nil, accountType: nil, accountHolderName: nil,
+          accountNumber: nil, routingNumber: nil,
+          privateKey: nil, publicKey: nil, keyType: nil,
+          fingerprint: nil, comment: nil, keySize: nil,
+          softwareName: nil, licenseKey: nil, version: nil, licensee: nil,
+          relyingPartyId: nil, relyingPartyName: nil,
+          credentialId: nil, creationDate: nil, deviceInfo: nil
+        )
+      ),
+      // 3. CREDIT_CARD — Corporate VISA
+      FixtureEntry(
+        id: "a3000000-0000-0000-0000-000000000003",
+        entryType: "CREDIT_CARD",
+        isFavorite: false,
+        overview: OverviewBlob(
+          title: "Corporate VISA", username: nil, urlHost: nil, tags: [],
+          hasTOTP: nil, relyingPartyId: nil, credentialId: nil
+        ),
+        full: FullBlob(
+          title: "Corporate VISA",
+          username: nil, password: nil, url: nil, notes: nil, tags: [], totp: nil,
+          content: nil, isMarkdown: nil,
+          cardholderName: "Alice Example",
+          cardNumber: "4111111111111111",
+          brand: "Visa",
+          expiryMonth: "12",
+          expiryYear: "2030",
+          cvv: "123",
+          fullName: nil, givenName: nil, familyName: nil,
+          email: nil, phone: nil,
+          bankName: nil, accountType: nil, accountHolderName: nil,
+          accountNumber: nil, routingNumber: nil,
+          privateKey: nil, publicKey: nil, keyType: nil,
+          fingerprint: nil, comment: nil, keySize: nil,
+          softwareName: nil, licenseKey: nil, version: nil, licensee: nil,
+          relyingPartyId: nil, relyingPartyName: nil,
+          credentialId: nil, creationDate: nil, deviceInfo: nil
+        )
+      ),
+      // 4. IDENTITY — Alice Identity
+      FixtureEntry(
+        id: "a4000000-0000-0000-0000-000000000004",
+        entryType: "IDENTITY",
+        isFavorite: false,
+        overview: OverviewBlob(
+          title: "Alice Identity", username: nil, urlHost: nil, tags: [],
+          hasTOTP: nil, relyingPartyId: nil, credentialId: nil
+        ),
+        full: FullBlob(
+          title: "Alice Identity",
+          username: nil, password: nil, url: nil, notes: nil, tags: [], totp: nil,
+          content: nil, isMarkdown: nil,
+          cardholderName: nil, cardNumber: nil, brand: nil,
+          expiryMonth: nil, expiryYear: nil, cvv: nil,
+          fullName: "Alice Example",
+          givenName: "Alice",
+          familyName: "Example",
+          email: "alice@example.com",
+          phone: "+1-555-0100",
+          bankName: nil, accountType: nil, accountHolderName: nil,
+          accountNumber: nil, routingNumber: nil,
+          privateKey: nil, publicKey: nil, keyType: nil,
+          fingerprint: nil, comment: nil, keySize: nil,
+          softwareName: nil, licenseKey: nil, version: nil, licensee: nil,
+          relyingPartyId: nil, relyingPartyName: nil,
+          credentialId: nil, creationDate: nil, deviceInfo: nil
+        )
+      ),
+      // 5. PASSKEY — GitHub Passkey
+      FixtureEntry(
+        id: "a5000000-0000-0000-0000-000000000005",
+        entryType: "PASSKEY",
+        isFavorite: false,
+        overview: OverviewBlob(
+          title: "GitHub Passkey",
+          username: "alice@example.com",
+          urlHost: "github.com",
+          tags: [],
+          hasTOTP: nil,
+          relyingPartyId: "github.com",
+          credentialId: "Y3JlZEV4YW1wbGU"
+        ),
+        full: FullBlob(
+          title: "GitHub Passkey",
+          username: "alice@example.com",
+          password: nil, url: nil, notes: nil, tags: [], totp: nil,
+          content: nil, isMarkdown: nil,
+          cardholderName: nil, cardNumber: nil, brand: nil,
+          expiryMonth: nil, expiryYear: nil, cvv: nil,
+          fullName: nil, givenName: nil, familyName: nil,
+          email: nil, phone: nil,
+          bankName: nil, accountType: nil, accountHolderName: nil,
+          accountNumber: nil, routingNumber: nil,
+          privateKey: nil, publicKey: nil, keyType: nil,
+          fingerprint: nil, comment: nil, keySize: nil,
+          softwareName: nil, licenseKey: nil, version: nil, licensee: nil,
+          relyingPartyId: "github.com",
+          relyingPartyName: "GitHub",
+          credentialId: "Y3JlZEV4YW1wbGU",
+          creationDate: "2024-01-01",
+          deviceInfo: "iPhone"
+        )
+      ),
+      // 6. SECURE_NOTE — VPN Recovery Notes
+      FixtureEntry(
+        id: "a6000000-0000-0000-0000-000000000006",
+        entryType: "SECURE_NOTE",
+        isFavorite: false,
+        overview: OverviewBlob(
+          title: "VPN Recovery Notes", username: nil, urlHost: nil, tags: [],
+          hasTOTP: nil, relyingPartyId: nil, credentialId: nil
+        ),
+        full: FullBlob(
+          title: "VPN Recovery Notes",
+          username: nil, password: nil, url: nil, notes: nil, tags: [], totp: nil,
+          content: "Sample secure note for demo.",
+          isMarkdown: false,
+          cardholderName: nil, cardNumber: nil, brand: nil,
+          expiryMonth: nil, expiryYear: nil, cvv: nil,
+          fullName: nil, givenName: nil, familyName: nil,
+          email: nil, phone: nil,
+          bankName: nil, accountType: nil, accountHolderName: nil,
+          accountNumber: nil, routingNumber: nil,
+          privateKey: nil, publicKey: nil, keyType: nil,
+          fingerprint: nil, comment: nil, keySize: nil,
+          softwareName: nil, licenseKey: nil, version: nil, licensee: nil,
+          relyingPartyId: nil, relyingPartyName: nil,
+          credentialId: nil, creationDate: nil, deviceInfo: nil
+        )
+      ),
+      // 7. BANK_ACCOUNT — Acme Savings
+      FixtureEntry(
+        id: "a7000000-0000-0000-0000-000000000007",
+        entryType: "BANK_ACCOUNT",
+        isFavorite: false,
+        overview: OverviewBlob(
+          title: "Acme Savings", username: nil, urlHost: nil, tags: [],
+          hasTOTP: nil, relyingPartyId: nil, credentialId: nil
+        ),
+        full: FullBlob(
+          title: "Acme Savings",
+          username: nil, password: nil, url: nil, notes: nil, tags: [], totp: nil,
+          content: nil, isMarkdown: nil,
+          cardholderName: nil, cardNumber: nil, brand: nil,
+          expiryMonth: nil, expiryYear: nil, cvv: nil,
+          fullName: nil, givenName: nil, familyName: nil,
+          email: nil, phone: nil,
+          bankName: "Acme Bank",
+          accountType: "Savings",
+          accountHolderName: "Alice Example",
+          accountNumber: "000123456",
+          routingNumber: "110000000",
+          privateKey: nil, publicKey: nil, keyType: nil,
+          fingerprint: nil, comment: nil, keySize: nil,
+          softwareName: nil, licenseKey: nil, version: nil, licensee: nil,
+          relyingPartyId: nil, relyingPartyName: nil,
+          credentialId: nil, creationDate: nil, deviceInfo: nil
+        )
+      ),
+      // 8. SOFTWARE_LICENSE — Adobe License
+      FixtureEntry(
+        id: "a8000000-0000-0000-0000-000000000008",
+        entryType: "SOFTWARE_LICENSE",
+        isFavorite: false,
+        overview: OverviewBlob(
+          title: "Adobe License", username: nil, urlHost: nil, tags: [],
+          hasTOTP: nil, relyingPartyId: nil, credentialId: nil
+        ),
+        full: FullBlob(
+          title: "Adobe License",
+          username: nil, password: nil, url: nil, notes: nil, tags: [], totp: nil,
+          content: nil, isMarkdown: nil,
+          cardholderName: nil, cardNumber: nil, brand: nil,
+          expiryMonth: nil, expiryYear: nil, cvv: nil,
+          fullName: nil, givenName: nil, familyName: nil,
+          email: "alice@example.com", phone: nil,
+          bankName: nil, accountType: nil, accountHolderName: nil,
+          accountNumber: nil, routingNumber: nil,
+          privateKey: nil, publicKey: nil, keyType: nil,
+          fingerprint: nil, comment: nil, keySize: nil,
+          softwareName: "Adobe CC",
+          licenseKey: "EXAMPLE-1234-5678-9ABC",
+          version: "2026",
+          licensee: "Alice Example",
+          relyingPartyId: nil, relyingPartyName: nil,
+          credentialId: nil, creationDate: nil, deviceInfo: nil
+        )
+      ),
+      // 9. SSH_KEY — Deploy Key (keySize as a JSON NUMBER to match web client)
+      FixtureEntry(
+        id: "a9000000-0000-0000-0000-000000000009",
+        entryType: "SSH_KEY",
+        isFavorite: false,
+        overview: OverviewBlob(
+          title: "Deploy Key", username: nil, urlHost: nil, tags: [],
+          hasTOTP: nil, relyingPartyId: nil, credentialId: nil
+        ),
+        full: FullBlob(
+          title: "Deploy Key",
+          username: nil, password: nil, url: nil, notes: nil, tags: [], totp: nil,
+          content: nil, isMarkdown: nil,
+          cardholderName: nil, cardNumber: nil, brand: nil,
+          expiryMonth: nil, expiryYear: nil, cvv: nil,
+          fullName: nil, givenName: nil, familyName: nil,
+          email: nil, phone: nil,
+          bankName: nil, accountType: nil, accountHolderName: nil,
+          accountNumber: nil, routingNumber: nil,
+          privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\n(demo only)\n-----END OPENSSH PRIVATE KEY-----",
+          publicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample",
+          keyType: "ed25519",
+          fingerprint: "SHA256:exampleexample",
+          comment: "alice@example.com",
+          keySize: 256,
+          softwareName: nil, licenseKey: nil, version: nil, licensee: nil,
+          relyingPartyId: nil, relyingPartyName: nil,
+          credentialId: nil, creationDate: nil, deviceInfo: nil
+        )
+      ),
+    ]
+  }
+  // swiftlint:enable function_body_length
+
+  // MARK: - Private helpers
+
+  private static func buildDemoEntries(
+    vaultKey: SymmetricKey,
+    userId: String
+  ) throws -> [CacheEntry] {
+    let encoder = JSONEncoder()
+    return try fixtures().map { fixture in
+      let entryId = fixture.id
+
+      let blobAAD = try buildPersonalEntryAAD(
+        userId: userId, entryId: entryId, vaultType: VaultType.blob)
+      let overviewAAD = try buildPersonalEntryAAD(
+        userId: userId, entryId: entryId, vaultType: VaultType.overview)
+
+      let overviewData = try encoder.encode(fixture.overview)
+      let blobData = try encoder.encode(fixture.full)
+
+      let overviewEncrypted = try encryptAESGCMEncoded(
+        plaintext: overviewData, key: vaultKey, aad: overviewAAD)
+      let blobEncrypted = try encryptAESGCMEncoded(
+        plaintext: blobData, key: vaultKey, aad: blobAAD)
+
+      return CacheEntry(
+        id: entryId,
+        teamId: nil,
+        aadVersion: 1,
+        keyVersion: 1,
+        teamKeyVersion: nil,
+        itemKeyVersion: nil,
+        encryptedItemKey: nil,
+        encryptedBlob: blobEncrypted,
+        encryptedOverview: overviewEncrypted,
+        entryType: fixture.entryType,
+        isFavorite: fixture.isFavorite
+      )
+    }
+  }
+}

--- a/ios/Shared/Demo/DemoVaultPresentation.swift
+++ b/ios/Shared/Demo/DemoVaultPresentation.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Read-only flags describing Demo Mode capabilities. Consumed by DemoVaultView
+/// and unit-tested (DemoModeStateTests) as the falsifiable isolation proof that
+/// demo never enables mutation, sync, or favicon fetch.
+public struct DemoVaultPresentation: Sendable {
+  public let showsMutationAffordances: Bool = false
+  public let showsSyncControls: Bool = false
+  public let showsFavicons: Bool = false
+  /// Label for the exit affordance. String (not LocalizedStringKey) for Sendable conformance.
+  public let exitLabel: String = "Exit Demo"
+
+  public init() {}
+}


### PR DESCRIPTION
## Why

The iOS app was rejected under **App Store Guideline 2.1** — the reviewer could not sign in, because the app only offers SSO (Google / SAML / Magic Link) with no email+password path that completes inside `ASWebAuthenticationSession`. Apple's recommended remedy for SSO-only apps is a demonstration mode. This adds one.

## What

A **"Try Demo Mode"** button on the sign-in and server-URL screens opens a read-only vault populated from an in-memory `DemoVaultFactory` (9 fixtures covering all 8 entry types: login×2, credit card, identity, passkey, secure note, bank account, software license, SSH key). No server, account, SSO, or master passphrase required. "Exit Demo" returns to the start screen.

## Isolation is structural, not guard-based

Because this is an E2E-encrypted vault sharing an App Group container + Keychain with the AutoFill extension, a demo session must never touch a real user's data. `DemoVaultView` holds **no** `apiClient` / `hostSyncService` / `autoLockService` / `FaviconLoader` — so there is no code path to the network or to shared cache / Keychain / QuickType / settings. A grep-gate unit test (`DemoModeStateTests`) enforces the forbidden-symbol contract and is the falsifiable isolation proof (verified able to go red).

## Read-only seam

`EntryDetailView` / `VaultCategoryListView` gain an `isReadOnly` flag and optional live-service deps (default `nil`), so demo reuses the full per-type detail rendering without naming the forbidden collaborators. Live call sites are unchanged (defaulted params) — no behavior change for the real app.

## Sample data

All fake: RFC 2606 reserved domains (`example.com`), the universally-published TOTP test seed, placeholder SSH key. The Bitwarden-compat export JSON is not bundled.

## Testing

629 unit + 2 UI tests pass, including new demo tests (per-type decrypt via the real decrypt path, TOTP, NFR3 domains, ephemeral key, isolation grep gates with prove-red).

## Out of scope

Read-only browse only; local create/edit/delete deferred (SC1). Tappable URLs in entry detail are a separate PR.

## Review

Developed via `/triangulate` — plan (2 rounds) + code review (2 rounds), all findings resolved. Artifacts in `docs/archive/review/ios-demo-mode-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)