### PR TITLE
fix(maintenance): fail-closed tenant-scoped rate limits, canonical OpenAPI host, bounded rate-limit eviction

### DIFF
--- a/scripts/checks/check-fail-closed-routes-have-test.sh
+++ b/scripts/checks/check-fail-closed-routes-have-test.sh
@@ -112,7 +112,12 @@ fi
 # 63 incl. the 2 admin-vault-reset trigger limiters (adminResetLimiter +
 #   targetResetLimiter, tenant/members/[userId]/reset-vault) — destructive
 #   privileged action, found by the rateLimited() audit during that PR.
-EXPECTED_LIMITER_COUNT=63
+# 69 incl. 6 maintenance limiters converted from fail-open + global key to
+#   fail-closed + per-tenant key (purge-history, purge-audit-logs,
+#   audit-outbox-metrics, audit-outbox-purge-failed, dcr-cleanup,
+#   audit-chain-verify) — external-review hygiene: a Redis outage must not
+#   shed the throttle on destructive/privileged maintenance ops.
+EXPECTED_LIMITER_COUNT=69
 limiter_count=$(grep -rh 'failClosedOnRedisError: true' "$REPO_ROOT/src/app/api" | wc -l)
 if [ "$limiter_count" -ne "$EXPECTED_LIMITER_COUNT" ]; then
   echo "AC4.4 FAIL: expected $EXPECTED_LIMITER_COUNT 'failClosedOnRedisError: true' instantiations; found $limiter_count"

--- a/src/__tests__/api/v1/openapi-json.test.ts
+++ b/src/__tests__/api/v1/openapi-json.test.ts
@@ -20,6 +20,11 @@ describe("GET /api/v1/openapi.json", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    // Canonical origin configured — the servers[] host derives from it and the
+    // public response is cacheable. Tests exercising the no-origin fallback
+    // override this locally.
+    vi.stubEnv("APP_URL", "https://api.example.test");
+    vi.stubEnv("AUTH_URL", "https://api.example.test");
   });
 
   afterEach(() => {
@@ -47,6 +52,26 @@ describe("GET /api/v1/openapi.json", () => {
 
       expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
       expect(res.headers.get("Vary")).toBe("Authorization");
+    });
+
+    it("derives servers[].url from the configured origin, not the request Host", async () => {
+      const { GET } = await import("@/app/api/v1/openapi.json/route");
+
+      const req = createRequest("GET", "http://attacker.evil/api/v1/openapi.json");
+      await GET(req);
+
+      expect(mockBuildOpenApiSpec).toHaveBeenCalledWith("https://api.example.test");
+    });
+
+    it("falls back to no-store (not public cache) when no origin is configured", async () => {
+      vi.stubEnv("APP_URL", "");
+      vi.stubEnv("AUTH_URL", "");
+      const { GET } = await import("@/app/api/v1/openapi.json/route");
+
+      const req = createRequest("GET", URL);
+      const res = await GET(req);
+
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
     });
   });
 

--- a/src/app/api/maintenance/audit-chain-verify/route.test.ts
+++ b/src/app/api/maintenance/audit-chain-verify/route.test.ts
@@ -122,6 +122,14 @@ describe("GET /api/maintenance/audit-chain-verify", () => {
     expect(res.status).toBe(429);
   });
 
+  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+    mockCheck.mockResolvedValue({ redisErrored: true });
+    const req = createRequest({ tenantId: TENANT_ID }, VALID_OP_TOKEN);
+    const res = await GET(req);
+    expect(res.status).toBe(503);
+  });
+
   // ─── Query Validation ────────────────────────────────────
 
   it("returns 400 when tenantId query param is missing", async () => {

--- a/src/app/api/maintenance/audit-chain-verify/route.ts
+++ b/src/app/api/maintenance/audit-chain-verify/route.ts
@@ -15,12 +15,13 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { verifyAdminToken } from "@/lib/auth/tokens/admin-token";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { requireMaintenanceOperator } from "@/lib/auth/access/maintenance-auth";
 import { withRequestLog } from "@/lib/http/with-request-log";
-import { errorResponse, rateLimited, unauthorized, forbidden } from "@/lib/http/api-response";
+import { errorResponse, unauthorized, forbidden } from "@/lib/http/api-response";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { parseQuery } from "@/lib/http/parse-body";
 import {
@@ -31,7 +32,13 @@ import {
 import { MS_PER_DAY } from "@/lib/constants/time";
 import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 
-const rateLimiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 3 });
+// Fail-closed on Redis error; the tenant-scoped key uses the operator-token's
+// bound tenant (auth.tenantId), not the caller-supplied query param.
+const rateLimiter = createRateLimiter({
+  windowMs: RATE_WINDOW_MS,
+  max: 3,
+  failClosedOnRedisError: true,
+});
 
 const FIVE_YEARS_MS = 5 * 365 * MS_PER_DAY;
 const MAX_ROWS_PER_REQUEST = 10_000;
@@ -97,11 +104,15 @@ async function handleGET(req: NextRequest) {
   }
   const { auth } = authResult;
 
-  const tenantIdParam = req.nextUrl.searchParams.get("tenantId") ?? "global";
-  const rl = await rateLimiter.check(`rl:admin:chain-verify:${tenantIdParam}`);
-  if (!rl.allowed) {
-    return rateLimited(rl.retryAfterMs);
-  }
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: rateLimiter,
+    key: `rl:maintenance:chain-verify:${auth.tenantId}`,
+    scope: "maintenance.chain_verify",
+    userId: auth.subjectUserId,
+    tenantId: auth.tenantId,
+  });
+  if (blocked) return blocked;
 
   const querySchema = buildQuerySchema();
   const result = parseQuery(req, querySchema);

--- a/src/app/api/maintenance/audit-outbox-metrics/route.test.ts
+++ b/src/app/api/maintenance/audit-outbox-metrics/route.test.ts
@@ -124,6 +124,14 @@ describe("GET /api/maintenance/audit-outbox-metrics", () => {
     expect(res.status).toBe(429);
   });
 
+  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+    mockCheck.mockResolvedValue({ redisErrored: true });
+    const req = createRequest(VALID_OP_TOKEN);
+    const res = await GET(req);
+    expect(res.status).toBe(503);
+  });
+
   // ─── Operator Membership Check ────────────────────────────
 
   it("returns 400 when operator is not an active admin", async () => {

--- a/src/app/api/maintenance/audit-outbox-metrics/route.ts
+++ b/src/app/api/maintenance/audit-outbox-metrics/route.ts
@@ -12,15 +12,22 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { verifyAdminToken } from "@/lib/auth/tokens/admin-token";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { requireMaintenanceOperator } from "@/lib/auth/access/maintenance-auth";
 import { withRequestLog } from "@/lib/http/with-request-log";
-import { rateLimited, unauthorized } from "@/lib/http/api-response";
+import { unauthorized } from "@/lib/http/api-response";
 import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 
-const rateLimiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 6 });
+// Keyed per-tenant so one tenant's operator cannot exhaust another tenant's
+// metrics quota in the same window; fail-closed on Redis error.
+const rateLimiter = createRateLimiter({
+  windowMs: RATE_WINDOW_MS,
+  max: 6,
+  failClosedOnRedisError: true,
+});
 
 interface MetricsRow {
   pending: bigint;
@@ -38,10 +45,15 @@ async function handleGET(req: NextRequest) {
   }
   const { auth } = authResult;
 
-  const rl = await rateLimiter.check("rl:admin:outbox-metrics");
-  if (!rl.allowed) {
-    return rateLimited(rl.retryAfterMs);
-  }
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: rateLimiter,
+    key: `rl:maintenance:outbox-metrics:${auth.tenantId}`,
+    scope: "maintenance.outbox_metrics",
+    userId: auth.subjectUserId,
+    tenantId: auth.tenantId,
+  });
+  if (blocked) return blocked;
 
   const op = await requireMaintenanceOperator(auth.subjectUserId, {
     tenantId: auth.tenantId,

--- a/src/app/api/maintenance/audit-outbox-purge-failed/route.test.ts
+++ b/src/app/api/maintenance/audit-outbox-purge-failed/route.test.ts
@@ -118,6 +118,14 @@ describe("POST /api/maintenance/audit-outbox-purge-failed", () => {
     expect(res.status).toBe(429);
   });
 
+  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+    mockCheck.mockResolvedValue({ redisErrored: true });
+    const req = createRequest({}, VALID_OP_TOKEN);
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+  });
+
   // ─── Operator Membership Check ────────────────────────────
 
   it("returns 400 when operator is not an active admin", async () => {

--- a/src/app/api/maintenance/audit-outbox-purge-failed/route.ts
+++ b/src/app/api/maintenance/audit-outbox-purge-failed/route.ts
@@ -17,15 +17,22 @@ import { prisma } from "@/lib/prisma";
 import { parseBody } from "@/lib/http/parse-body";
 import { verifyAdminToken } from "@/lib/auth/tokens/admin-token";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit/audit";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { requireMaintenanceOperator } from "@/lib/auth/access/maintenance-auth";
 import { withRequestLog } from "@/lib/http/with-request-log";
-import { rateLimited, unauthorized, forbidden } from "@/lib/http/api-response";
+import { unauthorized, forbidden } from "@/lib/http/api-response";
 import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 
-const rateLimiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 1 });
+// Fail-closed on Redis error and keyed per-tenant so one tenant's operator
+// cannot 429 another tenant's purge in the same window.
+const rateLimiter = createRateLimiter({
+  windowMs: RATE_WINDOW_MS,
+  max: 1,
+  failClosedOnRedisError: true,
+});
 
 const bodySchema = z.object({
   tenantId: z.string().uuid().optional(),
@@ -39,10 +46,15 @@ async function handlePOST(req: NextRequest) {
   }
   const { auth } = authResult;
 
-  const rl = await rateLimiter.check("rl:admin:outbox-purge");
-  if (!rl.allowed) {
-    return rateLimited(rl.retryAfterMs);
-  }
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: rateLimiter,
+    key: `rl:maintenance:outbox-purge:${auth.tenantId}`,
+    scope: "maintenance.outbox_purge",
+    userId: auth.subjectUserId,
+    tenantId: auth.tenantId,
+  });
+  if (blocked) return blocked;
 
   const result = await parseBody(req, bodySchema);
   if (!result.ok) return result.response;

--- a/src/app/api/maintenance/dcr-cleanup/route.test.ts
+++ b/src/app/api/maintenance/dcr-cleanup/route.test.ts
@@ -102,6 +102,14 @@ describe("POST /api/maintenance/dcr-cleanup (410 deprecation stub)", () => {
     expect(res.status).toBe(429);
   });
 
+  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+    mockCheck.mockResolvedValue({ redisErrored: true });
+    const req = createRequest(VALID_OP_TOKEN);
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+  });
+
   it("checks rate limit after auth (401 before 429 for unauthenticated requests)", async () => {
     mockCheck.mockResolvedValue({ allowed: false, retryAfterMs: 30_000 });
 

--- a/src/app/api/maintenance/dcr-cleanup/route.ts
+++ b/src/app/api/maintenance/dcr-cleanup/route.ts
@@ -16,14 +16,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdminToken } from "@/lib/auth/tokens/admin-token";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit/audit";
 import { requireMaintenanceOperator } from "@/lib/auth/access/maintenance-auth";
 import { withRequestLog } from "@/lib/http/with-request-log";
-import { rateLimited, unauthorized } from "@/lib/http/api-response";
+import { unauthorized } from "@/lib/http/api-response";
 import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 
-const rateLimiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 1 });
+// Keyed per-tenant + fail-closed on Redis error for parity with the other
+// maintenance routes, even though this endpoint is a 410-Gone stub.
+const rateLimiter = createRateLimiter({
+  windowMs: RATE_WINDOW_MS,
+  max: 1,
+  failClosedOnRedisError: true,
+});
 
 async function handlePOST(req: NextRequest) {
   const authResult = await verifyAdminToken(req);
@@ -32,10 +39,15 @@ async function handlePOST(req: NextRequest) {
   }
   const { auth } = authResult;
 
-  const rl = await rateLimiter.check("rl:admin:dcr-cleanup");
-  if (!rl.allowed) {
-    return rateLimited(rl.retryAfterMs);
-  }
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: rateLimiter,
+    key: `rl:maintenance:dcr-cleanup:${auth.tenantId}`,
+    scope: "maintenance.dcr_cleanup",
+    userId: auth.subjectUserId,
+    tenantId: auth.tenantId,
+  });
+  if (blocked) return blocked;
 
   const op = await requireMaintenanceOperator(auth.subjectUserId, {
     tenantId: auth.tenantId,

--- a/src/app/api/maintenance/purge-audit-logs/route.test.ts
+++ b/src/app/api/maintenance/purge-audit-logs/route.test.ts
@@ -131,6 +131,14 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
     expect(res.status).toBe(429);
   });
 
+  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+    mockCheck.mockResolvedValue({ redisErrored: true });
+    const req = createRequest({}, VALID_OP_TOKEN);
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+  });
+
   it("checks rate limit after auth (401 before 429 for unauthenticated requests)", async () => {
     mockCheck.mockResolvedValue({ allowed: false, retryAfterMs: 30_000 });
 

--- a/src/app/api/maintenance/purge-audit-logs/route.ts
+++ b/src/app/api/maintenance/purge-audit-logs/route.ts
@@ -16,6 +16,7 @@ import { prisma } from "@/lib/prisma";
 import { parseBody } from "@/lib/http/parse-body";
 import { verifyAdminToken } from "@/lib/auth/tokens/admin-token";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit/audit";
 import { AUDIT_METADATA_KEY } from "@/lib/constants";
@@ -24,12 +25,19 @@ import { requireMaintenanceOperator } from "@/lib/auth/access/maintenance-auth";
 import { MS_PER_DAY } from "@/lib/constants/time";
 import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 import { withRequestLog } from "@/lib/http/with-request-log";
-import { rateLimited, unauthorized } from "@/lib/http/api-response";
+import { unauthorized } from "@/lib/http/api-response";
 
 // Rate limiter shares the same key for dryRun and real calls intentionally:
 // preventing probe→exploit racing (an admin cannot dry-run-probe matching
 // counts then immediately delete within the same 60-second window).
-const rateLimiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 1 });
+// Fail-closed on Redis error: a destructive maintenance op must not shed its
+// throttle during a Redis outage. Keyed per-tenant so one tenant's operator
+// cannot 429 another tenant's purge in the same window.
+const rateLimiter = createRateLimiter({
+  windowMs: RATE_WINDOW_MS,
+  max: 1,
+  failClosedOnRedisError: true,
+});
 
 const bodySchema = z.object({
   retentionDays: z.number().int().min(30).max(3650).default(365),
@@ -85,10 +93,15 @@ async function handlePOST(req: NextRequest) {
   }
   const { auth } = authResult;
 
-  const rl = await rateLimiter.check("rl:admin:purge-audit-logs");
-  if (!rl.allowed) {
-    return rateLimited(rl.retryAfterMs);
-  }
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: rateLimiter,
+    key: `rl:maintenance:purge-audit-logs:${auth.tenantId}`,
+    scope: "maintenance.purge_audit_logs",
+    userId: auth.subjectUserId,
+    tenantId: auth.tenantId,
+  });
+  if (blocked) return blocked;
 
   const result = await parseBody(req, bodySchema);
   if (!result.ok) return result.response;

--- a/src/app/api/maintenance/purge-history/route.test.ts
+++ b/src/app/api/maintenance/purge-history/route.test.ts
@@ -119,6 +119,15 @@ describe("POST /api/maintenance/purge-history", () => {
     expect(res.status).toBe(429);
   });
 
+  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+    mockCheck.mockResolvedValue({ redisErrored: true });
+    const req = createRequest({}, VALID_OP_TOKEN);
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    expect(mockDeleteMany).not.toHaveBeenCalled();
+  });
+
   it("checks rate limit after auth (401 before 429 for unauthenticated requests)", async () => {
     mockCheck.mockResolvedValue({ allowed: false, retryAfterMs: 30_000 });
 

--- a/src/app/api/maintenance/purge-history/route.ts
+++ b/src/app/api/maintenance/purge-history/route.ts
@@ -15,6 +15,7 @@ import { prisma } from "@/lib/prisma";
 import { parseBody } from "@/lib/http/parse-body";
 import { verifyAdminToken } from "@/lib/auth/tokens/admin-token";
 import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
 import { AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit/audit";
 import { AUDIT_METADATA_KEY } from "@/lib/constants";
@@ -23,12 +24,19 @@ import { requireMaintenanceOperator } from "@/lib/auth/access/maintenance-auth";
 import { MS_PER_DAY } from "@/lib/constants/time";
 import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 import { withRequestLog } from "@/lib/http/with-request-log";
-import { rateLimited, unauthorized } from "@/lib/http/api-response";
+import { unauthorized } from "@/lib/http/api-response";
 
 // Rate limiter shares the same key for dryRun and real calls intentionally:
 // preventing probe→exploit racing (an admin cannot dry-run-probe matching
 // counts then immediately delete within the same 60-second window).
-const rateLimiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 1 });
+// Fail-closed on Redis error: a destructive maintenance op must not shed its
+// throttle during a Redis outage. Keyed per-tenant so one tenant's operator
+// cannot 429 another tenant's purge in the same window.
+const rateLimiter = createRateLimiter({
+  windowMs: RATE_WINDOW_MS,
+  max: 1,
+  failClosedOnRedisError: true,
+});
 
 const bodySchema = z.object({
   retentionDays: z.number().int().min(1).max(3650).default(90),
@@ -42,10 +50,15 @@ async function handlePOST(req: NextRequest) {
   }
   const { auth } = authResult;
 
-  const rl = await rateLimiter.check("rl:admin:purge-history");
-  if (!rl.allowed) {
-    return rateLimited(rl.retryAfterMs);
-  }
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: rateLimiter,
+    key: `rl:maintenance:purge-history:${auth.tenantId}`,
+    scope: "maintenance.purge_history",
+    userId: auth.subjectUserId,
+    tenantId: auth.tenantId,
+  });
+  if (blocked) return blocked;
 
   const result = await parseBody(req, bodySchema);
   if (!result.ok) return result.response;

--- a/src/app/api/v1/openapi.json/route.test.ts
+++ b/src/app/api/v1/openapi.json/route.test.ts
@@ -33,8 +33,9 @@ describe("GET /api/v1/openapi.json", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
-    // Default: public mode (no auth required)
-    delete process.env.OPENAPI_PUBLIC;
+    // Default: public mode (no auth required). Empty string is not "false",
+    // so the route treats it as public.
+    vi.stubEnv("OPENAPI_PUBLIC", "");
     // Canonical origin configured — the servers[] host derives from it and the
     // response is public-cacheable. Tests that exercise the no-origin fallback
     // override this locally.
@@ -59,7 +60,7 @@ describe("GET /api/v1/openapi.json", () => {
   });
 
   it("returns 401 when OPENAPI_PUBLIC=false and unauthenticated", async () => {
-    process.env.OPENAPI_PUBLIC = "false";
+    vi.stubEnv("OPENAPI_PUBLIC", "false");
     mockAuthOrToken.mockResolvedValue(null);
     const req = createRequest("GET", "http://localhost:3000/api/v1/openapi.json");
     const res = await GET(req);
@@ -69,7 +70,7 @@ describe("GET /api/v1/openapi.json", () => {
   });
 
   it("returns spec when OPENAPI_PUBLIC=false and authenticated", async () => {
-    process.env.OPENAPI_PUBLIC = "false";
+    vi.stubEnv("OPENAPI_PUBLIC", "false");
     mockAuthOrToken.mockResolvedValue({ userId: "user-1" });
     const req = createRequest("GET", "http://localhost:3000/api/v1/openapi.json");
     const res = await GET(req);
@@ -79,7 +80,7 @@ describe("GET /api/v1/openapi.json", () => {
   });
 
   it("sets private cache headers when OPENAPI_PUBLIC=false", async () => {
-    process.env.OPENAPI_PUBLIC = "false";
+    vi.stubEnv("OPENAPI_PUBLIC", "false");
     mockAuthOrToken.mockResolvedValue({ userId: "user-1" });
     const req = createRequest("GET", "http://localhost:3000/api/v1/openapi.json");
     const res = await GET(req);

--- a/src/app/api/v1/openapi.json/route.test.ts
+++ b/src/app/api/v1/openapi.json/route.test.ts
@@ -32,8 +32,14 @@ import { GET } from "./route";
 describe("GET /api/v1/openapi.json", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     // Default: public mode (no auth required)
     delete process.env.OPENAPI_PUBLIC;
+    // Canonical origin configured — the servers[] host derives from it and the
+    // response is public-cacheable. Tests that exercise the no-origin fallback
+    // override this locally.
+    vi.stubEnv("APP_URL", "https://api.example.test");
+    vi.stubEnv("AUTH_URL", "https://api.example.test");
   });
 
   it("returns OpenAPI spec without auth when OPENAPI_PUBLIC is not 'false'", async () => {
@@ -81,9 +87,21 @@ describe("GET /api/v1/openapi.json", () => {
     expect(res.headers.get("Cache-Control")).toContain("no-store");
   });
 
-  it("passes baseUrl derived from request to buildOpenApiSpec", async () => {
-    const req = createRequest("GET", "http://localhost:3000/api/v1/openapi.json");
+  it("derives baseUrl from the configured origin, not the request Host", async () => {
+    // Request arrives on an internal/attacker-controllable host; the spec must
+    // still advertise the canonical configured origin, never the request host.
+    const req = createRequest("GET", "http://attacker.evil/api/v1/openapi.json");
     await GET(req);
+    expect(mockBuildOpenApiSpec).toHaveBeenCalledWith("https://api.example.test");
+  });
+
+  it("falls back to no-store (not public cache) when no origin is configured", async () => {
+    vi.stubEnv("APP_URL", "");
+    vi.stubEnv("AUTH_URL", "");
+    const req = createRequest("GET", "http://localhost:3000/api/v1/openapi.json");
+    const res = await GET(req);
+    // Host came from the request → must not be public-cached (poisoning guard).
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
     expect(mockBuildOpenApiSpec).toHaveBeenCalledWith("http://localhost:3000");
   });
 });

--- a/src/app/api/v1/openapi.json/route.ts
+++ b/src/app/api/v1/openapi.json/route.ts
@@ -4,6 +4,7 @@ import { authOrToken } from "@/lib/auth/session/auth-or-token";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { errorResponse } from "@/lib/http/api-response";
 import { API_ERROR } from "@/lib/http/api-error-codes";
+import { getAppOrigin, resolveBasePath } from "@/lib/url-helpers";
 
 // GET /api/v1/openapi.json — OpenAPI 3.1 specification
 async function handleGET(req: NextRequest) {
@@ -19,13 +20,37 @@ async function handleGET(req: NextRequest) {
     }
   }
 
-  const url = new URL(req.url);
-  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
-  const baseUrl = `${url.protocol}//${url.host}${basePath}`;
+  // Derive the servers[].url from the configured canonical origin
+  // (APP_URL/AUTH_URL), never from the request Host header. A request-derived
+  // host lets a Host-header-poisoning request inject an attacker domain into
+  // the spec's servers[], which the public cache below would then serve to
+  // other clients. This mirrors the host policy used elsewhere (e.g. the
+  // mobile authorize redirect helper). When no origin is configured, fall back
+  // to a request-derived base but never public-cache it.
+  const origin = getAppOrigin();
+  let baseUrl: string;
+  let hostIsCanonical: boolean;
+  if (origin) {
+    const base = new URL(origin);
+    baseUrl = `${base.origin}${resolveBasePath(base)}`;
+    hostIsCanonical = true;
+  } else {
+    const url = new URL(req.url);
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+    baseUrl = `${url.protocol}//${url.host}${basePath}`;
+    hostIsCanonical = false;
+  }
   const spec = buildOpenApiSpec(baseUrl);
 
+  // Public-cache only when the servers[] host came from configured origin.
+  // A request-derived host must not be cached (would poison other clients).
+  const publicCacheable = isPublic && hostIsCanonical;
   const headers: Record<string, string> = {
-    "Cache-Control": isPublic ? "public, max-age=3600" : "private, no-store",
+    "Cache-Control": publicCacheable
+      ? "public, max-age=3600"
+      : isPublic
+        ? "no-store"
+        : "private, no-store",
   };
   if (isPublic) {
     headers["Vary"] = "Authorization";

--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -120,8 +120,16 @@ export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
         for (const [k, v] of store) {
           if (v.resetAt < now) store.delete(k);
         }
-        // If still too large, clear all
-        if (store.size >= RATE_LIMIT_MAP_MAX_SIZE) store.clear();
+        // If still too large, drop the OLDEST entries (Maps preserve insertion
+        // order) until back under cap. NEVER clear all: a flood of distinct
+        // keys during a Redis outage would otherwise reset every live counter,
+        // handing attackers a rate-limit reset. Mirrors the bounded-LRU
+        // eviction in rate-limit-audit.ts (pruneAndAdd).
+        while (store.size >= RATE_LIMIT_MAP_MAX_SIZE) {
+          const oldest = store.keys().next();
+          if (oldest.done) break;
+          store.delete(oldest.value);
+        }
       }
       store.set(key, { resetAt: now + windowMs, count: 1 });
       return { allowed: true };


### PR DESCRIPTION
## Summary

Three hygiene fixes from an external security review, all Minor severity and none a merge blocker:

1. **Maintenance rate limiters** — six `/api/maintenance/*` routes used a **global** rate-limit key and defaulted to **fail-open**. During a Redis outage the throttle silently dropped on destructive purges, and one tenant's operator could `429` another tenant's op within the same window. All six now route through `checkRateLimitOrFail` with `failClosedOnRedisError: true` and a **per-tenant key** (`auth.tenantId`).
2. **OpenAPI host** — `/api/v1/openapi.json` derived `servers[].url` from the request `Host` header and public-cached the result, letting a Host-poisoning request inject an attacker domain into the cached spec. The host is now derived from the configured origin (`getAppOrigin()` / `resolveBasePath()`); when unset it falls back to the request host but is never public-cached.
3. **Rate-limit memory fallback** — the in-memory fallback in `rate-limit.ts` called `store.clear()` on overflow, handing a rate-limit reset to a key-flood during a Redis outage. Replaced with bounded-LRU eviction (mirrors `rate-limit-audit.ts`).

## Motivation

An external reviewer flagged four findings. Finding 1 (`GET /api/mobile/authorize` issuing a bridge code as a side-effectful GET) was verified as **not-a-vuln** — DPoP proof-of-possession at token exchange plus a fixed custom-scheme redirect leave no attacker-usable token path — and is intentionally **not** addressed here. This PR handles the three real-but-Minor findings (2–4), each of which already had a correct in-repo precedent to follow.

## Implementation notes

- **Finding 2**: `purge-history`, `purge-audit-logs`, `audit-outbox-metrics`, `audit-outbox-purge-failed`, `dcr-cleanup` moved from a global `rl:admin:*` key to `rl:maintenance:<op>:${auth.tenantId}` via `checkRateLimitOrFail` (unifies the 503-on-Redis-error path with the mobile/vault routes). `audit-chain-verify` was already tenant-scoped but keyed on the **caller-supplied** `tenantId` query param (default `"global"`); it now keys on the operator token's bound `auth.tenantId` and is fail-closed.
- **Finding 3**: `openapi.json/route.ts` builds `baseUrl` from `getAppOrigin()`; a request-derived host is returned with `Cache-Control: no-store` and never public-cached.
- **Finding 4**: `rate-limit.ts` `checkMemory` overflow now drops oldest entries until under cap, never clearing the whole map.
- Each newly fail-closed maintenance route gets a `redisErrored → 503` regression test (satisfies the `check-fail-closed-routes-have-test` CI gate, AC4.3); `EXPECTED_LIMITER_COUNT` bumped 63 → 69.

## Follow-up (out of scope, noted for a separate PR)

36 non-maintenance routes still call `limiter.check()` directly and are fail-open (normal CRUD/read paths — passwords, share-links, sends, sessions, watchtower, etc.). Converting those requires a per-route availability-vs-security judgment (fail-closed would `503` normal vault reads during a Redis outage) and is deliberately left out of this hygiene PR. `tenant/members/[userId]/reset-vault` already fail-closes correctly via a hand-written two-limiter branch and is left as-is.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` (maintenance + both openapi suites + rate-limit) — 107 passed, incl. 6 new fail-closed 503 tests
- [x] `npx next build` — succeeds
- [x] `scripts/pre-pr.sh` — all 40 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)