### PR TITLE
fix(ui): add step-up reauth recovery to 8 stale-session-dead-end callers

### DIFF
--- a/docs/archive/review/step-up-client-handoff.md
+++ b/docs/archive/review/step-up-client-handoff.md
@@ -1,0 +1,103 @@
+# Handoff: step-up client reauth — lateral expansion (横展開)
+
+## Status at handoff (2026-07-01)
+
+Two pieces of work on branch `fix/admin-vault-reset-approve-stepup`:
+
+### Piece A — reset-vault M1/M2/F2 (DONE, uncommitted, verified)
+Triangulate review of an external security report on the admin vault reset
+dual-approval flow. All applied, all green (vitest 11921 pass, `next build` ok,
+`pre-pr.sh` 40 checks pass). NOT yet committed. 7 files changed:
+
+- `src/app/api/tenant/members/[userId]/reset-vault/[resetId]/approve/route.ts`
+  — M1: added `requireRecentCurrentAuthMethod(req)` step-up, placed AFTER
+  eligibility checks, BEFORE the rate-limit block (so a stale session does not
+  burn the low per-target limiter).
+- `src/components/settings/security/tenant-reset-history-dialog.tsx`
+  — M1 client: `useInlineReauth` wired into approve handler (403
+  SESSION_STEP_UP_REQUIRED -> triggerOnStaleError -> retry). Simplified to the
+  plain-closure convention (no submitRef/useRef apparatus).
+- `src/components/settings/security/tenant-vault-reset-button.tsx`
+  — F2: same wiring on the initiate button (it was already server-side
+  step-up-gated but the client had no reauth path — a pre-existing prod bug).
+- `src/app/api/tenant/members/[userId]/reset-vault/route.ts`
+  — M2: comment documenting the intentional view(permission-gate)/action
+  (hierarchy-gate) authz split on GET. No behavior change (M2 is NOT a real
+  gap — no secret leak, cross-rank read is the codebase norm).
+- 3 test files: approve step-up denial test (RT8: 403 + limiter/decrypt/
+  updateMany/notification/email all not-called) + ordering test; GET M2 intent
+  test (cross-rank read 200 + insufficient_role); button test next-intl
+  `useLocale` mock added.
+
+**DECISION: Piece A goes in its OWN PR first.** Commit + `/pr-create` this.
+Do NOT bundle Piece B into it.
+
+### Piece B — lateral expansion (NOT STARTED, next session's work)
+Same bug class as F2: routes that enforce server-side step-up but whose UI
+caller does NOT handle the SESSION_STEP_UP_REQUIRED 403 (generic error toast,
+no reauth recovery path — a UX dead-end on a stale session).
+
+**This goes on a SEPARATE branch + SEPARATE PR.** User instruction.
+
+## Piece B — verified gap list (8 REAL gaps, already triple-checked)
+
+Two false positives already eliminated during verification:
+- `share-dialog.tsx` — only does GET teamPolicy, no mutating step-up call. NOT a gap.
+- `operator-token-card.tsx` — already has a custom-but-correct reauth flow. NOT a gap.
+
+Reference implementation to copy: `src/components/settings/developer/api-key-manager.tsx`
+(line 91 `useInlineReauth(() => handleCreate())`, lines 159-160 the 403 branch,
+lines 214-218 the two dialogs render). Convention is INLINE per-component (7
+existing consumers all inline — do NOT extract a shared wrapper). Use the
+plain-closure form `useInlineReauth(() => handler())`, NOT a useRef/submitRef
+apparatus (reverted in Piece A as unnecessary — the hook memoizes nothing, so a
+fresh closure each render always captures the latest handler).
+
+| # | Component | Route/method | fetchApi line(s) | current 403 handling | cancelLabel |
+|---|-----------|--------------|------------------|----------------------|-------------|
+| 1 | src/components/settings/developer/directory-sync-card.tsx | PUT+DELETE directory-sync/[id] | PUT:202, DELETE:254 | generic `t("syncFailed")` | `tCommon("cancel")` (imported) or `DirectorySync.cancel` |
+| 2 | src/components/team/security/team-rotate-key-button.tsx | POST rotate-key | 241 | generic `t("rotateKeyFailed")` | `Teams` has NO `cancel` — add `useTranslations("Common")` -> `tCommon("cancel")`, or reuse `Teams.rotateKeyCancel` |
+| 3 | src/components/team/members/team-add-from-tenant-section.tsx | POST teams/[teamId]/members | 85 | throws -> catch -> `t("addMemberFailed")` | `t("cancel")` (Team has cancel) |
+| 4 | src/components/breakglass/breakglass-dialog.tsx | POST tenant/breakglass | 91 | generic apiError toast (else) | `tc("cancel")` = Common.cancel (wired line 238) |
+| 5 | src/components/breakglass/breakglass-grant-list.tsx | DELETE tenant/breakglass/[id] | 81 (handleRevoke) | generic apiError toast | `tc("cancel")` = Common.cancel (wired line 215) |
+| 6 | src/components/settings/security/passkey-credentials-card.tsx | DELETE+PATCH webauthn/credentials/[id] | DELETE:260, PATCH:276 | `t("deleteError")` / `t("nicknameUpdateError")` | `t("cancel")` (WebAuthn has cancel) |
+| 7 | src/components/settings/developer/audit-delivery-target-card.tsx | POST + PATCH(toggle) tenant/audit-delivery-targets[/[id]] | POST:182, PATCH:203 | `t("createFailed")` / `t("updateFailed")` | `tCommon("cancel")` (wired) |
+| 8 | src/app/[locale]/vault-reset/page.tsx | POST vault/reset | 39 | inline `setError(...)` string | `tCommon("cancel")` (wired). Standalone full-page form, not dialog-in-card — wire dialogs into page JSX; locale provider already present |
+
+Notes:
+- #2: rotate-key POST takes no per-row arg, so `() => handleRotate()` suffices.
+- #6 has TWO mutating step-up methods (DELETE delete-credential, PATCH rename);
+  both handlers (handleDelete:260, handleRename:276) need the 403 branch. Either
+  a small retry-target state (like access-request-card's reauthApproveTargetId)
+  or two handlers each calling triggerOnStaleError — judge during impl.
+- #8 is a page not a card; render the two reauth dialogs in page JSX.
+- The PRF-rebootstrap POST in #6 (webauthn/credentials/[id]/prf, lines 358/399)
+  is NOT step-up-gated — out of scope.
+
+## Per-component fix recipe
+1. imports: `useInlineReauth` from `@/hooks/auth/use-inline-reauth`;
+   `RecentSessionRequiredDialog` from `@/components/auth/recent-session-required-dialog`;
+   `PasskeyReauthDialog` from `@/components/auth/passkey-reauth-dialog`;
+   `readApiErrorBody` from `@/lib/http/read-api-error-body`;
+   `API_ERROR` from `@/lib/http/api-error-codes`.
+2. `const inlineReauth = useInlineReauth(() => handler());` (lazy closure above handler).
+3. In the 403 branch: `const body = await readApiErrorBody(res); if (body?.error
+   === API_ERROR.SESSION_STEP_UP_REQUIRED) { await inlineReauth.triggerOnStaleError();
+   return; }` then fall through to existing generic error.
+4. Render both dialogs in JSX with `cancelLabel={...}` from the table.
+5. Tests: rendering the component pulls in RecentSessionRequiredDialog -> internal
+   `useLocale()`. If a test mocks `next-intl` without `useLocale`, add
+   `useLocale: () => "en"` (exact fix needed in Piece A's button test). Add a
+   step-up denial test per component (RT8): 403 SESSION_STEP_UP_REQUIRED ->
+   triggerOnStaleError path, mutation not committed.
+
+## Verification gates
+- `npx vitest run` (full) ; `npx next build` ; `bash scripts/pre-pr.sh` (40 checks)
+- Security boundary (step-up) -> re-run affected route/component tests explicitly (R21).
+
+## Recommended next-session entry point
+Start at triangulate Phase 2 (coding) with THIS list as the finalized plan —
+discovery + verification (Phase 1) already done and recorded above. Do NOT redo
+the Explore/verify fan-out. After Piece A's PR is up:
+`git checkout main && git pull && git checkout -b fix/step-up-client-reauth-lateral`
+then implement #1-#8, test, build, pre-pr, one PR.

--- a/src/app/[locale]/vault-reset/page.test.tsx
+++ b/src/app/[locale]/vault-reset/page.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { VAULT_CONFIRMATION_PHRASE } from "@/lib/constants/vault";
+
+const {
+  mockFetch,
+  mockCanUsePasskeyRecovery,
+  mockReauthenticateWithPasskey,
+} = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
+}));
+
+vi.mock("@/lib/url-helpers", () => ({
+  fetchApi: (...args: unknown[]) => mockFetch(...args),
+  withBasePath: (p: string) => p,
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
+}));
+
+import VaultResetPage from "./page";
+
+const TOKEN = VAULT_CONFIRMATION_PHRASE.DELETE_VAULT;
+
+describe("VaultResetPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true });
+  });
+
+  it("disables the submit button until the confirmation phrase is typed", () => {
+    render(<VaultResetPage />);
+    const submit = screen.getByRole("button", { name: "resetButton" });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("confirmationLabel"), {
+      target: { value: TOKEN },
+    });
+    expect(submit).not.toBeDisabled();
+  });
+
+  // RT8: a stale-session reset must surface the reauth recovery path, not the
+  // inline error string, and must NOT navigate away.
+  it("opens the recent-session dialog on a SESSION_STEP_UP_REQUIRED reset (RT8)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+    });
+
+    render(<VaultResetPage />);
+    fireEvent.change(screen.getByLabelText("confirmationLabel"), {
+      target: { value: TOKEN },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "resetButton" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    // The inline error string must NOT be shown for a step-up denial.
+    expect(screen.queryByText("unknownError")).toBeNull();
+  });
+});

--- a/src/app/[locale]/vault-reset/page.tsx
+++ b/src/app/[locale]/vault-reset/page.tsx
@@ -2,8 +2,11 @@
 
 import { useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
-import { apiErrorToI18nKey } from "@/lib/http/api-error-codes";
+import { apiErrorToI18nKey, API_ERROR } from "@/lib/http/api-error-codes";
 import { readApiErrorBody } from "@/lib/http/read-api-error-body";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 import { preventIMESubmit } from "@/lib/ui/ime-guard";
 import { API_PATH } from "@/lib/constants";
 import { VAULT_CONFIRMATION_PHRASE } from "@/lib/constants/vault";
@@ -28,8 +31,11 @@ export default function VaultResetPage() {
 
   const isValid = confirmation === CONFIRMATION_TOKEN;
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  // Inline step-up reauth — vault reset is server-side step-up-gated. On a
+  // stale session the hook replays the reset after reauth.
+  const inlineReauth = useInlineReauth(() => submitReset());
+
+  async function submitReset() {
     if (!isValid) return;
 
     setLoading(true);
@@ -44,7 +50,9 @@ export default function VaultResetPage() {
 
       if (!res.ok) {
         const body = await readApiErrorBody(res);
-        if (body?.error) {
+        if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          await inlineReauth.triggerOnStaleError();
+        } else if (body?.error) {
           setError(tApi(apiErrorToI18nKey(body.error)));
         } else {
           setError(tApi("unknownError"));
@@ -63,6 +71,11 @@ export default function VaultResetPage() {
     } finally {
       setLoading(false);
     }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await submitReset();
   }
 
   return (
@@ -116,6 +129,15 @@ export default function VaultResetPage() {
           </Button>
         </form>
       </div>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
     </div>
   );
 }

--- a/src/components/breakglass/breakglass-dialog.test.tsx
+++ b/src/components/breakglass/breakglass-dialog.test.tsx
@@ -12,14 +12,23 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
-const { mockFetchApi, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
+const {
+  mockFetchApi,
+  mockToastSuccess,
+  mockToastError,
+  mockCanUsePasskeyRecovery,
+  mockReauthenticateWithPasskey,
+} = vi.hoisted(() => ({
   mockFetchApi: vi.fn(),
   mockToastSuccess: vi.fn(),
   mockToastError: vi.fn(),
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
 }));
 
 vi.mock("@/lib/url-helpers", () => ({
@@ -124,6 +133,17 @@ vi.mock("@/components/ui/label", () => ({
   ),
 }));
 
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
+}));
+
 import { BreakGlassDialog } from "./breakglass-dialog";
 
 const members = [
@@ -143,6 +163,8 @@ describe("BreakGlassDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     onGrantCreated = vi.fn<() => void>();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true });
   });
 
   it("renders trigger button when closed", () => {
@@ -297,5 +319,34 @@ describe("BreakGlassDialog", () => {
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith("selfAccessError");
     });
+  });
+
+  // RT8: a stale-session create must surface the reauth recovery path, not a
+  // generic error toast, and must NOT fire onGrantCreated.
+  it("opens the recent-session dialog on a SESSION_STEP_UP_REQUIRED submit (RT8)", async () => {
+    mockFetchApi.mockResolvedValueOnce({ ok: true, json: async () => members });
+    mockFetchApi.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: "SESSION_STEP_UP_REQUIRED" }),
+    });
+
+    render(<BreakGlassDialog onGrantCreated={onGrantCreated} />);
+    openDialog();
+
+    await waitFor(() => screen.getByText("Alice/alice@example.com"));
+
+    fireEvent.click(screen.getByText("Alice/alice@example.com"));
+    fireEvent.change(screen.getByLabelText("reason"), {
+      target: { value: "long enough reason text" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "submit" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(onGrantCreated).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
   });
 });

--- a/src/components/breakglass/breakglass-dialog.tsx
+++ b/src/components/breakglass/breakglass-dialog.tsx
@@ -18,9 +18,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AlertTriangle, Check, Loader2, Search, ShieldAlert } from "lucide-react";
 import { apiPath, API_PATH } from "@/lib/constants";
-import { apiErrorToI18nKey } from "@/lib/http/api-error-codes";
+import { apiErrorToI18nKey, API_ERROR } from "@/lib/http/api-error-codes";
 import { readApiErrorBody } from "@/lib/http/read-api-error-body";
 import { fetchApi } from "@/lib/url-helpers";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 import { filterMembers } from "@/lib/filter-members";
 import { cn } from "@/lib/utils";
 import { MemberInfo } from "@/components/member-info";
@@ -49,6 +52,10 @@ export function BreakGlassDialog({ onGrantCreated, trigger }: BreakGlassDialogPr
   const [reason, setReason] = useState("");
   const [incidentRef, setIncidentRef] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  // Inline step-up reauth — creating a break-glass grant is server-side
+  // step-up-gated. On a stale session the hook replays the submit after reauth.
+  const inlineReauth = useInlineReauth(() => handleSubmit());
 
   useEffect(() => {
     if (!open) return;
@@ -123,6 +130,13 @@ export function BreakGlassDialog({ onGrantCreated, trigger }: BreakGlassDialogPr
         toast.error(t("duplicateGrantError"));
       } else if (res.status === 429) {
         toast.error(t("rateLimitExceeded"));
+      } else if (res.status === 403) {
+        const body = await readApiErrorBody(res);
+        if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          await inlineReauth.triggerOnStaleError();
+        } else {
+          toast.error(body?.error ? tApi(apiErrorToI18nKey(body.error)) : tApi("unknownError"));
+        }
       } else {
         const body = await readApiErrorBody(res);
         toast.error(body?.error ? tApi(apiErrorToI18nKey(body.error)) : tApi("unknownError"));
@@ -135,6 +149,7 @@ export function BreakGlassDialog({ onGrantCreated, trigger }: BreakGlassDialogPr
   const canSubmit = targetUserId && reason.length >= 10 && !submitting;
 
   return (
+    <>
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         {trigger ?? (
@@ -244,5 +259,15 @@ export function BreakGlassDialog({ onGrantCreated, trigger }: BreakGlassDialogPr
         </DialogFooter>
       </DialogContent>
     </Dialog>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={tc("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        cancelLabel={tc("cancel")}
+      />
+    </>
   );
 }

--- a/src/components/breakglass/breakglass-grant-list.test.tsx
+++ b/src/components/breakglass/breakglass-grant-list.test.tsx
@@ -4,10 +4,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
-const { mockFetchApi, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
+const {
+  mockFetchApi,
+  mockToastSuccess,
+  mockToastError,
+  mockCanUsePasskeyRecovery,
+  mockReauthenticateWithPasskey,
+} = vi.hoisted(() => ({
   mockFetchApi: vi.fn(),
   mockToastSuccess: vi.fn(),
   mockToastError: vi.fn(),
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
@@ -82,6 +90,17 @@ vi.mock("@/components/ui/alert-dialog", () => ({
   }) => <button onClick={onClick}>{children}</button>,
 }));
 
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
+}));
+
 import { BreakGlassGrantList } from "./breakglass-grant-list";
 
 const activeGrant = {
@@ -107,6 +126,10 @@ describe("BreakGlassGrantList", () => {
     mockFetchApi.mockReset();
     mockToastSuccess.mockReset();
     mockToastError.mockReset();
+    mockCanUsePasskeyRecovery.mockReset();
+    mockReauthenticateWithPasskey.mockReset();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true });
   });
 
   it("shows loader initially then empty state when there are no grants", async () => {
@@ -176,6 +199,37 @@ describe("BreakGlassGrantList", () => {
       );
     });
     expect(mockToastSuccess).toHaveBeenCalled();
+  });
+
+  // RT8: a stale-session revoke must surface the reauth recovery path, not the
+  // generic error toast, and must NOT report success.
+  it("opens the recent-session dialog on a SESSION_STEP_UP_REQUIRED revoke (RT8)", async () => {
+    mockFetchApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [activeGrant] }),
+    });
+    // Revoke DELETE → stale session
+    mockFetchApi.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: "SESSION_STEP_UP_REQUIRED" }),
+    });
+
+    render(<BreakGlassGrantList refreshTrigger={0} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Target")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText("revoke")[0]);
+    const allRevokes = screen.getAllByText("revoke");
+    fireEvent.click(allRevokes[allRevokes.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
   });
 
   it("toggles history visibility and renders historical grants", async () => {

--- a/src/components/breakglass/breakglass-grant-list.tsx
+++ b/src/components/breakglass/breakglass-grant-list.tsx
@@ -66,14 +66,9 @@ export function BreakGlassGrantList({ refreshTrigger }: BreakGlassGrantListProps
   const [revokeTargetId, setRevokeTargetId] = useState<string | null>(null);
 
   // Inline step-up reauth — revoking a break-glass grant is server-side
-  // step-up-gated. The retry target remembers which grant was being revoked so
+  // step-up-gated. The retry arg (owned by the hook) carries the grant id so
   // the post-reauth retry replays the same revoke.
-  const [reauthRevokeId, setReauthRevokeId] = useState<string | null>(null);
-  const inlineReauth = useInlineReauth(async () => {
-    const id = reauthRevokeId;
-    setReauthRevokeId(null);
-    if (id) await handleRevoke(id);
-  });
+  const inlineReauth = useInlineReauth<string>((id) => handleRevoke(id));
 
   const fetchGrants = useCallback(async () => {
     setLoading(true);
@@ -101,8 +96,7 @@ export function BreakGlassGrantList({ refreshTrigger }: BreakGlassGrantListProps
       } else if (res.status === 403) {
         const body = await readApiErrorBody(res);
         if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-          setReauthRevokeId(grantId);
-          await inlineReauth.triggerOnStaleError();
+          await inlineReauth.triggerOnStaleError(grantId);
         } else {
           toast.error(body?.error ? tApi(apiErrorToI18nKey(body.error)) : tApi("unknownError"));
         }
@@ -253,10 +247,6 @@ export function BreakGlassGrantList({ refreshTrigger }: BreakGlassGrantListProps
       />
       <PasskeyReauthDialog
         {...inlineReauth.reauthDialogProps}
-        onOpenChange={(open) => {
-          inlineReauth.reauthDialogProps.onOpenChange(open);
-          if (!open) setReauthRevokeId(null);
-        }}
         cancelLabel={tc("cancel")}
       />
     </>

--- a/src/components/breakglass/breakglass-grant-list.tsx
+++ b/src/components/breakglass/breakglass-grant-list.tsx
@@ -18,9 +18,13 @@ import {
 import { Loader2, Eye, X } from "lucide-react";
 import { InactiveItemsSection } from "@/components/settings/shared/inactive-items-section";
 import { apiPath, GRANT_STATUS } from "@/lib/constants";
-import { apiErrorToI18nKey } from "@/lib/http/api-error-codes";
+import { apiErrorToI18nKey, API_ERROR } from "@/lib/http/api-error-codes";
+import { readApiErrorBody } from "@/lib/http/read-api-error-body";
 import type { GrantStatus } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 import { DISPLAY_REASON_PREVIEW } from "@/lib/validations/common";
 import { formatDateTime } from "@/lib/format/format-datetime";
 import { formatUserName } from "@/lib/format/format-user";
@@ -61,6 +65,16 @@ export function BreakGlassGrantList({ refreshTrigger }: BreakGlassGrantListProps
   const [revoking, setRevoking] = useState<string | null>(null);
   const [revokeTargetId, setRevokeTargetId] = useState<string | null>(null);
 
+  // Inline step-up reauth — revoking a break-glass grant is server-side
+  // step-up-gated. The retry target remembers which grant was being revoked so
+  // the post-reauth retry replays the same revoke.
+  const [reauthRevokeId, setReauthRevokeId] = useState<string | null>(null);
+  const inlineReauth = useInlineReauth(async () => {
+    const id = reauthRevokeId;
+    setReauthRevokeId(null);
+    if (id) await handleRevoke(id);
+  });
+
   const fetchGrants = useCallback(async () => {
     setLoading(true);
     const res = await fetchApi(apiPath.tenantBreakglass());
@@ -84,6 +98,14 @@ export function BreakGlassGrantList({ refreshTrigger }: BreakGlassGrantListProps
       if (res.ok) {
         toast.success(t("revokeSuccess"));
         fetchGrants();
+      } else if (res.status === 403) {
+        const body = await readApiErrorBody(res);
+        if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          setReauthRevokeId(grantId);
+          await inlineReauth.triggerOnStaleError();
+        } else {
+          toast.error(body?.error ? tApi(apiErrorToI18nKey(body.error)) : tApi("unknownError"));
+        }
       } else {
         const data = await res.json().catch(() => null);
         const code = typeof data?.error === "string" ? data.error : null;
@@ -224,6 +246,19 @@ export function BreakGlassGrantList({ refreshTrigger }: BreakGlassGrantListProps
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={tc("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        onOpenChange={(open) => {
+          inlineReauth.reauthDialogProps.onOpenChange(open);
+          if (!open) setReauthRevokeId(null);
+        }}
+        cancelLabel={tc("cancel")}
+      />
     </>
   );
 }

--- a/src/components/settings/developer/access-request-card.tsx
+++ b/src/components/settings/developer/access-request-card.tsx
@@ -91,12 +91,9 @@ export function AccessRequestCard() {
   const [approving, setApproving] = useState<string | null>(null);
   const [jitToken, setJitToken] = useState<string | null>(null);
   const [jitTokenOpen, setJitTokenOpen] = useState(false);
-  const [reauthApproveTargetId, setReauthApproveTargetId] = useState<string | null>(null);
-  const inlineReauth = useInlineReauth(async () => {
-    const target = reauthApproveTargetId;
-    setReauthApproveTargetId(null);
-    if (target) await handleApprove(target);
-  });
+  // The retry arg (owned by the hook) carries the request id so the post-reauth
+  // retry approves the same request the operator was acting on.
+  const inlineReauth = useInlineReauth<string>((requestId) => handleApprove(requestId));
 
   // Create dialog state
   const [createOpen, setCreateOpen] = useState(false);
@@ -200,10 +197,8 @@ export function AccessRequestCard() {
         const body = await readApiErrorBody(res);
         const code = body?.error ?? "";
         if (code === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-          // Remember which request the operator was trying to approve so the
-          // post-reauth retry hits the same target.
-          setReauthApproveTargetId(requestId);
-          await inlineReauth.triggerOnStaleError();
+          // Pass the request id so the post-reauth retry approves the same one.
+          await inlineReauth.triggerOnStaleError(requestId);
         } else if (res.status === 409 && code === API_ERROR.SA_TOKEN_LIMIT_EXCEEDED) {
           toast.error(t("arTokenLimitExceeded"));
         } else if (res.status === 409 && code === API_ERROR.SA_INACTIVE) {
@@ -281,10 +276,6 @@ export function AccessRequestCard() {
         />
         <PasskeyReauthDialog
           {...inlineReauth.reauthDialogProps}
-          onOpenChange={(open) => {
-            inlineReauth.reauthDialogProps.onOpenChange(open);
-            if (!open) setReauthApproveTargetId(null);
-          }}
           cancelLabel={tCommon("cancel")}
         />
         <section className="space-y-3">

--- a/src/components/settings/developer/audit-delivery-target-card.test.tsx
+++ b/src/components/settings/developer/audit-delivery-target-card.test.tsx
@@ -11,10 +11,13 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   } as unknown as typeof ResizeObserver;
 }
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
-  mockFetch: vi.fn(),
-  mockToast: { success: vi.fn(), error: vi.fn() },
-}));
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } =
+  vi.hoisted(() => ({
+    mockFetch: vi.fn(),
+    mockToast: { success: vi.fn(), error: vi.fn() },
+    mockCanUsePasskeyRecovery: vi.fn(),
+    mockReauthenticateWithPasskey: vi.fn(),
+  }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () =>
@@ -68,6 +71,17 @@ vi.mock("@/components/ui/select", () => ({
   SelectValue: () => null,
 }));
 
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
+}));
+
 import { AuditDeliveryTargetCard } from "./audit-delivery-target-card";
 
 function setupTargets(targets: Array<Record<string, unknown>>) {
@@ -90,6 +104,8 @@ function setupTargets(targets: Array<Record<string, unknown>>) {
 describe("AuditDeliveryTargetCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true });
   });
 
   it("renders empty state when no targets", async () => {
@@ -233,6 +249,50 @@ describe("AuditDeliveryTargetCard", () => {
       expect(titles.length).toBe(1);
     });
     expect(mockToast.success).toHaveBeenCalledWith("created");
+  });
+
+  // RT8: a stale-session create must surface the reauth recovery path, not the
+  // generic createFailed toast, and must NOT report success.
+  it("opens the recent-session dialog on a SESSION_STEP_UP_REQUIRED create (RT8)", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ targets: [] }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+
+    render(<AuditDeliveryTargetCard />);
+    await waitFor(() => expect(screen.getByText("noTargets")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /addTarget/ }));
+    await waitFor(() => {
+      expect(screen.getAllByText("addTarget").length).toBeGreaterThan(1);
+    });
+
+    fireEvent.click(screen.getByText("kindWebhook"));
+    fireEvent.change(screen.getByLabelText("url"), {
+      target: { value: "https://hooks.example.com/audit" },
+    });
+    fireEvent.change(screen.getByLabelText("secret"), {
+      target: { value: "s3cret" },
+    });
+
+    const addButtons = screen.getAllByRole("button", { name: /addTarget/ });
+    fireEvent.click(addButtons[addButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.success).not.toHaveBeenCalled();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 
   it("does NOT render the create form when limit is reached (limitReached path)", async () => {

--- a/src/components/settings/developer/audit-delivery-target-card.tsx
+++ b/src/components/settings/developer/audit-delivery-target-card.tsx
@@ -37,6 +37,11 @@ import { SectionCardHeader } from "@/components/settings/account/section-card-he
 import { InactiveItemsSection } from "@/components/settings/shared/inactive-items-section";
 import { fetchApi } from "@/lib/url-helpers";
 import { apiPath } from "@/lib/constants";
+import { API_ERROR } from "@/lib/http/api-error-codes";
+import { readApiErrorBody } from "@/lib/http/read-api-error-body";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 import { MAX_AUDIT_DELIVERY_TARGETS } from "@/lib/validations/common";
 import { formatDateTime } from "@/lib/format/format-datetime";
 import { toast } from "sonner";
@@ -91,6 +96,19 @@ export function AuditDeliveryTargetCard() {
   const [config, setConfig] = useState<ConfigState>(defaultConfig);
   const [urlError, setUrlError] = useState("");
   const [showInactive, setShowInactive] = useState(false);
+
+  // Inline step-up reauth — creating a target and toggling its active state are
+  // both server-side step-up-gated. The retry target remembers which mutation
+  // the admin was attempting so the post-reauth retry replays the same one.
+  const [reauthRetry, setReauthRetry] = useState<
+    { type: "create" } | { type: "toggle"; target: TargetItem } | null
+  >(null);
+  const inlineReauth = useInlineReauth(async () => {
+    const retry = reauthRetry;
+    setReauthRetry(null);
+    if (retry?.type === "create") await handleCreate();
+    else if (retry?.type === "toggle") await handleToggleActive(retry.target);
+  });
 
   const fetchTargets = useCallback(async () => {
     try {
@@ -185,6 +203,14 @@ export function AuditDeliveryTargetCard() {
         body: JSON.stringify(buildPayload()),
       });
       if (!res.ok) {
+        if (res.status === 403) {
+          const body = await readApiErrorBody(res);
+          if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+            setReauthRetry({ type: "create" });
+            await inlineReauth.triggerOnStaleError();
+            return;
+          }
+        }
         toast.error(t("createFailed"));
         return;
       }
@@ -206,6 +232,14 @@ export function AuditDeliveryTargetCard() {
         body: JSON.stringify({ isActive: !target.isActive }),
       });
       if (!res.ok) {
+        if (res.status === 403) {
+          const body = await readApiErrorBody(res);
+          if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+            setReauthRetry({ type: "toggle", target });
+            await inlineReauth.triggerOnStaleError();
+            return;
+          }
+        }
         toast.error(t("updateFailed"));
         return;
       }
@@ -520,6 +554,19 @@ export function AuditDeliveryTargetCard() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        onOpenChange={(open) => {
+          inlineReauth.reauthDialogProps.onOpenChange(open);
+          if (!open) setReauthRetry(null);
+        }}
+        cancelLabel={tCommon("cancel")}
+      />
     </Card>
   );
 }

--- a/src/components/settings/developer/audit-delivery-target-card.tsx
+++ b/src/components/settings/developer/audit-delivery-target-card.tsx
@@ -98,16 +98,13 @@ export function AuditDeliveryTargetCard() {
   const [showInactive, setShowInactive] = useState(false);
 
   // Inline step-up reauth — creating a target and toggling its active state are
-  // both server-side step-up-gated. The retry target remembers which mutation
-  // the admin was attempting so the post-reauth retry replays the same one.
-  const [reauthRetry, setReauthRetry] = useState<
-    { type: "create" } | { type: "toggle"; target: TargetItem } | null
-  >(null);
-  const inlineReauth = useInlineReauth(async () => {
-    const retry = reauthRetry;
-    setReauthRetry(null);
-    if (retry?.type === "create") await handleCreate();
-    else if (retry?.type === "toggle") await handleToggleActive(retry.target);
+  // both server-side step-up-gated. The retry arg (owned by the hook) records
+  // which mutation the admin was attempting so the post-reauth retry replays
+  // the same one.
+  type ReauthRetry = { type: "create" } | { type: "toggle"; target: TargetItem };
+  const inlineReauth = useInlineReauth<ReauthRetry>(async (retry) => {
+    if (retry.type === "create") await handleCreate();
+    else if (retry.type === "toggle") await handleToggleActive(retry.target);
   });
 
   const fetchTargets = useCallback(async () => {
@@ -206,8 +203,7 @@ export function AuditDeliveryTargetCard() {
         if (res.status === 403) {
           const body = await readApiErrorBody(res);
           if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-            setReauthRetry({ type: "create" });
-            await inlineReauth.triggerOnStaleError();
+            await inlineReauth.triggerOnStaleError({ type: "create" });
             return;
           }
         }
@@ -235,8 +231,7 @@ export function AuditDeliveryTargetCard() {
         if (res.status === 403) {
           const body = await readApiErrorBody(res);
           if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-            setReauthRetry({ type: "toggle", target });
-            await inlineReauth.triggerOnStaleError();
+            await inlineReauth.triggerOnStaleError({ type: "toggle", target });
             return;
           }
         }
@@ -561,10 +556,6 @@ export function AuditDeliveryTargetCard() {
       />
       <PasskeyReauthDialog
         {...inlineReauth.reauthDialogProps}
-        onOpenChange={(open) => {
-          inlineReauth.reauthDialogProps.onOpenChange(open);
-          if (!open) setReauthRetry(null);
-        }}
         cancelLabel={tCommon("cancel")}
       />
     </Card>

--- a/src/components/settings/developer/directory-sync-card.test.tsx
+++ b/src/components/settings/developer/directory-sync-card.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
 if (typeof globalThis.ResizeObserver === "undefined") {
@@ -11,10 +11,13 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   } as unknown as typeof ResizeObserver;
 }
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
-  mockFetch: vi.fn(),
-  mockToast: { success: vi.fn(), error: vi.fn() },
-}));
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } =
+  vi.hoisted(() => ({
+    mockFetch: vi.fn(),
+    mockToast: { success: vi.fn(), error: vi.fn() },
+    mockCanUsePasskeyRecovery: vi.fn(),
+    mockReauthenticateWithPasskey: vi.fn(),
+  }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () =>
@@ -32,6 +35,17 @@ vi.mock("@/lib/url-helpers", () => ({
 vi.mock("@/lib/format/format-datetime", () => ({
   formatDateTime: (d: string) => d,
   formatRelativeTime: (d: string) => d,
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import { DirectorySyncCard } from "./directory-sync-card";
@@ -56,9 +70,26 @@ function setupConfigs(configs: Array<Record<string, unknown>>) {
   });
 }
 
+const SAMPLE_CONFIG = {
+  id: "cfg-del",
+  provider: "AZURE_AD",
+  displayName: "DeleteMe",
+  enabled: true,
+  syncIntervalMinutes: 60,
+  status: "IDLE",
+  lastSyncAt: null,
+  lastSyncError: null,
+  lastSyncStats: null,
+  nextSyncAt: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
 describe("DirectorySyncCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true });
   });
 
   it("renders empty state when no configs", async () => {
@@ -141,5 +172,47 @@ describe("DirectorySyncCard", () => {
       expect(screen.getByText("GW-Failed")).toBeInTheDocument();
     });
     expect(screen.getByText("auth failure xyz")).toBeInTheDocument();
+  });
+
+  // RT8: a stale-session DELETE must surface the reauth recovery path, not the
+  // generic syncFailed toast, and must NOT commit the deletion.
+  it("opens the recent-session dialog on a SESSION_STEP_UP_REQUIRED delete (RT8)", async () => {
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (String(url).includes("directory-sync") && method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve([SAMPLE_CONFIG]),
+        });
+      }
+      if (method === "DELETE") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    });
+
+    render(<DirectorySyncCard />);
+    await waitFor(() => {
+      expect(screen.getByText("DeleteMe")).toBeInTheDocument();
+    });
+
+    // The trash trigger is the last button in the config row; clicking it opens
+    // the delete-confirm dialog whose action button is labelled deleteConfig.
+    const rowButtons = screen.getAllByRole("button");
+    fireEvent.click(rowButtons[rowButtons.length - 1]);
+
+    const confirmBtn = await screen.findByRole("button", { name: "deleteConfig" });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.success).not.toHaveBeenCalledWith("configDeleted");
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/developer/directory-sync-card.tsx
+++ b/src/components/settings/developer/directory-sync-card.tsx
@@ -143,16 +143,12 @@ export function DirectorySyncCard() {
   const [runningSyncId, setRunningSyncId] = useState<string | null>(null);
 
   // Inline step-up reauth — create/update/delete are server-side step-up-gated.
-  // The retry target remembers which mutation the operator was attempting so
-  // the post-reauth retry replays the same one.
-  const [reauthRetry, setReauthRetry] = useState<
-    { type: "save" } | { type: "delete"; id: string } | null
-  >(null);
-  const inlineReauth = useInlineReauth(async () => {
-    const target = reauthRetry;
-    setReauthRetry(null);
-    if (target?.type === "save") await handleSave();
-    else if (target?.type === "delete") await handleDelete(target.id);
+  // The retry arg (owned by the hook) records which mutation the operator was
+  // attempting so the post-reauth retry replays the same one.
+  type ReauthRetry = { type: "save" } | { type: "delete"; id: string };
+  const inlineReauth = useInlineReauth<ReauthRetry>(async (retry) => {
+    if (retry.type === "save") await handleSave();
+    else if (retry.type === "delete") await handleDelete(retry.id);
   });
 
   // ─── Fetch configs ──────────────────────────────────────────
@@ -229,8 +225,7 @@ export function DirectorySyncCard() {
         } else if (res.status === 403) {
           const errBody = await readApiErrorBody(res);
           if (errBody?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-            setReauthRetry({ type: "save" });
-            await inlineReauth.triggerOnStaleError();
+            await inlineReauth.triggerOnStaleError({ type: "save" });
           } else {
             toast.error(t("syncFailed"));
           }
@@ -261,8 +256,7 @@ export function DirectorySyncCard() {
         } else if (res.status === 403) {
           const errBody = await readApiErrorBody(res);
           if (errBody?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-            setReauthRetry({ type: "save" });
-            await inlineReauth.triggerOnStaleError();
+            await inlineReauth.triggerOnStaleError({ type: "save" });
           } else {
             toast.error(t("syncFailed"));
           }
@@ -292,8 +286,7 @@ export function DirectorySyncCard() {
       } else if (res.status === 403) {
         const errBody = await readApiErrorBody(res);
         if (errBody?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-          setReauthRetry({ type: "delete", id });
-          await inlineReauth.triggerOnStaleError();
+          await inlineReauth.triggerOnStaleError({ type: "delete", id });
         } else {
           toast.error(t("syncFailed"));
         }
@@ -814,10 +807,6 @@ export function DirectorySyncCard() {
       />
       <PasskeyReauthDialog
         {...inlineReauth.reauthDialogProps}
-        onOpenChange={(open) => {
-          inlineReauth.reauthDialogProps.onOpenChange(open);
-          if (!open) setReauthRetry(null);
-        }}
         cancelLabel={tCommon("cancel")}
       />
     </>

--- a/src/components/settings/developer/directory-sync-card.tsx
+++ b/src/components/settings/developer/directory-sync-card.tsx
@@ -46,11 +46,15 @@ import { FolderSync, Loader2, Play, Plus, ScrollText, Trash2 } from "lucide-reac
 import { toast } from "sonner";
 import { fetchApi } from "@/lib/url-helpers";
 import { readApiErrorBody, getApiErrorDetail } from "@/lib/http/read-api-error-body";
+import { API_ERROR } from "@/lib/http/api-error-codes";
 import { NAME_MAX_LENGTH } from "@/lib/validations";
 import { apiPath, API_PATH } from "@/lib/constants";
 import { formatDateTime, formatRelativeTime } from "@/lib/format/format-datetime";
 import { useFormDirty } from "@/hooks/form/use-form-dirty";
 import { FormDirtyBadge } from "@/components/settings/account/form-dirty-badge";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 
 // ─── Types ───────────────────────────────────────────────────
 
@@ -138,6 +142,19 @@ export function DirectorySyncCard() {
   // Running sync
   const [runningSyncId, setRunningSyncId] = useState<string | null>(null);
 
+  // Inline step-up reauth — create/update/delete are server-side step-up-gated.
+  // The retry target remembers which mutation the operator was attempting so
+  // the post-reauth retry replays the same one.
+  const [reauthRetry, setReauthRetry] = useState<
+    { type: "save" } | { type: "delete"; id: string } | null
+  >(null);
+  const inlineReauth = useInlineReauth(async () => {
+    const target = reauthRetry;
+    setReauthRetry(null);
+    if (target?.type === "save") await handleSave();
+    else if (target?.type === "delete") await handleDelete(target.id);
+  });
+
   // ─── Fetch configs ──────────────────────────────────────────
 
   const fetchConfigs = useCallback(async () => {
@@ -209,6 +226,14 @@ export function DirectorySyncCard() {
           setEditInitial({ ...editCurrent });
           setDialogOpen(false);
           fetchConfigs();
+        } else if (res.status === 403) {
+          const errBody = await readApiErrorBody(res);
+          if (errBody?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+            setReauthRetry({ type: "save" });
+            await inlineReauth.triggerOnStaleError();
+          } else {
+            toast.error(t("syncFailed"));
+          }
         } else if (res.status === 400) {
           toast.error(t("validationError"));
         } else {
@@ -233,6 +258,14 @@ export function DirectorySyncCard() {
           fetchConfigs();
         } else if (res.status === 409) {
           toast.error(t("syncConflict"));
+        } else if (res.status === 403) {
+          const errBody = await readApiErrorBody(res);
+          if (errBody?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+            setReauthRetry({ type: "save" });
+            await inlineReauth.triggerOnStaleError();
+          } else {
+            toast.error(t("syncFailed"));
+          }
         } else if (res.status === 400) {
           toast.error(t("validationError"));
         } else {
@@ -248,22 +281,27 @@ export function DirectorySyncCard() {
 
   // ─── Delete ─────────────────────────────────────────────────
 
-  async function handleDelete() {
-    if (!deletingId) return;
+  async function handleDelete(id: string) {
     try {
-      const res = await fetchApi(apiPath.directorySyncById(deletingId), {
+      const res = await fetchApi(apiPath.directorySyncById(id), {
         method: "DELETE",
       });
       if (res.ok) {
         toast.success(t("configDeleted"));
         fetchConfigs();
+      } else if (res.status === 403) {
+        const errBody = await readApiErrorBody(res);
+        if (errBody?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          setReauthRetry({ type: "delete", id });
+          await inlineReauth.triggerOnStaleError();
+        } else {
+          toast.error(t("syncFailed"));
+        }
       } else {
         toast.error(t("syncFailed"));
       }
     } catch {
       toast.error(t("syncFailed"));
-    } finally {
-      setDeletingId(null);
     }
   }
 
@@ -692,7 +730,15 @@ export function DirectorySyncCard() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete}>{t("deleteConfig")}</AlertDialogAction>
+            <AlertDialogAction
+              onClick={() => {
+                const id = deletingId;
+                setDeletingId(null);
+                if (id) handleDelete(id);
+              }}
+            >
+              {t("deleteConfig")}
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -761,6 +807,19 @@ export function DirectorySyncCard() {
           </div>
         </SheetContent>
       </Sheet>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        onOpenChange={(open) => {
+          inlineReauth.reauthDialogProps.onOpenChange(open);
+          if (!open) setReauthRetry(null);
+        }}
+        cancelLabel={tCommon("cancel")}
+      />
     </>
   );
 }

--- a/src/components/settings/security/passkey-credentials-card.test.tsx
+++ b/src/components/settings/security/passkey-credentials-card.test.tsx
@@ -17,6 +17,8 @@ const {
   mockGenerateNickname,
   capturedSecretKey,
   capturedPrfOutput,
+  mockCanUsePasskeyRecovery,
+  mockReauthenticateWithPasskey,
 } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
@@ -28,6 +30,8 @@ const {
   mockGenerateNickname: vi.fn<typeof generateDefaultNickname>(() => "auto-name"),
   capturedSecretKey: { value: null as Uint8Array | null },
   capturedPrfOutput: { value: null as Uint8Array | null },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
@@ -66,6 +70,17 @@ vi.mock("@/lib/auth/webauthn/webauthn-client", () => ({
   },
   generateDefaultNickname: (...args: Parameters<typeof generateDefaultNickname>) =>
     mockGenerateNickname(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import { PasskeyCredentialsCard } from "./passkey-credentials-card";
@@ -139,6 +154,8 @@ describe("PasskeyCredentialsCard", () => {
       status: "unlocked",
       getSecretKey: () => makeSentinelSecretKey(),
     });
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true });
   });
 
   it("disables register button when vault is locked (R26 disabled cue)", async () => {
@@ -361,5 +378,63 @@ describe("PasskeyCredentialsCard", () => {
     await waitFor(() => {
       expect(mockToast.warning).toHaveBeenCalledWith("requestPending");
     });
+  });
+
+  // RT8: a stale-session credential delete must surface the reauth recovery
+  // path, not the generic deleteError toast, and must NOT report success.
+  it("opens the recent-session dialog on a SESSION_STEP_UP_REQUIRED delete (RT8)", async () => {
+    const cred = {
+      id: "cred-del",
+      credentialId: "cid-del",
+      nickname: "My Key",
+      deviceType: "multiDevice",
+      backedUp: true,
+      discoverable: true,
+      minPinLength: null,
+      largeBlobSupported: null,
+      transports: ["internal"],
+      prfSupported: false,
+      prfWrappingPresent: false,
+      registeredDevice: null,
+      lastUsedDevice: null,
+      createdAt: "2026-05-04",
+      lastUsedAt: null,
+    };
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("/api/webauthn/credentials") && (init?.method ?? "GET") === "GET") {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([cred]) });
+      }
+      if (u.includes("auth-provider")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ canPasskeySignIn: true }),
+        });
+      }
+      if (init?.method === "DELETE") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    });
+
+    render(<PasskeyCredentialsCard />);
+    await waitFor(() => {
+      expect(screen.getByText("My Key")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "delete" }));
+    const confirmBtn = await screen.findByRole("button", { name: "confirm" });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.success).not.toHaveBeenCalledWith("deleteSuccess");
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/security/passkey-credentials-card.tsx
+++ b/src/components/settings/security/passkey-credentials-card.tsx
@@ -27,6 +27,9 @@ import { API_PATH, apiPath } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { readApiErrorBody } from "@/lib/http/read-api-error-body";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 import { NAME_MAX_LENGTH } from "@/lib/validations";
 import { DISPLAY_ID_SHORT } from "@/lib/validations/common";
 import { formatDateTime } from "@/lib/format/format-datetime";
@@ -104,6 +107,17 @@ export function PasskeyCredentialsCard() {
   // PRF re-bootstrap state — tracks which credential is currently being
   // re-bootstrapped after vault rotation cleared its wrapping (#433/F3).
   const [rebootstrappingId, setRebootstrappingId] = useState<string | null>(null);
+
+  // Inline step-up reauth — deleting a credential is server-side
+  // step-up-gated. The retry target remembers which credential was being
+  // deleted so the post-reauth retry replays the same delete. (Rename/PATCH is
+  // not step-up-gated, so only delete needs this recovery path.)
+  const [reauthDeleteId, setReauthDeleteId] = useState<string | null>(null);
+  const inlineReauth = useInlineReauth(async () => {
+    const id = reauthDeleteId;
+    setReauthDeleteId(null);
+    if (id) await handleDelete(id);
+  });
 
   const vaultUnlocked = status === VAULT_STATUS.UNLOCKED;
   const webAuthnAvailable = isWebAuthnSupported();
@@ -263,6 +277,14 @@ export function PasskeyCredentialsCard() {
       if (res.ok) {
         toast.success(t("deleteSuccess"));
         fetchCredentials();
+      } else if (res.status === 403) {
+        const body = await readApiErrorBody(res);
+        if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          setReauthDeleteId(credentialId);
+          await inlineReauth.triggerOnStaleError();
+        } else {
+          toast.error(t("deleteError"));
+        }
       } else {
         toast.error(t("deleteError"));
       }
@@ -707,6 +729,19 @@ export function PasskeyCredentialsCard() {
             </div>
           )}
         </section>
+
+        <RecentSessionRequiredDialog
+          {...inlineReauth.recentSessionDialogProps}
+          cancelLabel={t("cancel")}
+        />
+        <PasskeyReauthDialog
+          {...inlineReauth.reauthDialogProps}
+          onOpenChange={(open) => {
+            inlineReauth.reauthDialogProps.onOpenChange(open);
+            if (!open) setReauthDeleteId(null);
+          }}
+          cancelLabel={t("cancel")}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/settings/security/passkey-credentials-card.tsx
+++ b/src/components/settings/security/passkey-credentials-card.tsx
@@ -109,15 +109,10 @@ export function PasskeyCredentialsCard() {
   const [rebootstrappingId, setRebootstrappingId] = useState<string | null>(null);
 
   // Inline step-up reauth — deleting a credential is server-side
-  // step-up-gated. The retry target remembers which credential was being
-  // deleted so the post-reauth retry replays the same delete. (Rename/PATCH is
-  // not step-up-gated, so only delete needs this recovery path.)
-  const [reauthDeleteId, setReauthDeleteId] = useState<string | null>(null);
-  const inlineReauth = useInlineReauth(async () => {
-    const id = reauthDeleteId;
-    setReauthDeleteId(null);
-    if (id) await handleDelete(id);
-  });
+  // step-up-gated. The retry arg (owned by the hook) carries the credential id
+  // so the post-reauth retry replays the same delete. (Rename/PATCH is not
+  // step-up-gated, so only delete needs this recovery path.)
+  const inlineReauth = useInlineReauth<string>((id) => handleDelete(id));
 
   const vaultUnlocked = status === VAULT_STATUS.UNLOCKED;
   const webAuthnAvailable = isWebAuthnSupported();
@@ -280,8 +275,7 @@ export function PasskeyCredentialsCard() {
       } else if (res.status === 403) {
         const body = await readApiErrorBody(res);
         if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-          setReauthDeleteId(credentialId);
-          await inlineReauth.triggerOnStaleError();
+          await inlineReauth.triggerOnStaleError(credentialId);
         } else {
           toast.error(t("deleteError"));
         }
@@ -736,10 +730,6 @@ export function PasskeyCredentialsCard() {
         />
         <PasskeyReauthDialog
           {...inlineReauth.reauthDialogProps}
-          onOpenChange={(open) => {
-            inlineReauth.reauthDialogProps.onOpenChange(open);
-            if (!open) setReauthDeleteId(null);
-          }}
           cancelLabel={t("cancel")}
         />
       </CardContent>

--- a/src/components/team/members/__tests__/team-add-from-tenant-section.test.tsx
+++ b/src/components/team/members/__tests__/team-add-from-tenant-section.test.tsx
@@ -12,13 +12,20 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   } as unknown as typeof ResizeObserver;
 }
 
-const { mockFetchApi } = vi.hoisted(() => ({ mockFetchApi: vi.fn() }));
+const { mockFetchApi, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(
+  () => ({
+    mockFetchApi: vi.fn(),
+    mockCanUsePasskeyRecovery: vi.fn(),
+    mockReauthenticateWithPasskey: vi.fn(),
+  }),
+);
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string, values?: Record<string, string>) =>
     key === "addFromTenantCrossTenantNote" && values?.tenantName
       ? `${key}:${values.tenantName}`
       : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({
@@ -66,11 +73,24 @@ vi.mock("@/components/ui/select", () => ({
   SelectValue: () => null,
 }));
 
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
+}));
+
 import { TeamAddFromTenantSection } from "../team-add-from-tenant-section";
 
 describe("TeamAddFromTenantSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true });
     vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
@@ -158,5 +178,47 @@ describe("TeamAddFromTenantSection", () => {
     );
 
     expect(screen.getByText("addFromTenantCrossTenantNote:Security Tenant")).toBeInTheDocument();
+  });
+
+  // RT8: a stale-session add must surface the reauth recovery path, not the
+  // generic addMemberFailed toast, and must NOT report success.
+  it("opens the recent-session dialog on a SESSION_STEP_UP_REQUIRED add (RT8)", async () => {
+    mockFetchApi
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ userId: "user-1", name: "Alice", email: "alice@example.com", image: null }],
+        signal: { aborted: false },
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+
+    const onSuccess = vi.fn();
+    render(<TeamAddFromTenantSection teamId="team-1" onSuccess={onSuccess} />);
+
+    fireEvent.change(screen.getByPlaceholderText("searchTenantMembers"), {
+      target: { value: "alice" },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(350);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("member-info")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("addButton"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 });

--- a/src/components/team/members/team-add-from-tenant-section.tsx
+++ b/src/components/team/members/team-add-from-tenant-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { MemberInfo } from "@/components/member-info";
 import { Button } from "@/components/ui/button";
@@ -18,6 +18,9 @@ import { TEAM_ROLE, apiPath } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { readApiErrorBody } from "@/lib/http/read-api-error-body";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 
 interface TenantMemberResult {
   userId: string;
@@ -40,6 +43,16 @@ export function TeamAddFromTenantSection({ teamId, onSuccess, teamTenantName }: 
   const [searchResults, setSearchResults] = useState<TenantMemberResult[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+
+  // Inline step-up reauth — adding a tenant member is server-side
+  // step-up-gated. The retry target remembers which user the admin was adding
+  // so the post-reauth retry replays the same add.
+  const [reauthAddUserId, setReauthAddUserId] = useState<string | null>(null);
+  const inlineReauth = useInlineReauth(async () => {
+    const userId = reauthAddUserId;
+    setReauthAddUserId(null);
+    if (userId) await handleAddMember(userId);
+  });
 
   // Debounced tenant member search
   useEffect(() => {
@@ -79,7 +92,7 @@ export function TeamAddFromTenantSection({ teamId, onSuccess, teamTenantName }: 
     };
   }, [addSearch, teamId]);
 
-  const handleAddMember = useCallback(async (userId: string) => {
+  const handleAddMember = async (userId: string) => {
     setAdding(userId);
     try {
       const res = await fetchApi(apiPath.teamMembers(teamId), {
@@ -97,6 +110,15 @@ export function TeamAddFromTenantSection({ teamId, onSuccess, teamTenantName }: 
         setAdding(null);
         return;
       }
+      if (res.status === 403) {
+        const body = await readApiErrorBody(res);
+        if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          setReauthAddUserId(userId);
+          await inlineReauth.triggerOnStaleError();
+          setAdding(null);
+          return;
+        }
+      }
       if (!res.ok) throw new Error("Failed");
       toast.success(t("memberAdded"));
       setAddSearch("");
@@ -107,9 +129,10 @@ export function TeamAddFromTenantSection({ teamId, onSuccess, teamTenantName }: 
     } finally {
       setAdding(null);
     }
-  }, [teamId, addRole, t, onSuccess]);
+  };
 
   return (
+    <>
     <section className="space-y-4">
       <div>
         <h3 className="text-sm font-medium">{t("addFromTenantLabel")}</h3>
@@ -184,5 +207,19 @@ export function TeamAddFromTenantSection({ teamId, onSuccess, teamTenantName }: 
         </div>
       )}
     </section>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={t("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        onOpenChange={(open) => {
+          inlineReauth.reauthDialogProps.onOpenChange(open);
+          if (!open) setReauthAddUserId(null);
+        }}
+        cancelLabel={t("cancel")}
+      />
+    </>
   );
 }

--- a/src/components/team/members/team-add-from-tenant-section.tsx
+++ b/src/components/team/members/team-add-from-tenant-section.tsx
@@ -45,14 +45,9 @@ export function TeamAddFromTenantSection({ teamId, onSuccess, teamTenantName }: 
   const abortRef = useRef<AbortController | null>(null);
 
   // Inline step-up reauth — adding a tenant member is server-side
-  // step-up-gated. The retry target remembers which user the admin was adding
-  // so the post-reauth retry replays the same add.
-  const [reauthAddUserId, setReauthAddUserId] = useState<string | null>(null);
-  const inlineReauth = useInlineReauth(async () => {
-    const userId = reauthAddUserId;
-    setReauthAddUserId(null);
-    if (userId) await handleAddMember(userId);
-  });
+  // step-up-gated. The retry arg (owned by the hook) carries the user id so the
+  // post-reauth retry replays the same add.
+  const inlineReauth = useInlineReauth<string>((userId) => handleAddMember(userId));
 
   // Debounced tenant member search
   useEffect(() => {
@@ -113,8 +108,7 @@ export function TeamAddFromTenantSection({ teamId, onSuccess, teamTenantName }: 
       if (res.status === 403) {
         const body = await readApiErrorBody(res);
         if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-          setReauthAddUserId(userId);
-          await inlineReauth.triggerOnStaleError();
+          await inlineReauth.triggerOnStaleError(userId);
           setAdding(null);
           return;
         }
@@ -214,10 +208,6 @@ export function TeamAddFromTenantSection({ teamId, onSuccess, teamTenantName }: 
       />
       <PasskeyReauthDialog
         {...inlineReauth.reauthDialogProps}
-        onOpenChange={(open) => {
-          inlineReauth.reauthDialogProps.onOpenChange(open);
-          if (!open) setReauthAddUserId(null);
-        }}
         cancelLabel={t("cancel")}
       />
     </>

--- a/src/components/team/security/team-rotate-key-button.test.tsx
+++ b/src/components/team/security/team-rotate-key-button.test.tsx
@@ -29,12 +29,16 @@ const {
   deriveTeamKeyMock,
   rawItemKeysSnapshot,
   newTeamKeysSnapshot,
+  mockCanUsePasskeyRecovery,
+  mockReauthenticateWithPasskey,
 } = vi.hoisted(() => {
   const rawSnap: { refs: Uint8Array[] } = { refs: [] };
   const teamKeySnap: { refs: Uint8Array[] } = { refs: [] };
   return {
     mockFetch: vi.fn(),
     mockToast: { error: vi.fn(), success: vi.fn() },
+    mockCanUsePasskeyRecovery: vi.fn(),
+    mockReauthenticateWithPasskey: vi.fn(),
     generateTeamKeyMock: vi.fn<typeof generateTeamSymmetricKey>(() => {
       const buf = new Uint8Array(32).fill(0xab);
       teamKeySnap.refs.push(buf);
@@ -70,6 +74,7 @@ const {
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string, opts?: Record<string, unknown>) =>
     opts ? `${key}:${JSON.stringify(opts)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({ toast: mockToast }));
@@ -99,6 +104,17 @@ vi.mock("@/lib/crypto/crypto-aad", () => ({
   buildTeamEntryAAD: vi.fn(() => "team-aad"),
   buildItemKeyWrapAAD: vi.fn(() => "item-key-aad"),
   VAULT_TYPE: { BLOB: "blob", OVERVIEW: "overview" },
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import { TeamRotateKeyButton } from "./team-rotate-key-button";
@@ -138,7 +154,11 @@ const ENTRIES = [
 
 const MEMBERS = [{ userId: "u1", ecdhPublicKey: "pk1" }];
 
-function setupRotateFetch(opts?: { rotateOk?: boolean; rotateStatus?: number }) {
+function setupRotateFetch(opts?: {
+  rotateOk?: boolean;
+  rotateStatus?: number;
+  rotateBody?: Record<string, unknown>;
+}) {
   mockFetch.mockImplementation((url: string, init?: RequestInit) => {
     if (url.includes("rotate-key/data") || url.includes("rotate-key-data")) {
       return Promise.resolve({
@@ -155,7 +175,7 @@ function setupRotateFetch(opts?: { rotateOk?: boolean; rotateStatus?: number }) 
       return Promise.resolve({
         ok: opts?.rotateOk ?? true,
         status: opts?.rotateStatus ?? 200,
-        json: () => Promise.resolve({}),
+        json: () => Promise.resolve(opts?.rotateBody ?? {}),
       });
     }
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
@@ -181,6 +201,8 @@ describe("TeamRotateKeyButton — §Sec-1 crypto invariants", () => {
     vi.clearAllMocks();
     rawItemKeysSnapshot.refs.length = 0;
     newTeamKeysSnapshot.refs.length = 0;
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true });
   });
 
   it("renders the rotate-key trigger button", () => {
@@ -266,6 +288,23 @@ describe("TeamRotateKeyButton — §Sec-1 crypto invariants", () => {
     await waitFor(() => {
       expect(mockToast.error).toHaveBeenCalledWith("rotateKeyVersionConflict");
     });
+  });
+
+  // RT8: a stale-session rotate POST must surface the reauth recovery path, not
+  // the generic rotateKeyFailed toast, and must NOT report success.
+  it("opens the recent-session dialog on a SESSION_STEP_UP_REQUIRED rotate (RT8)", async () => {
+    setupRotateFetch({
+      rotateOk: false,
+      rotateStatus: 403,
+      rotateBody: { error: "SESSION_STEP_UP_REQUIRED" },
+    });
+    render(<TeamRotateKeyButton teamId="team-1" />);
+    await openAndConfirm();
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.success).not.toHaveBeenCalled();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 
   it("disables confirm button until 'rotate' typed", async () => {

--- a/src/components/team/security/team-rotate-key-button.tsx
+++ b/src/components/team/security/team-rotate-key-button.tsx
@@ -31,6 +31,9 @@ import { apiPath } from "@/lib/constants";
 import { useTeamVault } from "@/lib/team/team-vault-core";
 import { readApiErrorBody } from "@/lib/http/read-api-error-body";
 import { API_ERROR } from "@/lib/http/api-error-codes";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -93,6 +96,11 @@ export function TeamRotateKeyButton({ teamId, onSuccess }: TeamRotateKeyButtonPr
   const [phase, setPhase] = useState<RotatePhase>("idle");
   const [progress, setProgress] = useState({ current: 0, total: 0 });
   const [confirmInput, setConfirmInput] = useState("");
+
+  // Inline step-up reauth — rotate-key is server-side step-up-gated. On a stale
+  // session the confirm dialog stays open and the hook replays the rotation
+  // (re-fetch + re-encrypt) after reauth.
+  const inlineReauth = useInlineReauth(() => handleRotate());
 
   const handleRotate = async () => {
     setLoading(true);
@@ -252,6 +260,8 @@ export function TeamRotateKeyButton({ teamId, onSuccess }: TeamRotateKeyButtonPr
         const body = await readApiErrorBody(res);
         if (res.status === 409) {
           toast.error(t("rotateKeyVersionConflict"));
+        } else if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          await inlineReauth.triggerOnStaleError();
         } else if (body?.error === API_ERROR.ENTRY_COUNT_MISMATCH) {
           toast.error(t("rotateKeyEntryMismatch"));
         } else {
@@ -280,6 +290,7 @@ export function TeamRotateKeyButton({ teamId, onSuccess }: TeamRotateKeyButtonPr
   const progressLabel = describeProgress(phase, progress.current, progress.total);
 
   return (
+    <>
     <AlertDialog open={open} onOpenChange={(v) => { if (!loading) { setOpen(v); if (!v) setConfirmInput(""); } }}>
       <AlertDialogTrigger asChild>
         <Button variant="destructive" size="sm">
@@ -332,5 +343,15 @@ export function TeamRotateKeyButton({ teamId, onSuccess }: TeamRotateKeyButtonPr
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={t("rotateKeyCancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        cancelLabel={t("rotateKeyCancel")}
+      />
+    </>
   );
 }

--- a/src/hooks/auth/use-inline-reauth.test.tsx
+++ b/src/hooks/auth/use-inline-reauth.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const { mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
+}));
+
+import { useInlineReauth } from "./use-inline-reauth";
+
+// Minimal harness: a button per scenario that calls triggerOnStaleError with a
+// retry arg, plus the passkey dialog's onAction (the reauth confirm) wired to a
+// button so the test can drive the WebAuthn success path.
+function Harness({ onSuccess }: { onSuccess: (arg: string) => Promise<void> }) {
+  const reauth = useInlineReauth<string>(onSuccess);
+  return (
+    <div>
+      <button onClick={() => void reauth.triggerOnStaleError("target-A")}>trigger-A</button>
+      <button onClick={() => void reauth.triggerOnStaleError("target-B")}>trigger-B</button>
+      <button onClick={() => void reauth.reauthDialogProps.onAction()}>confirm</button>
+      <button onClick={() => reauth.reauthDialogProps.onOpenChange(false)}>dismiss</button>
+      <span data-testid="reauth-open">{String(reauth.reauthDialogProps.open)}</span>
+    </div>
+  );
+}
+
+describe("useInlineReauth retry argument", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Passkey path so onAction drives the reauth ceremony.
+    mockCanUsePasskeyRecovery.mockResolvedValue(true);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true });
+  });
+
+  it("replays onSuccess with the exact arg passed to triggerOnStaleError", async () => {
+    const onSuccess = vi.fn(async () => {});
+    render(<Harness onSuccess={onSuccess} />);
+
+    fireEvent.click(screen.getByText("trigger-A"));
+    await waitFor(() => {
+      expect(screen.getByTestId("reauth-open")).toHaveTextContent("true");
+    });
+
+    fireEvent.click(screen.getByText("confirm"));
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith("target-A");
+    });
+  });
+
+  it("uses the latest arg when triggerOnStaleError is re-invoked before confirm", async () => {
+    const onSuccess = vi.fn(async () => {});
+    render(<Harness onSuccess={onSuccess} />);
+
+    fireEvent.click(screen.getByText("trigger-A"));
+    fireEvent.click(screen.getByText("trigger-B"));
+    await waitFor(() => {
+      expect(screen.getByTestId("reauth-open")).toHaveTextContent("true");
+    });
+
+    fireEvent.click(screen.getByText("confirm"));
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith("target-B");
+    });
+  });
+
+  it("clears the retry arg on dialog dismissal (no stale replay)", async () => {
+    const onSuccess = vi.fn(async () => {});
+    render(<Harness onSuccess={onSuccess} />);
+
+    fireEvent.click(screen.getByText("trigger-A"));
+    await waitFor(() => {
+      expect(screen.getByTestId("reauth-open")).toHaveTextContent("true");
+    });
+
+    // Dismiss, then a fresh confirm must not replay the cleared target.
+    fireEvent.click(screen.getByText("dismiss"));
+    fireEvent.click(screen.getByText("confirm"));
+
+    await waitFor(() => {
+      expect(mockReauthenticateWithPasskey).toHaveBeenCalled();
+    });
+    // onSuccess fires with the cleared arg (undefined), never the stale "target-A".
+    expect(onSuccess).not.toHaveBeenCalledWith("target-A");
+  });
+});

--- a/src/hooks/auth/use-inline-reauth.ts
+++ b/src/hooks/auth/use-inline-reauth.ts
@@ -24,13 +24,18 @@ interface InlineRecentSessionDialogProps {
   actionLabel: string;
 }
 
-interface UseInlineReauthResult {
+interface UseInlineReauthResult<T> {
   /** Spread into <PasskeyReauthDialog>. cancelLabel must still be provided by the caller (its source namespace varies). */
   reauthDialogProps: InlineReauthDialogProps;
   /** Spread into <RecentSessionRequiredDialog>. cancelLabel must still be provided by the caller. */
   recentSessionDialogProps: InlineRecentSessionDialogProps;
-  /** Call this from the SESSION_STEP_UP_REQUIRED branch of the API error handler. */
-  triggerOnStaleError: () => Promise<void>;
+  /**
+   * Call this from the SESSION_STEP_UP_REQUIRED branch of the API error handler.
+   * Pass the retry argument identifying which mutation to replay after reauth
+   * (a row id, a discriminated action, …); it is handed back to `onSuccess`.
+   * Single-action callers omit it (`T = void`).
+   */
+  triggerOnStaleError: (retryArg: T) => Promise<void>;
 }
 
 /**
@@ -50,19 +55,33 @@ interface UseInlineReauthResult {
  * Operator Token has a more complex retry path (limit-exceeded vs second
  * stale-session vs generic retry-failed) and does NOT use this hook — see
  * `operator-token-card.tsx` for that flow.
+ *
+ * Retry argument:
+ *  - Multi-target callers (a list of rows, or several distinct mutations
+ *    behind one hook) pass `triggerOnStaleError(arg)` to record WHICH mutation
+ *    failed; the hook stores it and hands it back to `onSuccess(arg)` on
+ *    reauth success, and clears it when the dialog is dismissed. This replaces
+ *    the hand-written `reauthTargetId` useState + clear-on-cancel apparatus
+ *    each caller used to maintain.
+ *  - Single-action callers use the default `T = void`: call
+ *    `triggerOnStaleError()` and ignore the arg in `onSuccess`.
  */
-export function useInlineReauth(
-  onSuccess: () => Promise<void>,
-): UseInlineReauthResult {
+export function useInlineReauth<T = void>(
+  onSuccess: (retryArg: T) => Promise<void>,
+): UseInlineReauthResult<T> {
   const tAuth = useTranslations("Auth");
 
   const [reauthOpen, setReauthOpen] = useState(false);
   const [reauthenticating, setReauthenticating] = useState(false);
   const [reauthError, setReauthError] = useState<string | null>(null);
   const [recentSessionOpen, setRecentSessionOpen] = useState(false);
+  // The mutation to replay after reauth. Owned here so callers no longer
+  // maintain their own retry-target state + clear-on-cancel plumbing.
+  const [retryArg, setRetryArg] = useState<T | undefined>(undefined);
 
-  const triggerOnStaleError = async () => {
+  const triggerOnStaleError = async (arg: T) => {
     setReauthError(null);
+    setRetryArg(arg);
     if (await canUsePasskeyRecovery()) {
       setReauthOpen(true);
     } else {
@@ -84,16 +103,33 @@ export function useInlineReauth(
         return;
       }
       setReauthOpen(false);
-      await onSuccess();
+      // `retryArg` is set by `triggerOnStaleError(arg)` before this dialog can
+      // open, so it holds a `T` on every path that reaches here; the stored
+      // `undefined` only exists pre-trigger and after dismissal (which never
+      // calls onSuccess). For the `T = void` default the cast is a no-op.
+      const arg = retryArg as T;
+      setRetryArg(undefined);
+      await onSuccess(arg);
     } finally {
       setReauthenticating(false);
     }
   };
 
+  // Clearing retryArg on dismissal mirrors the per-caller clear-on-cancel
+  // behaviour that previously lived in each component's dialog onOpenChange.
+  const handleReauthOpenChange = (open: boolean) => {
+    setReauthOpen(open);
+    if (!open) setRetryArg(undefined);
+  };
+  const handleRecentSessionOpenChange = (open: boolean) => {
+    setRecentSessionOpen(open);
+    if (!open) setRetryArg(undefined);
+  };
+
   return {
     reauthDialogProps: {
       open: reauthOpen,
-      onOpenChange: setReauthOpen,
+      onOpenChange: handleReauthOpenChange,
       title: tAuth("reauthTitle"),
       description: tAuth("reauthDescription"),
       actionLabel: tAuth("reauthAction"),
@@ -103,7 +139,7 @@ export function useInlineReauth(
     },
     recentSessionDialogProps: {
       open: recentSessionOpen,
-      onOpenChange: setRecentSessionOpen,
+      onOpenChange: handleRecentSessionOpenChange,
       title: tAuth("recentSessionTitle"),
       description: tAuth("recentSessionDescription"),
       actionLabel: tAuth("recentSessionAction"),


### PR DESCRIPTION
## Summary

Eight components call server-side step-up-gated routes (`requireRecentCurrentAuthMethod`) but had **no client recovery** for the `SESSION_STEP_UP_REQUIRED` 403. On a stale session the user hit a generic error toast (or an inline error string) with no way to re-authenticate and retry — a UX dead-end. This is the same bug class fixed for the admin vault-reset **initiate** button in PR `#625` (F2); this PR is the lateral expansion to the rest of the callers.

The fix wires `useInlineReauth` (inline per-component convention; `api-key-manager.tsx` is the reference) into each 403 branch. A stale session now opens the passkey / recent-session reauth dialog and replays the original mutation on success.

## Components fixed

| Component | Step-up-gated method(s) wired |
|---|---|
| `settings/developer/directory-sync-card.tsx` | create `POST`, update `PUT`, delete `DELETE` |
| `team/security/team-rotate-key-button.tsx` | rotate `POST` |
| `team/members/team-add-from-tenant-section.tsx` | add-member `POST` |
| `breakglass/breakglass-dialog.tsx` | grant create `POST` |
| `breakglass/breakglass-grant-list.tsx` | grant revoke `DELETE` |
| `settings/security/passkey-credentials-card.tsx` | credential delete `DELETE` |
| `settings/developer/audit-delivery-target-card.tsx` | create `POST`, active-toggle `PATCH` |
| `app/[locale]/vault-reset/page.tsx` | self-reset `POST` |

### Scope corrections during implementation (verified against the routes)

- **directory-sync** — the handoff listed only `PUT`/`DELETE`, but `POST` (create) is also step-up-gated; all three are wired.
- **passkey-credentials-card** — only `DELETE` is step-up-gated. The rename `PATCH` (and the PRF-rebootstrap `POST`) are **not** gated, so they are intentionally left untouched (wiring them would be dead code).

## Tests

- Each component gets an **RT8 step-up-denial test**: a 403 `SESSION_STEP_UP_REQUIRED` opens the reauth dialog and the mutation is **not** committed (no success toast / no navigation / `onSuccess` not fired).
- Added the missing `useLocale` mock to the `next-intl` stubs in the four existing tests that now render the reauth dialogs (the dialogs call `useLocale()`).
- New test files for the two components that lacked one: `vault-reset/page.test.tsx`; `team-add-from-tenant-section` RT8 added to its existing `__tests__/` file.

## Verification

- `npx vitest run` — 11930 passed, 1 skipped
- `npx next build` — succeeds
- `bash scripts/pre-pr.sh` — 40/40 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)