### PR TITLE
docs(ios): switch App Store review notes to Demo Mode; drop Face ID claim

### DIFF
--- a/docs/ios-app-store-listing.md
+++ b/docs/ios-app-store-listing.md
@@ -47,9 +47,6 @@ the right credential above the keyboard.
 Everything is encrypted with AES-256-GCM before it touches the network. The
 server stores only ciphertext.
 
-- Face ID unlock — Unlock your vault and reveal credentials with Face ID. The
-vault re-locks automatically after a timeout you choose.
-
 - Passkeys — Sign in with WebAuthn passkeys stored in your vault, and create new
 ones, all from the AutoFill flow.
 
@@ -70,7 +67,7 @@ password,vault,autofill,passkey,totp,2fa,self-hosted,e2e,encryption,sso,security
 ### What's New (release notes for v0.4.60)
 
 First public release. Self-hosted password vault with native iOS AutoFill,
-TOTP, passkey assertion and registration, and Face ID unlock.
+TOTP, and passkey assertion and registration.
 
 ### Support & Marketing URLs
 


### PR DESCRIPTION
## Summary

Updates the App Store review documentation to match the Demo Mode approach now used for App Review, after two Guideline rejections on the previous live-server/Google-SSO instructions.

## Changes (`docs/ios-app-store-listing.md`)

- **Review notes (Part 3) → Demo Mode flow**: reviewers tap "Try Demo Mode" on the first screen and browse a read-only sample vault — no server, account, or credentials. This replaces the live-server + Google-SSO sign-in instructions that caused Guideline 2.1 "could not sign in" rejections (the reviewer was signing in with the App-Review credential rather than reading the notes).
- **Drop the "Face ID unlock" claim**: removed from the listing Description bullet and the release-notes line. Face ID is only reachable behind a real sign-in (not in Demo Mode), so advertising it triggered a Guideline 2.3 metadata-accuracy flag ("could not locate Face ID unlock").

## Context

Demo Mode itself shipped in #609 (0.4.61). This PR only syncs the submission runbook to what was actually submitted to App Review for 0.4.61 (currently Waiting for Review after resubmission with these corrections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
