### PR TITLE
chore(security): CI guard enforcing step-up on irreversible vault deletes

### DIFF
--- a/docs/archive/review/stepup-ci-guard-code-review.md
+++ b/docs/archive/review/stepup-ci-guard-code-review.md
@@ -1,0 +1,30 @@
+# Code Review: stepup-ci-guard
+Date: 2026-06-27
+Review round: 1 (initial)
+
+## Changes from Previous Round
+Initial review of the uncommitted guard diff (3 experts: functionality / security / testing).
+
+## Functionality Findings
+- **No findings.** Detection completeness independently grep-verified (no hard-delete path the signal set misses — at the time of review, before S2); false-positive set confirmed (soft-deletes/history/attachments not matched); step-up grep correctly requires a CALL; bash 3.2 robustness, exempt parsing, and anti-drift all verified by running.
+
+## Security Findings
+- **S2 (Low, real class gap) — FIXED.** `/api/teams/[teamId]` DELETE hard-deletes ALL team password entries via cascade (`team.delete()` → `TeamPasswordEntry.team @relation(onDelete: Cascade)`) — more destructive than bulk-purge — but the signal set keyed only on entry-table primitives, so the cascade-via-parent class was structurally invisible. Added `team.delete(` (boundary-anchored to avoid `teamMember.delete`/`teamFolder.delete` false-positives). The route already has step-up, so the guard now covers it and passes.
+- **S4 (Low) — FIXED.** The exempt-list reason-comment was convention-only (parser stripped it). Now enforced: a non-comment exempt line without a ≥10-char trailing `# reason` fails with `EXEMPT_NO_REASON`, raising the bar on the guard's one bypass surface from code-review-vigilance to a CI gate.
+- **S1 (Low, accepted parity) — documented.** The gate is file-level (any step-up call in the file satisfies it, regardless of method/branch) — same granularity as the existing fail-closed guard. Holds today because every matched route is single-purpose; added a header note that multi-handler routes need manual confirmation.
+- **S3 (Info).** `vault/admin-reset` exemption verified correct (dual-admin one-time token ceremony, initiator≠target — stronger than session-recency step-up).
+- **S5 (Info) — FIXED in doc.** Class-7 prose now notes team-cascade is machine-enforced too.
+- No Critical/High; nothing to escalate.
+
+## Testing Findings
+- **T1 (Low, parity gap) — FIXED (exceeded).** No sibling route-grep guard has a self-test, but a security backstop warrants one. Added `scripts/__tests__/check-permanent-delete-stepup.test.mjs` (11 cases) driving the guard against fixtures via new `STEPUP_GUARD_*` env overrides: pass/soft-delete/missing-stepup/prefixed-rename/bare-import/team-cascade/false-positive-guard/exempt-with-reason/exempt-no-reason/stale-exempt(×2). Sets a better precedent than the un-tested siblings.
+- Verified: guard passes clean (exit 0), catches MISSING_STEPUP + STALE_EXEMPT (both branches); runs in CI's always-on static-checks job via `PRE_PR_STATIC_ONLY=1`; failure message is actionable.
+
+## Resolution Status
+All findings (S2, S4, T1 + S1/S5 doc) resolved. The guard now covers the cascade-destruction class, enforces exempt justification, documents its file-level granularity, and has an 11-case self-test. `pre-pr.sh` exit 0 (Passed: 39, guard ✓, self-test green in the suite). No Critical/Major remained.
+
+## Recurring Issue Check (consolidated)
+- R1 (reuse): PASS — follows the established grep-guard + run_step + exempt-allowlist pattern.
+- R3 (propagation/completeness): the guard IS the completeness fix; S2 closed the one structurally-uncovered destruction class (cascade). The signal set + anti-drift + reason-enforcement keep the bypass surface honest.
+- Guard-completeness / false-assurance: file-level granularity disclosed (S1); single-purpose-route assumption documented.
+- Self-test: present (T1) — exceeds sibling-guard parity.

--- a/docs/security/step-up-reauth-routes.md
+++ b/docs/security/step-up-reauth-routes.md
@@ -40,14 +40,22 @@ A mutation is in scope when it touches one of these:
    data + key material).
 6. **Secret minting / high-privilege token issuance** — operator tokens, SCIM
    tokens, service-account tokens, JIT approval, vault admin-reset.
+7. **Irreversible vault-data destruction** — permanent (hard) delete of password
+   entries: single permanent delete, empty-trash, bulk-purge, full self-reset,
+   AND team deletion (which cascades to all team password entries). A leaked
+   session cookie alone must not be able to wipe vault data. This class is
+   mechanically enforced by `scripts/checks/check-permanent-delete-stepup.sh`
+   (see Maintenance), including the cascade-via-parent case (`team.delete`).
 
 **NOT gated** (ordinary content CRUD — gating these hurts UX with no real benefit;
 the threat is the *governance/identity/key* surface, not individual records):
-passwords (create/update/delete/bulk/restore/favorite/attachments/history),
-folders, tags, invitation *accept* (the invitee, not an admin), and
-`/api/teams/[teamId]` **PUT** (team rename/description only — `updateTeamSchema`
-is `name`+`description`, no key/identity/policy consequence; security-relevant
-team settings live in the team `policy` PUT, which IS gated).
+passwords create/update, **soft-delete (move to trash)**, restore, favorite,
+attachments, history; folders, tags; invitation *accept* (the invitee, not an
+admin); and `/api/teams/[teamId]` **PUT** (team rename/description only —
+`updateTeamSchema` is `name`+`description`, no key/identity/policy consequence;
+security-relevant team settings live in the team `policy` PUT, which IS gated).
+Note: **permanent** (hard) delete of passwords IS gated (class 7) — only the
+recoverable soft-delete/trash path is friction-free.
 
 ## Tenant routes (gated)
 
@@ -87,6 +95,27 @@ team settings live in the team `policy` PUT, which IS gated).
 | `/api/teams/[teamId]/rotate-key` | POST | key custody (key rotation) |
 | `/api/teams/[teamId]` | DELETE | lifecycle destruction (deletes team = all vault data + key material) |
 
+## Vault-data permanent-delete routes (gated — class 7)
+
+Irreversible hard-deletes of password entries. Soft-delete (trash) is NOT here.
+Enforced by `scripts/checks/check-permanent-delete-stepup.sh`.
+
+| Route | Method(s) | Note |
+|-------|-----------|------|
+| `/api/passwords/[id]` | DELETE | only when `?permanent=true` (soft-delete is friction-free); also 403s token callers (this route is Bearer-reachable) |
+| `/api/passwords/empty-trash` | POST | purges all trashed entries |
+| `/api/passwords/bulk-purge` | POST | purges selected trashed entries |
+| `/api/teams/[teamId]/passwords/[id]` | DELETE | only when `?permanent=true`; the permanent path can hard-delete a LIVE entry (not just trashed) |
+| `/api/teams/[teamId]/passwords/empty-trash` | POST | purges all trashed team entries |
+| `/api/teams/[teamId]/passwords/bulk-purge` | POST | purges selected trashed team entries |
+| `/api/vault/reset` | POST | self-reset — wholesale-deletes ALL of the user's vault data |
+| `/api/teams/[teamId]` | DELETE | team deletion cascades to all team password entries (also listed under Team routes as lifecycle destruction) |
+
+**Exempt** (matches a delete primitive but intentionally not step-up'd):
+`/api/vault/admin-reset` — dual-admin-approved one-time token (`AdminVaultReset.tokenHash`);
+initiator ≠ target, so the session-recency helper is inapplicable and the token
+ceremony is stronger. Recorded in `scripts/checks/stepup-delete-exempt.txt`.
+
 ## Deferred / not-yet-gated (tracked)
 
 | Route | Method | Why deferred |
@@ -104,6 +133,11 @@ team settings live in the team `policy` PUT, which IS gated).
   reject test asserting the mutation spy is not called. Missing the centralized mock
   silently 401s every existing test for that handler.
 - This doc is the lightweight stand-in for a centralized operation-sensitivity guard
-  (the structural SSoT — see PR #606 SC2). Until that guard exists, this table is the
-  audit surface; a quick conformance check is
+  (the structural SSoT — see PR #606 SC2). For one gated class it is now
+  machine-enforced: **class 7 (irreversible vault-data delete)** is checked by
+  `scripts/checks/check-permanent-delete-stepup.sh` (wired into `pre-pr.sh` and CI).
+  A new route that hard-deletes password entries without step-up — and is not in
+  `scripts/checks/stepup-delete-exempt.txt` — fails CI. The other gated classes
+  (identity/key/sink/policy/mint) are not yet machine-enforced; for those this table
+  remains the audit surface, conformance-checkable with
   `grep -rL requireRecentCurrentAuthMethod <each gated route file>`.

--- a/scripts/__tests__/check-permanent-delete-stepup.test.mjs
+++ b/scripts/__tests__/check-permanent-delete-stepup.test.mjs
@@ -1,0 +1,164 @@
+/**
+ * Self-test for scripts/checks/check-permanent-delete-stepup.sh — the CI guard
+ * that requires step-up (requireRecentCurrentAuthMethod) on every route that
+ * irreversibly hard-deletes vault data.
+ *
+ * The guard is the completeness backstop for an enumeration class; a regression
+ * in its detection (regex, exempt parsing, anti-drift) would silently make it
+ * fail-open, so it gets its own test asserting it catches each failure mode.
+ *
+ * The guard is driven against fixtures via the STEPUP_GUARD_* env overrides
+ * (API_DIR / PATH_ROOT / EXEMPT_FILE) so the test never mutates tracked files.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const GUARD = join(REPO_ROOT, "scripts/checks/check-permanent-delete-stepup.sh");
+
+const DELETE_LINE = "await prisma.passwordEntry.deleteMany({ where: { userId } });";
+const STEPUP_LINE =
+  "const stepUp = await requireRecentCurrentAuthMethod(req); if (stepUp) return stepUp;";
+
+let root;
+let apiDir;
+let exemptFile;
+
+/** Run the guard against the fixture tree. */
+function runGuard() {
+  const r = spawnSync("bash", [GUARD], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      STEPUP_GUARD_API_DIR: apiDir,
+      STEPUP_GUARD_PATH_ROOT: root,
+      STEPUP_GUARD_EXEMPT_FILE: exemptFile,
+    },
+  });
+  return { exitCode: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+
+/** Create a fixture route file at api/<rel>/route.ts with the given body. */
+function writeRoute(rel, body) {
+  const dir = join(apiDir, rel);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "route.ts"), body, "utf8");
+  return `api/${rel}/route.ts`; // PATH_ROOT-relative path the guard prints
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "stepup-guard-"));
+  apiDir = join(root, "api");
+  exemptFile = join(root, "exempt.txt");
+  mkdirSync(apiDir, { recursive: true });
+  writeFileSync(exemptFile, "# fixture exempt list\n", "utf8");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("check-permanent-delete-stepup.sh", () => {
+  it("passes when a hard-delete route has step-up", () => {
+    writeRoute("passwords/empty-trash", `${STEPUP_LINE}\n${DELETE_LINE}\n`);
+    const { exitCode } = runGuard();
+    expect(exitCode).toBe(0);
+  });
+
+  it("passes when a route only soft-deletes (no hard-delete primitive)", () => {
+    writeRoute(
+      "passwords/[id]",
+      "await prisma.passwordEntry.update({ data: { deletedAt: new Date() } });\n",
+    );
+    const { exitCode } = runGuard();
+    expect(exitCode).toBe(0);
+  });
+
+  it("FAILS (MISSING_STEPUP) when a hard-delete route lacks step-up", () => {
+    writeRoute("passwords/bulk-purge", `${DELETE_LINE}\n`);
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("MISSING_STEPUP");
+    expect(stdout).toContain("api/passwords/bulk-purge/route.ts");
+  });
+
+  it("does NOT accept a prefixed/renamed step-up identifier", () => {
+    writeRoute(
+      "passwords/empty-trash",
+      `const x = DISABLED_requireRecentCurrentAuthMethod(req);\n${DELETE_LINE}\n`,
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("MISSING_STEPUP");
+  });
+
+  it("does NOT accept a bare import without a call", () => {
+    writeRoute(
+      "passwords/empty-trash",
+      `import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";\n${DELETE_LINE}\n`,
+    );
+    const { exitCode } = runGuard();
+    expect(exitCode).toBe(1);
+  });
+
+  it("catches team deletion (cascade) without step-up", () => {
+    writeRoute(
+      "teams/[teamId]",
+      "await tx.team.delete({ where: { id: teamId } });\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("MISSING_STEPUP");
+  });
+
+  it("does NOT false-positive on teamMember.delete / teamFolder.delete", () => {
+    writeRoute(
+      "teams/[teamId]/members/[memberId]",
+      "await tx.teamMember.delete({ where: { id } });\nawait tx.teamFolder.delete({ where: { id } });\n",
+    );
+    const { exitCode } = runGuard();
+    expect(exitCode).toBe(0);
+  });
+
+  it("passes when a hard-delete route is exempted WITH a reason", () => {
+    const rel = writeRoute("vault/admin-reset", "await executeVaultReset(userId);\n");
+    writeFileSync(exemptFile, `${rel}  # token-gated dual-admin ceremony\n`, "utf8");
+    const { exitCode } = runGuard();
+    expect(exitCode).toBe(0);
+  });
+
+  it("FAILS (EXEMPT_NO_REASON) when an exempt entry has no justification", () => {
+    const rel = writeRoute("vault/admin-reset", "await executeVaultReset(userId);\n");
+    writeFileSync(exemptFile, `${rel}\n`, "utf8");
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("EXEMPT_NO_REASON");
+  });
+
+  it("FAILS (STALE_EXEMPT) when an exempt entry points to a missing file", () => {
+    writeFileSync(
+      exemptFile,
+      "api/does/not/exist/route.ts  # bogus stale entry\n",
+      "utf8",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("STALE_EXEMPT");
+  });
+
+  it("FAILS (STALE_EXEMPT) when an exempt route no longer hard-deletes", () => {
+    const rel = writeRoute(
+      "vault/admin-reset",
+      "await prisma.passwordEntry.update({ data: { deletedAt: new Date() } });\n",
+    );
+    writeFileSync(exemptFile, `${rel}  # used to hard-delete, now soft only\n`, "utf8");
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("STALE_EXEMPT");
+  });
+});

--- a/scripts/checks/check-permanent-delete-stepup.sh
+++ b/scripts/checks/check-permanent-delete-stepup.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# CI gate: every API route that performs an IRREVERSIBLE vault-data hard-delete
+# MUST call `requireRecentCurrentAuthMethod` (step-up reauth), OR be listed in
+# the exempt allowlist (scripts/checks/stepup-delete-exempt.txt) with a reason.
+#
+# Background: the OWASP re-review (owasp-rereview-stepup-and-failclosed) found
+# that bulk/wholesale permanent-purge endpoints lacked the step-up that single
+# permanent-delete already required (a leaked session cookie could wipe data).
+# That gap was an enumeration miss — the destructive route set was never
+# mechanically defined. This guard makes the set machine-checked so a NEW
+# destructive route cannot land step-up-free without an explicit, justified
+# allowlist entry.
+#
+# Detection (route files only — src/app/api/**/route.ts):
+#   A file is a "vault-destruction route" if it contains any of the four
+#   irreversible-delete primitives below (hard-delete of vault entry rows or a
+#   full-vault wipe). Soft-deletes (`update { deletedAt }`), history-trim
+#   (`passwordEntryHistory.*`), attachment-management deletes, and non-vault
+#   tables are intentionally NOT matched.
+#
+#   passwordEntry.delete( / .deleteMany(        — personal entry hard-delete
+#   teamPasswordEntry.delete( / .deleteMany(    — team entry hard-delete
+#   executeVaultReset(                          — full-vault wipe (route call)
+#   deleteTeamPassword(                         — team entry service (perm flag)
+#   team.delete(                                — team deletion CASCADES to all
+#                                                 team password entries (schema
+#                                                 onDelete: Cascade) — wholesale
+#                                                 vault-data destruction via the
+#                                                 parent row, so it is in-class.
+#
+# Pass criteria, per matched file:
+#   (a) the file also contains `requireRecentCurrentAuthMethod`, OR
+#   (b) the file path appears in stepup-delete-exempt.txt.
+#
+# Fail: exits 1 with one MISSING_STEPUP line per offending route.
+#
+# Scope note: only `src/app/api/**/route.ts` is scanned. Service/worker files
+# (src/lib/services, src/lib/vault, retention-gc worker) legitimately contain
+# the delete primitives but are gated by the ROUTE that calls them; scanning
+# them would false-positive. SCIM/maintenance hard-deletes target non-vault or
+# non-entry tables and are excluded by the table-name-specific primitives.
+#
+# Known limitations (same granularity as the project's other grep-based guards):
+#   - The gate is satisfied by ANY `requireRecentCurrentAuthMethod(` call in the
+#     file, regardless of which HTTP method or branch it guards. This holds for
+#     today's routes because every matched file is single-purpose (the
+#     destructive method IS the gated one), but a future multi-handler route
+#     that step-up's a GET while leaving its DELETE unguarded would pass. Such
+#     routes need manual confirmation.
+#   - A step-up call that is COMMENTED OUT still satisfies the call-pattern grep.
+# The guard targets the realistic failure mode — a new destructive route landing
+# with no step-up at all, or the line being deleted — both of which it catches.
+# Deliberately commenting out / misplacing a security check is a conscious act
+# for code review to catch; teaching this bash grep to do reachability/ordering
+# analysis is not worth the fragility.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Scan root, exempt file, and path-root are overridable so the self-test
+# (scripts/__tests__/check-permanent-delete-stepup.test.mjs) can point the guard
+# at fixtures. Production CI uses the defaults. Reported/exempt paths are
+# resolved against PATH_ROOT; enumerated route paths are stripped of PATH_ROOT/
+# so they print repo-relative.
+API_DIR="${STEPUP_GUARD_API_DIR:-$REPO_ROOT/src/app/api}"
+PATH_ROOT="${STEPUP_GUARD_PATH_ROOT:-$REPO_ROOT}"
+EXEMPT_FILE="${STEPUP_GUARD_EXEMPT_FILE:-$REPO_ROOT/scripts/checks/stepup-delete-exempt.txt}"
+
+# Build the exempt allowlist (paths only; strip comments/blanks/CR). bash 3.2
+# has no associative arrays, so keep a newline-delimited list + grep -qxF.
+#
+# Every exempt entry MUST carry a non-trivial trailing `# reason` — the
+# allowlist is the guard's only bypass, so a no-justification add (which would
+# silently disable step-up on a destructive route) is rejected at the CI layer,
+# not left to code-review vigilance.
+EXEMPT_LIST=""
+EXEMPT_PARSE_FAIL=0
+if [ -f "$EXEMPT_FILE" ]; then
+  while IFS= read -r raw; do
+    raw="${raw%$'\r'}"
+    # Skip blank lines and full-line comments.
+    trimmed="${raw#"${raw%%[![:space:]]*}"}"
+    [ -z "$trimmed" ] && continue
+    case "$trimmed" in \#*) continue ;; esac
+
+    # Path = text before the first `#`; reason = text after.
+    path="${raw%%#*}"
+    path="${path#"${path%%[![:space:]]*}"}"
+    path="${path%"${path##*[![:space:]]}"}"
+    [ -z "$path" ] && continue
+
+    reason=""
+    case "$raw" in *#*) reason="${raw#*#}" ;; esac
+    reason="${reason#"${reason%%[![:space:]]*}"}"
+    reason="${reason%"${reason##*[![:space:]]}"}"
+    # Require a reason of at least a few characters (not just `#` or `# x`).
+    if [ "${#reason}" -lt 10 ]; then
+      echo "EXEMPT_NO_REASON: $path has no (or too short) justification comment in stepup-delete-exempt.txt — every exemption MUST state why step-up does not apply."
+      EXEMPT_PARSE_FAIL=1
+    fi
+
+    EXEMPT_LIST="${EXEMPT_LIST}${path}
+"
+  done < "$EXEMPT_FILE"
+fi
+
+if [ "$EXEMPT_PARSE_FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+is_exempt() {
+  printf '%s' "$EXEMPT_LIST" | grep -qxF "$1"
+}
+
+# Irreversible vault-data delete primitives (extended regex). Keep table-name
+# specific so soft-deletes / history / attachments do not match. `team.delete(`
+# is included because team deletion cascades to all team password entries.
+DELETE_SIGNAL='passwordEntry\.delete(Many)?\(|teamPasswordEntry\.delete(Many)?\(|executeVaultReset\(|deleteTeamPassword\(|[^A-Za-z0-9_]team\.delete\('
+
+# Enumerate candidate route files. bash 3.2 has no `mapfile`.
+fail=0
+routes=()
+while IFS= read -r route_line; do
+  [ -n "$route_line" ] && routes+=("$route_line")
+done < <(
+  grep -rlE "$DELETE_SIGNAL" "$API_DIR" --include='route.ts' 2>/dev/null \
+    | sed "s|^$PATH_ROOT/||" \
+    | sort
+)
+
+for route in ${routes[@]+"${routes[@]}"}; do
+  # Require an actual CALL `requireRecentCurrentAuthMethod(` (open paren), not a
+  # bare identifier — so a stale import, a comment, or a prefixed rename
+  # (e.g. DISABLED_requireRecentCurrentAuthMethod) does not satisfy the gate.
+  # The leading boundary [^A-Za-z0-9_] (or start-of-token via grep -oE) rejects
+  # a different identifier that merely ends with the name.
+  if grep -qE '(^|[^A-Za-z0-9_])requireRecentCurrentAuthMethod\(' "$PATH_ROOT/$route" 2>/dev/null; then
+    continue # step-up present (called)
+  fi
+  if is_exempt "$route"; then
+    continue # documented exemption
+  fi
+  echo "MISSING_STEPUP: $route performs an irreversible vault-data delete but does not call requireRecentCurrentAuthMethod (and is not in the exempt allowlist)."
+  fail=1
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "Add 'const stepUp = await requireRecentCurrentAuthMethod(req); if (stepUp) return stepUp;'"
+  echo "BEFORE the delete (for conditional ?permanent=true, gate it inside that branch),"
+  echo "OR add the route to scripts/checks/stepup-delete-exempt.txt with a justified reason."
+  echo "See docs/archive/review/owasp-rereview-stepup-and-failclosed-plan.md (C1)."
+  exit 1
+fi
+
+# Anti-drift: every exempt entry must still be a real vault-destruction route.
+# A stale allowlist entry (route deleted, or no longer hard-deletes) silently
+# weakens the guard's documentation — fail so it gets cleaned up.
+EXEMPT_DRIFT=0
+while IFS= read -r exempt_path; do
+  [ -z "$exempt_path" ] && continue
+  if [ ! -f "$PATH_ROOT/$exempt_path" ]; then
+    echo "STALE_EXEMPT: $exempt_path is allowlisted but the file does not exist."
+    EXEMPT_DRIFT=1
+    continue
+  fi
+  if ! grep -qE "$DELETE_SIGNAL" "$PATH_ROOT/$exempt_path" 2>/dev/null; then
+    echo "STALE_EXEMPT: $exempt_path is allowlisted but no longer matches a vault-delete primitive — remove it from stepup-delete-exempt.txt."
+    EXEMPT_DRIFT=1
+  fi
+done < <(printf '%s' "$EXEMPT_LIST")
+
+if [ "$EXEMPT_DRIFT" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/scripts/checks/check-permanent-delete-stepup.sh
+++ b/scripts/checks/check-permanent-delete-stepup.sh
@@ -12,7 +12,7 @@
 # allowlist entry.
 #
 # Detection (route files only — src/app/api/**/route.ts):
-#   A file is a "vault-destruction route" if it contains any of the four
+#   A file is a "vault-destruction route" if it contains any of the
 #   irreversible-delete primitives below (hard-delete of vault entry rows or a
 #   full-vault wipe). Soft-deletes (`update { deletedAt }`), history-trim
 #   (`passwordEntryHistory.*`), attachment-management deletes, and non-vault

--- a/scripts/checks/check-permanent-delete-stepup.sh
+++ b/scripts/checks/check-permanent-delete-stepup.sh
@@ -129,11 +129,13 @@ done < <(
 )
 
 for route in ${routes[@]+"${routes[@]}"}; do
-  # Require an actual CALL `requireRecentCurrentAuthMethod(` (open paren), not a
-  # bare identifier — so a stale import, a comment, or a prefixed rename
-  # (e.g. DISABLED_requireRecentCurrentAuthMethod) does not satisfy the gate.
-  # The leading boundary [^A-Za-z0-9_] (or start-of-token via grep -oE) rejects
-  # a different identifier that merely ends with the name.
+  # Require the call-shaped token `requireRecentCurrentAuthMethod(` (open paren),
+  # not a bare import or a prefixed/renamed identifier
+  # (e.g. DISABLED_requireRecentCurrentAuthMethod) — the leading boundary
+  # [^A-Za-z0-9_] rejects an identifier that merely ends with the name. This is
+  # still a grep, not an AST check: a COMMENTED-OUT call satisfies it too (see
+  # the "Known limitations" note in the header) — catching that is left to code
+  # review, by design.
   if grep -qE '(^|[^A-Za-z0-9_])requireRecentCurrentAuthMethod\(' "$PATH_ROOT/$route" 2>/dev/null; then
     continue # step-up present (called)
   fi

--- a/scripts/checks/stepup-delete-exempt.txt
+++ b/scripts/checks/stepup-delete-exempt.txt
@@ -1,0 +1,14 @@
+# Step-up exempt allowlist (check-permanent-delete-stepup.sh)
+#
+# Route files that perform an irreversible vault-data hard-delete but are
+# INTENTIONALLY exempt from the `requireRecentCurrentAuthMethod` (step-up)
+# requirement, because they are gated by a stronger / different ceremony.
+#
+# One repo-relative path per line. Lines beginning with `#` are comments.
+# Every entry MUST state, in a trailing comment, why step-up does not apply.
+#
+# Adding a route here is a security decision — it must be justified, not a
+# convenience to silence the guard. The default answer for a new vault-delete
+# route is "add requireRecentCurrentAuthMethod", NOT "add to this file".
+
+src/app/api/vault/admin-reset/route.ts  # dual-admin-approved one-time token (AdminVaultReset.tokenHash) — initiator != target, so the session-recency helper is inapplicable; the token possession + 2nd-admin approval is a stronger ceremony than step-up.

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -162,6 +162,7 @@ run_step "Static: settings-card-layout"  bash scripts/checks/check-settings-card
 run_step "Static: api-error-codes" bash scripts/checks/check-api-error-codes.sh
 run_step "Static: api-error-body-drift" bash scripts/checks/check-api-error-body-drift.sh
 run_step "Static: fail-closed-routes-have-test" bash scripts/checks/check-fail-closed-routes-have-test.sh
+run_step "Static: permanent-delete-stepup" bash scripts/checks/check-permanent-delete-stepup.sh
 run_step "Static: raw-body-read" bash scripts/checks/check-raw-body-read.sh
 run_step "Static: actions-sha-pinned" bash scripts/checks/check-actions-sha-pinned.sh
 run_step "Static: dockerfile-prisma-pin" bash scripts/checks/check-dockerfile-prisma-pin.sh


### PR DESCRIPTION
## Summary

A CI guard that mechanically enforces **"every API route performing an irreversible vault-data hard-delete must call `requireRecentCurrentAuthMethod` (step-up)"**.

### Why

The OWASP re-review (`#617`) found that bulk/wholesale permanent-purge endpoints lacked the step-up that single permanent-delete already required. That was an **enumeration miss** — the destructive-route set was never mechanically defined, so a reviewer following the externally-supplied list could (and did) overlook the most destructive path (`/api/vault/reset`). This guard makes that set machine-checked: a NEW vault-delete route can no longer land step-up-free, and removing step-up from a covered route fails CI.

### How

`scripts/checks/check-permanent-delete-stepup.sh` scans `src/app/api/**/route.ts` for the irreversible vault-data delete primitives:

- `passwordEntry.delete*`, `teamPasswordEntry.delete*` — entry hard-delete
- `executeVaultReset(` — full-vault wipe
- `deleteTeamPassword(` — team-entry service (permanent flag)
- `team.delete(` — **team deletion cascades to all team password entries** (`onDelete: Cascade`), a destruction class the entry-table primitives alone couldn't see (caught in review)

A matched route fails unless it calls `requireRecentCurrentAuthMethod` OR is in `scripts/checks/stepup-delete-exempt.txt` (currently only `vault/admin-reset`, which is token-gated by a dual-admin one-time token — a stronger ceremony than session-recency, and the initiator ≠ target so the helper is inapplicable).

Hardening:
- **Exempt entries must carry a justification comment** (machine-enforced — a no-reason add fails with `EXEMPT_NO_REASON`, so the one bypass surface isn't left to code-review vigilance).
- **Anti-drift**: a stale exempt entry (file gone, or no longer hard-deletes) fails with `STALE_EXEMPT`.
- Detection is table-name-specific, so soft-deletes (`update { deletedAt }`), history-trim, and attachment deletes are **not** flagged. Only route files are scanned — services/workers are gated by their calling route.

Wired into `scripts/pre-pr.sh`'s static block, so CI runs it via the existing `PRE_PR_STATIC_ONLY=1` static-checks job (no workflow change needed).

### Self-test

`scripts/__tests__/check-permanent-delete-stepup.test.mjs` (11 cases) drives the guard against fixtures via new `STEPUP_GUARD_*` env overrides, covering every pass/fail mode: pass-with-stepup, soft-delete, missing-stepup, prefixed-rename, bare-import-only, team-cascade, the `teamMember.delete`/`teamFolder.delete` false-positive guard, exempt-with-reason, `EXEMPT_NO_REASON`, and both `STALE_EXEMPT` branches. (The sibling grep-guards have no self-test; this sets a better precedent for a security backstop.)

### Doc

`docs/security/step-up-reauth-routes.md` (the living step-up SSoT) is brought back in lockstep: the stale "passwords NOT gated" claim is corrected (permanent delete IS gated — class 7, incl. team-cascade; only the recoverable soft-delete/trash path is friction-free), the routes are tabled, and the admin-reset exemption + machine-enforcement are recorded.

### Known limitations (documented in the script header, parity with the other grep guards)

- File-level granularity: any `requireRecentCurrentAuthMethod(` call in the file satisfies the gate regardless of method/branch. Holds today because every matched route is single-purpose; multi-handler routes need manual confirmation.
- A commented-out step-up call still satisfies the call-pattern grep.

## Testing

`pre-pr.sh` passes (Passed: 39 — the guard is the +1; self-test green in the vitest suite). `next build` unaffected (no app code changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
