### PR TITLE
refactor(security): promote operator-gated route guards from lexical to AST matching

### DIFF
--- a/docs/archive/review/issue-security-ci-guards-lexical-to-ast-code-review.md
+++ b/docs/archive/review/issue-security-ci-guards-lexical-to-ast-code-review.md
@@ -1,0 +1,104 @@
+# Code Review: security-ci-guards-lexical-to-ast
+
+Date: 2026-07-05
+Review rounds: 2 (Round 1 findings → fixed; Round 2 CONVERGED)
+
+## Changes from Previous Round
+Initial code review (Round 1) on the committed AST-guards implementation, then
+Round 2 verification of the two fixes (mandatory: security-boundary edits).
+
+## Functionality Findings
+
+- **F1 [Major → fixed]** `limiterFlagFlowsToChecker` resolved the `limiter:` identifier
+  by matching ANY same-name `VariableDeclaration` in the file (`.some(decl => decl.getName() === name)`),
+  not the scoped binding. A flagless *consumed* `const rateLimiter` plus an unrelated
+  fail-closed `const rateLimiter` in another scope returned `true` — reopening a narrower
+  form of the S2 dataflow gap. Empirically reproduced by both functionality and security
+  experts independently. Zero impact today (all 10 routes have one module-scope const).
+  → **Fixed** in 4b8bd0fd: resolve via `getSymbol()?.getValueDeclaration()` (scope-aware,
+  no Program needed — empirically confirmed to work with the Prisma client hidden).
+  Committed shadowing regression test (mutation-verified: old logic returns true).
+
+- **F2 [Minor → fixed]** = S2 (fail-open on parseDiagnostics absence). See Security.
+
+Non-findings verified clean: comment-range dedup (`seen` Set), StringLiteral inside `${}`
+stays blanked while interpolation code visible, char-by-char blanking preserves newline
+count / multiline anchoring, `calleeName` property-access tail correct for all real forms,
+same-file single-const resolution sufficient, behavior parity old→new (zero manifest edits).
+
+## Security Findings
+
+- **S1 [Low → fixed]** = F1 (scope-aware resolution). RS3 dataflow-vs-existence at a finer
+  grain. escalate: false.
+
+- **S2 [Low → fixed]** `parseRouteSource` fail-closed guard was `if (diagnostics && diagnostics.length > 0) throw`.
+  If a future ts-morph/TS drops the `@internal parseDiagnostics` field, `diagnostics` is
+  `undefined`, the throw never fires, and malformed source passes silently — the exact
+  fail-open NF-R4 exists to prevent. RS2. escalate: false.
+  → **Fixed** in 4b8bd0fd: `if (!Array.isArray(diagnostics) || diagnostics.length > 0) throw`
+  — absence of the diagnostics channel is itself treated as a parse failure.
+
+Verified clean: no aliased/re-exported imports of the guarded symbols in maintenance/admin
+routes; unhandled `limiter:` forms (spread, function-return, property-access) all return
+`false` (fail-closed); `${}` interpolation stays visible (real `tx.x.delete(` still matches);
+two-tier delegated-write floor unchanged, not widened; guard1 is strictly stronger than the
+old five independent `source.includes`/`.test(source)` existence checks.
+
+## Testing Findings
+
+**No findings.** All 4 boolean helpers verified mutation-resistant in BOTH directions
+(positive case kills const-false, decoy kills const-true) — verified by executing fixtures,
+not reading assertions. I-C3-5 committed gap-closure proof present and unique (the only test
+with a comment-hidden `failClosedOnRedisError: true` + real call). I-C3-4 fixture genuinely
+unparseable (parseDiagnostics.length=2). Shared module-level Project + fixed `"test.ts"`
+virtualPath with `overwrite:true` proven leak-free. Zero manifest edits confirmed. All
+helper branches (inline-call + variable-binding for limiter flow; StringLiteral /
+NoSubstitutionTemplateLiteral / TemplateHead-Middle-Tail / regex-literal for blanking) covered.
+
+## Round 2 Verification
+CONVERGED. Both fixes correct-and-complete. Key new risk (getSymbol requiring a Program that
+fails without prisma generate) empirically CLEARED: with `node_modules/.prisma/client` hidden,
+`getSymbol()` on a same-file local identifier resolves correctly and the full suite passes —
+`skipFileDependencyResolution: true` + in-memory FS isolate it. `let`-reassignment not followed
+(fail-closed-leaning, zero routes affected) — non-blocking pre-existing property of a syntactic guard.
+
+## Adjacent Findings
+Both F1/S1 and F2/S2 were flagged independently by two experts (functionality + security) —
+strong triangulation signal. Merged; fixed once.
+
+## Quality Warnings
+None — every finding carried empirical evidence (ts-morph probes, reproduced decoys, real route reads).
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1 (reuse): ts-morph reused (precedent check-state-mutation-centralization.ts); no duplication.
+- R2 (constants): N/A — regexes stay in route-class-patterns.json SSoT.
+- R42 (member-set): all 4 guard1 callees + both guard2 regexes upgraded incl. assertion 6
+  (memo named only 7). F1 was the same class at finer grain (name-match vs. resolution) — fixed.
+
+### Security expert
+- RS2 (fail-open): S2 — flagged and fixed (diagnostics-absence now fail-closed).
+- RS3 (dataflow-vs-existence): S1 — flagged and fixed (scope resolution not name existence).
+- R42: all 10 operatorGated:true routes enumerated from manifest, each uses the handled form.
+
+### Testing expert
+- RT (mutation-resistance): both directions for all 4 helpers, empirically executed.
+- Shared-state: module-level Project + fixed virtualPath proven leak-free via overwrite:true.
+- R42: member-set fully upgraded; no surviving lexical `source.includes(`/`.test(source)` for guarded callees.
+
+## Environment Verification Report
+N/A — no environment constraints declared in Phase 1 (all guards run local + app-ci vitest,
+no external service). The one runtime-environment concern (getSymbol vs. no-prisma-generate)
+was raised and empirically cleared in Round 2 — classified `verified-local` (Prisma-client-hidden re-run passed).
+
+## Resolution Status
+
+### F1/S1 [Major/Low] limiterFlagFlowsToChecker name-match not scope resolution — Fixed
+- Action: replaced whole-file name-match with `getSymbol()?.getValueDeclaration()` scope resolution.
+- Modified file: src/__tests__/proxy/ast-guards.ts (limiterFlagFlowsToChecker identifier branch)
+- Test: src/__tests__/proxy/ast-guards.test.ts (shadowing decoy, mutation-verified)
+
+### F2/S2 [Minor/Low] parseDiagnostics absence fails open — Fixed
+- Action: treat non-array/absent diagnostics as a parse failure (throw).
+- Modified file: src/__tests__/proxy/ast-guards.ts (parseRouteSource)

--- a/docs/archive/review/issue-security-ci-guards-lexical-to-ast-plan.md
+++ b/docs/archive/review/issue-security-ci-guards-lexical-to-ast-plan.md
@@ -1,0 +1,378 @@
+# Plan: Promote route-policy security CI guards from lexical to AST matching
+
+## Project context
+
+- **Type**: web app (Next.js) — this change touches only the **CI guard / test layer**, no runtime/product code.
+- **Test infrastructure**: unit + integration + E2E + CI/CD. The guards under change ARE tests (vitest `route-policy-manifest.test.ts`) and CI scripts.
+- **Verification environment constraints**: none. Every guard runs in local `npx vitest run` and in the `app-ci` CI job (vitest, prisma generated — see NF-R2) with no external service, DB, or network dependency. All acceptance paths are `verifiable-local`.
+
+## Objective
+
+Eliminate the **false-negative (guard-strength) gap** in the operator-gated route
+security assertions of `src/__tests__/proxy/route-policy-manifest.test.ts`, by
+replacing `source.includes(...)` / `regex.test(source)` lexical matching with
+AST-aware matching that asserts a **real call expression / argument** rather than
+mere token presence.
+
+Two guards are in scope (per user decision "guard1 + guard2 in this PR"):
+
+- **guard1** — assertion 8b/8c: operator-gated routes must carry a real
+  fail-closed rate-limit call, not a token that could sit in a comment / unused
+  import / unrelated call.
+- **guard2** — assertion 6 (`destructive` ⇔ `DELETE_SIGNAL`) and assertion 7
+  (`sideEffectingGet` floor ⇔ `WRITE_PRIMITIVE`): the write-primitive / delete-signal
+  regexes currently match anywhere in source text, including comments and string
+  literals.
+
+guard3 (raw-SQL `// raw-sql-ident:` marker) is **out of scope** — see SC1.
+
+**No runtime vulnerability is being fixed.** The runtime is correct in every case
+today (verified: all 10 operator-gated routes carry the real calls; #634 already
+merged). This is a detection-strength upgrade so a *future* regression that hides
+a required call in a comment/string cannot pass green.
+
+## Requirements
+
+### Functional
+- F-R1: assertion 8b passes iff each `operatorGated:true` route file contains, as
+  **real call expressions**, all of: `verifyAdminToken(...)`,
+  `requireMaintenanceOperator(...)`, `createRateLimiter({ ... failClosedOnRedisError: true ... })`,
+  `checkRateLimitOrFail(...)`. The `failClosedOnRedisError: true` must be a real
+  object-literal property of the argument to a real `createRateLimiter` call — NOT
+  a bare regex over the whole file.
+- F-R2: assertion 8c passes iff every route file that contains a **real call** to
+  `requireMaintenanceOperator(...)` is declared `operatorGated:true`. A commented-out
+  or string-literal occurrence must NOT trigger the reverse-drift requirement.
+- F-R3: assertion 6 (`destructive`) and assertion 7 (`sideEffectingGet`) evaluate
+  their `DELETE_SIGNAL` / `WRITE_PRIMITIVE` patterns against **code text only**
+  (comments and string-literal contents excluded), preserving the existing
+  documented two-tier floor (delegated writes via imported service functions are
+  still not detected — that is a separate, already-accepted heuristic ceiling).
+- F-R4: the shared `route-class-patterns.json` regexes remain the single source of
+  truth for guard2. The AST upgrade changes *where* the regex is applied (code
+  text only), NOT the regex itself — so the `.sh` check and the vitest test still
+  cannot drift on the pattern definition.
+
+### Non-functional
+- NF-R1: no new npm dependency. Use `ts-morph@28.0.0` (already in `dependencies`)
+  and `typescript@5.9.3` — both installed. Precedent: `scripts/check-state-mutation-centralization.ts`.
+- NF-R2: **CI topology (corrected per review T1/F2)** — `route-policy-manifest.test.ts`
+  is a **vitest** test. It runs in the **`app-ci`** CI job (`.github/workflows/ci.yml`,
+  `npm run test:coverage`) which DOES run `npx prisma generate` first — NOT in the
+  `static-checks` job (which runs `PRE_PR_STATIC_ONLY=1` and skips vitest entirely,
+  `scripts/pre-pr.sh:~493`). Therefore the generated Prisma client IS available at test
+  time; the memory note `project_static_check_ci_no_prisma_generate` applies to `.mjs`/`.tsx`
+  guards invoked directly by `pre-pr.sh` static mode, NOT to this vitest test.
+  The AST helper still MUST NOT import `@prisma/client` — but for **hygiene/speed**
+  (the helper only inspects syntactic call/object shape; no type info is needed), NOT
+  as a CI-failure-avoidance gate. It parses route source as text via a ts-morph
+  `Project` created with `{ useInMemoryFileSystem: true, skipFileDependencyResolution: true }`
+  so a route file that itself `import`s `@prisma/client` needs no generated client to parse
+  (verified: parsing does not resolve imports).
+- NF-R3: parsing all ~212 route files is cheap — measured ~137 ms for a single
+  parse-all pass, ~303 ms for 4 passes (once per assertion). This is within the existing
+  suite's budget; **no caching is required (YAGNI)**. Parse per-file with a fresh
+  `SourceFile`. If a module-level `Project` is reused for speed, files MUST be added
+  with `{ overwrite: true }` and keyed by repo-relative virtual path, and the helper
+  MUST NOT leak state across calls (each call operates on exactly the file it parsed) —
+  a shared mutable `Project` is per-test state and must not violate "each test starts clean".
+- NF-R4: fail-closed **(corrected per review S1 — critical)**. ts-morph is a *recovering*
+  parser: `Project.createSourceFile(...)` does **NOT throw** on malformed source (verified
+  empirically — it returns a partial AST, and call nodes surrounding a syntax error survive).
+  Therefore fail-closed cannot rely on a parse throw. `parseRouteSource` MUST explicitly
+  inspect `sf.compilerNode.parseDiagnostics` (populated by the **parser**, no Program/type
+  resolution needed — verified it returns >0 for broken source WITHOUT a Program) and
+  `throw` when `length > 0`. It MUST NOT use `getPreEmitDiagnostics()` — that requires a
+  Program and would pull type resolution / generated types, violating NF-R2. A route file
+  the parser rejects surfaces as a **test failure**, never a silent green.
+
+## Technical approach
+
+### Shared AST helper
+
+Create `src/__tests__/proxy/ast-guards.ts` (test-support module, colocated with the
+consuming test; NOT under `src/lib` because it is test-only and pulls `ts-morph`).
+
+It exposes pure functions over a single route file's source text:
+
+- `parseRouteSource(source: string, virtualPath: string): SourceFile` — parse one
+  file into a ts-morph `SourceFile` via an in-memory `Project`
+  (`{ useInMemoryFileSystem: true, skipFileDependencyResolution: true }`). No tsconfig,
+  no dependency resolution. **After parsing, if `sf.compilerNode.parseDiagnostics.length > 0`,
+  `throw`** (NF-R4 fail-closed — ts-morph does not throw on its own). No try/catch that
+  returns a default anywhere on this path.
+- `hasRealCall(sf: SourceFile, calleeName: string): boolean` — true iff the file
+  contains a `CallExpression` whose callee is an identifier (or property-access tail)
+  named `calleeName`. Excludes occurrences inside comments/strings AND import
+  specifiers by construction (the AST has no `CallExpression` node for those).
+- `hasCallWithObjectFlag(sf: SourceFile, calleeName: string, flag: string, value: boolean): boolean`
+  — true iff some `CallExpression` to `calleeName` has a first argument that is an
+  `ObjectLiteralExpression` containing a `PropertyAssignment` named `flag` whose
+  initializer is the boolean literal `value`. Returns `false` when the first arg is not
+  an object literal (e.g. `createRateLimiter(config)` with a variable) — the flag cannot
+  be proven, so guard1 fails closed for that route.
+- `limiterFlagFlowsToChecker(sf: SourceFile): boolean` **(new per review S2 — closes the
+  dataflow residual)** — true iff the object passed as the `limiter:` property to a real
+  `checkRateLimitOrFail({ ... })` call resolves, **within the same file**, to a
+  `const <id> = createRateLimiter({ ... failClosedOnRedisError: true ... })` binding.
+  This links the fail-closed limiter to the limiter the handler actually consumes,
+  rather than checking `createRateLimiter`-with-flag and `checkRateLimitOrFail` as two
+  independent existence facts. Same-file `const` lookback only (no Program, mirrors
+  `check-raw-sql-usage.mjs`'s variable-lookback approach). If `checkRateLimitOrFail`'s
+  `limiter:` arg is an inline `createRateLimiter({...})` call expression (not a variable),
+  match its flag directly. Closes the guard1 analogue of guard3's "validator exists vs.
+  validator guards THIS value" gap.
+- `matchesInCodeText(sf: SourceFile, re: RegExp): boolean` — applies `re` to the
+  file's text **with comment ranges and string/template-literal contents blanked
+  out**, so guard2 keeps using the shared regex but only over real code. Rationale
+  for keeping regex (not full call-node matching) for guard2: `WRITE_PRIMITIVE` /
+  `DELETE_SIGNAL` are deliberately broad member-set re-derivations (`prisma.X.create(`,
+  `$executeRaw`, `consume*(`, model-specific deletes) sourced from
+  `route-class-patterns.json`; re-expressing them as structural AST matchers would
+  (a) fork the SSoT the `.sh` check depends on and (b) risk missing a member the
+  regex catches. Blanking comments+strings is the minimal, sufficient fix for the
+  stated lexical gap. This is the "enumerate A's implicit constraints before
+  replacing A" discipline: the regex's constraint is "stays byte-identical to the
+  `.sh` check's pattern" — preserved by keeping the regex and only changing its input.
+
+### Comment/string blanking (guard2)
+
+**Hard rule (per review F1 — implementer trap):** comment and string ranges MUST be
+obtained from **ts-morph AST nodes / TS scanner comment ranges** — NEVER from independent
+regex passes over the text. A naive regex blanker (blank `/* */`, then `//`, then
+`'...'`/`"..."` as separate passes) was empirically shown to false-flip ≥3 real routes
+(`mcp/register`, `mobile/authorize`, `tenant/mcp-clients`): an unpaired apostrophe inside
+a comment (`iOS app's`, `user's tenant`) makes the string-blanking regex swallow the
+following real `tx.x.create(`/`deleteMany(` line, re-opening the false-negative. AST node
+ranges avoid this by construction.
+
+`matchesInCodeText` walks the SourceFile once:
+- Collect comment ranges via the TS scanner / ts-morph comment-range APIs (node-anchored,
+  not regex).
+- Collect `StringLiteral`, `NoSubstitutionTemplateLiteral`, and template-literal
+  **text spans** (`TemplateHead`/`TemplateMiddle`/`TemplateTail` fixed text) by node range —
+  the `${expr}` interpolation code stays visible, since an interpolated `prisma.x.delete(`
+  IS real executed code (fail-secure toward detection). Regex-literal bodies (`/prisma\.x\.delete\(/`)
+  are code and stay visible (they are not StringLiteral nodes).
+- Replace those ranges' characters with spaces (char-for-char, preserving offsets and line
+  numbers so multi-line regex behavior and any diagnostic stay correct), then run
+  `re.test(blanked)`.
+- Precedent: `check-raw-sql-usage.mjs:158-188` already solves the template-literal span
+  problem (brace-depth-aware); reuse that conceptual approach rather than re-deriving it.
+
+### Integration into the test file
+
+`route-policy-manifest.test.ts` currently reads each route's source with
+`readFileSync` and applies `source.includes(...)` / `RE.test(source)`. Rewrite
+assertions 6, 7, 8b, 8c to parse the source once per file into a `SourceFile` and
+call the helper functions. `readFileSync` still supplies the raw text to the parser.
+
+## Contracts
+
+### C1 — AST helper module `src/__tests__/proxy/ast-guards.ts`
+
+- **Signatures** (no bodies):
+  - `export function parseRouteSource(source: string, virtualPath: string): SourceFile`
+  - `export function hasRealCall(sf: SourceFile, calleeName: string): boolean`
+  - `export function hasCallWithObjectFlag(sf: SourceFile, calleeName: string, flag: string, value: boolean): boolean`
+  - `export function limiterFlagFlowsToChecker(sf: SourceFile): boolean` (S2)
+  - `export function matchesInCodeText(sf: SourceFile, re: RegExp): boolean`
+- **Invariants** (all app-enforced — these are test-support functions, no storage layer):
+  - I-C1-1: `hasRealCall` / `hasCallWithObjectFlag` return `false` for any occurrence
+    of `calleeName` that is inside a comment or a string/template-text span (there is
+    no CallExpression node for such text). **Member-set of "callees checked by guard1"**:
+    derived from assertion 8b/8c source =
+    `grep -oE '(verifyAdminToken|requireMaintenanceOperator|createRateLimiter|checkRateLimitOrFail)\(' src/__tests__/proxy/route-policy-manifest.test.ts | sort -u`
+    → { verifyAdminToken, requireMaintenanceOperator, createRateLimiter, checkRateLimitOrFail }.
+    All four must route through `hasRealCall` (or `hasCallWithObjectFlag` for
+    createRateLimiter). No lexical `source.includes(` for these four survives in the diff.
+  - I-C1-2: `hasCallWithObjectFlag(sf, "createRateLimiter", "failClosedOnRedisError", true)`
+    returns `true` for the module-scope `const rateLimiter = createRateLimiter({ ..., failClosedOnRedisError: true })`
+    form (the real form in all 10 routes) and `false` when the property is absent,
+    is `false`, or when `failClosedOnRedisError: true` appears only in a comment or a
+    *different* call's argument.
+  - I-C1-3: `matchesInCodeText` yields identical results to the old
+    `RE.test(source)` for all current route files (no false-negative regression on
+    real code), while returning `false` for a synthetic file whose only match is
+    inside a comment or string literal.
+  - I-C1-4 (parse fail-closed, NF-R4): ts-morph does NOT throw on malformed source
+    (recovering parser — verified). `parseRouteSource` MUST inspect
+    `sf.compilerNode.parseDiagnostics` and throw when non-empty; the calling test
+    surfaces it as a failure (never a silent pass). A truncated/garbage-source fixture
+    that MUST throw is a C3 test case (I-C3-4), NOT just a prose invariant.
+  - I-C1-5 (S2 dataflow link): `limiterFlagFlowsToChecker` returns `false` for a file
+    where a decoy `const decoy = createRateLimiter({ failClosedOnRedisError: true })`
+    exists but `checkRateLimitOrFail({ limiter: otherLimiter })` consumes a *different*
+    limiter lacking the flag; returns `true` for all 10 real routes where the same
+    `const rateLimiter` flows into `checkRateLimitOrFail`'s `limiter:`.
+- **Forbidden patterns** (checked in Phase 2-4 grep):
+  - pattern: `source\.includes\("(verifyAdminToken|requireMaintenanceOperator|createRateLimiter|checkRateLimitOrFail)\(` — reason: guard1 callee must go through AST, not lexical includes.
+  - pattern: `/failClosedOnRedisError:\\s*true/\.test\(source\)` (F3) — reason: the flag
+    check must go through `hasCallWithObjectFlag` (real object-literal property of a real
+    createRateLimiter call), not a whole-file regex. This completes the guard1 member-set
+    enforcement (previously only C2's `.test(source)` ban covered it).
+  - pattern: `from "@prisma/client"` in `ast-guards.ts` — reason: hygiene/speed (NF-R2,
+    corrected) — the helper needs no type info; keep it dependency-free.
+- **Acceptance criteria**:
+  - AC-C1-1: unit tests for the helper (see C3) pass, covering each invariant with a
+    positive case AND a comment/string-decoy negative case.
+  - AC-C1-2: helper imports only from `ts-morph` and `node:*` — no `@/` app imports,
+    no `@prisma/client` (hygiene, not a CI gate — NF-R2 corrected).
+- **Consumer-flow walkthrough** (the helper's output shape is consumed by the test):
+  - Consumer `route-policy-manifest.test.ts` (assertion 8b) reads the booleans from
+    `hasRealCall(sf, "verifyAdminToken")`, `hasRealCall(sf, "requireMaintenanceOperator")`,
+    `hasCallWithObjectFlag(sf, "createRateLimiter", "failClosedOnRedisError", true)`,
+    `hasRealCall(sf, "checkRateLimitOrFail")`, AND `limiterFlagFlowsToChecker(sf)` (S2)
+    and pushes a violation string when any is `false`. It uses only the boolean — no
+    other field. Satisfiable from the signatures.
+  - Consumer assertion 8c reads `hasRealCall(sf, "requireMaintenanceOperator")` and
+    cross-checks `manifest.routes[path].operatorGated === true`. Boolean only.
+  - Consumer assertions 6/7 read `matchesInCodeText(sf, DELETE_SIGNAL)` /
+    `matchesInCodeText(sf, WRITE_PRIMITIVE)` in place of `RE.test(source)`. Boolean only.
+
+### C2 — rewrite assertions 6, 7, 8b, 8c in `route-policy-manifest.test.ts`
+
+- **Signatures**: no new exports; the four `it(...)` blocks change their body to call
+  C1 helpers. `parseRouteSource(source, repoRelPath)` per file per assertion — no caching
+  (NF-R3: ~303 ms total, YAGNI).
+- **Invariants** (app-enforced):
+  - I-C2-1: assertion 8b/8c behavior is **unchanged for all current routes** — the
+    same 10 routes pass 8b, the same reverse-drift set passes 8c. Only the *detection
+    mechanism* changes. Verified by the suite staying green with zero manifest edits.
+  - I-C2-2: assertion 6/7 pass/fail decisions are **unchanged for all current routes**
+    (I-C1-3). The two-tier delegated-write floor documented in the file header remains
+    accurate — update the header comment only if wording implies pure-lexical matching.
+  - I-C2-3 (R42 member-set): the class "lexical security guards in this file" =
+    { assertion 6 (DELETE_SIGNAL), assertion 7 (WRITE_PRIMITIVE), assertion 8b
+    (4 includes + failClosedOnRedisError regex), assertion 8c (1 includes) }. Derived by
+    `grep -nE 'source\.includes\(|\.test\(source\)' src/__tests__/proxy/route-policy-manifest.test.ts`.
+    ALL members in this set are upgraded — assertion 6 is included even though the
+    issue memo named only assertion 7, because it is the identical `DELETE_SIGNAL.test(source)`
+    lexical pattern (member-set derived from code, not from the memo's list).
+- **Forbidden patterns**:
+  - pattern: `\.test\(source\)` in the four rewritten assertions — reason: guard2 must
+    apply patterns via `matchesInCodeText`, not raw source. (assertion 3's
+    `METHOD_EXPORT_RE` over source is a DIFFERENT concern — export extraction, not a
+    security-value guard — and is explicitly NOT in this member-set; it stays as-is.
+    See SC2.)
+  - pattern: `source\.includes\(` for the guard1 callees (per C1 forbidden list).
+- **Acceptance criteria**:
+  - AC-C2-1: `npx vitest run src/__tests__/proxy/route-policy-manifest.test.ts` green,
+    zero edits to `route-policy-manifest.json` or `route-class-patterns.json`. This
+    zero-manifest-edit gate is **blocking, not advisory** — a forced manifest edit means
+    behavior changed (a bug in this PR).
+  - AC-C2-2 (T2/T4 — corrected): the mutation proof that the gap is closed is a
+    **committed permanent test in C3** (I-C3-5), NOT a manual reverted injection. An
+    optional one-time manual comment-injection MAY be run as a sanity demo but is not the
+    load-bearing artifact — the committed C3 decoy is.
+
+### C3 — unit tests for the AST helper `src/__tests__/proxy/ast-guards.test.ts`
+
+- **Signatures**: vitest `describe`/`it` blocks; no product exports.
+- **Invariants**:
+  - I-C3-1: each helper function has ≥1 positive case and ≥1 comment-decoy and ≥1
+    string-literal-decoy negative case, using inline source strings (no filesystem).
+    For `hasRealCall`, additionally an **import-specifier-only decoy**
+    (`import { createRateLimiter } from "..."` with no call → `false`) — the case most
+    likely to regress if the impl is "optimized" to a name-only search (T3).
+  - I-C3-2: `hasCallWithObjectFlag` has cases: (a) `failClosedOnRedisError: false` → `false`;
+    (b) flag on a *different* call than `createRateLimiter` → `false`; (c) first arg is a
+    **variable, not an object literal** (`createRateLimiter(config)`) → `false` (T3);
+    (d) **multi-line / reformatted** object literal
+    (`createRateLimiter({\n  failClosedOnRedisError:\n  true,\n})`) → `true` (T3).
+  - I-C3-3: `matchesInCodeText` has cases: pattern matches only inside a template-literal
+    fixed-text span (→ `false`); matches inside a `${...}` interpolation expression
+    (→ `true`, real code); matches inside a **regex literal body** `/tx\.x\.delete\(/`
+    (→ `true`, real code, not a string node) (T6); a **comment apostrophe regression
+    fixture** — `// the user's tenant` immediately before a real `tx.mcpClient.create(`
+    must still match (→ `true`), guarding the F1 false-flip (T6/F1).
+  - I-C3-4 (S1 fail-closed): `parseRouteSource` on a **truncated/garbage source** throws
+    (not returns) — asserted with `expect(() => parseRouteSource(garbage, "x.ts")).toThrow()`.
+  - I-C3-5 (T2/T4 — the load-bearing gap-closure proof, committed permanently):
+    `hasCallWithObjectFlag(parseRouteSource('const r = createRateLimiter({ prefix: "x" });\n// failClosedOnRedisError: true', "x.ts"), "createRateLimiter", "failClosedOnRedisError", true)`
+    returns **`false`**. This exact input passed the OLD `/failClosedOnRedisError:\s*true/.test(source)`
+    (matched the comment) and MUST fail the new check — the permanent regression guard that
+    replaces manual AC-C2-2.
+  - I-C3-6 (S2): `limiterFlagFlowsToChecker` has a decoy-limiter negative case
+    (per I-C1-5) and a real-flow positive case.
+- **Forbidden patterns**: none specific.
+- **Acceptance criteria**: AC-C3-1: `npx vitest run src/__tests__/proxy/ast-guards.test.ts` green;
+  mutation-resistant in **both directions** per boolean helper (T5): each function has a
+  positive case that fails if the function is mutated to constant-`false`, AND a decoy
+  case that fails if mutated to constant-`true`. Decoy-flip alone is insufficient.
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | AST helper module `ast-guards.ts` (parse-fail-closed + 4 matchers incl. limiter-flow) | locked |
+| C2 | Rewrite assertions 6/7/8b/8c to use the helper | locked |
+| C3 | Unit tests for the AST helper (decoy negatives + committed gap-closure proof) | locked |
+
+## Testing strategy
+
+- **Helper unit tests (C3)**: inline-source, decoy-driven — the core proof that the
+  AST layer closes the lexical gap. Each negative case is a comment/string that the
+  OLD lexical check would have accepted.
+- **Manifest parity suite (C2)**: must stay green with zero manifest/pattern edits —
+  proves behavior-preservation for all real routes (I-C2-1, I-C2-2).
+- **Committed gap-closure proof (I-C3-5)**: the permanent regression test proving a
+  comment-hidden `failClosedOnRedisError: true` no longer satisfies guard1. Replaces the
+  former manual/reverted mutation spot-check.
+- **Full gates (CLAUDE.md mandatory)**: `npx vitest run` + `npx tsc --noEmit`
+  (**typecheck**, corrected per review Adjacent): `next build` EXCLUDES test files and does
+  NOT typecheck `ast-guards.ts` (imported only by tests) — `tsc --noEmit` (the `typecheck`
+  script, which includes test files and runs in `app-ci`) is what covers it. Per memory
+  `feedback_skip_build_for_test_only` the diff is test-support-only so `next build` MAY be
+  skipped, but `typecheck` is mandatory. Then `scripts/pre-pr.sh`.
+
+## Considerations & constraints
+
+### Scope contract
+
+- **SC1** — guard3 (raw-SQL `// raw-sql-ident:` marker RESIDUAL in
+  `check-raw-sql-usage.mjs:418-442`) is deferred. Owner: the branded-type
+  (`SafeSqlIdentifier`) / worker-policy-manifest design track (triangulate P4).
+  Rationale: guard3's gap is "value was validated" — a **dataflow** property that AST
+  call-matching cannot close; the issue memo itself concludes the correct fix is
+  type-level (branded types), not AST. Tracked in
+  `docs/archive/review/issue-security-ci-guards-lexical-to-ast.md` §3. Not a 30-minute
+  fix; deferral justified (design-layer entanglement, not "easy but skipped").
+- **SC2** — assertion 3's `METHOD_EXPORT_RE` (HTTP-method export extraction) and
+  assertion 1/2/4/5 are NOT lexical *security-value* guards (they extract structure or
+  call real production functions) and are out of scope. Only the DELETE/WRITE-primitive
+  and operator-gated-call guards (the false-negative security-detection surface) are
+  upgraded.
+
+### Known risks
+- **R-risk-1**: ts-morph parse cost across ~212 files. Resolved (not just mitigated):
+  measured ~303 ms for 4 parse-all passes (NF-R3) — within budget, so parse per-file
+  per-assertion with NO caching (YAGNI; a shared mutable Project would introduce
+  cross-test state, which NF-R3 forbids).
+- **R-risk-2**: template-literal blanking must NOT blank `${expr}` code. Mitigation:
+  I-C1-3 / I-C3-3 explicit interpolation-visible test case. This mirrors the existing
+  `check-raw-sql-usage.mjs` brace-depth span logic — same hazard, already solved there;
+  reuse the conceptual approach.
+- **R-risk-3**: `matchesInCodeText` offset preservation — blanking must replace
+  char-for-char (spaces), not delete, so line/column in any future diagnostic stays
+  correct and multi-line regex behavior is unchanged.
+
+### Out of scope
+- No change to `route-policy-manifest.json`, `route-class-patterns.json`, or any
+  route runtime code. If the suite requires a manifest edit to pass, that is a
+  behavior change and a bug in this PR — stop and re-examine.
+- guard3 (SC1), assertion 3 method extraction (SC2).
+
+## User operation scenarios
+
+1. **Regression a developer might introduce**: a maintenance route refactor drops the
+   real `createRateLimiter({ failClosedOnRedisError: true })` call but leaves a
+   `// TODO: re-add failClosedOnRedisError: true` comment. OLD 8b: passes (token in
+   comment). NEW 8b: fails. ← the exact gap being closed.
+2. **False-positive avoidance**: a route legitimately has the string
+   `"createRateLimiter("` inside an error message or doc comment but ALSO the real
+   call. NEW guard: still passes (real call present). No new false positive.
+3. **assertion 6/7 comment decoy**: a GET-only route has `// prisma.x.delete(...)` in
+   a comment explaining why it does NOT delete. OLD 7: false-positive violation
+   (WRITE_PRIMITIVE matches the comment). NEW 7: correctly no match. ← removes a
+   latent false-positive too, not only false-negatives.

--- a/docs/archive/review/issue-security-ci-guards-lexical-to-ast-review.md
+++ b/docs/archive/review/issue-security-ci-guards-lexical-to-ast-review.md
@@ -1,0 +1,89 @@
+# Plan Review: security-ci-guards-lexical-to-ast
+
+Date: 2026-07-05
+Review round: 1
+
+## Changes from Previous Round
+Initial review.
+
+## Functionality Findings
+
+- **F1 [Minor — implementer trap]** `matchesInCodeText` must use AST/scanner node ranges,
+  never regex-based comment/string blanking. Empirically, a naive regex blanker false-flips
+  3 real routes (`mcp/register`, `mobile/authorize`, `tenant/mcp-clients`) because an
+  unpaired apostrophe in a comment (`user's tenant`) makes the string-blanking regex swallow
+  the following real `tx.x.create(`. → **Reflected**: added "Hard rule" to blanking section +
+  I-C3-3 apostrophe regression fixture.
+- **F2 [Minor]** NF-R2 rationale misattributed (this vitest test runs in `app-ci` with prisma
+  generate, not `static-checks`). → **Reflected**: NF-R2 rewritten with correct CI topology;
+  `@prisma/client` ban reframed as hygiene, not CI gate.
+- **F3 [Minor]** C1 forbidden-pattern list omitted line 299's `/failClosedOnRedisError:\s*true/.test(source)`
+  regex form. → **Reflected**: added it to C1 forbidden patterns.
+- Verified-correct (no finding): `hasCallWithObjectFlag` decomposition, `hasRealCall` vs
+  imports, SSoT preservation, template `${expr}` visibility, NF-R4 intent.
+
+## Security Findings
+
+- **S1 [Critical]** NF-R4 fail-closed relies on ts-morph `createSourceFile` throwing on
+  malformed source — it does NOT (recovering parser, verified). A syntax-broken route keeps
+  its call nodes and passes guard1 green. → **Reflected**: NF-R4 + I-C1-4 rewritten to require
+  explicit `sf.compilerNode.parseDiagnostics` check + throw; must NOT use `getPreEmitDiagnostics()`
+  (Program/type resolution, NF-R2 violation). Added I-C3-4 throwing fixture. escalate: true.
+- **S2 [High/Major]** guard1 overclaims: `createRateLimiter`-with-flag and `checkRateLimitOrFail`
+  are checked as independent existence facts; nothing verifies the fail-closed limiter is the one
+  the handler consumes — same dataflow residual class as guard3/SC1, but presented as fully closed.
+  → **Reflected**: added `limiterFlagFlowsToChecker` (C1 signature + I-C1-5), wired into assertion 8b
+  consumer walkthrough, added I-C3-6 decoy-limiter test. Chose to close it (a) rather than merely
+  disclose (b), since the limiter is a same-file `const` and ts-morph is already the tool.
+- **S3/S4 [Low, informational]** guard2 blanking direction correct; SC1 (guard3 scope-out) sound —
+  "value was validated" is a genuine dataflow/branded-type property AST call-matching cannot close.
+  No fix required.
+
+## Testing Findings
+
+- **T1 [High]** Same as F2 (NF-R2 CI topology wrong). → **Reflected** (shared fix).
+- **T2/T4 [Medium]** Mutation proof was manual/reverted/non-committed → no durable regression guard
+  for the PR's raison-d'être. → **Reflected**: promoted to committed I-C3-5 (exact comment-hidden-flag
+  input → false); AC-C2-2 downgraded to optional sanity demo.
+- **T3 [Medium]** C3 decoy set missing import-specifier / non-object-arg / multi-line cases.
+  → **Reflected**: I-C3-1 (import decoy), I-C3-2 (c)(d) (non-object arg, multi-line).
+- **T5 [Low]** "removing decoy flips result" is one-sided mutation proof for a boolean predicate.
+  → **Reflected**: AC-C3-1 now requires both-direction mutation resistance.
+- **T6 [Low]** guard2 blanking edge cases (regex literal, escaped backtick). → **Reflected**:
+  I-C3-3 regex-literal + apostrophe cases; reuse `check-raw-sql-usage.mjs` span logic noted.
+- **T7 [Low]** Parse-cache "measure and decide" is over-engineering (303 ms measured); shared
+  mutable Project risks cross-test state. → **Reflected**: NF-R3 states no caching (YAGNI).
+- **[Adjacent Low]** `next build` excludes test files → won't typecheck `ast-guards.ts`; real
+  coverage is `tsc --noEmit`. → **Reflected**: testing-strategy gate corrected to typecheck.
+
+## Adjacent Findings
+- (Testing→Functionality) `next build` vs `typecheck` coverage of `ast-guards.ts` — reflected above.
+- (Functionality→Testing) shared ts-morph pattern with `check-state-mutation-centralization.ts` —
+  precedent cited in NF-R1; no duplication to eliminate (that script is a standalone CLI, not importable).
+
+## Quality Warnings
+None — all findings carried empirical evidence (live ts-morph probes, grep output, real route reads).
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1 (shared-util reimpl): checked — no pre-existing importable AST helper; `check-state-mutation-centralization.ts`
+  is a standalone CLI. New `ast-guards.ts` justified.
+- R2 (hardcoded constants): clean — callee names passed as args, guard2 regexes stay in `route-class-patterns.json` SSoT.
+- R42 (member-set): PASS — independent grep reproduced the plan's set exactly (assertions 6,7,8b×5,8c);
+  assertion 3 `METHOD_EXPORT_RE` correctly excluded (SC2). One enforcement-grep gap (F3) fixed.
+
+### Security expert
+- R42: partially — callee member-set complete, but the fail-closed *contract*-part set was under-enumerated
+  at the dataflow grain (S2: two members, one closed). Fixed by adding `limiterFlagFlowsToChecker`.
+- RS2 (fail-open posture): APPLIED — S1 (ts-morph fails open absent explicit diagnostics check).
+- RS3 (dataflow vs existence): APPLIED — S2, S4 (validated-value-flow distinction).
+- RS4 (secrets/logging): N/A — test layer, no secrets.
+- RS5 (new blind spot): APPLIED — S1 is a new recovering-parser blind spot the lexical check lacked.
+
+### Testing expert
+- R42: PASS — re-derived member-set from code matches plan; assertion 6 correctly added over the memo's list.
+- RT (mutation resistance, committed regression, shared-state, vacuous assertions): APPLIED — T2/T4/T5/T7.
+- Precedent parity: helper is importable predicate (direct import + inline fixtures), correctly diverges from
+  the CLI `--fixture`/exit-code precedent. No CI wiring change needed (runs in existing app-ci vitest).
+- N/A: flaky-sleep, DB-mock, snapshot-drift, msw/fetch (no async/DB/snapshot/network in helper).

--- a/docs/archive/review/issue-security-ci-guards-lexical-to-ast.md
+++ b/docs/archive/review/issue-security-ci-guards-lexical-to-ast.md
@@ -1,0 +1,46 @@
+# Promote security CI guards from lexical (string/regex) to AST matching
+
+## Summary
+
+Several security CI guards decide whether a route/file satisfies a
+security-relevant invariant by testing whether a **string or regex appears
+anywhere in the source text**. Because the match is lexical, a comment, a
+string literal, or an unused import that merely *contains* the token satisfies
+the guard — even though no real call site exists. The runtime is currently
+correct in every case, so this is a **guard-strength (false-negative) gap**,
+not a live vulnerability. This issue tracks migrating these guards to AST-aware
+checks that assert the actual call/argument, and doing it as one unified pass
+rather than piecemeal.
+
+## Affected guards
+
+### 1. `route-policy-manifest.test.ts` assertion 8b/8c — operator-gated route requirements
+- `src/__tests__/proxy/route-policy-manifest.test.ts:290-302` (8b) and `:313` (8c)
+- Uses `source.includes("verifyAdminToken(")`, `source.includes("requireMaintenanceOperator(")`, `source.includes("createRateLimiter(")`, `source.includes("checkRateLimitOrFail(")`, and `/failClosedOnRedisError:\s*true/.test(source)`.
+- False negative: any of these tokens sitting in a comment or unused import satisfies the requirement without a real call. In particular `failClosedOnRedisError: true` is text-matched, not verified to be the argument of the *same* `createRateLimiter` call that the route actually uses.
+- AST target: assert a real `createRateLimiter({ failClosedOnRedisError: true })` call expression and a real `checkRateLimitOrFail({ limiter: ... })` call, not just token presence.
+
+### 2. `route-policy-manifest.test.ts` assertion 7 — side-effecting GET / destructive classification
+- `src/__tests__/proxy/route-policy-manifest.test.ts:77-78,213,230`
+- `DELETE_SIGNAL` / `WRITE_PRIMITIVE` are regexes over source text. Same lexical class: a matching token in a comment/string would mis-signal. (Lower priority — these are already documented two-tier heuristics.)
+
+### 3. `check-raw-sql-usage.mjs` ident marker — validator-guards-value gap (Security Minor-2 from triangulate)
+- `scripts/checks/check-raw-sql-usage.mjs` (marker mechanism ~`:148-155`, self-documented RESIDUAL ~`:418-442`)
+- A `// raw-sql-ident:` marker naming a validator present *anywhere in the file* passes even if that validator does not guard the interpolated value at that call site. Same lexical ceiling.
+- AST target (or type-level, see below): confirm the interpolated expression is the *return* of an identifier-validation call, not merely that a validator name appears in the file.
+
+## Candidate approaches
+
+- **AST matching** (ts-morph / typescript compiler API) for guards 1 and 2: match call expressions and their argument object literals structurally.
+- **Branded types** for guard 3 (the P4 item from the triangulate review): `type SafeSqlIdentifier = string & { readonly __brand: "SafeSqlIdentifier" }`; the validator returns `SafeSqlIdentifier` and the raw-SQL helper accepts only that type. This moves the "value was validated" guarantee from a lexical marker into the type system. This belongs with the broader **worker policy manifest / raw SQL helper type design** work, so guard 3 should be scoped together with that.
+
+## Why one unified pass, not piecemeal
+
+- 8b/8c and assertion 7 already share the `source.includes` / regex idiom; upgrading only part of one assertion leaves inconsistent detection strength inside a single test file.
+- Guard 3 (raw SQL) is entangled with the worker-policy-manifest / branded-type design layer (triangulate P4), which is itself a "sit down and design it" task, not a one-line fix.
+- Doing all three at once lets a single AST-helper (or shared ts-morph setup) serve every guard, and keeps the "small, safe, focused" property of the tenant-scoped-rate-limit PR intact by keeping this out of it.
+
+## Non-goals / current status
+
+- No runtime vulnerability is implied — the maintenance routes verified in the tenant-scoped-rate-limit PR do carry the real calls with real `failClosedOnRedisError: true` and tenant-scoped keys.
+- This is deferred from the PR `test/maintenance-rate-limit-tenant-key-guards` per reviewer agreement (finding 2 = guard 1 above; finding was Low severity).

--- a/src/__tests__/proxy/ast-guards.test.ts
+++ b/src/__tests__/proxy/ast-guards.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseRouteSource,
+  hasRealCall,
+  hasCallWithObjectFlag,
+  limiterFlagFlowsToChecker,
+  matchesInCodeText,
+} from "./ast-guards";
+
+// The real form every operator-gated route uses: a module-scope fail-closed
+// limiter const flowing into an in-handler checkRateLimitOrFail call.
+const REAL_ROUTE = `
+import { createRateLimiter } from "@/lib/security/rate-limit";
+import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
+const rateLimiter = createRateLimiter({
+  windowMs: 1000,
+  max: 1,
+  failClosedOnRedisError: true,
+});
+async function handlePOST(req) {
+  const blocked = await checkRateLimitOrFail({
+    req,
+    limiter: rateLimiter,
+    key: "rl:maintenance:x",
+  });
+  if (blocked) return blocked;
+}
+`;
+
+const parse = (src: string) => parseRouteSource(src, "test.ts");
+
+describe("parseRouteSource — fail-closed (I-C3-4)", () => {
+  it("throws on truncated / malformed source", () => {
+    expect(() => parse("const x = createRateLimiter({ @@@ broken")).toThrow();
+  });
+
+  it("does not throw on valid source", () => {
+    expect(() => parse(REAL_ROUTE)).not.toThrow();
+  });
+});
+
+describe("hasRealCall", () => {
+  it("true for a real call expression", () => {
+    expect(hasRealCall(parse(REAL_ROUTE), "createRateLimiter")).toBe(true);
+  });
+
+  it("false when the callee appears only in a comment (decoy)", () => {
+    const src = `// createRateLimiter( is documented here\nconst x = 1;`;
+    expect(hasRealCall(parse(src), "createRateLimiter")).toBe(false);
+  });
+
+  it("false when the callee appears only in a string literal (decoy)", () => {
+    const src = `const msg = "call createRateLimiter( to build one";`;
+    expect(hasRealCall(parse(src), "createRateLimiter")).toBe(false);
+  });
+
+  it("false for an import specifier with no call (I-C3-1)", () => {
+    const src = `import { createRateLimiter } from "@/lib/security/rate-limit";`;
+    expect(hasRealCall(parse(src), "createRateLimiter")).toBe(false);
+  });
+
+  it("true for a member call (a.b.checkRateLimitOrFail())", () => {
+    const src = `svc.limits.checkRateLimitOrFail({ req });`;
+    expect(hasRealCall(parse(src), "checkRateLimitOrFail")).toBe(true);
+  });
+});
+
+describe("hasCallWithObjectFlag", () => {
+  const flag = "failClosedOnRedisError";
+
+  it("true when the flag is a real property of the call's object arg", () => {
+    expect(hasCallWithObjectFlag(parse(REAL_ROUTE), "createRateLimiter", flag, true)).toBe(true);
+  });
+
+  it("false when the property is false (I-C3-2a)", () => {
+    const src = `const r = createRateLimiter({ failClosedOnRedisError: false });`;
+    expect(hasCallWithObjectFlag(parse(src), "createRateLimiter", flag, true)).toBe(false);
+  });
+
+  it("false when the flag is on a different call (I-C3-2b)", () => {
+    const src = `const r = createRateLimiter({ max: 1 });\nconst o = other({ failClosedOnRedisError: true });`;
+    expect(hasCallWithObjectFlag(parse(src), "createRateLimiter", flag, true)).toBe(false);
+  });
+
+  it("false when the first arg is a variable, not an object literal (I-C3-2c)", () => {
+    const src = `const config = { failClosedOnRedisError: true };\nconst r = createRateLimiter(config);`;
+    expect(hasCallWithObjectFlag(parse(src), "createRateLimiter", flag, true)).toBe(false);
+  });
+
+  it("true for a multi-line / reformatted object literal (I-C3-2d)", () => {
+    const src = `const r = createRateLimiter({\n  failClosedOnRedisError:\n    true,\n});`;
+    expect(hasCallWithObjectFlag(parse(src), "createRateLimiter", flag, true)).toBe(true);
+  });
+
+  it("false when the flag is present only in a comment (I-C3-5 gap-closure proof)", () => {
+    // This exact input passed the OLD /failClosedOnRedisError:\s*true/.test(source)
+    // (matched the comment) and MUST fail the AST check — the permanent regression
+    // guard proving the lexical gap is closed.
+    const src = `const r = createRateLimiter({ prefix: "x" });\n// failClosedOnRedisError: true`;
+    expect(hasCallWithObjectFlag(parse(src), "createRateLimiter", flag, true)).toBe(false);
+  });
+});
+
+describe("limiterFlagFlowsToChecker (S2 dataflow link)", () => {
+  it("true when the fail-closed const limiter flows into checkRateLimitOrFail", () => {
+    expect(limiterFlagFlowsToChecker(parse(REAL_ROUTE))).toBe(true);
+  });
+
+  it("true for an inline createRateLimiter in the limiter position", () => {
+    const src = `
+async function h(req) {
+  await checkRateLimitOrFail({ limiter: createRateLimiter({ failClosedOnRedisError: true }) });
+}`;
+    expect(limiterFlagFlowsToChecker(parse(src))).toBe(true);
+  });
+
+  it("false when checker consumes a different, flagless limiter (I-C3-6 decoy)", () => {
+    // A decoy fail-closed limiter exists, but the handler passes a different
+    // limiter that lacks the flag — hasCallWithObjectFlag alone would pass here.
+    const src = `
+const decoy = createRateLimiter({ failClosedOnRedisError: true });
+const other = createRateLimiter({ max: 1 });
+async function h(req) {
+  await checkRateLimitOrFail({ limiter: other, key: "x" });
+}`;
+    const sf = parse(src);
+    expect(hasCallWithObjectFlag(sf, "createRateLimiter", "failClosedOnRedisError", true)).toBe(true);
+    expect(limiterFlagFlowsToChecker(sf)).toBe(false);
+  });
+});
+
+describe("matchesInCodeText", () => {
+  const WRITE = /\btx\.[A-Za-z]+\.(create|delete)\(/;
+
+  it("true when the pattern matches real code", () => {
+    const src = `async function h() { await tx.mcpClient.create({ data }); }`;
+    expect(matchesInCodeText(parse(src), WRITE)).toBe(true);
+  });
+
+  it("false when the match is only inside a comment", () => {
+    const src = `// tx.mcpClient.delete( is intentionally not called here\nconst x = 1;`;
+    expect(matchesInCodeText(parse(src), WRITE)).toBe(false);
+  });
+
+  it("false when the match is only inside a template fixed-text span", () => {
+    const src = "const s = `tx.mcpClient.delete( is documented`;";
+    expect(matchesInCodeText(parse(src), WRITE)).toBe(false);
+  });
+
+  it("true when the match is inside a ${} interpolation (real code)", () => {
+    const src = "const s = `${await tx.mcpClient.delete({ where })}`;";
+    expect(matchesInCodeText(parse(src), WRITE)).toBe(true);
+  });
+
+  it("does not blank regex-literal bodies as if they were strings (I-C3-3)", () => {
+    // A regex literal is code, not a StringLiteral node, so its text is not
+    // blanked. Assert the identifier inside it survives (the fixed-text blanker
+    // must not have swallowed it).
+    const src = `const re = /createRateLimiter/;`;
+    expect(matchesInCodeText(parse(src), /createRateLimiter/)).toBe(true);
+  });
+
+  it("still matches real code after a comment apostrophe (F1 regression fixture)", () => {
+    // A naive regex string-blanker treats the comment apostrophe as a string
+    // opener and swallows the following real create() line. AST ranges do not.
+    const src = `// scope deletion to the user's tenant\nasync function h() { await tx.mcpClient.create({ data }); }`;
+    expect(matchesInCodeText(parse(src), WRITE)).toBe(true);
+  });
+});

--- a/src/__tests__/proxy/ast-guards.test.ts
+++ b/src/__tests__/proxy/ast-guards.test.ts
@@ -127,6 +127,21 @@ async function h(req) {
     expect(hasCallWithObjectFlag(sf, "createRateLimiter", "failClosedOnRedisError", true)).toBe(true);
     expect(limiterFlagFlowsToChecker(sf)).toBe(false);
   });
+
+  it("false when a same-name fail-closed const shadows the consumed flagless one", () => {
+    // Scope-aware resolution: the handler consumes a flagless `rateLimiter`; an
+    // unrelated same-name fail-closed const exists in another scope. Name-only
+    // matching would pass here — symbol resolution must not.
+    const src = `
+function h() {
+  const rateLimiter = createRateLimiter({ max: 1 });
+  return checkRateLimitOrFail({ limiter: rateLimiter, key: "x" });
+}
+function unused() {
+  const rateLimiter = createRateLimiter({ failClosedOnRedisError: true });
+}`;
+    expect(limiterFlagFlowsToChecker(parse(src))).toBe(false);
+  });
 });
 
 describe("matchesInCodeText", () => {

--- a/src/__tests__/proxy/ast-guards.ts
+++ b/src/__tests__/proxy/ast-guards.ts
@@ -33,8 +33,10 @@ type WithParseDiagnostics = { parseDiagnostics?: ReadonlyArray<unknown> };
 export function parseRouteSource(source: string, virtualPath: string): SourceFile {
   const sf = project.createSourceFile(virtualPath, source, { overwrite: true });
   const diagnostics = (sf.compilerNode as unknown as WithParseDiagnostics).parseDiagnostics;
-  if (diagnostics && diagnostics.length > 0) {
-    throw new Error(`parseRouteSource: ${virtualPath} has parse diagnostics`);
+  // Fail closed: absence of the diagnostics channel (a future ts-morph/TS field
+  // rename) is itself a reason to refuse the parse, not to trust it silently.
+  if (!Array.isArray(diagnostics) || diagnostics.length > 0) {
+    throw new Error(`parseRouteSource: ${virtualPath} has parse diagnostics or none available`);
   }
   return sf;
 }
@@ -114,12 +116,13 @@ export function limiterFlagFlowsToChecker(sf: SourceFile): boolean {
     if (Node.isCallExpression(limiter)) return isFailClosedLimiterCall(limiter);
 
     if (Node.isIdentifier(limiter)) {
-      const name = limiter.getText();
-      return sf.getDescendantsOfKind(SyntaxKind.VariableDeclaration).some((decl) => {
-        if (decl.getName() !== name) return false;
-        const init = decl.getInitializer();
-        return init !== undefined && Node.isCallExpression(init) && isFailClosedLimiterCall(init);
-      });
+      // Resolve the identifier to the binding it actually refers to (scope-aware),
+      // NOT any same-name declaration in the file — a shadowing fail-closed const
+      // elsewhere must not satisfy the guard when the consumed limiter is flagless.
+      const decl = limiter.getSymbol()?.getValueDeclaration();
+      if (!decl || !Node.isVariableDeclaration(decl)) return false;
+      const init = decl.getInitializer();
+      return init !== undefined && Node.isCallExpression(init) && isFailClosedLimiterCall(init);
     }
     return false;
   });

--- a/src/__tests__/proxy/ast-guards.ts
+++ b/src/__tests__/proxy/ast-guards.ts
@@ -1,0 +1,174 @@
+/**
+ * AST-based matchers for route-policy security guards (test support).
+ *
+ * Promotes the lexical (`source.includes(...)` / `regex.test(source)`) guards in
+ * route-policy-manifest.test.ts to AST matching, so a required security call
+ * hidden in a comment, string literal, or unused import can no longer satisfy a
+ * guard. Uses ts-morph (already a dependency; precedent:
+ * scripts/check-state-mutation-centralization.ts). Test-support only — colocated
+ * with the consuming test, NOT under src/lib.
+ *
+ * fail-closed: ts-morph is a RECOVERING parser — createSourceFile does NOT throw
+ * on malformed source (it returns a partial AST whose surviving call nodes would
+ * still satisfy an existence check). parseRouteSource therefore inspects
+ * parseDiagnostics and throws, so a syntactically broken route surfaces as a test
+ * failure rather than a silent green. parseDiagnostics is populated by the parser
+ * alone — no Program / type resolution / generated Prisma client needed.
+ */
+import { Node, Project, SyntaxKind } from "ts-morph";
+import type { CallExpression, ObjectLiteralExpression, SourceFile } from "ts-morph";
+
+const project = new Project({
+  useInMemoryFileSystem: true,
+  skipFileDependencyResolution: true,
+});
+
+// `parseDiagnostics` is a real property the parser populates on every
+// ts.SourceFile, but TypeScript marks it @internal so it is absent from the
+// public type. Reading it needs no Program / type resolution (unlike
+// getPreEmitDiagnostics, which would pull generated types and violate NF-R2), so
+// we narrow the compiler node to just this field rather than casting to `any`.
+type WithParseDiagnostics = { parseDiagnostics?: ReadonlyArray<unknown> };
+
+export function parseRouteSource(source: string, virtualPath: string): SourceFile {
+  const sf = project.createSourceFile(virtualPath, source, { overwrite: true });
+  const diagnostics = (sf.compilerNode as unknown as WithParseDiagnostics).parseDiagnostics;
+  if (diagnostics && diagnostics.length > 0) {
+    throw new Error(`parseRouteSource: ${virtualPath} has parse diagnostics`);
+  }
+  return sf;
+}
+
+// The callee text of a CallExpression: bare identifier (`f(`) or the trailing
+// property name of a member call (`a.b.f(` → "f"). Import specifiers and
+// comment/string occurrences are not CallExpression nodes, so they never match.
+function calleeName(call: CallExpression): string {
+  const expr = call.getExpression();
+  if (Node.isPropertyAccessExpression(expr)) return expr.getName();
+  return expr.getText();
+}
+
+function callsTo(sf: SourceFile, name: string): CallExpression[] {
+  return sf
+    .getDescendantsOfKind(SyntaxKind.CallExpression)
+    .filter((call) => calleeName(call) === name);
+}
+
+export function hasRealCall(sf: SourceFile, name: string): boolean {
+  return callsTo(sf, name).length > 0;
+}
+
+// True iff some call to `name` passes an object literal whose `flag` property is
+// the boolean literal `value`. A non-object first argument (e.g. a variable) is
+// not provable → false (guard fails closed for that route).
+function objectFlagIs(obj: ObjectLiteralExpression, flag: string, value: boolean): boolean {
+  const prop = obj.getProperty(flag);
+  if (!prop || !Node.isPropertyAssignment(prop)) return false;
+  const init = prop.getInitializer();
+  return init?.getText() === String(value);
+}
+
+export function hasCallWithObjectFlag(
+  sf: SourceFile,
+  name: string,
+  flag: string,
+  value: boolean,
+): boolean {
+  return callsTo(sf, name).some((call) => {
+    const arg0 = call.getArguments()[0];
+    return arg0 !== undefined && Node.isObjectLiteralExpression(arg0) && objectFlagIs(arg0, flag, value);
+  });
+}
+
+// Does the object passed as `createRateLimiter`'s first argument carry
+// failClosedOnRedisError: true?
+function isFailClosedLimiterCall(call: CallExpression): boolean {
+  if (calleeName(call) !== "createRateLimiter") return false;
+  const arg0 = call.getArguments()[0];
+  return (
+    arg0 !== undefined &&
+    Node.isObjectLiteralExpression(arg0) &&
+    objectFlagIs(arg0, "failClosedOnRedisError", true)
+  );
+}
+
+/**
+ * Closes the guard1 dataflow residual: verifies the fail-closed limiter is the
+ * one the handler actually consumes, not merely that a fail-closed
+ * createRateLimiter call and a checkRateLimitOrFail call both exist somewhere.
+ *
+ * True iff a checkRateLimitOrFail({ limiter: L }) call has an L that resolves —
+ * within the same file — to a createRateLimiter({ ... failClosedOnRedisError:
+ * true ... }) call: either L is that call inline, or L is an identifier bound by
+ * a `const L = createRateLimiter({...})` declaration in the file.
+ */
+export function limiterFlagFlowsToChecker(sf: SourceFile): boolean {
+  return callsTo(sf, "checkRateLimitOrFail").some((call) => {
+    const arg0 = call.getArguments()[0];
+    if (arg0 === undefined || !Node.isObjectLiteralExpression(arg0)) return false;
+    const limiterProp = arg0.getProperty("limiter");
+    if (!limiterProp || !Node.isPropertyAssignment(limiterProp)) return false;
+    const limiter = limiterProp.getInitializer();
+    if (!limiter) return false;
+
+    if (Node.isCallExpression(limiter)) return isFailClosedLimiterCall(limiter);
+
+    if (Node.isIdentifier(limiter)) {
+      const name = limiter.getText();
+      return sf.getDescendantsOfKind(SyntaxKind.VariableDeclaration).some((decl) => {
+        if (decl.getName() !== name) return false;
+        const init = decl.getInitializer();
+        return init !== undefined && Node.isCallExpression(init) && isFailClosedLimiterCall(init);
+      });
+    }
+    return false;
+  });
+}
+
+// Blank comment ranges and string / template fixed-text spans (char-for-char, so
+// offsets and line numbers are preserved), then test `re` against code text only.
+// `${expr}` interpolation code, regex-literal bodies, and identifiers stay
+// visible — an interpolated `tx.x.delete(` IS real executed code. Ranges come
+// from AST/scanner nodes, NEVER from independent regex passes: a comment
+// apostrophe (`user's tenant`) breaks single-pass string-blanking regexes and
+// would swallow the following real code line.
+export function matchesInCodeText(sf: SourceFile, re: RegExp): boolean {
+  const chars = sf.getFullText().split("");
+
+  const blank = (start: number, end: number): void => {
+    for (let i = start; i < end; i++) {
+      if (chars[i] !== "\n" && chars[i] !== "\r") chars[i] = " ";
+    }
+  };
+
+  for (const node of sf.getDescendantsOfKind(SyntaxKind.StringLiteral)) {
+    blank(node.getStart(), node.getEnd());
+  }
+  for (const node of sf.getDescendantsOfKind(SyntaxKind.NoSubstitutionTemplateLiteral)) {
+    blank(node.getStart(), node.getEnd());
+  }
+  // Template literal fixed-text spans (head/middle/tail) — the ${expr} between
+  // them is a separate expression node and stays visible.
+  const templateKinds = [
+    SyntaxKind.TemplateHead,
+    SyntaxKind.TemplateMiddle,
+    SyntaxKind.TemplateTail,
+  ];
+  for (const kind of templateKinds) {
+    for (const node of sf.getDescendantsOfKind(kind)) {
+      blank(node.getStart(), node.getEnd());
+    }
+  }
+  // Comment ranges (leading + trailing) across all descendants, deduped by start.
+  const seen = new Set<number>();
+  for (const node of sf.getDescendants()) {
+    for (const range of [...node.getLeadingCommentRanges(), ...node.getTrailingCommentRanges()]) {
+      const start = range.getPos();
+      if (seen.has(start)) continue;
+      seen.add(start);
+      blank(start, range.getEnd());
+    }
+  }
+
+  return re.test(chars.join(""));
+}

--- a/src/__tests__/proxy/route-policy-manifest.test.ts
+++ b/src/__tests__/proxy/route-policy-manifest.test.ts
@@ -26,10 +26,13 @@
  * Multi-method files are excluded from assertion 7 entirely (writes belong to
  * their mutating handlers, not the GET branch).
  *
- * Assertion 8b requires a fail-closed rate-limit call (createRateLimiter +
- * failClosedOnRedisError: true + checkRateLimitOrFail) in every
- * `operatorGated: true` file. If the limiter symbols are ever renamed,
- * re-derive them with:
+ * Assertion 8b requires a fail-closed rate-limit call (a real
+ * createRateLimiter({ failClosedOnRedisError: true }) call, a real
+ * checkRateLimitOrFail call, and the fail-closed limiter flowing into it) in
+ * every `operatorGated: true` file. Assertions 6/7/8b/8c match via AST
+ * (src/__tests__/proxy/ast-guards.ts) rather than lexical source text, so a
+ * required call hidden in a comment / string / unused import no longer satisfies
+ * a guard. If the limiter symbols are ever renamed, re-derive them with:
  *   grep -rn 'RateLimit' src/app/api/maintenance src/app/api/admin --include=route.ts
  */
 import { describe, it, expect } from "vitest";
@@ -37,6 +40,13 @@ import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { classifyRoute } from "@/lib/proxy/route-policy";
 import { isBearerBypassRoute } from "@/lib/proxy/cors-gate";
+import {
+  parseRouteSource,
+  hasRealCall,
+  hasCallWithObjectFlag,
+  limiterFlagFlowsToChecker,
+  matchesInCodeText,
+} from "./ast-guards";
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const API_DIR = path.join(REPO_ROOT, "src/app/api");
@@ -210,7 +220,7 @@ describe("route-policy-manifest.json parity", () => {
     const mismatches: string[] = [];
     for (const repoRelPath of manifestKeys) {
       const source = readFileSync(path.join(REPO_ROOT, repoRelPath), "utf8");
-      const actualDestructive = DELETE_SIGNAL.test(source);
+      const actualDestructive = matchesInCodeText(parseRouteSource(source, repoRelPath), DELETE_SIGNAL);
       const declaredDestructive = manifest.routes[repoRelPath].destructive === true;
       if (actualDestructive !== declaredDestructive) {
         mismatches.push(
@@ -227,7 +237,8 @@ describe("route-policy-manifest.json parity", () => {
       const entry = manifest.routes[repoRelPath];
       const isGetOnly = entry.methods.length === 1 && entry.methods[0] === "GET";
       const source = readFileSync(path.join(REPO_ROOT, repoRelPath), "utf8");
-      const hasWritePrimitive = isGetOnly && WRITE_PRIMITIVE.test(source);
+      const hasWritePrimitive =
+        isGetOnly && matchesInCodeText(parseRouteSource(source, repoRelPath), WRITE_PRIMITIVE);
       const hasReason = Boolean(entry.sideEffectingGet && entry.sideEffectingGet.length >= 10);
       const exemptionReason = SIDE_EFFECTING_GET_EXEMPTIONS[repoRelPath];
 
@@ -272,35 +283,41 @@ describe("route-policy-manifest.json parity", () => {
   });
 
   it("assertion 8b: every operatorGated:true entry enforces admin auth AND fail-closed rate limiting", () => {
-    // Two invariants for every operator-gated route:
-    //   1. Admin auth: verifyAdminToken( + requireMaintenanceOperator(
-    //   2. Fail-closed rate limiting (#629): createRateLimiter( +
-    //      failClosedOnRedisError: true + checkRateLimitOrFail(
-    // The rate-limit half is a structural (existence) guard: it catches a
-    // route that ships without any throttle, or one whose limiter drops
-    // failClosedOnRedisError (shedding its throttle during a Redis outage —
-    // exactly the blast-radius #629 closed). It does NOT verify the key is
-    // tenant-scoped — that argument-level contract is pinned per route in the
-    // maintenance route.test.ts files ("returns 429 when rate limited"), a
-    // separate layer this existence check cannot see.
+    // Two invariants for every operator-gated route, verified by AST (not lexical
+    // source.includes) so a required call hidden in a comment / string / unused
+    // import cannot satisfy the guard:
+    //   1. Admin auth: verifyAdminToken( + requireMaintenanceOperator( as real calls
+    //   2. Fail-closed rate limiting (#629): a real createRateLimiter({
+    //      failClosedOnRedisError: true }) call, a real checkRateLimitOrFail( call,
+    //      AND the fail-closed limiter flows into checkRateLimitOrFail's `limiter:`
+    //      arg (limiterFlagFlowsToChecker — closes the "flag exists somewhere vs.
+    //      the consumed limiter carries it" dataflow gap).
+    // It does NOT verify the key is tenant-scoped — that argument-level contract is
+    // pinned per route in the maintenance route.test.ts files ("returns 429 when
+    // rate limited"), a separate layer this existence check cannot see.
     const violations: string[] = [];
     for (const repoRelPath of manifestKeys) {
       if (manifest.routes[repoRelPath].operatorGated !== true) continue;
       const source = readFileSync(path.join(REPO_ROOT, repoRelPath), "utf8");
-      if (!source.includes("verifyAdminToken(")) {
+      const sf = parseRouteSource(source, repoRelPath);
+      if (!hasRealCall(sf, "verifyAdminToken")) {
         violations.push(`${repoRelPath}: operatorGated=true but missing verifyAdminToken(`);
       }
-      if (!source.includes("requireMaintenanceOperator(")) {
+      if (!hasRealCall(sf, "requireMaintenanceOperator")) {
         violations.push(`${repoRelPath}: operatorGated=true but missing requireMaintenanceOperator(`);
       }
-      if (!source.includes("createRateLimiter(")) {
-        violations.push(`${repoRelPath}: operatorGated=true but missing createRateLimiter(`);
+      if (!hasCallWithObjectFlag(sf, "createRateLimiter", "failClosedOnRedisError", true)) {
+        violations.push(
+          `${repoRelPath}: operatorGated=true but missing createRateLimiter({ failClosedOnRedisError: true })`,
+        );
       }
-      if (!/failClosedOnRedisError:\s*true/.test(source)) {
-        violations.push(`${repoRelPath}: operatorGated=true but missing failClosedOnRedisError: true`);
-      }
-      if (!source.includes("checkRateLimitOrFail(")) {
+      if (!hasRealCall(sf, "checkRateLimitOrFail")) {
         violations.push(`${repoRelPath}: operatorGated=true but missing checkRateLimitOrFail(`);
+      }
+      if (!limiterFlagFlowsToChecker(sf)) {
+        violations.push(
+          `${repoRelPath}: operatorGated=true but the fail-closed limiter does not flow into checkRateLimitOrFail`,
+        );
       }
     }
     expect(violations).toEqual([]);
@@ -310,7 +327,7 @@ describe("route-policy-manifest.json parity", () => {
     const violations: string[] = [];
     for (const repoRelPath of routeFiles) {
       const source = readFileSync(path.join(REPO_ROOT, repoRelPath), "utf8");
-      if (!source.includes("requireMaintenanceOperator(")) continue;
+      if (!hasRealCall(parseRouteSource(source, repoRelPath), "requireMaintenanceOperator")) continue;
       const entry = manifest.routes[repoRelPath];
       if (!entry || entry.operatorGated !== true) {
         violations.push(`${repoRelPath}: calls requireMaintenanceOperator( but is not declared operatorGated:true`);


### PR DESCRIPTION
## Summary

Promotes the operator-gated route security guards in `route-policy-manifest.test.ts` from **lexical** (`source.includes(...)` / `regex.test(source)`) to **AST** matching. The lexical guards decided whether a route carried fail-closed rate limiting + admin auth by testing whether a token appeared anywhere in the source text — so a required call sitting in a comment, string literal, or unused import satisfied the guard with no real call site.

This is a **guard-strength (false-negative) upgrade, not a live vulnerability fix**: all 10 operator-gated routes (4 admin rotate-master-key + 6 maintenance) carry the real calls today. Follow-up to the merged `#634` tenant-scoped rate-limit guards, deferred from that PR by reviewer agreement.

## What changed

- **New `src/__tests__/proxy/ast-guards.ts`** — AST matchers over route source via `ts-morph` (already a dependency; precedent: `scripts/check-state-mutation-centralization.ts`). No new dependency.
- **Assertions 6 / 7 / 8b / 8c rewritten** to route through the helper instead of text matching. Zero edits to `route-policy-manifest.json` / `route-class-patterns.json` — behavior preserved for every current route.
- **`src/__tests__/proxy/ast-guards.test.ts`** — 23 unit tests, both-direction mutation-resistant, including the committed regression proof that a comment-hidden `failClosedOnRedisError: true` no longer satisfies guard1.

Two upgrades beyond the tracking issue's ask:

- **`limiterFlagFlowsToChecker`** closes the guard1 dataflow residual — verifies the fail-closed limiter is the one flowing into `checkRateLimitOrFail`'s `limiter:` argument (scope-aware via `getSymbol()`), not merely that a fail-closed `createRateLimiter` call and a `checkRateLimitOrFail` call both exist somewhere. This is the guard3-class "call exists vs. it guards *this* value" gap.
- **Assertion 6** (`DELETE_SIGNAL`) is upgraded alongside assertion 7 — the same lexical pattern the tracking issue named only for assertion 7 (member-set derived from code, not the memo's list).

## Design notes

- **Fail-closed parsing**: `ts-morph` is a recovering parser that does not throw on malformed source, so `parseRouteSource` inspects `parseDiagnostics` explicitly and throws when non-empty **or absent** (a future field rename must fail closed). It never uses `getPreEmitDiagnostics()`, which would need a Program and pull generated types.
- **NF: no Program / no `prisma generate` dependency** — `getSymbol()` on same-file local identifiers resolves without a Program (verified by hiding the generated Prisma client and re-running). guard2 keeps the shared `route-class-patterns.json` regexes as the SSoT; only their input changes to code-text-only (comments + string/template-fixed-text blanked via AST node ranges, `${expr}` kept visible).
- **Out of scope**: guard3 (raw-SQL `// raw-sql-ident:` marker) — its "value was validated" residual is a dataflow property AST call-matching cannot close; it needs branded types (`SafeSqlIdentifier`), tracked separately.

## Test plan

- `npx tsc --noEmit` — clean
- `npx vitest run src/__tests__/proxy/` — 33 tests pass
- `scripts/pre-pr.sh` — 42/42 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
