### PR TITLE
fix(security): fail-closed rate limiters + remove GET-side trash auto-purge

### DIFF
--- a/docs/archive/review/rate-limiter-fail-closed-and-get-purge-plan.md
+++ b/docs/archive/review/rate-limiter-fail-closed-and-get-purge-plan.md
@@ -1,0 +1,141 @@
+# Plan: rate-limiter fail-closed + GET auto-purge removal
+
+## Project context
+
+- **Type**: web app + service (Next.js 16 App Router, multi-tenant, E2E-encrypted password manager)
+- **Test infrastructure**: unit (vitest) + integration (real-DB) + E2E (playwright) + CI/CD
+- **Verification environment constraints**:
+  - Redis-unavailable fail-closed paths: `verifiable-local` via mocking `getRedis()` → null (unit). No live Redis outage needed.
+  - retention-gc worker trash-purge: `verifiable-CI` (real-DB integration suite already covers `sweepTrashEntry`).
+  - OAuth/SAML callback under real IdP outage: `blocked-deferred` — cannot exercise a real Redis+IdP simultaneous outage locally; unit test asserts the 503 branch via mocked limiter result. (Cost-justification: a real dual-outage rig requires a staged IdP + Redis cluster; out of proportion to a 3-line branch addition that is unit-covered.)
+
+## Objective
+
+Phase 1 of the external OWASP review remediation:
+1. Make security-sensitive rate limiters fail **closed** on Redis error (M1, M4, M5, M6).
+2. Remove the destructive, observability-blind trash auto-purge side effect from `GET /api/passwords` and `GET /api/teams/[teamId]/passwords` (L3). The retention-gc worker already owns this purge.
+
+Out of scope (separate PR / accepted): M2/M3 Bearer matcher narrowing, L1 orphan-blob retry, L2 SCIM session-invalidation hardening.
+
+## Requirements
+
+### Functional
+- R-FC1: Every limiter listed below returns 503 (canonical `{error:"SERVICE_UNAVAILABLE"}`) when Redis is unreachable, instead of falling back to the in-memory Map.
+- R-FC2: Normal over-limit behavior (429) is unchanged when Redis is healthy.
+- R-FC3: Fail-closed 503 events emit the standard rate-limit-fail-closed audit/warn (via `checkRateLimitOrFail` → `emitRateLimitFailClosed`).
+- R-L3-1: `GET /api/passwords` and `GET /api/teams/[teamId]/passwords` perform NO writes/deletes. They become read-only.
+- R-L3-2: Trash auto-purge continues to run via the retention-gc worker (already registered: `PER_TENANT_TRASH` for `password_entries` + `team_password_entries`).
+
+### Non-functional
+- No new dependency. Reuse the existing `checkRateLimitOrFail` helper (`src/lib/security/rate-limit-audit.ts`) and `createRateLimiter` option `failClosedOnRedisError`.
+- Match the existing fail-closed routes' envelope and audit wiring.
+
+## Technical approach
+
+### Rate limiters → fail-closed
+
+The limiter factory already supports `failClosedOnRedisError: true`. On Redis error it returns `{ allowed:false, redisErrored:true }`. The route must translate `redisErrored` → 503. The canonical translator is `checkRateLimitOrFail` (already used by ~22 fail-closed routes); it fires `emitRateLimitFailClosed` internally.
+
+Two shapes:
+- **Direct-limiter routes** (v1 passwords, autofill, breakglass): pass `{ limiter, key }` to `checkRateLimitOrFail`.
+- **IP-keyed wrapper routes** (auth callback, magic link): `checkIpRateLimit` already returns a `RateLimitResult` (propagating `redisErrored`). Pass `{ result }` to `checkRateLimitOrFail`. The wrappers currently branch only on `!rl.allowed`; add the `redisErrored → 503` branch.
+
+`magicLinkEmailLimiter` (per-email, in `auth.config.ts`) is ALREADY `failClosedOnRedisError: true`. This PR closes the per-IP asymmetry.
+
+### L3 → delete inline purge
+
+The retention-gc worker (`sweepTrashEntry`, registry `PER_TENANT_TRASH`) already auto-purges trashed entries per-tenant using `trashRetentionDays` (NULL → tenant skipped = opt-in, "no implicit deletion"). The GET-route inline purge is a leftover duplicate that (a) puts a destructive `deleteMany` on a GET, (b) swallows failures via `.catch(()=>[])` with zero audit/log/metric, and (c) force-purges at a hardcoded 30 days regardless of the tenant's opt-in. Removing it **completes** the migration to the worker's opt-in model.
+
+**Behavior change to surface**: tenants with `trashRetentionDays = NULL` will no longer have trash auto-purged at 30 days on list. This is the worker's intended opt-in semantics; it is not a regression but IS an observable behavior change. Documented here for reviewer awareness.
+
+## Contracts
+
+### C1 — `failClosedOnRedisError` on five limiters — locked
+- **Files**:
+  - `src/lib/security/rate-limiters.ts` — `v1ApiKeyLimiter` (M1)
+  - `src/app/api/auth/[...nextauth]/route.ts` — `callbackRateLimiter`, `magicLinkIpLimiter` (M4)
+  - `src/app/api/mobile/autofill-token/route.ts` — `mintLimiter` (M5)
+  - `src/app/api/tenant/breakglass/route.ts` — `breakglassRateLimiter` (M6)
+- **Invariant** (app-enforced): each `createRateLimiter(...)` above includes `failClosedOnRedisError: true`.
+- **Forbidden patterns**:
+  - `pattern: v1ApiKeyLimiter = createRateLimiter\(\{[^}]*\}\)` without `failClosedOnRedisError` — reason: M1 must be fail-closed
+- **Acceptance**: grep each factory call → `failClosedOnRedisError: true` present.
+
+### C2 — v1 passwords routes translate redisErrored → 503 — locked
+- **Files**: `src/app/api/v1/passwords/route.ts` (GET+POST), `src/app/api/v1/passwords/[id]/route.ts` (the shared `checkAuth` helper at top of file).
+- **Approach**: replace the `const rl = await v1ApiKeyLimiter.check(...); if (!rl.allowed) return rateLimited(...)` blocks with `checkRateLimitOrFail({ req, limiter: v1ApiKeyLimiter, key, scope:"v1.passwords", userId, tenantId })`. Returns 503 on redisErrored, 429 on over-limit, null to proceed.
+- **Invariant** (app-enforced): no v1 passwords path falls back to in-memory on Redis error.
+- **Acceptance**: unit test — limiter `check` mocked to `{redisErrored:true}` → response 503; mocked `{allowed:false,retryAfterMs}` → 429; `{allowed:true}` → proceeds.
+- **Consumer-flow walkthrough**: the only consumer of these responses is the v1 API client (CLI / REST). It reads HTTP status: 503 → retry-after backoff; 429 → rate-limit backoff. Both statuses are already in the v1 contract (`SERVICE_UNAVAILABLE`, `RATE_LIMIT_EXCEEDED`). No body-shape field is newly required.
+
+### C3 — autofill-token + breakglass translate redisErrored → 503 — locked
+- **Files**: `src/app/api/mobile/autofill-token/route.ts`, `src/app/api/tenant/breakglass/route.ts`.
+- **Approach**: same `checkRateLimitOrFail` swap. breakglass: scope `"breakglass"`, userId + tenantId available. autofill: scope `"mobile.autofill_token"`, userId available (tenantId too).
+- **Acceptance**: same 503/429/proceed unit matrix.
+
+### C4 — auth callback + magic-link wrappers translate redisErrored → 503 — locked
+- **File**: `src/app/api/auth/[...nextauth]/route.ts`.
+- **Approach**: in `withCallbackRateLimit` and `withMagicLinkIpRateLimit`, after `const rl = await checkIpRateLimit(...)`, call `checkRateLimitOrFail({ req: request, result: rl, scope, userId: null })` and return its non-null result as `Response`. Pre-auth (userId null) → `emitRateLimitFailClosed` warn-logs (per its pre-auth branch).
+- **Invariant** (app-enforced): callback/magic-link return 503 on Redis error; null-IP still fail-OPEN (existing `checkIpRateLimit` behavior, intentional — proxy-misconfig detection, NOT changed here).
+- **Acceptance**: unit — mocked `checkIpRateLimit` → `{redisErrored:true}` yields 503; `{allowed:false}` yields 429; `{allowed:true}` proceeds to handler; null-IP path (`{allowed:true}` from helper) proceeds.
+- **Note**: This makes OAuth/SAML login callbacks fail-closed during a Redis outage (login blocked until Redis recovers). User explicitly accepted this trade-off ("今回は全部 fail-closed").
+
+### C5 — remove inline trash auto-purge from GET list routes — locked
+- **Files** (exact per-file import edits — verified against actual usage by Phase-1 functionality review F1):
+  - `src/app/api/passwords/route.ts` — delete lines 71-100 (the `if (!trashOnly) { ... auto-purge ... }` block). Then remove imports that become unused (sole uses were in that block): `collectEntryAttachmentRefs`, `deleteAttachmentBlobs`, `AttachmentBlobRef` (the whole `@/lib/blob-store/cleanup` import group), `MS_PER_DAY`. From the line-12 import, remove ONLY `TRASH_PURGE_BATCH_SIZE` — `FILENAME_MAX_LENGTH` (same line) is still used at line ~186.
+  - `src/app/api/teams/[teamId]/passwords/route.ts` — delete lines 59-68 (the `if (!trashOnly) { ...purgeExpiredTeamPasswords... }` block) + remove ONLY the `deleteAttachmentBlobs` import (line 16). `errorResponse`, `TeamPasswordServiceError`, `FILENAME_MAX_LENGTH` remain used.
+  - `src/lib/services/team-password-service.ts` — delete `purgeExpiredTeamPasswords` (dead code; worker uses `sweepTrashEntry`, not this helper). Remove ONLY the now-unused `MS_PER_DAY` and `TRASH_PURGE_BATCH_SIZE` imports. **KEEP `collectEntryAttachmentRefs` and `AttachmentBlobRef` (lines 9-10)** — still used by `deleteTeamPassword` (~lines 590/593). Verify no other caller of `purgeExpiredTeamPasswords` exists via grep before deleting.
+- **Invariant** (app-enforced): `GET /api/passwords` and `GET /api/teams/[teamId]/passwords` contain no `deleteMany` / `deleteAttachmentBlobs` / purge call.
+- **Forbidden patterns**:
+  - `pattern: passwordEntry\.deleteMany` in `src/app/api/passwords/route.ts` — reason: GET must be read-only
+  - `pattern: purgeExpiredTeamPasswords` anywhere after this PR — reason: dead helper removed
+- **Acceptance**:
+  - grep the two GET route files → no `deleteMany`, no `deleteAttachmentBlobs`, no `purgeExpired*`.
+  - existing GET list tests still pass (list output unchanged).
+  - retention-gc integration test (`retention-gc-worker-sweep`) still green (worker still purges).
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | `failClosedOnRedisError:true` on 5 limiters | locked |
+| C2 | v1 passwords routes → 503 on redisErrored | locked |
+| C3 | autofill + breakglass → 503 on redisErrored | locked |
+| C4 | auth callback + magic-link wrappers → 503 on redisErrored | locked |
+| C5 | remove inline trash auto-purge from GET list routes + dead helper | locked |
+
+## Testing strategy
+
+Canonical mock pattern (mirror `src/app/api/mobile/authorize/route.test.ts:71-73,182-193`): mock `@/lib/security/rate-limit-audit` with a hoisted `mockCheckRateLimitOrFail`, default `mockResolvedValue(null)` in `beforeEach`, and per-case `mockResolvedValueOnce(503-response)` / `(429-response)`. This avoids running the real `emitRateLimitFailClosed` (which calls real audit/tenant resolution) in unit env.
+
+- **R-FC2/R-FC3 mapping owned by `src/lib/security/rate-limit-audit.test.ts`** — the `{allowed:false}→429`, `{redisErrored}→503`, and `emitRateLimitFailClosed`-fired assertions live at the helper level. Verify this test exists and covers the redisErrored branch (R-FC3 is otherwise untested). Route tests mock the helper and assert *propagation* only.
+- **C2 (v1 passwords)**: in GET/POST + the `[id]` local `checkAuth`, mock `checkRateLimitOrFail`. redisErrored test MUST assert `status===503` AND that the handler body did not run (`expect(mockEntryFindMany / mockEntryCreate / mockEntryUpdate).not.toHaveBeenCalled()`) — guards the vacuous-test trap (T7). Keep a 429 propagation test and an `{allowed→null}` proceed test.
+- **C3 (autofill, breakglass)**: autofill test currently has NO rate-limit mock seam (drives the real limiter) — add the `@/lib/security/rate-limit-audit` mock (T1). redisErrored → assert 503 AND `expect(mockIssueAutofill).not.toHaveBeenCalled()`. breakglass → 503 AND no grant created.
+- **C4 (auth callback + magic link)**: the existing test already mocks `@/lib/security/rate-limit` returning `{check: mockRateLimitCheck}`; set `mockRateLimitCheck.mockResolvedValue({redisErrored:true})` so `checkIpRateLimit` propagates it and the real `checkRateLimitOrFail({result})` yields 503 — assert `status===503` AND `expect(inner).not.toHaveBeenCalled()`. Also add a null-IP test asserting the path still PROCEEDS (no 503) — locks the intentional null-IP fail-open invariant (T7). **Export `withMagicLinkIpRateLimit` as `_withMagicLinkIpRateLimit`** (currently unexported) so magic-link's 503 path is testable (T2); mirror the existing `_withCallbackRateLimit` describe block.
+- **C5**:
+  - personal `passwords/route.test.ts`: remove the now-dead `deleteMany.mockResolvedValue(...)` setup lines; add a regression guard `it("GET performs no deleteMany (read-only after L3)")` → `expect(mockPrismaPasswordEntry.deleteMany).not.toHaveBeenCalled()` (T5 — converts grep-only acceptance into an executable guard).
+  - team route has NO route test file (T6) — read-only-ness is grep-enforced (forbidden-pattern) + dead-helper removal; acknowledge the team GET is route-test-blind.
+  - Worker trash-purge coverage already exists in `src/__tests__/db-integration/retention-gc-trash-purge.integration.test.ts` (personal trash + cascade + NULL-retention skip) and unit `src/workers/retention-gc-worker/__tests__/sweep-trash.test.ts` (personal + team registries). C5 does NOT reduce net coverage (T3/T4).
+- Mandatory: `npx vitest run` + `npx next build`.
+
+## Considerations & constraints
+
+### Scope contract
+- **SC1**: M2 Bearer-matcher narrowing (`/api/teams/.../passwords/**`) — deferred to a separate PR (route policy = method + exact path + token kind). Owner: future security-hardening PR. Currently latent (all team mutating children are `auth()`-only).
+- **SC2**: M3 personal `/api/passwords/**` — NOT a vulnerability (scope-gated `passwords:write` is intended); folded into SC1's latent-risk note.
+- **SC3**: L1 orphan-blob retry/audit — accepted. Worst case: orphaned E2E-encrypted blob (billing/storage leak, no plaintext exposure). Likelihood: low (delete failures are rare). Cost to fix: a retry queue is a multi-file change. Deferred; tracked by external review L1.
+- **SC4**: L2 SCIM session-invalidation hardening — accepted. The token/membership validators are fail-closed (next request rejected), so the invalidation failure is a latency-of-revocation issue, not a bypass. Deferred; tracked by external review L2.
+
+### Known risks
+- C4 makes login callbacks fail-closed on Redis outage (availability cost). Accepted by user. **Operational note (S3)**: this makes Redis a hard dependency for SSO login availability — a Redis flap/failover converts a throttling outage into a login outage (self-DoS angle). The callback limiter guards low-value (replay-flood blunting), not a secret. Record in the ops runbook + ensure Redis HA/fast-failover. Magic-link IP gate guards SMTP cost (reasonable to fail-closed; OAuth/passkey unaffected by that one gate).
+- C5 behavior change: NULL-`trashRetentionDays` tenants lose 30-day auto-purge-on-list; the worker's opt-in model governs going forward. Documented above. The retained rows are E2E-encrypted (no plaintext-at-rest exposure) — this is retention-policy drift, not a confidentiality issue. Moving to opt-in means data is retained LONGER by default = the safer-for-user direction (no silent destruction).
+- C5 operational dependency (F2): trash auto-purge now requires the `worker:retention-gc` process to be deployed. Deployments without it get no trash auto-purge at all (storage growth, not a correctness/security bug).
+- S2 (deferred, confirm-before-close): the `/api/passwords/[id]/attachments` upload limiter remains fail-open. Acceptable IF attachments are quota-bounded (`assertQuotaAvailable`). Confirm during implementation; if not quota-gated, track as a Phase-2 candidate. Not a Phase-1 blocker.
+
+## User operation scenarios
+
+1. Redis down, CLI calls `GET /api/v1/passwords` → 503 (was: silently in-memory limited, effectively bypassed across pods).
+2. Redis down, user submits magic-link email → 503 (was: per-pod in-memory limit).
+3. Redis healthy, user exceeds v1 100/min → 429 (unchanged).
+4. User lists vault (`GET /api/passwords`) → entries returned, no deletion happens during the request (was: up to 500 stale-trash rows hard-deleted as a side effect).
+5. Tenant with `trashRetentionDays=14` → retention-gc worker purges at 14 days (unchanged, worker-driven).

--- a/docs/archive/review/rate-limiter-fail-closed-and-get-purge-review.md
+++ b/docs/archive/review/rate-limiter-fail-closed-and-get-purge-review.md
@@ -1,0 +1,39 @@
+# Plan Review: rate-limiter-fail-closed-and-get-purge
+Date: 2026-06-26
+Review round: 1 (initial)
+
+## Changes from Previous Round
+Initial review. Three expert sub-agents (functionality / security / testing) reviewed the plan against the actual codebase.
+
+## Functionality Findings
+- **F1 (Major) — FIXED in plan**: C5 unused-import list was imprecise. `collectEntryAttachmentRefs` / `AttachmentBlobRef` in `team-password-service.ts` are STILL used by `deleteTeamPassword` and must be KEPT. Plan C5 now lists exact per-file import edits.
+- **F2 (Minor) — recorded as risk**: removal assumes the `worker:retention-gc` process is deployed; without it, no trash auto-purge at all (storage growth only).
+- **F3 (Minor) — recorded**: C4 fail-closed applies to the OAuth callback GET path too (in-flight login completion blocked during Redis outage). Within accepted trade-off.
+- Verified clean: `checkRateLimitOrFail` accepts both `{limiter,key}` and `{result}` forms; C2 `[id]` local checkAuth swap preserves 401/403→429/503 ordering; breakglass existing SERVICE_UNAVAILABLE catch does not collide with new 503.
+
+## Security Findings
+- **S1 (Info)**: completeness confirmed — deferred limiters (scim-tokens, service-accounts, operator-tokens, reset-vault, mcp revokeAll, passwords list/create) are correctly EXCLUDED; each sits behind a session+admin or self-scoped auth gate, making fail-open an availability/self-harm concern, not a bypass. M1/M4/M5/M6 line drawn correctly.
+- **S2 (Low) — recorded, confirm before close**: attachments upload limiter remains fail-open; acceptable if quota-bounded.
+- **S3 (Medium design risk) — recorded in runbook note**: callback fail-closed makes Redis a hard dependency for SSO login (self-DoS on Redis flap). User accepted; ensure Redis HA.
+- **S4/S6/S7 (Info, verified pass)**: `emitRateLimitFailClosed` is null-safe (pre-auth warn-only, no PII leak); C5 is a net security IMPROVEMENT (removes destructive GET + silent `.catch`); observability IMPROVED (worker emits atomic `TRASH_RETENTION_PURGED` audit vs old zero-audit purge).
+- **S5 (Info)**: null-IP fail-open in `checkIpRateLimit` intentionally left unchanged — correct.
+- No Critical findings → no escalation.
+
+## Testing Findings
+- **T1 (Major) — FIXED in plan**: autofill-token test has no rate-limit mock seam; must mock `@/lib/security/rate-limit-audit`.
+- **T2 (Major) — FIXED in plan**: `withMagicLinkIpRateLimit` must be exported as `_withMagicLinkIpRateLimit` for testability.
+- **T3 (Minor) — FIXED in plan**: corrected worker-coverage reference to `retention-gc-trash-purge.integration.test.ts` + `__tests__/sweep-trash.test.ts`.
+- **T5 (Major) — FIXED in plan**: add executable "GET performs no deleteMany" regression guard; remove dead `deleteMany.mockResolvedValue` setup.
+- **T6 (Minor) — recorded**: team GET route has no route test; read-only-ness is grep-enforced only.
+- **T7/T8 (Minor) — FIXED in plan**: vacuous-test hardening (assert handler body did NOT run on 503); 429/redisErrored mapping owned by `rate-limit-audit.test.ts`; null-IP-proceeds test added.
+
+## Resolution Status
+All Major findings reflected in the plan. No Critical findings. Minor findings either reflected (T3, T5, T6, T7, T8) or recorded as risks/confirm-items (F2, F3, S2, S3). No blockers to Phase 2.
+
+## Recurring Issue Check (consolidated)
+- R1 (shared-util reuse): PASS — reuses `checkRateLimitOrFail` / `failClosedOnRedisError`.
+- R3 (pattern propagation): PASS — fail-closed applied consistently to all 5 limiters; personal list/create limiters intentionally out of scope.
+- R5 (transaction / no write on GET): PASS/IMPROVED — C5 removes `deleteMany` from GET.
+- R17/R22 (helper adoption): PASS (with F1 import-precision fix).
+- RT1/RT6 (vacuous tests / regression guard): FIXED via T5/T7 plan updates.
+- Others: n/a.

--- a/scripts/checks/check-fail-closed-routes-have-test.sh
+++ b/scripts/checks/check-fail-closed-routes-have-test.sh
@@ -103,7 +103,10 @@ fi
 # per-limiter coverage. Per-line grep guards against this.
 # 53 incl. the SSH agent sign-authorize limiter (vault/ssh/sign-authorize).
 # 54 incl. the iOS bridge-code limiter (mobile/authorize, per-user fail-closed).
-EXPECTED_LIMITER_COUNT=54
+# 58 incl. 4 from rate-limiter-fail-closed-and-get-purge (OWASP M4/M5/M6):
+#   auth callbackRateLimiter + magicLinkIpLimiter, mobile autofill mintLimiter,
+#   tenant breakglassRateLimiter. (v1ApiKeyLimiter lives in src/lib, not counted here.)
+EXPECTED_LIMITER_COUNT=58
 limiter_count=$(grep -rh 'failClosedOnRedisError: true' "$REPO_ROOT/src/app/api" | wc -l)
 if [ "$limiter_count" -ne "$EXPECTED_LIMITER_COUNT" ]; then
   echo "AC4.4 FAIL: expected $EXPECTED_LIMITER_COUNT 'failClosedOnRedisError: true' instantiations; found $limiter_count"

--- a/src/app/api/auth/[...nextauth]/route.test.ts
+++ b/src/app/api/auth/[...nextauth]/route.test.ts
@@ -278,6 +278,20 @@ describe("withCallbackRateLimit", () => {
     expect(inner).toHaveBeenCalledTimes(2);
   });
 
+  it("fails closed with 503 when the limiter reports redisErrored (does NOT invoke handler)", async () => {
+    mockRateLimitCheck.mockResolvedValue({ allowed: false, redisErrored: true });
+    const { _withCallbackRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn<RouteHandler>(async () => new Response("ok"));
+    const wrapped = _withCallbackRateLimit(inner);
+
+    const res = await wrapped(makeReq("/api/auth/callback/google", "GET"));
+
+    expect(res.status).toBe(503);
+    expect(inner).not.toHaveBeenCalled();
+  });
+
   it("skips the limiter and warn-logs when client IP cannot be determined", async () => {
     mockExtractClientIp.mockReturnValue(null);
     const { _withCallbackRateLimit } = await import(
@@ -318,5 +332,95 @@ describe("withCallbackRateLimit", () => {
       "rl:auth_callback:203.0.113.5",
       "rl:auth_callback:198.51.100.7",
     ]);
+  });
+});
+
+describe("withMagicLinkIpRateLimit", () => {
+  beforeEach(() => {
+    mockRateLimitCheck.mockReset();
+    mockExtractClientIp.mockReset();
+    mockLoggerWarn.mockReset();
+    mockRateLimitCheck.mockResolvedValue({ allowed: true });
+    mockExtractClientIp.mockReturnValue("203.0.113.5");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  function makeReq(pathname: string, method: "GET" | "POST" = "POST") {
+    return new NextRequest(`http://localhost:3000${pathname}`, { method });
+  }
+
+  it("skips the limiter and forwards when the path is not a magic-link signin", async () => {
+    const { _withMagicLinkIpRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn<RouteHandler>(async () => new Response("ok"));
+    const wrapped = _withMagicLinkIpRateLimit(inner);
+
+    const res = await wrapped(makeReq("/api/auth/callback/google"));
+
+    expect(res.status).toBe(200);
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(mockRateLimitCheck).not.toHaveBeenCalled();
+  });
+
+  it("invokes the limiter with `rl:magic_link_signin:<ip>` and forwards on allowed", async () => {
+    const { _withMagicLinkIpRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn<RouteHandler>(async () => new Response("ok"));
+    const wrapped = _withMagicLinkIpRateLimit(inner);
+
+    const res = await wrapped(makeReq("/api/auth/signin/nodemailer"));
+
+    expect(res.status).toBe(200);
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(mockRateLimitCheck).toHaveBeenCalledWith("rl:magic_link_signin:203.0.113.5");
+  });
+
+  it("returns 429 when the limiter denies (does NOT invoke handler)", async () => {
+    mockRateLimitCheck.mockResolvedValue({ allowed: false, retryAfterMs: 1500 });
+    const { _withMagicLinkIpRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn<RouteHandler>(async () => new Response("ok"));
+    const wrapped = _withMagicLinkIpRateLimit(inner);
+
+    const res = await wrapped(makeReq("/api/auth/signin/email"));
+
+    expect(res.status).toBe(429);
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with 503 when the limiter reports redisErrored (does NOT invoke handler)", async () => {
+    mockRateLimitCheck.mockResolvedValue({ allowed: false, redisErrored: true });
+    const { _withMagicLinkIpRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn<RouteHandler>(async () => new Response("ok"));
+    const wrapped = _withMagicLinkIpRateLimit(inner);
+
+    const res = await wrapped(makeReq("/api/auth/signin/nodemailer"));
+
+    expect(res.status).toBe(503);
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it("fail-OPEN: forwards when client IP cannot be determined (no 503)", async () => {
+    mockExtractClientIp.mockReturnValue(null);
+    const { _withMagicLinkIpRateLimit } = await import(
+      "@/app/api/auth/[...nextauth]/route"
+    );
+    const inner = vi.fn<RouteHandler>(async () => new Response("ok"));
+    const wrapped = _withMagicLinkIpRateLimit(inner);
+
+    const res = await wrapped(makeReq("/api/auth/signin/nodemailer"));
+
+    expect(res.status).toBe(200);
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(mockRateLimitCheck).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -7,7 +7,7 @@ import { tenantClaimStorage } from "@/lib/tenant/tenant-claim-storage";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { extractClientIp } from "@/lib/auth/policy/ip-access";
 import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
-import { rateLimited } from "@/lib/http/api-response";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 
 export const runtime = "nodejs";
@@ -77,6 +77,7 @@ const CALLBACK_RATE_LIMIT_MAX = 60;
 const callbackRateLimiter = createRateLimiter({
   windowMs: CALLBACK_RATE_LIMIT_WINDOW_MS,
   max: CALLBACK_RATE_LIMIT_MAX,
+  failClosedOnRedisError: true,
 });
 
 function isCallbackRoute(pathname: string): boolean {
@@ -94,9 +95,15 @@ function withCallbackRateLimit<H extends RouteHandler>(handler: H): H {
       scope: "auth_callback",
       limiter: callbackRateLimiter,
     });
-    if (!rl.allowed) {
-      return rateLimited(rl.retryAfterMs) as unknown as Response;
-    }
+    // Pre-auth surface: userId null → checkRateLimitOrFail warn-logs the
+    // fail-closed (no audit row). redisErrored → 503; over-limit → 429.
+    const blocked = await checkRateLimitOrFail({
+      req: request,
+      result: rl,
+      scope: "auth_callback",
+      userId: null,
+    });
+    if (blocked) return blocked as unknown as Response;
     return handler(request, ...rest);
   };
   return wrapped as unknown as H;
@@ -120,6 +127,7 @@ const MAGIC_LINK_IP_MAX = 10;
 const magicLinkIpLimiter = createRateLimiter({
   windowMs: MAGIC_LINK_IP_WINDOW_MS,
   max: MAGIC_LINK_IP_MAX,
+  failClosedOnRedisError: true,
 });
 
 function isMagicLinkSigninRoute(pathname: string, method: string): boolean {
@@ -143,9 +151,13 @@ function withMagicLinkIpRateLimit<H extends RouteHandler>(handler: H): H {
       scope: "magic_link_signin",
       limiter: magicLinkIpLimiter,
     });
-    if (!rl.allowed) {
-      return rateLimited(rl.retryAfterMs) as unknown as Response;
-    }
+    const blocked = await checkRateLimitOrFail({
+      req: request,
+      result: rl,
+      scope: "magic_link_signin",
+      userId: null,
+    });
+    if (blocked) return blocked as unknown as Response;
     return handler(request, ...rest);
   };
   return wrapped as unknown as H;
@@ -154,6 +166,7 @@ function withMagicLinkIpRateLimit<H extends RouteHandler>(handler: H): H {
 // Exported for testing
 export { withAuthBasePath as _withAuthBasePath };
 export { withCallbackRateLimit as _withCallbackRateLimit };
+export { withMagicLinkIpRateLimit as _withMagicLinkIpRateLimit };
 export { isCallbackRoute as _isCallbackRoute };
 
 export const GET = withRequestLog(

--- a/src/app/api/mobile/autofill-token/route.test.ts
+++ b/src/app/api/mobile/autofill-token/route.test.ts
@@ -3,12 +3,13 @@ import { createRequest, parseResponse } from "@/__tests__/helpers/request-builde
 
 // ─── Hoisted mocks ───────────────────────────────────────────
 
-const { mockCheckAuth, mockIssueAutofill, mockLogAudit, mockWarn, mockError } = vi.hoisted(() => ({
+const { mockCheckAuth, mockIssueAutofill, mockLogAudit, mockWarn, mockError, mockCheckRateLimitOrFail } = vi.hoisted(() => ({
   mockCheckAuth: vi.fn(),
   mockIssueAutofill: vi.fn(),
   mockLogAudit: vi.fn(),
   mockWarn: vi.fn(),
   mockError: vi.fn(),
+  mockCheckRateLimitOrFail: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/session/check-auth", () => ({ checkAuth: mockCheckAuth }));
@@ -17,8 +18,12 @@ vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
   personalAuditBase: () => ({}),
 }));
+// Mock the rate-limit translator so the real helper (and its transitive prisma
+// import) never loads; the 429/503 mapping itself is covered in rate-limit-audit.test.ts.
+vi.mock("@/lib/security/rate-limit-audit", () => ({ checkRateLimitOrFail: mockCheckRateLimitOrFail }));
 vi.mock("@/lib/logger", () => ({
   logger: { warn: mockWarn, error: mockError, info: vi.fn(), debug: vi.fn() },
+  getLogger: () => ({ warn: mockWarn, error: mockError, info: vi.fn(), debug: vi.fn() }),
 }));
 
 import { POST } from "./route";
@@ -33,6 +38,8 @@ describe("POST /api/mobile/autofill-token", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLogAudit.mockResolvedValue(undefined);
+    // Default: rate limit allows the request through (helper returns null).
+    mockCheckRateLimitOrFail.mockResolvedValue(null);
   });
 
   it("mints a token bound to the supplied jwk for an authenticated host token", async () => {
@@ -51,6 +58,15 @@ describe("POST /api/mobile/autofill-token", () => {
     expect(res.headers.get("Cache-Control")).toBe("no-store");
     expect(json.token).toBe("secret-token");
     expect(json.scope).toEqual(["passwords:write"]);
+    // The mint is rate-limited per authenticated user under the correct scope.
+    expect(mockCheckRateLimitOrFail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "rl:mobile_autofill_token:u1",
+        scope: "mobile.autofill_token",
+        userId: "u1",
+        tenantId: "t1",
+      }),
+    );
     // The route computes cnf.jkt from the body jwk and binds the token to it.
     const passed = mockIssueAutofill.mock.calls[0][0];
     expect(passed).toMatchObject({ userId: "u1", tenantId: "t1" });
@@ -106,28 +122,31 @@ describe("POST /api/mobile/autofill-token", () => {
     expect(mockIssueAutofill).not.toHaveBeenCalled();
   });
 
-  it("429 once the per-user mint budget is exhausted", async () => {
+  it("429 when the per-user mint budget is exhausted (does NOT mint)", async () => {
     mockCheckAuth.mockResolvedValue({
       ok: true,
       auth: { type: "token", userId: "u-rl", tenantId: "t1", clientKind: "IOS_APP" },
     });
-    mockIssueAutofill.mockResolvedValue({
-      token: "secret-token",
-      expiresAt: new Date("2026-06-13T00:05:00.000Z"),
-      cnfJkt: "jkt",
-      scope: "passwords:write",
+    mockCheckRateLimitOrFail.mockResolvedValueOnce(
+      Response.json({ error: "RATE_LIMIT_EXCEEDED" }, { status: 429 }),
+    );
+
+    const res = await POST(post({ jwk: VALID_JWK }));
+    expect(res.status).toBe(429);
+    expect(mockIssueAutofill).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with 503 when the limiter reports redisErrored (does NOT mint)", async () => {
+    mockCheckAuth.mockResolvedValue({
+      ok: true,
+      auth: { type: "token", userId: "u-rl", tenantId: "t1", clientKind: "IOS_APP" },
     });
+    mockCheckRateLimitOrFail.mockResolvedValueOnce(
+      Response.json({ error: "SERVICE_UNAVAILABLE" }, { status: 503 }),
+    );
 
-    let rateLimitedStatus: number | undefined;
-    for (let i = 0; i < 31; i++) {
-      const res = await POST(post({ jwk: VALID_JWK }));
-      if (res.status === 429) {
-        rateLimitedStatus = res.status;
-        break;
-      }
-      expect(res.status).toBe(201);
-    }
-
-    expect(rateLimitedStatus).toBe(429);
+    const res = await POST(post({ jwk: VALID_JWK }));
+    expect(res.status).toBe(503);
+    expect(mockIssueAutofill).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/mobile/autofill-token/route.ts
+++ b/src/app/api/mobile/autofill-token/route.ts
@@ -5,8 +5,9 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { NO_STORE_HEADERS } from "@/lib/http/cache-headers";
 import { parseBody } from "@/lib/http/parse-body";
 import { checkAuth } from "@/lib/auth/session/check-auth";
-import { rateLimited, unauthorized } from "@/lib/http/api-response";
+import { unauthorized } from "@/lib/http/api-response";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { MS_PER_HOUR } from "@/lib/constants/time";
 import { EXTENSION_TOKEN_SCOPE } from "@/lib/constants/auth/extension-token";
 import { jwkThumbprint } from "@/lib/auth/dpop/verify";
@@ -23,6 +24,7 @@ export const runtime = "nodejs";
 const mintLimiter = createRateLimiter({
   windowMs: MS_PER_HOUR,
   max: 30,
+  failClosedOnRedisError: true,
 });
 
 // The AutoFill extension's own DPoP public key (P-256). The minted token binds
@@ -65,10 +67,15 @@ export const POST = withRequestLog(async (req: NextRequest) => {
 
   // Rate-limit per user, after auth (the bucket key is the authenticated
   // identity) and before the mint/audit work.
-  const rl = await mintLimiter.check(`rl:mobile_autofill_token:${userId}`);
-  if (!rl.allowed) {
-    return rateLimited(rl.retryAfterMs);
-  }
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: mintLimiter,
+    key: `rl:mobile_autofill_token:${userId}`,
+    scope: "mobile.autofill_token",
+    userId,
+    tenantId,
+  });
+  if (blocked) return blocked;
 
   const parsed = await parseBody(req, BodySchema);
   if (!parsed.ok) return parsed.response;

--- a/src/app/api/passwords/route.test.ts
+++ b/src/app/api/passwords/route.test.ts
@@ -131,7 +131,6 @@ describe("GET /api/passwords", () => {
     mockPrismaUser.findUnique.mockResolvedValue({ tenantId: "tenant-1" });
     mockPrismaFolder.findFirst.mockResolvedValue({ id: "folder-1" });
     mockPrismaTag.count.mockResolvedValue(1);
-    mockPrismaPasswordEntry.deleteMany.mockResolvedValue({ count: 0 });
     mockExtTokenUpdate.mockResolvedValue({});
     mockVerifyDpop.mockResolvedValue({ ok: true, claims: {}, jkt: VALID_CNF_JKT });
   });
@@ -141,6 +140,13 @@ describe("GET /api/passwords", () => {
     mockExtTokenFindUnique.mockResolvedValue(null);
     const res = await GET(createRequest("GET", "http://localhost:3000/api/passwords"));
     expect(res.status).toBe(401);
+  });
+
+  it("is read-only: performs no deleteMany (trash auto-purge moved to retention-gc worker, L3)", async () => {
+    mockPrismaPasswordEntry.findMany.mockResolvedValue([mockEntry]);
+    const res = await GET(createRequest("GET", "http://localhost:3000/api/passwords"));
+    expect(res.status).toBe(200);
+    expect(mockPrismaPasswordEntry.deleteMany).not.toHaveBeenCalled();
   });
 
   it("returns 401 for service_account auth type", async () => {
@@ -810,7 +816,6 @@ describe("POST /api/passwords", () => {
     mockPrismaPasswordEntry.findMany.mockResolvedValue([
       { ...mockEntry, id: "pw-card", entryType: "CREDIT_CARD" },
     ]);
-    mockPrismaPasswordEntry.deleteMany.mockResolvedValue({ count: 0 });
     const res = await GET(createRequest("GET", "http://localhost:3000/api/passwords"));
     const json = await res.json();
     expect(json[0].entryType).toBe("CREDIT_CARD");
@@ -841,7 +846,6 @@ describe("POST /api/passwords", () => {
     mockPrismaPasswordEntry.findMany.mockResolvedValue([
       { ...mockEntry, id: "pw-identity", entryType: "IDENTITY" },
     ]);
-    mockPrismaPasswordEntry.deleteMany.mockResolvedValue({ count: 0 });
     const res = await GET(createRequest("GET", "http://localhost:3000/api/passwords"));
     const json = await res.json();
     expect(json[0].entryType).toBe("IDENTITY");
@@ -872,7 +876,6 @@ describe("POST /api/passwords", () => {
     mockPrismaPasswordEntry.findMany.mockResolvedValue([
       { ...mockEntry, id: "pw-passkey", entryType: "PASSKEY" },
     ]);
-    mockPrismaPasswordEntry.deleteMany.mockResolvedValue({ count: 0 });
     const res = await GET(createRequest("GET", "http://localhost:3000/api/passwords"));
     const json = await res.json();
     expect(json[0].entryType).toBe("PASSKEY");
@@ -903,7 +906,6 @@ describe("POST /api/passwords", () => {
     mockPrismaPasswordEntry.findMany.mockResolvedValue([
       { ...mockEntry, id: "pw-bank", entryType: "BANK_ACCOUNT" },
     ]);
-    mockPrismaPasswordEntry.deleteMany.mockResolvedValue({ count: 0 });
     const res = await GET(createRequest("GET", "http://localhost:3000/api/passwords"));
     const json = await res.json();
     expect(json[0].entryType).toBe("BANK_ACCOUNT");
@@ -946,7 +948,6 @@ describe("POST /api/passwords", () => {
     mockPrismaPasswordEntry.findMany.mockResolvedValue([
       { ...mockEntry, id: "pw-license", entryType: "SOFTWARE_LICENSE" },
     ]);
-    mockPrismaPasswordEntry.deleteMany.mockResolvedValue({ count: 0 });
     const res = await GET(createRequest("GET", "http://localhost:3000/api/passwords"));
     const json = await res.json();
     expect(json[0].entryType).toBe("SOFTWARE_LICENSE");
@@ -993,7 +994,6 @@ describe("POST /api/passwords", () => {
 
   it("ignores invalid entryType query param", async () => {
     mockPrismaPasswordEntry.findMany.mockResolvedValue([]);
-    mockPrismaPasswordEntry.deleteMany.mockResolvedValue({ count: 0 });
     await GET(createRequest("GET", "http://localhost:3000/api/passwords", {
       searchParams: { type: "INVALID_TYPE" },
     }));

--- a/src/app/api/passwords/route.ts
+++ b/src/app/api/passwords/route.ts
@@ -9,18 +9,12 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import type { EntryType } from "@prisma/client";
 import { ENTRY_TYPE_VALUES, EXTENSION_TOKEN_SCOPE, AUDIT_TARGET_TYPE, AUDIT_ACTION } from "@/lib/constants";
 import { createPersonalPasswordEntry } from "@/lib/services/personal-password-service";
-import { FILENAME_MAX_LENGTH, TRASH_PURGE_BATCH_SIZE } from "@/lib/validations/common";
+import { FILENAME_MAX_LENGTH } from "@/lib/validations/common";
 import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { ACTIVE_ENTRY_WHERE } from "@/lib/prisma/prisma-filters";
-import {
-  collectEntryAttachmentRefs,
-  deleteAttachmentBlobs,
-  type AttachmentBlobRef,
-} from "@/lib/blob-store/cleanup";
-import { MS_PER_DAY } from "@/lib/constants/time";
 import { assertQuotaAvailable, QuotaExceededError } from "@/lib/quota/resource-quotas";
 import { errorResponse } from "@/lib/http/api-response";
 import { API_ERROR } from "@/lib/http/api-error-codes";
@@ -68,36 +62,9 @@ async function handleGET(req: NextRequest) {
     }),
   );
 
-  // Auto-purge items deleted more than 30 days ago
-  if (!trashOnly) {
-    const thirtyDaysAgo = new Date(Date.now() - 30 * MS_PER_DAY);
-    const purgedRefs = await withUserTenantRls(userId, async () => {
-      // Cap per-request cleanup to avoid pathological cases (very old users with
-      // thousands of trashed entries); remaining entries purged on next load.
-      const staleEntries = await prisma.passwordEntry.findMany({
-        where: { userId, deletedAt: { lt: thirtyDaysAgo } },
-        select: { id: true },
-        take: TRASH_PURGE_BATCH_SIZE,
-      });
-      if (staleEntries.length === 0) return [] as AttachmentBlobRef[];
-
-      // Capture external blob refs before the cascade delete removes the rows
-      const refs = await collectEntryAttachmentRefs(prisma, {
-        kind: "personal",
-        entryIds: staleEntries.map((e) => e.id),
-      });
-
-      await prisma.passwordEntry.deleteMany({
-        where: { id: { in: staleEntries.map((e) => e.id) } },
-      });
-
-      return refs;
-    }).catch(() => [] as AttachmentBlobRef[]);
-
-    // Purge external blobs OUTSIDE the RLS transaction — don't hold a DB tx
-    // (and its pooled connection) open during blob-store network I/O.
-    await deleteAttachmentBlobs(purgedRefs);
-  }
+  // Trash auto-purge (entries deleted past the tenant's retention) runs in the
+  // retention-gc worker (PER_TENANT_TRASH registry entry), not on this read path.
+  // GET is read-only; it performs no deletes.
 
   // Return encrypted overviews (and optionally blobs) for client-side decryption
   const entries = passwords.map((entry) => ({

--- a/src/app/api/teams/[teamId]/passwords/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/route.ts
@@ -13,7 +13,6 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { errorResponse, handleAuthError, unauthorized } from "@/lib/http/api-response";
 import * as teamPasswordService from "@/lib/services/team-password-service";
 import { TeamPasswordServiceError } from "@/lib/services/team-password-service";
-import { deleteAttachmentBlobs } from "@/lib/blob-store/cleanup";
 
 type Params = { params: Promise<{ teamId: string }> };
 
@@ -56,16 +55,8 @@ async function handleGET(req: NextRequest, { params }: Params) {
     }),
   );
 
-  // Auto-purge items deleted more than 30 days ago (async nonblocking, F-20).
-  // Blob refs are collected under RLS; the external-store purge runs AFTER the
-  // tx closes so blob I/O never holds a DB connection open.
-  if (!trashOnly) {
-    withTeamTenantRls(teamId, () =>
-      teamPasswordService.purgeExpiredTeamPasswords(teamId),
-    )
-      .then((refs) => deleteAttachmentBlobs(refs))
-      .catch(() => {});
-  }
+  // Trash auto-purge runs in the retention-gc worker (PER_TENANT_TRASH registry
+  // entry for team_password_entries), not on this read path. GET is read-only.
 
   return NextResponse.json(entries);
 }

--- a/src/app/api/tenant/breakglass/route.test.ts
+++ b/src/app/api/tenant/breakglass/route.test.ts
@@ -394,6 +394,20 @@ describe("POST /api/tenant/breakglass", () => {
     expect(json.error).toBe("RATE_LIMIT_EXCEEDED");
   });
 
+  it("fails closed with 503 when the limiter reports redisErrored (no grant created)", async () => {
+    mockRateLimiterCheck.mockResolvedValue({ allowed: false, redisErrored: true });
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/tenant/breakglass", {
+        body: validBody,
+        headers: { origin: "http://localhost" },
+      }),
+    );
+    const { status, json } = await parseResponse(res);
+    expect(status).toBe(503);
+    expect(json.error).toBe("SERVICE_UNAVAILABLE");
+    expect(mockGrantCreate).not.toHaveBeenCalled();
+  });
+
   it("returns 403 when target user is not a tenant member", async () => {
     mockTenantMemberFindFirst.mockResolvedValue(null);
     const res = await POST(

--- a/src/app/api/tenant/breakglass/route.ts
+++ b/src/app/api/tenant/breakglass/route.ts
@@ -11,10 +11,11 @@ import { BREAKGLASS_USER_LIST_LIMIT } from "@/lib/validations/common.server";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { SEC_PER_HOUR } from "@/lib/constants/time";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { createNotification } from "@/lib/notification";
 import { createBreakglassGrantSchema } from "@/lib/validations";
 import { API_ERROR } from "@/lib/http/api-error-codes";
-import { errorResponse, forbidden, handleAuthError, rateLimited, unauthorized, validationError } from "@/lib/http/api-response";
+import { errorResponse, forbidden, handleAuthError, unauthorized, validationError } from "@/lib/http/api-response";
 import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 import { parseBody } from "@/lib/http/parse-body";
 import { AUDIT_ACTION } from "@/lib/constants";
@@ -26,6 +27,7 @@ export const runtime = "nodejs";
 const breakglassRateLimiter = createRateLimiter({
   windowMs: MS_PER_HOUR,
   max: 5,
+  failClosedOnRedisError: true,
 });
 
 // POST /api/tenant/breakglass — Create a break-glass personal log access grant
@@ -52,12 +54,15 @@ async function handlePOST(req: NextRequest) {
 
   // Rate limit BEFORE body parse so authenticated admins cannot trigger
   // body-parse memory allocation on every call before hitting the 5/hour cap.
-  const rlResult = await breakglassRateLimiter.check(
-    `rl:breakglass:${userId}`,
-  );
-  if (!rlResult.allowed) {
-    return rateLimited(rlResult.retryAfterMs);
-  }
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: breakglassRateLimiter,
+    key: `rl:breakglass:${userId}`,
+    scope: "breakglass",
+    userId,
+    tenantId: actor.tenantId,
+  });
+  if (blocked) return blocked;
 
   // Parse and validate request body
   const bodyResult = await parseBody(req, createBreakglassGrantSchema);

--- a/src/app/api/v1/passwords/[id]/route.test.ts
+++ b/src/app/api/v1/passwords/[id]/route.test.ts
@@ -78,6 +78,8 @@ vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
   personalAuditBase: vi.fn((_, userId) => ({ scope: "PERSONAL", userId })),
+  // Used by emitRateLimitFailClosed (rate-limit-audit.ts) on the redisErrored path.
+  tenantAuditBase: vi.fn((_, userId, tenantId) => ({ scope: "TENANT", userId, tenantId })),
 }));
 
 import { GET, PUT, DELETE } from "./route";
@@ -140,6 +142,29 @@ describe("GET /api/v1/passwords/[id]", () => {
     );
     const { status } = await parseResponse(res);
     expect(status).toBe(403);
+  });
+
+  it("returns 429 when rate limit exceeded (no DB access)", async () => {
+    mockCheck.mockResolvedValue({ allowed: false, retryAfterMs: 30_000 });
+    const res = await GET(
+      createRequest("GET", `http://localhost/api/v1/passwords/${PW_ID}`),
+      createParams({ id: PW_ID }),
+    );
+    const { status } = await parseResponse(res);
+    expect(status).toBe(429);
+    expect(mockEntryFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with 503 when the limiter reports redisErrored (no DB access)", async () => {
+    mockCheck.mockResolvedValue({ allowed: false, redisErrored: true });
+    const res = await GET(
+      createRequest("GET", `http://localhost/api/v1/passwords/${PW_ID}`),
+      createParams({ id: PW_ID }),
+    );
+    const { status, json } = await parseResponse(res);
+    expect(status).toBe(503);
+    expect(json).toEqual({ error: "SERVICE_UNAVAILABLE" });
+    expect(mockEntryFindUnique).not.toHaveBeenCalled();
   });
 
   it("returns 404 when entry not found", async () => {

--- a/src/app/api/v1/passwords/[id]/route.ts
+++ b/src/app/api/v1/passwords/[id]/route.ts
@@ -8,12 +8,13 @@ import { validateV1Auth } from "@/lib/auth/session/v1-auth";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { v1ApiKeyLimiter } from "@/lib/security/rate-limiters";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { API_KEY_SCOPE } from "@/lib/constants/auth/api-key";
 import { AUDIT_TARGET_TYPE, AUDIT_ACTION } from "@/lib/constants";
 import { enforceAccessRestriction } from "@/lib/auth/policy/access-restriction";
 
 
-import { errorResponse, errorResponseWithMessage, notFound, rateLimited, validationError } from "@/lib/http/api-response";
+import { errorResponse, errorResponseWithMessage, notFound, validationError } from "@/lib/http/api-response";
 import type { V1AuthResult } from "@/lib/auth/session/v1-auth";
 import { dedupeTagIds, tagSet } from "@/lib/services/tag-relation";
 
@@ -34,10 +35,15 @@ async function checkAuth(
     return { ok: false, error: errorResponse(error, status) };
   }
 
-  const rl = await v1ApiKeyLimiter.check(`rl:api_key:${authResult.data.rateLimitKey}`);
-  if (!rl.allowed) {
-    return { ok: false, error: rateLimited(rl.retryAfterMs) };
-  }
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: v1ApiKeyLimiter,
+    key: `rl:api_key:${authResult.data.rateLimitKey}`,
+    scope: "v1.passwords",
+    userId: authResult.data.userId,
+    tenantId: authResult.data.tenantId,
+  });
+  if (blocked) return { ok: false, error: blocked };
 
   return { ok: true, data: authResult.data };
 }

--- a/src/app/api/v1/passwords/route.test.ts
+++ b/src/app/api/v1/passwords/route.test.ts
@@ -40,6 +40,8 @@ vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
   personalAuditBase: vi.fn((_, userId) => ({ scope: "PERSONAL", userId })),
+  // Used by emitRateLimitFailClosed (rate-limit-audit.ts) on the redisErrored path.
+  tenantAuditBase: vi.fn((_, userId, tenantId) => ({ scope: "TENANT", userId, tenantId })),
 }));
 vi.mock("@/lib/logger", () => {
   const noop = vi.fn();
@@ -126,6 +128,15 @@ describe("GET /api/v1/passwords", () => {
     const { status } = await parseResponse(res);
     expect(status).toBe(429);
     expect(res.headers.get("Retry-After")).toBe("30");
+  });
+
+  it("fails closed with 503 when the limiter reports redisErrored (no DB access)", async () => {
+    mockCheck.mockResolvedValue({ allowed: false, redisErrored: true });
+    const res = await GET(createRequest("GET", "http://localhost/api/v1/passwords"));
+    const { status, json } = await parseResponse(res);
+    expect(status).toBe(503);
+    expect(json).toEqual({ error: "SERVICE_UNAVAILABLE" });
+    expect(mockEntryFindMany).not.toHaveBeenCalled();
   });
 
   it("returns access restriction response when denied", async () => {
@@ -346,6 +357,17 @@ describe("POST /api/v1/passwords", () => {
     const { status } = await parseResponse(res);
     expect(status).toBe(429);
     expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("fails closed with 503 when the limiter reports redisErrored (no create)", async () => {
+    mockCheck.mockResolvedValue({ allowed: false, redisErrored: true });
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/v1/passwords", { body: validBody }),
+    );
+    const { status, json } = await parseResponse(res);
+    expect(status).toBe(503);
+    expect(json).toEqual({ error: "SERVICE_UNAVAILABLE" });
+    expect(mockEntryCreate).not.toHaveBeenCalled();
   });
 
   it("returns 400 on invalid body (missing required fields)", async () => {

--- a/src/app/api/v1/passwords/route.ts
+++ b/src/app/api/v1/passwords/route.ts
@@ -8,6 +8,7 @@ import { validateV1Auth } from "@/lib/auth/session/v1-auth";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { v1ApiKeyLimiter } from "@/lib/security/rate-limiters";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { API_KEY_SCOPE } from "@/lib/constants/auth/api-key";
 import { ENTRY_TYPE_VALUES, AUDIT_TARGET_TYPE, AUDIT_ACTION } from "@/lib/constants";
 import { toBlobColumns, toOverviewColumns } from "@/lib/crypto/crypto-blob";
@@ -15,7 +16,7 @@ import { enforceAccessRestriction } from "@/lib/auth/policy/access-restriction";
 import { ACTIVE_ENTRY_WHERE } from "@/lib/prisma/prisma-filters";
 import { dedupeTagIds, tagConnect } from "@/lib/services/tag-relation";
 import type { EntryType } from "@prisma/client";
-import { errorResponse, errorResponseWithMessage, rateLimited, unauthorized } from "@/lib/http/api-response";
+import { errorResponse, errorResponseWithMessage, unauthorized } from "@/lib/http/api-response";
 
 const VALID_ENTRY_TYPES: Set<string> = new Set(ENTRY_TYPE_VALUES);
 
@@ -39,10 +40,15 @@ async function handleGET(req: NextRequest) {
   const denied = await enforceAccessRestriction(req, userId, tenantId);
   if (denied) return denied;
 
-  const rl = await v1ApiKeyLimiter.check(`rl:api_key:${rateLimitKey}`);
-  if (!rl.allowed) {
-    return rateLimited(rl.retryAfterMs);
-  }
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: v1ApiKeyLimiter,
+    key: `rl:api_key:${rateLimitKey}`,
+    scope: "v1.passwords",
+    userId,
+    tenantId,
+  });
+  if (blocked) return blocked;
 
   const { searchParams } = new URL(req.url);
   const tagId = searchParams.get("tag");
@@ -125,10 +131,15 @@ async function handlePOST(req: NextRequest) {
   const denied = await enforceAccessRestriction(req, userId, tenantId);
   if (denied) return denied;
 
-  const rl = await v1ApiKeyLimiter.check(`rl:api_key:${rateLimitKey}`);
-  if (!rl.allowed) {
-    return rateLimited(rl.retryAfterMs);
-  }
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: v1ApiKeyLimiter,
+    key: `rl:api_key:${rateLimitKey}`,
+    scope: "v1.passwords",
+    userId,
+    tenantId,
+  });
+  if (blocked) return blocked;
 
   const result = await parseBody(req, createE2EPasswordSchema);
   if (!result.ok) return result.response;

--- a/src/lib/security/rate-limiters.test.ts
+++ b/src/lib/security/rate-limiters.test.ts
@@ -2,8 +2,12 @@
  * Tests for the shared rate limiter instances exported from rate-limiters.ts.
  *
  * The module exposes pre-configured limiter singletons (no factory params).
- * The behavioral surface is tested via behavioral check + a smoke test that
- * the singleton has the expected window/max budget.
+ * v1ApiKeyLimiter is configured `failClosedOnRedisError: true` (M1): when Redis
+ * is unreachable it must signal `redisErrored` (→ 503 at the route) instead of
+ * falling back to the per-process in-memory Map (the cross-pod bypass this
+ * remediates). The budget / clear / per-key mechanics of the Redis path are
+ * covered at the factory level in rate-limit.test.ts; here we assert the
+ * singleton's configured contract (fail-closed + Redis delegation).
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -14,13 +18,21 @@ vi.mock("@/lib/redis", () => ({
 }));
 
 import { v1ApiKeyLimiter } from "./rate-limiters";
-import { MS_PER_MINUTE } from "@/lib/constants/time";
+
+type PipelineResult = [Error | null, number][];
+function makePipeline(results: PipelineResult) {
+  const pipeline = {
+    incr: vi.fn().mockReturnThis(),
+    pexpire: vi.fn().mockReturnThis(),
+    pttl: vi.fn().mockReturnThis(),
+    exec: vi.fn().mockResolvedValue(results),
+  };
+  return pipeline;
+}
 
 describe("rate-limiters", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useRealTimers();
-    mockGetRedis.mockReturnValue(null); // force in-memory path
   });
 
   describe("v1ApiKeyLimiter", () => {
@@ -29,49 +41,39 @@ describe("rate-limiters", () => {
       expect(typeof v1ApiKeyLimiter.clear).toBe("function");
     });
 
-    it("allows the first 100 requests then rejects", async () => {
-      // Use a unique key to avoid collisions with other tests in the suite
-      const key = `test:rate-limiters:100-budget:${Date.now()}-${Math.random()}`;
-      // Within budget
-      for (let i = 0; i < 100; i++) {
-        const result = await v1ApiKeyLimiter.check(key);
-        expect(result.allowed).toBe(true);
-      }
-      // 101st must be rejected
-      const blocked = await v1ApiKeyLimiter.check(key);
-      expect(blocked.allowed).toBe(false);
-      expect(blocked.retryAfterMs).toBeGreaterThan(0);
+    it("fails closed (redisErrored) when Redis is unreachable — no in-memory fallback (M1)", async () => {
+      mockGetRedis.mockReturnValue(null);
+      const result = await v1ApiKeyLimiter.check("test:v1:fail-closed");
+      expect(result.allowed).toBe(false);
+      expect(result.redisErrored).toBe(true);
     });
 
-    it("retryAfterMs reflects the per-minute window when over budget", async () => {
-      const key = `test:rate-limiters:retry-after:${Date.now()}-${Math.random()}`;
-      for (let i = 0; i < 100; i++) {
-        await v1ApiKeyLimiter.check(key);
-      }
-      const blocked = await v1ApiKeyLimiter.check(key);
-      expect(blocked.retryAfterMs).toBeLessThanOrEqual(MS_PER_MINUTE);
+    it("allows via the Redis path when INCR count <= max", async () => {
+      const pipeline = makePipeline([
+        [null, 1], // incr
+        [null, 1], // pexpire
+        [null, 60_000], // pttl
+      ]);
+      mockGetRedis.mockReturnValue({ pipeline: () => pipeline });
+
+      const result = await v1ApiKeyLimiter.check("test:v1:redis-allow");
+      expect(result.allowed).toBe(true);
+      expect(result.redisErrored).toBeUndefined();
+      expect(pipeline.incr).toHaveBeenCalledWith("test:v1:redis-allow");
     });
 
-    it("clear() resets the counter", async () => {
-      const key = `test:rate-limiters:clear:${Date.now()}-${Math.random()}`;
-      for (let i = 0; i < 100; i++) {
-        await v1ApiKeyLimiter.check(key);
-      }
-      expect((await v1ApiKeyLimiter.check(key)).allowed).toBe(false);
-      await v1ApiKeyLimiter.clear(key);
-      expect((await v1ApiKeyLimiter.check(key)).allowed).toBe(true);
-    });
+    it("rejects (429-signal) via the Redis path when INCR count > max", async () => {
+      const pipeline = makePipeline([
+        [null, 101], // incr — over the 100 budget
+        [null, 0],
+        [null, 5_000], // pttl
+      ]);
+      mockGetRedis.mockReturnValue({ pipeline: () => pipeline });
 
-    it("isolates counters per key (independent budgets)", async () => {
-      const a = `test:rate-limiters:isolate:A:${Date.now()}-${Math.random()}`;
-      const b = `test:rate-limiters:isolate:B:${Date.now()}-${Math.random()}`;
-      // Burn A to its limit
-      for (let i = 0; i < 100; i++) {
-        await v1ApiKeyLimiter.check(a);
-      }
-      expect((await v1ApiKeyLimiter.check(a)).allowed).toBe(false);
-      // B has its own budget
-      expect((await v1ApiKeyLimiter.check(b)).allowed).toBe(true);
+      const result = await v1ApiKeyLimiter.check("test:v1:redis-reject");
+      expect(result.allowed).toBe(false);
+      expect(result.redisErrored).toBeUndefined();
+      expect(result.retryAfterMs).toBe(5_000);
     });
   });
 });

--- a/src/lib/security/rate-limiters.ts
+++ b/src/lib/security/rate-limiters.ts
@@ -16,6 +16,7 @@ import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 export const v1ApiKeyLimiter = createRateLimiter({
   windowMs: RATE_WINDOW_MS,
   max: 100,
+  failClosedOnRedisError: true,
 });
 
 /** Per-user limiter for `PUT /api/passwords/[id]/attachments/[id]/migrate`. */

--- a/src/lib/services/team-password-service.ts
+++ b/src/lib/services/team-password-service.ts
@@ -14,8 +14,6 @@ import { API_ERROR, type ApiErrorCode } from "@/lib/http/api-error-codes";
 import { toBlobColumns, toOverviewColumns } from "@/lib/crypto/crypto-blob";
 import { dedupeTagIds, tagConnect, tagSet } from "@/lib/services/tag-relation";
 import type { EntryType } from "@prisma/client";
-import { MS_PER_DAY } from "@/lib/constants/time";
-import { TRASH_PURGE_BATCH_SIZE } from "@/lib/validations/common";
 
 // ---------------------------------------------------------------------------
 // Shared types
@@ -218,42 +216,6 @@ export async function listTeamPasswords(
   });
 
   return entries;
-}
-
-// ---------------------------------------------------------------------------
-// purgeExpiredTeamPasswords (fire-and-forget helper used by GET list route)
-// ---------------------------------------------------------------------------
-
-/**
- * Delete trash older than 30 days for a team. Runs the DB work under the
- * caller's RLS context and returns the external blob refs to purge — the caller
- * must `deleteAttachmentBlobs(refs)` AFTER the RLS transaction closes, so
- * blob-store network I/O does not hold a DB tx open.
- */
-export async function purgeExpiredTeamPasswords(
-  teamId: string,
-): Promise<AttachmentBlobRef[]> {
-  const thirtyDaysAgo = new Date(Date.now() - 30 * MS_PER_DAY);
-  // Cap per-request cleanup (parity with the personal GC) so a team with a
-  // large trash backlog can't load/delete unboundedly on a list request;
-  // remaining entries are purged on the next load.
-  const expired = await prisma.teamPasswordEntry.findMany({
-    where: { teamId, deletedAt: { lt: thirtyDaysAgo } },
-    select: { id: true },
-    take: TRASH_PURGE_BATCH_SIZE,
-  });
-  if (expired.length === 0) return [];
-
-  // Capture external blob refs before the cascade delete removes the rows
-  const refs = await collectEntryAttachmentRefs(prisma, {
-    kind: "team",
-    teamId,
-    entryIds: expired.map((e) => e.id),
-  });
-  await prisma.teamPasswordEntry.deleteMany({
-    where: { teamId, id: { in: expired.map((e) => e.id) } },
-  });
-  return refs;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 1 of remediating an external OWASP Top 10 review. Two classes of finding, both verified against the current codebase before implementing.

### 1. Security-sensitive rate limiters now fail **closed** (M1/M4/M5/M6)

`createRateLimiter` defaults to fail-**open**: on a Redis error it falls back to a per-process in-memory `Map`. In a multi-Pod deployment a Redis outage therefore relaxes the effective cap to `Pod-count × max`, and a Pod restart resets the counter. For authentication / token-minting / API surfaces, the limiter is a real defense line, not best-effort.

This PR opts the security-critical limiters into `failClosedOnRedisError: true` and routes their checks through the canonical `checkRateLimitOrFail` helper, so a Redis error returns `503 { "error": "SERVICE_UNAVAILABLE" }` (with a fail-closed audit/warn) instead of silently falling open:

| Limiter | Route | Finding |
|---------|-------|---------|
| `v1ApiKeyLimiter` | `/api/v1/passwords` (GET/POST) + `[id]` (GET/PUT/DELETE) | M1 |
| `callbackRateLimiter` | OAuth/SAML callback | M4 |
| `magicLinkIpLimiter` | magic-link sign-in (per-IP) | M4 |
| `mintLimiter` | `/api/mobile/autofill-token` | M5 |
| `breakglassRateLimiter` | `/api/tenant/breakglass` | M6 |

This also closes the per-email vs per-IP asymmetry on the magic-link path — the per-email limiter (`magicLinkEmailLimiter`) was already fail-closed; the per-IP one was not.

**Operational note:** making the OAuth/SAML callback fail-closed means a Redis outage blocks SSO login completion until Redis recovers — Redis becomes a hard dependency for SSO login availability. Ensure Redis HA / fast failover.

### 2. Removed destructive trash auto-purge from GET list endpoints (L3)

`GET /api/passwords` and `GET /api/teams/<teamId>/passwords` ran a `deleteMany` of 30-day-old trash as a request side effect, swallowing failures via `.catch(() => [])` — a destructive, observability-blind write on a read path. The retention-gc worker already owns this purge (`PER_TENANT_TRASH` registry entries for both `password_entries` and `team_password_entries`), honoring per-tenant `trashRetentionDays` and emitting a transactional `TRASH_RETENTION_PURGED` audit. The inline purge is removed and the now-dead `purgeExpiredTeamPasswords` helper deleted.

**Behavior change:** tenants with `trashRetentionDays = NULL` no longer get an implicit 30-day purge on list — the worker's opt-in model governs. Retained rows are E2E-encrypted (no plaintext-at-rest exposure); this is retention-policy drift, not a confidentiality change, and the safer-for-user direction (no silent destruction).

## Out of scope (deferred)

- **M2/M3** — Bearer-bypass matcher narrowing (`/api/teams/<id>/passwords/**`). Latent only: all team mutating children are `auth()`-only today. Tracked for a follow-up PR (route policy = method + exact path + token kind). M3 (personal `passwords:write` via token) is intended scope-gated behavior, not a vulnerability.
- **L1** — orphan-blob retry/audit. Orphaned blobs are E2E-encrypted (billing/storage only).
- **L2** — SCIM session-invalidation hardening. Token/membership validators are already fail-closed (next request rejected), so this is revocation latency, not a bypass.

## Testing

- Per-route unit tests added for the `redisErrored → 503` branch, each asserting the protected operation does **not** run (no mint / create / findUnique / deleteMany / handler invocation).
- New `withMagicLinkIpRateLimit` test block (allowed / 429 / 503 / null-IP fail-open).
- `GET /api/passwords` regression guard: performs no `deleteMany`.
- `rate-limiters.test.ts` rewritten to assert the fail-closed config + Redis-path behavior (the in-memory budget mechanics are covered at the factory level in `rate-limit.test.ts`).
- Full suite: 11716 passed / 1 skipped. `next build` succeeds. `pre-pr.sh` passes (the fail-closed-routes guard count was bumped 54 → 58 for the 4 new in-`src/app/api` limiters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
