### PR TITLE
fix(security): narrow Bearer-bypass matcher to method + exact path

### DIFF
--- a/docs/archive/review/bearer-bypass-matcher-narrowing-plan.md
+++ b/docs/archive/review/bearer-bypass-matcher-narrowing-plan.md
@@ -1,0 +1,150 @@
+# Plan: Bearer-bypass matcher narrowing (method + exact path)
+
+## Project context
+
+- **Type**: web app + service (Next.js 16 App Router, multi-tenant E2E password manager). Proxy (`src/proxy.ts` + `src/lib/proxy/*`) is the single ingress.
+- **Test infrastructure**: unit (vitest) + integration (real-DB) + E2E (playwright) + CI/CD. Proxy behavior is unit-tested in `src/__tests__/proxy.test.ts` and `src/lib/proxy/*` tests.
+- **Verification environment constraints**:
+  - Proxy matcher logic: `verifiable-local` (pure-function unit tests on `isBearerBypassRoute`).
+  - Extension passkey-replace DELETE flow end-to-end: `blocked-deferred` — requires a real browser extension + WebAuthn authenticator. The handler-level token auth change is unit-tested; the extension wiring already exists (`swFetch` DELETE) and is exercised manually. (Cost-justification: a full WebAuthn-in-extension E2E rig is out of proportion; the handler change is unit-covered and the extension already issues the call.)
+
+## Objective
+
+Remediate OWASP review M2/M3: the Bearer-bypass matcher (`isBearerBypassRoute` in `src/lib/proxy/cors-gate.ts`) is path-prefix-based and over-broad — `/api/passwords/**` and `/api/teams/<id>/passwords/**` make every mutating child (bulk-*, empty-trash, attachments, etc.) Bearer-REACHABLE at the proxy. Today those children are `auth()`-only so a cookieless Bearer 401s at the handler, but the matcher is a latent risk: migrating any child to a write scope silently makes it Bearer-WRITABLE (the `S1 LOCKED CONSTRAINT` comment warns about exactly this).
+
+**Goal**: replace the prefix matchers with a **method + exact-path allowlist** so only the routes that legitimately need Bearer access are reachable, structurally closing the latent risk.
+
+**Coupled essential fix (user-directed, no deferral)**: the browser extension's passkey-replace cleanup issues `DELETE /api/passwords/[id]` via Bearer (`extension/src/background/passkey-provider.ts:449`), but the handler is `checkAuth(req)` (session-only) so it 401s and the extension swallows it (`.catch(()=>{})`) — a pre-existing broken flow. Migrate the DELETE handler to `checkAuth(req, {scope: PASSWORDS_WRITE})` for **soft-delete only**, keeping permanent-delete (`?permanent=true`) closed to tokens (step-up cannot be satisfied by a Bearer token).
+
+## Requirements
+
+### Functional
+- R1: `isBearerBypassRoute` becomes method-aware: `isBearerBypassRoute(pathname, method)`. The caller (`src/lib/proxy/api-route.ts:24`) passes `request.method`.
+- R2: The matcher allows ONLY these (method, exact-path) pairs (derived from the verified needs-Bearer map):
+  - `GET /api/passwords`, `POST /api/passwords`
+  - `GET /api/passwords/<id>`, `PUT /api/passwords/<id>`, `DELETE /api/passwords/<id>`
+  - `GET /api/teams`
+  - `GET /api/teams/<id>/member-key`
+  - `GET /api/teams/<id>/passwords`, `GET /api/teams/<id>/passwords/<id>`
+  - `GET /api/vault/status`, `GET /api/vault/unlock/data`
+  - `GET /api/vault/delegation/check`
+  - `POST /api/vault/ssh/sign-authorize`
+  - `DELETE /api/extension/token`, `POST /api/extension/token/refresh`, `POST /api/extension/key/reset` (unchanged exact matches)
+  - `GET /api/tenant/access-requests` is session-only — **excluded**; `POST /api/tenant/access-requests` (SA token JIT) **kept**.
+- R3: Every mutating child currently reachable via prefix (bulk-*, empty-trash, restore, favorite, attachments, history, generate; team POST/PUT/DELETE; `/api/teams` POST; `/api/vault/delegation` POST/GET/DELETE; access-requests `[id]/**` and GET) is NO LONGER Bearer-reachable. Behavior for these is unchanged for real clients: they were session-only and already 401 a cookieless Bearer; now the 401 comes from the proxy instead of the handler.
+- R4: `DELETE /api/passwords/<id>` handler accepts a `passwords:write` token for **soft-delete**. With `?permanent=true` AND a token caller → 403 (tokens cannot satisfy step-up; return an explicit FORBIDDEN, not a confusing 401). Session callers retain full behavior incl. permanent-delete with step-up.
+
+### Non-functional
+- R5: No change to which legitimate client flows work (extension/iOS/CLI). The only behavioral change is the now-working extension passkey-replace soft-delete (R4) and the proxy returning 401 earlier for never-legitimate Bearer paths.
+- R6: Keep `isBearerBypassRoute` a pure function; method+path only, no I/O.
+
+## Technical approach
+
+### Matcher: method + exact-path table
+
+Replace `EXTENSION_TOKEN_ROUTES` prefix logic + `isBearerBypassTeamPath` with a single declarative table of `{ method, test(pathname) }` entries, where `test` is an exact regex (anchored) or exact-string compare. Path params (`<id>`) use `[^/]+` anchored segments. The three already-exact extension-token routes stay exact.
+
+Structure (illustrative, not final code):
+```
+type BearerRule = { methods: ReadonlySet<string>; match: (p: string) => boolean };
+const BEARER_RULES: readonly BearerRule[] = [ ... ];
+export function isBearerBypassRoute(pathname: string, method: string): boolean {
+  return BEARER_RULES.some(r => r.methods.has(method) && r.match(pathname));
+}
+```
+- Exact paths (`/api/passwords`, `/api/teams`, vault leaves, extension-token leaves): string equality.
+- Param paths (`/api/passwords/<id>`, `/api/teams/<id>/passwords`, `/api/teams/<id>/passwords/<id>`, `/api/teams/<id>/member-key`, `/api/vault/delegation/check`): anchored regex with `[^/]+` for the id segment(s) and NO trailing `(/.*)?` (that trailing wildcard is the bug).
+
+### Caller wiring
+
+`src/lib/proxy/api-route.ts`: the bypass branch (line 83) uses `isBearerBypassRoute(pathname, request.method)`. OPTIONS preflight (line 29-30) must still allow extension CORS for any path with ANY Bearer-allowed method, but an OPTIONS request's method is `"OPTIONS"` (not in any allowlist), so a method-aware call would return false and break preflight. Therefore api-route.ts computes TWO values: `isBearerBypassPath(pathname)` (path-only, any-method) wired into the preflight `isBearerRoute` field (line 30), and `isBearerBypassRoute(pathname, request.method)` (method-aware) for the bypass branch (line 83). Do NOT collapse the current single `isBearerRoute` assignment into one method-aware call — line 30 must read the path-only value (F3).
+
+**Caller blast-radius (signature change):** `isBearerBypassRoute(pathname)` → `(pathname, method)` breaks callers that pass one arg. Enumerated callers to update:
+- `src/lib/proxy/api-route.ts` — the two-value wiring above.
+- `src/lib/proxy/cors-gate.test.ts` — the truth table at `:67` calls `isBearerBypassRoute(tc.path)` single-arg across ~35 rows; the whole table must be restructured to `{path, method, expected}` (F5/T1).
+- `src/lib/proxy/route-policy.ts` does NOT call it (comments only, lines 24/96/155-161) — but those comments claim cors-gate "mirrors" route-policy's prefix matcher, which becomes false after this change; update them to state cors-gate is now method+exact and intentionally no longer mirrors the prefix classifier (F7).
+
+### Stale comment replacement
+
+The `S1 LOCKED CONSTRAINT` block (cors-gate.ts:41-46) warns that the prefix makes mutating children Bearer-reachable. After narrowing this is obsolete; replace it with: "The matcher is the structural Bearer gate — a route is Bearer-reachable ONLY if its (method, exact-path) appears in `BEARER_RULES`. A handler-level `checkAuth(req, {scope})` with a write scope is now SAFE without a matching table entry: the proxy fails closed (cookieless Bearer → session-required → 401) before the handler runs. To actually enable Bearer write for a new route, add its (method, exact-path) pair here." (S5)
+
+### DELETE handler token support (R4)
+
+`src/app/api/passwords/[id]/route.ts` handleDELETE:
+- Change `checkAuth(req)` → `checkAuth(req, { scope: EXTENSION_TOKEN_SCOPE.PASSWORDS_WRITE })`.
+- After resolving `permanent`: if `permanent === true` AND `authResult.auth.type !== "session"` → return a 403 BEFORE the step-up call. **Use `!== "session"`, NOT `=== "token"`** — the auth discriminants are `session | token | api_key | mcp_token`; `=== "token"` would miss api_key/mcp_token callers (F1/S1/RS2), leaving the invariant unenforced for them and giving a confusing 401 from step-up. `!== "session"` covers all non-session token types and mirrors the v1 precedent (`v1/passwords/[id]/route.ts:307-312`).
+- `forbidden()` takes NO arguments (`api-response.ts:81`). To carry a clear message use `errorResponseWithMessage(API_ERROR.FORBIDDEN, "Permanent deletion requires step-up authentication and is not available via token.")` (F2). Defense-in-depth: even if this guard regressed, `requireRecentCurrentAuthMethod` reads the session cookie and a Bearer-only request has none → 401, so permanent-delete stays closed regardless (S1).
+- Soft-delete path: unchanged logic, now reachable by token.
+- Update the handler's `// Session-only` comment (line 273) to reflect token soft-delete support.
+
+## Contracts
+
+### C1 — method-aware `isBearerBypassRoute` + path-only `isBearerBypassPath` — locked
+- **File**: `src/lib/proxy/cors-gate.ts`.
+- **Signatures**:
+  - `isBearerBypassRoute(pathname: string, method: string): boolean`
+  - `isBearerBypassPath(pathname: string): boolean` (any method allowed for that path — preflight use)
+- **Invariant** (app-enforced): `isBearerBypassRoute(p, m)` returns true IFF `(m, p)` is in the R2 allowlist. No prefix/`startsWith` wildcard remains for password paths.
+- **Forbidden patterns**:
+  - `pattern: passwords\(\\/\.\*\)\?` — reason: the trailing-wildcard team-passwords regex is the M2 bug; must be gone
+  - `pattern: startsWith\(route \+ "/"\)` in cors-gate.ts — reason: prefix matching for password routes is the M3 bug
+- **Acceptance**: unit tests enumerate every R2 (method,path) → true; every R3 mutating child (all methods) → false; wrong method on an allowed path (e.g. `POST /api/teams`, `DELETE /api/teams/<id>/passwords/<id>`, `PUT /api/passwords/<id>/attachments`) → false.
+- **Consumer-flow walkthrough**:
+  - Consumer `handleApiAuth` (path: `src/lib/proxy/api-route.ts`) reads `isBearerBypassRoute(pathname, request.method)` at the bypass branch (line 83) and `isBearerBypassPath(pathname)` for the OPTIONS preflight `isBearerRoute` (line 24/30). It uses the boolean to decide whether a cookieless Bearer request short-circuits to `NextResponse.next()` (bypass) vs falls through to the session-required 401 path. Both signatures are satisfiable from (pathname, method) alone — no other field needed.
+
+### C2 — caller passes method; preflight unchanged — locked
+- **File**: `src/lib/proxy/api-route.ts`.
+- **Change**: line 24 → `isBearerBypassRoute(pathname, request.method)` for the bypass branch; preflight (`handleApiPreflight`) uses `isBearerBypassPath(pathname)` so OPTIONS still allows extension CORS for any path with a Bearer-allowed method.
+- **Invariant**: OPTIONS preflight CORS behavior for Bearer paths is unchanged (extension can still preflight GET/PUT/DELETE on `/api/passwords/<id>`).
+- **Acceptance**: proxy test — cookieless Bearer to an R2 (method,path) → `NextResponse.next()` (bypass); cookieless Bearer to an R3 child or wrong-method → 401 (session-required path). OPTIONS to `/api/passwords/<id>` → preflight allows extension origin.
+
+### C3 — DELETE /api/passwords/[id] token soft-delete; token+permanent → 403 — locked
+- **File**: `src/app/api/passwords/[id]/route.ts` (handleDELETE).
+- **Change**: `checkAuth(req, {scope: PASSWORDS_WRITE})`; `permanent && auth.type !== "session"` → `errorResponseWithMessage(API_ERROR.FORBIDDEN, ...)` before step-up; session behavior unchanged.
+- **Invariant** (app-enforced): a `passwords:write` token (any of token/api_key/mcp_token) can soft-delete (trash) its own entry; NO non-session caller can permanent-delete (explicit 403 + step-up backstop); cross-user delete → 404 (existing oracle collapse preserved).
+- **Forbidden patterns**:
+  - `pattern: const authResult = await checkAuth\(req\);` in `[id]/route.ts` handleDELETE — reason: must pass the write scope now
+  - `pattern: permanent && authResult.auth.type === "token"` — reason: must be `!== "session"` to cover api_key/mcp_token (F1)
+- **Acceptance**: unit — token soft-delete → 200 + entry trashed (assert `update` with `deletedAt`, `delete` NOT called); token + `?permanent=true` → 403 (no delete/update/audit); **api_key + permanent → 403 AND mcp_token + permanent → 403** (pin the `!== "session"` discriminant, T4); cross-user token → 404; session + permanent + fresh step-up → 200 hard-delete (unchanged); **session + permanent + stale step-up → step-up response (proves step-up still session-reachable)**; **ordering: token + permanent with step-up mocked to return 401 → response is 403 (token guard short-circuits before step-up, T5)**; **scope-wiring: assert `checkAuth` called with `{scope: PASSWORDS_WRITE}` (the mock is arg-agnostic, so without this the scope change is vacuously untested, T4.5)**.
+- **Consumer-flow walkthrough**: Consumer = browser extension passkey-replace cleanup (path: `extension/src/background/passkey-provider.ts:449`). It issues `DELETE /api/passwords/<replaceEntryId>` with a Bearer token (via `swFetch`, no `?permanent`), expecting the stale passkey entry to be trashed. It reads only the HTTP status (currently `.catch(()=>{})`-swallowed). After C3 the call succeeds (200, soft-delete). No response body field is consumed. iOS/CLI do not call this DELETE with permanent via token.
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | method-aware matcher + path-only preflight helper | locked |
+| C2 | caller wiring (method passed; preflight via path-only helper) | locked |
+| C3 | DELETE token soft-delete; token+permanent → 403 | locked |
+
+## Testing strategy
+
+- **C1** (`src/lib/proxy/cors-gate.test.ts`): restructure the truth table from `{path, expected}` to `{path, method, expected}` (T1). Several EXISTING rows must **flip** (not just gain a method field) — these are false-green traps asserting the old over-broad behavior:
+  - `/api/teams/<id>/passwords/bulk-import` → **false** (was true, the M2 bug)
+  - `/api/vault/delegation` (bare, non-check) → **false** (was true)
+  - `/api/vault/unlock/data/extra` (child wildcard) → **false** (was true)
+  - `/api/tenant/access-requests` → method-split: `POST`→true, `GET`→false
+  - Add wrong-method negatives: `POST /api/teams`→false, `DELETE /api/teams/<id>/passwords/<id>`→false, `PUT /api/passwords/<id>/attachments`→false, `POST /api/vault/unlock/data`→false.
+  - All R2 allow-rows enumerated per-method (incl. `member-key` exact, `delegation/check` exact, `ssh/sign-authorize` POST, the three extension-token leaves).
+  - Add a separate `describe("isBearerBypassPath")` block (path-only, any-method): true for `/api/passwords/<id>`, `/api/teams/<id>/passwords`, `/api/extension/token`; false for a never-Bearer path like `/api/teams/<id>/webhooks` and `/api/passwordsx` (T2).
+- **C2** (`src/__tests__/proxy.test.ts`): `createApiRequest` defaults to GET and cannot express a method — extend it (add a method param) or build raw `NextRequest`s (T3). Add: cookieless Bearer `POST /api/passwords/bulk-import`→401; `DELETE /api/teams/<id>/passwords/<id>`→401; `POST /api/teams`→401 (wrong method on allowed path); `DELETE /api/passwords/<id>`→bypass (the new R4 flow through the proxy); OPTIONS preflight on a CHILD path (`/api/passwords/<id>`)→allows extension origin (covers `isBearerBypassPath`). Also add a `classifyRoute` assertion that a representative R3 child (`/api/passwords/bulk-import`) maps to `API_SESSION_REQUIRED`, so a future route-policy regression can't silently re-open the gate (S5).
+- **C3** (`src/app/api/passwords/[id]/route.test.ts`): mirror the GET block's token-auth mock shape (`{type:"token", scopes:["passwords:write"]}`, route.test.ts:139) and the v1 permanent-403 oracle (`v1/passwords/[id]/route.test.ts:563-577`, asserts no DB/audit). Cases: token soft-delete→200; token+permanent→403; api_key+permanent→403; mcp_token+permanent→403; cross-user token→404; session+permanent+fresh→200; session+permanent+stale→step-up; token+permanent with step-up mocked non-null→403 (ordering); scope-wiring assertion `checkAuth` called with `{scope: PASSWORDS_WRITE}`. Note the existing session DELETE tests survive (mock is arg-agnostic) — that's why the scope-wiring assertion is required to avoid a vacuous pass.
+- Mandatory: `npx vitest run` + `npx next build` + `bash scripts/pre-pr.sh`.
+
+## Considerations & constraints
+
+### Scope contract
+- **SC1**: This PR does NOT add Bearer/token support to any mutating child beyond the DELETE soft-delete fix (R4). bulk-*, empty-trash, restore, favorite, attachments, history, generate, team POST/PUT/DELETE remain session-only AND now proxy-unreachable via Bearer. Future token support for any of them MUST add the (method, exact-path) pair to the C1 table in the same change (the table is now the single gate). Owner: future feature PR if needed.
+- **SC2**: `/api/vault/delegation` POST/GET/DELETE lose Bearer-reachability (only `/check` is kept). Verified: the CLI agent only calls `/check` via Bearer; the POST/GET/DELETE management endpoints are session-only (web app). If a future CLI flow needs them, add to the C1 table.
+- **SC3**: The extension's `DELETE` was the only client-side Bearer call to a previously-session-only password route. No other extension/iOS/CLI Bearer call targets an R3 child (verified in the needs-Bearer map). If this is wrong, the proxy will start 401ing a previously-working flow — covered by C2 tests + manual extension check.
+
+### Known risks
+- Over-narrowing risk: if the needs-Bearer map missed a legitimate Bearer client flow, that flow breaks (proxy 401). Mitigation: the map was built by grepping extension/ios/cli for Bearer calls; C2 tests assert each kept route; manual extension smoke for the DELETE flow.
+- C3 widens write-surface: `DELETE /api/passwords/<id>` (soft-delete) is now token-writable. This is intentional and consistent with POST/PUT already being `passwords:write`. Permanent-delete stays session+step-up only.
+
+## User operation scenarios
+
+1. Extension passkey-replace: registers a new passkey replacing an old entry → extension `DELETE /api/passwords/<oldId>` (Bearer) → entry trashed (was: 401 swallowed, stale entry lingered).
+2. Attacker with a leaked `passwords:write` token tries `POST /api/passwords/bulk-import` cross-origin Bearer → proxy 401 (was: reached handler, which 401'd as auth()-only; now structurally blocked at proxy, and can never become writable by a future scope migration without an explicit table entry).
+3. CLI agent `GET /api/vault/delegation/check` (Bearer) → works (kept). CLI has no need for `POST /api/vault/delegation` → that stays session-only.
+4. Token caller `DELETE /api/passwords/<id>?permanent=true` → 403 (permanent needs step-up; tokens can't). Session caller same with fresh reauth → hard-delete.
+5. Web app (session cookie) on any of these routes → unchanged (never used the Bearer bypass).

--- a/docs/archive/review/bearer-bypass-matcher-narrowing-review.md
+++ b/docs/archive/review/bearer-bypass-matcher-narrowing-review.md
@@ -1,0 +1,49 @@
+# Plan Review: bearer-bypass-matcher-narrowing
+Date: 2026-06-26
+Review round: 1 (initial)
+
+## Changes from Previous Round
+Initial review. Three expert sub-agents (functionality / security / testing) reviewed the plan against the codebase. Testing agent's first run hit a transient API socket error; re-run succeeded.
+
+## Functionality Findings
+- **F1 (Major) — FIXED in plan**: permanent-delete guard `=== "token"` misses api_key/mcp_token (discriminants are session|token|api_key|mcp_token). Use `!== "session"` (mirrors v1 precedent). Step-up is a backstop regardless.
+- **F2 (Minor) — FIXED**: `forbidden()` takes no args; use `errorResponseWithMessage(API_ERROR.FORBIDDEN, msg)`.
+- **F3 (Minor) — FIXED**: the two-helper split (isBearerBypassPath for preflight, method-aware isBearerBypassRoute for bypass) is necessary because OPTIONS method ∉ allowlist; api-route.ts must wire both, line 30 reads path-only.
+- **F5 (Major) — FIXED**: `cors-gate.test.ts:67` single-arg call is an un-enumerated caller → build break; the truth table must be restructured + several rows flipped. Added to blast-radius + testing strategy.
+- **F7 (Minor) — FIXED**: route-policy.ts comments (24/96/155-161) claim cors-gate mirrors its prefix matcher — becomes false; update comments.
+- Verified clean: signature change does not break route-policy compilation (comments only); pathname excludes query; access-requests POST/GET method split is expressible.
+
+## Security Findings
+- **S1 (Low, == F1) — FIXED**: same as F1; additionally confirmed defense-in-depth — step-up reads session cookie, unsatisfiable by Bearer-only → permanent-delete stays closed for all token types regardless of the explicit guard. Order correct (403 before findUnique/delete).
+- **S3 (no finding)**: narrowing is strictly fail-closed — removed (method,path) pairs fall through to session-required 401; no new bypass.
+- **S4 (no finding)**: access-requests GET excluded / POST kept is correct; GET was never legitimately Bearer-reachable (session-only handler).
+- **S5 (no finding, the win) — note added**: the table is now the structural gate; a future handler scope-migration without a table entry is SAFE (proxy fails closed). Replaced obsolete `S1 LOCKED CONSTRAINT` comment framing. Added a `classifyRoute` regression assertion for an R3 child.
+- **S6 (info)**: no audit coverage lost (handlers 401'd before audit anyway).
+- No Critical findings → no escalation.
+
+## Testing Findings
+- **T1 (High, == F5) — FIXED**: truth-table restructure + row flips (bulk-import, delegation bare, unlock/data/extra, access-requests GET) are false-green traps; enumerated in testing strategy.
+- **T2 (Medium) — FIXED**: `isBearerBypassPath` needs its own test block.
+- **T3 (Medium) — FIXED**: proxy.test.ts `createApiRequest` can't express method; need method-bearing proxy cases (child/wrong-method → 401, DELETE bypass, child OPTIONS preflight) + classifyRoute assertion.
+- **T4 (High) — FIXED**: DELETE token cases must cover ALL non-session types (token/api_key/mcp_token + permanent → 403), token soft-delete → 200, cross-user → 404, plus a scope-wiring assertion (mock is arg-agnostic → otherwise vacuous).
+- **T5 (Medium) — FIXED**: ordering test — token+permanent with step-up mocked non-null must yield 403 (guard short-circuits before step-up).
+
+## Resolution Status
+All Major findings (F1/S1, F5/T1, T4) reflected in the plan. All Minor/Medium reflected. No Critical. No contract signature/invariant changed — only specifics sharpened, so contracts remain `locked`. Cleared to Phase 2.
+
+## Phase 3 (code review of implementation)
+Three experts reviewed the implemented diff.
+- **Functionality: No findings.** Verified BEARER_RULES table, `entryUnder` + PASSWORD_SUBROUTES exclusion (all 7 personal + 6 team literals covered), api-route wiring, DELETE guard placement/arity. One Minor note (EXTENSION_TOKEN_ROUTES "Derived" comment) — fixed.
+- **Security: No findings.** Exhaustively tested matcher-bypass vectors (trailing/double/encoded slash, case, traversal, subroute-collision) — all fail closed. Permanent-delete double-gated (type guard + step-up backstop). Structural guarantee confirmed: handler scope-migration without a BEARER_RULES entry stays Bearer-unreachable.
+- **Testing: 2 Low — both FIXED.** T1: brittle step-up mock restore → moved reset into `beforeEach`, removed manual restore (stable 3× isolated). T2: re-added dropped boundary guards (`/api/teams-export`, `/api/extension/tokenizer`).
+
+Implementation discovery during Phase 2: the naive `[^/]+` single-entry pattern collided with literal subroutes (`bulk-import` etc.) — fixed by `PASSWORD_SUBROUTES` exclusion in both personal (`entryUnder`) and team matchers, with regression cases added.
+
+Final: full suite 11744 passed / 1 skipped; `next build` OK; `pre-pr.sh` exit 0 (38 passed).
+
+## Recurring Issue Check (consolidated)
+- R1 (reuse): PASS — reuses checkRateLimitOrFail-style table + existing error helpers (F2 corrected the forbidden() misuse).
+- R3 (propagation / all callers): FIXED — cors-gate.test.ts + route-policy comments enumerated (F5/F7).
+- R17 (helper adoption): PASS — two-helper split correctly wired (F3).
+- RS2 (type checking): FIXED — `!== "session"` over `=== "token"` (F1).
+- RT1/vacuous tests: FIXED — row flips, scope-wiring assertion, ordering test (T1/T4/T5).

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -50,8 +50,9 @@ const APP_ORIGIN = "http://localhost:3000";
 function createApiRequest(
   path: string,
   headers?: Record<string, string>,
+  method: string = "GET",
 ): NextRequest {
-  return new NextRequest(`${APP_ORIGIN}${path}`, { headers });
+  return new NextRequest(`${APP_ORIGIN}${path}`, { headers, method });
 }
 
 describe("proxy — handleApiAuth Bearer bypass", () => {
@@ -95,18 +96,18 @@ describe("proxy — handleApiAuth Bearer bypass", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("bypasses session check for Bearer + /api/extension/token (revoke)", async () => {
+  it("bypasses session check for Bearer DELETE /api/extension/token (revoke)", async () => {
     const res = await proxy(
-      createApiRequest("/api/extension/token", { Authorization: "Bearer tok123" }),
+      createApiRequest("/api/extension/token", { Authorization: "Bearer tok123" }, "DELETE"),
       dummyOptions,
     );
     expect(res.status).toBe(200);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("bypasses session check for Bearer + /api/extension/token/refresh", async () => {
+  it("bypasses session check for Bearer POST /api/extension/token/refresh", async () => {
     const res = await proxy(
-      createApiRequest("/api/extension/token/refresh", { Authorization: "Bearer tok123" }),
+      createApiRequest("/api/extension/token/refresh", { Authorization: "Bearer tok123" }, "POST"),
       dummyOptions,
     );
     expect(res.status).toBe(200);
@@ -153,6 +154,48 @@ describe("proxy — handleApiAuth Bearer bypass", () => {
       dummyOptions,
     );
     expect(res.status).toBe(401);
+  });
+
+  it("bypasses for Bearer DELETE /api/passwords/[id] (soft-delete, extension passkey-replace)", async () => {
+    const res = await proxy(
+      createApiRequest("/api/passwords/pw-1", { Authorization: "Bearer tok123" }, "DELETE"),
+      dummyOptions,
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT bypass for Bearer POST /api/passwords/bulk-import (mutating child, session-only)", async () => {
+    const res = await proxy(
+      createApiRequest("/api/passwords/bulk-import", { Authorization: "Bearer tok123" }, "POST"),
+      dummyOptions,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("does NOT bypass for Bearer DELETE /api/teams/[id]/passwords/[id] (team mutating child, session-only)", async () => {
+    const res = await proxy(
+      createApiRequest("/api/teams/t1/passwords/e1", { Authorization: "Bearer tok123" }, "DELETE"),
+      dummyOptions,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("does NOT bypass for Bearer POST /api/teams (wrong method on Bearer-GET path)", async () => {
+    const res = await proxy(
+      createApiRequest("/api/teams", { Authorization: "Bearer tok123" }, "POST"),
+      dummyOptions,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("bypasses for Bearer GET /api/teams/[id]/passwords (team list read)", async () => {
+    const res = await proxy(
+      createApiRequest("/api/teams/t1/passwords", { Authorization: "Bearer tok123" }, "GET"),
+      dummyOptions,
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("allows /api/v1/passwords without session (public API)", async () => {
@@ -594,6 +637,32 @@ describe("proxy — CORS preflight and headers", () => {
     const req = new NextRequest(`${APP_ORIGIN}/api/passwords`, {
       method: "OPTIONS",
       headers: { origin: "http://evil.com" },
+    } as ConstructorParameters<typeof NextRequest>[1]);
+    const res = await proxy(req, dummyOptions);
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("OPTIONS /api/passwords/[id] (chrome-extension) allows extension origin (preflight is path-only)", async () => {
+    // The child path's only Bearer methods are GET/PUT/DELETE; the OPTIONS
+    // request's method is OPTIONS, so preflight must gate on path-eligibility
+    // (isBearerBypassPath), not the method-aware matcher — otherwise the
+    // extension cannot preflight the DELETE soft-delete flow.
+    const req = new NextRequest(`${APP_ORIGIN}/api/passwords/pw-1`, {
+      method: "OPTIONS",
+      headers: { origin: CHROME_EXT_ALLOWED },
+    } as ConstructorParameters<typeof NextRequest>[1]);
+    const res = await proxy(req, dummyOptions);
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(CHROME_EXT_ALLOWED);
+  });
+
+  it("OPTIONS /api/passwords/bulk-import (chrome-extension) does NOT allow extension origin (not Bearer-eligible)", async () => {
+    const req = new NextRequest(`${APP_ORIGIN}/api/passwords/bulk-import`, {
+      method: "OPTIONS",
+      headers: { origin: CHROME_EXT_ALLOWED },
     } as ConstructorParameters<typeof NextRequest>[1]);
     const res = await proxy(req, dummyOptions);
 

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -143,8 +143,9 @@ describe("proxy — handleApiAuth Bearer bypass", () => {
       createApiRequest("/api/api-keys", { Authorization: "Bearer tok123" }),
       dummyOptions,
     );
-    // Post-C2: api-keys removed from EXTENSION_TOKEN_ROUTES. Bearer-only request
-    // (no session cookie) short-circuits to 401 without a session lookup.
+    // api-keys is not a Bearer-bypass route (cors-gate.ts BEARER_RULES). A
+    // Bearer-only request (no session cookie) short-circuits to 401 without a
+    // session lookup.
     expect(res.status).toBe(401);
   });
 

--- a/src/app/api/extension/key/reset/route.ts
+++ b/src/app/api/extension/key/reset/route.ts
@@ -11,7 +11,8 @@
  *  4. Revokes all ExtensionToken rows for the userId with matching cnfJkt.
  *  5. Emits EXTENSION_TOKEN_FAMILY_REVOKED audit with reason "user_key_reset".
  *
- * No session cookie required — endpoint is in EXTENSION_TOKEN_ROUTES bypass list.
+ * No session cookie required — POST /api/extension/key/reset is a Bearer-bypass
+ * route (cors-gate.ts BEARER_RULES).
  */
 
 import { NextRequest, NextResponse } from "next/server";

--- a/src/app/api/passwords/[id]/route.test.ts
+++ b/src/app/api/passwords/[id]/route.test.ts
@@ -866,10 +866,16 @@ describe("PUT /api/passwords/[id]", () => {
 });
 
 describe("DELETE /api/passwords/[id]", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     mockCheckAuth.mockResolvedValue({ ok: true, auth: { type: "session", userId: "test-user-id" } });
     mockAuditCreate.mockResolvedValue({});
+    // vi.clearAllMocks() wipes the factory default (mockResolvedValue(null)),
+    // so re-establish "fresh step-up" here — no test then depends on leaked state.
+    const { requireRecentCurrentAuthMethod } = await import(
+      "@/lib/auth/session/recent-current-auth-method"
+    );
+    vi.mocked(requireRecentCurrentAuthMethod).mockResolvedValue(null);
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -961,5 +967,137 @@ describe("DELETE /api/passwords/[id]", () => {
         data: { deletedAt: expect.any(Date) },
       }),
     );
+  });
+
+  // ── C3: token soft-delete (extension passkey-replace) + permanent-delete guard ──
+
+  const tokenAuth = (type: "token" | "api_key" | "mcp_token") => ({
+    ok: true as const,
+    auth: { type, userId: "test-user-id", scopes: ["passwords:write"] },
+  });
+
+  it("requests the PASSWORDS_WRITE scope (token soft-delete enabled)", async () => {
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+    mockPrismaPasswordEntry.update.mockResolvedValue({});
+    await DELETE(
+      createRequest("DELETE", `http://localhost:3000/api/passwords/${PW_ID}`),
+      createParams({ id: PW_ID }),
+    );
+    // The mock is arg-agnostic, so without this assertion the scope change is
+    // vacuously untested.
+    expect(mockCheckAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: "passwords:write" }),
+    );
+  });
+
+  it("soft-deletes for a passwords:write token (200, trashed, no hard delete)", async () => {
+    mockCheckAuth.mockResolvedValue(tokenAuth("token"));
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+    mockPrismaPasswordEntry.update.mockResolvedValue({});
+
+    const res = await DELETE(
+      createRequest("DELETE", `http://localhost:3000/api/passwords/${PW_ID}`),
+      createParams({ id: PW_ID }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockPrismaPasswordEntry.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { deletedAt: expect.any(Date) } }),
+    );
+    expect(mockPrismaPasswordEntry.delete).not.toHaveBeenCalled();
+  });
+
+  it.each(["token", "api_key", "mcp_token"] as const)(
+    "rejects permanent=true for a %s caller with 403 (no delete)",
+    async (type) => {
+      mockCheckAuth.mockResolvedValue(tokenAuth(type));
+      mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+
+      const res = await DELETE(
+        createRequest("DELETE", `http://localhost:3000/api/passwords/${PW_ID}`, {
+          searchParams: { permanent: "true" },
+        }),
+        createParams({ id: PW_ID }),
+      );
+      const json = await res.json();
+      expect(res.status).toBe(403);
+      expect(json.error).toBe("FORBIDDEN");
+      expect(mockPrismaPasswordEntry.delete).not.toHaveBeenCalled();
+      expect(mockPrismaPasswordEntry.update).not.toHaveBeenCalled();
+    },
+  );
+
+  it("token permanent=true short-circuits to 403 BEFORE step-up (ordering)", async () => {
+    // Even if step-up would have produced its own response, the token guard
+    // must win first → 403, not the step-up 401. Use a persistent (non-Once)
+    // override so an un-consumed Once value cannot leak into a later test.
+    const { requireRecentCurrentAuthMethod } = await import(
+      "@/lib/auth/session/recent-current-auth-method"
+    );
+    vi.mocked(requireRecentCurrentAuthMethod).mockResolvedValue(
+      NextResponse.json({ error: "STEP_UP" }, { status: 401 }),
+    );
+    mockCheckAuth.mockResolvedValue(tokenAuth("token"));
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+
+    const res = await DELETE(
+      createRequest("DELETE", `http://localhost:3000/api/passwords/${PW_ID}`, {
+        searchParams: { permanent: "true" },
+      }),
+      createParams({ id: PW_ID }),
+    );
+    expect(res.status).toBe(403);
+    expect(requireRecentCurrentAuthMethod).not.toHaveBeenCalled();
+    // No manual restore needed — beforeEach re-establishes the null default.
+  });
+
+  it("returns 404 for a token caller deleting another user's entry (oracle collapse)", async () => {
+    mockCheckAuth.mockResolvedValue(tokenAuth("token"));
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue({ ...ownedEntry, userId: "other-user" });
+
+    const res = await DELETE(
+      createRequest("DELETE", `http://localhost:3000/api/passwords/${PW_ID}`),
+      createParams({ id: PW_ID }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("session permanent=true still works with fresh step-up (unchanged)", async () => {
+    const { requireRecentCurrentAuthMethod } = await import(
+      "@/lib/auth/session/recent-current-auth-method"
+    );
+    vi.mocked(requireRecentCurrentAuthMethod).mockResolvedValue(null); // fresh
+    mockCheckAuth.mockResolvedValue({ ok: true, auth: { type: "session", userId: "test-user-id" } });
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+    mockPrismaPasswordEntry.delete.mockResolvedValue({});
+
+    const res = await DELETE(
+      createRequest("DELETE", `http://localhost:3000/api/passwords/${PW_ID}`, {
+        searchParams: { permanent: "true" },
+      }),
+      createParams({ id: PW_ID }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockPrismaPasswordEntry.delete).toHaveBeenCalled();
+  });
+
+  it("session permanent=true with stale step-up returns the step-up response", async () => {
+    const { requireRecentCurrentAuthMethod } = await import(
+      "@/lib/auth/session/recent-current-auth-method"
+    );
+    vi.mocked(requireRecentCurrentAuthMethod).mockResolvedValueOnce(
+      NextResponse.json({ error: "STEP_UP_REQUIRED" }, { status: 401 }),
+    );
+    mockCheckAuth.mockResolvedValue({ ok: true, auth: { type: "session", userId: "test-user-id" } });
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+
+    const res = await DELETE(
+      createRequest("DELETE", `http://localhost:3000/api/passwords/${PW_ID}`, {
+        searchParams: { permanent: "true" },
+      }),
+      createParams({ id: PW_ID }),
+    );
+    expect(res.status).toBe(401);
+    expect(mockPrismaPasswordEntry.delete).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/passwords/[id]/route.ts
+++ b/src/app/api/passwords/[id]/route.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/blob-store/cleanup";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { updateE2EPasswordSchema } from "@/lib/validations";
-import { errorResponse, notFound, rateLimited, validationError } from "@/lib/http/api-response";
+import { errorResponse, errorResponseWithMessage, notFound, rateLimited, validationError } from "@/lib/http/api-response";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { checkAuth } from "@/lib/auth/session/check-auth";
 import { parseBody } from "@/lib/http/parse-body";
@@ -270,12 +270,14 @@ async function handlePUT(
 }
 
 // DELETE /api/passwords/[id] - Soft delete (move to trash)
-// Session-only: token support for deletion deferred to Phase E (requires PASSWORDS_DELETE scope)
+// Soft-delete accepts a passwords:write token (extension/iOS/CLI), matching
+// POST/PUT. Permanent delete (?permanent=true) stays session-only: it requires
+// step-up reauth, which a Bearer token cannot satisfy.
 async function handleDELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const authResult = await checkAuth(req);
+  const authResult = await checkAuth(req, { scope: EXTENSION_TOKEN_SCOPE.PASSWORDS_WRITE });
   if (!authResult.ok) return authResult.response;
   const { userId } = authResult.auth;
 
@@ -285,9 +287,17 @@ async function handleDELETE(
 
   // A01-3: permanent delete is unrecoverable. Require fresh credential
   // possession (15-min step-up window) so a leaked session cookie alone
-  // cannot wipe entries. Soft-delete (trash) remains gated only by
-  // session — the trash itself acts as a recovery window.
+  // cannot wipe entries. A token caller can never satisfy step-up (it reads
+  // the session cookie), so reject non-session callers up front with a clear
+  // 403 rather than the confusing 401 step-up would emit. Soft-delete (trash)
+  // remains available to tokens — the trash itself acts as a recovery window.
   if (permanent) {
+    if (authResult.auth.type !== "session") {
+      return errorResponseWithMessage(
+        API_ERROR.FORBIDDEN,
+        "Permanent deletion requires step-up authentication and is not available via token.",
+      );
+    }
     const stepUp = await requireRecentCurrentAuthMethod(req);
     if (stepUp) return stepUp;
   }

--- a/src/lib/proxy/api-route.ts
+++ b/src/lib/proxy/api-route.ts
@@ -4,6 +4,7 @@ import {
   applyCorsHeaders,
   handleApiPreflight,
   isBearerBypassRoute,
+  isBearerBypassPath,
 } from "./cors-gate";
 import { getSessionInfo, hasSessionCookie } from "./auth-gate";
 import { classifyRoute, ROUTE_POLICY_KIND } from "./route-policy";
@@ -21,13 +22,22 @@ export async function handleApiAuth(request: NextRequest) {
   // that accept Bearer as alternative auth are still classified as
   // api-session-required; we ask cors-gate directly whether the bypass
   // dispatch is eligible for this specific path.
-  const isBearerRoute = isBearerBypassRoute(pathname);
+  // Method-aware bypass eligibility for the actual request. Preflight uses
+  // the path-only variant below — an OPTIONS request's method is never an
+  // allowlisted method, so a method-aware check would wrongly deny preflight.
+  const isBearerRoute = isBearerBypassRoute(pathname, request.method);
   const isExchangeRoute = policy.kind === ROUTE_POLICY_KIND.API_EXTENSION_EXCHANGE;
   const isBridgeCodeRoute = policy.kind === ROUTE_POLICY_KIND.API_EXTENSION_BRIDGE_CODE;
 
-  // Preflight (handled regardless of policy.kind).
+  // Preflight (handled regardless of policy.kind). CORS preflight grants no
+  // server-side auth, so it gates on path-eligibility (any allowed method);
+  // the real request still passes through the method-aware gate above.
   if (request.method === "OPTIONS") {
-    return handleApiPreflight(request, { isBearerRoute, isExchangeRoute, isBridgeCodeRoute });
+    return handleApiPreflight(request, {
+      isBearerRoute: isBearerBypassPath(pathname),
+      isExchangeRoute,
+      isBridgeCodeRoute,
+    });
   }
 
   // Non-CSRF early returns. ALL paths outside the cookie-CSRF threat

--- a/src/lib/proxy/cors-gate.test.ts
+++ b/src/lib/proxy/cors-gate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
 import {
-  EXTENSION_TOKEN_ROUTES,
+  BEARER_BYPASS_ROUTE_SUMMARY,
   isBearerBypassRoute,
   isBearerBypassPath,
   isExtensionExchangeRoute,
@@ -90,8 +90,8 @@ describe("isBearerBypassRoute — method + exact-path truth table", () => {
     });
   }
 
-  it("EXTENSION_TOKEN_ROUTES is a non-empty readonly list", () => {
-    expect(EXTENSION_TOKEN_ROUTES.length).toBeGreaterThan(0);
+  it("BEARER_BYPASS_ROUTE_SUMMARY is a non-empty readonly list", () => {
+    expect(BEARER_BYPASS_ROUTE_SUMMARY.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/lib/proxy/cors-gate.test.ts
+++ b/src/lib/proxy/cors-gate.test.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   EXTENSION_TOKEN_ROUTES,
   isBearerBypassRoute,
+  isBearerBypassPath,
   isExtensionExchangeRoute,
   handleApiPreflight,
   applyCorsHeaders,
@@ -21,56 +22,99 @@ function makeRequest(
   return new NextRequest(`${APP_ORIGIN}${path}`, { method, headers });
 }
 
-describe("isBearerBypassRoute — Bearer-bypass detection truth table", () => {
-  type Case = { path: string; expected: boolean; reason: string };
+describe("isBearerBypassRoute — method + exact-path truth table", () => {
+  type Case = { path: string; method: string; expected: boolean; reason: string };
   const CASES: readonly Case[] = [
-    // Allow (Bearer-bypass eligible)
-    { path: "/api/passwords", expected: true, reason: "passwords exact" },
-    { path: "/api/passwords/abc", expected: true, reason: "passwords child" },
-    { path: "/api/vault/status", expected: true, reason: "vault status exact" },
-    { path: "/api/vault/unlock/data", expected: true, reason: "vault unlock data exact" },
-    { path: "/api/vault/unlock/data/extra", expected: true, reason: "child of vault unlock data" },
-    { path: "/api/teams", expected: true, reason: "teams list — Bearer (iOS app / extension)" },
-    { path: "/api/teams/t1/passwords", expected: true, reason: "team passwords — child of teams" },
-    { path: "/api/teams/t1/member-key", expected: true, reason: "team member-key — child of teams" },
-    { path: "/api/teams/t1/passwords/e1", expected: true, reason: "single team entry — extension teamPasswordById" },
-    { path: "/api/teams/t1/passwords/bulk-import", expected: true, reason: "passwords child — auth()-gated handler (S1 constraint)" },
-    { path: "/api/teams/t1/webhooks", expected: false, reason: "web-only sensitive config — not Bearer" },
-    { path: "/api/teams/t1/policy", expected: false, reason: "web-only" },
-    { path: "/api/teams/t1/members", expected: false, reason: "web-only" },
-    { path: "/api/teams/t1", expected: false, reason: "team CRUD — web-only" },
-    { path: "/api/teams/t1/member-key/extra", expected: false, reason: "member-key is leaf-exact" },
-    { path: "/api/teams/t1/passwordsX", expected: false, reason: "passwords suffix-collision — boundary requires end or /" },
-    { path: "/api/teams-export", expected: false, reason: "sibling collision — not under /api/teams/" },
-    { path: "/api/api-keys", expected: false, reason: "api-keys removed from Bearer-bypass list (session-only post-C2)" },
-    { path: "/api/api-keys/k1", expected: false, reason: "api-keys child also session-only post-C2" },
-    { path: "/api/extension/token", expected: true, reason: "extension token EXACT only" },
-    { path: "/api/extension/token/refresh", expected: true, reason: "extension token refresh EXACT only" },
-    { path: "/api/tenant/access-requests", expected: true, reason: "SA JIT" },
-    { path: "/api/vault/delegation", expected: true, reason: "vault delegation exact" },
-    { path: "/api/vault/delegation/check", expected: true, reason: "vault delegation child" },
-    { path: "/api/vault/ssh/sign-authorize", expected: true, reason: "SSH agent sign-authorize — CLI Bearer" },
+    // ── ALLOW (method + exact-path in the allowlist) ──
+    { path: "/api/passwords", method: "GET", expected: true, reason: "passwords list read" },
+    { path: "/api/passwords", method: "POST", expected: true, reason: "passwords create" },
+    { path: "/api/passwords/abc", method: "GET", expected: true, reason: "single entry read" },
+    { path: "/api/passwords/abc", method: "PUT", expected: true, reason: "single entry update" },
+    { path: "/api/passwords/abc", method: "DELETE", expected: true, reason: "single entry soft-delete (extension passkey-replace)" },
+    { path: "/api/teams", method: "GET", expected: true, reason: "team list read" },
+    { path: "/api/teams/t1/member-key", method: "GET", expected: true, reason: "team member-key read" },
+    { path: "/api/teams/t1/passwords", method: "GET", expected: true, reason: "team passwords list read" },
+    { path: "/api/teams/t1/passwords/e1", method: "GET", expected: true, reason: "single team entry read" },
+    { path: "/api/vault/status", method: "GET", expected: true, reason: "vault status" },
+    { path: "/api/vault/unlock/data", method: "GET", expected: true, reason: "vault unlock data" },
+    { path: "/api/vault/delegation/check", method: "GET", expected: true, reason: "CLI agent delegation check" },
+    { path: "/api/vault/ssh/sign-authorize", method: "POST", expected: true, reason: "CLI SSH sign-authorize" },
+    { path: "/api/extension/token", method: "DELETE", expected: true, reason: "extension token revoke" },
+    { path: "/api/extension/token/refresh", method: "POST", expected: true, reason: "extension token refresh" },
+    { path: "/api/extension/key/reset", method: "POST", expected: true, reason: "extension key reset" },
+    { path: "/api/tenant/access-requests", method: "POST", expected: true, reason: "SA JIT create" },
 
-    // Deny (NOT Bearer-bypass)
-    { path: "/api/tags", expected: false, reason: "tags not in list" },
-    { path: "/api/notifications", expected: false, reason: "notifications not in list" },
-    { path: "/api/extension/token/extra", expected: false, reason: "child of token (not in EXACT-list)" },
-    { path: "/api/extension/tokenizer", expected: false, reason: "prefix-collision token vs tokenizer" },
-    { path: "/api/extension/bridge-code", expected: false, reason: "non-token extension path" },
-    { path: "/api/auth/session", expected: false, reason: "auth session" },
-    { path: "/api/v1/passwords", expected: false, reason: "v1 has its own auth model" },
-    { path: "/api/passwordsx", expected: false, reason: "passwords prefix-collision" },
+    // ── DENY: wrong method on an allowed path ──
+    { path: "/api/teams", method: "POST", expected: false, reason: "team create is session-only (wrong method)" },
+    { path: "/api/teams/t1/passwords/e1", method: "DELETE", expected: false, reason: "team entry delete is session-only (wrong method)" },
+    { path: "/api/teams/t1/passwords", method: "POST", expected: false, reason: "team entry create is session-only (wrong method)" },
+    { path: "/api/passwords/abc", method: "PATCH", expected: false, reason: "no PATCH on single entry" },
+    { path: "/api/vault/unlock/data", method: "POST", expected: false, reason: "vault unlock data is GET-only" },
+    { path: "/api/tenant/access-requests", method: "GET", expected: false, reason: "access-requests GET is session-only" },
+    { path: "/api/vault/ssh/sign-authorize", method: "GET", expected: false, reason: "sign-authorize is POST-only" },
+
+    // ── DENY: mutating children no longer Bearer-reachable (was the M2/M3 bug) ──
+    { path: "/api/passwords/bulk-import", method: "POST", expected: false, reason: "bulk-import is session-only (FLIP: was Bearer-reachable)" },
+    { path: "/api/passwords/bulk-import", method: "GET", expected: false, reason: "subroute literal must not collide with single-entry [id] GET" },
+    { path: "/api/passwords/generate", method: "GET", expected: false, reason: "generate subroute must not collide with [id] GET" },
+    { path: "/api/teams/t1/passwords/bulk-import", method: "GET", expected: false, reason: "team subroute literal must not collide with single-entry [id] GET" },
+    { path: "/api/passwords/empty-trash", method: "POST", expected: false, reason: "empty-trash is session-only" },
+    { path: "/api/passwords/abc/attachments", method: "PUT", expected: false, reason: "attachments are session-only" },
+    { path: "/api/passwords/abc/history", method: "GET", expected: false, reason: "history is session-only" },
+    { path: "/api/teams/t1/passwords/bulk-import", method: "POST", expected: false, reason: "team bulk-import is session-only (FLIP: was Bearer-reachable)" },
+    { path: "/api/teams/t1/passwords/empty-trash", method: "POST", expected: false, reason: "team empty-trash is session-only" },
+
+    // ── DENY: narrowed paths that prefix-matching used to allow ──
+    { path: "/api/vault/unlock/data/extra", method: "GET", expected: false, reason: "no child wildcard (FLIP: was Bearer-reachable)" },
+    { path: "/api/vault/delegation", method: "POST", expected: false, reason: "delegation parent is session-only (FLIP: was Bearer-reachable)" },
+    { path: "/api/vault/delegation", method: "GET", expected: false, reason: "only /check is Bearer; parent is session-only" },
+    { path: "/api/teams/t1/member-key/extra", method: "GET", expected: false, reason: "member-key is leaf-exact" },
+    { path: "/api/teams/t1/passwordsX", method: "GET", expected: false, reason: "suffix collision — exact segment boundary" },
+    { path: "/api/teams-export", method: "GET", expected: false, reason: "sibling collision — not under /api/teams/" },
+    { path: "/api/extension/token/extra", method: "DELETE", expected: false, reason: "extension token is exact only" },
+    { path: "/api/extension/tokenizer", method: "DELETE", expected: false, reason: "prefix collision — token vs tokenizer" },
+
+    // ── DENY: never-Bearer routes ──
+    { path: "/api/teams/t1", method: "GET", expected: false, reason: "team CRUD — web-only" },
+    { path: "/api/teams/t1/webhooks", method: "GET", expected: false, reason: "web-only sensitive config" },
+    { path: "/api/api-keys", method: "GET", expected: false, reason: "api-keys session-only" },
+    { path: "/api/tags", method: "GET", expected: false, reason: "tags not Bearer" },
+    { path: "/api/extension/bridge-code", method: "POST", expected: false, reason: "exchange route handled separately" },
+    { path: "/api/v1/passwords", method: "GET", expected: false, reason: "v1 has its own auth model" },
+    { path: "/api/passwordsx", method: "GET", expected: false, reason: "passwords prefix collision" },
   ];
 
   for (const tc of CASES) {
-    it(`${tc.expected ? "ALLOW" : "DENY"}: ${tc.reason} (${tc.path})`, () => {
-      expect(isBearerBypassRoute(tc.path)).toBe(tc.expected);
+    it(`${tc.expected ? "ALLOW" : "DENY"}: ${tc.method} ${tc.path} — ${tc.reason}`, () => {
+      expect(isBearerBypassRoute(tc.path, tc.method)).toBe(tc.expected);
     });
   }
 
   it("EXTENSION_TOKEN_ROUTES is a non-empty readonly list", () => {
     expect(EXTENSION_TOKEN_ROUTES.length).toBeGreaterThan(0);
   });
+});
+
+describe("isBearerBypassPath — path-only (any-method) for OPTIONS preflight", () => {
+  // True when ANY method is allowed for the path (preflight grants CORS, not auth).
+  type Case = { path: string; expected: boolean; reason: string };
+  const CASES: readonly Case[] = [
+    { path: "/api/passwords", expected: true, reason: "GET/POST allowed" },
+    { path: "/api/passwords/abc", expected: true, reason: "GET/PUT/DELETE allowed" },
+    { path: "/api/teams/t1/passwords", expected: true, reason: "GET allowed" },
+    { path: "/api/extension/token", expected: true, reason: "DELETE allowed" },
+    { path: "/api/tenant/access-requests", expected: true, reason: "POST allowed (any-method semantics)" },
+    { path: "/api/passwords/bulk-import", expected: false, reason: "no method allowed" },
+    { path: "/api/teams/t1/webhooks", expected: false, reason: "never-Bearer path" },
+    { path: "/api/passwordsx", expected: false, reason: "prefix collision" },
+    { path: "/api/vault/delegation", expected: false, reason: "only /check leaf is Bearer" },
+  ];
+
+  for (const tc of CASES) {
+    it(`${tc.expected ? "ELIGIBLE" : "NOT"}: ${tc.path} — ${tc.reason}`, () => {
+      expect(isBearerBypassPath(tc.path)).toBe(tc.expected);
+    });
+  }
 });
 
 describe("isExtensionExchangeRoute", () => {

--- a/src/lib/proxy/cors-gate.ts
+++ b/src/lib/proxy/cors-gate.ts
@@ -12,67 +12,122 @@ import { API_PATH } from "@/lib/constants";
 import { handlePreflight, applyCorsHeaders } from "@/lib/http/cors";
 
 /**
- * Routes that accept extension Bearer tokens as alternative auth.
- * The proxy lets these through without session validation when only
- * a Bearer header is present (no session cookie).
+ * Method + exact-path Bearer-bypass allowlist.
  *
- * IMPROVE(#39): harden allowlist matching — add edge-case tests for child paths
+ * The proxy lets a cookieless Bearer request through without session
+ * validation ONLY for an exact (method, path) pair below. This is the
+ * structural Bearer gate: a route is Bearer-reachable IFF its
+ * (method, exact-path) appears here. A handler-level
+ * `checkAuth(req, {scope})` with a write scope is SAFE without a matching
+ * entry — the proxy fails closed (cookieless Bearer → session-required →
+ * 401) before the handler runs. To enable Bearer access for a new route,
+ * add its (method, exact-path) pair here.
+ *
+ * Each rule's `match` is an EXACT matcher (no trailing wildcard): a literal
+ * string for static paths, or an anchored regex with `[^/]+` for id
+ * segments. Mutating children (bulk-*, empty-trash, attachments, history,
+ * etc.) are deliberately absent — they are session-only and stay
+ * proxy-unreachable via Bearer.
+ */
+type BearerRule = { methods: ReadonlySet<string>; match: (pathname: string) => boolean };
+
+const exact = (route: string) => (pathname: string) => pathname === route;
+const re = (pattern: RegExp) => (pathname: string) => pattern.test(pathname);
+
+const M = (...methods: string[]) => new Set(methods);
+
+// Literal sub-routes that sit alongside the `[id]` dynamic segment under
+// .../passwords/. A naive `[^/]+` id pattern would also match these (they ARE
+// single segments), so a Bearer GET to e.g. /api/passwords/bulk-import would
+// wrongly match the single-entry rule. Entry ids are CUID/UUID and never equal
+// these literals, so excluding them is safe and keeps the mutating children
+// (which are session-only) off the Bearer surface.
+const PASSWORD_SUBROUTES: ReadonlySet<string> = new Set([
+  "bulk-archive",
+  "bulk-import",
+  "bulk-purge",
+  "bulk-restore",
+  "bulk-trash",
+  "empty-trash",
+  "generate",
+]);
+
+// Match `<base>/<segment>` exactly where <segment> is a real entry id, not a
+// reserved sub-route literal.
+const entryUnder = (base: string) => {
+  const pattern = new RegExp(`^${base.replace(/\//g, "\\/")}\\/([^/]+)$`);
+  return (pathname: string) => {
+    const m = pattern.exec(pathname);
+    return m !== null && !PASSWORD_SUBROUTES.has(m[1]);
+  };
+};
+
+const BEARER_RULES: readonly BearerRule[] = [
+  // Personal passwords — list + create + single-entry read/update/soft-delete.
+  { methods: M("GET", "POST"), match: exact(API_PATH.PASSWORDS) },
+  { methods: M("GET", "PUT", "DELETE"), match: entryUnder("/api/passwords") },
+
+  // Teams — list (read) + member-key (wrapped key) + team password read.
+  { methods: M("GET"), match: exact(API_PATH.TEAMS) },
+  { methods: M("GET"), match: re(/^\/api\/teams\/[^/]+\/member-key$/) },
+  { methods: M("GET"), match: re(/^\/api\/teams\/[^/]+\/passwords$/) },
+  { methods: M("GET"), match: (p) => {
+    const m = /^\/api\/teams\/[^/]+\/passwords\/([^/]+)$/.exec(p);
+    return m !== null && !PASSWORD_SUBROUTES.has(m[1]);
+  } },
+
+  // Vault — status + unlock data (read); delegation check + SSH sign (CLI agent).
+  { methods: M("GET"), match: exact(API_PATH.VAULT_STATUS) },
+  { methods: M("GET"), match: exact(API_PATH.VAULT_UNLOCK_DATA) },
+  { methods: M("GET"), match: exact(`${API_PATH.VAULT_DELEGATION}/check`) },
+  { methods: M("POST"), match: exact(API_PATH.VAULT_SSH_SIGN_AUTHORIZE) },
+
+  // Extension token lifecycle (Bearer + DPoP, no session cookie).
+  { methods: M("DELETE"), match: exact(API_PATH.EXTENSION_TOKEN) },
+  { methods: M("POST"), match: exact(API_PATH.EXTENSION_TOKEN_REFRESH) },
+  { methods: M("POST"), match: exact(API_PATH.EXTENSION_KEY_RESET) },
+
+  // Service-account self-service JIT — create only (GET is session-only).
+  { methods: M("POST"), match: exact(API_PATH.TENANT_ACCESS_REQUESTS) },
+];
+
+/**
+ * Method-aware Bearer-bypass test. Returns true IFF `(method, pathname)`
+ * is an explicit allowlist entry. Used by the proxy bypass branch.
+ */
+export function isBearerBypassRoute(pathname: string, method: string): boolean {
+  return BEARER_RULES.some((rule) => rule.methods.has(method) && rule.match(pathname));
+}
+
+/**
+ * Path-only (any-method) Bearer-bypass test. Used for the OPTIONS preflight
+ * `allowExtension` decision: an OPTIONS request's method is "OPTIONS" (never
+ * an allowlisted method), so the preflight must check path-eligibility
+ * regardless of method. The actual GET/PUT/DELETE request that follows still
+ * goes through the method-aware `isBearerBypassRoute` gate — CORS preflight
+ * grants no server-side auth.
+ */
+export function isBearerBypassPath(pathname: string): boolean {
+  return BEARER_RULES.some((rule) => rule.match(pathname));
+}
+
+/**
+ * Documentation/diagnostic list of the base paths that accept a Bearer token
+ * as alternative auth. This is NOT the matcher — `BEARER_RULES` is the
+ * authoritative (method, exact-path) gate. Kept as a hand-maintained summary
+ * for readers; the only test on it asserts it is non-empty.
  */
 export const EXTENSION_TOKEN_ROUTES: readonly string[] = [
   API_PATH.PASSWORDS,
   API_PATH.VAULT_STATUS,
   API_PATH.VAULT_UNLOCK_DATA,
-  API_PATH.EXTENSION_TOKEN,         // DELETE (revoke) — validated by route handler
-  API_PATH.EXTENSION_TOKEN_REFRESH, // POST (refresh) — validated by route handler
-  API_PATH.EXTENSION_KEY_RESET,     // POST (key reset) — Bearer + DPoP, no session cookie
-  API_PATH.TENANT_ACCESS_REQUESTS,  // SA self-service JIT — validated by route handler via authOrToken
-  API_PATH.VAULT_DELEGATION,        // Delegation check — CLI agent uses Bearer for /check
-  API_PATH.VAULT_SSH_SIGN_AUTHORIZE, // SSH agent per-signature authorize — CLI uses Bearer
+  API_PATH.EXTENSION_TOKEN,
+  API_PATH.EXTENSION_TOKEN_REFRESH,
+  API_PATH.EXTENSION_KEY_RESET,
+  API_PATH.TENANT_ACCESS_REQUESTS,
+  API_PATH.VAULT_DELEGATION,
+  API_PATH.VAULT_SSH_SIGN_AUTHORIZE,
 ];
-
-/**
- * Narrow Bearer-bypass matcher for /api/teams paths.
- *
- * iOS/extension only need:
- *   - /api/teams                         (exact) — team list
- *   - /api/teams/<teamId>/member-key     (exact, leaf) — wrapped key
- *   - /api/teams/<teamId>/passwords/**   (prefix) — entry list + single entry
- *
- * S1 LOCKED CONSTRAINT: the passwords prefix makes mutating children
- * (bulk-import, empty-trash, bulk-*) Bearer-REACHABLE. Safe today — those
- * handlers are auth()-only (session) and 401 a cookieless Bearer. Do NOT
- * migrate any teams/<teamId>/passwords mutating child to checkAuth with a
- * write scope (PASSWORDS_WRITE / TEAM_PASSWORDS_WRITE) without narrowing this
- * matcher — it would make them Bearer-WRITABLE.
- */
-function isBearerBypassTeamPath(pathname: string): boolean {
-  return (
-    /^\/api\/teams$/.test(pathname) ||
-    /^\/api\/teams\/[^/]+\/member-key$/.test(pathname) ||
-    /^\/api\/teams\/[^/]+\/passwords(\/.*)?$/.test(pathname)
-  );
-}
-
-/**
- * Match a request path against the Bearer-bypass route list.
- * Extension token endpoints are exact-match only; password/vault routes
- * allow child paths.
- */
-export function isBearerBypassRoute(pathname: string): boolean {
-  return (
-    isBearerBypassTeamPath(pathname) ||
-    EXTENSION_TOKEN_ROUTES.some((route) => {
-      if (
-        route === API_PATH.EXTENSION_TOKEN ||
-        route === API_PATH.EXTENSION_TOKEN_REFRESH ||
-        route === API_PATH.EXTENSION_KEY_RESET
-      ) {
-        return pathname === route;
-      }
-      return pathname === route || pathname.startsWith(route + "/");
-    })
-  );
-}
 
 /**
  * Whether this is the bridge-code exchange route. The route bootstraps a

--- a/src/lib/proxy/cors-gate.ts
+++ b/src/lib/proxy/cors-gate.ts
@@ -108,12 +108,14 @@ export function isBearerBypassPath(pathname: string): boolean {
 }
 
 /**
- * Documentation/diagnostic list of the base paths that accept a Bearer token
- * as alternative auth. This is NOT the matcher — `BEARER_RULES` is the
- * authoritative (method, exact-path) gate. Kept as a hand-maintained summary
- * for readers; the only test on it asserts it is non-empty.
+ * Documentation/diagnostic SUMMARY of the base paths that accept a Bearer token
+ * as alternative auth. This is deliberately NOT named like a matcher and MUST
+ * NOT be used as one — `BEARER_RULES` is the authoritative (method, exact-path)
+ * gate. This is a hand-maintained reader's summary; the only test on it asserts
+ * it is non-empty. (Renamed from EXTENSION_TOKEN_ROUTES so it can never be
+ * mistaken for the route-matching allowlist it used to be.)
  */
-export const EXTENSION_TOKEN_ROUTES: readonly string[] = [
+export const BEARER_BYPASS_ROUTE_SUMMARY: readonly string[] = [
   API_PATH.PASSWORDS,
   API_PATH.VAULT_STATUS,
   API_PATH.VAULT_UNLOCK_DATA,

--- a/src/lib/proxy/cors-gate.ts
+++ b/src/lib/proxy/cors-gate.ts
@@ -52,29 +52,25 @@ const PASSWORD_SUBROUTES: ReadonlySet<string> = new Set([
   "generate",
 ]);
 
-// Match `<base>/<segment>` exactly where <segment> is a real entry id, not a
-// reserved sub-route literal.
-const entryUnder = (base: string) => {
-  const pattern = new RegExp(`^${base.replace(/\//g, "\\/")}\\/([^/]+)$`);
-  return (pathname: string) => {
-    const m = pattern.exec(pathname);
-    return m !== null && !PASSWORD_SUBROUTES.has(m[1]);
-  };
+// Match a single-entry path via a STATIC regex whose capture group 1 is the
+// entry-id segment, excluding reserved sub-route literals (bulk-*, etc.). The
+// regex is passed as a literal — never built from string concatenation — so
+// there is no escaping/injection surface.
+const entryMatch = (pattern: RegExp) => (pathname: string) => {
+  const m = pattern.exec(pathname);
+  return m !== null && !PASSWORD_SUBROUTES.has(m[1]);
 };
 
 const BEARER_RULES: readonly BearerRule[] = [
   // Personal passwords — list + create + single-entry read/update/soft-delete.
   { methods: M("GET", "POST"), match: exact(API_PATH.PASSWORDS) },
-  { methods: M("GET", "PUT", "DELETE"), match: entryUnder("/api/passwords") },
+  { methods: M("GET", "PUT", "DELETE"), match: entryMatch(/^\/api\/passwords\/([^/]+)$/) },
 
   // Teams — list (read) + member-key (wrapped key) + team password read.
   { methods: M("GET"), match: exact(API_PATH.TEAMS) },
   { methods: M("GET"), match: re(/^\/api\/teams\/[^/]+\/member-key$/) },
   { methods: M("GET"), match: re(/^\/api\/teams\/[^/]+\/passwords$/) },
-  { methods: M("GET"), match: (p) => {
-    const m = /^\/api\/teams\/[^/]+\/passwords\/([^/]+)$/.exec(p);
-    return m !== null && !PASSWORD_SUBROUTES.has(m[1]);
-  } },
+  { methods: M("GET"), match: entryMatch(/^\/api\/teams\/[^/]+\/passwords\/([^/]+)$/) },
 
   // Vault — status + unlock data (read); delegation check + SSH sign (CLI agent).
   { methods: M("GET"), match: exact(API_PATH.VAULT_STATUS) },

--- a/src/lib/proxy/route-policy.test.ts
+++ b/src/lib/proxy/route-policy.test.ts
@@ -43,6 +43,11 @@ const POSITIVE_CASES: Record<RoutePolicyKind, readonly ClassifyCase[]> = {
   ],
   [ROUTE_POLICY_KIND.API_SESSION_REQUIRED]: [
     { pathname: "/api/passwords", description: "passwords prefix" },
+    // Mutating children must classify session-required so a cookieless Bearer
+    // request (not in the cors-gate method+path allowlist) falls through to the
+    // 401 path — the structural backstop for the Bearer-bypass narrowing.
+    { pathname: "/api/passwords/bulk-import", description: "passwords mutating child — session-required (Bearer-gate backstop)" },
+    { pathname: "/api/teams/team-1/passwords/bulk-import", description: "team mutating child — session-required" },
     { pathname: "/api/teams/team-1", description: "teams prefix" },
     { pathname: "/api/vault/setup", description: "vault prefix" },
     { pathname: "/api/folders", description: "folders prefix" },

--- a/src/lib/proxy/route-policy.ts
+++ b/src/lib/proxy/route-policy.ts
@@ -21,10 +21,10 @@ import { API_PATH } from "@/lib/constants";
  * Routes that accept extension Bearer as alternative auth (e.g., /api/passwords)
  * are still fundamentally session-required. The Bearer-bypass is a code-path
  * concern (which dispatch branch the orchestrator takes), NOT a classification
- * concern. The orchestrator uses `isBearerBypassRoute(pathname)` from
- * cors-gate to decide whether the bypass dispatch is eligible for a given
- * request, while `api-session-required` covers all session-cookie-protected
- * routes (including bypass-eligible ones).
+ * concern. The orchestrator uses `isBearerBypassRoute(pathname, method)` from
+ * cors-gate (a method + exact-path allowlist) to decide whether the bypass
+ * dispatch is eligible for a given request, while `api-session-required`
+ * covers all session-cookie-protected routes (including bypass-eligible ones).
  */
 export const ROUTE_POLICY_KIND = {
   PREFLIGHT: "preflight",
@@ -92,8 +92,10 @@ const SESSION_REQUIRED_EXACT_PATHS: readonly string[] = [
  * Boundary-aware prefix match: a path belongs to `prefix` only when it equals
  * the prefix exactly or continues with a `/` segment boundary. Without this,
  * `startsWith("/api/passwords")` would also capture an unrelated sibling like
- * `/api/passwords-export`. Mirrors the matcher in `cors-gate.ts`
- * (`isBearerBypassRoute`) so both gates classify paths identically.
+ * `/api/passwords-export`. This is route-POLICY's own prefix classifier (which
+ * subtree a path belongs to); it is intentionally NOT the same as cors-gate's
+ * `isBearerBypassRoute`, which is now a method + exact-path allowlist — the two
+ * gates answer different questions (classification vs. Bearer eligibility).
  */
 function pathMatchesPrefix(pathname: string, prefix: string): boolean {
   return pathname === prefix || pathname.startsWith(`${prefix}/`);
@@ -156,7 +158,7 @@ export function classifyRoute(pathname: string): RoutePolicy {
   // covered by a SESSION_REQUIRED_PREFIXES match, so we don't import
   // isBearerBypassRoute here — keeping route-policy as a pure pathname
   // classifier with no dependency on cors-gate. The orchestrator calls
-  // isBearerBypassRoute(pathname) directly to decide whether the
+  // isBearerBypassRoute(pathname, method) directly to decide whether the
   // bypass dispatch is taken for a given request; the classification
   // stays "api-session-required" either way.
   if (

--- a/src/lib/proxy/route-policy.ts
+++ b/src/lib/proxy/route-policy.ts
@@ -154,7 +154,7 @@ export function classifyRoute(pathname: string): RoutePolicy {
   // Session-required API routes. This includes Bearer-bypass-eligible
   // routes (PASSWORDS, API_KEYS, VAULT_DELEGATION etc.) — they're
   // fundamentally session-required, with optional Bearer as alternative
-  // auth. Every EXTENSION_TOKEN_ROUTES entry (cors-gate.ts) is already
+  // auth. Every Bearer-bypass route (cors-gate.ts BEARER_RULES) is already
   // covered by a SESSION_REQUIRED_PREFIXES match, so we don't import
   // isBearerBypassRoute here — keeping route-policy as a pure pathname
   // classifier with no dependency on cors-gate. The orchestrator calls


### PR DESCRIPTION
## Summary

Phase 2 of the external OWASP review remediation (follow-up to the rate-limiter PR). Addresses **M2/M3**: the proxy Bearer-bypass matcher was over-broad.

### The latent risk

`isBearerBypassRoute` (`src/lib/proxy/cors-gate.ts`) matched by path prefix: `/api/passwords/**` and `/api/teams/<id>/passwords/**` made every mutating child (`bulk-*`, `empty-trash`, `attachments`, `history`, etc.) Bearer-**reachable** at the proxy. Those handlers are `auth()`-only today, so a cookieless Bearer 401s at the handler — but the matcher was a documented latent risk (`S1 LOCKED CONSTRAINT` comment): migrating any child to a write scope would silently make it Bearer-**writable**.

### The fix: method + exact-path allowlist

Replaced the prefix matchers with a declarative `(method, exact-path)` allowlist (`BEARER_RULES`). A route is Bearer-reachable **IFF** its `(method, path)` is listed; the proxy fails closed (cookieless Bearer → session-required → 401) for everything else.

- The matcher is now the **structural gate**: a future handler scope-migration without a table entry can no longer open a Bearer write surface.
- Single-entry rules (`/api/passwords/<id>`, team equivalent) exclude reserved subroute literals (`PASSWORD_SUBROUTES`) so `/api/passwords/bulk-import` never matches the `[id]` pattern.
- OPTIONS preflight uses a path-only helper (`isBearerBypassPath`) — an OPTIONS request's method is never in the allowlist, so a method-aware check would wrongly deny preflight. CORS preflight grants no auth; the real request still passes the method-aware gate.

Kept Bearer-reachable (verified against extension/iOS/CLI Bearer call sites): `GET/POST /api/passwords`, `GET/PUT/DELETE /api/passwords/<id>`, `GET /api/teams`, `GET /api/teams/<id>/member-key`, `GET /api/teams/<id>/passwords[/<id>]`, `GET /api/vault/status`, `GET /api/vault/unlock/data`, `GET /api/vault/delegation/check`, `POST /api/vault/ssh/sign-authorize`, the three extension-token lifecycle leaves, and `POST /api/tenant/access-requests` (SA JIT). Everything else falls through to session-required.

### Coupled fix (no deferral): DELETE token soft-delete

The browser extension's passkey-replace cleanup issues `DELETE /api/passwords/<id>` via Bearer (`extension/.../passkey-provider.ts`), but the handler was `checkAuth(req)` (session-only) → it 401'd and the extension swallowed it (`.catch(()=>{})`) — a pre-existing broken flow. Migrated the DELETE handler to `checkAuth(PASSWORDS_WRITE)` for **soft-delete** (consistent with POST/PUT). Permanent delete (`?permanent=true`) stays session-only: a non-session caller (`token`/`api_key`/`mcp_token`) gets **403** before any DB access, and step-up reauth is a backstop regardless (it reads the session cookie, which a Bearer-only request lacks).

## Out of scope (unchanged)

No mutating child gains token support beyond the DELETE soft-delete fix. `bulk-*`, `empty-trash`, restore, favorite, attachments, history, team POST/PUT/DELETE remain session-only **and** now proxy-unreachable via Bearer. Enabling Bearer for any of them in future requires an explicit `BEARER_RULES` entry.

## Testing

- `cors-gate.test.ts`: truth table restructured to `{path, method, expected}`; rows that asserted the old over-broad behavior **flipped** to deny (`bulk-import`, bare `/delegation`, `unlock/data/extra`); wrong-method negatives added; subroute-collision regression cases; new `isBearerBypassPath` block.
- `proxy.test.ts`: method-aware bypass-vs-401 cases (mutating child → 401, wrong method → 401, DELETE soft-delete → bypass), child-path OPTIONS preflight (allowed for `<id>`, denied for `bulk-import`).
- `route-policy.test.ts`: mutating children classify `API_SESSION_REQUIRED` (the structural backstop).
- `passwords/[id]/route.test.ts`: token soft-delete → 200; permanent → 403 for `token`/`api_key`/`mcp_token` (via `it.each`); guard-before-step-up ordering; cross-user → 404; scope-wiring assertion; session step-up fresh/stale.
- Full suite: 11744 passed / 1 skipped. `next build` OK. `pre-pr.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
