### PR TITLE
fix(security): step-up on permanent purge + fail-closed mint/SCIM/reset limiters

### DIFF
--- a/docs/archive/review/owasp-rereview-stepup-and-failclosed-plan.md
+++ b/docs/archive/review/owasp-rereview-stepup-and-failclosed-plan.md
@@ -1,0 +1,123 @@
+# Plan: OWASP re-review follow-ups — step-up on permanent purge + fail-closed mint/SCIM limiters
+
+## Project context
+
+- **Type**: web app + service (Next.js 16, multi-tenant E2E password manager).
+- **Test infra**: unit (vitest) + integration (real-DB) + E2E + CI/CD. Not config-only.
+- **Verification constraints**: all changes are unit-testable (mock `requireRecentCurrentAuthMethod` / the limiter). Redis-outage fail-closed is verified by mocking the limiter result; no live Redis outage needed.
+
+## Objective
+
+Remediate three OWASP re-review findings, all extensions of patterns already established in merged PRs:
+
+- **M1 (Medium, A01/A04/A07)**: irreversible permanent-purge endpoints lack the step-up reauth that single permanent-delete already requires. Add `requireRecentCurrentAuthMethod` to the 5 purge endpoints.
+- **M2 (Medium, A05/A07)**: SCIM runtime limiter is fail-open on Redis error. Make it fail-closed (503).
+- **M3 (Low–Medium, A05/A07)**: token/account **create** limiters are fail-open. Make the 3 create limiters fail-closed (the #611 `checkRateLimitOrFail` pattern). Leave list limiters fail-open.
+
+## Requirements
+
+### M1 — step-up on permanent purge
+- R-M1-1: These endpoints require a recent-auth (step-up) check after their existing auth+permission gate, matching `DELETE /api/passwords/[id]?permanent=true`:
+  - `POST /api/passwords/empty-trash`
+  - `POST /api/passwords/bulk-purge`
+  - `DELETE /api/teams/[teamId]/passwords/[id]?permanent=true` (only the permanent branch)
+  - `POST /api/teams/[teamId]/passwords/empty-trash`
+  - `POST /api/teams/[teamId]/passwords/bulk-purge`
+  - `POST /api/vault/reset` (self-reset — wholesale deletes ALL entries; added per security review S1)
+- R-M1-2: All 5 are session-only (`auth()`), so NO token-type 403 guard is needed (unlike the reference handler). The step-up helper reads the session cookie and 401s a cookieless caller — but these are already session-gated, so it only adds the recency requirement.
+- R-M1-3: The step-up check fires BEFORE any delete/body-mutation work (consistent ordering with the reference handler and breakglass).
+- R-M1-4: team single-delete: gate step-up inside the existing `if (permanent)` branch only — soft-delete (trash) stays step-up-free (trash is the recovery window, matching personal).
+
+### M2 — SCIM limiter fail-closed
+- R-M2-1: `checkScimRateLimit` returns `RateLimitResult` (not boolean); the SCIM limiter sets `failClosedOnRedisError: true`.
+- R-M2-2: `authorizeScim` returns `scimError(503, ...)` on `redisErrored`, `scimError(429, ...)` on `!allowed`, proceeds otherwise. 503 uses the SCIM error envelope (RFC 7644), not the canonical JSON.
+- R-M2-3: Preserve the tenant-keyed rate key `rl:scim:${scopeId}`.
+
+### M3 — mint limiters fail-closed
+- R-M3-1: `scimTokenCreateLimiter`, operator-token `createTokenLimiter`, `saCreateLimiter` set `failClosedOnRedisError: true` and route through `checkRateLimitOrFail` (emits canonical 429 + 503 + audit).
+- R-M3-2: Operator-token `listTokenLimiter` stays fail-open (list is not security-critical).
+- R-M3-3: Bump `EXPECTED_LIMITER_COUNT` in `scripts/checks/check-fail-closed-routes-have-test.sh` 58 → 61; each of the 3 route test files gains a `redisErrored` assertion (the guard requires a sibling test referencing `redisErrored`).
+
+### Non-functional
+- Reuse `requireRecentCurrentAuthMethod` (M1) and `checkRateLimitOrFail` (M3); no new helpers except the SCIM 503 envelope wiring (M2).
+
+## Contracts
+
+### C1 — step-up on the 6 permanent-purge endpoints — locked
+- **Files**: `src/app/api/passwords/empty-trash/route.ts`, `bulk-purge/route.ts`, `src/app/api/teams/[teamId]/passwords/[id]/route.ts` (DELETE permanent branch), `teams/[teamId]/passwords/empty-trash/route.ts`, `bulk-purge/route.ts`, `src/app/api/vault/reset/route.ts`.
+- **Approach**: after the auth+permission gate and before any delete, insert `const stepUp = await requireRecentCurrentAuthMethod(req); if (stepUp) return stepUp;`. `req`/`request` is in scope in every handler (verified).
+  - **empty-trash / bulk-purge (always permanent)**: insert right after the `auth()`/`requireTeamPermission` gate, before `parseBody`/`withTenantRls`.
+  - **vault/reset**: insert after the `auth()` gate and the existing `checkRateLimitOrFail`, before `executeVaultReset`. NOTE: step-up here only checks session recency (≤15min), NOT the passphrase — so it is compatible with the "lost passphrase/recovery key" last-resort purpose (the user still has a recent valid session); it only blocks a stale/leaked cookie.
+  - **team single-delete (F2 fix)**: the current handler computes `const permanent = searchParams.get("permanent")==="true"` AFTER the existence check. To mirror the reference handler (`passwords/[id]`) and avoid an existence-oracle before step-up, HOIST the `permanent` computation to just after `requireTeamPermission`, then gate `if (permanent) { const stepUp = await requireRecentCurrentAuthMethod(req); if (stepUp) return stepUp; }` there — before the existence lookup. Do NOT add the reference handler's `auth.type !== "session"` token guard: this DELETE is `auth()`-only, so no token path exists.
+- **Invariant** (app-enforced): no permanent-purge of entry rows (trashed OR live) occurs without a recent (≤15min) session. Soft-delete paths are unaffected.
+- **Forbidden patterns**:
+  - `pattern: deleteMany` reachable before a `requireRecentCurrentAuthMethod` call in each of the 5 handlers — reason: step-up must precede destructive delete
+- **Acceptance** (every endpoint, MANDATORY both halves): stale session → 403 (step-up response) **AND the delete mock NOT called** (proves step-up precedes delete — the security-critical ordering); fresh session → 200 + delete called; team soft-delete (no `?permanent`) → unchanged (no step-up); vault/reset stale → 403 AND `executeVaultReset`/its deleteMany NOT called.
+- **Consumer-flow walkthrough**: the consumers are the web app's trash/empty-trash, bulk-purge, and vault-reset UI flows. They already handle the single-delete step-up 403 (re-prompt for reauth), so the same 403 envelope on these endpoints is consumed identically. No new response field; the existing `SESSION_STEP_UP_REQUIRED` envelope is reused. (Manual-test: trigger empty-trash with a >15min-old session → expect reauth prompt.)
+
+### C2 — SCIM limiter fail-closed (503) — locked
+- **Files**: `src/lib/scim/rate-limit.ts`, `src/lib/scim/with-scim-auth.ts`.
+- **Breaking signature change (R3 / F7)**: `checkScimRateLimit` changes return type `Promise<boolean>` → `Promise<RateLimitResult>`. It has exactly ONE production caller, `authorizeScim` (must update the `if (!(await ...))` consumption), and ONE test file `src/lib/scim/rate-limit.test.ts` (2 boolean assertions must become object-form).
+- **Approach**: limiter gets `failClosedOnRedisError: true`. `checkScimRateLimit` returns the full `RateLimitResult`. `authorizeScim`: `const rl = await checkScimRateLimit(tenantId); if (rl.redisErrored) { emitRateLimitFailClosed({req, scope:"scim", userId:null, tenantId}); return scimError(503, "Service temporarily unavailable"); } if (!rl.allowed) return scimError(429, "Too many requests");`. The SCIM error envelope (RFC 7644) is preserved for both 503 and 429.
+- **Audit (S8 — MANDATORY, not optional)**: fire `emitRateLimitFailClosed({req, scope:"scim", userId:null, tenantId})` on the redisErrored branch for forensic parity with M3 (the "heavy deps" concern is unfounded — the helper is already imported by sibling routes; `tenantId` is in scope so it emits a real audit row, not a dead-letter; scope `"scim"` matches `SCOPE_RE`; the helper's 5-min throttle prevents audit storms). A Redis-outage SCIM 503 on a provisioning/deprovisioning surface is exactly the event that must be queryable, not log-only.
+- **Invariant** (app-enforced): a Redis outage makes SCIM return 503, never fall to a per-Pod in-memory limit.
+- **Acceptance**: `checkScimRateLimit` mocked `{redisErrored:true}` → `authorizeScim` returns 503 (SCIM envelope `schemas`/`status`/`detail`) AND does NOT proceed to the handler; `{allowed:false}` → 429 (SCIM envelope); `{allowed:true}` → proceeds. `rate-limit.test.ts`: rewrite the 2 boolean assertions to `result.allowed === true/false` AND add a `{redisErrored:true}` case asserting `result.redisErrored === true`.
+- **Consumer-flow walkthrough**: consumer = the IdP's SCIM client. It reads HTTP status; 503 (with `Retry-After` semantics) and 429 are both standard SCIM backoff signals. The SCIM error body shape (`schemas`/`status`/`detail`) is preserved for both. No new field.
+
+### C3 — mint limiters fail-closed — locked
+- **Files**: `src/app/api/tenant/scim-tokens/route.ts`, `src/app/api/tenant/operator-tokens/route.ts` (create only), `src/app/api/tenant/service-accounts/route.ts`; `scripts/checks/check-fail-closed-routes-have-test.sh`.
+- **Approach**: add `failClosedOnRedisError: true` to the 3 create limiters; replace `const rl = await limiter.check(key); if (!rl.allowed) return rateLimited(...)` with `const blocked = await checkRateLimitOrFail({ req, limiter, key, scope, userId: session.user.id, tenantId: actor.tenantId }); if (blocked) return blocked;`. Use `SCOPE_RE`-valid scope strings: `"tenant.scim_token_create"`, `"tenant.operator_token_create"`, `"tenant.service_account_create"`. Leave `listTokenLimiter` (operator-tokens GET) untouched.
+- **Per-file `rateLimited` import (F9 — NOT uniform)**:
+  - `scim-tokens/route.ts`: `rateLimited` used only by the create path → **remove the import** after the swap.
+  - `service-accounts/route.ts`: same → **remove the import**.
+  - `operator-tokens/route.ts`: `rateLimited` still used by the list/GET path → **KEEP the import**. `createRateLimiter` import stays in all 3.
+- **CI guard (R-M3-3 / T11)**: bump `EXPECTED_LIMITER_COUNT` 58→61 in `check-fail-closed-routes-have-test.sh` AND extend the explanatory comment block (lines ~104-106) to record the +3 from this PR. The callsite floor (`EXPECTED_MIN_CALLSITE_COUNT=50`) is unaffected (swap adds callsites). The SCIM limiter (C2) lives in `src/lib/scim/` and is NOT counted by this guard (scoped to `src/app/api`) — no count change for C2.
+- **(C3b — added during implementation, found by a full `rateLimited()` audit)**: `src/app/api/tenant/members/[userId]/reset-vault/route.ts` — the admin-vault-reset TRIGGER limiters (`adminResetLimiter` + `targetResetLimiter`) were fail-open. Admin vault reset is a destructive privileged action (force-resets another member's vault), so both get `failClosedOnRedisError: true`. The handler does a DUAL `Promise.all` check with custom retry-after, so instead of `checkRateLimitOrFail` (single-limiter) it adds an explicit `if (adminResult.redisErrored || targetResult.redisErrored) { emitRateLimitFailClosed(...); return serviceUnavailable(); }` branch before the existing 429 branch. `rateLimited` import stays (used by the 429 branch + the MAX_PENDING_RESETS count guard, which is NOT a Redis limiter and stays as-is). This adds 2 to the limiter count → `EXPECTED_LIMITER_COUNT` 61→63. NOTE: the `operator-tokens/[id]` DELETE revoke limiter is deliberately NOT changed — revoke is fail-safe (over-revoking shrinks attack surface), consistent with the review's "create/mint only" scoping.
+- **Invariant** (app-enforced): create/mint of scim-token / operator-token / service-account AND the admin-vault-reset trigger fail closed (503) on Redis error.
+- **Forbidden patterns**:
+  - `pattern: saCreateLimiter = createRateLimiter\(\{[^}]*\}\)` without `failClosedOnRedisError` — reason: SA create must be fail-closed
+- **Acceptance**: per route — limiter mocked `{redisErrored:true}` → 503 **AND the create mock NOT called**; `{allowed:false}` → 429 AND no create; `{allowed:true}` → proceeds. List limiter (operator-tokens GET) unchanged. Tests mock the limiter `.check` (NOT `checkRateLimitOrFail` directly) so the real helper maps results — this keeps existing 429 tests meaningful and lands the literal `redisErrored` token (CI guard requirement) in a LIVE mock value, not a comment. service-accounts has no 429 test today → add both a 429 and a 503 test.
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | step-up on 6 permanent-purge endpoints (incl. vault/reset per S1) | locked |
+| C2 | SCIM limiter fail-closed (503) + mandatory audit | locked |
+| C3 | 3 mint limiters fail-closed + CI count bump | locked |
+
+## Testing strategy
+
+- **C1** (6 endpoints):
+  - **MANDATORY mock**: existing test files for empty-trash (personal + team) and team `[id]` DELETE do NOT mock `requireRecentCurrentAuthMethod` today — adding the step-up call makes them run the REAL helper, which reads the session cookie and returns 401/403 in the test env, BREAKING every happy-path 200 test. Each of these 3 files MUST add `vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({ requireRecentCurrentAuthMethod: vi.fn() }))` and set `mockResolvedValue(null)` in `beforeEach` (re-set inside `beforeEach` because some files use `resetAllMocks`). Mirror `scim-tokens/route.test.ts` step-up mock pattern. vault/reset test also needs this mock added. (The "returns undefined and behavior is fine" assumption is WRONG — the real helper does not return undefined.)
+  - **Per endpoint**: stale (`requireRecentCurrentAuthMethod → 403`) → assert 403 AND `expect(<deleteMany spy>).not.toHaveBeenCalled()` (vacuous-403 guard, T3/T9); fresh (`→ null`) → assert 200 + delete called. Team soft-delete (no `?permanent`) → unchanged.
+  - **New test files**: `passwords/bulk-purge/route.test.ts` and `teams/[teamId]/passwords/bulk-purge/route.test.ts` do not exist — create them.
+  - **Fixture refactor (T4)**: team empty-trash test builds its `deleteMany` spy inside the `mockPrismaTransaction` closure (not observable from the test body). Hoist it to a module-level const so the stale-session test can assert `.not.toHaveBeenCalled()`. Mirror personal empty-trash's `mockDeleteMany`.
+- **C2** (the ONLY safety net for M2 — SC2: not CI-guarded):
+  - `src/lib/scim/rate-limit.test.ts`: rewrite the 2 boolean assertions (`toBe(true)`/`toBe(false)`) to `result.allowed === true/false`; add a `{redisErrored:true}` case asserting `result.redisErrored === true`.
+  - `with-scim-auth.test.ts`: change `beforeEach` mock `true` → `{allowed:true}` and the 429 test mock `false` → `{allowed:false}`; ADD a `{redisErrored:true}→503` test asserting `res.response.status===503`, the SCIM envelope body shape, AND that the handler is not reached.
+- **C3**: each of the 3 route tests — mock the limiter `.check` (NOT `checkRateLimitOrFail`); add `mockCheck.mockResolvedValueOnce({ allowed:false, redisErrored:true })` → assert 503 AND `expect(<create spy>).not.toHaveBeenCalled()` (the `redisErrored` literal must appear in this LIVE mock — CI guard requirement). service-accounts: add BOTH a 429 test and the 503 test (none exist today). Verify the real `emitRateLimitFailClosed` pulled in by the swap doesn't need new mocks in these files (audit/prisma deps); add mocks if it does.
+- Mandatory: `npx vitest run` + `npx next build` + `bash scripts/pre-pr.sh` (the latter validates the bumped `EXPECTED_LIMITER_COUNT`).
+
+## Considerations & constraints
+
+### Scope contract
+- **SC1**: list limiters stay fail-open (operator-tokens GET) — only create/mint are security-critical. Owner: this PR's explicit scope.
+- **SC2**: M2 SCIM limiter lives in `src/lib/scim/` → NOT counted by the CI guard (which scopes to `src/app/api`); no count bump for M2, and no guard enforcement — coverage relies on `src/lib/scim/*.test.ts` (so C2's tests are the sole safety net — see Testing strategy).
+- **SC3**: L1 (orphan blob observability) remains deferred (E2E-encrypted, DB-backend no-op) — unchanged by this PR.
+- **SC4 (S1)**: `/api/vault/admin-reset` is deliberately NOT given step-up. Unlike self-reset, it requires a single-use admin-issued token (`token: hexHash` validated against a DB `AdminVaultReset` record) PLUS the target's session + confirmation — the token IS the out-of-band possession proof, and the flow is admin-initiated with its own approval/revoke lifecycle. Self-reset (`/api/vault/reset`) has only session + a fixed public confirmation phrase, so it is the one added to C1. Documented here so the exclusion is auditable rather than silent.
+- **SC5 (S7 residual)**: service-account create remains step-up-free (only `auth()` + `SERVICE_ACCOUNT_MANAGE`), unlike scim-token/operator-token create which require step-up. C3 fail-closes its rate limiter (caps mint volume) but does not add step-up parity. Tracked as a possible follow-up; out of scope here.
+
+### Known risks / notes
+- **Team permanent single-delete hard-deletes a LIVE entry** (not restricted to trashed rows, unlike the purge endpoints) — so step-up there is especially important; the contract gates it inside `if (permanent)` (hoisted before the existence check per F2).
+- M1 changes previously-frictionless flows (empty-trash, vault-reset) to require recent auth. This is the intended security posture (matches single permanent-delete) but is a UX change — surface in the PR body. Web UI already handles the step-up 403 from single-delete, so the consumer path exists.
+- **M1 residual (S5)**: step-up checks session *recency* (≤15min), not a fresh credential — a session cookie leaked within 15min of login still passes. This is parity with the already-shipped single permanent-delete; M1 does not regress, but does not make permanent purge "unconditionally safe". State plainly in the PR body.
+- M2 makes SCIM depend on Redis for availability during an outage (fail-closed). **Deprovisioning-latency caveat (S6)**: a Redis outage also blocks SCIM `PATCH active=false` (deactivation), so a user who should be locked out stays active until Redis recovers + the IdP retries. Net judgment: fail-closed is still correct (a multi-Pod in-memory fallback does not actually cap; SCIM clients treat 503 as a standard retryable backoff; the uncapped-SCIM-auth-surface-during-outage risk outweighs the transient self-healing deactivation latency). Document this trade-off in the PR body; a future follow-up could fail-open only the `PATCH active=false` path if deployment prioritizes lockout latency.
+
+## User operation scenarios
+
+1. User clicks "empty trash" with a session older than 15 min → 403 step-up prompt → reauth → retry succeeds (was: silent permanent purge).
+2. Team admin bulk-purges with a fresh session → succeeds. With a stale session → step-up required.
+3. Redis down, IdP SCIM sync → 503 (was: per-Pod in-memory limit, effectively bypassed across Pods).
+4. Redis down, tenant admin creates a service account → 503 (was: fail-open mint).
+5. Redis healthy, normal operations → unchanged (429 only when actually over-limit).

--- a/docs/archive/review/owasp-rereview-stepup-and-failclosed-review.md
+++ b/docs/archive/review/owasp-rereview-stepup-and-failclosed-review.md
@@ -1,0 +1,51 @@
+# Plan Review: owasp-rereview-stepup-and-failclosed
+Date: 2026-06-27
+Review round: 1 (initial)
+
+## Changes from Previous Round
+Initial review. Three expert sub-agents (functionality / security / testing) reviewed the plan against the codebase.
+
+## Functionality Findings
+- **F2 (Major) — FIXED**: team `[id]` DELETE computes `permanent` AFTER the existence check; "inside if(permanent) after permission" was unsatisfiable. Plan now hoists `permanent` above the existence lookup and gates step-up right after `requireTeamPermission` (mirrors reference, avoids existence-oracle-before-step-up).
+- **F7 (Major) — FIXED**: C2's `checkScimRateLimit` boolean→`RateLimitResult` is a breaking signature change; plan now enumerates the single caller (`authorizeScim`) + the test file that must change.
+- **F9 (Major) — FIXED**: `rateLimited` import handling is per-file: remove from scim-tokens/service-accounts, KEEP in operator-tokens (list path still uses it).
+- **F5/F6 (Info/Low) — FIXED**: C2's manual `scimError` branch is cleaner than forcing `checkRateLimitOrFail`'s envelope form; confirmed `req`/`tenantId` in scope.
+- Verified clean: all 6 endpoints truly permanent-delete; `req` in scope everywhere; no token path on the session-only purge endpoints (no token-guard needed).
+
+## Security Findings
+- **S1 (High, escalate) — FIXED (scope extended)**: `/api/vault/reset` wholesale-deletes ALL entries with only session + a fixed public confirmation phrase, no step-up — strictly more destructive than the 5 scoped endpoints, contradicting C1's invariant. Added to C1. `/api/vault/admin-reset` deliberately excluded (token-gated, admin-initiated) and documented in SC4. (User approved extending M1 to vault/reset.)
+- **S6 (Info, analysis) — FIXED (documented)**: M2 fail-closed also blocks SCIM deactivation during a Redis outage (deprovisioning-latency regression). Net judgment: still correct (in-memory fallback doesn't actually cap; 503 is a retryable SCIM signal). Trade-off + possible follow-up documented.
+- **S7 (Low residual) — FIXED (documented SC5)**: SA-create has no step-up (unlike scim/operator-token create); C3 caps mint volume but step-up parity is a future follow-up.
+- **S8 (Low) — FIXED**: M2 audit made MANDATORY (`emitRateLimitFailClosed`), not optional — parity with M3; the "heavy deps" concern was unfounded.
+- **S3/S4/S5 (Info) — confirmed/documented**: team live-row hard-delete confirmed (gating inside if(permanent) correct); 15min step-up window correct to keep uniform; leaked-cookie-within-15min residual stated plainly.
+
+## Testing Findings
+- **T1/T2 (High) — FIXED**: 3 existing M1 test files lack a `requireRecentCurrentAuthMethod` mock → adding step-up breaks their happy-path 200 tests. Mock made MANDATORY; the misleading "returns undefined and behavior is fine" note removed.
+- **T3/T9 (High) — FIXED**: every stale/redisErrored test must assert BOTH the status AND that the delete/create did NOT run (vacuous-403/503 guard). Made mandatory in Testing strategy.
+- **T4 (Medium) — FIXED**: team empty-trash test hides its deleteMany spy in a closure; plan now requires hoisting it so the negative assertion is observable.
+- **T5/T6 (High) — FIXED**: C2 boolean→object breaks `rate-limit.test.ts` (2 assertions) + `with-scim-auth.test.ts` (beforeEach + 429 mock); enumerated. M2 coverage is the sole safety net (SC2).
+- **T7/T10 — FIXED**: mint route tests mock the limiter `.check` (not `checkRateLimitOrFail`) so existing 429 tests stay meaningful and the `redisErrored` literal lands in a live mock value.
+- **T8 (High) — FIXED**: service-accounts has no 429 test and no `redisErrored` → CI guard would fail on landing C3; plan now requires adding both.
+- **T11 (Info) — FIXED**: count math 58→61 confirmed; comment block update required.
+
+## Resolution Status
+All High findings (S1, T1/T2, T3/T9, T5/T6, T8) reflected. All Major (F2, F7, F9) reflected. Minor/Info documented. C1 expanded to 6 endpoints. No contract signature/invariant left contradictory. Cleared to Phase 2.
+
+## Phase 3 (code review of implementation)
+Three experts reviewed the implemented diff.
+- **Functionality: No findings.** Completeness independently re-verified by grep across app/services/vault — all 7 permanent password-delete endpoints enumerated (6 gated + admin-reset intentionally excluded). Placement, imports, ordering correct.
+- **Security: No findings.** Step-up unbypassable in all 6 (guard before delete; `permanent` hoisted in team [id]; soft-delete exempt); fail-closed correct in all 5 surfaces; reset-vault `||` covers both limiters before record creation; audit + residual sound. Confirmed all 6 endpoints are session-only (not Bearer-reachable via cors-gate BEARER_RULES).
+- **Testing: 1 Low (T1) — FIXED.** E2E `vault-reset.spec.ts` AND `trash.spec.ts` inject a global-setup session and call a now-step-up'd endpoint; if the suite runs >15min after setup, `requireRecentSession` (createdAt ≤15min) 403s them. Added an e2e helper `refreshSessionRecency(sessionToken)` (UPDATE sessions SET created_at = now()) and call it before the step-up'd action in both specs. **Cannot run Playwright locally — needs CI e2e verification.** No other e2e spec hits the step-up'd endpoints (verified by grep).
+
+### Implementation regression caught during Phase 2 (and the lesson)
+Adding step-up + the SCIM signature change initially broke **95 tests** because affected test files weren't fully enumerated: (a) 7 SCIM route tests mock `checkScimRateLimit` as a boolean (now returns RateLimitResult), and (b) duplicate purge tests in `src/__tests__/api/` (separate from the `route.test.ts` tree) didn't mock the step-up helper. Both fixed. Root cause = the same incomplete-enumeration failure mode as S1 in Phase 1. Mitigation applied: always grep ALL test files that mock a changed symbol or exercise a changed handler (both test trees + e2e), not just the obvious siblings.
+
+### Production nit caught by Phase 2 subagent — FIXED
+`emitRateLimitFailClosed` was called without `void` in both with-scim-auth.ts and reset-vault (floating promise, inconsistent with the canonical `void emit...` pattern). Both fixed.
+
+## Recurring Issue Check (consolidated)
+- R1 (reuse): PASS — reuses requireRecentCurrentAuthMethod (C1), checkRateLimitOrFail (C3); C2 deliberately uses a local scimError branch (forcing the helper would be worse).
+- R3 (propagation / all-callers): FIXED — checkScimRateLimit caller+test enumerated (F7); per-file rateLimited import (F9); 3 existing M1 test files (T1).
+- R17 (helper adoption): PASS — step-up + checkRateLimitOrFail adoption consistent; F2 placement corrected to mirror reference.
+- Anti-deferral (feedback_no_skip_existing_code): S1 honored — vault/reset not skipped despite predating the plan.
+- Vacuous tests (RT1): T3/T9/T4 made mandatory.

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -299,6 +299,20 @@ export async function seedSession(
   );
 }
 
+/**
+ * Reset a session's created_at to now() so it passes step-up
+ * (requireRecentCurrentAuthMethod, STEP_UP_WINDOW_MS = 15min). Sessions seeded
+ * in global-setup go stale once the suite has run >15min; call this right
+ * before a step-up-gated destructive action (permanent purge / vault reset).
+ */
+export async function refreshSessionRecency(sessionToken: string): Promise<void> {
+  const p = getPool();
+  await p.query(
+    `UPDATE sessions SET created_at = now() WHERE session_token = $1`,
+    [sessionToken]
+  );
+}
+
 export async function seedVaultKey(
   userId: string,
   verificationArtifact: {

--- a/e2e/tests/trash.spec.ts
+++ b/e2e/tests/trash.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type BrowserContext, type Page } from "@playwright/test";
 import { getAuthState } from "../helpers/fixtures";
 import { injectSession } from "../helpers/auth";
+import { refreshSessionRecency } from "../helpers/db";
 import { VaultLockPage } from "../page-objects/vault-lock.page";
 import { DashboardPage } from "../page-objects/dashboard.page";
 import { PasswordEntryPage } from "../page-objects/password-entry.page";
@@ -107,6 +108,11 @@ test.describe("Trash", () => {
 
   test("empty trash permanently deletes remaining entries", async () => {
     const trashPage = new TrashPage(page);
+
+    // empty-trash now requires a recent session (step-up); refresh the
+    // global-setup session's recency so it isn't stale (>15min) by this point.
+    const { vaultReady } = getAuthState();
+    await refreshSessionRecency(vaultReady.sessionToken);
 
     // Should be on /trash already — empty it
     await trashPage.emptyTrash();

--- a/e2e/tests/vault-reset.spec.ts
+++ b/e2e/tests/vault-reset.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { injectSession } from "../helpers/auth";
 import { getAuthState } from "../helpers/fixtures";
+import { refreshSessionRecency } from "../helpers/db";
 
 /**
  * Vault Reset tests.
@@ -35,6 +36,9 @@ test.describe("Vault Reset", () => {
   test("reset vault with correct confirmation", async ({ context, page }) => {
     // Destructive — uses dedicated reset user
     const { reset } = getAuthState();
+    // POST /api/vault/reset now requires a recent session (step-up); the
+    // global-setup session may be >15min old by the time this spec runs.
+    await refreshSessionRecency(reset.sessionToken);
     await injectSession(context, reset.sessionToken);
     await page.goto("/ja/vault-reset");
 

--- a/scripts/checks/check-fail-closed-routes-have-test.sh
+++ b/scripts/checks/check-fail-closed-routes-have-test.sh
@@ -106,7 +106,13 @@ fi
 # 58 incl. 4 from rate-limiter-fail-closed-and-get-purge (OWASP M4/M5/M6):
 #   auth callbackRateLimiter + magicLinkIpLimiter, mobile autofill mintLimiter,
 #   tenant breakglassRateLimiter. (v1ApiKeyLimiter lives in src/lib, not counted here.)
-EXPECTED_LIMITER_COUNT=58
+# 61 incl. 3 mint limiters from owasp-rereview-stepup-and-failclosed (OWASP M3):
+#   tenant scim-tokens create, operator-tokens create, service-accounts create.
+#   (The SCIM runtime limiter from that PR lives in src/lib/scim, not counted here.)
+# 63 incl. the 2 admin-vault-reset trigger limiters (adminResetLimiter +
+#   targetResetLimiter, tenant/members/[userId]/reset-vault) — destructive
+#   privileged action, found by the rateLimited() audit during that PR.
+EXPECTED_LIMITER_COUNT=63
 limiter_count=$(grep -rh 'failClosedOnRedisError: true' "$REPO_ROOT/src/app/api" | wc -l)
 if [ "$limiter_count" -ne "$EXPECTED_LIMITER_COUNT" ]; then
   echo "AC4.4 FAIL: expected $EXPECTED_LIMITER_COUNT 'failClosedOnRedisError: true' instantiations; found $limiter_count"

--- a/src/__tests__/api/passwords/bulk-purge.test.ts
+++ b/src/__tests__/api/passwords/bulk-purge.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
 import { DEFAULT_SESSION } from "../../helpers/mock-auth";
 import { createRequest, parseResponse } from "../../helpers/request-builder";
 
@@ -9,6 +10,7 @@ const {
   mockTransaction,
   mockLogAudit,
   mockWithUserTenantRls,
+  mockRequireRecentCurrentAuthMethod,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockFindMany: vi.fn(),
@@ -16,9 +18,13 @@ const {
   mockTransaction: vi.fn(),
   mockLogAudit: vi.fn(),
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
+  mockRequireRecentCurrentAuthMethod: vi.fn(),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: mockRequireRecentCurrentAuthMethod,
+}));
 vi.mock("@/lib/prisma", () => ({ prisma: { $transaction: mockTransaction } }));
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
@@ -43,6 +49,7 @@ describe("POST /api/passwords/bulk-purge", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireRecentCurrentAuthMethod.mockResolvedValue(null);
     mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
       fn({ passwordEntry: { findMany: mockFindMany, deleteMany: mockDeleteMany } }),
     );
@@ -123,5 +130,17 @@ describe("POST /api/passwords/bulk-purge", () => {
     const res = await POST(createRequest("POST", "http://localhost:3000/api/test", { body: { ids: [] } }));
     const { status } = await parseResponse(res);
     expect(status).toBe(400);
+  });
+
+  it("returns 403 and does not delete when step-up reauth is required (stale session)", async () => {
+    mockRequireRecentCurrentAuthMethod.mockResolvedValueOnce(
+      NextResponse.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const res = await POST(createRequest("POST", "http://localhost:3000/api/test", { body: { ids: [P1, P2] } }));
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(403);
+    expect(mockDeleteMany).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/api/teams/team-bulk-purge.test.ts
+++ b/src/__tests__/api/teams/team-bulk-purge.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
 import { DEFAULT_SESSION } from "../../helpers/mock-auth";
 import { createRequest, createParams, parseResponse } from "../../helpers/request-builder";
 
@@ -10,6 +11,7 @@ const {
   mockTransaction,
   mockLogAudit,
   mockWithTeamTenantRls,
+  mockRequireRecentCurrentAuthMethod,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockRequireTeamPermission: vi.fn(),
@@ -18,9 +20,13 @@ const {
   mockTransaction: vi.fn(),
   mockLogAudit: vi.fn(),
   mockWithTeamTenantRls: vi.fn(async (_teamId: string, fn: () => unknown) => fn()),
+  mockRequireRecentCurrentAuthMethod: vi.fn(),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: mockRequireRecentCurrentAuthMethod,
+}));
 vi.mock("@/lib/auth/access/team-auth", () => {
   class TeamAuthError extends Error {
     status: number;
@@ -58,6 +64,7 @@ describe("POST /api/teams/[teamId]/passwords/bulk-purge", () => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockRequireTeamPermission.mockResolvedValue(undefined);
+    mockRequireRecentCurrentAuthMethod.mockResolvedValue(null);
     mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
       fn({ teamPasswordEntry: { findMany: mockFindMany, deleteMany: mockDeleteMany } }),
     );
@@ -123,5 +130,20 @@ describe("POST /api/teams/[teamId]/passwords/bulk-purge", () => {
     await expect(
       POST(createRequest("POST", "http://localhost:3000/api/test", { body: { ids: [P1] } }), createParams({ teamId: TEAM_ID })),
     ).rejects.toThrow("unexpected");
+  });
+
+  it("returns 403 and does not delete when step-up reauth is required (stale session)", async () => {
+    mockRequireRecentCurrentAuthMethod.mockResolvedValueOnce(
+      NextResponse.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const res = await POST(
+      createRequest("POST", "http://localhost:3000/api/test", { body: { ids: [P1, P2] } }),
+      createParams({ teamId: TEAM_ID }),
+    );
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(403);
+    expect(mockDeleteMany).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/api/teams/team-empty-trash.test.ts
+++ b/src/__tests__/api/teams/team-empty-trash.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
 import { DEFAULT_SESSION } from "../../helpers/mock-auth";
 import { createRequest, createParams, parseResponse } from "../../helpers/request-builder";
 
@@ -10,6 +11,7 @@ const {
   mockTransaction,
   mockLogAudit,
   mockWithTeamTenantRls,
+  mockRequireRecentCurrentAuthMethod,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockRequireTeamPermission: vi.fn(),
@@ -18,9 +20,13 @@ const {
   mockTransaction: vi.fn(),
   mockLogAudit: vi.fn(),
   mockWithTeamTenantRls: vi.fn(async (_teamId: string, fn: () => unknown) => fn()),
+  mockRequireRecentCurrentAuthMethod: vi.fn(),
 }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: mockRequireRecentCurrentAuthMethod,
+}));
 vi.mock("@/lib/auth/access/team-auth", () => {
   class TeamAuthError extends Error {
     status: number;
@@ -62,6 +68,7 @@ describe("POST /api/teams/[teamId]/passwords/empty-trash", () => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockRequireTeamPermission.mockResolvedValue(undefined);
+    mockRequireRecentCurrentAuthMethod.mockResolvedValue(null);
     mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
       fn({
         teamPasswordEntry: {
@@ -181,5 +188,18 @@ describe("POST /api/teams/[teamId]/passwords/empty-trash", () => {
     await expect(
       POST(req, createParams({ teamId: TEAM_ID }))
     ).rejects.toThrow("db down");
+  });
+
+  it("returns 403 and does not delete when step-up reauth is required (stale session)", async () => {
+    mockRequireRecentCurrentAuthMethod.mockResolvedValueOnce(
+      NextResponse.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 })
+    );
+
+    const req = createRequest("POST");
+    const res = await POST(req, createParams({ teamId: TEAM_ID }));
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(403);
+    expect(mockDeleteMany).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/passwords/bulk-purge/route.test.ts
+++ b/src/app/api/passwords/bulk-purge/route.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+import { createRequest } from "@/__tests__/helpers/request-builder";
+
+const { mockAuth, mockFindMany, mockDeleteMany, mockTransaction, mockLogAudit, mockWithUserTenantRls } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockFindMany: vi.fn(),
+  mockDeleteMany: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockLogAudit: vi.fn(),
+  mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
+}));
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: mockTransaction,
+  },
+}));
+vi.mock("@/lib/audit/audit", () => ({
+  logAuditAsync: mockLogAudit,
+  logAuditBulkAsync: vi.fn(async (entries: unknown[]) => {
+    for (const e of entries) await mockLogAudit(e);
+  }),
+  extractRequestMeta: () => ({ ip: "127.0.0.1", userAgent: "Test" }),
+  personalAuditBase: vi.fn((_, userId) => ({ scope: "PERSONAL", userId })),
+}));
+vi.mock("@/lib/tenant-context", () => ({
+  withUserTenantRls: mockWithUserTenantRls,
+}));
+// Irreversible bulk purge gates on requireRecentCurrentAuthMethod (step-up).
+// Default: null (fresh session → allow). Stale-session tests override.
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: vi.fn().mockResolvedValue(null),
+}));
+
+import { POST } from "./route";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
+
+const mockRequireRecent = vi.mocked(requireRecentCurrentAuthMethod);
+
+const URL = "http://localhost:3000/api/passwords/bulk-purge";
+const ID_1 = "00000000-0000-4000-a000-000000000001";
+const ID_2 = "00000000-0000-4000-a000-000000000002";
+
+describe("POST /api/passwords/bulk-purge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireRecent.mockResolvedValue(null);
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } });
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        passwordEntry: {
+          findMany: mockFindMany,
+          deleteMany: mockDeleteMany,
+        },
+      })
+    );
+    mockFindMany.mockResolvedValue([{ id: ID_1 }, { id: ID_2 }]);
+    mockDeleteMany.mockResolvedValue({ count: 2 });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await POST(createRequest("POST", URL, { body: { ids: [ID_1] } }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects with 403 and does NOT delete when session is stale (step-up required)", async () => {
+    mockRequireRecent.mockResolvedValueOnce(
+      NextResponse.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const res = await POST(createRequest("POST", URL, { body: { ids: [ID_1, ID_2] } }));
+
+    expect(res.status).toBe(403);
+    // Security-critical ordering: the purge must not run before step-up passes.
+    expect(mockDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it("purges the supplied trashed ids when the session is fresh", async () => {
+    const res = await POST(createRequest("POST", URL, { body: { ids: [ID_1, ID_2] } }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.deletedCount).toBe(2);
+    expect(mockDeleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: "user-1",
+          id: { in: [ID_1, ID_2] },
+          deletedAt: { not: null },
+        }),
+      })
+    );
+  });
+
+  it("only targets trashed entries (deletedAt != null) in the scoped lookup", async () => {
+    await POST(createRequest("POST", URL, { body: { ids: [ID_1, ID_2] } }));
+
+    // The eligibility lookup must filter on deletedAt != null so live entries
+    // can never be hard-deleted via this endpoint.
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: "user-1",
+          id: { in: [ID_1, ID_2] },
+          deletedAt: { not: null },
+        }),
+      })
+    );
+  });
+});

--- a/src/app/api/passwords/bulk-purge/route.ts
+++ b/src/app/api/passwords/bulk-purge/route.ts
@@ -13,6 +13,7 @@ import {
 import { unauthorized } from "@/lib/http/api-response";
 import { parseBody } from "@/lib/http/parse-body";
 import { bulkIdsSchema } from "@/lib/validations";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 
 // POST /api/passwords/bulk-purge - Permanently delete selected entries from trash.
 // Like empty-trash, but scoped to the supplied ids. Only entries already in trash
@@ -22,6 +23,11 @@ async function handlePOST(req: NextRequest) {
   if (!session?.user?.id) {
     return unauthorized();
   }
+
+  // Irreversible bulk permanent delete — require a recent session (step-up),
+  // matching DELETE /api/passwords/[id]?permanent=true.
+  const stepUp = await requireRecentCurrentAuthMethod(req);
+  if (stepUp) return stepUp;
 
   const result = await parseBody(req, bulkIdsSchema);
   if (!result.ok) return result.response;

--- a/src/app/api/passwords/empty-trash/route.test.ts
+++ b/src/app/api/passwords/empty-trash/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 
 const { mockAuth, mockFindMany, mockDeleteMany, mockTransaction, mockLogAudit, mockWithUserTenantRls } = vi.hoisted(() => ({
@@ -27,12 +28,21 @@ vi.mock("@/lib/audit/audit", () => ({
 vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,
 }));
+// Irreversible bulk purge gates on requireRecentCurrentAuthMethod (step-up).
+// Default: null (fresh session → allow). Stale-session tests override.
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: vi.fn().mockResolvedValue(null),
+}));
 
 import { POST } from "./route";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
+
+const mockRequireRecent = vi.mocked(requireRecentCurrentAuthMethod);
 
 describe("POST /api/passwords/empty-trash", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRequireRecent.mockResolvedValue(null);
     mockAuth.mockResolvedValue({ user: { id: "user-1" } });
     mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
       fn({
@@ -129,6 +139,29 @@ describe("POST /api/passwords/empty-trash", () => {
         }),
       })
     );
+  });
+
+  it("rejects with 403 and does NOT delete when session is stale (step-up required)", async () => {
+    mockRequireRecent.mockResolvedValueOnce(
+      NextResponse.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const res = await POST(
+      createRequest("POST", "http://localhost:3000/api/passwords/empty-trash")
+    );
+
+    expect(res.status).toBe(403);
+    // Security-critical ordering: the purge must not run before step-up passes.
+    expect(mockDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with the purge when the session is fresh (step-up returns null)", async () => {
+    const res = await POST(
+      createRequest("POST", "http://localhost:3000/api/passwords/empty-trash")
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockDeleteMany).toHaveBeenCalled();
   });
 
   it("propagates db errors (framework handles 500)", async () => {

--- a/src/app/api/passwords/empty-trash/route.ts
+++ b/src/app/api/passwords/empty-trash/route.ts
@@ -11,6 +11,7 @@ import {
   type AttachmentBlobRef,
 } from "@/lib/blob-store/cleanup";
 import { unauthorized } from "@/lib/http/api-response";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 
 // POST /api/passwords/empty-trash - Permanently delete all entries in trash
 async function handlePOST(req: NextRequest) {
@@ -18,6 +19,12 @@ async function handlePOST(req: NextRequest) {
   if (!session?.user?.id) {
     return unauthorized();
   }
+
+  // Irreversible bulk permanent delete — require a recent session (step-up),
+  // matching DELETE /api/passwords/[id]?permanent=true. A leaked session cookie
+  // alone must not wipe trash.
+  const stepUp = await requireRecentCurrentAuthMethod(req);
+  if (stepUp) return stepUp;
 
   // Atomic findMany + deleteMany to prevent TOCTOU race
   const { entryIds, deletedCount, attachmentRefs } = await withUserTenantRls(session.user.id, async (): Promise<{ entryIds: string[]; deletedCount: number; attachmentRefs: AttachmentBlobRef[] }> => {

--- a/src/app/api/scim/v2/Groups/[id]/route.test.ts
+++ b/src/app/api/scim/v2/Groups/[id]/route.test.ts
@@ -82,7 +82,7 @@ describe("GET /api/scim/v2/Groups/[id]", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("returns 404 when mapping not found", async () => {
@@ -103,7 +103,7 @@ describe("GET /api/scim/v2/Groups/[id]", () => {
   });
 
   it("returns 429 when group lookups are rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
 
     const res = await GET(makeReq(), makeParams("grp-1"));
     expect(res.status).toBe(429);
@@ -136,7 +136,7 @@ describe("PATCH /api/scim/v2/Groups/[id]", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
     mockScimGroupMapping.findUnique.mockResolvedValue(mapping);
     // Default transaction: pass tx with batch-capable mocks
     mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
@@ -328,7 +328,7 @@ describe("PATCH /api/scim/v2/Groups/[id]", () => {
   });
 
   it("returns 429 when PATCH is rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
     const res = await PATCH(
       makeReq({
         method: "PATCH",
@@ -365,7 +365,7 @@ describe("PUT /api/scim/v2/Groups/[id]", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
     mockScimGroupMapping.findUnique.mockResolvedValue(mapping);
     // Default transaction: pass tx with batch-capable mocks
     mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
@@ -524,7 +524,7 @@ describe("PUT /api/scim/v2/Groups/[id]", () => {
   });
 
   it("returns 429 when PUT is rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
     const res = await PUT(
       makeReq({
         method: "PUT",
@@ -545,7 +545,7 @@ describe("DELETE /api/scim/v2/Groups/[id]", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("returns 405", async () => {
@@ -560,7 +560,7 @@ describe("DELETE /api/scim/v2/Groups/[id]", () => {
   });
 
   it("returns 429 when DELETE is rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
     const res = await DELETE(makeReq({ method: "DELETE" }), makeParams("grp-1"));
     expect(res.status).toBe(429);
   });

--- a/src/app/api/scim/v2/Groups/route.test.ts
+++ b/src/app/api/scim/v2/Groups/route.test.ts
@@ -57,7 +57,7 @@ describe("GET /api/scim/v2/Groups", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("returns tenant group mappings", async () => {
@@ -110,7 +110,7 @@ describe("GET /api/scim/v2/Groups", () => {
   });
 
   it("returns 429 when GET is rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
 
     const res = await GET(makeReq());
     expect(res.status).toBe(429);
@@ -139,7 +139,7 @@ describe("POST /api/scim/v2/Groups", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("creates a tenant group mapping", async () => {
@@ -229,7 +229,7 @@ describe("POST /api/scim/v2/Groups", () => {
   });
 
   it("returns 429 when POST is rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
 
     const res = await POST(
       makeReq({

--- a/src/app/api/scim/v2/ResourceTypes/route.test.ts
+++ b/src/app/api/scim/v2/ResourceTypes/route.test.ts
@@ -36,7 +36,7 @@ describe("GET /api/scim/v2/ResourceTypes", () => {
       ok: true,
       data: { tokenId: "t1", teamId: "team-1", tenantId: "tenant-1", createdById: "u1", auditUserId: "u1" },
     });
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("returns 401 when token is invalid", async () => {

--- a/src/app/api/scim/v2/Schemas/route.test.ts
+++ b/src/app/api/scim/v2/Schemas/route.test.ts
@@ -36,7 +36,7 @@ describe("GET /api/scim/v2/Schemas", () => {
       ok: true,
       data: { tokenId: "t1", teamId: "team-1", tenantId: "tenant-1", createdById: "u1", auditUserId: "u1" },
     });
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("returns User and Group schemas", async () => {

--- a/src/app/api/scim/v2/ServiceProviderConfig/route.test.ts
+++ b/src/app/api/scim/v2/ServiceProviderConfig/route.test.ts
@@ -36,7 +36,7 @@ describe("GET /api/scim/v2/ServiceProviderConfig", () => {
       ok: true,
       data: { tokenId: "t1", teamId: "team-1", tenantId: "tenant-1", createdById: "u1", auditUserId: "u1" },
     });
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("returns 401 when token is invalid", async () => {
@@ -46,7 +46,7 @@ describe("GET /api/scim/v2/ServiceProviderConfig", () => {
   });
 
   it("returns 429 when rate-limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
     const res = await GET(makeReq());
     expect(res.status).toBe(429);
   });

--- a/src/app/api/scim/v2/Users/[id]/route.test.ts
+++ b/src/app/api/scim/v2/Users/[id]/route.test.ts
@@ -81,7 +81,7 @@ describe("GET /api/scim/v2/Users/[id]", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("returns tenant user resource", async () => {
@@ -128,7 +128,7 @@ describe("GET /api/scim/v2/Users/[id]", () => {
   });
 
   it("returns 429 when GET is rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
     const res = await GET(makeReq(), makeParams("user-1"));
     expect(res.status).toBe(429);
   });
@@ -139,7 +139,7 @@ describe("PUT /api/scim/v2/Users/[id]", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("deactivates tenant member", async () => {
@@ -382,7 +382,7 @@ describe("PUT /api/scim/v2/Users/[id]", () => {
   });
 
   it("returns 429 when PUT is rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
     const res = await PUT(
       makeReq({
         method: "PUT",
@@ -574,7 +574,7 @@ describe("PATCH /api/scim/v2/Users/[id]", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("returns 400 for unsupported patch operation", async () => {
@@ -711,7 +711,7 @@ describe("PATCH /api/scim/v2/Users/[id]", () => {
   });
 
   it("returns 429 when PATCH is rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
     const res = await PATCH(
       makeReq({
         method: "PATCH",
@@ -819,7 +819,7 @@ describe("DELETE /api/scim/v2/Users/[id]", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("removes tenant member and related records", async () => {
@@ -867,7 +867,7 @@ describe("DELETE /api/scim/v2/Users/[id]", () => {
   });
 
   it("returns 429 when DELETE is rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
     const res = await DELETE(makeReq({ method: "DELETE" }), makeParams("user-1"));
     expect(res!.status).toBe(429);
   });

--- a/src/app/api/scim/v2/Users/route.test.ts
+++ b/src/app/api/scim/v2/Users/route.test.ts
@@ -70,7 +70,7 @@ describe("GET /api/scim/v2/Users", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("returns tenant users", async () => {
@@ -136,7 +136,7 @@ describe("GET /api/scim/v2/Users", () => {
   });
 
   it("returns 429 when GET is rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
 
     const res = await GET(makeReq());
     expect(res.status).toBe(429);
@@ -189,7 +189,7 @@ describe("POST /api/scim/v2/Users", () => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("creates tenant member", async () => {
@@ -310,7 +310,7 @@ describe("POST /api/scim/v2/Users", () => {
   });
 
   it("returns 429 when POST is rate limited", async () => {
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
 
     const res = await POST(
       makeReq({

--- a/src/app/api/teams/[teamId]/passwords/[id]/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/route.test.ts
@@ -59,9 +59,20 @@ vi.mock("@/lib/auth/access/team-auth", () => ({
 vi.mock("@/lib/tenant-context", () => ({
   withTeamTenantRls: mockWithTeamTenantRls,
 }));
+// permanent=true DELETE gates on requireRecentCurrentAuthMethod (step-up).
+// Default: null (fresh session → allow). Stale-session tests override.
+// NOTE: this file uses vi.resetAllMocks() in beforeEach, so the null default is
+// re-established in the DELETE describe's beforeEach below.
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: vi.fn().mockResolvedValue(null),
+}));
 
+import { NextResponse } from "next/server";
 import { GET, PUT, DELETE } from "./route";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 import { ENTRY_TYPE, TEAM_ROLE } from "@/lib/constants";
+
+const mockRequireRecent = vi.mocked(requireRecentCurrentAuthMethod);
 
 const TEAM_ID = "team-123";
 const PW_ID = "pw-456";
@@ -634,6 +645,8 @@ describe("DELETE /api/teams/[teamId]/passwords/[id]", () => {
     mockAuth.mockResolvedValue({ user: { id: "test-user-id" } });
     mockRequireTeamPermission.mockResolvedValue({ role: TEAM_ROLE.ADMIN });
     mockAuditLogCreate.mockResolvedValue({});
+    // vi.resetAllMocks() wipes the factory default → re-establish fresh step-up.
+    mockRequireRecent.mockResolvedValue(null);
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -738,5 +751,54 @@ describe("DELETE /api/teams/[teamId]/passwords/[id]", () => {
       createParams({ teamId: TEAM_ID, id: PW_ID }),
     );
     expect(res.status).toBe(404);
+  });
+
+  it("permanent=true with stale session returns 403 and does NOT delete (step-up)", async () => {
+    mockRequireRecent.mockResolvedValueOnce(
+      NextResponse.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+    mockPrismaTeamPasswordEntry.findUnique.mockResolvedValue({ id: PW_ID, teamId: TEAM_ID });
+    mockPrismaTeamPasswordEntry.deleteMany.mockResolvedValue({ count: 1 });
+
+    const res = await DELETE(
+      createRequest("DELETE", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/${PW_ID}`, {
+        searchParams: { permanent: "true" },
+      }),
+      createParams({ teamId: TEAM_ID, id: PW_ID }),
+    );
+
+    expect(res.status).toBe(403);
+    // Security-critical ordering: step-up gates before any existence lookup/delete.
+    expect(mockPrismaTeamPasswordEntry.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("permanent=true with fresh session proceeds with the hard delete (200)", async () => {
+    mockPrismaTeamPasswordEntry.findUnique.mockResolvedValue({ id: PW_ID, teamId: TEAM_ID });
+    mockPrismaTeamPasswordEntry.deleteMany.mockResolvedValue({ count: 1 });
+
+    const res = await DELETE(
+      createRequest("DELETE", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/${PW_ID}`, {
+        searchParams: { permanent: "true" },
+      }),
+      createParams({ teamId: TEAM_ID, id: PW_ID }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockPrismaTeamPasswordEntry.deleteMany).toHaveBeenCalled();
+  });
+
+  it("soft delete (no ?permanent) does not invoke step-up", async () => {
+    mockPrismaTeamPasswordEntry.findUnique.mockResolvedValue({ id: PW_ID, teamId: TEAM_ID });
+    mockPrismaTeamPasswordEntry.updateMany.mockResolvedValue({ count: 1 });
+
+    const res = await DELETE(
+      createRequest("DELETE", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/${PW_ID}`),
+      createParams({ teamId: TEAM_ID, id: PW_ID }),
+    );
+
+    expect(res.status).toBe(200);
+    // Step-up is permanent-only; soft delete stays frictionless.
+    expect(mockRequireRecent).not.toHaveBeenCalled();
+    expect(mockPrismaTeamPasswordEntry.deleteMany).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/teams/[teamId]/passwords/[id]/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/route.ts
@@ -17,6 +17,7 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { errorResponse, forbidden, handleAuthError, notFound, unauthorized } from "@/lib/http/api-response";
 import * as teamPasswordService from "@/lib/services/team-password-service";
 import { TeamPasswordServiceError } from "@/lib/services/team-password-service";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 
 type Params = { params: Promise<{ teamId: string; id: string }> };
 
@@ -168,6 +169,19 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     return handleAuthError(e);
   }
 
+  const { searchParams } = new URL(req.url);
+  const permanent = searchParams.get("permanent") === "true";
+
+  // Permanent delete is irreversible and (unlike the trash-purge endpoints) can
+  // hard-delete a LIVE entry directly. Require a recent session (step-up) before
+  // any existence lookup — mirrors DELETE /api/passwords/[id]?permanent=true.
+  // Soft-delete (trash) stays frictionless. No token-type guard needed: this
+  // handler is auth()-only (no Bearer path).
+  if (permanent) {
+    const stepUp = await requireRecentCurrentAuthMethod(req);
+    if (stepUp) return stepUp;
+  }
+
   const existing = await withTeamTenantRls(teamId, () =>
     teamPasswordService.getTeamPasswordForUpdate(teamId, id),
   );
@@ -175,9 +189,6 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
   if (!existing || existing.teamId !== teamId) {
     return notFound();
   }
-
-  const { searchParams } = new URL(req.url);
-  const permanent = searchParams.get("permanent") === "true";
 
   let blobRefs;
   try {

--- a/src/app/api/teams/[teamId]/passwords/bulk-purge/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-purge/route.test.ts
@@ -27,8 +27,7 @@ const {
     TeamAuthError: _TeamAuthError,
     mockWithTeamTenantRls: vi.fn(async (_teamId: string, fn: () => unknown) => fn()),
     mockLogAudit: vi.fn<typeof logAuditAsync>(),
-    // Hoisted so stale-session tests can assert deleteMany was NOT called —
-    // the per-tx spy created inside mockImplementation is not observable here.
+    // Hoisted so stale-session tests can assert deleteMany was NOT called.
     mockFindMany: vi.fn(),
     mockDeleteMany: vi.fn(),
   };
@@ -78,16 +77,16 @@ import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-curren
 const mockRequireRecent = vi.mocked(requireRecentCurrentAuthMethod);
 
 const TEAM_ID = "team-123";
+const ID_1 = "00000000-0000-4000-a000-000000000001";
+const ID_2 = "00000000-0000-4000-a000-000000000002";
 
-describe("POST /api/teams/[teamId]/passwords/empty-trash", () => {
+describe("POST /api/teams/[teamId]/passwords/bulk-purge", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequireRecent.mockResolvedValue(null);
     mockAuth.mockResolvedValue({ user: { id: "user-1" } });
     mockRequireTeamPermission.mockResolvedValue({ role: "OWNER" });
-    // Default: transaction returns 2 deleted entries. The findMany/deleteMany
-    // spies are module-level so stale-session tests can assert non-invocation.
-    mockFindMany.mockResolvedValue([{ id: "entry-1" }, { id: "entry-2" }]);
+    mockFindMany.mockResolvedValue([{ id: ID_1 }, { id: ID_2 }]);
     mockDeleteMany.mockResolvedValue({ count: 2 });
     mockPrismaTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
       const tx = {
@@ -103,77 +102,24 @@ describe("POST /api/teams/[teamId]/passwords/empty-trash", () => {
   it("returns 401 when not authenticated", async () => {
     mockAuth.mockResolvedValue(null);
     const res = await POST(
-      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/empty-trash`),
+      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/bulk-purge`, {
+        body: { ids: [ID_1] },
+      }),
       createParams({ teamId: TEAM_ID }),
     );
     expect(res.status).toBe(401);
   });
 
-  it("returns 403 when permission denied", async () => {
+  it("returns 403 when PASSWORD_DELETE permission is denied", async () => {
     mockRequireTeamPermission.mockRejectedValue(new TeamAuthError("INSUFFICIENT_PERMISSION", 403));
     const res = await POST(
-      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/empty-trash`),
+      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/bulk-purge`, {
+        body: { ids: [ID_1] },
+      }),
       createParams({ teamId: TEAM_ID }),
     );
     expect(res.status).toBe(403);
-  });
-
-  it("rethrows unexpected permission errors", async () => {
-    mockRequireTeamPermission.mockRejectedValue(new Error("boom"));
-    await expect(
-      POST(
-        createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/empty-trash`),
-        createParams({ teamId: TEAM_ID }),
-      ),
-    ).rejects.toThrow("boom");
-  });
-
-  it("permanently deletes all trashed entries and returns count", async () => {
-    const res = await POST(
-      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/empty-trash`),
-      createParams({ teamId: TEAM_ID }),
-    );
-    expect(res.status).toBe(200);
-    const json = await res.json();
-    expect(json.success).toBe(true);
-    expect(json.deletedCount).toBe(2);
-  });
-
-  it("returns 0 deletedCount when trash is already empty", async () => {
-    mockFindMany.mockResolvedValue([]);
-    mockDeleteMany.mockResolvedValue({ count: 0 });
-
-    const res = await POST(
-      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/empty-trash`),
-      createParams({ teamId: TEAM_ID }),
-    );
-    expect(res.status).toBe(200);
-    const json = await res.json();
-    expect(json.deletedCount).toBe(0);
-  });
-
-  it("logs ENTRY_EMPTY_TRASH audit event", async () => {
-    await POST(
-      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/empty-trash`),
-      createParams({ teamId: TEAM_ID }),
-    );
-    expect(mockLogAudit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        action: "ENTRY_EMPTY_TRASH",
-        teamId: TEAM_ID,
-      }),
-    );
-  });
-
-  it("logs ENTRY_PERMANENT_DELETE for each deleted entry", async () => {
-    await POST(
-      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/empty-trash`),
-      createParams({ teamId: TEAM_ID }),
-    );
-    const permanentDeleteCalls = mockLogAudit.mock.calls.filter(
-      ([call]) => call.action === "ENTRY_PERMANENT_DELETE",
-    );
-    expect(permanentDeleteCalls).toHaveLength(2);
+    expect(mockDeleteMany).not.toHaveBeenCalled();
   });
 
   it("rejects with 403 and does NOT delete when session is stale (step-up required)", async () => {
@@ -182,7 +128,9 @@ describe("POST /api/teams/[teamId]/passwords/empty-trash", () => {
     );
 
     const res = await POST(
-      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/empty-trash`),
+      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/bulk-purge`, {
+        body: { ids: [ID_1, ID_2] },
+      }),
       createParams({ teamId: TEAM_ID }),
     );
 
@@ -191,13 +139,25 @@ describe("POST /api/teams/[teamId]/passwords/empty-trash", () => {
     expect(mockDeleteMany).not.toHaveBeenCalled();
   });
 
-  it("proceeds with the purge when the session is fresh (step-up returns null)", async () => {
+  it("purges the supplied trashed ids when the session is fresh", async () => {
     const res = await POST(
-      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/empty-trash`),
+      createRequest("POST", `http://localhost:3000/api/teams/${TEAM_ID}/passwords/bulk-purge`, {
+        body: { ids: [ID_1, ID_2] },
+      }),
       createParams({ teamId: TEAM_ID }),
     );
+    const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(mockDeleteMany).toHaveBeenCalled();
+    expect(json.success).toBe(true);
+    expect(json.deletedCount).toBe(2);
+    expect(mockDeleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          teamId: TEAM_ID,
+          deletedAt: { not: null },
+        }),
+      })
+    );
   });
 });

--- a/src/app/api/teams/[teamId]/passwords/bulk-purge/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-purge/route.ts
@@ -18,6 +18,7 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { handleAuthError, unauthorized } from "@/lib/http/api-response";
 import { parseBody } from "@/lib/http/parse-body";
 import { bulkIdsSchema } from "@/lib/validations";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 
 type Params = { params: Promise<{ teamId: string }> };
 
@@ -36,6 +37,10 @@ async function handlePOST(req: NextRequest, { params }: Params) {
   } catch (e) {
     return handleAuthError(e);
   }
+
+  // Irreversible bulk permanent delete — require a recent session (step-up).
+  const stepUp = await requireRecentCurrentAuthMethod(req);
+  if (stepUp) return stepUp;
 
   const result = await parseBody(req, bulkIdsSchema);
   if (!result.ok) return result.response;

--- a/src/app/api/teams/[teamId]/passwords/empty-trash/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/empty-trash/route.ts
@@ -16,6 +16,7 @@ import {
 } from "@/lib/blob-store/cleanup";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { handleAuthError, unauthorized } from "@/lib/http/api-response";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 
 type Params = { params: Promise<{ teamId: string }> };
 
@@ -33,6 +34,10 @@ async function handlePOST(req: NextRequest, { params }: Params) {
   } catch (e) {
     return handleAuthError(e);
   }
+
+  // Irreversible bulk permanent delete — require a recent session (step-up).
+  const stepUp = await requireRecentCurrentAuthMethod(req);
+  if (stepUp) return stepUp;
 
   // Atomic findMany + deleteMany to prevent TOCTOU race
   const { entryIds, deletedCount, attachmentRefs } = await withTeamTenantRls(teamId, async (): Promise<{ entryIds: string[]; deletedCount: number; attachmentRefs: AttachmentBlobRef[] }> => {

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
@@ -81,6 +81,12 @@ vi.mock("@/lib/prisma", () => ({
 vi.mock("@/lib/security/rate-limit", () => ({
   createRateLimiter: vi.fn(() => ({ check: mockRateLimiterCheck })),
 }));
+// The route emits the fail-closed audit directly; stub it to a no-op so the
+// 503 path does not pull the emit helper's transitive deps.
+vi.mock("@/lib/security/rate-limit-audit", async (importOriginal) => ({
+  ...(await importOriginal()) as Record<string, unknown>,
+  emitRateLimitFailClosed: vi.fn(),
+}));
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
   extractRequestMeta: vi.fn(() => ({ ip: "127.0.0.1", userAgent: "test" })),
@@ -268,6 +274,31 @@ describe("POST /api/tenant/members/[userId]/reset-vault", () => {
     expect(res.status).toBe(429);
     const json = await res.json();
     expect(json.error).toBe("RATE_LIMIT_EXCEEDED");
+    expect(mockPrismaAdminVaultResetCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 (fail-closed) when the admin limiter signals redisErrored", async () => {
+    mockRateLimiterCheck
+      .mockResolvedValueOnce({ allowed: false, redisErrored: true })
+      .mockResolvedValueOnce({ allowed: true });
+    const res = await POST(
+      createRequest("POST", `http://localhost/api/tenant/members/${TARGET_USER_ID}/reset-vault`),
+      createParams({ userId: TARGET_USER_ID }),
+    );
+    expect(res.status).toBe(503);
+    expect(mockPrismaAdminVaultResetCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 (fail-closed) when the target limiter signals redisErrored", async () => {
+    mockRateLimiterCheck
+      .mockResolvedValueOnce({ allowed: true })
+      .mockResolvedValueOnce({ allowed: false, redisErrored: true });
+    const res = await POST(
+      createRequest("POST", `http://localhost/api/tenant/members/${TARGET_USER_ID}/reset-vault`),
+      createParams({ userId: TARGET_USER_ID }),
+    );
+    expect(res.status).toBe(503);
+    expect(mockPrismaAdminVaultResetCreate).not.toHaveBeenCalled();
   });
 
   it("returns 429 when target rate limit is exceeded", async () => {
@@ -282,6 +313,7 @@ describe("POST /api/tenant/members/[userId]/reset-vault", () => {
     expect(res.status).toBe(429);
     const json = await res.json();
     expect(json.error).toBe("RATE_LIMIT_EXCEEDED");
+    expect(mockPrismaAdminVaultResetCreate).not.toHaveBeenCalled();
   });
 
   it("returns 429 when max pending resets (3) reached", async () => {
@@ -293,6 +325,7 @@ describe("POST /api/tenant/members/[userId]/reset-vault", () => {
     expect(res.status).toBe(429);
     const json = await res.json();
     expect(json.error).toBe("RATE_LIMIT_EXCEEDED");
+    expect(mockPrismaAdminVaultResetCreate).not.toHaveBeenCalled();
   });
 
   it("returns 403 from step-up gate and does not create reset record", async () => {

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.ts
@@ -19,7 +19,8 @@ import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
 import { AUDIT_ACTION } from "@/lib/constants";
 import { NOTIFICATION_TYPE } from "@/lib/constants/audit/notification";
 import { withRequestLog } from "@/lib/http/with-request-log";
-import { forbidden, handleAuthError, notFound, rateLimited, unauthorized } from "@/lib/http/api-response";
+import { forbidden, handleAuthError, notFound, rateLimited, serviceUnavailable, unauthorized } from "@/lib/http/api-response";
+import { emitRateLimitFailClosed } from "@/lib/security/rate-limit-audit";
 import { MAX_PENDING_RESETS, VAULT_RESET_HISTORY_LIMIT } from "@/lib/validations/common.server";
 import { MS_PER_DAY, RESET_TOTAL_TTL_MS } from "@/lib/constants/time";
 import { encryptResetToken } from "@/lib/vault/admin-reset-token-crypto";
@@ -35,11 +36,13 @@ export const runtime = "nodejs";
 const adminResetLimiter = createRateLimiter({
   windowMs: MS_PER_DAY,
   max: 3,
+  failClosedOnRedisError: true,
 });
 
 const targetResetLimiter = createRateLimiter({
   windowMs: MS_PER_DAY,
   max: 1,
+  failClosedOnRedisError: true,
 });
 
 // POST /api/tenant/members/[userId]/reset-vault
@@ -109,11 +112,22 @@ async function handlePOST(
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 
-  // Rate limits
+  // Rate limits (fail-closed: admin vault reset is a destructive privileged
+  // action; a Redis outage must not relax the cap to a per-Pod in-memory limit).
   const [adminResult, targetResult] = await Promise.all([
     adminResetLimiter.check(`rl:admin-reset:admin:${session.user.id}`),
     targetResetLimiter.check(`rl:admin-reset:target:${targetUserId}`),
   ]);
+
+  if (adminResult.redisErrored || targetResult.redisErrored) {
+    void emitRateLimitFailClosed({
+      req,
+      scope: "tenant.admin_vault_reset",
+      userId: session.user.id,
+      tenantId: actor.tenantId,
+    });
+    return serviceUnavailable();
+  }
 
   if (!adminResult.allowed || !targetResult.allowed) {
     const retryAfterMs = !adminResult.allowed ? adminResult.retryAfterMs : targetResult.retryAfterMs;

--- a/src/app/api/tenant/operator-tokens/route.test.ts
+++ b/src/app/api/tenant/operator-tokens/route.test.ts
@@ -65,6 +65,12 @@ vi.mock("@/lib/security/rate-limit", () => ({
     clear: vi.fn(),
   })),
 }));
+// Keep the real checkRateLimitOrFail (so it maps redisErrored → 503) but
+// stub the audit emit to a no-op to avoid pulling its transitive deps.
+vi.mock("@/lib/security/rate-limit-audit", async (importOriginal) => ({
+  ...(await importOriginal()) as Record<string, unknown>,
+  emitRateLimitFailClosed: vi.fn(),
+}));
 vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
   requireRecentCurrentAuthMethod: mockRequireRecentCurrentAuthMethod,
 }));
@@ -249,6 +255,19 @@ describe("POST /api/tenant/operator-tokens", () => {
       }),
     );
     expect(res.status).toBe(429);
+    expect(mockPrismaOperatorToken.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 (fail-closed) when the create limiter signals redisErrored", async () => {
+    mockRateLimitCheck.mockResolvedValueOnce({ allowed: false, redisErrored: true });
+
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/tenant/operator-tokens", {
+        body: { name: "Test token" },
+      }),
+    );
+    expect(res.status).toBe(503);
+    expect(mockPrismaOperatorToken.create).not.toHaveBeenCalled();
   });
 
   it("creates token and returns plaintext with 201 and Cache-Control: no-store", async () => {

--- a/src/app/api/tenant/operator-tokens/route.ts
+++ b/src/app/api/tenant/operator-tokens/route.ts
@@ -20,6 +20,7 @@ import {
   unauthorized,
 } from "@/lib/http/api-response";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { MS_PER_DAY } from "@/lib/constants/time";
 import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
@@ -36,7 +37,12 @@ export const runtime = "nodejs";
 
 const TOKEN_LIMIT_PER_TENANT = 50;
 
-const createTokenLimiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 5 });
+const createTokenLimiter = createRateLimiter({
+  windowMs: RATE_WINDOW_MS,
+  max: 5,
+  failClosedOnRedisError: true,
+});
+// List is not security-critical — fail-open (in-memory fallback) is acceptable.
 const listTokenLimiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 30 });
 
 const createTokenSchema = z
@@ -130,10 +136,15 @@ async function handlePOST(req: NextRequest) {
   });
   if (stepUpError) return stepUpError;
 
-  const rl = await createTokenLimiter.check(
-    `rl:op_token_create:${actor.tenantId}`,
-  );
-  if (!rl.allowed) return rateLimited(rl.retryAfterMs);
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: createTokenLimiter,
+    key: `rl:op_token_create:${actor.tenantId}`,
+    scope: "tenant.operator_token_create",
+    userId: session.user.id,
+    tenantId: actor.tenantId,
+  });
+  if (blocked) return blocked;
 
   const result = await parseBody(req, createTokenSchema);
   if (!result.ok) return result.response;

--- a/src/app/api/tenant/scim-tokens/route.test.ts
+++ b/src/app/api/tenant/scim-tokens/route.test.ts
@@ -68,6 +68,12 @@ vi.mock("@/lib/security/rate-limit", () => ({
     clear: vi.fn(),
   })),
 }));
+// Keep the real checkRateLimitOrFail (so it maps redisErrored → 503) but
+// stub the audit emit to a no-op to avoid pulling its transitive deps.
+vi.mock("@/lib/security/rate-limit-audit", async (importOriginal) => ({
+  ...(await importOriginal()) as Record<string, unknown>,
+  emitRateLimitFailClosed: vi.fn(),
+}));
 vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
   requireRecentCurrentAuthMethod: mockRequireRecentSession,
 }));
@@ -273,6 +279,18 @@ describe("POST /api/tenant/scim-tokens", () => {
     );
     expect(res.status).toBe(429);
     expect(res.headers.get("Retry-After")).toBe("30");
+    expect(mockPrismaScimToken.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 (fail-closed) when the rate limiter signals redisErrored", async () => {
+    mockRateLimitCheck.mockResolvedValueOnce({ allowed: false, redisErrored: true });
+    const res = await POST(
+      createRequest("POST", "http://localhost/api/tenant/scim-tokens", {
+        body: { description: "test" },
+      }),
+    );
+    expect(res.status).toBe(503);
+    expect(mockPrismaScimToken.create).not.toHaveBeenCalled();
   });
 
   it("rethrows unexpected errors from POST", async () => {

--- a/src/app/api/tenant/scim-tokens/route.ts
+++ b/src/app/api/tenant/scim-tokens/route.ts
@@ -14,8 +14,9 @@ import { z } from "zod";
 import { SCIM_TOKEN_DESC_MAX_LENGTH } from "@/lib/validations";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { NO_STORE_HEADERS } from "@/lib/http/cache-headers";
-import { errorResponse, handleAuthError, rateLimited, unauthorized } from "@/lib/http/api-response";
+import { errorResponse, handleAuthError, unauthorized } from "@/lib/http/api-response";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import {
   SCIM_TOKEN_EXPIRY_MIN_DAYS,
   SCIM_TOKEN_EXPIRY_MAX_DAYS,
@@ -24,7 +25,11 @@ import {
 import { MS_PER_DAY, MS_PER_HOUR } from "@/lib/constants/time";
 import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 
-const scimTokenCreateLimiter = createRateLimiter({ windowMs: MS_PER_HOUR, max: 5 });
+const scimTokenCreateLimiter = createRateLimiter({
+  windowMs: MS_PER_HOUR,
+  max: 5,
+  failClosedOnRedisError: true,
+});
 
 export const runtime = "nodejs";
 
@@ -92,8 +97,15 @@ async function handlePOST(req: NextRequest) {
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 
-  const rl = await scimTokenCreateLimiter.check(`rl:scim_token_create:${actor.tenantId}`);
-  if (!rl.allowed) return rateLimited(rl.retryAfterMs);
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: scimTokenCreateLimiter,
+    key: `rl:scim_token_create:${actor.tenantId}`,
+    scope: "tenant.scim_token_create",
+    userId: session.user.id,
+    tenantId: actor.tenantId,
+  });
+  if (blocked) return blocked;
 
   const result = await parseBody(req, createTokenSchema);
   if (!result.ok) return result.response;

--- a/src/app/api/tenant/service-accounts/route.test.ts
+++ b/src/app/api/tenant/service-accounts/route.test.ts
@@ -59,6 +59,12 @@ vi.mock("@/lib/audit/audit", () => ({
 vi.mock("@/lib/security/rate-limit", () => ({
   createRateLimiter: () => ({ check: mockRateLimiterCheck }),
 }));
+// Keep the real checkRateLimitOrFail (so it maps redisErrored → 503) but
+// stub the audit emit to a no-op to avoid pulling its transitive deps.
+vi.mock("@/lib/security/rate-limit-audit", async (importOriginal) => ({
+  ...(await importOriginal()) as Record<string, unknown>,
+  emitRateLimitFailClosed: vi.fn(),
+}));
 vi.mock("@/lib/http/with-request-log", () => ({
   withRequestLog: (handler: (...args: unknown[]) => unknown) => handler,
 }));
@@ -214,5 +220,35 @@ describe("POST /api/tenant/service-accounts", () => {
     const { status } = await parseResponse(res);
 
     expect(status).toBe(403);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockRateLimiterCheck.mockResolvedValueOnce({ allowed: false, retryAfterMs: 30_000 });
+
+    const req = createRequest("POST", "http://localhost/api/tenant/service-accounts", {
+      body: { name: "ci-bot" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(429);
+    expect(mockServiceAccountCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 (fail-closed) when the create limiter signals redisErrored", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue(ACTOR);
+    mockRateLimiterCheck.mockResolvedValueOnce({ allowed: false, redisErrored: true });
+
+    const req = createRequest("POST", "http://localhost/api/tenant/service-accounts", {
+      body: { name: "ci-bot" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(503);
+    expect(mockServiceAccountCreate).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/tenant/service-accounts/route.ts
+++ b/src/app/api/tenant/service-accounts/route.ts
@@ -10,13 +10,18 @@ import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { withTenantRls } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/http/with-request-log";
-import { errorResponse, handleAuthError, rateLimited, unauthorized } from "@/lib/http/api-response";
+import { errorResponse, handleAuthError, unauthorized } from "@/lib/http/api-response";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { MAX_SERVICE_ACCOUNTS_PER_TENANT } from "@/lib/constants/auth/service-account";
 import { serviceAccountCreateSchema } from "@/lib/validations/service-account";
 import { MS_PER_HOUR } from "@/lib/constants/time";
 
-const saCreateLimiter = createRateLimiter({ windowMs: MS_PER_HOUR, max: 10 });
+const saCreateLimiter = createRateLimiter({
+  windowMs: MS_PER_HOUR,
+  max: 10,
+  failClosedOnRedisError: true,
+});
 
 export const runtime = "nodejs";
 
@@ -82,8 +87,15 @@ async function handlePOST(req: NextRequest) {
     return handleAuthError(err);
   }
 
-  const rl = await saCreateLimiter.check(`rl:sa_create:${actor.tenantId}`);
-  if (!rl.allowed) return rateLimited(rl.retryAfterMs);
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: saCreateLimiter,
+    key: `rl:sa_create:${actor.tenantId}`,
+    scope: "tenant.service_account_create",
+    userId: session.user.id,
+    tenantId: actor.tenantId,
+  });
+  if (blocked) return blocked;
 
   const result = await parseBody(req, serviceAccountCreateSchema);
   if (!result.ok) return result.response;

--- a/src/app/api/vault/reset/route.test.ts
+++ b/src/app/api/vault/reset/route.test.ts
@@ -70,15 +70,25 @@ vi.mock("@/lib/logger", () => ({
   requestContext: { run: (_l: unknown, fn: () => unknown) => fn() },
   getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
+// Irreversible full vault wipe gates on requireRecentCurrentAuthMethod (step-up).
+// Default: null (fresh session → allow). Stale-session tests override.
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: vi.fn().mockResolvedValue(null),
+}));
 
+import { NextResponse } from "next/server";
 import { POST } from "./route";
 import { VAULT_CONFIRMATION_PHRASE } from "@/lib/constants/vault";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
+
+const mockRequireRecent = vi.mocked(requireRecentCurrentAuthMethod);
 
 const URL = "http://localhost/api/vault/reset";
 
 describe("POST /api/vault/reset", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRequireRecent.mockResolvedValue(null);
     mockAuth.mockResolvedValue({ user: { id: "user-1" } });
     mockRateLimiter.check.mockResolvedValue({ allowed: true });
     mockPrismaPasswordEntry.count.mockResolvedValue(5);
@@ -110,6 +120,20 @@ describe("POST /api/vault/reset", () => {
       body: { confirmation: VAULT_CONFIRMATION_PHRASE.DELETE_VAULT },
     }));
     expect(res.status).toBe(429);
+  });
+
+  it("rejects with 403 and does NOT wipe the vault when session is stale (step-up)", async () => {
+    mockRequireRecent.mockResolvedValueOnce(
+      NextResponse.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const res = await POST(createRequest("POST", URL, {
+      body: { confirmation: VAULT_CONFIRMATION_PHRASE.DELETE_VAULT },
+    }));
+
+    expect(res.status).toBe(403);
+    // Security-critical ordering: the wipe must not run before step-up passes.
+    expect(mockExecuteVaultReset).not.toHaveBeenCalled();
   });
 
   it("returns 400 on wrong confirmation text", async () => {

--- a/src/app/api/vault/reset/route.ts
+++ b/src/app/api/vault/reset/route.ts
@@ -13,6 +13,7 @@ import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION } from "@/lib/constants/audit/audit";
 import { executeVaultReset } from "@/lib/vault/vault-reset";
 import { invalidateUserSessions } from "@/lib/auth/session/user-session-invalidation";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 import { z } from "zod/v4";
 
 export const runtime = "nodejs";
@@ -47,6 +48,14 @@ async function handlePOST(request: NextRequest) {
     userId: session.user.id,
   });
   if (blocked) return blocked;
+
+  // Irreversible: wholesale-deletes ALL entries. Require a recent session
+  // (step-up) so a leaked session cookie alone cannot wipe the vault. This
+  // checks session recency only (not the passphrase), so it is compatible with
+  // the lost-passphrase/recovery-key last-resort purpose — the user still has a
+  // valid recent session.
+  const stepUp = await requireRecentCurrentAuthMethod(request);
+  if (stepUp) return stepUp;
 
   const result = await parseBody(request, resetSchema);
   if (!result.ok) return result.response;

--- a/src/lib/scim/rate-limit.test.ts
+++ b/src/lib/scim/rate-limit.test.ts
@@ -17,17 +17,24 @@ describe("checkScimRateLimit", () => {
     vi.clearAllMocks();
   });
 
-  it("returns true when within rate limit", async () => {
+  it("returns the allowed result when within rate limit", async () => {
     mockCheck.mockResolvedValue({ allowed: true });
     const result = await checkScimRateLimit("team-1");
-    expect(result).toBe(true);
+    expect(result.allowed).toBe(true);
     expect(mockCheck).toHaveBeenCalledWith("rl:scim:team-1");
   });
 
-  it("returns false when rate limited", async () => {
-    mockCheck.mockResolvedValue({ allowed: false });
+  it("returns the denied result when rate limited", async () => {
+    mockCheck.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
     const result = await checkScimRateLimit("team-1");
-    expect(result).toBe(false);
+    expect(result.allowed).toBe(false);
+  });
+
+  it("propagates redisErrored so the caller can fail closed (503)", async () => {
+    mockCheck.mockResolvedValue({ allowed: false, redisErrored: true });
+    const result = await checkScimRateLimit("team-1");
+    expect(result.allowed).toBe(false);
+    expect(result.redisErrored).toBe(true);
   });
 
   it("uses team-specific key", async () => {

--- a/src/lib/scim/rate-limit.ts
+++ b/src/lib/scim/rate-limit.ts
@@ -1,15 +1,26 @@
-import { createRateLimiter } from "@/lib/security/rate-limit";
+import { createRateLimiter, type RateLimitResult } from "@/lib/security/rate-limit";
 import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 
 /**
  * SCIM-specific rate limiter.
  * 200 requests / 60 seconds per scope, keyed by `rl:scim:${scopeId}`.
  * Scope should be tenantId when available, otherwise teamId.
+ *
+ * fail-closed: SCIM is an admin provisioning/deprovisioning surface; on a Redis
+ * outage a per-Pod in-memory fallback would not actually cap the limit across a
+ * multi-Pod deployment, so the limiter signals redisErrored and the caller
+ * returns 503 instead of failing open.
  */
-const limiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 200 });
+const limiter = createRateLimiter({
+  windowMs: RATE_WINDOW_MS,
+  max: 200,
+  failClosedOnRedisError: true,
+});
 
-/** Returns true if allowed, false if rate-limited. */
-export async function checkScimRateLimit(scopeId: string): Promise<boolean> {
-  const { allowed } = await limiter.check(`rl:scim:${scopeId}`);
-  return allowed;
+/**
+ * Returns the full RateLimitResult so the caller can distinguish
+ * over-limit (429) from a Redis failure (redisErrored → 503).
+ */
+export async function checkScimRateLimit(scopeId: string): Promise<RateLimitResult> {
+  return limiter.check(`rl:scim:${scopeId}`);
 }

--- a/src/lib/scim/with-scim-auth.test.ts
+++ b/src/lib/scim/with-scim-auth.test.ts
@@ -5,10 +5,12 @@ const {
   mockValidateScimToken,
   mockEnforceAccessRestriction,
   mockCheckScimRateLimit,
+  mockEmitRateLimitFailClosed,
 } = vi.hoisted(() => ({
   mockValidateScimToken: vi.fn(),
   mockEnforceAccessRestriction: vi.fn(),
   mockCheckScimRateLimit: vi.fn(),
+  mockEmitRateLimitFailClosed: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/tokens/scim-token", () => ({
@@ -21,6 +23,10 @@ vi.mock("@/lib/auth/policy/access-restriction", () => ({
 
 vi.mock("@/lib/scim/rate-limit", () => ({
   checkScimRateLimit: mockCheckScimRateLimit,
+}));
+
+vi.mock("@/lib/security/rate-limit-audit", () => ({
+  emitRateLimitFailClosed: mockEmitRateLimitFailClosed,
 }));
 
 import { authorizeScim } from "./with-scim-auth";
@@ -45,7 +51,7 @@ describe("authorizeScim", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockEnforceAccessRestriction.mockResolvedValue(null);
-    mockCheckScimRateLimit.mockResolvedValue(true);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("returns ok=true and validated data on the happy path", async () => {
@@ -92,13 +98,38 @@ describe("authorizeScim", () => {
 
   it("returns 429 when the rate limiter denies", async () => {
     mockValidateScimToken.mockResolvedValue({ ok: true, data: validatedToken });
-    mockCheckScimRateLimit.mockResolvedValue(false);
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, retryAfterMs: 1000 });
 
     const res = await authorizeScim(fakeRequest());
     expect(res.ok).toBe(false);
     if (!res.ok) {
       expect(res.response.status).toBe(429);
     }
+    expect(mockEmitRateLimitFailClosed).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with 503 (SCIM envelope) when the limiter reports redisErrored", async () => {
+    mockValidateScimToken.mockResolvedValue({ ok: true, data: validatedToken });
+    mockCheckScimRateLimit.mockResolvedValue({ allowed: false, redisErrored: true });
+
+    const res = await authorizeScim(fakeRequest());
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.response.status).toBe(503);
+      const body = (await res.response.json()) as {
+        schemas: string[];
+        status: string;
+        detail: string;
+      };
+      expect(body.schemas).toContain(
+        "urn:ietf:params:scim:api:messages:2.0:Error",
+      );
+      expect(body.status).toBe("503");
+    }
+    // fail-closed event audited for forensic parity with the mint limiters.
+    expect(mockEmitRateLimitFailClosed).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "scim", userId: null, tenantId: "tenant-1" }),
+    );
   });
 
   it("propagates expired-token error code as 401 (no access check, no rate limit)", async () => {

--- a/src/lib/scim/with-scim-auth.ts
+++ b/src/lib/scim/with-scim-auth.ts
@@ -3,6 +3,7 @@ import { validateScimToken, type ValidatedScimToken } from "@/lib/auth/tokens/sc
 import { scimError } from "@/lib/scim/response";
 import { enforceAccessRestriction } from "@/lib/auth/policy/access-restriction";
 import { checkScimRateLimit } from "@/lib/scim/rate-limit";
+import { emitRateLimitFailClosed } from "@/lib/security/rate-limit-audit";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
 
@@ -26,7 +27,13 @@ export async function authorizeScim(
   const { tenantId } = result.data;
   const denied = await enforceAccessRestriction(req, SYSTEM_ACTOR_ID, tenantId);
   if (denied) return { ok: false, response: denied };
-  if (!(await checkScimRateLimit(tenantId))) {
+  const rl = await checkScimRateLimit(tenantId);
+  if (rl.redisErrored) {
+    // fail-closed: Redis is the only place a global cap can hold across Pods.
+    void emitRateLimitFailClosed({ req, scope: "scim", userId: null, tenantId });
+    return { ok: false, response: scimError(503, "Service temporarily unavailable") };
+  }
+  if (!rl.allowed) {
     return { ok: false, response: scimError(429, "Too many requests") };
   }
   return { ok: true, data: result.data };


### PR DESCRIPTION
## Summary

OWASP re-review follow-ups: **M1** (step-up on irreversible permanent-purge), **M2** (SCIM limiter fail-closed), **M3** (token/account mint limiters fail-closed). All extend patterns already established in merged PRs. A security review of the plan also caught a higher-value omission (S1) and a full `rateLimited()` audit surfaced one more fail-open destructive gate — both folded in.

### M1 — step-up on permanent purge (A01/A04/A07)

`DELETE /api/passwords/[id]?permanent=true` already required `requireRecentCurrentAuthMethod` (step-up). The bulk/wholesale purge paths did not, despite being equally or more destructive. Added the same gate to:

- `POST /api/passwords/empty-trash`, `POST /api/passwords/bulk-purge`
- `POST /api/teams/<id>/passwords/empty-trash`, `.../bulk-purge`
- `DELETE /api/teams/<id>/passwords/<id>?permanent=true` (permanent branch only — soft-delete stays frictionless; the team permanent path can hard-delete a **live** entry, not just trashed, so step-up matters most here)
- `POST /api/vault/reset` (**self-reset wholesale-deletes ALL entries** — flagged by the plan security review as the most destructive omission; `vault/admin-reset` is excluded because it is already token-gated with an admin-issued single-use token)

The team single-delete hoists the `?permanent` parse above the existence lookup so step-up precedes any existence oracle.

### M2 — SCIM runtime limiter fail-closed (A05/A07)

`checkScimRateLimit` returned a boolean and fell back to a per-Pod in-memory cap on a Redis error. It now returns the full `RateLimitResult`; `authorizeScim` returns **503** (SCIM RFC-7644 envelope) on `redisErrored` and fires the fail-closed audit, matching the mint limiters. (A multi-Pod in-memory fallback does not actually cap a global limit — fail-closed is the correct posture for an admin provisioning surface.)

### M3 — mint/account-create limiters fail-closed (A05/A07)

`scimTokenCreateLimiter`, operator-token `createTokenLimiter`, `saCreateLimiter` now `failClosedOnRedisError: true` via `checkRateLimitOrFail`. A full audit of every `rateLimited()` call site also surfaced the **admin-vault-reset trigger** limiters (`adminResetLimiter` + `targetResetLimiter` in `tenant/members/<id>/reset-vault`) as fail-open gates on a destructive privileged action — made fail-closed too (explicit dual-limiter `redisErrored` branch, since the handler checks both via `Promise.all`). List limiters (operator-tokens GET) stay fail-open. `EXPECTED_LIMITER_COUNT` 58→63.

## Out of scope / residuals (documented)

- **Step-up is session-recency (≤15min), not a fresh credential** — a cookie leaked within 15min of login still passes. This is parity with the existing single-delete, not a new gap; M1 closes the prior *no-step-up-at-all* state.
- **SA-create has no step-up** (unlike scim/operator-token create); M3 caps its mint volume but step-up parity is a possible follow-up.
- **operator-token revoke** stays fail-open — revoke is fail-safe (over-revoking shrinks attack surface).
- L1 (orphan blob observability) remains deferred (E2E-encrypted, DB-backend no-op).

## Testing

- Per-endpoint step-up tests (6 endpoints, both the `route.test.ts` tree and the `__tests__/api` duplicates): every stale-session test asserts **403 AND the delete spy was not called** (the security-critical ordering). Two endpoints had no test file — created.
- SCIM: `rate-limit.test.ts` migrated to `RateLimitResult`; `with-scim-auth.test.ts` adds a `redisErrored→503` SCIM-envelope test; 7 SCIM route tests updated for the boolean→object mock.
- Mint/reset: `redisErrored→503` tests (limiter-level mock, real `checkRateLimitOrFail`), each asserting **no create**; service-accounts gained both a 429 and a 503 test.
- E2E: `vault-reset.spec.ts` + `trash.spec.ts` inject a global-setup session and call a now-step-up'd endpoint; added `refreshSessionRecency()` so the session isn't stale (>15min) by the time the spec runs. **Needs CI e2e verification** (Playwright not runnable locally).
- Full suite: 11791 passed / 1 skipped. `next build` OK. `pre-pr.sh` passes (fail-closed-routes guard validates count=63 + a `redisErrored` test per fail-closed route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
