### PR TITLE
fix(extension): don't bypass vault setup on ext_connect; fix disconnect-reason race

### DIFF
--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -1140,6 +1140,36 @@ describe("session persistence", () => {
     );
   });
 
+  it("returns EXPIRED in GET_STATUS on lazy expiry even if the reason write has not flushed", async () => {
+    // Regression: the lazy-expiry branch clears the token and records the reason
+    // via a fire-and-forget storage write, then reads it back in the same turn.
+    // If GET_STATUS depended on that write completing, the read could race and
+    // return null. Make the storage write hang forever and confirm the response
+    // still carries EXPIRED (determined locally, not via storage round-trip).
+    const store: Record<string, unknown> = {};
+    chromeMock!.storage.session.get = vi.fn(async (key: string) => ({ [key]: store[key] }));
+    chromeMock!.storage.session.set = vi.fn(() => new Promise<void>(() => {})); // never resolves
+
+    const expiresAt = Date.now() + 60_000;
+    applyToken("tok-1", expiresAt, STATIC_TEST_JKT);
+
+    // Advance real wall-clock past expiry so the GET_STATUS lazy check fires.
+    vi.useFakeTimers();
+    vi.setSystemTime(expiresAt + 1_000);
+    try {
+      const status = await sendMessage({ type: "GET_STATUS" });
+      expect(status).toEqual(
+        expect.objectContaining({
+          type: "GET_STATUS",
+          hasToken: false,
+          disconnectReason: DISCONNECT_REASON.EXPIRED,
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("clears the disconnect reason after a fresh successful connect", async () => {
     applyToken("tok-1", Date.now() + 600_000, STATIC_TEST_JKT);
     await sendMessage({ type: "CLEAR_TOKEN" });

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1911,14 +1911,23 @@ async function handleMessage(
       return;
 
     case EXT_MSG.GET_STATUS: {
+      // When we clear the token lazily HERE, recordDisconnectReason() is a
+      // fire-and-forget storage write; reading it back in the same turn could
+      // race and return null. Track the reason locally so the response always
+      // carries it for the just-expired case, independent of the storage write.
+      let lazyExpiredReason: DisconnectReason | null = null;
       if (tokenExpiresAt && Date.now() >= tokenExpiresAt) {
         clearToken(DISCONNECT_REASON.EXPIRED);
+        lazyExpiredReason = DISCONNECT_REASON.EXPIRED;
       }
       // Only meaningful when disconnected — explains why the popup shows the
       // Connect prompt (expired vs revoked vs manual) and lets it forewarn
-      // about possible re-authentication.
+      // about possible re-authentication. Prefer the locally-determined reason
+      // for a lazy expiry; otherwise read the persisted reason.
       const disconnectReason =
-        currentToken === null ? await readDisconnectReason() : null;
+        currentToken !== null
+          ? null
+          : lazyExpiredReason ?? (await readDisconnectReason());
       sendResponse({
         type: EXT_MSG.GET_STATUS,
         hasToken: currentToken !== null,

--- a/src/components/vault/vault-gate.test.tsx
+++ b/src/components/vault/vault-gate.test.tsx
@@ -102,6 +102,19 @@ describe("VaultGate", () => {
       expect(container.querySelector("svg")).not.toBeInTheDocument();
     });
 
+    it("does NOT bypass the setup wizard when the vault is not yet initialized", () => {
+      // SETUP_REQUIRED must win over the connect overlay: an uninitialized vault
+      // has nothing for the extension to use, and bypassing setup would let the
+      // connect flow mint an extension token before the vault exists.
+      mockUseVault.mockReturnValue({ status: "SETUP_REQUIRED" });
+      mockUseSearchParams.mockReturnValue(new URLSearchParams("ext_connect=1"));
+
+      render(<VaultGate><div>children</div></VaultGate>);
+
+      expect(screen.getByTestId("vault-setup-wizard")).toBeInTheDocument();
+      expect(screen.queryByTestId("auto-extension-connect")).not.toBeInTheDocument();
+    });
+
     it("falls back to the normal gate once the connect flow reports idle", () => {
       mockUseVault.mockReturnValue({ status: "LOCKED" });
       mockUseSearchParams.mockReturnValue(new URLSearchParams("ext_connect=1"));

--- a/src/components/vault/vault-gate.tsx
+++ b/src/components/vault/vault-gate.tsx
@@ -45,7 +45,13 @@ export function VaultGate({ children }: VaultGateProps) {
     () => searchParams.get(EXT_CONNECT_PARAM) === "1",
   );
 
-  if (connectActive) {
+  // The overlay deliberately precedes the LOCKED gate (connecting needs only a
+  // session, not an unlocked vault) — but it must NOT precede SETUP_REQUIRED. A
+  // user whose vault is not yet initialized has no vault to use the extension
+  // with; bypassing the setup wizard would also let the connect flow mint an
+  // extension token before the vault exists. Defer to the setup wizard first;
+  // once setup completes, the latch still shows the overlay.
+  if (connectActive && status !== VAULT_STATUS.SETUP_REQUIRED) {
     return <AutoExtensionConnect onActiveChange={setConnectActive} />;
   }
 


### PR DESCRIPTION
Two follow-ups from an external review of `#620` (already merged).

## Finding 1 — `ext_connect=1` bypassed the vault setup wizard

`VaultGate` returned the connect overlay before the `SETUP_REQUIRED` check, so a user whose vault is not yet initialized skipped the setup wizard entirely. Worse, the bridge-code route has no vault-initialized gate, so the connect flow could mint an extension token before any vault exists — breaking the implicit "extension tokens are for vault-initialized users" expectation.

**Fix:** gate the overlay on `status !== VAULT_STATUS.SETUP_REQUIRED`. The setup wizard wins for an uninitialized vault; once setup completes, the latch still surfaces the connect overlay. The overlay still precedes the `LOADING`/`LOCKED` gates (connecting needs only a session, not an unlocked vault — the point of `#620`).

## Finding 2 — disconnect-reason race in `GET_STATUS` lazy expiry

`GET_STATUS`'s lazy-expiry branch called `clearToken(EXPIRED)`, which records the reason via a fire-and-forget `chrome.storage.session` write, then read it back via `readDisconnectReason()` in the same turn. The read could race the write and return `null`, dropping the "session timed out" forewarning the popup shows.

**Fix:** determine the reason locally for the just-expired case (`lazyExpiredReason`) instead of depending on the storage write flushing. The persisted read is still used for the non-lazy paths (manual disconnect, server-revoked, TTL-alarm).

## Tests

- `vault-gate.test.tsx` — `ext_connect` + `SETUP_REQUIRED` shows the setup wizard, not the overlay.
- `background.test.ts` — `GET_STATUS` returns `EXPIRED` on lazy expiry even when the storage write never flushes (the write is mocked to hang).

Full web suite + extension build/test + `pre-pr.sh` (39 gates) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)