### PR TITLE
fix(security): treat Redis pipeline per-command errors as fail-closed

### DIFF
--- a/src/lib/security/rate-limit.test.ts
+++ b/src/lib/security/rate-limit.test.ts
@@ -184,6 +184,57 @@ describe("createRateLimiter", () => {
       expect((await limiter.check("k")).allowed).toBe(true);
     });
 
+    it("fails closed when a per-command pipeline error is present (failClosedOnRedisError)", async () => {
+      // ioredis does NOT throw on a per-command failure — the offending entry is
+      // [err, null]. A failed INCR must not leave count=null (which coerces to a
+      // fail-OPEN allow); it must signal a Redis failure.
+      const pipeline = makePipeline([
+        [new Error("ERR command failed"), null],
+        [null, 1],
+        [null, 60_000],
+      ]);
+      mockGetRedis.mockReturnValue({ pipeline: () => pipeline, del: vi.fn() });
+      const limiter = createRateLimiter({
+        windowMs: 60_000,
+        max: 1,
+        failClosedOnRedisError: true,
+      });
+      const result = await limiter.check("k");
+      expect(result.allowed).toBe(false);
+      expect(result.redisErrored).toBe(true);
+    });
+
+    it("falls back to in-memory on a per-command pipeline error (fail-open default)", async () => {
+      const pipeline = makePipeline([
+        [new Error("ERR command failed"), null],
+        [null, 1],
+        [null, 60_000],
+      ]);
+      mockGetRedis.mockReturnValue({ pipeline: () => pipeline, del: vi.fn() });
+      const limiter = createRateLimiter({ windowMs: 60_000, max: 1 });
+      // Per-command error → Redis signals null → in-memory fallback (no redisErrored).
+      const result = await limiter.check("k");
+      expect(result.allowed).toBe(true);
+      expect(result.redisErrored).toBeUndefined();
+    });
+
+    it("fails closed when INCR returns a non-numeric value (unexpected pipeline shape)", async () => {
+      const pipeline = makePipeline([
+        [null, null], // INCR value missing
+        [null, "OK"],
+        [null, 60_000],
+      ]);
+      mockGetRedis.mockReturnValue({ pipeline: () => pipeline, del: vi.fn() });
+      const limiter = createRateLimiter({
+        windowMs: 60_000,
+        max: 1,
+        failClosedOnRedisError: true,
+      });
+      const result = await limiter.check("k");
+      expect(result.allowed).toBe(false);
+      expect(result.redisErrored).toBe(true);
+    });
+
     it("clear() calls Redis DEL when Redis is available", async () => {
       const del = vi.fn().mockResolvedValue(1);
       mockGetRedis.mockReturnValue({

--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -63,10 +63,23 @@ export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
       pipeline.pttl(key);
       const results = await pipeline.exec();
 
-      // ioredis pipeline results: [[err, value], ...]
+      // ioredis pipeline results: [[err, value], ...]. A whole-pipeline failure
+      // throws or yields null (handled above); a PER-COMMAND failure does NOT
+      // throw — the offending entry is [err, null]. Treat any per-command error
+      // (or a non-numeric INCR/PTTL value) as a Redis failure and signal null so
+      // the caller honors failClosedOnRedisError. Without this, a failed INCR
+      // leaves count = null, and `null <= max` coerces to true → fail-OPEN even
+      // for a fail-closed limiter.
       if (!results) return null;
-      const count = results[0]?.[1] as number;
-      const ttl = results[2]?.[1] as number;
+      const commandError = results.find(([err]) => err != null)?.[0];
+      if (commandError) {
+        logRedisError((commandError as { code?: string } | undefined)?.code);
+        return null;
+      }
+
+      const count = results[0]?.[1];
+      const ttl = results[2]?.[1];
+      if (typeof count !== "number" || typeof ttl !== "number") return null;
 
       if (count <= max) {
         return { allowed: true };

--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -79,7 +79,12 @@ export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
 
       const count = results[0]?.[1];
       const ttl = results[2]?.[1];
-      if (typeof count !== "number" || typeof ttl !== "number") return null;
+      if (typeof count !== "number" || typeof ttl !== "number") {
+        // Unexpected pipeline shape — surface it like any other Redis failure
+        // for operational visibility (symmetry with the per-command error log).
+        logRedisError("unexpected_pipeline_shape");
+        return null;
+      }
 
       if (count <= max) {
         return { allowed: true };


### PR DESCRIPTION
## Summary

Follow-up to the rate-limiter fail-closed PR (`#611`). A reviewer found that the fail-closed contract was **incomplete**: it covered whole-pipeline failure but not a per-command failure inside the ioredis pipeline.

## The bug

`createRateLimiter` runs an ioredis pipeline (`INCR` + `PEXPIRE NX` + `PTTL`). ioredis does **not** throw when a single command in the pipeline fails — instead the offending entry is `[err, null]`, and `exec()` resolves normally. The old code read the INCR value without checking its per-command error:

```ts
const count = results[0]?.[1] as number;   // null if INCR errored
if (count <= max) return { allowed: true };  // null <= max → true → fail-OPEN
```

So a failed `INCR` (e.g. Redis OOM, a command-level error) left `count = null`, and `null <= max` coerces to `true` in JS → the limiter returned `{ allowed: true }` **even for a `failClosedOnRedisError: true` limiter**. That is a fail-open hole in the exact fail-closed guarantee the rate limiter is supposed to provide — directly relevant to the security-critical limiters (`v1ApiKeyLimiter`, auth callback / magic-link, autofill mint, breakglass) that `#611` opted into fail-closed.

## The fix

After `exec()`, inspect every pipeline entry for a per-command error, and guard that the INCR/PTTL values are actually numbers. On any anomaly, signal a Redis failure (`return null`) so `check()` honors the caller's fail-open (in-memory fallback) vs fail-closed (`redisErrored: true` → 503) decision — the same path a thrown/null `exec()` already takes.

A genuine `PEXPIRE` error also fails the check: the fixed-window integrity depends on the TTL being set. `PEXPIRE NX` returning `0` (key already has a TTL) is a **value** in `result[1][1]`, not an error in `result[1][0]`, so normal operation is unaffected (verified against the existing success-path tests).

## Testing

Added to `rate-limit.test.ts`:
- per-command INCR error + `failClosedOnRedisError: true` → `{ allowed: false, redisErrored: true }`
- per-command INCR error + default → in-memory fallback (no `redisErrored`)
- non-numeric INCR value (malformed pipeline shape) → fail-closed

Full suite: 11719 passed / 1 skipped. `next build` OK. `pre-pr.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
