### PR TITLE
Add regression guards for tenant-scoped maintenance rate limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "generate:env-example": "tsx scripts/generate-env-example.ts",
     "check:env-docs": "tsx scripts/check-env-docs.ts",
     "generate:security-matrices": "tsx scripts/generate-security-matrices.ts",
-    "check:security-matrices": "tsx scripts/generate-security-matrices.ts && git diff --quiet -- docs/security/route-policy-matrix.md docs/security/deletion-retention-matrix.md",
+    "check:security-matrices": "bash scripts/checks/check-security-matrices.sh",
     "init:env": "tsx scripts/init-env.ts",
     "docker:up": "docker compose -f docker-compose.yml -f docker-compose.override.yml up",
     "docker:down": "docker compose -f docker-compose.yml -f docker-compose.override.yml down"

--- a/scripts/checks/check-security-matrices.sh
+++ b/scripts/checks/check-security-matrices.sh
@@ -2,16 +2,19 @@
 # CI check: the generated security matrices are in sync with the code.
 #
 # Regenerates docs/security/route-policy-matrix.md and
-# docs/security/deletion-retention-matrix.md, then asserts each generated file
-# is tracked, non-empty, and byte-identical to the committed version.
+# docs/security/deletion-retention-matrix.md, then asserts:
+#   1. the generator wrote EXACTLY the expected set of paths (no more, no less)
+#   2. each expected file is tracked by git and non-empty
+#   3. each expected file is byte-identical to the committed version
 #
 # `git diff --quiet` alone only detects MODIFICATIONS to tracked files: it
-# reports clean if the generator starts writing to an untracked path, if a
-# matrix file is `git rm`'d, or if it is truncated to empty. The explicit
-# tracked + non-empty guards close those silent-pass modes so the drift check
-# cannot vacuously pass while a matrix is missing.
+# reports clean if the generator's output path drifts to a new (untracked)
+# file while the old tracked matrix sits unchanged, if a matrix is `git rm`'d,
+# or if one is truncated to empty. Check 1 (written-set equality, driven off
+# the generator's own `Wrote <path>` lines) closes the path-drift false
+# negative; checks 2-3 close the removed/empty ones.
 #
-# Exit 0 = in sync, Exit 1 = drift / missing / empty.
+# Exit 0 = in sync, Exit 1 = drift / missing / empty / unexpected output path.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -21,18 +24,42 @@ cd "$REPO_ROOT"
 # node_modules/.bin) or is invoked directly (it does not).
 export PATH="$REPO_ROOT/node_modules/.bin:$PATH"
 
+# Expected outputs, as absolute paths (the generator's `Wrote` lines are
+# absolute). Keep in sync with ROUTE_POLICY_OUT / DELETION_RETENTION_OUT in
+# scripts/generate-security-matrices.ts — check 1 fails loudly if they drift.
+EXPECTED_ABS=(
+  "$REPO_ROOT/docs/security/route-policy-matrix.md"
+  "$REPO_ROOT/docs/security/deletion-retention-matrix.md"
+)
+# Repo-relative forms for the git checks.
 MATRICES=(
   "docs/security/route-policy-matrix.md"
   "docs/security/deletion-retention-matrix.md"
 )
 
-# Regenerate in place; the generator is deterministic (sorted keys).
-tsx scripts/generate-security-matrices.ts
+# Regenerate; capture stdout so we can verify WHICH paths were written.
+gen_out="$(tsx scripts/generate-security-matrices.ts)"
 
 failures=0
+
+# Check 1: the set of `Wrote <path>` lines must equal the expected set exactly.
+# A generator whose output path drifted would write a path not in EXPECTED_ABS
+# (or fail to write an expected one), which this catches — unlike a fixed-path
+# git diff, which would see the stale file unchanged and pass.
+written_sorted="$(printf '%s\n' "$gen_out" | sed -n 's/^Wrote //p' | LC_ALL=C sort)"
+expected_sorted="$(printf '%s\n' "${EXPECTED_ABS[@]}" | LC_ALL=C sort)"
+if [ "$written_sorted" != "$expected_sorted" ]; then
+  echo "check-security-matrices: FAIL — generator wrote a different set of paths than expected." >&2
+  echo "  expected:" >&2; printf '    %s\n' "$expected_sorted" >&2
+  echo "  written:"  >&2; printf '    %s\n' "${written_sorted:-<none>}" >&2
+  echo "  (generator output path drifted? update EXPECTED_ABS + MATRICES to match.)" >&2
+  failures=1
+fi
+
+# Check 2: each expected file is tracked and non-empty.
 for f in "${MATRICES[@]}"; do
   if ! git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
-    echo "check-security-matrices: FAIL — $f is not tracked by git (generator output path drift or file removed)" >&2
+    echo "check-security-matrices: FAIL — $f is not tracked by git (output path drift or file removed)" >&2
     failures=1
     continue
   fi
@@ -42,8 +69,7 @@ for f in "${MATRICES[@]}"; do
   fi
 done
 
-# Only meaningful for files that exist; drift on a missing file is already
-# reported above.
+# Check 3: regenerated content matches the committed version.
 if ! git diff --quiet -- "${MATRICES[@]}"; then
   echo "check-security-matrices: FAIL — generated matrices differ from committed version. Run 'npm run generate:security-matrices' and commit the result." >&2
   git --no-pager diff --stat -- "${MATRICES[@]}" >&2

--- a/scripts/checks/check-security-matrices.sh
+++ b/scripts/checks/check-security-matrices.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# CI check: the generated security matrices are in sync with the code.
+#
+# Regenerates docs/security/route-policy-matrix.md and
+# docs/security/deletion-retention-matrix.md, then asserts each generated file
+# is tracked, non-empty, and byte-identical to the committed version.
+#
+# `git diff --quiet` alone only detects MODIFICATIONS to tracked files: it
+# reports clean if the generator starts writing to an untracked path, if a
+# matrix file is `git rm`'d, or if it is truncated to empty. The explicit
+# tracked + non-empty guards close those silent-pass modes so the drift check
+# cannot vacuously pass while a matrix is missing.
+#
+# Exit 0 = in sync, Exit 1 = drift / missing / empty.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Resolve the local `tsx` whether this runs via `npm run` (PATH already has
+# node_modules/.bin) or is invoked directly (it does not).
+export PATH="$REPO_ROOT/node_modules/.bin:$PATH"
+
+MATRICES=(
+  "docs/security/route-policy-matrix.md"
+  "docs/security/deletion-retention-matrix.md"
+)
+
+# Regenerate in place; the generator is deterministic (sorted keys).
+tsx scripts/generate-security-matrices.ts
+
+failures=0
+for f in "${MATRICES[@]}"; do
+  if ! git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+    echo "check-security-matrices: FAIL — $f is not tracked by git (generator output path drift or file removed)" >&2
+    failures=1
+    continue
+  fi
+  if [ ! -s "$f" ]; then
+    echo "check-security-matrices: FAIL — $f is empty" >&2
+    failures=1
+  fi
+done
+
+# Only meaningful for files that exist; drift on a missing file is already
+# reported above.
+if ! git diff --quiet -- "${MATRICES[@]}"; then
+  echo "check-security-matrices: FAIL — generated matrices differ from committed version. Run 'npm run generate:security-matrices' and commit the result." >&2
+  git --no-pager diff --stat -- "${MATRICES[@]}" >&2
+  failures=1
+fi
+
+if [ "$failures" -ne 0 ]; then
+  exit 1
+fi
+
+echo "check-security-matrices: OK"

--- a/src/__tests__/proxy/route-policy-manifest.test.ts
+++ b/src/__tests__/proxy/route-policy-manifest.test.ts
@@ -26,10 +26,10 @@
  * Multi-method files are excluded from assertion 7 entirely (writes belong to
  * their mutating handlers, not the GET branch).
  *
- * TODO(route-policy-sql-security): after the P1 branch
- * (hardening/maintenance-ratelimit-openapi-host) merges, strengthen assertion
- * 8b to also require a rate-limit call in every `operatorGated: true` file.
- * Derive the then-current limiter symbol with:
+ * Assertion 8b requires a fail-closed rate-limit call (createRateLimiter +
+ * failClosedOnRedisError: true + checkRateLimitOrFail) in every
+ * `operatorGated: true` file. If the limiter symbols are ever renamed,
+ * re-derive them with:
  *   grep -rn 'RateLimit' src/app/api/maintenance src/app/api/admin --include=route.ts
  */
 import { describe, it, expect } from "vitest";
@@ -271,7 +271,18 @@ describe("route-policy-manifest.json parity", () => {
     expect(violations).toEqual([]);
   });
 
-  it("assertion 8b: every operatorGated:true entry's source contains both verifyAdminToken( and requireMaintenanceOperator(", () => {
+  it("assertion 8b: every operatorGated:true entry enforces admin auth AND fail-closed rate limiting", () => {
+    // Two invariants for every operator-gated route:
+    //   1. Admin auth: verifyAdminToken( + requireMaintenanceOperator(
+    //   2. Fail-closed rate limiting (#629): createRateLimiter( +
+    //      failClosedOnRedisError: true + checkRateLimitOrFail(
+    // The rate-limit half is a structural (existence) guard: it catches a
+    // route that ships without any throttle, or one whose limiter drops
+    // failClosedOnRedisError (shedding its throttle during a Redis outage —
+    // exactly the blast-radius #629 closed). It does NOT verify the key is
+    // tenant-scoped — that argument-level contract is pinned per route in the
+    // maintenance route.test.ts files ("returns 429 when rate limited"), a
+    // separate layer this existence check cannot see.
     const violations: string[] = [];
     for (const repoRelPath of manifestKeys) {
       if (manifest.routes[repoRelPath].operatorGated !== true) continue;
@@ -281,6 +292,15 @@ describe("route-policy-manifest.json parity", () => {
       }
       if (!source.includes("requireMaintenanceOperator(")) {
         violations.push(`${repoRelPath}: operatorGated=true but missing requireMaintenanceOperator(`);
+      }
+      if (!source.includes("createRateLimiter(")) {
+        violations.push(`${repoRelPath}: operatorGated=true but missing createRateLimiter(`);
+      }
+      if (!/failClosedOnRedisError:\s*true/.test(source)) {
+        violations.push(`${repoRelPath}: operatorGated=true but missing failClosedOnRedisError: true`);
+      }
+      if (!source.includes("checkRateLimitOrFail(")) {
+        violations.push(`${repoRelPath}: operatorGated=true but missing checkRateLimitOrFail(`);
       }
     }
     expect(violations).toEqual([]);

--- a/src/app/api/maintenance/audit-chain-verify/route.test.ts
+++ b/src/app/api/maintenance/audit-chain-verify/route.test.ts
@@ -120,6 +120,15 @@ describe("GET /api/maintenance/audit-chain-verify", () => {
     const req = createRequest({ tenantId: TENANT_ID }, VALID_OP_TOKEN);
     const res = await GET(req);
     expect(res.status).toBe(429);
+
+    // #629 headline property: the maintenance rate-limit key is tenant-scoped
+    // so one tenant's operator cannot 429 another tenant's op. A regression
+    // dropping `${auth.tenantId}` (global key) or swapping in subjectUserId
+    // would still pass the 429/503 behavior tests — only an exact-key assertion
+    // pinning the route discriminator + tenantId segment catches it. The key is
+    // passed to check() before the limiter's verdict, so asserting it here
+    // needs no route-specific success mocks.
+    expect(mockCheck).toHaveBeenCalledWith(`rl:maintenance:chain-verify:${TENANT_ID}`);
   });
 
   it("returns 503 when the rate limiter fails closed on a Redis error", async () => {

--- a/src/app/api/maintenance/audit-outbox-metrics/route.test.ts
+++ b/src/app/api/maintenance/audit-outbox-metrics/route.test.ts
@@ -122,6 +122,15 @@ describe("GET /api/maintenance/audit-outbox-metrics", () => {
     const req = createRequest(VALID_OP_TOKEN);
     const res = await GET(req);
     expect(res.status).toBe(429);
+
+    // #629 headline property: the maintenance rate-limit key is tenant-scoped
+    // so one tenant's operator cannot 429 another tenant's op. A regression
+    // dropping `${auth.tenantId}` (global key) or swapping in subjectUserId
+    // would still pass the 429/503 behavior tests — only an exact-key assertion
+    // pinning the route discriminator + tenantId segment catches it. The key is
+    // passed to check() before the limiter's verdict, so asserting it here
+    // needs no route-specific success mocks.
+    expect(mockCheck).toHaveBeenCalledWith(`rl:maintenance:outbox-metrics:${TENANT_ID}`);
   });
 
   it("returns 503 when the rate limiter fails closed on a Redis error", async () => {

--- a/src/app/api/maintenance/audit-outbox-purge-failed/route.test.ts
+++ b/src/app/api/maintenance/audit-outbox-purge-failed/route.test.ts
@@ -116,6 +116,15 @@ describe("POST /api/maintenance/audit-outbox-purge-failed", () => {
     const req = createRequest({}, VALID_OP_TOKEN);
     const res = await POST(req);
     expect(res.status).toBe(429);
+
+    // #629 headline property: the maintenance rate-limit key is tenant-scoped
+    // so one tenant's operator cannot 429 another tenant's op. A regression
+    // dropping `${auth.tenantId}` (global key) or swapping in subjectUserId
+    // would still pass the 429/503 behavior tests — only an exact-key assertion
+    // pinning the route discriminator + tenantId segment catches it. The key is
+    // passed to check() before the limiter's verdict, so asserting it here
+    // needs no route-specific success mocks.
+    expect(mockCheck).toHaveBeenCalledWith(`rl:maintenance:outbox-purge:${TENANT_ID}`);
   });
 
   it("returns 503 when the rate limiter fails closed on a Redis error", async () => {

--- a/src/app/api/maintenance/dcr-cleanup/route.test.ts
+++ b/src/app/api/maintenance/dcr-cleanup/route.test.ts
@@ -100,6 +100,15 @@ describe("POST /api/maintenance/dcr-cleanup (410 deprecation stub)", () => {
     const req = createRequest(VALID_OP_TOKEN);
     const res = await POST(req);
     expect(res.status).toBe(429);
+
+    // #629 headline property: the maintenance rate-limit key is tenant-scoped
+    // so one tenant's operator cannot 429 another tenant's op. A regression
+    // dropping `${auth.tenantId}` (global key) or swapping in subjectUserId
+    // would still pass the 429/503 behavior tests — only an exact-key assertion
+    // pinning the route discriminator + tenantId segment catches it. The key is
+    // passed to check() before the limiter's verdict, so asserting it here
+    // needs no route-specific success mocks.
+    expect(mockCheck).toHaveBeenCalledWith(`rl:maintenance:dcr-cleanup:${TENANT_ID}`);
   });
 
   it("returns 503 when the rate limiter fails closed on a Redis error", async () => {

--- a/src/app/api/maintenance/purge-audit-logs/route.test.ts
+++ b/src/app/api/maintenance/purge-audit-logs/route.test.ts
@@ -132,6 +132,15 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
     const req = createRequest({}, VALID_OP_TOKEN);
     const res = await POST(req);
     expect(res.status).toBe(429);
+
+    // #629 headline property: the maintenance rate-limit key is tenant-scoped
+    // so one tenant's operator cannot 429 another tenant's purge. A regression
+    // dropping `${auth.tenantId}` (global key) or swapping in subjectUserId
+    // would still pass the 429/503 behavior tests — only an exact-key assertion
+    // pinning the route discriminator + tenantId segment catches it. The key is
+    // passed to check() before the limiter's verdict, so asserting it here
+    // needs no route-specific success mocks.
+    expect(mockCheck).toHaveBeenCalledWith(`rl:maintenance:purge-audit-logs:${TENANT_ID}`);
   });
 
   it("returns 503 when the rate limiter fails closed on a Redis error", async () => {

--- a/src/app/api/maintenance/purge-history/route.test.ts
+++ b/src/app/api/maintenance/purge-history/route.test.ts
@@ -135,6 +135,21 @@ describe("POST /api/maintenance/purge-history", () => {
     expect(mockDeleteMany).not.toHaveBeenCalled();
   });
 
+  it("keys the rate limiter on the operator-token's tenantId (tenant-scoped, exact key)", async () => {
+    // #629 headline property: the maintenance rate-limit key is tenant-scoped
+    // so one tenant's operator cannot 429 another tenant's purge. A regression
+    // that drops `${auth.tenantId}` (global key) or swaps in subjectUserId
+    // would still pass the 429/503 behavior tests — only an exact-key assertion
+    // on the discriminator segment catches it.
+    mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
+    mockDeleteMany.mockResolvedValue({ count: 0 });
+
+    const req = createRequest({}, VALID_OP_TOKEN);
+    await POST(req);
+
+    expect(mockCheck).toHaveBeenCalledWith(`rl:maintenance:purge-history:${TENANT_ID}`);
+  });
+
   it("checks rate limit after auth (401 before 429 for unauthenticated requests)", async () => {
     mockCheck.mockResolvedValue({ allowed: false, retryAfterMs: 30_000 });
 

--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -123,8 +123,16 @@ export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
         // If still too large, drop the OLDEST entries (Maps preserve insertion
         // order) until back under cap. NEVER clear all: a flood of distinct
         // keys during a Redis outage would otherwise reset every live counter,
-        // handing attackers a rate-limit reset. Mirrors the bounded-LRU
-        // eviction in rate-limit-audit.ts (pruneAndAdd).
+        // handing attackers a rate-limit reset.
+        //
+        // This is bounded FIFO (insertion-order) eviction, NOT true LRU: a hit
+        // (count += 1 below) does not re-insert the entry, so a still-active
+        // counter sits at the head and can be evicted before a newer near-idle
+        // one. rate-limit-audit.ts (pruneAndAdd) additionally bumps on access
+        // (delete+set) to approximate real LRU; this path deliberately does not,
+        // trading recency-accuracy for a simpler counter update. Acceptable on
+        // this fail-open fallback (the fail-closed limiters return 503 before
+        // reaching here); see the P2-A follow-up to make it true LRU.
         while (store.size >= RATE_LIMIT_MAP_MAX_SIZE) {
           const oldest = store.keys().next();
           if (oldest.done) break;


### PR DESCRIPTION
## Summary

Follow-up regression guards for the maintenance rate-limit hardening shipped in
`#629`. That PR made the maintenance rate-limit key tenant-scoped
(`rl:maintenance:<route>:${auth.tenantId}`) and fail-closed on Redis error, but
the test suite pinned neither property mechanically: a regression dropping the
`tenantId` segment (global key → cross-tenant 429/DoS) or dropping
`failClosedOnRedisError` (throttle shed during a Redis outage) would have passed
every existing test green.

This adds guards on both the argument level (the key's contents) and the
structural level (the limiter's existence and fail-closed flag), plus two small
CI-guard robustness fixes surfaced during review. No runtime/product behavior
changes — the affected routes already carry the correct calls.

## Changes

- **`test: assert tenant-scoped maintenance rate-limit keys`** — each of the 6
  maintenance route tests now asserts the exact rate-limit key
  (`rl:maintenance:<route>:${TENANT_ID}`). `checkRateLimitOrFail` passes the key
  string directly to `limiter.check(key)`, so the assertion is an exact string
  match; it pins both the tenant segment and the route discriminator (which is
  not always the directory name, e.g. `audit-chain-verify` → `chain-verify`).
- **`test: require fail-closed rate limiting for operator-gated routes`** —
  promotes the `assertion 8b` TODO in `route-policy-manifest.test.ts`: every
  `operatorGated: true` route must carry `createRateLimiter(` +
  `failClosedOnRedisError: true` + `checkRateLimitOrFail(`. All 10 operator-gated
  routes (4 admin rotate-master-key + 6 maintenance) already satisfy this, so
  this is a structural guard with no implementation change.
- **`ci: harden generated security matrix drift check`** — extracts
  `check:security-matrices` into `scripts/checks/check-security-matrices.sh` and
  adds tracked + non-empty guards alongside the `git diff`, so a removed or
  empty matrix fails instead of silently passing.
- **`ci: verify security-matrix generator wrote exactly the expected paths`** —
  parses the generator's `Wrote <path>` lines and asserts the written set equals
  the expected set, closing an output-path-drift false negative that a
  fixed-path `git diff` alone would miss.
- **`docs: clarify memory fallback uses bounded FIFO eviction, not LRU`** —
  corrects a comment in `rate-limit.ts` that claimed the memory-fallback
  eviction mirrors `rate-limit-audit.ts`'s bounded-LRU; this path does not bump
  on access, so it is insertion-order FIFO. Comment-only.

## Guard responsibilities (why both test-level and manifest-level)

| Guard | Protects |
|-------|----------|
| Route `route.test.ts` exact-key assert | the key is tenant-scoped (argument contents) |
| `manifest.test.ts` assertion 8b | a fail-closed limiter exists on every operator-gated route (existence) |

Both are needed: the manifest guard cannot see the key contents, and the
route-test guard cannot enforce the limiter's presence on future routes.

## Verification

- `npx vitest run` — full suite green (933 files, 11984 passed / 1 skipped)
- `npx next build` — succeeds
- `scripts/pre-pr.sh` — all 42 checks pass (incl. the modified
  `check:security-matrices` and `route-policy-manifest` test)
- Non-vacuous checks confirmed by fault injection: the exact-key asserts fail if
  the tenant segment is dropped; `assertion 8b` fails on `failClosedOnRedisError:
  false`; the matrix check fails on drift, empty, removed, and output-path-drift.

## Follow-ups (out of scope, tracked separately)

- True LRU for the memory-fallback eviction (affects only fail-open limiters).
- Promote the lexical (`source.includes` / regex / raw-sql marker) security CI
  guards to AST/type-level matching — tracked in `#635`, draft in
  `docs/archive/review/issue-security-ci-guards-lexical-to-ast.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
