### PR TITLE
fix(ios): heal biometric unlock on stale cache + collapse concurrent token refreshes

### DIFF
--- a/docs/archive/review/ios-biometric-stale-cache-resync-code-review.md
+++ b/docs/archive/review/ios-biometric-stale-cache-resync-code-review.md
@@ -1,0 +1,142 @@
+# Code Review: ios-biometric-stale-cache-resync
+
+Date: 2026-07-04
+Review round: 1 (incremental — on top of Phase 2 self-R-check baseline)
+
+## Changes from Previous Round
+
+Initial code review. Phase 2 Step 2-5 self-R-check already returned "No findings"
+from all three experts (R1-R42 + RS*/RT*). Phase 3 Round 1 targeted NOVEL angles
+the rote R-check does not cover: SwiftUI data-flow, control-flow completeness on
+the new early-return path, security composition with surrounding readers, and the
+passphrase-path behavior change. The three Phase-3 sub-agents hit the session
+token limit mid-review; their verified conclusions (captured before termination)
+plus the orchestrator's direct verification of the remaining open questions are
+consolidated below.
+
+## Functionality Findings
+
+- **F1 [Major] — Passphrase-path empty-vault regression.** `decidePostSync`
+  returned `.failLocked` for `(syncReport=nil, cacheRecovered=true,
+  persistedCache=nil)`. Since the passphrase path always sets `cacheRecovered=true`,
+  a **valid passphrase unlock** that then fails to sync AND has no persisted cache
+  (brand-new account with zero entries, or first unlock while offline) was routed
+  to `.vaultLocked` — a correct passphrase landing on the locked screen with no
+  data. The old code synthesized an empty vault here, which for the passphrase path
+  is the correct success state. This violated the spirit of INV-C5.2 (passphrase
+  offline behavior unchanged). The `.failLocked` fail-closed semantics belong ONLY
+  to the biometric `cacheRecovered=false` case (stale/rolled-back cache).
+  - **Fix (applied)**: added a distinct `.useEmptyCache` outcome. When
+    `cacheRecovered==true && sync-failed && persistedCache==nil` → `.useEmptyCache`
+    (synthesize empty vault, proceed to `.vaultUnlocked`). `.failLocked` now fires
+    ONLY when `cacheRecovered==false`. S2 is untouched (the empty cache is
+    synthesized, never read from disk; the `cacheRecovered==false` path still fails
+    closed). `PostSyncDecision.swift`, `RootView.swift` switch, and the AC-C5.4 test
+    updated; a new test pins the fail-closed direction for `cacheRecovered==false`.
+
+- **F2 [verified clean] — `.failLocked` early-return control flow.** On the
+  `.failLocked` path `handleVaultUnlocked` sets `appState=.vaultLocked` and returns
+  `false` before `onVaultReady`/`tokenRefresher`/`autoLockService.startTimer`. The
+  `autoLockService` created earlier is simply not started (no timer leak — it's a
+  local that is deinitialized); `hostSyncService` was assigned but is harmless
+  (overwritten on the next successful unlock). No resource leak that affects a
+  retry.
+
+- **F3 [verified clean] — SwiftUI data-flow for the error banner.** Setting the
+  `@State biometricErrorText` after `handleVaultUnlocked` (which set
+  `appState=.vaultLocked`) triggers one batched re-render; `body` → `.vaultLocked`
+  → `vaultLockedScreen` → `VaultUnlockView(externalError: biometricErrorText)`
+  reads the fresh value. The passphrase-attempt closure clears it (`:307`). Error
+  is displayed, not set-but-lost.
+
+- **F4 [verified clean] — zero-personal-entries keyVersion.** `syncedKeyVersion`
+  returns `max(1, nil ?? 1) = 1` when the synced cache has no personal entry —
+  consistent with the existing fresh-cache biometric path (`VaultUnlocker.swift:261`).
+  Not a bug.
+
+- **F5 [verified clean] — I/O error vs staleness in the catch.** `catch let error
+  as EntryCacheError` catches BOTH `.rejection` (stale/counter/AAD) AND `.ioError`
+  (corrupt/unreadable file). Degrading a corrupt local cache to `cacheRecovered=false`
+  → resync is correct (rebuild from server), same as staleness. Catching both is
+  intended.
+
+## Security Findings
+
+- **S1 [verified clean] — composition, no stale read on the resync path.**
+  `HostSyncService.performSync` on the unlock path always returns a non-nil
+  `cacheData` (`HostSyncService.swift:128,145-150`), so `syncReport != nil ⟹
+  cacheData != nil` and `.useFreshCache` never presents empty. On the
+  `cacheRecovered==false`→`.useFreshCache` path, `refreshCredentialIdentities`
+  receives `cacheData = syncReport.cacheData` (freshly synced), NOT the stale file
+  (`RootView.swift:451-453`). No other reader decodes the stale cache before the
+  resync overwrites it. S2 gating (readCacheFile unreachable when
+  `cacheRecovered==false`) re-confirmed in the committed code.
+- **S2 [verified clean] — F1 fix does not weaken fail-closed.** `.useEmptyCache`
+  fires only when `cacheRecovered==true`; the empty cache is synthesized, never read
+  from disk. The `cacheRecovered==false` path is unchanged (`.failLocked`). The
+  rollback/replay invariant is preserved.
+- **S3 [verified clean] — persisted userId integrity.** `recoveredUserId` flows to
+  `runSync`'s userId param + cache-header AAD + `refreshCredentialIdentities`. A
+  tampered App-Group userId causes self-healing AAD drift only; server authz is
+  DPoP-token-bound, not userId-bound (plan S3 confirmed in code).
+- **S4 [verified clean] — no sensitive log/state leak.** The `handleVaultUnlocked`
+  `Logger.error` line is pre-existing and logs a `MobileAPIError` description (no
+  token/userId/key). `biometricErrorText` only ever holds the static localized
+  "session out of date" string or `nil`.
+
+## Testing Findings
+
+- **T1 [addressed by F1 fix]** — AC-C5.4 was updated from `.failLocked` to
+  `.useEmptyCache` and a new `testDecidePostSync_failedSync_cacheless_stillFailsClosed`
+  pins the fail-closed direction for `cacheRecovered==false`. The passphrase-empty-vault
+  behavior is covered at the `decidePostSync` seam (the RootView switch only maps
+  `.useEmptyCache → emptyCacheData`, a trivial glue not independently testable
+  without a SwiftUI host — VC2-deferred, acceptable).
+- **T2 [verified clean]** — Phase 2 self-R-check already confirmed fails-before for
+  the three biometric regression tests, adequate coverage of the 4 new pure symbols,
+  and determinism (fixed `now` injection). No new gap introduced by the F1 fix.
+
+## Adjacent Findings
+
+None.
+
+## Quality Warnings
+
+None.
+
+## Recurring Issue Check
+
+Phase 2 Step 2-5 self-R-check ran the full R1-R42 (+ RS1-RS5 / RT1-RT7) pass with
+all three experts returning "No findings" (recorded in the Phase 2 completion
+report). Phase 3 incremental review surfaced one novel behavior-change finding
+(F1) outside the rote checklist and confirmed the rest clean. No R-rule regression
+introduced by the F1 fix (the `.useEmptyCache` addition is a pure-function branch +
+one switch case + two test updates).
+
+## Environment Verification Report
+
+Per the Phase 1 `Verification environment constraints`:
+- **VC1 (real Face ID/Touch ID prompt)**: `blocked-deferred (VC1)` — the biometric
+  keychain read is exercised via `MockKeychainAccessor`; the real Secure-Enclave
+  prompt requires a physical device (Anti-Deferral cost-justification recorded in
+  Phase 1). Everything downstream of the keychain read is `verified-local`.
+- **VC2 (SwiftUI state transitions)**: `blocked-deferred (VC2)` — RootView
+  `appState` transitions verified by code review + the pure-function tests
+  (`decidePostSync`/`biometricUnlockError`/`resolveDisplayError`); no SwiftUI test
+  host in the target (Anti-Deferral recorded in Phase 1).
+- All non-VC1/VC2 paths: `verified-local` — `xcodebuild test -scheme PasswdSSOApp`,
+  683 unit + 2 UI tests, 0 failures.
+
+## Resolution Status
+
+### F1 [Major] Passphrase-path empty-vault regression — FIXED
+- Action: added `.useEmptyCache` outcome to `PostSyncOutcome`; `decidePostSync`
+  returns it for `(nil, cacheRecovered=true, nil)` instead of `.failLocked`;
+  RootView switch maps it to `emptyCacheData`. Fail-closed (`.failLocked`) now fires
+  only for `cacheRecovered==false`.
+- Modified: `ios/PasswdSSOApp/Vault/PostSyncDecision.swift`,
+  `ios/PasswdSSOApp/Views/RootView.swift`,
+  `ios/PasswdSSOTests/PostSyncDecisionTests.swift`.
+- Verified: 683 unit tests pass.
+
+All other Phase-3 angles (F2-F5, S1-S4, T2) verified clean — no action needed.

--- a/docs/archive/review/ios-biometric-stale-cache-resync-code-review.md
+++ b/docs/archive/review/ios-biometric-stale-cache-resync-code-review.md
@@ -140,3 +140,118 @@ Per the Phase 1 `Verification environment constraints`:
 - Verified: 683 unit tests pass.
 
 All other Phase-3 angles (F2-F5, S1-S4, T2) verified clean — no action needed.
+
+---
+
+# Code Review: ios-biometric-stale-cache-resync — Round 2 (token-refresh replay fix)
+
+Date: 2026-07-04
+Review round: 2 (new scope — TokenRefreshCoordinator + sessionExpired, see deviation D4-D7)
+
+## Changes from Previous Round
+
+New scope discovered while verifying the stale-cache heal flow: concurrent/sequential
+token refreshes presented the same stale refresh token, tripping the server's
+refresh-token replay detector and revoking the token family (the same dead-session
+symptom this branch fixes). Added the `TokenRefreshCoordinator` actor (process-global
+single-flight + short success cache), `VaultUnlockError.sessionExpired` routing, and
+removed the verification-only diagnostic logging. Three sub-agents (functionality /
+security / testing) reviewed the working-tree diff + the two new files.
+
+## Functionality Findings
+
+- **F1 [Minor] — Contradictory doc comment on failure caching.**
+  `TokenRefreshCoordinator.swift` header claimed `authenticationRequired` is cached
+  on the failure side, but the code caches ONLY successes (correct, safe behavior).
+  Self-contradicts the inline comment + `testFailureIsNotCached`. Doc-only.
+- Cleared after tracing: single-flight join is race-free (no `await` between the
+  cache/in-flight checks and `inFlight` registration → atomic on the actor); the
+  `.networkError` rethrow stays retryable (not cached, not converted); both
+  `handleVaultUnlocked` call sites correct (biometric switches on the enum,
+  passphrase uses `@discardableResult`); all production sites use `.shared`.
+
+## Security Findings
+
+- **S1 [Minor, accepted] — No backoff on sequential `networkError` refresh
+  retrigger.** Failures are deliberately not cached, so on a transient network
+  failure each sequential unlock-flow step re-hits `/refresh`. Bounded (a handful of
+  steps per flow, not a loop), no client backoff exists anywhere on this path, and
+  `authenticationRequired` terminates the flow. Concurrent bursts are already
+  collapsed by the in-flight join.
+  - Anti-Deferral (acceptable risk): Worst case — a few extra `/refresh` calls
+    against one's own server under flapping connectivity (mild self-amplification,
+    not DoS). Likelihood — low (needs sustained transient failure mid-unlock).
+    Cost to fix — adding sub-second networkError caching or per-key backoff is net-new
+    behavior with its own edge cases; retrying a transient blip is arguably correct.
+    Not fixing: the retry is desirable, the amplification is negligible.
+- Cleared: no token/secret leakage (only surviving log is the pre-existing `sync`
+  logger over a `MobileAPIError`, which carries no token material); cache key is the
+  single-user Keychain service (no cross-boundary leak); the cached value is the
+  ACCESS token (never re-presented to `/refresh`, so it cannot trip the replay
+  detector or mask family revocation — a revoked token 401s on the next API call);
+  fail-closed never presents an empty vault as success and never wipes tokens.
+
+## Testing Findings
+
+- **T1 [Major] — Missing: flight that THROWS while callers are joined.** No test
+  covered failure propagation to joiners + `inFlight` cleanup + retryability — the
+  exact concurrent-dead-session path the fix targets.
+- **T2 [Major] — Missing: `.failedSessionExpired` vs `.failedOffline` banner
+  selection.** The load-bearing new discrimination (dead session vs offline) lived
+  inline in the untestable `@MainActor handleVaultUnlocked` and had zero coverage.
+- **T3 [Minor, accepted] — `testConcurrentCallersCollapseToSingleRefresh` uses a
+  100ms `Task.sleep`.** Cannot false-pass (a missed straggler pushes the count to 2 →
+  red, never a vacuous green), so acceptable; a barrier gate would make it
+  deterministic. Not changed.
+  - Anti-Deferral (acceptable risk): Worst case — a flaky RED under extreme CI load.
+    Likelihood — low (100ms is generous for 6-8 actor hops). Cost to fix — a second
+    barrier continuation; deferred as the failure mode is a visible red, not a
+    silent pass.
+- **T4 [Minor, accepted] — cache-precedence-over-in-flight not directly tested.**
+  Ordering is trivial (cache check precedes in-flight check with no await between).
+  - Anti-Deferral (acceptable risk): Worst case — a reordering regression ships
+    untested. Likelihood — very low (4 lines, obvious order). Cost to fix — one small
+    test; the two behaviors are already covered independently.
+
+## Recurring Issue Check
+
+- R1 (reuse): `TokenRefreshCoordinator` is a genuinely new primitive; replaces the
+  removed instance-local `refreshTask`. No parallel single-flight helper existed.
+- R2 (hardcoded constants): `resultTTL: 3` and the server's `5s` grace are documented
+  inline; single-use, no shared-constant duplication.
+- R25 (persisted-state symmetry): N/A — the coordinator cache is in-memory only,
+  crosses no process/restart boundary.
+- RS1 (timing-safe compare): N/A — no credential comparison added.
+- RT4 (race-test vacuous guard): the concurrency tests assert `== 1` / `== N`
+  (lower+upper bound), not `>= 0`; the throw test verifies all N joiners get the error.
+- RT6 (new code untested): `TokenRefreshCoordinator` (5+1 tests), `sessionExpired`
+  mapping (VaultUnlocker test), banner selection (4 PostSyncDecision tests). Covered.
+
+## Resolution Status
+
+### F1 [Minor] Contradictory failure-caching doc comment — FIXED
+- Action: rewrote the header comment to state only successes are cached and every
+  failure (incl. `authenticationRequired`) stays immediately retryable.
+- Modified: `ios/PasswdSSOApp/Network/TokenRefreshCoordinator.swift` (doc only).
+
+### S1 [Minor] No backoff on sequential networkError retrigger — ACCEPTED (see above)
+
+### T1 [Major] Missing concurrent-throw coverage — FIXED
+- Action: added `testConcurrentCallersAllReceiveThrownErrorAndInFlightIsCleared` —
+  6 callers join a flight that throws; asserts all 6 receive the error, exactly one
+  flight ran, and a subsequent call re-invokes (inFlight cleared, failure not cached).
+- Modified: `ios/PasswdSSOTests/TokenRefreshCoordinatorTests.swift`.
+
+### T2 [Major] Missing banner-selection coverage — FIXED
+- Action: extracted the inline logic into pure helpers `syncFailedSessionExpired(from:)`
+  and `failClosedResult(sessionExpired:)` (+ moved `UnlockedResult` to a top-level
+  public enum) in `PostSyncDecision.swift`; added 4 tests covering
+  authenticationRequired→sign-in, offline/other/serverError→passphrase-retry, and
+  both fail-closed outcomes. RootView now calls the helpers.
+- Modified: `ios/PasswdSSOApp/Vault/PostSyncDecision.swift`,
+  `ios/PasswdSSOApp/Views/RootView.swift`,
+  `ios/PasswdSSOTests/PostSyncDecisionTests.swift`.
+
+### T3, T4 [Minor] — ACCEPTED (see Anti-Deferral above)
+
+Verified: full suite green after fixes (see final report).

--- a/docs/archive/review/ios-biometric-stale-cache-resync-deviation.md
+++ b/docs/archive/review/ios-biometric-stale-cache-resync-deviation.md
@@ -1,0 +1,18 @@
+# Coding Deviation Log: ios-biometric-stale-cache-resync
+
+## D1 — biometricUnlockError signature refinement (Minor, non-behavioral)
+- Plan C2 sketched `biometricUnlockError(from: Error?, syncFailedCacheless: Bool) -> String?`.
+- Implemented as `biometricUnlockError(from:syncFailedCacheless:message:)` with a
+  `message: @autoclosure () -> String` param, so the localized string is injected by
+  the caller (RootView, via L10n.string) rather than hardcoded in the pure function.
+- Reason: keeps the pure function free of the i18n/`L10n` dependency so it stays a
+  plain unit-testable free function (tests pass a literal "msg"). No behavioral change;
+  the mapping logic (nil on .biometricFailed, message otherwise / on cacheless failure)
+  is exactly as specified.
+
+## D2 — emptyCacheData / syncedKeyVersion extracted as private RootView helpers (Minor)
+- Plan C5 described the keyVersion re-derivation and empty-cache synthesis inline.
+- Implemented as two private helpers (`emptyCacheData(userId:)`, `syncedKeyVersion(from:)`)
+  for readability. `syncedKeyVersion` reuses the same `max(1, first{teamId==nil}?.keyVersion ?? 1)`
+  idiom as VaultUnlocker (3rd copy of a one-line pattern; left un-extracted per YAGNI —
+  the three sites are in different modules/contexts). No behavioral change.

--- a/docs/archive/review/ios-biometric-stale-cache-resync-deviation.md
+++ b/docs/archive/review/ios-biometric-stale-cache-resync-deviation.md
@@ -26,3 +26,51 @@
 - Fix: added a `.useEmptyCache` outcome; `.failLocked` is now reserved for the
   `cacheRecovered==false` (biometric stale/rolled-back) case only. S2 fail-closed
   invariant unchanged. Plan AC-C5.4 updated to match.
+
+## D4 — TokenRefreshCoordinator: process-global refresh single-flight (NEW scope, Major)
+
+- Not in the original plan. Discovered while verifying the stale-cache heal flow: the
+  heal path fires several independent token refreshes back-to-back (unlock-data fetch,
+  sync, QuickType refresh, drain) and, across distinct `MobileAPIClient` instances,
+  concurrently. Each presented the same stale refresh token, tripping the server's
+  refresh-token replay detector (`MOBILE_REFRESH_REUSE_DETECTED`), which revokes the
+  whole token family → a dead session that looked like the very stale-cache bounce this
+  branch set out to fix.
+- Fix: new `TokenRefreshCoordinator` actor (`ios/PasswdSSOApp/Network/`) — a process-
+  global gate keyed by the token store's Keychain service identifier that (a) joins an
+  in-flight refresh (concurrent collapse) and (b) replays a recent SUCCESS within a
+  short TTL (3s, < the server's 5s replay grace) for sequential re-tries. Only successes
+  are cached; failures stay retryable so a re-sign-in can recover at any time.
+- Replaced `MobileAPIClient`'s former instance-local `refreshTask` single-flight (which
+  could not coordinate across instances) with a call into the coordinator, keyed by
+  `HostTokenStore.serviceIdentifier` (new public accessor).
+
+## D5 — MobileAPIClient.refreshCoordinator injected (Minor, testability)
+
+- `MobileAPIClient.init` gained `refreshCoordinator: TokenRefreshCoordinator = .shared`.
+- Reason: the process-global singleton's success cache leaks across tests (one test's
+  rotated token replays into the next, suppressing the refresh the test asserts on).
+  Production defaults to `.shared` (correct cross-instance behavior); tests inject a
+  fresh instance for isolation. Mirrors the existing `now:` clock-seam injection —
+  a production DI seam, not a test-only hack.
+
+## D6 — VaultUnlockError.sessionExpired + RootView UnlockedResult enum (NEW scope, Minor)
+
+- Not in the original plan. A dead refresh token surfaced as `serverResponseInvalid`
+  ("check your connection and try again"), sending the user into a passphrase retry loop
+  that no passphrase can break.
+- Fix: new `VaultUnlockError.sessionExpired` (mapped from `MobileAPIError`
+  `.authenticationRequired` in `VaultUnlocker`) routed to a "Your session has expired.
+  Please sign in again." banner. `RootView.handleVaultUnlocked` return type changed from
+  `Bool` to an `UnlockedResult` enum (`reachedVault` / `failedSessionExpired` /
+  `failedOffline`) so the biometric call site picks the correct fail-closed banner
+  (dead session → sign in again; offline → try passphrase). Fail-closed invariant
+  (never present an empty vault as success) unchanged.
+
+## D7 — Verification-only diagnostic logging removed before commit
+
+- During debugging, temporary OSLog diagnostics were added across MobileAPIClient,
+  VaultUnlocker, VaultUnlockView, and RootView to trace the refresh/unlock failure path.
+  All were removed before commit; only RootView's pre-existing `sync`-category error log
+  (which carries no token material) remains. No secrets were ever logged (MobileAPIError
+  cases carry no token data), but the diagnostics were scaffolding, not shipping code.

--- a/docs/archive/review/ios-biometric-stale-cache-resync-deviation.md
+++ b/docs/archive/review/ios-biometric-stale-cache-resync-deviation.md
@@ -84,6 +84,21 @@
   leak a URL / response / internal state with no code change at the log site.
 - Fix: log only the already-classified `sessionExpired` Bool
   (`syncFailedSessionExpired(from:)`), never the raw error. Same fixed-code shape the
-  banner selection already relies on. The analogous raw-error dump in
-  `AutofillTokenRefresher.swift:51` is out of scope (unchanged file, not in this diff);
-  noted here for a follow-up.
+  banner selection already relies on.
+
+## D9 — Cross-cutting: raw-error log dumps reduced to the error TYPE (post-review, Medium)
+
+- Swept the whole iOS tree for the same weak pattern (`String(describing: error)` at
+  `privacy: .public`). Seven other sites dumped an arbitrary caught `Error` — including
+  API (`MobileAPIError`), OS (`ASExtension`/`LAError`), and cache-I/O errors whose
+  associated values can carry a URL / OSStatus / file path / response.
+- Fix: replaced the payload dump with `type(of: error)` (the error's type name only) at
+  all eight sites — enough to tell WHICH kind of failure occurred for debugging,
+  without emitting any associated value:
+  - `AutofillTokenRefresher.swift:53`
+  - `CredentialProviderViewController.swift:266,362,395,461`
+  - `CredentialResolver.swift:143,488`
+  - `BridgeKeyStore.swift:204`
+- Untouched: `CredentialProviderViewController.swift:412` logs a `decision` enum (no
+  associated secret), and the `keyStatus`/`rpId` OSStatus logs (already non-secret
+  scalars). No behavior change — logging text only.

--- a/docs/archive/review/ios-biometric-stale-cache-resync-deviation.md
+++ b/docs/archive/review/ios-biometric-stale-cache-resync-deviation.md
@@ -16,3 +16,13 @@
   for readability. `syncedKeyVersion` reuses the same `max(1, first{teamId==nil}?.keyVersion ?? 1)`
   idiom as VaultUnlocker (3rd copy of a one-line pattern; left un-extracted per YAGNI —
   the three sites are in different modules/contexts). No behavioral change.
+
+## D3 — Phase 3 F1: .useEmptyCache added (plan AC-C5.4 corrected)
+- The Round-0 plan's AC-C5.4 specified `decidePostSync(nil, true, nil) → .failLocked`.
+  Phase-3 review found this regresses the passphrase path: a valid passphrase unlock
+  of a brand-new/empty vault (or first offline unlock) would bounce to the locked
+  screen instead of showing the legitimately-empty vault (the old code synthesized an
+  empty vault here, which INV-C5.2 requires preserving).
+- Fix: added a `.useEmptyCache` outcome; `.failLocked` is now reserved for the
+  `cacheRecovered==false` (biometric stale/rolled-back) case only. S2 fail-closed
+  invariant unchanged. Plan AC-C5.4 updated to match.

--- a/docs/archive/review/ios-biometric-stale-cache-resync-deviation.md
+++ b/docs/archive/review/ios-biometric-stale-cache-resync-deviation.md
@@ -74,3 +74,16 @@
   All were removed before commit; only RootView's pre-existing `sync`-category error log
   (which carries no token material) remains. No secrets were ever logged (MobileAPIError
   cases carry no token data), but the diagnostics were scaffolding, not shipping code.
+
+## D8 — RootView sync-failure log hardened to classified outcome (post-review, Medium)
+
+- Post-commit review flagged that RootView's surviving `sync`-category log dumped the
+  full `runSync` error via `String(describing: error)` at `privacy: .public`. Today's
+  `MobileAPIError` cases carry no token material, but `runSync` throws an arbitrary
+  `Error`; the day it starts throwing a richer type (e.g. `URLError`), the log would
+  leak a URL / response / internal state with no code change at the log site.
+- Fix: log only the already-classified `sessionExpired` Bool
+  (`syncFailedSessionExpired(from:)`), never the raw error. Same fixed-code shape the
+  banner selection already relies on. The analogous raw-error dump in
+  `AutofillTokenRefresher.swift:51` is out of scope (unchanged file, not in this diff);
+  noted here for a follow-up.

--- a/docs/archive/review/ios-biometric-stale-cache-resync-plan.md
+++ b/docs/archive/review/ios-biometric-stale-cache-resync-plan.md
@@ -1,0 +1,680 @@
+# Plan: iOS Biometric Unlock — Stale-Cache Resync Fallback
+
+## Objective
+
+Fix the UX defect where, after the app has been idle/backgrounded "a while",
+tapping **Unlock with Face ID** authenticates successfully but silently bounces
+the user back to the passphrase screen. Make biometric unlock reach the vault
+list whenever the biometric key material is present — falling back to a fresh
+server sync when the local cache is stale/unreadable, exactly as the passphrase
+path already does — and surface an explicit error only when both the local cache
+AND the server are unusable.
+
+## Project context
+
+- **Type**: `mixed` — native iOS app (Swift 6 / SwiftUI), part of the passwd-sso monorepo.
+- **Test infrastructure**: `unit + integration` for iOS via XCTest
+  (`ios/PasswdSSOTests/*`). Rich existing harness for this area:
+  `StubVaultAPIClient` (drives real `VaultUnlocker` crypto without network),
+  `MockKeychainAccessor` / `MockKeychain`, `TempDirWrappedKeyStore`, injectable
+  `now: @Sendable () -> Date`, and `buildCacheFileForBiometricTest`. Build+test
+  runnable locally: `xcodegen generate` → `xcodebuild test -scheme PasswdSSOApp
+  -destination 'id=<sim udid>'` (Xcode 26.4.1 available in this shell — see
+  memory `ios-build-env-available`).
+- **Verification environment constraints**:
+  - **VC1 — Real Face ID/Touch ID prompt**: `unlockWithBiometrics` calls
+    `bridgeKeyStore.readForFill(reason:)` which triggers `LAContext`
+    evaluation. Unit tests use `MockKeychainAccessor` (no biometric gate), so the
+    *actual* biometric prompt is `blocked-deferred` to manual device testing.
+    The crypto/fallback logic AFTER the keychain read IS `verifiable-local`
+    (the mock returns the blob, then real crypto + real cache-read + real
+    fallback branch run). Anti-Deferral: cost to exercise a real Secure-Enclave
+    biometric gate in CI is a physical-device farm (hours+, external infra) —
+    out of proportion to the change; the LAContext read is unchanged by this
+    plan, only the code path AFTER it is. Classify: keychain-read =
+    `blocked-deferred (VC1)`, everything downstream = `verifiable-local`.
+  - **VC2 — SwiftUI state transition (`appState` → `.vaultUnlocked`)**: RootView
+    view-state transitions are `blocked-deferred` (no ViewInspector/SwiftUI test
+    host in this target). The orchestration logic they gate is exercised
+    indirectly via the `VaultUnlocker` return contract; the RootView wiring is
+    verified by manual device testing + code review. Anti-Deferral: adding a
+    SwiftUI view-testing framework is a multi-day infra addition, out of scope
+    for a targeted UX fix (cost ≫ 30 min).
+
+## Requirements
+
+### Functional
+
+- FR1: When biometric key material is present (bridge_key + wrapped vault key)
+  and the biometric read + wrapped-key decrypt succeed, biometric unlock MUST
+  reach the vault list even if the local cache file is stale, counter-mismatched,
+  AAD-mismatched, or absent — provided a server sync can rebuild it.
+- FR2: When the local cache read fails AND the server sync also fails (offline,
+  dead token, server error), biometric unlock MUST surface an explicit,
+  localized error directing the user to enter their passphrase — never a silent
+  return to the passphrase screen.
+- FR3: When the local cache read succeeds (fresh cache), the *`unlockWithBiometrics`
+  step itself* performs no network round-trip (it reads keychain + local cache
+  only) — unchanged from today. NOTE: the end-to-end unlock flow
+  (`handleVaultUnlocked`) already calls `runSync` **unconditionally**
+  (`RootView.swift:347`), so "biometric unlock does no network" was never true for
+  the whole flow, only for the `unlockWithBiometrics` method. This plan does NOT
+  change that: `runSync` stays unconditional; the offline guarantee comes from
+  `runSync` failing gracefully and falling back to the persisted cache, not from
+  suppressing the network call. (Round-1 F4/T7.)
+- FR4: The biometric-unlock button visibility is unchanged in the common case;
+  it continues to appear whenever key material is present (`biometricUnlockAvailable()`).
+  Rationale: the whole point is that biometric unlock now *works* after idle, so
+  hiding the button on staleness (the rejected "hide-the-button" option) is not
+  needed and would degrade the exact scenario we are fixing.
+
+### Non-functional
+
+- NFR1 (security): The resync fallback MUST NOT weaken any invariant the
+  passphrase path relies on. Specifically the fresh sync in the fallback path
+  uses the SAME `HostSyncService.runSync(vaultKey:userId:cacheKey:)` the
+  passphrase path uses, with the SAME DPoP-signed `MobileAPIClient` — no new
+  network client, no new token path, no relaxation of AAD/counter binding on the
+  rewritten cache.
+- NFR2 (no plaintext at rest): `vaultKey` continues to live only in memory;
+  no new persistence of key material is introduced.
+- NFR3 (offline-first): The fresh-cache fast path (FR3) must not regress into an
+  always-online path; the network sync is a *fallback*, gated on cache-read
+  failure.
+
+## Technical approach
+
+### Root cause (confirmed against code)
+
+`unlockWithBiometrics` (`VaultUnlocker.swift:215-272`) recovers the `vaultKey`
+successfully at Step 4 (`VaultUnlocker.swift:235-243`), then at Step 5
+(`VaultUnlocker.swift:246-252`) reads the encrypted cache **only to recover
+`userId` and `keyVersion`**. `readCacheFile` (`EntryCacheFile.swift:163-282`)
+enforces staleness (`:250-252`), counter match (`:238-240`), and AAD
+(`:335-368`). After "a while" idle, `cacheIssuedAt < now-1h AND
+lastSuccessfulRefreshAt < now-24h` → `.rejection(.headerStale)` is thrown. The
+`throw` propagates out of `unlockWithBiometrics`, caught by the **empty catch**
+in RootView (`RootView.swift:271-273`), leaving `appState` at `.vaultLocked` with
+no error shown.
+
+The asymmetry: the passphrase path (`unlock`, `VaultUnlocker.swift:75-207`) never
+reads the cache — it fetches fresh unlock data, derives `vaultKey`, and returns.
+Then `handleVaultUnlocked` (`RootView.swift:299-425`) runs `runSync`
+(`RootView.swift:347`) which **rebuilds the cache from scratch**
+(`HostSyncService.performSync`, `HostSyncService.swift:61-151`). So the cache the
+biometric path chokes on is one the very next step would have overwritten.
+
+### Design: graceful cache-read degradation + explicit failure
+
+The fix has two coordinated parts.
+
+**Part A — `VaultUnlocker.unlockWithBiometrics` stops treating a cache-read
+failure as fatal.** It splits the outcome into:
+- vault-key recovery (Steps 1–4): still fatal on failure (biometric/keychain/
+  wrapped-key errors are genuine "cannot unlock biometrically").
+- metadata recovery (Step 5–6, cache read): now *best-effort*. On cache-read
+  failure it returns a result flagged `cacheRecovered = false` with `userId`
+  recovered from a **non-staleness-gated source** (the wrapped-key /
+  bridge-meta layer — see Consumer-flow walkthrough C1 for exactly where
+  `userId` comes from) and `keyVersion` defaulted to the safe floor (`1`, same
+  default the current code already uses at `VaultUnlocker.swift:261` when no
+  personal entry is present). The subsequent server sync supplies the
+  authoritative entry set + keyVersion.
+
+**Part B — RootView's biometric closure stops swallowing errors and drives the
+fallback deterministically.** `handleVaultUnlocked` already runs `runSync` and
+already falls back to the persisted cache when sync fails
+(`RootView.swift:345-397`). The change:
+1. Replace the empty `catch` (`RootView.swift:271-273`) with an explicit handler
+   that sets a user-visible error on the unlock screen (FR2) instead of silently
+   returning.
+2. When `unlockWithBiometrics` returns `cacheRecovered = false`,
+   `handleVaultUnlocked` MUST treat a *sync failure* as a hard failure for this
+   unlock attempt (there is no valid local cache to fall back to), route back to
+   `.vaultLocked`, and propagate an explicit error — rather than proceeding to
+   `.vaultUnlocked` with an empty vault (the `else` branch at
+   `RootView.swift:385-397` that synthesizes an empty `CacheData`). When
+   `cacheRecovered = true`, the existing persisted-cache fallback remains valid.
+
+### Where `userId` comes from without a valid cache (critical design point)
+
+`runSync` requires `userId`. Today the biometric path sources it from the cache
+header. If the cache is unreadable we need another in-hand source. Options
+evaluated against the code:
+
+- The `WrappedVaultKey` (`WrappedKeyStore.loadVaultKey()`) does **not** carry
+  `userId` today (see its fields at `EntryCacheFile`/`WrappedKeyStore`; it is
+  `ciphertext/iv/authTag/issuedAt`).
+- The ECDH wrapped blob IS bound to `userId` via AAD but recovering it requires
+  the userId as *input* (AAD), so it cannot *produce* userId.
+- **Chosen source**: persist `userId` alongside the wrapped vault key at unlock
+  time (in `unlock`, Step 6, `VaultUnlocker.swift:168-174`), so the biometric
+  path can read it back without the cache. This is metadata, not secret key
+  material (userId already travels in the cache header in plaintext-after-decrypt
+  and in the unlock response). Contract **C4** covers this store addition.
+  - If, at review, adding a field to the persisted wrapped-key record is judged
+    too invasive, the fallback source is a fresh `GET /api/vault/unlock/data`
+    **metadata-only** read is NOT viable in the biometric path (no passphrase to
+    derive the wrapping key) — but `userId` is returned by that endpoint
+    unconditionally and does not require the passphrase to READ. This is the
+    documented alternative in C4's rationale; C1 walkthrough picks the primary.
+
+## Contracts
+
+### C1 — `unlockWithBiometrics` graceful degradation
+
+- **Signature** (unchanged public shape; behavior change):
+  `public func unlockWithBiometrics(reason: String) async throws -> UnlockResult`
+- **New field on `UnlockResult`**:
+  `public let cacheRecovered: Bool` — `true` when Step 5 read a valid local
+  cache (fresh-cache fast path), `false` when the cache was stale/unreadable and
+  the caller MUST rely on a server sync to populate the vault. The passphrase
+  path (`unlock`) sets **`cacheRecovered = true`** (LOCKED). Semantics: the field
+  means "the caller MAY rely on a persisted local cache if the sync fails."
+  - Biometric path: `true` only when Step 5 read a valid cache; `false` when the
+    cache was stale/unreadable (there is no trustworthy local cache to fall back
+    to).
+  - Passphrase path: always `true` — it does not read a cache during unlock, but
+    a valid persisted cache from a prior session MAY exist, and its existing
+    offline fallback (`RootView.swift:377-384`) must be preserved unchanged
+    (INV-C5.2). Setting `false` here would newly route a passphrase unlock with a
+    failed sync to `.vaultLocked`, a regression.
+  This decouples the two paths: `cacheRecovered` is consumed by
+  `handleVaultUnlocked` ONLY to decide whether a *sync failure* may fall back to
+  the persisted cache.
+- **Behavior**:
+  1. Steps 1–4 unchanged (biometric read → cacheKey → load wrapped key →
+     decrypt vaultKey). Failures here still `throw` the existing errors
+     (`.biometricFailed`, `.biometricUnavailable`, crypto errors).
+  2. Step 5 (cache read) wrapped in `do/catch`. On success: `cacheRecovered =
+     true`, `userId`/`keyVersion` from cache as today. On
+     `EntryCacheError` (any kind): `cacheRecovered = false`, `userId` from the
+     persisted wrapped-key userId (C4), `keyVersion = 1` (placeholder — the
+     authoritative keyVersion is re-derived post-sync by C5, see F2 fix).
+  3. The empty-userId guard (`VaultUnlocker.swift:254-257`) still applies to the
+     success branch. In the failure branch, if the persisted userId is ALSO
+     empty/absent (`nil` for a legacy vault, or `""`), throw `.cacheUnreadable`
+     (there is genuinely no way to sync). See the **legacy-vault bootstrap
+     scenario** below (F1) — this is the one-time transitional case.
+
+- **Legacy-vault bootstrap (F1 — Round 1 Critical)**: a vault set up BEFORE this
+  ships has `wrapped-vault-key.json` with no `userId` (decodes to `nil` — C4). On
+  the FIRST post-upgrade biometric unlock **with a stale cache**, C1 step 3 finds
+  `userId=nil` → throws `.cacheUnreadable` → C2 surfaces the FR2 error → the user
+  does ONE passphrase unlock, which re-persists `userId` (C4 producer) → all
+  subsequent biometric unlocks heal via resync. This is an accepted one-time
+  transition, NOT a silent regression (the user gets an explicit error, never a
+  silent bounce). The offline+legacy+stale combination is an unavoidable hard-fail
+  (no cache, no network, no persisted userId) — also surfaced explicitly, not
+  silently. Covered by AC-C1.4 + Scenario 6.
+- **Invariants**:
+  - INV-C1.1 (app-enforced): `vaultKey` is only returned when Steps 1–4 fully
+    succeed. A cache-read failure never causes a wrong/empty vaultKey to be
+    returned. *Absence surfaces as: biometric unlock returns a bad key → all
+    decrypt fails.*
+  - INV-C1.2 (app-enforced): `cacheRecovered == false` ⇒ `userId` is non-empty
+    (guaranteed by the throw in step 3 above). *Absence surfaces as: runSync
+    writes a cache header with empty userId → AAD drift → next unlock rejects.*
+  - INV-C1.3 (app-enforced, SCOPED to `unlockWithBiometrics`): the
+    `unlockWithBiometrics` METHOD introduces no network call on the fresh-cache
+    path — it reads keychain + local cache only, byte-for-byte as today. This
+    invariant is about the METHOD, not the end-to-end flow: `handleVaultUnlocked`
+    still calls `runSync` unconditionally (see FR3 note). *Absence surfaces as:
+    `unlockWithBiometrics` gains a network dependency, breaking its offline-read
+    contract.* (Round-1 F4/T7 scope correction.)
+- **Forbidden patterns**:
+  - pattern: `catch {` immediately followed by only a comment inside
+    `biometricUnlock` closure in RootView — reason: the empty-swallow catch is
+    the bug; the closure must set an error or route explicitly.
+  - pattern: `try? readCacheFile` inside `unlockWithBiometrics` — reason: the
+    read must distinguish success from failure to set `cacheRecovered`; a `try?`
+    would collapse the signal.
+- **Acceptance criteria**:
+  - AC-C1.1: With a seeded STALE cache (now injected 25h ahead) + valid
+    bridge_key + wrapped key, `unlockWithBiometrics` returns a result with the
+    correct `vaultKey` and `cacheRecovered == false` (does NOT throw).
+  - AC-C1.2: With a seeded FRESH cache, returns `cacheRecovered == true`,
+    `userId`/`keyVersion` from cache, no data source call (StubVaultAPIClient in
+    `.wrongPassphrase`/counting mode is never hit).
+  - AC-C1.3: With stale cache AND persisted userId absent (`nil`, legacy) or
+    empty → throws `.cacheUnreadable`.
+  - AC-C1.4 (F1 legacy bootstrap): seed a `WrappedVaultKey` WITHOUT `userId`
+    (`userId=nil`, simulating a pre-upgrade file) + a stale cache →
+    `unlockWithBiometrics` throws `.cacheUnreadable` (does not crash, does not
+    return a result with empty userId). Then persist a `userId` (simulating a
+    passphrase unlock) + keep the stale cache → biometric unlock now returns
+    `cacheRecovered=false` with the recovered userId (proves the transition heals).
+
+- **Consumer-flow walkthrough** (UnlockResult is a shape consumed outside the producer):
+  - **Consumer: `RootView.handleVaultUnlocked`** (path:
+    `ios/PasswdSSOApp/Views/RootView.swift:299-425`) reads `{ vaultKey, userId,
+    keyVersion, tenantAutoLockMinutes, cacheKey, cacheRecovered }` and uses:
+    `vaultKey`+`userId`+`cacheKey` to call `runSync` (`:347`); `userId` for the
+    empty-cache-synthesis header (`:393`); `keyVersion` to populate
+    `.vaultUnlocked` (`:419`); `tenantAutoLockMinutes` for `applyTenantPolicy`
+    (`:317`); `cacheKey` for QuickType identity refresh (`:411`) and
+    `onVaultReady` (`:404`); **`cacheRecovered` (new)** to decide whether a
+    `runSync` failure is fatal (cacheRecovered==false → fatal, route to
+    `.vaultLocked` with error) or recoverable-from-local-cache (cacheRecovered==
+    true → existing persisted-cache fallback at `:377-384`).
+    - Required fields present in locked shape: yes — all six. `cacheRecovered`
+      is the only addition; every consumer op above is satisfiable.
+  - **Consumer: `VaultUnlockView.attemptUnlock`** (path:
+    `ios/PasswdSSOApp/Views/Vault/VaultUnlockView.swift:126-146`) reads the
+    passphrase-path `UnlockResult` and passes it to `onUnlocked`. It does not
+    read `cacheRecovered`. No change needed; the added field is ignored here.
+  - **Consumer: `VaultUnlockerTests`** (path:
+    `ios/PasswdSSOTests/VaultUnlockerTests.swift`) constructs `UnlockResult`
+    only via the producer (never by literal), so an added field with a producer
+    default does not break existing exact-shape assertions — confirm no
+    `UnlockResult(` literal exists in tests (grep in C1 acceptance).
+
+### C2 — RootView biometric closure: explicit error, no silent swallow
+
+- **Signature** (closure shape unchanged):
+  `biometricUnlock: (@MainActor @Sendable () async -> Void)?`
+- **Behavior**: the closure body (`RootView.swift:257-274`) replaces the empty
+  `catch` with:
+  - on `VaultUnlockError.biometricFailed`: **no error banner**, remain on the
+    passphrase screen. **Code-derived constraint**: `readForFill` collapses BOTH
+    `errSecUserCanceled` AND `errSecAuthFailed` into a single `Error.biometryFailed`
+    (`BridgeKeyStore.swift:229-231`), which `unlockWithBiometrics` maps to
+    `.biometricFailed` (`VaultUnlocker.swift:220-221`). Therefore the closure
+    CANNOT distinguish an intentional user cancel from a biometric mismatch — both
+    are `.biometricFailed`. Treating the whole class as "no banner, stay on
+    passphrase screen" is the correct conservative choice: a mismatch already
+    leaves the passphrase field available, and showing a scary error on a simple
+    cancel would be worse UX. (If finer distinction is ever needed, that requires
+    threading the OSStatus/`LAError.Code` out of `BridgeKeyStore` — SC5, out of
+    scope here.)
+  - on any other thrown error, AND on the `handleVaultUnlocked` returning
+    `false` for the `cacheRecovered == false` sync-failure case (C5): set an
+    explicit localized error message on the unlock screen (FR2). This is the
+    branch that fixes the silent bounce — the failure is a *sync/network* failure
+    after a *successful* biometric auth, which is exactly when the user needs to
+    be told "your session data is stale, please enter your passphrase."
+- **Design note**: the error must reach `VaultUnlockView`. Today
+  `VaultUnlockView` owns `errorMessage` and sets it only from its own
+  `attemptUnlock`. The biometric closure is created in RootView and cannot set
+  the View's `@State`. Contract **C3** adds the plumbing.
+- **Pure error-mapping extraction (T4/T5 — Round 1)**: the closure's
+  error→message decision MUST be extracted into a pure, testable free function so
+  INV-C2.1 is guarded *behaviorally*, not only by a forbidden-pattern grep
+  (grep is bypassable by rewording the comment):
+  `func biometricUnlockError(from error: Error?, syncFailedCacheless: Bool) -> String?`
+  returning `nil` for `VaultUnlockError.biometricFailed` (cancel/mismatch — no
+  banner) and a localized message for every other error AND for the
+  `syncFailedCacheless == true` case (C5 `.failLocked`). The closure calls this
+  and pushes the result into `biometricErrorText` (C3). This is the *symptom*
+  regression test surface (T5): a test feeding a non-cancel error asserts a
+  non-nil message, which would fail if someone re-introduced the swallow.
+- **Invariants**:
+  - INV-C2.1 (app-enforced): no code path in the biometric closure leaves the
+    user on the passphrase screen with NO feedback after a *non-cancel* failure.
+    *Absence surfaces as: the exact bug we are fixing — silent bounce.*
+- **Forbidden patterns**:
+  - pattern: `// Biometric cancel/fail → silent fallback to passphrase`
+    — reason: this exact comment marks the swallow being removed; its presence
+    in the final diff means the fix was not applied.
+- **Acceptance criteria**:
+  - AC-C2.1 (logic, T4/T5): `biometricUnlockError(from: .biometricFailed,
+    syncFailedCacheless: false)` returns `nil` (no banner on cancel/mismatch);
+    `biometricUnlockError(from: someOtherError, ...)` and
+    `biometricUnlockError(from: nil, syncFailedCacheless: true)` each return a
+    non-nil localized message. This is the fails-before/passes-after regression
+    test for the reported silent-bounce symptom.
+  - AC-C2.2 (manual, VC2): stale-cache + offline → tap Face ID → biometric
+    succeeds → the message from AC-C2.1 is shown in the red-caption region,
+    passphrase field focusable.
+
+### C3 — Error surfacing from biometric closure into `VaultUnlockView`
+
+- **Signature (LOCKED)**: add one parameter to `VaultUnlockView`:
+  `let externalError: String?` (default `nil` in the memberwise `init`, so the
+  passphrase-only call sites need no change). RootView owns
+  `@State private var biometricErrorText: String?`, the biometric closure sets
+  it, and RootView passes `externalError: biometricErrorText` into the
+  `.vaultLocked`/`.signedIn` `VaultUnlockView`. Rejected `@Binding` (forces the
+  parent to hold a `Binding` and complicates the existing two `vaultLockedScreen`
+  call sites) and a callback shape (the View must *render* the error in its own
+  red-caption region, not just receive it).
+- **Behavior**: `VaultUnlockView` shows the result of a pure free function
+  `func resolveDisplayError(external: String?, internalError: String?) -> String?`
+  = `external ?? internalError` (T8 — extracted, NOT inlined, so precedence is
+  unit-tested without a SwiftUI host; the "if not extractable" hedge is removed —
+  it IS extractable, it is a one-liner). A new successful passphrase attempt
+  clears both.
+- **Invariants**:
+  - INV-C3.1 (app-enforced): setting `externalError` non-nil renders it in the
+    existing red caption region (`VaultUnlockView.swift:80-84`); no second error
+    UI is introduced (R8 — UI consistency).
+- **Acceptance criteria**:
+  - AC-C3.1 (logic, T8): `resolveDisplayError(external:"x", internalError:nil) ==
+    "x"`; `resolveDisplayError(external:"x", internalError:"y") == "x"` (external
+    wins); `resolveDisplayError(external:nil, internalError:"y") == "y"`.
+  - AC-C3.2: a subsequent successful unlock clears `externalError` (parent
+    resets its `@State` before `handleVaultUnlocked` swaps `appState`).
+
+### C4 — Persist `userId` with the wrapped vault key (source for cacheless sync)
+
+- **Signature (LOCKED)**: add an **optional** field
+  `public let userId: String?` to `WrappedVaultKey`
+  (`WrappedKeyStore.swift:5-17`), AND add it to the memberwise `init` with a
+  **default**: `init(ciphertext:, iv:, authTag:, issuedAt:, userId: String? = nil)`
+  (F3 — Round 1). The default is load-bearing: without it, all 15 existing
+  constructors break. `WrappedVaultKey` is a `Codable` struct serialized as JSON
+  in the App Group file `wrapped-vault-key.json` (`WrappedKeyStore.swift:84-94`).
+  An **optional** field is decode-backward-compatible: pre-existing files
+  (written without `userId`) decode with `userId = nil` (JSONDecoder tolerates a
+  missing optional key). The default `JSONEncoder` omits `nil` optionals (does NOT
+  emit `"userId":null`), so round-trip equality of legacy instances holds
+  (verified requirement for T6 below).
+- **Construction-site sweep (R3 propagation — code-derived, CORRECTED per F3/T6)**:
+  `grep -rn 'WrappedVaultKey(' ios --include='*.swift'` → **15 constructors**:
+  - **2 production** (must pass the new field explicitly):
+    - `VaultUnlocker.swift:168` (the `unlock` path — passes `userId: unlockData.userId`).
+    - `DebugVaultLoader.swift:98` (DEBUG-only seeding — passes its known test
+      userId; DEBUG target, must compile).
+  - **13 test constructors** (unchanged thanks to the `= nil` default; each uses
+    only the first 4 params): `AutoLockServiceTests.swift:122,166,242,294`,
+    `CredentialResolverTests.swift:218`, `VaultUnlockerTests.swift:120`,
+    `WrappedKeyStoreTests.swift:30,44,50,136,164,192,223`.
+- **Equatable sweep (CORRECTED per T6)**: `WrappedVaultKey` is `Equatable` and IS
+  compared in tests: `WrappedKeyStoreTests.swift:40,60,217`
+  (`XCTAssertEqual(loaded, expected)` on `WrappedVaultKey`). These stay green
+  because both sides get `userId = nil` (neither passes it) and the encoder omits
+  nil. (The Round-0 sweep wrongly claimed "no production code compares two
+  instances" as the safety basis — the real basis is optional + nil-omitted, NOT
+  the absence of equality assertions.) Consumers of `loadVaultKey()` verified
+  read-only on `ciphertext/iv/authTag` (no struct equality):
+  `CredentialResolver.swift:151,282,378,493,585` (AutoFill extension).
+- **Tampered-userId note (S3 — Round 1)**: the persisted userId lives in the
+  attacker-writable App Group file. A flipped value is **self-defeating, not
+  exploitable**: server authz is DPoP-token-bound (not local-userId-bound) so no
+  cross-user disclosure; entries are vaultKey-bound AEAD so no forgery; and the
+  next passphrase unlock overwrites it with the real `unlockData.userId`. Worst
+  case is a self-healing AAD-drift resync. No code change required beyond keeping
+  it out of the biometric ACL (INV-C4.3).
+- **Invariants**:
+  - INV-C4.1 (app-enforced): the persisted userId written at `unlock` equals
+    `unlockData.userId`. *Absence surfaces as: cacheless sync uses wrong userId →
+    AAD drift.*
+  - INV-C4.2 (app-enforced): reading back the persisted userId in
+    `unlockWithBiometrics` yields the same string. *Round-trip.*
+  - INV-C4.3 (security, app-enforced): the persisted userId is NOT secret and its
+    storage MUST NOT reduce the protection class of the wrapped key material
+    (store it at the same or *weaker*-sensitivity item, never move the wrapped
+    key to a weaker item to accommodate it).
+- **Forbidden patterns**:
+  - pattern: writing `userId` into the biometric-gated `bridge-key-v2` ACL item
+    — reason: userId is non-secret; gating it behind biometrics is pointless and
+    risks a biometric prompt on a metadata read. Store with the wrapped key
+    (App Group file) or the no-ACL meta.
+- **Acceptance criteria**:
+  - AC-C4.1: after `unlock(passphrase:)`, the persisted userId round-trips to
+    `unlockData.userId`.
+  - AC-C4.2: `unlockWithBiometrics` on a stale cache recovers that userId and
+    returns it in `UnlockResult.userId`.
+  - AC-C4.3 (T6 store-layer round-trip): save a `WrappedVaultKey` with a NON-nil
+    `userId`, load it, assert `loaded == saved` AND `loaded.userId == "…"` —
+    proves the new field survives JSON encode/decode at the store layer (not only
+    via `unlockWithBiometrics`).
+
+### C5 — `handleVaultUnlocked` fatal-vs-recoverable sync failure
+
+- **Signature (LOCKED)**: change return type to
+  `@discardableResult private func handleVaultUnlocked(...) async -> Bool`
+  (true = reached `.vaultUnlocked`). `@discardableResult` (F6) lets the
+  passphrase call site (`RootView.swift:285-296`) ignore it warning-free; the
+  biometric call site inspects it to set `biometricErrorText` (C2/C3).
+- **Pure decision function (LOCKED per S2/T2 — takes `CacheData?`, NOT `Bool`)**:
+  ```
+  enum PostSyncOutcome: Equatable { case useFreshCache, useLocalCache, failLocked }
+  func decidePostSync(
+    syncReport: SyncReport?,          // nil = sync failed
+    cacheRecovered: Bool,
+    persistedCache: CacheData?        // the already-read persisted cache, or nil
+  ) -> PostSyncOutcome
+  ```
+  Logic (pure, total):
+  - `syncReport != nil` → `.useFreshCache`.
+  - `syncReport == nil && cacheRecovered == false` → `.failLocked`
+    **regardless of `persistedCache`** — this is the S2 fix: a cacheless failed
+    sync NEVER trusts a persisted cache, even if a (possibly rolled-back /
+    mildly-stale-but-readable) one exists.
+  - `syncReport == nil && cacheRecovered == true && persistedCache != nil` →
+    `.useLocalCache`.
+  - `syncReport == nil && cacheRecovered == true && persistedCache == nil` →
+    `.failLocked`.
+- **Behavior / structural ordering (LOCKED per S2)**: after the `runSync`
+  do/catch, RootView MUST:
+  1. On `cacheRecovered == false`, **NOT** call `readCacheFile` again at all. The
+     persisted-cache read (`RootView.swift:377-384`) is gated behind
+     `cacheRecovered == true`. This closes the S2 counter-splice window (two reads
+     with independent `expectedCounter` sources) structurally.
+  2. Read the persisted cache **once** (only when `cacheRecovered == true`), bind
+     its `CacheData?` result (F5 — single read), pass it to `decidePostSync`, then
+     `switch`:
+     - `.useFreshCache` → use `syncReport!.cacheData`; **derive the authoritative
+       keyVersion from those synced entries** (`max(1, entries.first { $0.teamId
+       == nil }?.keyVersion ?? 1)`, same logic as `VaultUnlocker.swift:261`) and
+       use THAT for `.vaultUnlocked(keyVersion:)` — NOT `unlockResult.keyVersion`
+       (F2 fix: prevents a stale keyVersion=1 being written back to the server on
+       a later edit).
+     - `.useLocalCache` → use the already-read `persistedCache` data.
+     - `.failLocked` → `appState = .vaultLocked(serverConfig:apiClient:)`,
+       return `false`. Do NOT synthesize an empty `CacheData`.
+- **Invariants**:
+  - INV-C5.1 (app-enforced): `cacheRecovered == false` AND sync-failed ⇒
+    `appState` becomes `.vaultLocked`, NOT `.vaultUnlocked` with empty entries,
+    AND no `readCacheFile` is called on this path. *Absence surfaces as: user
+    lands on an empty vault after Face ID (data-loss-looking), OR a caller-layer
+    counter-splice re-opens (S2).*
+  - INV-C5.2 (app-enforced): the passphrase path's existing offline behavior
+    (`cacheRecovered == true`, unlock succeeds, falls back to persisted cache) is
+    unchanged. *Regression guard.*
+  - INV-C5.3 (app-enforced, F2): when `syncReport != nil`, the keyVersion handed
+    to `.vaultUnlocked` is derived from the SYNCED entries, not the possibly-stale
+    `unlockResult.keyVersion`. *Absence surfaces as: keyVersion=1 written back to
+    the server on a create/edit in a resync-healed session.*
+- **Forbidden patterns**:
+  - pattern: `readCacheFile` reachable when `cacheRecovered == false` — reason:
+    the S2 counter-splice window + the empty-synthesis fall-through both live past
+    that read; the failure path must never re-read.
+  - pattern: synthesizing `CacheData(header: CacheHeader(... entryCount: 0 ...)`
+    reachable when `cacheRecovered == false` — reason: empty-vault-as-success on a
+    cacheless failed sync (INV-C5.1).
+  - pattern: `keyVersion: unlockResult.keyVersion` at the `.vaultUnlocked(...)`
+    construction when a `syncReport` is present — reason: must use the synced
+    keyVersion (INV-C5.3 / F2).
+- **Acceptance criteria** (all logic-level via `decidePostSync`, VC2-free):
+  - AC-C5.1: `decidePostSync(syncReport: nil, cacheRecovered: false,
+    persistedCache: <non-nil>)` → `.failLocked` (S2 — a readable persisted cache
+    does NOT rescue a cacheless failed sync).
+  - AC-C5.2: `decidePostSync(nil, false, nil)` → `.failLocked`.
+  - AC-C5.3: `decidePostSync(nil, true, <non-nil>)` → `.useLocalCache`.
+  - AC-C5.4: `decidePostSync(nil, true, nil)` → `.failLocked`.
+  - AC-C5.5: `decidePostSync(<non-nil>, _, _)` → `.useFreshCache`.
+  - AC-C5.6 (F2, mildly-stale realism): the S2 sharp case — a cache that is
+    >1h old but refreshed <24h ago (so `readCacheFile` would NOT throw staleness)
+    but was rejected by the biometric read for a DIFFERENT reason (counter
+    mismatch) → `cacheRecovered=false` → even though such a file is
+    independently readable, `decidePostSync(nil, false, <that readable cache>)`
+    still returns `.failLocked`.
+
+## Testing strategy
+
+Because RootView's SwiftUI transitions are VC2-blocked, ALL load-bearing logic is
+extracted into **pure, testable free functions** (mirroring the `LockStateReducer`
+split `AutoLockService` already uses): `decidePostSync` (C5), `biometricUnlockError`
+(C2), `resolveDisplayError` (C3). RootView becomes a thin wrapper that reads the
+cache once and switches on the pure results. This is the Round-1 convergent fix —
+the bug's real logic must not live only in the untested VC2 layer.
+
+- **C1**: extend `VaultUnlockerTests` — new tests for stale-cache (inject `now`
+  25h ahead of the seeded cache) returning `cacheRecovered=false` without throw
+  (AC-C1.1); fresh-cache returning `cacheRecovered=true` (AC-C1.2); stale+absent
+  persisted-userId throwing `.cacheUnreadable` (AC-C1.3); legacy-vault bootstrap
+  transition (AC-C1.4). Reuse `buildCacheFileForBiometricTest`,
+  `MockKeychainAccessor`, `TempDirWrappedKeyStore`, injectable `now`.
+- **T1 (FR1 end-to-end healing — Round 1 Critical)**: a `HostSyncService`-level
+  test that closes the gap `decidePostSync` structurally cannot. All of
+  `HostSyncService`'s collaborators (`EntryFetcher`/`apiClient`, `bridgeKeyStore`,
+  `wrappedKeyStore`, `cacheURL`) are injectable. Seed a stale/absent cache + a stub
+  entry source returning N known entries, call `runSync(vaultKey:userId:cacheKey:)`,
+  then assert the rewritten cache file is readable at the NEW counter with those N
+  entries and a fresh `cacheIssuedAt`. This proves "false→runSync→populated vault"
+  actually heals — the headline FR1 requirement.
+- **C4**: `AC-C4.1/4.2` (unlock persists userId; biometric-on-stale recovers it)
+  in `VaultUnlockerTests`, PLUS `AC-C4.3` store-layer round-trip
+  (`WrappedKeyStoreTests`: save with non-nil userId, load, assert equality +
+  `userId`).
+- **C5**: pure-function tests for `decidePostSync` — AC-C5.1..C5.6 (six cases,
+  including the S2 "readable persisted cache does NOT rescue a cacheless failed
+  sync" and the F2 mildly-stale realism case).
+- **C2**: pure-function tests for `biometricUnlockError` — AC-C2.1 (nil on
+  `.biometricFailed`; non-nil on other errors and on `syncFailedCacheless`). This
+  is the SYMPTOM regression test (T4/T5) — fails-before if the swallow is
+  re-introduced.
+- **C3**: pure-function tests for `resolveDisplayError` — AC-C3.1 precedence +
+  AC-C3.2 clear-on-success. No SwiftUI host needed (T8 — hedge removed).
+- **Counter-mismatch branch**: C1 test — seed cache at counter N, call
+  `bks.incrementCounter(newCounter: N+1)` (public API, `BridgeKeyStore.swift:275`),
+  then `unlockWithBiometrics` → `readCacheFile` throws `.counterMismatch` → assert
+  the result is `cacheRecovered=false` (NOT a throw) (T3). Proves FR1 covers all
+  `EntryCacheError` kinds, not just staleness.
+- **Forbidden-pattern grep guards** are DEFENSE-IN-DEPTH ONLY, not the primary
+  guard (T4). If a source-grep gate is added, it MUST use `#filePath` + a
+  non-swallow `try` and be prove-red'd (memory `ios-swift6-file-vacuous-gate` —
+  a `#file` + `try?` gate silently passes with zero assertions).
+- Full suite: `xcodebuild test -scheme PasswdSSOApp` must stay green (all ~526
+  existing tests + new).
+
+## Considerations & constraints
+
+### Security analysis (NFR1 — the reviewer's explicit concern)
+
+The fallback path does **not** open a new authz/DPoP/token hole because:
+- It reuses `handleVaultUnlocked`'s existing `runSync` with the SAME
+  `MobileAPIClient` (DPoP-signed via the SE key from the coordinator,
+  `RootView.buildRealAPIClient:453-476`). No new client, no `NoOpDPoPSigner`
+  path, no token minting.
+- The `vaultKey` used to (re)encrypt the rebuilt cache is the one recovered from
+  the biometric-gated bridge_key — identical trust to today's fresh-cache
+  biometric unlock. The sync does not lower the bar for *obtaining* the vaultKey;
+  it only changes what happens with an already-recovered vaultKey when the local
+  cache is stale.
+- `userId` persistence (C4) stores a **non-secret** identifier. It must not be
+  placed behind the biometric ACL (forbidden pattern in C4) and must not weaken
+  the wrapped-key item's protection class (INV-C4.3).
+- Staleness exists as a **rollback/replay** defense on the *cache file*, not on
+  the vault key. Bypassing it for the biometric path is safe **because** we then
+  immediately fetch authoritative data from the server and rewrite the cache
+  with a fresh counter — i.e. we replace the possibly-rolled-back cache rather
+  than trusting it. On the `cacheRecovered == false` path the stale entries are
+  **never decoded or displayed** — the stale file is only ever discarded and
+  replaced (Round-1 security verdict, axes a/b: SAFE). The one case where we can't
+  reach the server, we now FAIL CLOSED to `.vaultLocked` (INV-C5.1) instead of
+  trusting stale entries — and C5's structural guard (no `readCacheFile` on the
+  `cacheRecovered==false` path) closes the S2 counter-splice window. This is
+  strictly stronger than today's silent bounce (which also failed closed, just
+  without feedback) and never weaker.
+- **Scope of the rollback guarantee (S1 — host-app only)**: the "resync
+  neutralizes rollback" property applies to the **host-app** read path. The
+  AutoFill extension (`CredentialResolver`) reads the same cache file with its own
+  counter-consistency check but has NO resync — a captured consistent (file, meta)
+  rollback pair remains servable to AutoFill until the next host sync bumps the
+  counter. This is **pre-existing** (AutoFill always trusted a counter-consistent
+  file; this plan does not change AutoFill) and is tracked as SC6, not fixed here.
+  The plan does not claim to close it.
+
+### Scope contract
+
+- **SC1**: The 1h/24h staleness thresholds in `EntryCacheFile.swift:250-252`
+  are NOT changed. This plan changes how the *caller* reacts to a staleness
+  rejection, not the rejection policy itself. Owner: any future cache-policy
+  tuning PR.
+- **SC2**: The passphrase-path offline behavior is NOT redesigned. It keeps its
+  current persisted-cache fallback. Owner: N/A (deliberately unchanged).
+- **SC3**: Team-key resync semantics inside `runSync` are unchanged; this plan
+  does not touch `refreshTeamKeys`. Owner: N/A.
+- **SC4**: Real biometric-prompt E2E (VC1) is manual device testing, not
+  automated here.
+- **SC5**: Distinguishing an intentional Face ID *cancel* from a biometric
+  *mismatch* is NOT added. Both surface as `.biometricFailed` today
+  (`BridgeKeyStore.swift:229-231`); teaching `BridgeKeyStore` to thread the
+  `LAError.Code`/OSStatus out is a separate refinement. Owner: future biometric-UX
+  PR. This plan's C2 handles the whole `.biometricFailed` class as "no banner,
+  stay on passphrase screen," which is correct regardless of the sub-cause.
+- **SC6** (S1 — Round 1): AutoFill-extension freshness hardening against a
+  captured consistent (file, meta) rollback pair is NOT addressed here. The
+  AutoFill path (`CredentialResolver`) has an independent counter-consistency
+  check but no resync, so it can serve a rolled-back-but-consistent cache until
+  the next host sync. This is pre-existing and out of scope. Owner: future
+  AutoFill-freshness PR (candidate mitigations: a monotonic floor on the meta
+  counter, or a server-side freshness nonce for AutoFill). `TODO(ios-biometric-stale-cache-resync): AutoFill rollback-freshness (SC6)`.
+
+### User operation scenarios
+
+1. **Idle 2h then reopen (the reported bug)**: cold-or-warm launch →
+   `.vaultLocked`/`.signedIn` → auto-prompt Face ID → biometric succeeds →
+   cache stale → `cacheRecovered=false` → `runSync` succeeds → fresh cache →
+   `.vaultUnlocked` list shown. **Fixed.**
+2. **Idle 2h then reopen, but offline**: same until sync → sync fails →
+   `cacheRecovered=false` → `.vaultLocked` + explicit "enter passphrase" error.
+   User types passphrase → `unlock` fetches fresh data → list. **Graceful.**
+3. **Locked 5 min, still online (fresh cache)**: Face ID → cache fresh →
+   `cacheRecovered=true` → offline-fast unlock, no network. **Unchanged/fast.**
+4. **AutoFill extension bumped the counter between app foregrounds**: cache
+   counter mismatches bridge-meta → `readCacheFile` throws `.counterMismatch` →
+   `cacheRecovered=false` → resync heals. **Fixed (bonus).**
+5. **User cancels the Face ID sheet**: `readForFill` throws biometric-cancel →
+   `.biometricFailed` → C2 treats intentional cancel as no-banner, stays on
+   passphrase screen. **No spurious error.**
+6. **Legacy vault, first post-upgrade unlock, stale cache (F1)**: `wrapped-vault-key.json`
+   has `userId=nil` → `unlockWithBiometrics` on a stale cache throws
+   `.cacheUnreadable` → C2 shows explicit "enter passphrase" error → user does one
+   passphrase unlock → `userId` re-persisted → every later biometric unlock heals
+   via resync. **One-time transition, explicit (never silent).** Offline+legacy+stale
+   is an unavoidable hard-fail, also explicit.
+
+## Go/No-Go Gate
+
+| ID  | Subject                                                        | Status  |
+|-----|---------------------------------------------------------------|---------|
+| C1  | `unlockWithBiometrics` graceful cache-read degradation + `cacheRecovered` field | locked |
+| C2  | RootView biometric closure: explicit error, no silent swallow (`biometricUnlockError` pure fn) | locked |
+| C3  | Error surfacing into `VaultUnlockView` (`externalError` + `resolveDisplayError` pure fn) | locked |
+| C4  | Persist `userId` with wrapped vault key (optional + init default) | locked |
+| C5  | `handleVaultUnlocked` fatal-vs-recoverable (`decidePostSync(CacheData?)` + keyVersion propagation) | locked |
+
+**Round-1 resolution log** (three-expert review — all findings reflected):
+
+- **S2 [Critical, escalated]** → C5 rewritten: `decidePostSync` takes `CacheData?`
+  (not `Bool`); structural guard so `cacheRecovered==false` NEVER re-reads the
+  cache + forbidden-pattern + AC-C5.1/C5.6. Counter-splice window closed.
+- **F1 [Critical]** → legacy-vault bootstrap documented in C1 + AC-C1.4 +
+  Scenario 6. One-time explicit transition, not a silent regression.
+- **T1 [Critical]** → HostSyncService-level FR1 healing test added (Testing
+  strategy) — closes the "resync heals" coverage gap `decidePostSync` can't.
+- **F2 [Major]** → INV-C5.3 + C5 behavior: synced keyVersion propagated to
+  `.vaultUnlocked` (prevents keyVersion=1 write-back on edit).
+- **F3 [Major]** → C4: memberwise init gains `userId: String? = nil` default;
+  sweep corrected to 15 constructors (2 prod + 13 test).
+- **T4/T5 [Major]** → C2: `biometricUnlockError` pure fn + AC-C2.1 behavioral
+  symptom regression. Grep guards demoted to defense-in-depth.
+- **T6 [Major]** → C4: Equatable sweep corrected (WrappedKeyStoreTests:40,60,217)
+  + AC-C4.3 store-layer round-trip.
+- **T2 [Major]** → subsumed by S2 fix (`CacheData?` decision input).
+- **S1 [Major]** → SC6 scope note (AutoFill rollback-freshness, pre-existing,
+  tracked follow-up) + security-analysis scope correction.
+- **F4/T7 [Minor]** → FR3 + INV-C1.3 scoped to `unlockWithBiometrics`;
+  acknowledged `runSync` is unconditional.
+- **F5 [Minor]** → C5 single-read ordering specified.
+- **F6 [Info]** → C5: `@discardableResult`.
+- **S3 [Minor]** → C4 tampered-userId note. **S4 [Info]** → noted (security-safe;
+  F2 handles the functional side). **T3/T8 [Info/Minor]** → test recipes locked.
+
+All contracts are LOCKED. Ready for Phase 2 (coding). A Round-2 verification pass
+should confirm the S2 structural guard and F2 keyVersion propagation are correctly
+reflected before implementation begins.

--- a/docs/archive/review/ios-biometric-stale-cache-resync-plan.md
+++ b/docs/archive/review/ios-biometric-stale-cache-resync-plan.md
@@ -493,7 +493,14 @@ evaluated against the code:
     does NOT rescue a cacheless failed sync).
   - AC-C5.2: `decidePostSync(nil, false, nil)` → `.failLocked`.
   - AC-C5.3: `decidePostSync(nil, true, <non-nil>)` → `.useLocalCache`.
-  - AC-C5.4: `decidePostSync(nil, true, nil)` → `.failLocked`.
+  - AC-C5.4 (REVISED — Phase 3 F1): `decidePostSync(nil, true, nil)` →
+    `.useEmptyCache` (NOT `.failLocked`). A valid unlock (passphrase always sets
+    `cacheRecovered=true`) with no persisted cache is a brand-new / first-offline
+    vault — a legitimate empty-vault success state, not a fail-closed condition.
+    Fail-closed (`.failLocked`) is reserved for the `cacheRecovered==false`
+    (biometric stale/rolled-back) case. The Round-0 plan had this wrong; the
+    empty-vault synthesis the old code did for the passphrase path was correct and
+    must be preserved (INV-C5.2). A distinct `.useEmptyCache` outcome carries this.
   - AC-C5.5: `decidePostSync(<non-nil>, _, _)` → `.useFreshCache`.
   - AC-C5.6 (F2, mildly-stale realism): the S2 sharp case — a cache that is
     >1h old but refreshed <24h ago (so `readCacheFile` would NOT throw staleness)

--- a/docs/archive/review/ios-biometric-stale-cache-resync-plan.md
+++ b/docs/archive/review/ios-biometric-stale-cache-resync-plan.md
@@ -638,6 +638,59 @@ The fallback path does **not** open a new authz/DPoP/token hole because:
    via resync. **One-time transition, explicit (never silent).** Offline+legacy+stale
    is an unavoidable hard-fail, also explicit.
 
+## Implementation Checklist (Step 2-1)
+
+**Confirmed error copy (user-approved)**:
+- en (key): `Your session is out of date. Enter your passphrase to unlock.`
+- ja: `セッション情報が古くなっています。パスフレーズを入力して解錠してください。`
+- Location: `ios/PasswdSSOApp/Localizable.xcstrings` (hand-authored `en`+`ja`
+  `stringUnit`, `extractionState: "stale"` — matches the 2 existing unlock keys;
+  xcodebuild does not write extraction back, per memory `ios-string-catalog-notes`).
+
+**Files to modify**:
+1. `ios/Shared/Storage/WrappedKeyStore.swift` — C4: add `userId: String?` to
+   `WrappedVaultKey` + memberwise `init(..., userId: String? = nil)`.
+2. `ios/PasswdSSOApp/Vault/VaultUnlocker.swift` — C1: add `cacheRecovered: Bool`
+   to `UnlockResult`; `unlock` passes `userId:` to `WrappedVaultKey` (C4 producer)
+   + sets `cacheRecovered: true`; `unlockWithBiometrics` wraps Step 5 in do/catch,
+   sets `cacheRecovered` + legacy-userId fallback + `.cacheUnreadable` throw.
+   (2 `UnlockResult(` producers at :200,:265; both get the new field.)
+3. `ios/PasswdSSOApp/Debug/DebugVaultLoader.swift:98` — C4 producer: pass `userId:`.
+4. `ios/PasswdSSOApp/Views/RootView.swift` — C2/C3/C5: `@discardableResult ... -> Bool`;
+   `decidePostSync` call + structural guard (no re-read on cacheRecovered==false);
+   synced-keyVersion derivation; biometric closure sets `biometricErrorText` via
+   `biometricUnlockError`; pass `externalError:` into `VaultUnlockView`.
+5. `ios/PasswdSSOApp/Views/Vault/VaultUnlockView.swift` — C3: add `externalError: String?`
+   param (default nil); display via `resolveDisplayError`.
+6. New pure functions (app target, `@testable`-importable like `VaultViewModel`):
+   `decidePostSync`, `biometricUnlockError`, `resolveDisplayError` — colocate in a
+   small `PostSyncDecision.swift` (mirrors `LockStateReducer` split).
+7. `ios/PasswdSSOApp/Localizable.xcstrings` — new error key (above).
+
+**Tests to add/update**:
+- `ios/PasswdSSOTests/VaultUnlockerTests.swift` — AC-C1.1..C1.4 (stale→false,
+  fresh→true, counter-mismatch→false, legacy bootstrap), AC-C4.1/4.2.
+- `ios/PasswdSSOTests/WrappedKeyStoreTests.swift` — AC-C4.3 store round-trip.
+- `ios/PasswdSSOTests/HostSyncServiceTests.swift` (new or existing) — T1 healing.
+- New `ios/PasswdSSOTests/PostSyncDecisionTests.swift` — AC-C5.1..C5.6, AC-C2.1,
+  AC-C3.1/3.2.
+
+**Reuse (no reimplementation)**:
+- `L10n.string(...)` for the new error (existing i18n helper).
+- `max(1, entries.first { $0.teamId == nil }?.keyVersion ?? 1)` keyVersion logic
+  already at `VaultUnlocker.swift:261` — reuse the same expression in C5.
+- `readCacheFile` / `writeCacheFile` (unchanged), `HostSyncService.runSync`.
+- Test helpers: `buildCacheFileForBiometricTest`, `MockKeychainAccessor`,
+  `TempDirWrappedKeyStore`, `StubVaultAPIClient`, injectable `now`.
+
+**No parallel-implementation risk**: `UnlockResult(` = 2 sites (both `VaultUnlocker`),
+`WrappedVaultKey(` = 15 sites (2 prod + 13 test, all safe via `= nil` default),
+`handleVaultUnlocked` = 2 call sites (`:262` biometric, `:286` passphrase).
+
+**CI parity**: iOS CI runs `xcodegen generate` + `xcodebuild test`. After adding
+`PostSyncDecision.swift` / `PostSyncDecisionTests.swift`, `xcodegen generate` must
+regenerate the pbxproj and it must be committed (memory `ios-xcodegen-build-settings`).
+
 ## Go/No-Go Gate
 
 | ID  | Subject                                                        | Status  |

--- a/docs/archive/review/ios-biometric-stale-cache-resync-review.md
+++ b/docs/archive/review/ios-biometric-stale-cache-resync-review.md
@@ -1,0 +1,156 @@
+# Plan Review: ios-biometric-stale-cache-resync
+
+Date: 2026-07-04
+Review round: 1
+
+## Changes from Previous Round
+
+Initial review. Three expert agents (functionality, security, testing) reviewed
+the Round-0 plan against the actual source (`VaultUnlocker`, `RootView`,
+`EntryCacheFile`, `WrappedKeyStore`, `HostSyncService`, `VaultViewModel`,
+`CredentialResolver`, `VaultUnlockerTests`).
+
+**Convergent structural insight (all three experts):** the plan reasoned and
+proposed tests at the `unlockWithBiometrics` seam, but the load-bearing logic —
+the actual cache healing (FR1), the fail-closed guarantee (INV-C5.1), and
+keyVersion correctness — all live in `handleVaultUnlocked` (`RootView.swift:345-397`),
+which is the VC2-blocked, untested layer. The Round-2 plan must push that logic
+into pure, tested functions and lock the sharp edges.
+
+## Functionality Findings
+
+- **F1 [Critical]** Legacy-vault bootstrapping gap. C4's optional `userId` field
+  is decode-compatible but NOT behavior-compatible: a user who set up their vault
+  before this ships has `userId=nil` in `wrapped-vault-key.json`. First
+  post-upgrade biometric unlock **with a stale cache** → C1 failure branch reads
+  `userId=nil` → throws `.cacheUnreadable`. The reported bug is only partially
+  fixed for existing users until they do one passphrase unlock. Undocumented,
+  untested. Offline+legacy+stale is an unavoidable hard-fail. (Verified:
+  `VaultUnlocker.swift:168` producer, `WrappedKeyStore.swift:84-94` store.)
+- **F2 [Major]** `keyVersion=1` on the `cacheRecovered=false` branch reaches
+  `.vaultUnlocked` (`RootView.swift:419` uses `unlockResult.keyVersion`, not the
+  synced value) and is **written back to the server** on create/edit
+  (`VaultViewModel.swift:263,268,335,339` — `liveKeyVersion = max(1, keyVersion)`;
+  `VaultListView.swift:18` threads it in). No decrypt/read problem (entry AAD is
+  `userId+entryId+vaultType`, not keyVersion), but a wrong-low keyVersion is
+  persisted on any mutation in that session. Plan's claim "sync supplies
+  authoritative keyVersion" is false for the app-level value. **Confirmed against
+  code.**
+- **F3 [Major]** `WrappedVaultKey` memberwise `init` must add `userId: String? = nil`
+  (default) or 15 call sites break (2 production + 13 test constructors). Plan's
+  sweep undercounted producers (claimed 2, missed 13 test sites). With the
+  default it's clean.
+- **F4 [Minor]** FR3/INV-C1.3 "no network on fresh cache" conflates
+  `unlockWithBiometrics` (genuinely no network) with the whole flow
+  (`handleVaultUnlocked` always calls `runSync`, `RootView.swift:347`). The
+  offline guarantee comes from `runSync` failure→persisted-cache fallback, not
+  suppressed network. **Converges with T7.**
+- **F5 [Minor]** `decidePostSync`'s `hasPersistedCache` is only knowable by doing
+  the read that IS the fallback. Feasible with a single read; plan must specify
+  the ordering (mirror `LockStateReducer` split).
+- **F6 [Info]** `handleVaultUnlocked -> Bool`: passphrase call site ignores the
+  return → Swift warning. Use `@discardableResult`.
+
+## Security Findings
+
+**Central verdict: the core design is SAFE on the rollback/replay axis.** Stale
+entries are never decoded/displayed on the `cacheRecovered=false` path — the stale
+file is only ever discarded and replaced by a fresh server sync at counter N+1.
+DPoP/token path is clean (reuses the existing real-signer `MobileAPIClient`, no
+NoOp/unsigned path introduced). userId persistence is confidentiality-safe
+(already in the cache header + unlock response) and integrity-benign.
+
+- **S2 [Critical, escalate]** `decidePostSync` as specified omits the "sync failed
+  BUT `readCacheFile` succeeds" sub-case on the `cacheRecovered=false` path. The
+  existing fallback (`RootView.swift:377-384`) inlines `try? readCacheFile` with an
+  **independent `expectedCounter`** source (`readDirect()` vs the biometric meta
+  read at `VaultUnlocker.swift:250`). Staleness is **AND-gated** (issuedAt>1h AND
+  lastRefresh>24h), so a mildly-stale file reads cleanly. A literal implementation
+  that reaches the line-377 re-read on the failure path can decrypt entries the
+  first read rejected → a caller-layer counter-splice window. **Fix: lock C5 so on
+  `cacheRecovered==false` the code NEVER calls `readCacheFile` again and NEVER
+  reaches 377-397 — `guard` before the if-let ladder, return `.failLocked`. Add a
+  forbidden-pattern + an AC for the mildly-stale case.**
+- **S1 [Major]** The "resync neutralizes rollback" guarantee is **host-app-only**.
+  The AutoFill extension (`CredentialResolver.swift`) reads the same cache file with
+  its own counter check and no resync; a captured consistent (file, meta) rollback
+  pair remains servable to AutoFill until the next host sync bumps the counter.
+  Pre-existing (plan doesn't worsen it), but the plan's security claim is
+  over-broad. **Fix: scope-note it; track AutoFill freshness hardening separately.**
+- **S3 [Minor]** Tampered persisted `userId` is self-defeating (server authz is
+  DPoP-token-bound, not local-userId-bound; entries are vaultKey-bound AEAD).
+  Not exploitable. Add a one-line note to C4.
+- **S4 [Info]** `keyVersion=1` floor is security-safe (entry decrypt uses per-entry
+  keyVersion from the blob). [Note: F2 shows it is a *functional* write-path bug
+  even though it is not a security bug.]
+
+## Testing Findings
+
+- **T1 [Critical]** FR1 "the resync heals" has no end-to-end test. The C1 tests
+  prove `unlockWithBiometrics` *returns* `cacheRecovered=false`, but the healing
+  (false→runSync→fresh populated vault) lives in the untested `handleVaultUnlocked`.
+  `decidePostSync` returns only a decision enum, not a populated `cacheData`. **Fix:
+  add a `HostSyncService`-level test (collaborators are injectable) that seeds a
+  stale/absent cache, runs `runSync`, and asserts the rewritten cache is readable
+  at the new counter with the expected entries.** Converges with S2/T2.
+- **T2 [Major]** `decidePostSync(...,hasPersistedCache: Bool)` — the "valid
+  persisted cache" is decoupled from the real read; the pure function can return
+  `.useLocalCache` while the real read fails, keeping empty-synthesis reachable.
+  **Fix: pass `CacheData?` (not `Bool`) into the pure function** so `nil` +
+  `cacheRecovered==false` deterministically yields `.failLocked`. Converges with S2.
+- **T4 [Major]** No behavioral regression test forbids re-introducing the
+  empty-catch (C2) or empty-synthesis (C5). Plan leans on grep forbidden-patterns
+  (bypassable). **Fix: extract `biometricUnlockError(from:decision:) -> String?`
+  and unit-test it** so INV-C2.1 is behaviorally guarded. (memory
+  `ios-swift6-file-vacuous-gate`: any source-grep gate must use `#filePath` +
+  non-swallow `try` + prove-red.)
+- **T5 [Major]** The bug-fix fails-before test covers the *mechanism* (throw→return,
+  AC-C1.1) but not the user *symptom* (silent bounce = RootView swallow + fatal
+  routing). **Fix: T4's pure-function test is the symptom regression; state which
+  test is fails-before for the reported bug.**
+- **T6 [Major]** R19: C4's Equatable sweep missed `WrappedKeyStoreTests.swift:40,60,217`
+  (exact `XCTAssertEqual` on `WrappedVaultKey`). Safe because the field is optional
+  + JSON-omitted, but the plan's stated justification is wrong. **Fix: correct the
+  sweep; add a store-layer round-trip test with a non-nil `userId`.**
+- **T7 [Minor]** AC-C1.2 "no data source call" is vacuous (the method never calls
+  the source on any branch). INV-C1.3 "no network on fresh" may already be false
+  (`runSync` unconditional). **Converges with F4.**
+- **T8 [Minor, Adjacent]** C3's `externalError ?? errorMessage` precedence IS
+  extractable (one-liner) — remove the "if not extractable" hedge; extract
+  `resolveDisplayError(external:internal:)` and test AC-C3.1/AC-C3.2.
+- **T3 [Info]** Counter-mismatch test recipe is sound with the existing API
+  (`incrementCounter` is public); assert `cacheRecovered==false`, not a throw.
+
+## Adjacent Findings
+
+- **T8-A** (testing → C3 display layer): precedence rule extraction — routed into C3.
+- **S1** flags an AutoFill (cross-target) interaction — routed to a scope note +
+  a tracked follow-up (not fixed in this PR; pre-existing).
+
+## Quality Warnings
+
+None — all findings carry file:line evidence and concrete fixes.
+
+## Recurring Issue Check
+
+### Functionality expert
+R1 clean · R2 finding (F2 keyVersion=1) · R3 finding (F3 sweep) · R4 clean ·
+R5 clean · R6 clean · R7 finding (F3 init default) · R8 clean · R9 clean ·
+R10 clean · R11 finding (F4) · R12 clean · R13 finding (F1 nil vs empty) ·
+R14 finding (F1/F3 backward-compat) · R15 clean · R16 finding (F6) ·
+R17 clean · R18 finding (F5 double-read) · R19 finding (F3) · R20 finding (F2) ·
+R21 clean · R22 n-a · R23 clean · R24 n-a · R25 finding (F1 implicit migration) ·
+R26 clean · R27 clean · R28 clean · R29 clean · R30 clean · R31 n-a · R32 clean ·
+R33 clean · R34 clean · R35 n-a · R36 n-a · R37 n-a · R38 clean · R39 clean ·
+R40 finding (F1/F4 doc drift) · R41 finding (F6) · R42 clean
+
+### Security expert
+R1-R13 pass · R14 warn (S2 fail-open edge) · R15-R21 pass · R22 warn (S1 AutoFill) ·
+R23-R42 pass · RS1 pass · RS2 warn (S1/S2 rollback-replay caller/AutoFill) ·
+RS3 pass (DPoP unchanged) · RS4 pass (userId non-secret, out of biometric ACL) ·
+RS5 pass (AAD/counter binding intact)
+
+### Testing expert
+R1-R2 pass · R3 flag (T6) · R4-R18 pass · R19 flag (T6/T7) · R20-R42 pass ·
+RT1 flag (T1) · RT2 flag (T4) · RT3 flag (T2/T7) · RT4 flag (T5) · RT5 pass ·
+RT6 flag (T2/T8 extract pure fns) · RT7 pass

--- a/ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift
+++ b/ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift
@@ -47,8 +47,10 @@ public struct AutofillTokenRefresher: Sendable {
       let nonce = try? hostTokenStore.loadNonce()
       try uploadTokenStore.save(token: response.token, expiresAt: expiresAt, dpopNonce: nonce)
     } catch {
-      // No token data in MobileAPIError cases — safe to log the case name.
-      Self.log.error("autofill-token refresh failed: \(String(describing: error), privacy: .public)")
+      // Log only the error TYPE, never its associated values: `mintAutofillToken`
+      // throws an arbitrary Error, so dumping it whole risks leaking a URL /
+      // response / internal state the day it throws a richer type.
+      Self.log.error("autofill-token refresh failed: \(String(describing: type(of: error)), privacy: .public)")
     }
   }
 

--- a/ios/PasswdSSOApp/Debug/DebugVaultLoader.swift
+++ b/ios/PasswdSSOApp/Debug/DebugVaultLoader.swift
@@ -99,7 +99,8 @@ public enum DebugVaultLoader {
       ciphertext: cipher,
       iv: iv,
       authTag: tag,
-      issuedAt: Date()
+      issuedAt: Date(),
+      userId: fixtureUserId
     )
     try wrappedKeyStore.saveVaultKey(wrappedVaultKey)
 

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -2667,6 +2667,23 @@
         }
       }
     },
+    "Your session has expired. Please sign in again.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your session has expired. Please sign in again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッションの有効期限が切れました。もう一度サインインしてください。"
+          }
+        }
+      }
+    },
     "Your session is out of date. Enter your passphrase to unlock.": {
       "extractionState": "stale",
       "localizations": {

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -2667,6 +2667,23 @@
         }
       }
     },
+    "Your session is out of date. Enter your passphrase to unlock.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your session is out of date. Enter your passphrase to unlock."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッション情報が古くなっています。パスフレーズを入力して解錠してください。"
+          }
+        }
+      }
+    },
     "biometrics": {
       "comment": "Fallback biometry name when neither Face ID nor Touch ID is detected.",
       "extractionState": "stale",

--- a/ios/PasswdSSOApp/Network/MobileAPIClient.swift
+++ b/ios/PasswdSSOApp/Network/MobileAPIClient.swift
@@ -172,6 +172,10 @@ public actor MobileAPIClient: VaultUnlockDataSource {
   let tokenStore: HostTokenStore
   private let urlSession: URLSession
   private let now: @Sendable () -> Date
+  /// Process-global refresh gate. Defaults to the shared instance so every client
+  /// in the app collapses concurrent refreshes; tests inject a fresh instance to
+  /// isolate the success cache per test.
+  private let refreshCoordinator: TokenRefreshCoordinator
 
   public init(
     serverURL: URL,
@@ -179,7 +183,8 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     jwk: [String: String],
     tokenStore: HostTokenStore,
     urlSession: URLSession = .shared,
-    now: @Sendable @escaping () -> Date = { Date() }
+    now: @Sendable @escaping () -> Date = { Date() },
+    refreshCoordinator: TokenRefreshCoordinator = .shared
   ) {
     self.serverURL = serverURL
     self.signer = signer
@@ -187,6 +192,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     self.tokenStore = tokenStore
     self.urlSession = urlSession
     self.now = now
+    self.refreshCoordinator = refreshCoordinator
   }
 
   // MARK: - Public API
@@ -665,9 +671,6 @@ public actor MobileAPIClient: VaultUnlockDataSource {
   /// Proactive refresh skew: refresh the access token when it is within this many seconds of expiry.
   private let refreshSkewSeconds: TimeInterval = 60
 
-  /// In-flight single-flight refresh task. Nil when no refresh is in progress.
-  private var refreshTask: Task<String, Error>?
-
   /// Atomically persist a rotated token pair; uses now() for expiresAt.
   private func persist(_ r: TokenExchangeResponse) throws {
     try tokenStore.saveTokens(
@@ -695,15 +698,35 @@ public actor MobileAPIClient: VaultUnlockDataSource {
   /// Single-flight refresh gate. Joins an in-flight refresh if one is running,
   /// returns the already-rotated token if someone else just refreshed, or
   /// starts exactly one refresh and returns the new access token.
+  ///
+  /// The single-flight is enforced PROCESS-GLOBALLY via `TokenRefreshCoordinator`,
+  /// keyed by the token store's Keychain identifier — so distinct `MobileAPIClient`
+  /// instances backed by the same token store never fire concurrent refreshes with
+  /// the same refresh token (which would trip the server's replay detector and
+  /// revoke the whole token family). The instance-local `staleToken` fast-path
+  /// below still short-circuits when a prior refresh already rotated the token.
   private func ensureRefreshed(staleToken: String) async throws -> String {
-    // Join in-flight refresh (actors are reentrant at await — this is reachable).
-    if let task = refreshTask { return try await task.value }
-    // Already rotated by a prior concurrent call — return the current token.
+    // Already rotated (by this or another instance) — return the current token
+    // without a network round-trip.
     if let (current, _) = try? tokenStore.loadAccess(), current != staleToken { return current }
-    let task = Task { try await self.doRefreshAndPersist() }
-    refreshTask = task
-    defer { refreshTask = nil }
-    return try await task.value
+    // Process-global single-flight: collapse concurrent refreshes (across all
+    // MobileAPIClient instances backed by the same token store) into ONE network
+    // refresh, so we never present an already-rotated (revoked) refresh token to
+    // the server and trip its replay detector.
+    let key = tokenStore.serviceIdentifier
+    return try await refreshCoordinator.run(key: key) { [self] in
+      // Re-check inside the gate: a refresh that ran while we queued may have
+      // already rotated the token, making our network refresh unnecessary.
+      if let (current, _) = try? await self.loadAccessOnActor(), current != staleToken {
+        return current
+      }
+      return try await self.doRefreshAndPersist()
+    }
+  }
+
+  /// Actor-isolated Keychain read used inside the global refresh gate.
+  private func loadAccessOnActor() throws -> (String, Date)? {
+    try tokenStore.loadAccess()
   }
 
   /// Returns a non-expired access token.

--- a/ios/PasswdSSOApp/Network/TokenRefreshCoordinator.swift
+++ b/ios/PasswdSSOApp/Network/TokenRefreshCoordinator.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Process-global refresh gate that collapses redundant token refreshes into ONE
+/// network call.
+///
+/// Two failure modes trip the server's refresh-token replay detector (which
+/// revokes the whole token family → `MOBILE_REFRESH_REUSE_DETECTED` → dead
+/// session):
+///  1. CONCURRENT refreshes — multiple `MobileAPIClient` instances (SessionRestorer,
+///     AuthCoordinator, RootView, background sync) each fire a refresh with the same
+///     stale refresh token at the same time. Handled by the in-flight single-flight
+///     join below.
+///  2. SEQUENTIAL re-tries within one unlock flow — several independent steps
+///     (unlock-data fetch, sync, QuickType refresh, drain) each call `ensureRefreshed`
+///     back-to-back. The first rotates the token; the next presents the now-revoked
+///     old token before the Keychain write is observed. Handled by the short
+///     success cache below: within `resultTTL` (< the server's 5s replay grace), a
+///     repeat call for the same key replays the FIRST call's rotated token instead
+///     of hitting the network again.
+///
+/// Only successful refreshes are cached. Every failure — including
+/// `authenticationRequired` — stays immediately retryable, because a re-sign-in can
+/// install a fresh valid token at any moment and a cached failure would keep
+/// returning the dead-session error for the whole TTL even after recovery.
+public actor TokenRefreshCoordinator {
+  public static let shared = TokenRefreshCoordinator()
+
+  /// Window during which a settled refresh result is replayed to repeat callers.
+  /// Must be shorter than the server's replay grace (5s) so a legitimately-expired
+  /// cache does not mask a real rotation.
+  private let resultTTL: TimeInterval
+  private let now: @Sendable () -> Date
+
+  /// In-flight refresh per token-store key (single-flight for concurrent callers).
+  private var inFlight: [String: Task<String, Error>] = [:]
+
+  /// Last SUCCESSFUL refresh per key, with the time it settled. Only successes are
+  /// cached — a failure must never be replayed (a re-sign-in can recover at any time).
+  private enum CachedOutcome {
+    case success(String)
+  }
+  private var lastResult: [String: (outcome: CachedOutcome, at: Date)] = [:]
+
+  public init(
+    resultTTL: TimeInterval = 3,
+    now: @Sendable @escaping () -> Date = { Date() }
+  ) {
+    self.resultTTL = resultTTL
+    self.now = now
+  }
+
+  /// Run `refresh` under the global gate for `key`. Order of precedence:
+  ///  1. A fresh cached result (< resultTTL old) → replay it, no network call.
+  ///  2. An in-flight refresh → join it.
+  ///  3. Otherwise start exactly one refresh, cache its outcome, and return it.
+  public func run(
+    key: String,
+    refresh: @Sendable @escaping () async throws -> String
+  ) async throws -> String {
+    // 1. Replay a recent SUCCESS only. Failures are never cached: a re-sign-in can
+    //    install a fresh valid token at any moment, and caching a failure would
+    //    keep returning authenticationRequired for `resultTTL` even after recovery.
+    if let cached = lastResult[key], now().timeIntervalSince(cached.at) < resultTTL {
+      if case .success(let token) = cached.outcome {
+        return token
+      }
+    }
+
+    // 2. Join an in-flight refresh.
+    if let existing = inFlight[key] {
+      return try await existing.value
+    }
+
+    // 3. Start one refresh; cache ONLY a success for repeat callers.
+    let task = Task { try await refresh() }
+    inFlight[key] = task
+    defer { inFlight[key] = nil }
+    let token = try await task.value
+    lastResult[key] = (.success(token), now())
+    return token
+  }
+}

--- a/ios/PasswdSSOApp/Vault/PostSyncDecision.swift
+++ b/ios/PasswdSSOApp/Vault/PostSyncDecision.swift
@@ -89,3 +89,28 @@ public func biometricUnlockError(
 public func resolveDisplayError(external: String?, internalError: String?) -> String? {
   external ?? internalError
 }
+
+/// Outcome of `handleVaultUnlocked`, so the biometric call site can pick the right
+/// banner: reached the vault, failed closed on a dead session (→ "sign in again"),
+/// or failed closed offline (→ "enter passphrase / try again").
+public enum UnlockedResult: Equatable {
+  case reachedVault
+  case failedSessionExpired
+  case failedOffline
+}
+
+/// Classify an unlock-time `runSync` error: `true` only when the session is dead
+/// (the refresh token expired or a replay revoked the family), which surfaces from
+/// the API client as `MobileAPIError.authenticationRequired`. Every other error
+/// (offline, transient server, decode) is `false` — a recoverable/offline failure.
+public func syncFailedSessionExpired(from error: Error) -> Bool {
+  if case MobileAPIError.authenticationRequired = error { return true }
+  return false
+}
+
+/// Map a fail-closed unlock (sync failed with no trustworthy local cache) to the
+/// banner outcome: a dead session routes to "sign in again", a mere offline failure
+/// to "try again with your passphrase".
+public func failClosedResult(sessionExpired: Bool) -> UnlockedResult {
+  sessionExpired ? .failedSessionExpired : .failedOffline
+}

--- a/ios/PasswdSSOApp/Vault/PostSyncDecision.swift
+++ b/ios/PasswdSSOApp/Vault/PostSyncDecision.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Shared
+
+/// Pure decision helpers for the post-unlock flow. Extracted from `RootView`
+/// (which is not unit-testable without a SwiftUI host) so the load-bearing
+/// fatal-vs-recoverable logic, the biometric error mapping, and the error
+/// precedence are covered by plain XCTest — mirrors the `LockStateReducer`
+/// split used by `AutoLockService`.
+
+/// Outcome of the post-`runSync` decision in `handleVaultUnlocked`.
+public enum PostSyncOutcome: Equatable {
+  /// Sync succeeded — use the freshly-built cache it returned.
+  case useFreshCache
+  /// Sync failed but a valid persisted cache exists AND the biometric read had
+  /// recovered a valid local cache — fall back to the persisted cache (offline).
+  case useLocalCache
+  /// Route back to the locked screen and surface an explicit error. Reached when
+  /// the sync failed and there is no trustworthy local cache to fall back to.
+  case failLocked
+}
+
+/// Decide what `handleVaultUnlocked` does after `runSync`.
+///
+/// - Parameters:
+///   - syncReport: the sync result, or `nil` if the sync threw.
+///   - cacheRecovered: whether the unlock recovered a valid local cache. `false`
+///     means the on-disk cache was stale / counter-mismatched / unreadable, so it
+///     MUST NOT be trusted as a fallback — a failed sync then fails closed.
+///   - persistedCache: the already-read persisted cache (read ONCE by the caller),
+///     or `nil` if absent/unreadable.
+///
+/// Security note (S2): when `cacheRecovered == false`, a readable `persistedCache`
+/// does NOT rescue a failed sync — the result is `.failLocked` regardless. This is
+/// what forbids the caller from re-reading (and re-trusting) a possibly rolled-back
+/// cache on the failure path.
+public func decidePostSync(
+  syncReport: SyncReport?,
+  cacheRecovered: Bool,
+  persistedCache: CacheData?
+) -> PostSyncOutcome {
+  if syncReport != nil {
+    return .useFreshCache
+  }
+  // Sync failed from here on.
+  guard cacheRecovered else {
+    // No trustworthy local cache — never fall back, even if a readable file exists.
+    return .failLocked
+  }
+  return persistedCache != nil ? .useLocalCache : .failLocked
+}
+
+/// Map a biometric-unlock outcome to a user-facing error string, or `nil` when no
+/// banner should be shown.
+///
+/// - `VaultUnlockError.biometricFailed` (an intentional cancel OR a biometric
+///   mismatch — the two are indistinguishable at the keychain layer) → `nil`: stay
+///   on the passphrase screen with no scary banner.
+/// - `syncFailedCacheless == true` (biometric auth SUCCEEDED but the cacheless
+///   resync could not complete) → the explicit "session is out of date" message.
+/// - any other thrown error → the same explicit message.
+public func biometricUnlockError(
+  from error: Error?,
+  syncFailedCacheless: Bool,
+  message: @autoclosure () -> String
+) -> String? {
+  if let error {
+    if case VaultUnlockError.biometricFailed = error {
+      return nil
+    }
+    return message()
+  }
+  return syncFailedCacheless ? message() : nil
+}
+
+/// Precedence for the unlock screen's error caption: an externally-supplied error
+/// (from the biometric closure) wins over the view's own passphrase-attempt error.
+public func resolveDisplayError(external: String?, internalError: String?) -> String? {
+  external ?? internalError
+}

--- a/ios/PasswdSSOApp/Vault/PostSyncDecision.swift
+++ b/ios/PasswdSSOApp/Vault/PostSyncDecision.swift
@@ -11,11 +11,17 @@ import Shared
 public enum PostSyncOutcome: Equatable {
   /// Sync succeeded — use the freshly-built cache it returned.
   case useFreshCache
-  /// Sync failed but a valid persisted cache exists AND the biometric read had
-  /// recovered a valid local cache — fall back to the persisted cache (offline).
+  /// Sync failed but a valid persisted cache exists AND the unlock recovered a valid
+  /// local cache — fall back to the persisted cache (offline).
   case useLocalCache
-  /// Route back to the locked screen and surface an explicit error. Reached when
-  /// the sync failed and there is no trustworthy local cache to fall back to.
+  /// Sync failed, no persisted cache, but the unlock DID recover a valid local cache
+  /// (cacheRecovered == true) — this is a benign empty/new-vault or first-offline
+  /// state (e.g. a brand-new account with zero entries). Present an empty vault; the
+  /// passphrase was valid, so this is success, not a failure.
+  case useEmptyCache
+  /// Route back to the locked screen and surface an explicit error. Reached ONLY when
+  /// the sync failed AND the unlock could NOT recover a trustworthy local cache
+  /// (cacheRecovered == false — the biometric stale/rolled-back case).
   case failLocked
 }
 
@@ -25,7 +31,9 @@ public enum PostSyncOutcome: Equatable {
 ///   - syncReport: the sync result, or `nil` if the sync threw.
 ///   - cacheRecovered: whether the unlock recovered a valid local cache. `false`
 ///     means the on-disk cache was stale / counter-mismatched / unreadable, so it
-///     MUST NOT be trusted as a fallback — a failed sync then fails closed.
+///     MUST NOT be trusted as a fallback — a failed sync then fails closed. `true`
+///     for every passphrase unlock (its passphrase was valid) and for a biometric
+///     unlock that read a fresh cache.
 ///   - persistedCache: the already-read persisted cache (read ONCE by the caller),
 ///     or `nil` if absent/unreadable.
 ///
@@ -43,10 +51,14 @@ public func decidePostSync(
   }
   // Sync failed from here on.
   guard cacheRecovered else {
-    // No trustworthy local cache — never fall back, even if a readable file exists.
+    // Untrustworthy local cache (biometric stale/rolled-back) — fail closed, never
+    // fall back, even if a readable file exists (S2).
     return .failLocked
   }
-  return persistedCache != nil ? .useLocalCache : .failLocked
+  // A valid unlock (passphrase, or biometric with a fresh cache): a failed sync falls
+  // back to the persisted cache, or to an empty vault when none exists (a brand-new /
+  // first-offline vault is a legitimate success state — NOT a fail-closed condition).
+  return persistedCache != nil ? .useLocalCache : .useEmptyCache
 }
 
 /// Map a biometric-unlock outcome to a user-facing error string, or `nil` when no

--- a/ios/PasswdSSOApp/Vault/VaultUnlocker.swift
+++ b/ios/PasswdSSOApp/Vault/VaultUnlocker.swift
@@ -31,6 +31,12 @@ public struct UnlockResult: Sendable, Equatable {
   /// `readDirect()` returns an EMPTY bridge_key, so cacheKey CANNOT be re-derived
   /// later without a biometric `readForFill`. Thread this from unlock instead.
   public let cacheKey: SymmetricKey
+  /// Whether a valid local cache was already in hand at unlock. The passphrase path
+  /// sets `true` (a persisted cache from a prior session may exist and remains a
+  /// valid offline fallback). The biometric path sets `true` only when Step 5 read a
+  /// valid cache; `false` when the cache was stale / counter-mismatched / unreadable,
+  /// signalling the caller MUST rely on a server resync (and fail closed if it fails).
+  public let cacheRecovered: Bool
 }
 
 /// Source of the encrypted vault-unlock material. `MobileAPIClient` is the
@@ -169,7 +175,10 @@ public actor VaultUnlocker {
       ciphertext: cipher,
       iv: iv,
       authTag: tag,
-      issuedAt: Date()
+      issuedAt: Date(),
+      // Persist userId so the biometric re-unlock path can drive a cacheless
+      // resync when the local cache is stale (C4). Non-secret.
+      userId: unlockData.userId
     )
     try wrappedKeyStore.saveVaultKey(wrapped)
 
@@ -202,7 +211,10 @@ public actor VaultUnlocker {
       userId: unlockData.userId,
       keyVersion: unlockData.keyVersion,
       tenantAutoLockMinutes: unlockData.vaultAutoLockMinutes,
-      cacheKey: cacheKey
+      cacheKey: cacheKey,
+      // Passphrase path did not read a cache during unlock, but a persisted cache
+      // from a prior session may exist and remains a valid offline fallback.
+      cacheRecovered: true
     )
   }
 
@@ -242,32 +254,56 @@ public actor VaultUnlocker {
 
     let vaultKey = SymmetricKey(data: vaultKeyData)
 
-    // Step 5: read encrypted cache to recover userId and keyVersion
-    let cache = try readCacheFile(
-      path: cacheURL,
-      vaultKey: vaultKey,
-      expectedHostInstallUUID: blob.hostInstallUUID,
-      expectedCounter: blob.cacheVersionCounter,
-      now: now()
-    )
-
-    // Guard against empty userId — would silently corrupt personal-entry AAD
-    guard !cache.header.userId.isEmpty else {
-      throw VaultUnlockError.cacheUnreadable
+    // Step 5: read the encrypted cache to recover userId + keyVersion. This is
+    // BEST-EFFORT: a stale / counter-mismatched / unreadable cache must NOT abort
+    // the unlock (the vault_key is already recovered). On failure we degrade to
+    // cacheRecovered=false and let the caller drive a server resync, which rebuilds
+    // the cache from scratch (the same path the passphrase unlock relies on). The
+    // stale cache's entries are never decoded here — only header userId/keyVersion.
+    let recoveredUserId: String
+    let keyVersion: Int
+    let cacheRecovered: Bool
+    do {
+      let cache = try readCacheFile(
+        path: cacheURL,
+        vaultKey: vaultKey,
+        expectedHostInstallUUID: blob.hostInstallUUID,
+        expectedCounter: blob.cacheVersionCounter,
+        now: now()
+      )
+      // Guard against empty userId — would silently corrupt personal-entry AAD.
+      guard !cache.header.userId.isEmpty else {
+        throw VaultUnlockError.cacheUnreadable
+      }
+      let entries = (try? JSONDecoder().decode([CacheEntry].self, from: cache.entries)) ?? []
+      recoveredUserId = cache.header.userId
+      keyVersion = max(1, entries.first(where: { $0.teamId == nil })?.keyVersion ?? 1)
+      cacheRecovered = true
+    } catch let error as EntryCacheError {
+      // Cache stale / counter-mismatched / unreadable. Recover userId from the
+      // persisted wrapped-key metadata (C4) so a cacheless resync can proceed. A
+      // legacy vault (set up before userId was persisted) has no source here → the
+      // caller surfaces an explicit "enter passphrase" error rather than looping.
+      _ = error  // the specific EntryCacheError kind is not needed downstream
+      guard let persistedUserId = (try? wrappedKeyStore.loadVaultKey())?.userId,
+            !persistedUserId.isEmpty
+      else {
+        throw VaultUnlockError.cacheUnreadable
+      }
+      recoveredUserId = persistedUserId
+      keyVersion = 1  // placeholder — RootView re-derives from the synced entries (C5)
+      cacheRecovered = false
     }
-
-    // Step 6: recover keyVersion from the first personal entry in the cache
-    let entries = (try? JSONDecoder().decode([CacheEntry].self, from: cache.entries)) ?? []
-    let keyVersion = max(1, entries.first(where: { $0.teamId == nil })?.keyVersion ?? 1)
 
     // Biometric/offline path: no fresh policy fetch — pass nil so the persisted
     // tenant value is reused (RootView applies it non-authoritatively).
     return UnlockResult(
       vaultKey: vaultKey,
-      userId: cache.header.userId,
+      userId: recoveredUserId,
       keyVersion: keyVersion,
       tenantAutoLockMinutes: nil,
-      cacheKey: cacheKey
+      cacheKey: cacheKey,
+      cacheRecovered: cacheRecovered
     )
   }
 

--- a/ios/PasswdSSOApp/Vault/VaultUnlocker.swift
+++ b/ios/PasswdSSOApp/Vault/VaultUnlocker.swift
@@ -13,6 +13,11 @@ public enum VaultUnlockError: Error, Equatable {
   case biometricFailed
   /// Vault key recovered via biometrics but cache header userId is missing/empty.
   case cacheUnreadable
+  /// The session is dead — the server rejected the refresh token (expired, or a
+  /// replay/reuse revoked the token family). No passphrase can fix this; the only
+  /// recovery is re-sign-in. Distinct from `serverResponseInvalid` so the UI can
+  /// route to "Sign in again" instead of looping on a misleading retry message.
+  case sessionExpired
 }
 
 /// Result of a successful vault unlock; carries the in-memory vault key, the
@@ -85,6 +90,11 @@ public actor VaultUnlocker {
       unlockData = try await apiClient.fetchVaultUnlockData()
     } catch MobileAPIError.serverError(let status) where status == 401 {
       throw VaultUnlockError.invalidPassphrase
+    } catch MobileAPIError.authenticationRequired {
+      // The refresh token is dead (expired, or a replay revoked the family). No
+      // passphrase recovers this — surface as sessionExpired so the UI routes to
+      // "Sign in again" instead of a misleading "check your connection" retry loop.
+      throw VaultUnlockError.sessionExpired
     } catch {
       throw VaultUnlockError.serverResponseInvalid
     }

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -262,13 +262,11 @@ struct RootView: View {
       biometricUnlock = { @MainActor @Sendable in
         // Clear any prior banner at the start of an attempt.
         biometricErrorText = nil
-        let sessionStaleMessage = L10n.string(
-          "Your session is out of date. Enter your passphrase to unlock.")
         do {
           let result = try await unlocker.unlockWithBiometrics(
             reason: L10n.string("Unlock your passwd-sso vault.")
           )
-          let reached = await handleVaultUnlocked(
+          let outcome = await handleVaultUnlocked(
             unlockResult: result,
             serverConfig: serverConfig,
             apiClient: apiClient,
@@ -277,18 +275,24 @@ struct RootView: View {
             // Offline path: no fresh policy fetch — must not clear a persisted value.
             policyAuthoritative: false
           )
-          // Face ID succeeded but the cacheless resync failed and there was no
-          // trustworthy local cache — surface an explicit error instead of the
-          // former silent bounce back to the passphrase screen.
-          if !reached {
-            biometricErrorText = biometricUnlockError(
-              from: nil, syncFailedCacheless: true, message: sessionStaleMessage)
+          // Face ID succeeded but the cacheless resync failed — surface an explicit
+          // banner instead of the former silent bounce. A dead session routes to
+          // "sign in again"; a mere offline failure to "try again with passphrase".
+          switch outcome {
+          case .reachedVault:
+            break
+          case .failedSessionExpired:
+            biometricErrorText = L10n.string("Your session has expired. Please sign in again.")
+          case .failedOffline:
+            biometricErrorText = L10n.string(
+              "Your session is out of date. Enter your passphrase to unlock.")
           }
         } catch {
           // A biometric cancel / mismatch shows no banner (stays on passphrase
           // screen); any other error surfaces the explicit message.
           biometricErrorText = biometricUnlockError(
-            from: error, syncFailedCacheless: false, message: sessionStaleMessage)
+            from: error, syncFailedCacheless: false,
+            message: L10n.string("Your session is out of date. Enter your passphrase to unlock."))
         }
       }
     } else {
@@ -318,10 +322,9 @@ struct RootView: View {
     }
   }
 
-  /// Returns `true` when the unlock reached `.vaultUnlocked`, `false` when it failed
-  /// closed to `.vaultLocked` (cacheless resync failed with no trustworthy local
-  /// cache). The biometric call site turns a `false` into an explicit error banner;
-  /// the passphrase call site ignores it (its own screen already shows errors).
+  /// Drives the post-unlock sync + state transition. On a cacheless resync failure
+  /// with no trustworthy local cache it fails closed to `.vaultLocked` and reports
+  /// WHY (dead session vs offline) so the caller shows the correct banner.
   @discardableResult
   @MainActor
   private func handleVaultUnlocked(
@@ -331,7 +334,7 @@ struct RootView: View {
     bridgeKeyStore: BridgeKeyStore,
     wrappedKeyStore: any WrappedKeyStore,
     policyAuthoritative: Bool
-  ) async -> Bool {
+  ) async -> UnlockedResult {
     // MUST be the first statement — regression guard for the post-unlock flicker
     // fix (#3): replaces the passphrase/Face ID screen with the splash before the
     // async sync below, so it does not linger during the unlock→list gap. Do not
@@ -370,18 +373,18 @@ struct RootView: View {
     await drain.drainPendingFlags(vaultKey: vaultKey)
 
     let syncReport: SyncReport?
+    // Whether the sync failed specifically because the session is dead (refresh
+    // token expired / replay-revoked). Drives the fail-closed banner choice.
+    var sessionExpired = false
     do {
       syncReport = try await syncService.runSync(
         vaultKey: vaultKey, userId: unlockResult.userId, cacheKey: unlockResult.cacheKey)
     } catch {
-      // The user has just unlocked with a valid vault key + session. A sync
-      // failure here (network, server, or auth) must NOT bounce them back to
-      // sign-in or wipe tokens mid-unlock — that produced a sign-in loop. Fall
-      // back to the persisted cache; the access-token refresh (C1) already makes
-      // the sync succeed across a normal token expiry. A genuinely dead refresh
-      // token surfaces as stale data, recoverable by an explicit manual Sign Out.
-      // Diagnostic only (no secrets — MobileAPIError cases carry no token data):
-      // captures WHY an unlock-time sync failed so a stale-data report is debuggable.
+      // A sync failure here must NOT wipe tokens mid-unlock. When a valid local
+      // cache exists we fall back to it (offline-tolerant); when it does not, the
+      // caller fails closed and uses `sessionExpired` to pick the banner.
+      sessionExpired = syncFailedSessionExpired(from: error)
+      // Diagnostic only (no secrets — MobileAPIError cases carry no token data).
       Logger(subsystem: AppGroupContainer.loggerSubsystem, category: "sync")
         .error("unlock-time runSync failed: \(String(describing: error), privacy: .public)")
       syncReport = nil
@@ -411,12 +414,14 @@ struct RootView: View {
       persistedCache = nil
     }
 
-    let cacheData: CacheData
-    switch decidePostSync(
+    let outcome = decidePostSync(
       syncReport: syncReport,
       cacheRecovered: unlockResult.cacheRecovered,
       persistedCache: persistedCache
-    ) {
+    )
+
+    let cacheData: CacheData
+    switch outcome {
     case .useFreshCache:
       // Use the cache the sync just built in-memory. Re-reading the encrypted file
       // here races the write on the first unlock (fresh bridge-key counter/UUID
@@ -432,9 +437,10 @@ struct RootView: View {
     case .failLocked:
       // Face ID recovered the vault key but the resync failed and there is no
       // trustworthy local cache. Fail closed to the locked screen (never present an
-      // empty vault as success) and let the caller surface an explicit error.
+      // empty vault as success) and let the caller surface an explicit error —
+      // "sign in again" for a dead session, "try again" when merely offline.
       appState = .vaultLocked(serverConfig: serverConfig, apiClient: apiClient)
-      return false
+      return failClosedResult(sessionExpired: sessionExpired)
     }
 
     // Recover the authoritative keyVersion from the synced entries when a fresh sync
@@ -468,7 +474,7 @@ struct RootView: View {
       apiClient: apiClient,
       cacheKey: unlockResult.cacheKey
     )
-    return true
+    return .reachedVault
   }
 
   /// Synthesize an empty cache for the degenerate fallback (no fresh sync, no

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -425,6 +425,10 @@ struct RootView: View {
     case .useLocalCache:
       // Sync failed (e.g. offline) — fall back to the last persisted cache.
       cacheData = persistedCache ?? emptyCacheData(userId: unlockResult.userId)
+    case .useEmptyCache:
+      // Valid unlock, sync failed, no persisted cache — a brand-new / first-offline
+      // vault. Present an empty vault (the passphrase was valid → this is success).
+      cacheData = emptyCacheData(userId: unlockResult.userId)
     case .failLocked:
       // Face ID recovered the vault key but the resync failed and there is no
       // trustworthy local cache. Fail closed to the locked screen (never present an

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -384,9 +384,11 @@ struct RootView: View {
       // cache exists we fall back to it (offline-tolerant); when it does not, the
       // caller fails closed and uses `sessionExpired` to pick the banner.
       sessionExpired = syncFailedSessionExpired(from: error)
-      // Diagnostic only (no secrets — MobileAPIError cases carry no token data).
+      // Log only the classified outcome, never the raw error: dumping an arbitrary
+      // `Error` to a public log risks leaking a URL / response / internal state the
+      // day `runSync` starts throwing a richer error type.
       Logger(subsystem: AppGroupContainer.loggerSubsystem, category: "sync")
-        .error("unlock-time runSync failed: \(String(describing: error), privacy: .public)")
+        .error("unlock-time runSync failed (sessionExpired=\(sessionExpired, privacy: .public))")
       syncReport = nil
     }
 

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -46,6 +46,11 @@ struct RootView: View {
   // Shared dependency instances kept alive across state transitions
   @State private var hostSyncService: HostSyncService?
 
+  /// Error surfaced by the biometric-unlock closure onto the passphrase screen —
+  /// e.g. Face ID authenticated but the cacheless resync failed (offline / dead
+  /// token / stale legacy cache). Replaces the previous silent bounce.
+  @State private var biometricErrorText: String?
+
   /// Drives in-place re-localization on a language change without re-creating the
   /// view tree (so an open Settings sheet stays open and the vault stays
   /// unlocked). A `bump()` re-runs `body`, which re-reads `languageLocale`.
@@ -255,11 +260,15 @@ struct RootView: View {
     let biometricUnlock: (@MainActor @Sendable () async -> Void)?
     if biometricsAvailable {
       biometricUnlock = { @MainActor @Sendable in
+        // Clear any prior banner at the start of an attempt.
+        biometricErrorText = nil
+        let sessionStaleMessage = L10n.string(
+          "Your session is out of date. Enter your passphrase to unlock.")
         do {
           let result = try await unlocker.unlockWithBiometrics(
             reason: L10n.string("Unlock your passwd-sso vault.")
           )
-          await handleVaultUnlocked(
+          let reached = await handleVaultUnlocked(
             unlockResult: result,
             serverConfig: serverConfig,
             apiClient: apiClient,
@@ -268,8 +277,18 @@ struct RootView: View {
             // Offline path: no fresh policy fetch — must not clear a persisted value.
             policyAuthoritative: false
           )
+          // Face ID succeeded but the cacheless resync failed and there was no
+          // trustworthy local cache — surface an explicit error instead of the
+          // former silent bounce back to the passphrase screen.
+          if !reached {
+            biometricErrorText = biometricUnlockError(
+              from: nil, syncFailedCacheless: true, message: sessionStaleMessage)
+          }
         } catch {
-          // Biometric cancel/fail → silent fallback to passphrase
+          // A biometric cancel / mismatch shows no banner (stays on passphrase
+          // screen); any other error surfaces the explicit message.
+          biometricErrorText = biometricUnlockError(
+            from: error, syncFailedCacheless: false, message: sessionStaleMessage)
         }
       }
     } else {
@@ -280,10 +299,13 @@ struct RootView: View {
       unlocker: unlocker,
       biometricUnlock: biometricUnlock,
       biometryLabel: biometryLabel,
-      autoPromptOnAppear: autoPromptOnAppear
+      autoPromptOnAppear: autoPromptOnAppear,
+      externalError: biometricErrorText
     ) { result in
       Task { @MainActor in
-        await handleVaultUnlocked(
+        // A passphrase attempt clears any lingering biometric banner.
+        biometricErrorText = nil
+        _ = await handleVaultUnlocked(
           unlockResult: result,
           serverConfig: serverConfig,
           apiClient: apiClient,
@@ -296,6 +318,11 @@ struct RootView: View {
     }
   }
 
+  /// Returns `true` when the unlock reached `.vaultUnlocked`, `false` when it failed
+  /// closed to `.vaultLocked` (cacheless resync failed with no trustworthy local
+  /// cache). The biometric call site turns a `false` into an explicit error banner;
+  /// the passphrase call site ignores it (its own screen already shows errors).
+  @discardableResult
   @MainActor
   private func handleVaultUnlocked(
     unlockResult: UnlockResult,
@@ -304,7 +331,7 @@ struct RootView: View {
     bridgeKeyStore: BridgeKeyStore,
     wrappedKeyStore: any WrappedKeyStore,
     policyAuthoritative: Bool
-  ) async {
+  ) async -> Bool {
     // MUST be the first statement — regression guard for the post-unlock flicker
     // fix (#3): replaces the passphrase/Face ID screen with the splash before the
     // async sync below, so it does not linger during the unlock→list gap. Do not
@@ -368,33 +395,48 @@ struct RootView: View {
       cacheURL: cacheURL
     )
 
-    let cacheData: CacheData
-    if let freshCache = syncReport?.cacheData {
-      // Use the cache the sync just built in-memory. Re-reading the encrypted
-      // file here races the write on the first unlock (fresh bridge-key
-      // counter/UUID window), which left the list empty until a second unlock.
-      cacheData = freshCache
-    } else if let blob = try? bridgeKeyStore.readDirect(), let data = try? readCacheFile(
-      path: cacheURL,
-      vaultKey: vaultKey,
-      expectedHostInstallUUID: blob.hostInstallUUID,
-      expectedCounter: blob.cacheVersionCounter
-    ) {
-      // Sync failed (e.g. offline) — fall back to the last persisted cache.
-      cacheData = data
-    } else {
-      cacheData = CacheData(
-        header: CacheHeader(
-          cacheVersionCounter: 0,
-          cacheIssuedAt: Date(),
-          lastSuccessfulRefreshAt: Date(),
-          entryCount: 0,
-          hostInstallUUID: Data(repeating: 0, count: 16),
-          userId: unlockResult.userId
-        ),
-        entries: "[]".data(using: .utf8)!
+    // Read the persisted cache AT MOST ONCE, and ONLY when the unlock recovered a
+    // valid local cache. On the cacheRecovered==false path we must NEVER re-read the
+    // file: the stale/rolled-back cache must not be trusted, and re-reading with a
+    // second (independent) expectedCounter would re-open a counter-splice window (S2).
+    let persistedCache: CacheData?
+    if unlockResult.cacheRecovered, let blob = try? bridgeKeyStore.readDirect() {
+      persistedCache = try? readCacheFile(
+        path: cacheURL,
+        vaultKey: vaultKey,
+        expectedHostInstallUUID: blob.hostInstallUUID,
+        expectedCounter: blob.cacheVersionCounter
       )
+    } else {
+      persistedCache = nil
     }
+
+    let cacheData: CacheData
+    switch decidePostSync(
+      syncReport: syncReport,
+      cacheRecovered: unlockResult.cacheRecovered,
+      persistedCache: persistedCache
+    ) {
+    case .useFreshCache:
+      // Use the cache the sync just built in-memory. Re-reading the encrypted file
+      // here races the write on the first unlock (fresh bridge-key counter/UUID
+      // window), which left the list empty until a second unlock.
+      cacheData = syncReport?.cacheData ?? persistedCache ?? emptyCacheData(userId: unlockResult.userId)
+    case .useLocalCache:
+      // Sync failed (e.g. offline) — fall back to the last persisted cache.
+      cacheData = persistedCache ?? emptyCacheData(userId: unlockResult.userId)
+    case .failLocked:
+      // Face ID recovered the vault key but the resync failed and there is no
+      // trustworthy local cache. Fail closed to the locked screen (never present an
+      // empty vault as success) and let the caller surface an explicit error.
+      appState = .vaultLocked(serverConfig: serverConfig, apiClient: apiClient)
+      return false
+    }
+
+    // Recover the authoritative keyVersion from the synced entries when a fresh sync
+    // succeeded (the biometric cacheless path defaults keyVersion=1, which must NOT
+    // reach the server on a later create/edit). Falls back to the unlock's value.
+    let effectiveKeyVersion = syncedKeyVersion(from: syncReport) ?? unlockResult.keyVersion
 
     // Mint + stage the AutoFill upload token (plan C6 — passkey registration).
     // Best-effort: a mint failure must not affect the unlock flow.
@@ -416,12 +458,39 @@ struct RootView: View {
       serverConfig: serverConfig,
       vaultKey: vaultKey,
       userId: unlockResult.userId,
-      keyVersion: unlockResult.keyVersion,
+      keyVersion: effectiveKeyVersion,
       cacheData: cacheData,
       autoLockService: autoLockService,
       apiClient: apiClient,
       cacheKey: unlockResult.cacheKey
     )
+    return true
+  }
+
+  /// Synthesize an empty cache for the degenerate fallback (no fresh sync, no
+  /// persisted cache, but cacheRecovered==true so this is a benign offline case).
+  private func emptyCacheData(userId: String) -> CacheData {
+    CacheData(
+      header: CacheHeader(
+        cacheVersionCounter: 0,
+        cacheIssuedAt: Date(),
+        lastSuccessfulRefreshAt: Date(),
+        entryCount: 0,
+        hostInstallUUID: Data(repeating: 0, count: 16),
+        userId: userId
+      ),
+      entries: "[]".data(using: .utf8)!
+    )
+  }
+
+  /// Derive the authoritative keyVersion from a completed sync's entries (first
+  /// personal entry), matching `VaultUnlocker.unlockWithBiometrics`. Returns nil when
+  /// the sync did not surface a cache.
+  private func syncedKeyVersion(from syncReport: SyncReport?) -> Int? {
+    guard let entriesData = syncReport?.cacheData?.entries,
+          let entries = try? JSONDecoder().decode([CacheEntry].self, from: entriesData)
+    else { return nil }
+    return max(1, entries.first(where: { $0.teamId == nil })?.keyVersion ?? 1)
   }
 
   /// Restore the persisted auto-lock timeout onto a freshly-created service

--- a/ios/PasswdSSOApp/Views/Vault/VaultUnlockView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultUnlockView.swift
@@ -22,6 +22,10 @@ struct VaultUnlockView: View {
   /// on appear. False when reached by an in-app lock (explicit Lock / idle timeout) — stay
   /// locked on appear (a later foreground re-entry still auto-prompts via scenePhase).
   let autoPromptOnAppear: Bool
+  /// Error surfaced by the parent's biometric-unlock closure (e.g. a cacheless resync
+  /// failed after a successful Face ID). Takes precedence over the view's own
+  /// passphrase-attempt error; nil = no external error.
+  let externalError: String?
 
   @Environment(\.scenePhase) private var scenePhase
   @State private var passphrase: String = ""
@@ -37,12 +41,14 @@ struct VaultUnlockView: View {
     biometricUnlock: (@MainActor @Sendable () async -> Void)? = nil,
     biometryLabel: String = L10n.string("biometrics"),
     autoPromptOnAppear: Bool = false,
+    externalError: String? = nil,
     onUnlocked: @MainActor @escaping (UnlockResult) -> Void
   ) {
     self.unlocker = unlocker
     self.biometricUnlock = biometricUnlock
     self.biometryLabel = biometryLabel
     self.autoPromptOnAppear = autoPromptOnAppear
+    self.externalError = externalError
     self.onUnlocked = onUnlocked
   }
 
@@ -77,7 +83,7 @@ struct VaultUnlockView: View {
         .background(Color(.secondarySystemBackground))
         .clipShape(RoundedRectangle(cornerRadius: 10))
 
-      if let error = errorMessage {
+      if let error = resolveDisplayError(external: externalError, internalError: errorMessage) {
         Text(error)
           .font(.caption)
           .foregroundStyle(.red)

--- a/ios/PasswdSSOApp/Views/Vault/VaultUnlockView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultUnlockView.swift
@@ -145,6 +145,12 @@ struct VaultUnlockView: View {
       errorMessage = L10n.string("Incorrect passphrase. Please try again.")
       passphrase = ""
       isLoading = false
+    } catch VaultUnlockError.sessionExpired {
+      // Dead session — no passphrase recovers this. Tell the user to re-sign-in
+      // rather than looping on a "check your connection" message.
+      errorMessage = L10n.string("Your session has expired. Please sign in again.")
+      passphrase = ""
+      isLoading = false
     } catch {
       errorMessage = L10n.string("Unable to unlock vault. Check your connection and try again.")
       isLoading = false

--- a/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
+++ b/ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift
@@ -263,7 +263,7 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
         // normal success path, where expired == false.)
         _ = await extensionContext.completeAssertionRequest(using: credential)
       } catch {
-        Self.log.error("completePasskeyAssertion FAILED: \(String(describing: error), privacy: .public)")
+        Self.log.error("completePasskeyAssertion FAILED: \(String(describing: type(of: error)), privacy: .public)")
         cancel(with: error)
       }
     }
@@ -359,7 +359,7 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
         } catch CredentialResolver.Error.vaultLocked {
           Self.log.error("passkey registration: vault locked")
         } catch {
-          Self.log.error("passkey registration: crypto/encrypt failed: \(String(describing: error), privacy: .public)")
+          Self.log.error("passkey registration: crypto/encrypt failed: \(String(describing: type(of: error)), privacy: .public)")
           // encryptPasskeyEntry only ran after biometrics if crypto reached it;
           // treat any non-lock failure as a crypto failure (still a cancel).
           vaultUnlocked = true
@@ -392,7 +392,7 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
           do {
             uploadedEntryId = try await uploader.createEntry(body: body)
           } catch {
-            Self.log.error("passkey registration: upload failed: \(String(describing: error), privacy: .public)")
+            Self.log.error("passkey registration: upload failed: \(String(describing: type(of: error)), privacy: .public)")
           }
         } else {
           Self.log.error("passkey registration: no valid upload token / server config")
@@ -458,7 +458,7 @@ final class CredentialProviderViewController: ASCredentialProviderViewController
     do {
       try await resolver.appendEntryToCache(cacheEntry)
     } catch {
-      Self.log.error("passkey registration: cache append failed (next host sync recovers): \(String(describing: error), privacy: .public)")
+      Self.log.error("passkey registration: cache append failed (next host sync recovers): \(String(describing: type(of: error)), privacy: .public)")
     }
     await CredentialIdentityRegistrar().add(passkeys: [
       PasskeyIdentitySpec(

--- a/ios/PasswdSSOTests/HostSyncServiceTests.swift
+++ b/ios/PasswdSSOTests/HostSyncServiceTests.swift
@@ -190,6 +190,42 @@ final class HostSyncServiceTests: XCTestCase {
     XCTAssertEqual(blob.cacheVersionCounter, 6)
   }
 
+  /// T1 (FR1 end-to-end healing): starting from NO cache file at all (the worst case
+  /// the biometric cacheRecovered=false path lands in), runSync must rebuild a cache
+  /// that is readable at the new counter with the fetched entries — proving the
+  /// resync heals a missing/stale cache rather than leaving the vault empty.
+  func testSyncHealsAbsentCache() async throws {
+    let keychain = MockKeychain()
+    seedBlobInKeychain(keychain, counter: 42)
+    let bks = BridgeKeyStore(
+      accessGroup: "test", service: "com.passwd-sso.test.bridge-key", keychain: keychain)
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    let cacheURL = tmpDir.appending(path: "heal.cache", directoryHint: .notDirectory)
+    // Precondition: no cache file exists.
+    XCTAssertFalse(FileManager.default.fileExists(atPath: cacheURL.path))
+
+    let vaultKey = SymmetricKey(size: .bits256)
+    let dummyEncData = EncryptedData(
+      ciphertext: hexEncode(Data(repeating: 0xAA, count: 32)),
+      iv: hexEncode(Data(repeating: 0xBB, count: 12)),
+      authTag: hexEncode(Data(repeating: 0xCC, count: 16)))
+    let entries = [EncryptedEntry(id: "e1", encryptedOverview: dummyEncData, encryptedBlob: dummyEncData)]
+
+    let stub = StubHostSyncService(
+      bridgeKeyStore: bks, wrappedKeyStore: wks, cacheURL: cacheURL,
+      vaultKey: vaultKey, entries: entries)
+    let report = try await stub.runSync()
+
+    XCTAssertEqual(report.entriesFetched, 1)
+    let blob = try bks.readDirect()
+    XCTAssertEqual(blob.cacheVersionCounter, 43, "counter advanced 42 → 43")
+    // The rebuilt cache must be readable at the new counter (heals the absent cache).
+    let rebuilt = try readCacheFile(
+      path: cacheURL, vaultKey: vaultKey,
+      expectedHostInstallUUID: blob.hostInstallUUID, expectedCounter: 43)
+    XCTAssertEqual(rebuilt.header.entryCount, 1, "rebuilt cache carries the fetched entry")
+  }
+
   // MARK: - Team key refresh: happy path using fixture
 
   /// performSync with the fixture ECDH blob + team member-key endpoint → the stored

--- a/ios/PasswdSSOTests/MobileAPIClientTests.swift
+++ b/ios/PasswdSSOTests/MobileAPIClientTests.swift
@@ -1091,7 +1091,10 @@ final class TokenRefreshTests: XCTestCase {
     capturedRequests = []
   }
 
-  // Helper: make a client with the fixed clock.
+  // Helper: make a client with the fixed clock. A fresh refresh coordinator per
+  // client keeps the process-global success cache from leaking across tests (the
+  // shared singleton would otherwise replay one test's rotated token into the next,
+  // suppressing the refresh these tests assert on).
   private func makeClient(fixedDate: Date? = nil) -> MobileAPIClient {
     let t = fixedDate ?? fixedNow
     return MobileAPIClient(
@@ -1100,7 +1103,8 @@ final class TokenRefreshTests: XCTestCase {
       jwk: knownJWK,
       tokenStore: tokenStore,
       urlSession: session,
-      now: { t }
+      now: { t },
+      refreshCoordinator: TokenRefreshCoordinator()
     )
   }
 

--- a/ios/PasswdSSOTests/PostSyncDecisionTests.swift
+++ b/ios/PasswdSSOTests/PostSyncDecisionTests.swift
@@ -61,10 +61,22 @@ final class PostSyncDecisionTests: XCTestCase {
       .useLocalCache)
   }
 
-  /// AC-C5.4: failed sync + cacheRecovered=true + no persisted cache → failLocked.
-  func testDecidePostSync_failedSync_recovered_noCache_failsLocked() {
+  /// AC-C5.4 (revised — Phase 3 F-passphrase): failed sync + cacheRecovered=true + no
+  /// persisted cache → .useEmptyCache, NOT .failLocked. A valid unlock (passphrase, or
+  /// biometric-fresh) with a brand-new / first-offline vault must present the empty
+  /// vault as success — bouncing to the locked screen would be a regression for the
+  /// passphrase path (correct passphrase → locked screen with no data).
+  func testDecidePostSync_failedSync_recovered_noCache_useEmptyCache() {
     XCTAssertEqual(
       decidePostSync(syncReport: nil, cacheRecovered: true, persistedCache: nil),
+      .useEmptyCache)
+  }
+
+  /// The fail-closed direction is preserved for the biometric untrusted-cache case:
+  /// cacheRecovered=false + no cache still fails closed.
+  func testDecidePostSync_failedSync_cacheless_stillFailsClosed() {
+    XCTAssertEqual(
+      decidePostSync(syncReport: nil, cacheRecovered: false, persistedCache: nil),
       .failLocked)
   }
 

--- a/ios/PasswdSSOTests/PostSyncDecisionTests.swift
+++ b/ios/PasswdSSOTests/PostSyncDecisionTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import XCTest
+@testable import PasswdSSOApp
+@testable import Shared
+
+final class PostSyncDecisionTests: XCTestCase {
+
+  private func makeCacheData() -> CacheData {
+    CacheData(
+      header: CacheHeader(
+        cacheVersionCounter: 1,
+        cacheIssuedAt: Date(timeIntervalSince1970: 1_000_000),
+        lastSuccessfulRefreshAt: Date(timeIntervalSince1970: 1_000_000),
+        entryCount: 0,
+        hostInstallUUID: Data(repeating: 0, count: 16),
+        userId: "u"
+      ),
+      entries: "[]".data(using: .utf8)!
+    )
+  }
+
+  private func makeSyncReport() -> SyncReport {
+    SyncReport(
+      entriesFetched: 0, cacheBytesWritten: 0,
+      lastSuccessfulRefreshAt: Date(timeIntervalSince1970: 1_000_000),
+      cacheData: makeCacheData())
+  }
+
+  // MARK: - decidePostSync (C5)
+
+  /// AC-C5.5: a successful sync always yields .useFreshCache regardless of the rest.
+  func testDecidePostSync_syncSucceeded_useFreshCache() {
+    XCTAssertEqual(
+      decidePostSync(syncReport: makeSyncReport(), cacheRecovered: false, persistedCache: nil),
+      .useFreshCache)
+    XCTAssertEqual(
+      decidePostSync(syncReport: makeSyncReport(), cacheRecovered: true, persistedCache: makeCacheData()),
+      .useFreshCache)
+  }
+
+  /// AC-C5.1 (S2 core): a failed sync with cacheRecovered=false NEVER trusts a
+  /// readable persisted cache — it fails closed.
+  func testDecidePostSync_failedSync_cacheless_failsLockedEvenWithReadableCache() {
+    XCTAssertEqual(
+      decidePostSync(syncReport: nil, cacheRecovered: false, persistedCache: makeCacheData()),
+      .failLocked,
+      "a readable persisted cache must NOT rescue a cacheless failed sync (S2)")
+  }
+
+  /// AC-C5.2: failed sync + cacheRecovered=false + no persisted cache → failLocked.
+  func testDecidePostSync_failedSync_cacheless_noCache_failsLocked() {
+    XCTAssertEqual(
+      decidePostSync(syncReport: nil, cacheRecovered: false, persistedCache: nil),
+      .failLocked)
+  }
+
+  /// AC-C5.3: failed sync + cacheRecovered=true + persisted cache → useLocalCache.
+  func testDecidePostSync_failedSync_recovered_withCache_useLocalCache() {
+    XCTAssertEqual(
+      decidePostSync(syncReport: nil, cacheRecovered: true, persistedCache: makeCacheData()),
+      .useLocalCache)
+  }
+
+  /// AC-C5.4: failed sync + cacheRecovered=true + no persisted cache → failLocked.
+  func testDecidePostSync_failedSync_recovered_noCache_failsLocked() {
+    XCTAssertEqual(
+      decidePostSync(syncReport: nil, cacheRecovered: true, persistedCache: nil),
+      .failLocked)
+  }
+
+  // MARK: - biometricUnlockError (C2)
+
+  /// AC-C2.1: a biometric cancel/mismatch shows no banner.
+  func testBiometricUnlockError_biometricFailed_returnsNil() {
+    XCTAssertNil(
+      biometricUnlockError(
+        from: VaultUnlockError.biometricFailed, syncFailedCacheless: false, message: "msg"))
+  }
+
+  /// AC-C2.1: a non-cancel error surfaces the explicit message.
+  func testBiometricUnlockError_otherError_returnsMessage() {
+    XCTAssertEqual(
+      biometricUnlockError(
+        from: VaultUnlockError.cacheUnreadable, syncFailedCacheless: false, message: "msg"),
+      "msg")
+  }
+
+  /// AC-C2.1: a cacheless resync failure (no throw, but reached=false) surfaces the message.
+  func testBiometricUnlockError_syncFailedCacheless_returnsMessage() {
+    XCTAssertEqual(
+      biometricUnlockError(from: nil, syncFailedCacheless: true, message: "msg"),
+      "msg")
+  }
+
+  /// A clean success (no error, sync did not fail cacheless) shows no banner.
+  func testBiometricUnlockError_success_returnsNil() {
+    XCTAssertNil(biometricUnlockError(from: nil, syncFailedCacheless: false, message: "msg"))
+  }
+
+  // MARK: - resolveDisplayError (C3)
+
+  /// AC-C3.1: external error wins; internal shows when external is nil.
+  func testResolveDisplayError_precedence() {
+    XCTAssertEqual(resolveDisplayError(external: "x", internalError: nil), "x")
+    XCTAssertEqual(resolveDisplayError(external: "x", internalError: "y"), "x")
+    XCTAssertEqual(resolveDisplayError(external: nil, internalError: "y"), "y")
+    XCTAssertNil(resolveDisplayError(external: nil, internalError: nil))
+  }
+}

--- a/ios/PasswdSSOTests/PostSyncDecisionTests.swift
+++ b/ios/PasswdSSOTests/PostSyncDecisionTests.swift
@@ -118,4 +118,32 @@ final class PostSyncDecisionTests: XCTestCase {
     XCTAssertEqual(resolveDisplayError(external: nil, internalError: "y"), "y")
     XCTAssertNil(resolveDisplayError(external: nil, internalError: nil))
   }
+
+  // MARK: - Fail-closed banner selection (dead session vs offline)
+
+  /// A dead session (authenticationRequired) is the ONLY error that routes to the
+  /// "sign in again" banner — the whole point of the UnlockedResult split.
+  func testSyncFailedSessionExpired_authenticationRequired_isTrue() {
+    XCTAssertTrue(syncFailedSessionExpired(from: MobileAPIError.authenticationRequired))
+  }
+
+  /// An offline/transient failure must NOT be treated as a dead session — it routes
+  /// to the "try again with your passphrase" banner instead.
+  func testSyncFailedSessionExpired_offlineError_isFalse() {
+    let offline = MobileAPIError.networkError(URLError(.notConnectedToInternet))
+    XCTAssertFalse(syncFailedSessionExpired(from: offline))
+    // A non-MobileAPIError also falls through to the offline banner.
+    struct Other: Error {}
+    XCTAssertFalse(syncFailedSessionExpired(from: Other()))
+    // Another MobileAPIError case must not be mistaken for a dead session.
+    XCTAssertFalse(syncFailedSessionExpired(from: MobileAPIError.serverError(status: 500)))
+  }
+
+  func testFailClosedResult_sessionExpired_routesToSignIn() {
+    XCTAssertEqual(failClosedResult(sessionExpired: true), .failedSessionExpired)
+  }
+
+  func testFailClosedResult_offline_routesToPassphraseRetry() {
+    XCTAssertEqual(failClosedResult(sessionExpired: false), .failedOffline)
+  }
 }

--- a/ios/PasswdSSOTests/TokenRefreshCoordinatorTests.swift
+++ b/ios/PasswdSSOTests/TokenRefreshCoordinatorTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import XCTest
+@testable import PasswdSSOApp
+
+/// Coverage for the process-global refresh gate that collapses redundant token
+/// refreshes. The two failure modes it defends against (concurrent refreshes and
+/// sequential re-tries with a stale token) both trip the server's replay detector,
+/// so the single-flight join and the short success-cache are the load-bearing
+/// behaviors these tests pin down.
+final class TokenRefreshCoordinatorTests: XCTestCase {
+
+  /// Thread-safe invocation counter for the injected refresh closure.
+  private actor CallCounter {
+    private(set) var count = 0
+    func bump() -> Int {
+      count += 1
+      return count
+    }
+  }
+
+  /// A one-shot gate: awaiters suspend until `open()` is called, then all proceed.
+  /// Sendable so the `@Sendable` refresh closure can await it without capturing the
+  /// (non-Sendable) XCTestCase.
+  private actor Gate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    func wait() async {
+      if isOpen { return }
+      await withCheckedContinuation { waiters.append($0) }
+    }
+    func open() {
+      isOpen = true
+      for w in waiters { w.resume() }
+      waiters.removeAll()
+    }
+  }
+
+  /// A controllable clock the coordinator reads via its injected `now` closure.
+  private final class MutableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+    init(_ start: Date) { value = start }
+    func advance(by seconds: TimeInterval) {
+      lock.lock(); defer { lock.unlock() }
+      value = value.addingTimeInterval(seconds)
+    }
+    var now: Date {
+      lock.lock(); defer { lock.unlock() }
+      return value
+    }
+  }
+
+  // MARK: - Single-flight (concurrent callers)
+
+  /// N concurrent callers for the same key must collapse into exactly ONE refresh
+  /// network call — the whole point of the gate. The refresh closure blocks on a
+  /// continuation until every caller has joined, so the count is observed while
+  /// all N are in flight (not merely serialized fast enough to look like one).
+  func testConcurrentCallersCollapseToSingleRefresh() async throws {
+    let coordinator = TokenRefreshCoordinator()
+    let counter = CallCounter()
+    let gate = Gate()
+    let callerCount = 8
+
+    // The single refresh blocks on the gate until all callers have queued, so the
+    // invocation count is observed while all N are genuinely in flight.
+    let refresh: @Sendable () async throws -> String = {
+      _ = await counter.bump()
+      await gate.wait()
+      return "rotated-token"
+    }
+
+    // Launch all callers, then release the gate.
+    async let results: [String] = withThrowingTaskGroup(of: String.self) { group in
+      for _ in 0..<callerCount {
+        group.addTask { try await coordinator.run(key: "k", refresh: refresh) }
+      }
+      var out: [String] = []
+      for try await r in group { out.append(r) }
+      return out
+    }
+
+    // Give the callers a moment to all reach the gate, then release.
+    try await Task.sleep(nanoseconds: 100_000_000)
+    await gate.open()
+
+    let tokens = try await results
+    XCTAssertEqual(tokens.count, callerCount)
+    XCTAssertTrue(tokens.allSatisfy { $0 == "rotated-token" })
+    let calls = await counter.count
+    XCTAssertEqual(calls, 1, "concurrent callers must trigger exactly one refresh")
+  }
+
+  /// When the single flight THROWS while N callers are joined, every joined caller
+  /// must receive the error (a dead session must not silently succeed for the
+  /// joiners), and `inFlight` must be cleared so the NEXT call retries rather than
+  /// joining a dead task. This is the concurrent-failure path the fix exists for.
+  func testConcurrentCallersAllReceiveThrownErrorAndInFlightIsCleared() async throws {
+    let coordinator = TokenRefreshCoordinator()
+    let counter = CallCounter()
+    let gate = Gate()
+    let callerCount = 6
+    struct Boom: Error {}
+
+    // The single flight blocks until all callers queue, then throws.
+    let failing: @Sendable () async throws -> String = {
+      _ = await counter.bump()
+      await gate.wait()
+      throw Boom()
+    }
+
+    async let failures: Int = withTaskGroup(of: Bool.self) { group in
+      for _ in 0..<callerCount {
+        group.addTask {
+          do { _ = try await coordinator.run(key: "k", refresh: failing); return false }
+          catch is Boom { return true }
+          catch { return false }
+        }
+      }
+      var threw = 0
+      for await didThrow in group where didThrow { threw += 1 }
+      return threw
+    }
+
+    try await Task.sleep(nanoseconds: 100_000_000)
+    await gate.open()
+
+    let threwCount = await failures
+    XCTAssertEqual(threwCount, callerCount, "every joined caller must receive the thrown error")
+    let flights = await counter.count
+    XCTAssertEqual(flights, 1, "the failure must collapse to exactly one flight, not one per caller")
+
+    // inFlight must be cleared and the failure must NOT be cached: a fresh call
+    // re-invokes the refresh (now succeeding) instead of joining a dead task or
+    // replaying the error.
+    let recovery: @Sendable () async throws -> String = {
+      _ = await counter.bump()
+      return "recovered"
+    }
+    let token = try await coordinator.run(key: "k", refresh: recovery)
+    XCTAssertEqual(token, "recovered")
+    let total = await counter.count
+    XCTAssertEqual(total, 2, "a post-failure call must start a new refresh (inFlight cleared, failure not cached)")
+  }
+
+  // MARK: - Success cache (sequential callers)
+
+  /// A repeat call within the TTL replays the first call's success without a
+  /// second network refresh — the sequential-retry defense.
+  func testSequentialCallWithinTTLReplaysCachedSuccess() async throws {
+    let clock = MutableClock(Date(timeIntervalSince1970: 1000))
+    let coordinator = TokenRefreshCoordinator(resultTTL: 3, now: { clock.now })
+    let counter = CallCounter()
+    let refresh: @Sendable () async throws -> String = {
+      _ = await counter.bump()
+      return "token-1"
+    }
+
+    let first = try await coordinator.run(key: "k", refresh: refresh)
+    clock.advance(by: 1)  // still within the 3s TTL
+    let second = try await coordinator.run(key: "k", refresh: refresh)
+
+    XCTAssertEqual(first, "token-1")
+    XCTAssertEqual(second, "token-1")
+    let calls = await counter.count
+    XCTAssertEqual(calls, 1, "a repeat within TTL must not hit the network again")
+  }
+
+  /// Once the TTL lapses, the next call performs a fresh refresh.
+  func testCacheExpiresAfterTTL() async throws {
+    let clock = MutableClock(Date(timeIntervalSince1970: 1000))
+    let coordinator = TokenRefreshCoordinator(resultTTL: 3, now: { clock.now })
+    let counter = CallCounter()
+    let refresh: @Sendable () async throws -> String = {
+      let n = await counter.bump()
+      return "token-\(n)"
+    }
+
+    let first = try await coordinator.run(key: "k", refresh: refresh)
+    clock.advance(by: 4)  // past the 3s TTL
+    let second = try await coordinator.run(key: "k", refresh: refresh)
+
+    XCTAssertEqual(first, "token-1")
+    XCTAssertEqual(second, "token-2", "a call after TTL must refresh again")
+    let calls = await counter.count
+    XCTAssertEqual(calls, 2)
+  }
+
+  // MARK: - Failures are never cached
+
+  /// A failure must NOT be cached: a re-sign-in can install a valid token at any
+  /// moment, so the next call must be free to try again rather than replaying the
+  /// error for the whole TTL.
+  func testFailureIsNotCached() async throws {
+    let clock = MutableClock(Date(timeIntervalSince1970: 1000))
+    let coordinator = TokenRefreshCoordinator(resultTTL: 3, now: { clock.now })
+    let counter = CallCounter()
+    struct Boom: Error {}
+    let refresh: @Sendable () async throws -> String = {
+      let n = await counter.bump()
+      if n == 1 { throw Boom() }
+      return "recovered-token"
+    }
+
+    do {
+      _ = try await coordinator.run(key: "k", refresh: refresh)
+      XCTFail("Expected the first refresh to throw")
+    } catch is Boom {
+      // Expected
+    }
+
+    // Immediately retry within the TTL window — must re-invoke, not replay a failure.
+    let second = try await coordinator.run(key: "k", refresh: refresh)
+    XCTAssertEqual(second, "recovered-token")
+    let calls = await counter.count
+    XCTAssertEqual(calls, 2, "a failed refresh must stay retryable within the TTL")
+  }
+
+  // MARK: - Per-key isolation
+
+  /// Distinct keys (distinct token stores) do not share a cache or an in-flight
+  /// task — each refreshes independently.
+  func testDifferentKeysDoNotShareCache() async throws {
+    let clock = MutableClock(Date(timeIntervalSince1970: 1000))
+    let coordinator = TokenRefreshCoordinator(resultTTL: 3, now: { clock.now })
+    let counter = CallCounter()
+    let refresh: @Sendable () async throws -> String = {
+      let n = await counter.bump()
+      return "token-\(n)"
+    }
+
+    let a = try await coordinator.run(key: "key-a", refresh: refresh)
+    let b = try await coordinator.run(key: "key-b", refresh: refresh)
+
+    XCTAssertNotEqual(a, b, "distinct keys must not replay each other's cached token")
+    let calls = await counter.count
+    XCTAssertEqual(calls, 2)
+  }
+}

--- a/ios/PasswdSSOTests/VaultUnlockerTests.swift
+++ b/ios/PasswdSSOTests/VaultUnlockerTests.swift
@@ -619,6 +619,170 @@ final class VaultUnlockerTests: XCTestCase {
     XCTAssertNil(result.tenantAutoLockMinutes, "biometric/offline path fetches no fresh policy → nil")
   }
 
+  // MARK: - unlockWithBiometrics graceful stale-cache degradation (C1)
+
+  /// AC-C1.1: a STALE cache (issued 25h before `now`) must NOT throw — the unlock
+  /// returns the recovered vault key with cacheRecovered=false + userId from the
+  /// persisted wrapped-key metadata.
+  func testUnlockWithBiometrics_staleCache_returnsCacheRecoveredFalse() async throws {
+    let issuedAt = Date(timeIntervalSince1970: 1_000_000)
+    let now = issuedAt.addingTimeInterval(25 * 3600)  // 25h later → stale (AND-gate met)
+    let keychain = MockKeychainAccessor()
+    let bks = BridgeKeyStore(accessGroup: "test.jp.jpng.passwd-sso.shared.stale", keychain: keychain)
+    let blob = try bks.create()
+    let cacheKey = try deriveCacheVaultKey(bridgeKey: blob.bridgeKey)
+    let vaultKey = SymmetricKey(size: .bits256)
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    let vkBytes = vaultKey.withUnsafeBytes { Data($0) }
+    let (c, i, t) = try encryptAESGCM(plaintext: vkBytes, key: cacheKey)
+    try wks.saveVaultKey(
+      WrappedVaultKey(ciphertext: c, iv: i, authTag: t, issuedAt: Date(), userId: "persisted-user"))
+    let cacheURL = tmpDir.appending(path: "stale.cache", directoryHint: .notDirectory)
+    let entry = try makePersonalCacheEntryForBiometricTest(
+      vaultKey: vaultKey, userId: "cache-user", keyVersion: 3)
+    try buildCacheFileForBiometricTest(
+      at: cacheURL, entries: [entry], vaultKey: vaultKey,
+      hostInstallUUID: blob.hostInstallUUID, counter: blob.cacheVersionCounter,
+      userId: "cache-user", now: issuedAt)
+
+    let unlocker = VaultUnlocker(
+      apiClient: StubVaultAPIClient(mode: .wrongPassphrase),
+      bridgeKeyStore: bks, wrappedKeyStore: wks, cacheURL: cacheURL, now: { now })
+
+    let result = try await unlocker.unlockWithBiometrics(reason: "test")
+    XCTAssertFalse(result.cacheRecovered, "stale cache must degrade to cacheRecovered=false")
+    XCTAssertEqual(result.userId, "persisted-user", "userId must come from persisted wrapped key")
+    XCTAssertEqual(
+      result.vaultKey.withUnsafeBytes { Data($0) }, vkBytes, "vault key still recovered")
+  }
+
+  /// AC-C1.2: a FRESH cache returns cacheRecovered=true with userId/keyVersion from
+  /// the cache header (unchanged fast path).
+  func testUnlockWithBiometrics_freshCache_returnsCacheRecoveredTrue() async throws {
+    let now = Date()
+    let keychain = MockKeychainAccessor()
+    let bks = BridgeKeyStore(accessGroup: "test.jp.jpng.passwd-sso.shared.fresh", keychain: keychain)
+    let blob = try bks.create()
+    let cacheKey = try deriveCacheVaultKey(bridgeKey: blob.bridgeKey)
+    let vaultKey = SymmetricKey(size: .bits256)
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    let vkBytes = vaultKey.withUnsafeBytes { Data($0) }
+    let (c, i, t) = try encryptAESGCM(plaintext: vkBytes, key: cacheKey)
+    try wks.saveVaultKey(
+      WrappedVaultKey(ciphertext: c, iv: i, authTag: t, issuedAt: Date(), userId: "persisted-user"))
+    let cacheURL = tmpDir.appending(path: "fresh.cache", directoryHint: .notDirectory)
+    let entry = try makePersonalCacheEntryForBiometricTest(
+      vaultKey: vaultKey, userId: "cache-user", keyVersion: 5)
+    try buildCacheFileForBiometricTest(
+      at: cacheURL, entries: [entry], vaultKey: vaultKey,
+      hostInstallUUID: blob.hostInstallUUID, counter: blob.cacheVersionCounter,
+      userId: "cache-user", now: now)
+
+    let unlocker = VaultUnlocker(
+      apiClient: StubVaultAPIClient(mode: .wrongPassphrase),
+      bridgeKeyStore: bks, wrappedKeyStore: wks, cacheURL: cacheURL, now: { now })
+
+    let result = try await unlocker.unlockWithBiometrics(reason: "test")
+    XCTAssertTrue(result.cacheRecovered, "fresh cache → cacheRecovered=true")
+    XCTAssertEqual(result.userId, "cache-user", "userId from cache header on the fresh path")
+    XCTAssertEqual(result.keyVersion, 5, "keyVersion from cache entry on the fresh path")
+  }
+
+  /// AC-C1.1 (counter-mismatch variant, T3): a cache whose counter no longer matches
+  /// the (bumped) bridge-meta counter is rejected by readCacheFile with
+  /// .counterMismatch → must ALSO degrade gracefully to cacheRecovered=false, NOT throw.
+  func testUnlockWithBiometrics_counterMismatch_returnsCacheRecoveredFalse() async throws {
+    let now = Date()
+    let keychain = MockKeychainAccessor()
+    let bks = BridgeKeyStore(accessGroup: "test.jp.jpng.passwd-sso.shared.counter", keychain: keychain)
+    let blob = try bks.create()
+    let cacheKey = try deriveCacheVaultKey(bridgeKey: blob.bridgeKey)
+    let vaultKey = SymmetricKey(size: .bits256)
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    let vkBytes = vaultKey.withUnsafeBytes { Data($0) }
+    let (c, i, t) = try encryptAESGCM(plaintext: vkBytes, key: cacheKey)
+    try wks.saveVaultKey(
+      WrappedVaultKey(ciphertext: c, iv: i, authTag: t, issuedAt: Date(), userId: "persisted-user"))
+    let cacheURL = tmpDir.appending(path: "counter.cache", directoryHint: .notDirectory)
+    let entry = try makePersonalCacheEntryForBiometricTest(
+      vaultKey: vaultKey, userId: "cache-user", keyVersion: 1)
+    // Seed the cache at the CURRENT counter, then bump the bridge-meta counter so the
+    // biometric read's expectedCounter no longer matches the file.
+    try buildCacheFileForBiometricTest(
+      at: cacheURL, entries: [entry], vaultKey: vaultKey,
+      hostInstallUUID: blob.hostInstallUUID, counter: blob.cacheVersionCounter,
+      userId: "cache-user", now: now)
+    try bks.incrementCounter(newCounter: blob.cacheVersionCounter + 1)
+
+    let unlocker = VaultUnlocker(
+      apiClient: StubVaultAPIClient(mode: .wrongPassphrase),
+      bridgeKeyStore: bks, wrappedKeyStore: wks, cacheURL: cacheURL, now: { now })
+
+    let result = try await unlocker.unlockWithBiometrics(reason: "test")
+    XCTAssertFalse(result.cacheRecovered, "counter mismatch must degrade gracefully, not throw")
+    XCTAssertEqual(result.userId, "persisted-user")
+  }
+
+  /// AC-C1.3 / AC-C1.4: a legacy vault (persisted userId nil) with a STALE cache has
+  /// no cacheless-sync source → throws .cacheUnreadable. After a userId is persisted
+  /// (simulating one passphrase unlock), the same stale cache now degrades gracefully.
+  func testUnlockWithBiometrics_legacyVaultStaleCache_throwsThenHeals() async throws {
+    let issuedAt = Date(timeIntervalSince1970: 2_000_000)
+    let now = issuedAt.addingTimeInterval(25 * 3600)
+    let keychain = MockKeychainAccessor()
+    let bks = BridgeKeyStore(accessGroup: "test.jp.jpng.passwd-sso.shared.legacy", keychain: keychain)
+    let blob = try bks.create()
+    let cacheKey = try deriveCacheVaultKey(bridgeKey: blob.bridgeKey)
+    let vaultKey = SymmetricKey(size: .bits256)
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    let vkBytes = vaultKey.withUnsafeBytes { Data($0) }
+    let (c, i, t) = try encryptAESGCM(plaintext: vkBytes, key: cacheKey)
+    // Legacy: no userId on the wrapped key.
+    try wks.saveVaultKey(
+      WrappedVaultKey(ciphertext: c, iv: i, authTag: t, issuedAt: Date(), userId: nil))
+    let cacheURL = tmpDir.appending(path: "legacy.cache", directoryHint: .notDirectory)
+    let entry = try makePersonalCacheEntryForBiometricTest(
+      vaultKey: vaultKey, userId: "cache-user", keyVersion: 1)
+    try buildCacheFileForBiometricTest(
+      at: cacheURL, entries: [entry], vaultKey: vaultKey,
+      hostInstallUUID: blob.hostInstallUUID, counter: blob.cacheVersionCounter,
+      userId: "cache-user", now: issuedAt)
+
+    let unlocker = VaultUnlocker(
+      apiClient: StubVaultAPIClient(mode: .wrongPassphrase),
+      bridgeKeyStore: bks, wrappedKeyStore: wks, cacheURL: cacheURL, now: { now })
+
+    do {
+      _ = try await unlocker.unlockWithBiometrics(reason: "test")
+      XCTFail("legacy vault + stale cache must throw .cacheUnreadable")
+    } catch VaultUnlockError.cacheUnreadable {
+      // expected
+    }
+
+    // Heal: persist a userId (simulating one passphrase unlock), keep the stale cache.
+    try wks.saveVaultKey(
+      WrappedVaultKey(ciphertext: c, iv: i, authTag: t, issuedAt: Date(), userId: "backfilled-user"))
+    let healed = try await unlocker.unlockWithBiometrics(reason: "test")
+    XCTAssertFalse(healed.cacheRecovered)
+    XCTAssertEqual(healed.userId, "backfilled-user", "post-backfill unlock recovers gracefully")
+  }
+
+  /// AC-C4.1: after a passphrase unlock, the persisted wrapped vault key carries the
+  /// unlockData userId (C4 producer).
+  func testUnlock_persistsUserIdOnWrappedVaultKey() async throws {
+    let (unlockData, _) = try makeVaultUnlockData(passphrase: "p")
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+    let unlocker = VaultUnlocker(
+      apiClient: StubVaultAPIClient(mode: .success(unlockData)),
+      bridgeKeyStore: BridgeKeyStore(
+        accessGroup: "test", service: "com.passwd-sso.test.c4.bridge-key", keychain: MockKeychain()),
+      wrappedKeyStore: wks,
+      cacheURL: tmpDir.appending(path: "c4.cache", directoryHint: .notDirectory))
+    _ = try await unlocker.unlock(passphrase: "p")
+    let persisted = try XCTUnwrap(try wks.loadVaultKey())
+    XCTAssertEqual(persisted.userId, "test-user-42", "unlock must persist unlockData.userId")
+  }
+
   // MARK: - unlockWithBiometrics error paths
 
   func testUnlockWithBiometrics_missingWrappedKey_throwsBiometricUnavailable() async throws {

--- a/ios/PasswdSSOTests/VaultUnlockerTests.swift
+++ b/ios/PasswdSSOTests/VaultUnlockerTests.swift
@@ -94,7 +94,7 @@ private func makeVaultUnlockData(
 /// `VaultUnlocker` actor drives the unlock crypto path (hex decode, PBKDF2,
 /// AES-GCM) — a regression in `VaultUnlocker.unlock` now turns these tests red.
 private actor StubVaultAPIClient: VaultUnlockDataSource {
-  enum Mode { case success(VaultUnlockData); case wrongPassphrase }
+  enum Mode { case success(VaultUnlockData); case wrongPassphrase; case sessionDead }
   let mode: Mode
 
   init(mode: Mode) { self.mode = mode }
@@ -103,6 +103,10 @@ private actor StubVaultAPIClient: VaultUnlockDataSource {
     switch mode {
     case .success(let data): return data
     case .wrongPassphrase: throw MobileAPIError.serverError(status: 401)
+    // A dead refresh token surfaces from the API client as authenticationRequired
+    // (see MobileAPIClient.doRefreshAndPersist). VaultUnlocker must map it to
+    // sessionExpired so the UI routes to "sign in again", not a passphrase retry.
+    case .sessionDead: throw MobileAPIError.authenticationRequired
     }
   }
 }
@@ -315,6 +319,36 @@ final class VaultUnlockerTests: XCTestCase {
       _ = try await unlocker.unlock(passphrase: "wrong-passphrase")
       XCTFail("Expected VaultUnlockError.invalidPassphrase")
     } catch VaultUnlockError.invalidPassphrase {
+      // Expected
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  /// A dead refresh token (authenticationRequired from the API client) must map
+  /// to sessionExpired — NOT invalidPassphrase or serverResponseInvalid — so the
+  /// UI can route to "sign in again" instead of looping on a passphrase prompt.
+  func testDeadSessionThrowsSessionExpired() async throws {
+    let keychain = MockKeychain()
+    let bks = BridgeKeyStore(
+      accessGroup: "test",
+      service: "com.passwd-sso.test.bridge-key",
+      keychain: keychain
+    )
+    let wks = TempDirWrappedKeyStore(baseDir: tmpDir)
+
+    let stubClient = StubVaultAPIClient(mode: .sessionDead)
+    let unlocker = VaultUnlocker(
+      apiClient: stubClient,
+      bridgeKeyStore: bks,
+      wrappedKeyStore: wks,
+      cacheURL: tmpDir.appending(path: "test.cache", directoryHint: .notDirectory)
+    )
+
+    do {
+      _ = try await unlocker.unlock(passphrase: "any-passphrase")
+      XCTFail("Expected VaultUnlockError.sessionExpired")
+    } catch VaultUnlockError.sessionExpired {
       // Expected
     } catch {
       XCTFail("Unexpected error: \(error)")

--- a/ios/PasswdSSOTests/WrappedKeyStoreTests.swift
+++ b/ios/PasswdSSOTests/WrappedKeyStoreTests.swift
@@ -38,6 +38,24 @@ final class WrappedKeyStoreTests: XCTestCase {
     let loaded = try store.loadVaultKey()
     XCTAssertNotNil(loaded)
     XCTAssertEqual(loaded, wrapped)
+    XCTAssertNil(loaded?.userId, "userId defaults to nil when not supplied (legacy-compatible)")
+  }
+
+  /// AC-C4.3: a WrappedVaultKey with a non-nil userId round-trips through JSON
+  /// encode/decode at the store layer (proves the new C4 field persists).
+  func testVaultKeyRoundTrip_withUserId() throws {
+    let wrapped = WrappedVaultKey(
+      ciphertext: Data([0x01, 0x02]),
+      iv: Data(repeating: 0xAA, count: 12),
+      authTag: Data(repeating: 0xBB, count: 16),
+      issuedAt: Date(timeIntervalSince1970: 1_000_000),
+      userId: "user-abc"
+    )
+    try store.saveVaultKey(wrapped)
+
+    let loaded = try store.loadVaultKey()
+    XCTAssertEqual(loaded, wrapped)
+    XCTAssertEqual(loaded?.userId, "user-abc")
   }
 
   func testVaultKeyOverwrite() throws {

--- a/ios/Shared/AutoFill/CredentialResolver.swift
+++ b/ios/Shared/AutoFill/CredentialResolver.swift
@@ -140,7 +140,7 @@ public actor CredentialResolver {
     } catch {
       // BridgeKeyStore.readForFill already logged the raw OSStatus; record the
       // mapped cause here so the resolver-level branch is unambiguous.
-      Self.log.error("resolveCandidates: vaultLocked at bridge_key read: \(String(describing: error), privacy: .public)")
+      Self.log.error("resolveCandidates: vaultLocked at bridge_key read: \(String(describing: type(of: error)), privacy: .public)")
       throw Error.vaultLocked
     }
 
@@ -485,7 +485,7 @@ public actor CredentialResolver {
         reason: "Save passkey to passwd-sso vault"
       )
     } catch {
-      Self.log.error("encryptPasskeyEntry: vaultLocked at bridge_key read: \(String(describing: error), privacy: .public)")
+      Self.log.error("encryptPasskeyEntry: vaultLocked at bridge_key read: \(String(describing: type(of: error)), privacy: .public)")
       throw Error.vaultLocked
     }
 

--- a/ios/Shared/Storage/BridgeKeyStore.swift
+++ b/ios/Shared/Storage/BridgeKeyStore.swift
@@ -201,7 +201,7 @@ public final class BridgeKeyStore: Sendable {
           accessControl, operation: .useItem, localizedReason: reason
         )
       } catch {
-        Self.log.error("readForFillAuthenticated: evaluateAccessControl failed: \(String(describing: error), privacy: .public)")
+        Self.log.error("readForFillAuthenticated: evaluateAccessControl failed: \(String(describing: type(of: error)), privacy: .public)")
         throw Error.biometryFailed
       }
     }

--- a/ios/Shared/Storage/HostTokenStore.swift
+++ b/ios/Shared/Storage/HostTokenStore.swift
@@ -17,6 +17,11 @@ public final class HostTokenStore: Sendable {
   private let service: String
   private let keychain: KeychainAccessor
 
+  /// Stable identifier for this token store's Keychain item. Used as the
+  /// process-global refresh single-flight key so every `MobileAPIClient` backed
+  /// by the same Keychain item shares one refresh at a time.
+  public var serviceIdentifier: String { service }
+
   private enum Account: String {
     case accessToken = "access_token"
     case refreshToken = "refresh_token"

--- a/ios/Shared/Storage/WrappedKeyStore.swift
+++ b/ios/Shared/Storage/WrappedKeyStore.swift
@@ -7,12 +7,24 @@ public struct WrappedVaultKey: Sendable, Codable, Equatable {
   public let iv: Data
   public let authTag: Data
   public let issuedAt: Date
+  /// userId captured at passphrase unlock. Optional so pre-existing files (written
+  /// before this field existed) decode with `nil`; the biometric re-unlock path
+  /// reads it to drive a cacheless resync when the local cache is stale. Non-secret
+  /// (already travels in the cache header + unlock response).
+  public let userId: String?
 
-  public init(ciphertext: Data, iv: Data, authTag: Data, issuedAt: Date) {
+  public init(
+    ciphertext: Data,
+    iv: Data,
+    authTag: Data,
+    issuedAt: Date,
+    userId: String? = nil
+  ) {
     self.ciphertext = ciphertext
     self.iv = iv
     self.authTag = authTag
     self.issuedAt = issuedAt
+    self.userId = userId
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix silent biometric unlock bounce after idle by gracefully degrading stale cache reads and falling back to a server resync.
- Introduce `TokenRefreshCoordinator` to collapse concurrent/sequential token refreshes, eliminating server-side replay detection false-positives.
- Harden error logging across the iOS codebase to emit only error types instead of raw payloads at `privacy: .public` sites.
- Extract load-bearing unlock/sync logic into pure, unit-testable functions (`PostSyncDecision.swift`) to bypass SwiftUI testing constraints.

## Motivation
- Users experienced a silent bounce to the passphrase screen after idle periods because `VaultUnlocker.unlockWithBiometrics` treated any local cache mismatch (stale, counter-mismatch, or AAD drift) as a fatal error, despite the subsequent sync step being capable of rebuilding it. This asymmetric behavior relative to the passphrase path created a hidden failure state and poor UX, explicitly documented in `ios-biometric-stale-cache-resync-plan.md`.
- Concurrent and sequential token refreshes during the heal flow presented identical stale refresh tokens to the server, triggering `MOBILE_REFRESH_REUSE_DETECTED` and revoking the token family. This dead-session symptom masked the underlying fix. Addressed by commits `6a3227be` and `5a53bdf6` via a new coordination layer.
- Logging at `privacy: .public` was dumping full error payloads (`String(describing: error)`), risking accidental exposure of URLs or file paths when error types evolve. Commits `778df3d0` and `e57f45a0` harden these sites to emit only error types or classified outcomes to maintain security and observability standards.
- The biometric unlock flow lacked automated test coverage due to VC1 (real biometric prompt) and VC2 (SwiftUI state transitions) being blocked-deferred. Extracting pure decision functions enabled rigorous regression testing without a physical device farm or SwiftUI test host, as mandated by the review artifacts.

## Implementation notes
- **Graceful Cache Degradation:** `VaultUnlocker.unlockWithBiometrics` now wraps the cache metadata read in a `do/catch`, returning a `cacheRecovered: Bool` flag instead of throwing on `EntryCacheError`. When `false`, `RootView.handleVaultUnlocked` gates the persisted-cache re-read and treats a sync failure as a hard fail (`failLocked`), preventing empty-vault synthesis. This closes the S2 counter-splice window structurally.
- **Legacy Vault Bootstrap (F1):** Pre-upgrade vaults lack `userId` in `WrappedVaultKey`. The fix persists `userId` alongside the wrapped key (C4), with a one-time transitional throw (`.cacheUnreadable`) for legacy vaults on a stale cache, requiring a single passphrase unlock to heal the metadata.
- **Token Refresh Single-Flight:** `TokenRefreshCoordinator` (actor) uses process-global keying by `HostTokenStore.serviceIdentifier`. It joins in-flight refreshes and replays successful access tokens within a 3s TTL to bypass the server's 5s replay grace. Failures remain immediately retryable. Injected into `MobileAPIClient` for test isolation.
- **Error Routing & Logging:** `biometricUnlockError` and `resolveDisplayError` pure functions map errors to localized banners. Raw error dumps at `privacy: .public` sites were replaced with `type(of: error)`. Session expiration is now explicitly detected (`VaultUnlockError.sessionExpired`) to route users to a sign-in flow rather than a passphrase retry loop.
- **Tradeoffs:** The `cacheRecovered == false` path intentionally discards the stale cache without re-reading it to close a potential counter-splice window. The token refresh coordinator caches only successes; transient `networkError` refreshes may amplify slightly during sustained flaps, but this is bounded and avoids introducing client-side backoff complexity. The SwiftUI view-state transitions remain untested in CI (VC2) due to anti-deferral constraints, relying instead on pure-function unit tests and manual device verification.

## Review artifacts
- [ios-biometric-stale-cache-resync-plan.md](./docs/archive/review/ios-biometric-stale-cache-resync-plan.md)
- [ios-biometric-stale-cache-resync-deviation.md](./docs/archive/review/ios-biometric-stale-cache-resync-deviation.md)
- [ios-biometric-stale-cache-resync-code-review.md](./docs/archive/review/ios-biometric-stale-cache-resync-code-review.md)

## Test plan
- [ ] Verify biometric unlock on a stale cache (25h+ idle) successfully resolves to the vault list via server resync without silent bounce.
- [ ] Verify offline scenario after stale cache presents an explicit "enter passphrase" error and routes back to `.vaultLocked`.
- [ ] Confirm fresh-cache biometric unlock performs no network calls and returns `cacheRecovered: true`.
- [ ] Validate legacy vault transition: first biometric unlock on a pre-upgrade vault with stale cache throws `.cacheUnreadable`, shows error, and heals after one passphrase unlock.
- [ ] Run `xcodebuild test -scheme PasswdSSOApp` to ensure all 696 tests pass (694 unit + 2 UI), including new `PostSyncDecisionTests`, `TokenRefreshCoordinatorTests`, and `VaultUnlockerTests`.
- [ ] Confirm no raw error payloads are logged at `privacy: .public` sites; only error type names appear in logs.
- [ ] Verify concurrent/sequential token refreshes during heal flow do not trigger server-side replay detection or token family revocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
