### PR TITLE
fix(tenant): require step-up to approve admin vault reset; add client reauth recovery

### DIFF
--- a/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/approve/route.test.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/approve/route.test.ts
@@ -19,6 +19,7 @@ const {
   mockNotificationTitle,
   mockNotificationBody,
   mockDecryptResetToken,
+  mockRequireRecentSession,
   TenantAuthError,
 } = vi.hoisted(() => {
   class _TenantAuthError extends Error {
@@ -47,6 +48,7 @@ const {
     mockNotificationTitle: vi.fn(),
     mockNotificationBody: vi.fn(),
     mockDecryptResetToken: vi.fn(),
+    mockRequireRecentSession: vi.fn(),
     TenantAuthError: _TenantAuthError,
   };
 });
@@ -99,6 +101,9 @@ vi.mock("@/lib/notification/notification-messages", () => ({
 }));
 vi.mock("@/lib/vault/admin-reset-token-crypto", () => ({
   decryptResetToken: mockDecryptResetToken,
+}));
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: mockRequireRecentSession,
 }));
 vi.mock("@/lib/logger", () => ({
   default: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) },
@@ -175,6 +180,8 @@ describe("POST /api/tenant/members/[userId]/reset-vault/[resetId]/approve", () =
     });
     mockRequireTenantPermission.mockResolvedValue(ACTOR);
     mockIsTenantRoleAbove.mockReturnValue(true);
+    // Step-up passes by default (null = recent enough). Denial tests override.
+    mockRequireRecentSession.mockResolvedValue(null);
     mockPrismaAdminVaultResetFindFirst.mockResolvedValue(RESET_RECORD);
     mockPrismaTenantMemberFindFirst.mockResolvedValue(TARGET_MEMBER);
     mockPrismaAdminVaultResetUpdateMany.mockResolvedValue({ count: 1 });
@@ -267,6 +274,35 @@ describe("POST /api/tenant/members/[userId]/reset-vault/[resetId]/approve", () =
       }),
     );
     expect(mockPrismaAdminVaultResetUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("returns step-up Response and performs no privileged work when session is stale (M1, RT8)", async () => {
+    mockRequireRecentSession.mockResolvedValueOnce(
+      Response.json({ error: "SESSION_STEP_UP_REQUIRED" }, { status: 403 }),
+    );
+
+    const res = await POST(buildReq(), buildParams());
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("SESSION_STEP_UP_REQUIRED");
+
+    // RT8: every guarded side effect must be skipped on the denial path.
+    // The gate sits before the rate-limit block, so the limiter is untouched
+    // (a stale session must not burn the low per-target cap — griefing lever).
+    expect(mockRateLimiterCheck).not.toHaveBeenCalled();
+    expect(mockDecryptResetToken).not.toHaveBeenCalled();
+    expect(mockPrismaAdminVaultResetUpdateMany).not.toHaveBeenCalled();
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke step-up before authz/eligibility checks (M1 ordering)", async () => {
+    // A wrong-role attempt must 403 on eligibility WITHOUT prompting reauth.
+    mockIsTenantRoleAbove.mockReturnValue(false);
+    const res = await POST(buildReq(), buildParams());
+    expect(res.status).toBe(403);
+    expect(mockRequireRecentSession).not.toHaveBeenCalled();
   });
 
   it("returns 429 when actor rate limit is exceeded", async () => {

--- a/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/approve/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/approve/route.ts
@@ -10,6 +10,7 @@ import { adminVaultResetEmail } from "@/lib/email/templates/admin-vault-reset";
 import { serverAppUrl } from "@/lib/url-helpers";
 import { resolveUserLocale } from "@/lib/locale";
 import { requireTenantPermission } from "@/lib/auth/access/tenant-auth";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 import {
   APPROVE_ELIGIBILITY,
   computeApproveEligibility,
@@ -147,6 +148,14 @@ async function handlePOST(
     });
     return errorResponse(API_ERROR.RESET_TARGET_EMAIL_CHANGED);
   }
+
+  // Step-up: approve is a destructive-ceremony member (mirrors initiate and
+  // access-requests/approve). Placed AFTER eligibility so a wrong-role /
+  // self-approval attempt still 403s without prompting reauth, and BEFORE the
+  // rate-limit block so a stale session is rejected without burning the
+  // per-target limiter (a low cap that would otherwise be a griefing lever).
+  const stepUpError = await requireRecentCurrentAuthMethod(req);
+  if (stepUpError) return stepUpError;
 
   // Rate limits
   const [actorResult, targetResult] = await Promise.all([

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
@@ -706,4 +706,29 @@ describe("GET /api/tenant/members/[userId]/reset-vault", () => {
     );
     expect(Object.keys(json[0].initiatedBy).sort()).toEqual(["email", "id", "name"].sort());
   });
+
+  it("read is permission-gated but NOT role-hierarchy-gated: an admin reads a same/higher-rank target's history, with action eligibility insufficient_role (M2 — intentional view/action split)", async () => {
+    // Target is not below the actor in the hierarchy (e.g. peer ADMIN / OWNER).
+    // Use a different initiator so eligibility resolves on the role-hierarchy
+    // branch (insufficient_role), not the self-initiator short-circuit.
+    mockPrismaAdminVaultResetFindMany.mockResolvedValue([
+      { ...BASE_RESET, initiatedById: "other-admin" },
+    ]);
+    mockPrismaTenantMemberFindFirst.mockResolvedValue({ role: "ADMIN" });
+    mockIsTenantRoleAbove.mockReturnValue(false);
+
+    const res = await GET(
+      createRequest("GET", `http://localhost/api/tenant/members/${TARGET_USER_ID}/reset-vault`),
+      createParams({ userId: TARGET_USER_ID }),
+    );
+
+    // READ succeeds despite the rank — this is the deliberate split. If a
+    // future change adds a read-side hierarchy gate, this test goes red and
+    // forces a conscious decision.
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toHaveLength(1);
+    // ACTION is hierarchy-gated: the row is not approvable by this actor.
+    expect(json[0].approveEligibility).toBe("insufficient_role");
+  });
 });

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.ts
@@ -241,6 +241,15 @@ async function handlePOST(
 
 // GET /api/tenant/members/[userId]/reset-vault
 // Get reset history for a specific member. Tenant OWNER/ADMIN only.
+//
+// Intentional view/action authz split: READ access is permission-gated
+// (MEMBER_VAULT_RESET) but NOT role-hierarchy-gated, so any OWNER/ADMIN can
+// view a peer's or superior's reset history — consistent with other
+// tenant-admin reads (e.g. GET /api/tenant/members returns every member's
+// metadata without a rank gate). Only the ACTION (approve) is hierarchy-gated,
+// via the per-row `approveEligibility` computed below and re-enforced at the
+// approve endpoint's CAS. The response carries audit metadata only — never
+// `tokenHash`, `encryptedToken`, or the plaintext token.
 async function handleGET(
   req: NextRequest,
   { params }: { params: Promise<{ userId: string }> },

--- a/src/components/settings/security/tenant-reset-history-dialog.tsx
+++ b/src/components/settings/security/tenant-reset-history-dialog.tsx
@@ -37,6 +37,10 @@ import {
 import { VAULT_CONFIRMATION_PHRASE } from "@/lib/constants/vault";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { toastApiError } from "@/lib/http/toast-api-error";
+import { readApiErrorBody } from "@/lib/http/read-api-error-body";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 
 interface ResetActor {
   id: string;
@@ -95,6 +99,11 @@ export function TenantResetHistoryDialog({
   const [approveInput, setApproveInput] = useState("");
   const [approveError, setApproveError] = useState<string | null>(null);
   const [approving, setApproving] = useState(false);
+
+  // Inline step-up reauth, mirroring the developer-settings credential cards.
+  // The approve dialog stays open across the reauth ceremony; on success the
+  // hook re-runs the approve handler, which re-submits the current target.
+  const inlineReauth = useInlineReauth(() => handleApproveSubmit());
 
   const fetchHistory = useCallback(async () => {
     setLoading(true);
@@ -176,8 +185,15 @@ export function TenantResetHistoryDialog({
         closeApproveDialog();
         await fetchHistory();
       } else if (res.status === 403) {
-        // Surface specific reason (e.g. FORBIDDEN_INSUFFICIENT_ROLE).
-        await toastApiError(res, tApi, API_ERROR.FORBIDDEN);
+        const body = await readApiErrorBody(res);
+        if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          // Keep the approve dialog open so the post-reauth retry re-submits
+          // the same target. Mirrors the developer-settings cards' pattern.
+          await inlineReauth.triggerOnStaleError();
+        } else {
+          // Surface specific reason (e.g. FORBIDDEN_INSUFFICIENT_ROLE).
+          await toastApiError(res, tApi, API_ERROR.FORBIDDEN);
+        }
       } else {
         toast.error(t("approveFailed"));
       }
@@ -353,6 +369,15 @@ export function TenantResetHistoryDialog({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={t("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        cancelLabel={t("cancel")}
+      />
     </Dialog>
   );
 }

--- a/src/components/settings/security/tenant-vault-reset-button.test.tsx
+++ b/src/components/settings/security/tenant-vault-reset-button.test.tsx
@@ -12,6 +12,7 @@ vi.mock("next-intl", () => ({
   useTranslations: () =>
     (key: string, params?: Record<string, string>) =>
       params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({ toast: mockToast }));

--- a/src/components/settings/security/tenant-vault-reset-button.tsx
+++ b/src/components/settings/security/tenant-vault-reset-button.tsx
@@ -18,6 +18,11 @@ import { RotateCcw, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { fetchApi } from "@/lib/url-helpers";
 import { apiPath } from "@/lib/constants";
+import { API_ERROR } from "@/lib/http/api-error-codes";
+import { readApiErrorBody } from "@/lib/http/read-api-error-body";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 
 interface TenantVaultResetButtonProps {
   userId: string;
@@ -39,6 +44,11 @@ export function TenantVaultResetButton({
   const [confirmInput, setConfirmInput] = useState("");
   const [loading, setLoading] = useState(false);
 
+  // Inline step-up reauth — initiate is server-side step-up-gated; on a stale
+  // session the confirm dialog stays open and the hook re-runs initiate after
+  // reauth.
+  const inlineReauth = useInlineReauth(() => handleReset());
+
   const handleReset = async () => {
     setLoading(true);
     try {
@@ -57,6 +67,13 @@ export function TenantVaultResetButton({
         onSuccess?.();
       } else if (res.status === 429) {
         toast.error(t("vaultResetRateLimited"));
+      } else if (res.status === 403) {
+        const body = await readApiErrorBody(res);
+        if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          await inlineReauth.triggerOnStaleError();
+        } else {
+          toast.error(t("vaultResetFailed"));
+        }
       } else {
         toast.error(t("vaultResetFailed"));
       }
@@ -103,6 +120,15 @@ export function TenantVaultResetButton({
           </Button>
         </AlertDialogFooter>
       </AlertDialogContent>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={t("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        cancelLabel={t("cancel")}
+      />
     </AlertDialog>
   );
 }


### PR DESCRIPTION
## Summary

Closes a step-up gap in the admin-initiated vault-reset dual-approval flow and fixes a related client-side recovery dead-end, surfaced by an external security review and confirmed via a three-perspective (functionality / security / testing) triangulate review.

## Changes

### M1 — step-up on the second-admin approval (server + client)
The `POST .../reset-vault/[resetId]/approve` endpoint advanced the destructive ceremony (it decrypts the reset token and emails it to the target) without recent re-authentication, while every sibling in the ceremony family already required it (`initiate`, and the structurally-identical `access-requests/[id]/approve`). A stolen or idle second-admin session could approve.

- Added `requireRecentCurrentAuthMethod(req)` to the approve route, positioned after the eligibility checks but before the rate-limit block — a wrong-role/self-approval attempt still 403s without prompting reauth, and a stale session is rejected without burning the low per-target limiter (a griefing lever).
- Wired `useInlineReauth` into the approve dialog so a `SESSION_STEP_UP_REQUIRED` 403 opens the established reauth flow and retries, instead of a dead-end error toast.

### F2 — client reauth recovery for initiate (pre-existing bug)
The initiate button was already server-side step-up-gated, but its client surfaced the 403 as a generic failure (`"vaultResetFailed"` / 「保管庫リセットに失敗しました」) with no recovery path — initiate was silently uncompletable on a stale session. Wired `useInlineReauth` into the initiate button to match the approve dialog and the developer-settings credential cards.

### M2 — document the GET history view/action authz split (no behavior change)
`GET .../reset-vault` gates read on the `MEMBER_VAULT_RESET` permission (not role hierarchy) while gating the approve action on hierarchy. This is consistent with other tenant-admin reads (e.g. `GET /api/tenant/members`) and returns only audit metadata — never `tokenHash`, `encryptedToken`, or the plaintext token. Added a comment so the deliberate asymmetry is not mistaken for a missing read gate.

## Tests
- approve: step-up denial test (RT8 — asserts 403 and that the rate limiter, token decrypt, `updateMany`, notification, and email are all skipped) + ordering test (step-up is not invoked before authz/eligibility).
- GET: intent test pinning the view/action split (cross-rank read returns 200 with `insufficient_role` eligibility) so a future read-side hierarchy gate would go red and force a conscious decision.
- button test: added a `useLocale` mock pulled in by the reauth dialogs.

## Verification
- `npx vitest run` — 11921 passed
- `npx next build` — succeeds
- `bash scripts/pre-pr.sh` — 40 checks pass

## Follow-up (separate PR)
A lateral sweep found 8 other UI components with the same client-side step-up dead-end (e.g. passkey credential delete, breakglass, team key rotation). That fix is tracked separately and is intentionally not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
