### PR TITLE
fix(security): close count-then-create TOCTOU cap races (17 sites) + harden RLS callbacks

### DIFF
--- a/cli/src/__tests__/unit/audit-verify.test.ts
+++ b/cli/src/__tests__/unit/audit-verify.test.ts
@@ -95,14 +95,21 @@ const {
 
 describe("auditVerifyCommand", () => {
   let tmpDir: string;
+  let stderrSilence: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "audit-verify-test-"));
+    // Silence the intentional "--tag-secret on the command line" runtime WARN
+    // by default: several tests exercise the CLI tag-secret path only to reach
+    // downstream validation, and would otherwise leak that warning to the test
+    // console. Tests that assert ON the warning install their own spy, which
+    // shadows this one for their scope.
+    stderrSilence = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     vi.clearAllMocks();
   });
 
   afterEach(() => {
-    // Cleanup temp files created during tests
+    stderrSilence.mockRestore();
   });
 
   describe("tag-secret-file mode 0644 rejected (closes TF4)", () => {

--- a/docs/archive/review/bypass-rls-tx-callback-form-code-review.md
+++ b/docs/archive/review/bypass-rls-tx-callback-form-code-review.md
@@ -1,0 +1,70 @@
+# Code Review: bypass-rls-tx-callback-form
+
+Date: 2026-07-05
+Review rounds: 3 (Round 1 findings → fixed; Round 2 found a 6th TOCTOU site + 4 more →
+fixed; Round 3 found the final 7 → fixed + mechanized with a CI guard → CONVERGED)
+
+## Summary
+
+What began as "fix 2 non-fatal pre-pr WARNs" surfaced (via the user's instinct + adversarial
+review) a **confirmed pre-existing TOCTOU race class of 17 count-then-create cap sites**, plus
+a 41-callback RLS-form hardening. The primary security fix: per-user/tenant/team/entry
+`pg_advisory_xact_lock` serializing every `count/aggregate → check cap → create` sequence.
+
+## The TOCTOU class (17 sites, member-set derived from the primitive)
+
+Root cause: `withRls(prisma, ... count()) ; if (n >= MAX) reject ; withRls(prisma, ... create())`
+in separate txs (or one tx without a lock) → two concurrent requests both read `n < MAX`, both
+create, exceeding the cap. The seed instance (`auth-adapter` session limit) even *tried*
+Serializable but the Prisma-proxy `$transaction` fold silently dropped the isolationLevel
+(proven: ran at read committed).
+
+The member-set expanded across rounds because early enumeration anchored on a *symptom*
+(`isolationLevel` grep) rather than the *primitive* (`count()+create()+cap`). Rounds:
+1→5 (Round-1 S2), →6 (Round-2 api-keys), →10 (Round-2 four per-tenant), →17 (Round-3 exhaustive
+sweep: webhooks ×2, audit-delivery-targets, attachments ×2, reset-vault, mcp-register).
+
+**All 17 now serialize with an advisory lock.** Fix is the codebase's own idiom (7 prior
+precedents like attachments/vault-rotate-key); NOT Serializable (which needs 40001-retry the
+codebase lacks → would turn a silent over-count into a login 500 — Round-1 S1).
+
+## Mechanized completeness (the durable fix)
+
+`scripts/checks/check-count-then-create-lock.mjs` — a static guard flagging any RLS-wrapped
+`count/aggregate → cap-check → create` file lacking `pg_advisory_xact_lock`, with a reviewed
+soft-cap allowlist (resource-quotas.ts) + stale-exemption anti-drift. Mutation-verified +
+self-tested (4 cases). Wired into pre-pr.sh / the static-checks CI job. This prevents the
+member-set from silently regrowing.
+
+## Callback-form hardening (41 sites, behavior-preserving)
+
+`check-bypass-rls.mjs` mandates `(tx) => tx.x` (robust under DI/raw-client); eslint flagged the
+unused `tx`. Buckets: B_RAW_SQL (9, prisma.$→tx.$), C_HELPER_DB (4, db:prisma→db:tx),
+A_NESTED_TX (13, drop redundant inner $transaction), F_DELEGATE (15: F1 drop static SCIM
+wrappers, F2 thread tx through helpers, F3 documented eslint-disable for the unthreadable
+public fn(tenantId) contract). tx-unused: 41 → 0. All whitespace-verified behavior-preserving.
+
+## Verification
+- Full suite: 933 files, 11,988 tests pass.
+- pre-pr.sh: 43/43 (the new guard is +1).
+- Real-DB integration test proves the race is real WITHOUT the lock (count > cap) and closed
+  WITH it (count == cap), for bridge-code + api-keys — mutation-killing, DATABASE_URL-gated.
+- Per-site mutation-kill unit assertions (expectAdvisoryLockAcquired) at every lock site.
+- Empirically confirmed: `pg_advisory_xact_lock` serializes concurrent same-key txns (412ms
+  serialized vs 156ms concurrent); the Prisma proxy drops nested $transaction isolationLevel.
+
+## Recurring Issue Check
+- **R42 (member-set completeness)**: THE central lesson — the class was re-derived from the
+  primitive each round; a CI guard now mechanizes it (per feedback_triangulate_enumerate_completeness).
+- **RS2 (fail-open)**: advisory lock blocks-then-proceeds (no 40001/500), the correct posture
+  vs. Serializable-without-retry.
+- **RS3 (dataflow/TOCTOU)**: all 17 count→create races closed in one locked tx each.
+- **RT (mutation-resistance)**: integration test + per-site unit assertions both mutation-kill;
+  the guard itself is mutation-verified and self-tested.
+- **Process note**: two sub-agent rounds left `/* lock removed */` placeholders (from mutation-
+  testing the T2 assertions) — caught by the orchestrator's post-delegation lock cross-check.
+  Always grep for placeholders + `pg_advisory_xact_lock` count after delegating lock edits.
+
+## Resolution Status
+All Round-1/2/3 findings resolved. Class complete (17/17 locked), mechanized (guard), and
+regression-proofed (integration + unit + guard self-test). CONVERGED.

--- a/docs/archive/review/bypass-rls-tx-callback-form-plan.md
+++ b/docs/archive/review/bypass-rls-tx-callback-form-plan.md
@@ -1,0 +1,294 @@
+# Plan: fix Serializable-isolation drop under RLS bypass (TOCTOU); harden callback form; clear WARNs
+
+> **Primary theme: fix a confirmed pre-existing TOCTOU race in per-user "count-then-create"
+> limit enforcement — across 4 sites (member-set derived from code, R42), not 1.**
+>
+> The seed instance: `auth-adapter.ts:275` wraps `prisma.$transaction(fn, { isolationLevel:
+> "Serializable" })` inside `withBypassRls`. The Proxy folds nested `prisma.$transaction(fn,
+> opts)` → `fn(activeTx)`, **silently dropping `opts`** — the inner tx runs at **read
+> committed** (probe: `nested-under-bypass isolation: read committed`), so the intended
+> Serializable TOCTOU guard on `maxConcurrentSessions` is NOT applied.
+>
+> **R42 member-set (derived from the PRIMITIVE "findMany(active) → evict oldest → create"
+> under RLS, NOT from the `isolationLevel` symptom-grep):** 4 sites share this exact race:
+> 1. `auth-adapter.ts:275` — session limit (`maxConcurrentSessions`) — the seed
+> 2. `extension/bridge-code/route.ts:271` — `BRIDGE_CODE_MAX_ACTIVE`
+> 3. `auth/tokens/extension-token.ts:219` — `EXTENSION_TOKEN_MAX_ACTIVE`
+> 4. `auth/tokens/mobile-token.ts:145` — mobile token cap
+> (`resource-quotas.ts` is a *documented* pre-1.0 soft-cap — explicitly out of scope.)
+>
+> **Fix (matches the codebase's OWN established idiom — 7 existing precedents):** NOT
+> Serializable (which needs 40001-retry the codebase lacks → would turn a silent over-count
+> into a login 500). Instead prepend `SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`
+> as the first statement in each count-then-create transaction — retry-free, blocks-then-
+> proceeds, no 40001. Precedent: `attachments/route.ts:273`, `vault/rotate-key/route.ts:180`,
+> `access-requests/[id]/approve/route.ts:142`, etc. — the exact per-user-serialize pattern.
+>
+> Secondary: harden the 41 `with(Bypass|Tenant)Rls` callbacks to the guard-prescribed
+> `(tx) => tx.x` form (removes the ALS/Proxy fragility). Tertiary (done): 2 non-fatal WARNs.
+
+## Project context
+
+- **Type**: web app (Next.js) + CLI. This change touches **production RLS-adjacent code**
+  (25 files calling `withBypassRls` / `withTenantRls`) plus two non-fatal CI-WARN fixes
+  (already committed on this branch).
+- **Test infrastructure**: unit + integration (real Postgres) + E2E + CI. `check-bypass-rls.mjs`
+  is a CI guard enforcing the callback form; `npx eslint .` flags unused `tx`.
+- **Verification environment constraints**: the real-DB behavior (does `tx.x` == `prisma.x`
+  under bypass?) requires a running Postgres. Available locally (`docker compose`, dev DB).
+  Empirically verified: inside `withBypassRls`, `prisma.x` and `tx.x` return identical
+  cross-tenant results TODAY (the Proxy routes `prisma` to the bypassed tx via ALS). So this
+  is a **robustness/convention fix, not a live bug fix**.
+
+## Objective
+
+Resolve the standing tension between two rules that both operate on
+`with(Bypass|Tenant)Rls(prisma, (tx) => ...)` callbacks:
+
+- **`check-bypass-rls.mjs`** (CI guard, currently PASSES): forbids the tx-less `() =>` form
+  and mandates `(tx) => tx.x.method(...)`. Rationale (verbatim from the guard): *"The
+  bare-prisma form works only via the Prisma proxy's AsyncLocalStorage injection; it
+  brittle-fails in tests that inject a raw PrismaClient or use a DI wrapper."*
+- **`eslint no-unused-vars`** (currently 41 non-fatal WARNs): flags the `(tx)` param as
+  unused when the body uses `prisma` (or the ambient Proxy) instead of `tx`.
+
+Bring the 41 flagged callbacks into the guard's prescribed form (`tx` actually used), which
+satisfies BOTH rules AND removes the Proxy/ALS dependency (the exact fragility the guard
+exists to prevent). Where the tx-form is genuinely not threadable, decide and document the
+correct disposition (not a blanket suppression).
+
+**This was originally mis-scoped as "cosmetic lint cleanup" and once wrongly "fixed" by
+removing `tx` (→ `() =>`), which the guard immediately rejected. That revealed the guard's
+intent: the tx-form is the prescribed robust form. The correct fix is `prisma.x → tx.x` in
+the body, not param removal.**
+
+Secondary (already done, kept on this branch as the "ついで" part): eliminate the two
+non-fatal pre-pr WARNs — `security-doc-exists` (`## Overview` heading added to
+`audit-anchor-verification.md`) and the CLI `--tag-secret` stderr leak (silence stderr by
+default in `audit-verify.test.ts`).
+
+## The 41 sites, classified (member-set derived from `npx eslint . | grep "'tx' is defined but never used"`)
+
+| Bucket | Count | Shape | Disposition |
+|--------|-------|-------|-------------|
+| **B_RAW_SQL** | 9 | `(tx) => prisma.$queryRaw/$executeRaw(...)` | `prisma.$` → `tx.$` (mechanical, safe) |
+| **C_HELPER_DB** | 4 | `(tx) => helper({ db: prisma, ... })` | `db: prisma` → `db: tx` (helper already takes a client param) |
+| **A_NESTED_TX** | 13 | `(tx) => prisma.$transaction(async (tx) => { ...tx.x... })` | outer `tx` unused; inner `tx` used. See design C-A below |
+| **F_DELEGATE** | 15 | `(tx) => helperThatUsesAmbientPrisma(...)` / `(tx) => scimResponse([...])` / `(tx) => fn(tenantId)` | tx not threadable without changing helper signatures. See design C-F below |
+
+Exact site → bucket map is in `docs/archive/review/bypass-rls-tx-callback-form-sites.md`
+(generated; the Implementation Checklist references it).
+
+## Contracts
+
+### C-L1 — fix the count-then-create TOCTOU via advisory lock (PRIMARY, 4 sites)
+
+- **Root cause**: 4 per-user cap enforcers run `findMany(active) → evict oldest → create`
+  inside an RLS transaction at **read committed**. Two concurrent calls both observe
+  `active.length < max`, both evict the same oldest set, both insert → the cap is exceeded.
+  The session site *tried* to prevent this with a nested Serializable `$transaction`, but the
+  Proxy drops the isolationLevel (proven). The other 3 never even tried.
+- **Fix (uniform, per the codebase's own advisory-lock idiom)**: prepend, as the FIRST
+  statement inside each count-then-create transaction:
+  `await tx.$executeRaw\`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))\``.
+  This serializes all concurrent count-then-create ops for the same `userId` — the loser
+  BLOCKS until the winner commits, then sees the updated count (retry-free, no 40001, no
+  login-500). The advisory lock is transaction-scoped (auto-released on commit/rollback).
+  Precedents (verified): `attachments/route.ts:273`, `vault/rotate-key/route.ts:180`,
+  `access-requests/[id]/approve/route.ts:142`, `service-accounts/[id]/tokens/route.ts:141`,
+  `webauthn/credentials/[id]/prf/route.ts:124`.
+- **Sites & keys** (member-set = 5, re-derived from the primitive; R42 round-2 caught the 5th):
+  | Site | key | tx wrapper | note |
+  |------|-----|-----------|------|
+  | `auth-adapter.ts:275` | `session.userId` | `withBypassRls` | remove dead inner Serializable `$transaction`, run on outer `tx` |
+  | `extension/bridge-code/route.ts:271` | `userId` | `withBypassRls` | lock as first stmt |
+  | `auth/tokens/extension-token.ts:219` | `userId` | `withUserTenantRls` → inner `$transaction` | lock as first stmt |
+  | `auth/tokens/mobile-token.ts:145` | `userId` | `withBypassRls` | lock as first stmt |
+  | `sends/file/route.ts:159-217` | `session.user.id` | **currently 3 SEPARATE `withUserTenantRls` calls** | **byte-quota TOCTOU**: `aggregate(_sum sendSizeBytes)` → check `> SEND_MAX_ACTIVE_TOTAL_BYTES` → `create`, split across calls. Fix needs UNIFYING count+create into ONE `withUserTenantRls(userId, async (tx) => { lock; re-aggregate; if over → throw; create })` — keep the expensive encryption OUTSIDE the locked section (encrypt first, then lock+re-check+create) so the advisory lock is held only across the count+insert, not the crypto |
+- **NO Serializable, NO `withBypassRls` signature change.** (S1: Serializable without retry
+  → login 500; the codebase has no 40001-retry infra. Advisory lock is the retry-free idiom.)
+- **Invariant** I-CL1-1 (behavioral, real-DB, mutation-killing): for EACH of the 4 sites, two
+  truly-concurrent issue calls (two distinct pooled clients) at the cap boundary result in the
+  active count **never exceeding max** (the loser blocks, then evicts-and-creates against the
+  post-winner state). Test must be shown to go RED when the advisory lock line is removed.
+- **Invariant** I-CL1-2 (no availability regression): neither concurrent call throws `40001`
+  / `P2034` (advisory lock blocks, does not abort). Distinguishes advisory-lock from a naive
+  Serializable fix.
+- **Testability (T1 fix)**: the session path is bound to the singleton `prisma` inside
+  `createCustomAdapter`, so it cannot be raced with two injected clients directly. Extract the
+  count-then-create body of EACH site into a helper taking an explicit client
+  (e.g. `enforceSessionLimit(client, ...)`), then race via the existing
+  `raceTwoClients(clientA, clientB, ...)` harness (`db-integration/helpers.ts:297`) with two
+  `createPrismaForRole("app")` clients. If extraction is too invasive for a site, test the
+  primitive: two clients each run the site's exact CAS body by hand under the advisory lock.
+- **Test location (T4 fix)**: `src/__tests__/db-integration/count-then-create-toctou.integration.test.ts`,
+  one `describe` per site, `const SKIP = !process.env.DATABASE_URL; it.skipIf(SKIP)(...)`,
+  seed at-cap, race ≥50 iterations (per the T6/statistical-loop precedent).
+- **Forbidden pattern**: `findMany\([\s\S]*?(revokedAt|usedAt|expires)[\s\S]*?\}\)` followed by
+  `.create(` inside a `with(Bypass|Tenant)Rls`/`$transaction` WITHOUT a preceding
+  `pg_advisory_xact_lock` — per-site grep pinned in the checklist.
+- **Acceptance**: all 4 sites carry the advisory lock; I-CL1-1 RED-without-lock verified;
+  I-CL1-2 green (no 40001); `check-bypass-rls: OK`; `resource-quotas.ts` explicitly noted as
+  out-of-scope documented soft-cap (SC2).
+
+### C-B — B_RAW_SQL: `prisma.$queryRaw*` / `prisma.$executeRaw*` → `tx.$…`
+
+- **Signature**: no signature change; per-callsite body edit.
+- **Invariant** I-CB-1 (app-enforced): after edit, each of the 9 callbacks references `tx`
+  (satisfies eslint) and uses no `prisma.` inside the callback body (satisfies check-bypass-rls's
+  intent). `tx.$queryRawUnsafe` / `tx.$executeRaw` are valid on `Prisma.TransactionClient`.
+- **Invariant** I-CB-2 (verified against real DB): `tx.$queryRaw(...)` returns identical rows
+  to the pre-edit `prisma.$queryRaw(...)` under the same bypass — because `tx` IS the bypassed
+  transaction (empirically confirmed).
+- **Forbidden pattern**: `withBypassRls\([\s\S]*?async \(tx\) =>\s*prisma\.\$` in the 9 files — reason: must use `tx.$`.
+- **Acceptance**: `check-bypass-rls: OK`, these 9 no longer in eslint tx-unused set, suite green.
+
+### C-C — C_HELPER_DB: `db: prisma` → `db: tx`
+
+- **Signature**: no change — the helpers (`transition({db})`) already accept a client via `db`.
+- **Invariant** I-CC-1: the helper's `db` param type accepts `Prisma.TransactionClient`
+  (verify: `transition`'s signature). If it only accepts `PrismaClient`, widen to `TxOrPrisma`
+  (the existing union in `prisma.ts`) — do NOT narrow behavior.
+- **Consumer-flow walkthrough**: `transition({ db, where, to, actor })` (emergency-access
+  decline/request/reject, access-requests deny) reads `db` and runs a compare-and-swap update.
+  Passing `tx` makes the CAS run on the bypassed tx (same result today; robust tomorrow).
+- **Acceptance**: same as C-B for the 4 files; plus `transition`/state-helper unit tests green.
+
+### C-A — A_NESTED_TX: outer callback wraps `prisma.$transaction`
+
+- **Problem**: `withBypassRls(prisma, async (tx) => prisma.$transaction(async (tx) => {...}))`.
+  The outer `tx` is unused; the inner `prisma.$transaction` folds into the outer bypassed tx via
+  the Proxy (returns `arg(activeTx)`), so the inner `tx` IS the bypassed tx and is used.
+- **Design decision** (to be finalized in review): the inner `prisma.$transaction` is
+  **redundant** — `withBypassRls` already opened a transaction. Two candidate fixes:
+  - (A1) **Remove the redundant inner `$transaction` wrapper**, use the outer `tx` directly:
+    `withBypassRls(prisma, async (tx) => { ...tx.x... })`. Cleanest; outer tx now used.
+  - (A2) If the inner `$transaction` passes an **isolationLevel** (e.g. `auth-adapter.ts:275/279`
+    "Serializable prevents TOCTOU"), removing it may drop the isolation level. **BUT** — LATENT
+    CONCERN L1: the Proxy's `$transaction` fold (`arg(active)`) **silently ignores
+    isolationLevel** already today, so the Serializable guarantee may not currently hold. This
+    must be investigated per-site; do NOT blindly remove a `$transaction` that carries an
+    isolationLevel without confirming the isolation is (or is not) actually applied.
+- **Invariant** I-CA-1: after the fix, the outer `tx` is used (eslint clean) and the callback
+  contains no `prisma.` reference. Behavior (rows written/read, transaction atomicity)
+  unchanged — verified by the affected route's integration/unit tests.
+- **Forbidden pattern**: none blanket (per-site); the Implementation Checklist pins each.
+- **Acceptance**: per-site integration test green; `check-bypass-rls: OK`; isolationLevel
+  concern (L1) resolved with an explicit note per nested site.
+
+### C-F — F_DELEGATE: callback delegates to a helper using ambient `prisma`
+
+- **Problem**: `(tx) => fetchScimGroup(...)` / `(tx) => autoPromoteIfElapsed({...})` /
+  `(tx) => fn(tenantId)` / `(tx) => scimResponse([...static...])`. The callback never touches a
+  DB client directly; the work happens in a helper that reads the ambient Proxy `prisma`, or
+  there is no DB access at all (static SCIM discovery responses).
+- **This is the design-heavy bucket.** `tx` cannot be threaded without changing every helper's
+  signature to accept a client (`fetchScimGroup(tenantId, id, baseUrl, tx?)` etc.), which
+  cascades. Candidate dispositions (decide per sub-group in review):
+  - (F1) **Static-response SCIM sites** (`ResourceTypes`, `Schemas`, `ServiceProviderConfig`)
+    perform NO DB access inside the callback. The `withTenantRls` wrapper is arguably
+    unnecessary here (nothing tenant-scoped is read). Candidate: verify no DB access, and if so,
+    the correct fix may be to drop the pointless `withTenantRls` wrapper entirely (removing the
+    callback and its `tx`). MUST confirm the helper truly does no DB I/O.
+  - (F2) **Helper-delegating sites** (`fetchScimGroup`, `resolveUserId`, `autoPromoteIfElapsed`,
+    `findOrCreateSsoTenant`, `withUserTenantRls`'s `fn(tenantId)`): thread a client param through
+    the helper so the callback becomes `(tx) => helper(..., tx)`. Scope the cascade — some
+    helpers are called from many places. If the cascade is large, this sub-group is a candidate
+    for a **scope-out (SC1)** to a dedicated follow-up, with the tension documented.
+  - (F3) `withUserTenantRls`/`withTeamTenantRls` (`tenant-context.ts:54,73`): the callback is
+    `(tx) => fn(tenantId)` where `fn` is a caller-supplied `(tenantId) => Promise<T>` that does
+    NOT take a client. `tx` is structurally unthreadable here without changing the public
+    `withUserTenantRls` contract. Candidate: this is the definition-layer; a narrowly-scoped
+    `eslint-disable-next-line` WITH a written justification citing the ALS-Proxy contract may be
+    the honest disposition IF F2 threading is out of scope — but per `feedback_no_suppress_warnings`,
+    prefer a real fix; decide in review.
+- **Acceptance**: every F-site either (a) uses `tx`, (b) drops an unnecessary wrapper, or
+  (c) is explicitly scope-outed (SC1) with a TODO + rationale. NO silent `_tx` rename.
+
+### C-WARN — the two non-fatal WARN fixes (already committed: 77051e6f)
+
+- **Invariant**: `security-doc-exists` and CLI `--tag-secret` WARNs = 0 in pre-pr output.
+  Already verified. Kept on this branch as secondary scope.
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C-L1 | **PRIMARY**: advisory-lock TOCTOU fix across 4 count-then-create sites | pending |
+| C-B | B_RAW_SQL: 9 × `prisma.$` → `tx.$` | pending |
+| C-C | C_HELPER_DB: 4 × `db: prisma` → `db: tx` (`db` already `TxOrPrisma`) | pending |
+| C-A | A_NESTED_TX: 13 × use outer tx / drop redundant nested-$transaction | pending |
+| C-F | F_DELEGATE: 15 × thread-tx (F2, cascade ≤2 callers) / drop static wrapper (F1) / SC1 (F3 only) | pending |
+| C-WARN | 2 non-fatal WARN fixes | locked (committed) |
+
+**Contracts are `pending` — Round-1 review reshaped C-L1 (Serializable → advisory lock, 1→4
+sites). A Round-2 plan review must confirm the advisory-lock design and the per-site coverage
+matrix (T5) before implementation.**
+
+## Site → bucket map (inlines the referenced sites.md; F1 fix)
+
+- **B_RAW_SQL (9)**: audit-chain-verify:143,162,185,208,236; audit-outbox-metrics:66;
+  audit-outbox-purge-failed:82; webauthn-authorize:175; directory-sync/engine:183
+- **C_HELPER_DB (4)**: emergency-access decline:43, request:52, reject:45; access-requests/deny:73
+- **A_NESTED_TX (13)**: passkey reauth/verify:72; passkey/verify:120; emergency-access/[id]/accept:70;
+  emergency-access/accept:73; mcp/register:140; scim/Users:133; user/mcp-tokens:88;
+  account-lockout:190 (**keep `SET LOCAL lock_timeout` + `FOR UPDATE`** — F7); auth-adapter:275
+  (**C-L1 site**); directory-sync/engine:412; oauth-server:168,780; vault-reset:53
+- **F_DELEGATE (15)**: emergency-access/[id]/vault:54; Groups/[id]:33,55,117; ResourceTypes:14;
+  Schemas:14; ServiceProviderConfig:14 (**F1: static — drop wrapper**); Users/[id]:38,68,138,191;
+  auth-adapter:158 (**hybrid A_NESTED+F2**: drop inner $transaction AND thread tx into
+  `findOrCreateSsoTenant(pendingClaim, tx)` — 2 callers); tenant-context:23 (F2), 54, 73
+  (**F3: `fn(tenantId)` public contract — genuinely unthreadable; honest disposition TBD**)
+
+## Per-site test coverage matrix (T5 fix — honest verification status)
+
+| Cluster | Has test exercising the callback? | Disposition |
+|---------|-----------------------------------|-------------|
+| tenant-context, oauth-server, vault-reset (via centralize), account-lockout (via tenant-policy) | YES (~4 files) | suite green IS meaningful |
+| audit-chain-verify (5 sites), SCIM (11 sites), emergency-access routes, webauthn-authorize, passkey verify, directory-sync engine, mcp/register, user/mcp-tokens | **NO route test drives the callback** | protection is compile-time + `check-bypass-rls` guard ONLY. Add a smoke test for the two largest clusters (audit-chain-verify ×5, SCIM ×11); state the rest as guard-verified-only, not test-verified |
+| The 4 C-L1 sites | new I-CL1 integration test (this PR) | behaviorally verified |
+
+## Testing strategy
+
+- **Real-DB parity** (already run once, re-run after edits): the probe seeding 2 tenants and
+  comparing `prisma.x` vs `tx.x` count under bypass. Extend to cover a representative site from
+  each bucket.
+- **Per-site regression**: run the integration/unit tests for each touched route/module.
+- **Guard + lint**: `node scripts/checks/check-bypass-rls.mjs` (OK) AND
+  `npx eslint . | grep -c "'tx' is defined but never used"` (target: 0, minus any explicitly
+  scope-outed F3 sites which must then carry a justified disable + TODO).
+- **Full gates**: `npx vitest run` (11,984 tests baseline), `npx next build`, `scripts/pre-pr.sh`.
+
+## Considerations & constraints
+
+### Scope contract
+- **SC1** — F3 sites `tenant-context.ts:54,73` (`withTenantRls(prisma, tenantId, (tx) => fn(tenantId))`,
+  where `fn` is a caller-supplied `(tenantId) => Promise<T>` taking no client) are **genuinely
+  unthreadable** without changing the public `withUserTenantRls`/`withTeamTenantRls` contract.
+  Disposition (decide in Round 2): either (a) change the internal callback so `fn` still runs
+  inside the tenant tx via ambient Proxy but the wrapper doesn't declare an unused `tx` param
+  (the guard requires `(tx)`, so this needs care), or (b) a single narrowly-scoped
+  `eslint-disable-next-line` WITH written justification citing the ALS/Proxy contract + a
+  `TODO(bypass-rls-tx)`. Prefer (a). NOTE: F2 cascade is NOT large — measured ≤2 callers per
+  helper (`fetchScimGroup` 1, `resolveUserId` 4-all-in-one-file, `autoPromoteIfElapsed` 1,
+  `findOrCreateSsoTenant` 2), so F2 threading is IN scope; only F3 is deferred here.
+- **SC2** — `resource-quotas.ts` count-then-check-then-insert is a **documented pre-1.0
+  soft-cap** (its header explicitly accepts overshoot; hard-cap deferred). It is NOT one of the
+  4 C-L1 sites and is explicitly out of scope — not a silent exclusion.
+
+### Known risks / latent concerns
+- **Advisory-lock ordering / deadlock**: the lock key is `hashtext(userId)` — same key space as
+  the 7 existing precedents. Verify no code path takes the lock in a different order or holds
+  another advisory lock on the same key within an outer tx (would deadlock). `vault/rotate-key`
+  already documents this coordination — confirm the 4 new sites don't nest under it.
+- **Behavior-preservation is the bar** for the callback-form buckets (B/C/A/F): every edit must
+  be a no-op on observable behavior. C-L1 is the ONE intentional behavior change (closes the
+  race) — its tests prove the new behavior.
+- **No `_tx` suppression** anywhere (`feedback_no_suppress_warnings`); F3's disable (if chosen)
+  is the single documented exception, not a rename.
+
+### Out of scope
+- Changing the `check-bypass-rls.mjs` guard, the Proxy, or `withBypassRls`/`withTenantRls`
+  signatures. (C-C needs NO signature change — `transition`/`bulkTransition` `db` params are
+  already typed `TxOrPrisma`; F4 confirmed.)
+- `resource-quotas.ts` soft-cap (SC2). The 2 WARN fixes are done; not re-litigated.

--- a/docs/archive/review/bypass-rls-tx-callback-form-review.md
+++ b/docs/archive/review/bypass-rls-tx-callback-form-review.md
@@ -1,0 +1,90 @@
+# Plan Review: bypass-rls-tx-callback-form
+
+Date: 2026-07-05
+Review round: 1
+
+## Changes from Previous Round
+Initial review. Round 1 materially reshaped the primary contract (C-L1).
+
+## Security Findings
+
+- **S1 [High, escalate → adopted]** C-L1's original fix (make the tx Serializable) needs
+  40001/P2034 retry, which the codebase LACKS (zero retry infra in auth-adapter/auth.ts). It
+  would convert a silent over-count into a **user-facing login 500** under concurrent sign-in.
+  → **Adopted**: replaced Serializable with `pg_advisory_xact_lock(hashtext(userId))` — the
+  codebase's own retry-free idiom (7 precedents). No 40001, blocks-then-proceeds.
+- **S2 [High as a class, R42 → adopted]** L1 is NOT 1 site. The `isolationLevel`-grep was a
+  *symptom* grep; the *primitive* ("findMany(active)→evict→create under RLS") yields **4
+  sites**: session (seed), bridge-code, extension-token, mobile-token — the 3 siblings have the
+  identical TOCTOU but never asked for Serializable, so are silently unprotected.
+  → **Adopted**: C-L1 now covers all 4; `resource-quotas.ts` documented soft-cap → SC2.
+- **S3 [Informational]** `resource-quotas.ts` is an intentional documented soft-cap (not a bug)
+  → recorded as SC2, out of scope.
+
+## Functionality Findings
+
+- **F1 [Medium → adopted]** referenced `sites.md` didn't exist → **inlined** the full 41-site
+  → bucket map into the plan.
+- **F2 [Medium → adopted]** `auth-adapter.ts:158` is a HYBRID (A_NESTED + F2 `findOrCreateSsoTenant`)
+  → mapped explicitly; thread tx into `findOrCreateSsoTenant(pendingClaim, tx)` (2 callers).
+- **F3 [Low → adopted]** C-L1's tenant read folds into the serialized snapshot → moot now
+  (advisory-lock design; recorded in consumer-flow reasoning).
+- **F4 [Low → adopted]** C-C's "widen db to TxOrPrisma" contingency is dead — `transition`/
+  `bulkTransition` `db` is ALREADY `TxOrPrisma` → simplified C-C, removed the contingency from
+  Out-of-scope.
+- **F5 [Low → adopted]** F1 static-SCIM wrapper drop is safe (auth is upstream in `authorizeScim`)
+  → noted in the map.
+- **F6 [Low → adopted]** F2 cascade measured ≤2 callers per helper → SC1 narrowed to F3 only
+  (F2 is in-scope, not deferred).
+- **F7 [Low → adopted]** `account-lockout.ts:190` inner `$transaction` carries `SET LOCAL
+  lock_timeout` + `FOR UPDATE` → per-site note: preserve these on the outer tx when dropping
+  the wrapper.
+
+## Testing Findings
+
+- **T1 [High → adopted]** the TOCTOU test is unwritable against the singleton-bound
+  `createSession` (needs 2 injected clients; `raceTwoClients` needs 2 distinct clients).
+  → **Adopted**: extract each count-then-create body into a client-taking helper; race via
+  `raceTwoClients`. Pinned in C-L1 Testability.
+- **T2 [High → adopted]** the 40001/bounded assertion was unpinned. → advisory-lock design
+  makes it cleaner: assert count ≤ max AND no 40001 thrown (I-CL1-1 + I-CL1-2). Must go RED
+  without the lock.
+- **T3 [Medium → adopted]** I-CL1-1 (mechanism) vs I-CL1-2 (behavior) kept distinct and both
+  non-negotiable.
+- **T4 [Medium → adopted]** pinned the test file: `db-integration/count-then-create-toctou.integration.test.ts`,
+  `SKIP=!DATABASE_URL` + `it.skipIf(SKIP)`, ≥50 iterations.
+- **T5 [High → adopted]** "per-site test green" was false for ~20/27 files → added an honest
+  per-site coverage matrix: only ~4 files have callback coverage; SCIM (11) + audit-chain-verify
+  (5) get smoke tests; the rest are stated as guard-verified-only, not test-verified.
+- **T6 [Medium → adopted]** no atomicity test for the collapsed session tx → add a rollback
+  test (inject failure after evict, assert sessions still present).
+
+## Adjacent Findings
+- S2's sibling sites were flagged by Security; Functionality independently confirmed the bucket
+  map; Testing confirmed the coverage gap. Strong triangulation on the R42 member-set point.
+
+## Quality Warnings
+None — all findings carried empirical evidence (real-DB isolation probe, grep of precedents,
+caller counts, coverage greps).
+
+## Recurring Issue Check
+
+### Security expert
+- RS2 (fail-open/closed): S1 — Serializable-without-retry fails *closed too hard* (500); advisory
+  lock is the correct block-and-proceed posture.
+- RS3 (dataflow/TOCTOU): S2 — count→evict→create race across 4 sites, derived from the primitive.
+- R42: **the key finding** — L1 member-set is 4 (from the primitive), not 1 (from the symptom-grep).
+
+### Functionality expert
+- R1 (reuse): reuses `TxOrPrisma` + the advisory-lock idiom + the probe. No new primitives.
+- R42: 41-site member-set independently re-derived from `eslint` (matches, correct exclusions);
+  bucket counts sum to 41; hybrid site (:158) surfaced.
+
+### Testing expert
+- RT1 (mutation-killing): I-CL1-1 must go RED without the advisory lock — pinned.
+- RT2 (verified vs assumed-green): T5 — honest coverage matrix replaces the false blanket claim.
+- RT3 (real-DB): T4 — pinned file + DATABASE_URL gate matching the sibling integration tests.
+
+## Round 2 target
+Confirm: advisory-lock design correctness (deadlock/ordering), the 4-site member-set is complete
+(no 5th count-then-create site), the coverage-matrix dispositions, and F3's honest disposition.

--- a/docs/security/audit-anchor-verification.md
+++ b/docs/security/audit-anchor-verification.md
@@ -1,5 +1,7 @@
 # Audit Anchor Verification
 
+## Overview
+
 This document explains how customers and external auditors can independently verify the integrity
 of their audit log chain using the externally-committed anchor manifests. The design is specified
 in `docs/archive/review/audit-anchor-external-commitment-plan.md` (ADR). The manifest mechanism

--- a/scripts/__tests__/check-count-then-create-lock.test.mjs
+++ b/scripts/__tests__/check-count-then-create-lock.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * Regression tests for check-count-then-create-lock.mjs.
+ *
+ * The guard flags any RLS-wrapped file that does count/aggregate → cap-check →
+ * create WITHOUT a pg_advisory_xact_lock. These tests pin its detection so a
+ * future edit can't silently disable it (the class it protects expanded from 1
+ * to 17 sites during review precisely because completeness wasn't mechanized).
+ * Each case runs the real CLI against an isolated fixture tree via CTC_CHECK_ROOT.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CHECKER = fileURLToPath(new URL("../checks/check-count-then-create-lock.mjs", import.meta.url));
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ctc-check-"));
+  mkdirSync(join(dir, "src/app/api/x"), { recursive: true });
+  mkdirSync(join(dir, "src/lib/quota"), { recursive: true });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function run(relPath, source) {
+  mkdirSync(join(dir, relPath.split("/").slice(0, -1).join("/")), { recursive: true });
+  writeFileSync(join(dir, relPath), source, "utf8");
+  try {
+    const stdout = execFileSync("node", [CHECKER], {
+      env: { ...process.env, CTC_CHECK_ROOT: dir },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, stderr: "", stdout };
+  } catch (e) {
+    return { code: e.status, stderr: e.stderr?.toString() ?? "", stdout: e.stdout?.toString() ?? "" };
+  }
+}
+
+const CAP_THEN_CREATE_NO_LOCK = `
+import { withTenantRls } from "@/lib/tenant-rls";
+import { MAX_WIDGETS_PER_TENANT } from "@/lib/constants";
+async function handlePOST() {
+  const n = await withTenantRls(prisma, t, async (tx) => tx.widget.count({ where: { t } }));
+  if (n >= MAX_WIDGETS_PER_TENANT) return err();
+  return withTenantRls(prisma, t, async (tx) => tx.widget.create({ data: {} }));
+}`;
+
+const CAP_THEN_CREATE_WITH_LOCK = `
+import { withTenantRls } from "@/lib/tenant-rls";
+import { MAX_WIDGETS_PER_TENANT } from "@/lib/constants";
+async function handlePOST() {
+  return withTenantRls(prisma, t, async (tx) => {
+    await tx.$executeRaw\`SELECT pg_advisory_xact_lock(hashtext(\${t}::text))\`;
+    const n = await tx.widget.count({ where: { t } });
+    if (n >= MAX_WIDGETS_PER_TENANT) throw new Err();
+    return tx.widget.create({ data: {} });
+  });
+}`;
+
+// Length/size validation bounds paired with a create — NOT a count cap.
+const LENGTH_GUARD_ONLY = `
+import { withTenantRls } from "@/lib/tenant-rls";
+import { MAX_LENGTH, MAX_FILE_SIZE } from "@/lib/constants";
+async function handlePOST(name, size) {
+  if (name.length > MAX_LENGTH || size > MAX_FILE_SIZE) return err();
+  const n = await withTenantRls(prisma, t, async (tx) => tx.widget.count());
+  return withTenantRls(prisma, t, async (tx) => tx.widget.create({ data: {} }));
+}`;
+
+describe("check-count-then-create-lock", () => {
+  it("fails a cap-then-create site with no advisory lock", () => {
+    const r = run("src/app/api/x/route.ts", CAP_THEN_CREATE_NO_LOCK);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("missing a pg_advisory_xact_lock");
+    expect(r.stderr).toContain("src/app/api/x/route.ts");
+  });
+
+  it("passes a cap-then-create site that has the advisory lock", () => {
+    const r = run("src/app/api/x/route.ts", CAP_THEN_CREATE_WITH_LOCK);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("check-count-then-create-lock: OK");
+  });
+
+  it("does not flag a length/size guard paired with count+create (no count cap)", () => {
+    const r = run("src/app/api/x/route.ts", LENGTH_GUARD_ONLY);
+    expect(r.code).toBe(0);
+  });
+
+  it("does not flag a file that only creates (no count cap at all)", () => {
+    const r = run(
+      "src/app/api/x/route.ts",
+      `import { withTenantRls } from "@/lib/tenant-rls";
+       async function h() { return withTenantRls(prisma, t, async (tx) => tx.widget.create({})); }`,
+    );
+    expect(r.code).toBe(0);
+  });
+});

--- a/scripts/checks/check-bypass-rls.mjs
+++ b/scripts/checks/check-bypass-rls.mjs
@@ -194,6 +194,22 @@ const BYPASS_PURPOSE_RE = /BYPASS_PURPOSE\.\w+/;
 const TX_LESS_CALLBACK_RE =
   /with(?:Bypass|Tenant)Rls\([\s\S]*?,\s*(?:async\s+)?\(\)\s*=>/m;
 
+// F3 anti-drift: the ONLY sanctioned `(tx) => ...` callbacks that leave `tx`
+// unused (suppressed with `eslint-disable-next-line ...no-unused-vars`) are the
+// two thin wrappers in tenant-context.ts that delegate to a caller-supplied
+// `fn(tenantId)` public contract (SC1 deferral — threading tx would change that
+// contract). Any NEW such disable elsewhere is a silent reintroduction of the
+// Proxy/ALS-dependent form the guard exists to prevent — it must instead use the
+// real (tx) => tx.x form, or be added here after review. Keyed by file only
+// (the two lines within tenant-context.ts are the accepted pair).
+const F3_UNUSED_TX_DISABLE_ALLOWLIST = new Set([
+  "src/lib/tenant-context.ts",
+]);
+// An eslint-disable-next-line for no-unused-vars that guards a with*Rls (tx) =>
+// callback (i.e. suppresses an unused `tx` param on an RLS callback).
+const RLS_UNUSED_TX_DISABLE_RE =
+  /eslint-disable-next-line[^\n]*no-unused-vars[\s\S]{0,120}?with(?:Bypass|Tenant|UserTenant|TeamTenant)Rls\([\s\S]*?,\s*(?:async\s+)?\(\s*tx\s*\)\s*=>/m;
+
 function getSourceFiles() {
   const files = [];
   for (const entry of readdirSync("src", { recursive: true, withFileTypes: true })) {
@@ -281,7 +297,39 @@ for (const file of getSourceFiles()) {
   }
 }
 
+// F3 anti-drift scan: flag any file (outside the allowlist) that suppresses an
+// unused `tx` on a with*Rls callback with eslint-disable-next-line no-unused-vars.
+const f3DisableViolations = [];
+for (const file of getSourceFiles()) {
+  if (file.includes(".test.") || file.includes("__tests__")) continue;
+  const relFromRepo = file.replace(/\\/g, "/");
+  if ([...F3_UNUSED_TX_DISABLE_ALLOWLIST].some((a) => relFromRepo.endsWith(a))) continue;
+  const content = readFileSync(file, "utf8");
+  if (RLS_UNUSED_TX_DISABLE_RE.test(content)) {
+    f3DisableViolations.push(relFromRepo);
+  }
+}
+
 let failed = false;
+
+if (f3DisableViolations.length > 0) {
+  failed = true;
+  console.error(
+    "eslint-disable(no-unused-vars) on an unused `tx` in a with*Rls callback,",
+  );
+  console.error(
+    "outside the F3 allowlist. Use the (tx) => tx.x form (the guard's prescribed",
+  );
+  console.error(
+    "shape), or — only if the callback delegates to a client-less fn(tenantId)",
+  );
+  console.error(
+    "public contract — add the file to F3_UNUSED_TX_DISABLE_ALLOWLIST after review.",
+  );
+  console.error("");
+  for (const v of f3DisableViolations) console.error(`  ${v}`);
+  console.error("");
+}
 
 if (fileViolations.length > 0) {
   failed = true;

--- a/scripts/checks/check-count-then-create-lock.mjs
+++ b/scripts/checks/check-count-then-create-lock.mjs
@@ -47,7 +47,7 @@ const CAP_COMPARISON_RE =
   />=?\s*(MAX_(?!LENGTH|FILE_SIZE|BYTES|JSON|DAYS|AGE|DEPTH|EXPIRY|EXPIRES|DIMENSION|IMPORT_FOLDERS|CIDRS|BULK|ATTEMPTS|CONCURRENT_SESSIONS_(?:MIN|MAX))[A-Z_]*|[A-Z_]+_LIMIT(?:_PER_[A-Z]+)?|TOKEN_LIMIT[A-Z_]*)\b/;
 const COUNT_RE = /\.(count|aggregate)\s*\(/;
 const CREATE_RE = /\.create\s*\(/;
-const LOCK_RE = /pg_advisory_xact_lock/;
+const LOCK_RE = /pg_advisory_xact_lock|advisoryXactLock\s*\(/;
 const RLS_WRAPPER_RE = /with(?:Bypass|Tenant|UserTenant|TeamTenant)Rls\s*\(/;
 
 function walk(dir) {

--- a/scripts/checks/check-count-then-create-lock.mjs
+++ b/scripts/checks/check-count-then-create-lock.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * CI guard: every per-scope "count/aggregate → check cap → create" site under an
+ * RLS wrapper MUST serialize with a `pg_advisory_xact_lock` (else two concurrent
+ * requests both read count < cap and both create, exceeding the cap — a TOCTOU
+ * race). See the bypass-rls-tx-callback-form plan: this class expanded from 1 to
+ * 17 sites during review because it was enumerated by hand; this guard mechanizes
+ * completeness so a NEW cap-then-create site can't ship without a lock (or an
+ * explicit, reviewed soft-cap exemption).
+ *
+ * Detection is lexical-with-context (no AST dependency needed — cheap, runs in
+ * the static-checks job): a file is a "cap-then-create site" when it contains ALL
+ * of: (a) a `.count(` or `.aggregate(` call, (b) a cap comparison against a MAX_*
+ * / *_LIMIT* constant (`>= MAX_…`, `> …_LIMIT`, etc.), and (c) a `.create(` call.
+ * Every such file MUST also contain `pg_advisory_xact_lock`, OR appear in
+ * SOFT_CAP_EXEMPTIONS with a reviewed reason.
+ *
+ * This is a floor, not a proof of correctness — it cannot verify the lock is in
+ * the SAME tx as the count+create (that's review-enforced, and pinned by the
+ * per-site mutation-kill unit assertions). It DOES catch the common regression:
+ * a new cap enforcer added with no lock at all.
+ *
+ * Exit 0 = OK. Exit 1 = a cap-then-create site lacks a lock and isn't exempt.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join, extname } from "node:path";
+
+const REPO_ROOT = new URL("../..", import.meta.url).pathname;
+const ROOT = process.env.CTC_CHECK_ROOT ?? REPO_ROOT;
+const SCAN_DIRS = ["src/app/api", "src/lib"];
+
+// Files that legitimately count-then-create WITHOUT an advisory lock, with the
+// reviewed reason. Keep this list tight — every entry is a conscious decision
+// that the cap may overshoot (soft cap) or the race is otherwise impossible.
+const SOFT_CAP_EXEMPTIONS = new Map([
+  [
+    "src/lib/quota/resource-quotas.ts",
+    "documented pre-1.0 soft-cap: COUNT→check→INSERT is not atomic and may overshoot by N; hard-cap deferred (see file header)",
+  ],
+]);
+
+// A cap comparison: a >= or > against a MAX_* / *_LIMIT* / LIMIT_PER_* constant,
+// or a bare numeric cap next to such a name. Deliberately excludes length/size
+// guards (MAX_LENGTH, MAX_FILE_SIZE, MAX_BYTES, MAX_DAYS, …) which are validation
+// bounds, not count caps — those never pair a count() with a create() on a cap.
+const CAP_COMPARISON_RE =
+  />=?\s*(MAX_(?!LENGTH|FILE_SIZE|BYTES|JSON|DAYS|AGE|DEPTH|EXPIRY|EXPIRES|DIMENSION|IMPORT_FOLDERS|CIDRS|BULK|ATTEMPTS|CONCURRENT_SESSIONS_(?:MIN|MAX))[A-Z_]*|[A-Z_]+_LIMIT(?:_PER_[A-Z]+)?|TOKEN_LIMIT[A-Z_]*)\b/;
+const COUNT_RE = /\.(count|aggregate)\s*\(/;
+const CREATE_RE = /\.create\s*\(/;
+const LOCK_RE = /pg_advisory_xact_lock/;
+const RLS_WRAPPER_RE = /with(?:Bypass|Tenant|UserTenant|TeamTenant)Rls\s*\(/;
+
+function walk(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(full));
+    else if (e.isFile() && (extname(e.name) === ".ts" || extname(e.name) === ".tsx")) out.push(full);
+  }
+  return out;
+}
+
+const files = SCAN_DIRS.flatMap((d) => walk(join(ROOT, d)));
+const violations = [];
+const staleExemptions = [];
+
+for (const file of files) {
+  if (file.includes(".test.") || file.includes("__tests__")) continue;
+  const rel = file.slice(ROOT.length + 1);
+  const src = readFileSync(file, "utf8");
+
+  const isCapThenCreate =
+    RLS_WRAPPER_RE.test(src) &&
+    COUNT_RE.test(src) &&
+    CREATE_RE.test(src) &&
+    CAP_COMPARISON_RE.test(src);
+
+  const exemptReason = SOFT_CAP_EXEMPTIONS.get(rel);
+  if (exemptReason) {
+    if (!isCapThenCreate) staleExemptions.push(rel);
+    continue; // exempt sites are allowed to lack the lock
+  }
+
+  if (isCapThenCreate && !LOCK_RE.test(src)) {
+    violations.push(rel);
+  }
+}
+
+let failed = false;
+
+if (violations.length > 0) {
+  failed = true;
+  console.error(
+    "count-then-create cap site(s) missing a pg_advisory_xact_lock (TOCTOU risk):",
+  );
+  console.error(
+    "Wrap count + cap-check + create in ONE RLS tx with a per-scope advisory lock,",
+  );
+  console.error(
+    "or add the file to SOFT_CAP_EXEMPTIONS in this script with a reviewed reason.",
+  );
+  console.error("");
+  for (const v of violations) console.error(`  ${v}`);
+}
+
+if (staleExemptions.length > 0) {
+  failed = true;
+  if (violations.length > 0) console.error("");
+  console.error(
+    "SOFT_CAP_EXEMPTIONS entries that no longer match the cap-then-create pattern (stale — remove them):",
+  );
+  console.error("");
+  for (const s of staleExemptions) console.error(`  ${s}`);
+}
+
+if (failed) process.exit(1);
+console.log("check-count-then-create-lock: OK");

--- a/scripts/checks/raw-sql-usage.txt
+++ b/scripts/checks/raw-sql-usage.txt
@@ -54,11 +54,13 @@
 # Seeded via (R42 refresh, re-run at implementation start, 2026-07-04):
 #   grep -rlE '\$(queryRaw|executeRaw)(Unsafe)?\b' src scripts --include='*.ts' --include='*.tsx' \
 #     | grep -vE '\.test\.|__tests__|manual-tests|/e2e/' | sort
-# → 34 files (29 original + 5 advisory-lock TOCTOU fixes: bridge-code, sends/file,
-#   auth-adapter, extension-token, mobile-token — see bypass-rls-tx-callback-form plan).
+# → 35 files (29 original + 6 advisory-lock TOCTOU fixes: api-keys, bridge-code,
+#   sends/file, auth-adapter, extension-token, mobile-token — see
+#   bypass-rls-tx-callback-form plan).
 
 scripts/audit-chain-verify-worker.ts # standalone CLI: walks audit_logs chain per tenant via static SQL + $N params, no interpolation
 scripts/migrate-account-tokens-to-encrypted.ts # one-shot OAuth token re-encryption migration; batched SELECT/UPDATE against accounts table # ident-markers=2
+src/app/api/api-keys/route.ts # advisory lock serializing API-key creation against the per-user key cap (TOCTOU close)
 src/app/api/extension/bridge-code/route.ts # advisory lock serializing bridge-code issuance against the per-user active cap (TOCTOU close)
 src/app/api/maintenance/audit-chain-verify/route.ts # operator-gated chain-verify endpoint; static SQL + $N params reading audit_logs/audit_chain_anchors
 src/app/api/maintenance/audit-outbox-metrics/route.ts # operator-gated outbox depth/age metrics query, tagged-template $queryRaw

--- a/scripts/checks/raw-sql-usage.txt
+++ b/scripts/checks/raw-sql-usage.txt
@@ -54,49 +54,26 @@
 # Seeded via (R42 refresh, re-run at implementation start, 2026-07-04):
 #   grep -rlE '\$(queryRaw|executeRaw)(Unsafe)?\b' src scripts --include='*.ts' --include='*.tsx' \
 #     | grep -vE '\.test\.|__tests__|manual-tests|/e2e/' | sort
-# → 45 files (29 original + 6 advisory-lock TOCTOU fixes: api-keys, bridge-code,
-#   sends/file, auth-adapter, extension-token, mobile-token + 4 per-tenant
-#   advisory-lock TOCTOU fixes: operator-tokens, service-accounts, scim-tokens,
-#   mcp-clients + 6 per-scope cap advisory-lock TOCTOU fixes: tenant/webhooks,
-#   team/webhooks, audit-delivery-targets, team-attachments, reset-vault,
-#   mcp/register — see bypass-rls-tx-callback-form plan).
+# → 23 files. The 22 advisory-lock call sites that formerly inlined
+#   `pg_advisory_xact_lock` now call the shared `advisoryXactLock()` helper in
+#   src/lib/tenant-rls.ts, so those files no longer emit raw SQL and were dropped
+#   from this allowlist (the helper's raw SQL is covered by the tenant-rls.ts
+#   entry below). See bypass-rls-tx-callback-form plan.
 
 scripts/audit-chain-verify-worker.ts # standalone CLI: walks audit_logs chain per tenant via static SQL + $N params, no interpolation
 scripts/migrate-account-tokens-to-encrypted.ts # one-shot OAuth token re-encryption migration; batched SELECT/UPDATE against accounts table # ident-markers=2
-src/app/api/api-keys/route.ts # advisory lock serializing API-key creation against the per-user key cap (TOCTOU close)
-src/app/api/extension/bridge-code/route.ts # advisory lock serializing bridge-code issuance against the per-user active cap (TOCTOU close)
 src/app/api/maintenance/audit-chain-verify/route.ts # operator-gated chain-verify endpoint; static SQL + $N params reading audit_logs/audit_chain_anchors
 src/app/api/maintenance/audit-outbox-metrics/route.ts # operator-gated outbox depth/age metrics query, tagged-template $queryRaw
 src/app/api/maintenance/audit-outbox-purge-failed/route.ts # operator-gated purge of FAILED outbox rows, tagged-template $queryRaw
 src/app/api/maintenance/purge-audit-logs/route.ts # operator-gated system-wide audit log purge via audit_log_purge() definer fn
-src/app/api/mcp/register/route.ts # advisory lock serializing DCR registration against the global unclaimed-client cap (TOCTOU close)
-src/app/api/passwords/[id]/attachments/[attachmentId]/migrate/route.ts # advisory lock serializing attachment CEK rewrap against key rotation
-src/app/api/passwords/[id]/attachments/route.ts # advisory lock serializing attachment upload against key rotation
 src/app/api/passwords/[id]/route.ts # row lock (FOR UPDATE) for atomic blob snapshot+update on concurrent PUT
 src/app/api/share-links/[id]/content/route.ts # atomic view_count increment + revocation/expiry recheck (TOCTOU close)
-src/app/api/sends/file/route.ts # advisory lock serializing file-send creation against the per-user active byte-quota (TOCTOU close)
-src/app/api/teams/[teamId]/passwords/[id]/attachments/route.ts # advisory lock serializing team attachment upload against the per-entry cap (TOCTOU close)
-src/app/api/teams/[teamId]/webhooks/route.ts # advisory lock serializing team webhook creation against the per-team cap (TOCTOU close)
-src/app/api/tenant/access-requests/[id]/approve/route.ts # advisory lock serializing SA token issuance against per-account token cap
-src/app/api/tenant/audit-delivery-targets/route.ts # advisory lock serializing audit-delivery-target creation against the per-tenant cap (TOCTOU close)
-src/app/api/tenant/mcp-clients/route.ts # advisory lock serializing MCP-client creation against the per-tenant cap (TOCTOU close)
-src/app/api/tenant/members/[userId]/reset-vault/route.ts # advisory lock serializing admin vault-reset creation against the per-target pending-reset cap (TOCTOU close)
-src/app/api/tenant/operator-tokens/route.ts # advisory lock serializing operator-token creation against the per-tenant cap (TOCTOU close)
-src/app/api/tenant/scim-tokens/route.ts # advisory lock serializing SCIM-token creation against the per-tenant cap (TOCTOU close)
-src/app/api/tenant/service-accounts/[id]/tokens/route.ts # advisory lock serializing SA token issuance against per-account token cap
-src/app/api/tenant/service-accounts/route.ts # advisory lock serializing service-account creation against the per-tenant cap (TOCTOU close)
-src/app/api/tenant/webhooks/route.ts # advisory lock serializing tenant webhook creation against the per-tenant cap (TOCTOU close)
 src/app/api/v1/passwords/[id]/route.ts # row lock (FOR UPDATE) for atomic blob snapshot+update on concurrent PUT
-src/app/api/vault/rotate-key/route.ts # advisory lock preventing concurrent vault key rotations for the same user
-src/app/api/webauthn/credentials/[id]/prf/route.ts # advisory lock serializing PRF rebootstrap against key rotation
 src/app/s/[token]/download/route.ts # atomic view_count increment + revocation/expiry recheck on file download (TOCTOU close)
 src/app/s/[token]/page.tsx # atomic view_count increment + revocation/expiry recheck on share view (TOCTOU close)
 src/auth.ts # SECURITY DEFINER call to migrate audit_logs rows during tenant merge
 src/lib/audit/audit-outbox.ts # bypass_rls GUC set/verify + tenant-existence check before enqueueing audit outbox rows
 src/lib/auth/policy/account-lockout.ts # row lock (FOR UPDATE) + lock_timeout for atomic failed-login counter update
-src/lib/auth/session/auth-adapter.ts # advisory lock serializing session creation against the per-user concurrent-session cap (TOCTOU close)
-src/lib/auth/tokens/extension-token.ts # advisory lock serializing extension-token issuance against the per-user active cap (TOCTOU close)
-src/lib/auth/tokens/mobile-token.ts # advisory lock serializing mobile-token issuance against the per-user active cap (TOCTOU close)
 src/lib/auth/webauthn/webauthn-authorize.ts # CAS counter update on WebAuthn credential to prevent replay/clone
 src/lib/auth/webauthn/webauthn-server.ts # CAS counter update on WebAuthn credential within caller's tx
 src/lib/directory-sync/engine.ts # conditional status-transition UPDATE guarding concurrent directory sync runs

--- a/scripts/checks/raw-sql-usage.txt
+++ b/scripts/checks/raw-sql-usage.txt
@@ -54,10 +54,12 @@
 # Seeded via (R42 refresh, re-run at implementation start, 2026-07-04):
 #   grep -rlE '\$(queryRaw|executeRaw)(Unsafe)?\b' src scripts --include='*.ts' --include='*.tsx' \
 #     | grep -vE '\.test\.|__tests__|manual-tests|/e2e/' | sort
-# → 29 files (matches plan's R42 count).
+# → 34 files (29 original + 5 advisory-lock TOCTOU fixes: bridge-code, sends/file,
+#   auth-adapter, extension-token, mobile-token — see bypass-rls-tx-callback-form plan).
 
 scripts/audit-chain-verify-worker.ts # standalone CLI: walks audit_logs chain per tenant via static SQL + $N params, no interpolation
 scripts/migrate-account-tokens-to-encrypted.ts # one-shot OAuth token re-encryption migration; batched SELECT/UPDATE against accounts table # ident-markers=2
+src/app/api/extension/bridge-code/route.ts # advisory lock serializing bridge-code issuance against the per-user active cap (TOCTOU close)
 src/app/api/maintenance/audit-chain-verify/route.ts # operator-gated chain-verify endpoint; static SQL + $N params reading audit_logs/audit_chain_anchors
 src/app/api/maintenance/audit-outbox-metrics/route.ts # operator-gated outbox depth/age metrics query, tagged-template $queryRaw
 src/app/api/maintenance/audit-outbox-purge-failed/route.ts # operator-gated purge of FAILED outbox rows, tagged-template $queryRaw
@@ -66,6 +68,7 @@ src/app/api/passwords/[id]/attachments/[attachmentId]/migrate/route.ts # advisor
 src/app/api/passwords/[id]/attachments/route.ts # advisory lock serializing attachment upload against key rotation
 src/app/api/passwords/[id]/route.ts # row lock (FOR UPDATE) for atomic blob snapshot+update on concurrent PUT
 src/app/api/share-links/[id]/content/route.ts # atomic view_count increment + revocation/expiry recheck (TOCTOU close)
+src/app/api/sends/file/route.ts # advisory lock serializing file-send creation against the per-user active byte-quota (TOCTOU close)
 src/app/api/tenant/access-requests/[id]/approve/route.ts # advisory lock serializing SA token issuance against per-account token cap
 src/app/api/tenant/service-accounts/[id]/tokens/route.ts # advisory lock serializing SA token issuance against per-account token cap
 src/app/api/v1/passwords/[id]/route.ts # row lock (FOR UPDATE) for atomic blob snapshot+update on concurrent PUT
@@ -76,6 +79,9 @@ src/app/s/[token]/page.tsx # atomic view_count increment + revocation/expiry rec
 src/auth.ts # SECURITY DEFINER call to migrate audit_logs rows during tenant merge
 src/lib/audit/audit-outbox.ts # bypass_rls GUC set/verify + tenant-existence check before enqueueing audit outbox rows
 src/lib/auth/policy/account-lockout.ts # row lock (FOR UPDATE) + lock_timeout for atomic failed-login counter update
+src/lib/auth/session/auth-adapter.ts # advisory lock serializing session creation against the per-user concurrent-session cap (TOCTOU close)
+src/lib/auth/tokens/extension-token.ts # advisory lock serializing extension-token issuance against the per-user active cap (TOCTOU close)
+src/lib/auth/tokens/mobile-token.ts # advisory lock serializing mobile-token issuance against the per-user active cap (TOCTOU close)
 src/lib/auth/webauthn/webauthn-authorize.ts # CAS counter update on WebAuthn credential to prevent replay/clone
 src/lib/auth/webauthn/webauthn-server.ts # CAS counter update on WebAuthn credential within caller's tx
 src/lib/directory-sync/engine.ts # conditional status-transition UPDATE guarding concurrent directory sync runs

--- a/scripts/checks/raw-sql-usage.txt
+++ b/scripts/checks/raw-sql-usage.txt
@@ -54,9 +54,10 @@
 # Seeded via (R42 refresh, re-run at implementation start, 2026-07-04):
 #   grep -rlE '\$(queryRaw|executeRaw)(Unsafe)?\b' src scripts --include='*.ts' --include='*.tsx' \
 #     | grep -vE '\.test\.|__tests__|manual-tests|/e2e/' | sort
-# → 35 files (29 original + 6 advisory-lock TOCTOU fixes: api-keys, bridge-code,
-#   sends/file, auth-adapter, extension-token, mobile-token — see
-#   bypass-rls-tx-callback-form plan).
+# → 39 files (29 original + 6 advisory-lock TOCTOU fixes: api-keys, bridge-code,
+#   sends/file, auth-adapter, extension-token, mobile-token + 4 per-tenant
+#   advisory-lock TOCTOU fixes: operator-tokens, service-accounts, scim-tokens,
+#   mcp-clients — see bypass-rls-tx-callback-form plan).
 
 scripts/audit-chain-verify-worker.ts # standalone CLI: walks audit_logs chain per tenant via static SQL + $N params, no interpolation
 scripts/migrate-account-tokens-to-encrypted.ts # one-shot OAuth token re-encryption migration; batched SELECT/UPDATE against accounts table # ident-markers=2
@@ -72,7 +73,11 @@ src/app/api/passwords/[id]/route.ts # row lock (FOR UPDATE) for atomic blob snap
 src/app/api/share-links/[id]/content/route.ts # atomic view_count increment + revocation/expiry recheck (TOCTOU close)
 src/app/api/sends/file/route.ts # advisory lock serializing file-send creation against the per-user active byte-quota (TOCTOU close)
 src/app/api/tenant/access-requests/[id]/approve/route.ts # advisory lock serializing SA token issuance against per-account token cap
+src/app/api/tenant/mcp-clients/route.ts # advisory lock serializing MCP-client creation against the per-tenant cap (TOCTOU close)
+src/app/api/tenant/operator-tokens/route.ts # advisory lock serializing operator-token creation against the per-tenant cap (TOCTOU close)
+src/app/api/tenant/scim-tokens/route.ts # advisory lock serializing SCIM-token creation against the per-tenant cap (TOCTOU close)
 src/app/api/tenant/service-accounts/[id]/tokens/route.ts # advisory lock serializing SA token issuance against per-account token cap
+src/app/api/tenant/service-accounts/route.ts # advisory lock serializing service-account creation against the per-tenant cap (TOCTOU close)
 src/app/api/v1/passwords/[id]/route.ts # row lock (FOR UPDATE) for atomic blob snapshot+update on concurrent PUT
 src/app/api/vault/rotate-key/route.ts # advisory lock preventing concurrent vault key rotations for the same user
 src/app/api/webauthn/credentials/[id]/prf/route.ts # advisory lock serializing PRF rebootstrap against key rotation

--- a/scripts/checks/raw-sql-usage.txt
+++ b/scripts/checks/raw-sql-usage.txt
@@ -54,10 +54,12 @@
 # Seeded via (R42 refresh, re-run at implementation start, 2026-07-04):
 #   grep -rlE '\$(queryRaw|executeRaw)(Unsafe)?\b' src scripts --include='*.ts' --include='*.tsx' \
 #     | grep -vE '\.test\.|__tests__|manual-tests|/e2e/' | sort
-# → 39 files (29 original + 6 advisory-lock TOCTOU fixes: api-keys, bridge-code,
+# → 45 files (29 original + 6 advisory-lock TOCTOU fixes: api-keys, bridge-code,
 #   sends/file, auth-adapter, extension-token, mobile-token + 4 per-tenant
 #   advisory-lock TOCTOU fixes: operator-tokens, service-accounts, scim-tokens,
-#   mcp-clients — see bypass-rls-tx-callback-form plan).
+#   mcp-clients + 6 per-scope cap advisory-lock TOCTOU fixes: tenant/webhooks,
+#   team/webhooks, audit-delivery-targets, team-attachments, reset-vault,
+#   mcp/register — see bypass-rls-tx-callback-form plan).
 
 scripts/audit-chain-verify-worker.ts # standalone CLI: walks audit_logs chain per tenant via static SQL + $N params, no interpolation
 scripts/migrate-account-tokens-to-encrypted.ts # one-shot OAuth token re-encryption migration; batched SELECT/UPDATE against accounts table # ident-markers=2
@@ -67,17 +69,23 @@ src/app/api/maintenance/audit-chain-verify/route.ts # operator-gated chain-verif
 src/app/api/maintenance/audit-outbox-metrics/route.ts # operator-gated outbox depth/age metrics query, tagged-template $queryRaw
 src/app/api/maintenance/audit-outbox-purge-failed/route.ts # operator-gated purge of FAILED outbox rows, tagged-template $queryRaw
 src/app/api/maintenance/purge-audit-logs/route.ts # operator-gated system-wide audit log purge via audit_log_purge() definer fn
+src/app/api/mcp/register/route.ts # advisory lock serializing DCR registration against the global unclaimed-client cap (TOCTOU close)
 src/app/api/passwords/[id]/attachments/[attachmentId]/migrate/route.ts # advisory lock serializing attachment CEK rewrap against key rotation
 src/app/api/passwords/[id]/attachments/route.ts # advisory lock serializing attachment upload against key rotation
 src/app/api/passwords/[id]/route.ts # row lock (FOR UPDATE) for atomic blob snapshot+update on concurrent PUT
 src/app/api/share-links/[id]/content/route.ts # atomic view_count increment + revocation/expiry recheck (TOCTOU close)
 src/app/api/sends/file/route.ts # advisory lock serializing file-send creation against the per-user active byte-quota (TOCTOU close)
+src/app/api/teams/[teamId]/passwords/[id]/attachments/route.ts # advisory lock serializing team attachment upload against the per-entry cap (TOCTOU close)
+src/app/api/teams/[teamId]/webhooks/route.ts # advisory lock serializing team webhook creation against the per-team cap (TOCTOU close)
 src/app/api/tenant/access-requests/[id]/approve/route.ts # advisory lock serializing SA token issuance against per-account token cap
+src/app/api/tenant/audit-delivery-targets/route.ts # advisory lock serializing audit-delivery-target creation against the per-tenant cap (TOCTOU close)
 src/app/api/tenant/mcp-clients/route.ts # advisory lock serializing MCP-client creation against the per-tenant cap (TOCTOU close)
+src/app/api/tenant/members/[userId]/reset-vault/route.ts # advisory lock serializing admin vault-reset creation against the per-target pending-reset cap (TOCTOU close)
 src/app/api/tenant/operator-tokens/route.ts # advisory lock serializing operator-token creation against the per-tenant cap (TOCTOU close)
 src/app/api/tenant/scim-tokens/route.ts # advisory lock serializing SCIM-token creation against the per-tenant cap (TOCTOU close)
 src/app/api/tenant/service-accounts/[id]/tokens/route.ts # advisory lock serializing SA token issuance against per-account token cap
 src/app/api/tenant/service-accounts/route.ts # advisory lock serializing service-account creation against the per-tenant cap (TOCTOU close)
+src/app/api/tenant/webhooks/route.ts # advisory lock serializing tenant webhook creation against the per-tenant cap (TOCTOU close)
 src/app/api/v1/passwords/[id]/route.ts # row lock (FOR UPDATE) for atomic blob snapshot+update on concurrent PUT
 src/app/api/vault/rotate-key/route.ts # advisory lock preventing concurrent vault key rotations for the same user
 src/app/api/webauthn/credentials/[id]/prf/route.ts # advisory lock serializing PRF rebootstrap against key rotation

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -183,6 +183,7 @@ run_step "Static: env drift check"  npm run check:env-docs
 run_step "Static: security-matrices drift check" npm run check:security-matrices
 run_step "Static: team-auth-rls"  node scripts/checks/check-team-auth-rls.mjs
 run_step "Static: bypass-rls"     node scripts/checks/check-bypass-rls.mjs
+run_step "Static: count-then-create-lock" node scripts/checks/check-count-then-create-lock.mjs
 run_step "Static: crypto-domains" node scripts/checks/check-crypto-domains.mjs
 run_step "Static: migration-drift" node scripts/checks/check-migration-drift.mjs
 run_step "Static: raw-sql-usage" node scripts/checks/check-raw-sql-usage.mjs

--- a/src/__tests__/api/extension/bridge-code-cnfJkt.test.ts
+++ b/src/__tests__/api/extension/bridge-code-cnfJkt.test.ts
@@ -71,6 +71,8 @@ vi.mock("@/lib/auth/policy/access-restriction", () => ({
 vi.mock("@/lib/tenant-rls", () => ({
   withBypassRls: mockWithBypassRls,
   BYPASS_PURPOSE: { TOKEN_LIFECYCLE: "TOKEN_LIFECYCLE" },
+  advisoryXactLock: (client: { $executeRaw: (...args: unknown[]) => unknown }, key: string) =>
+    client.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${key}::text))`,
 }));
 vi.mock("@/lib/tenant-context", () => ({
   withUserTenantRls: mockWithUserTenantRls,

--- a/src/__tests__/api/extension/bridge-code-cnfJkt.test.ts
+++ b/src/__tests__/api/extension/bridge-code-cnfJkt.test.ts
@@ -152,6 +152,7 @@ describe("POST /api/extension/bridge-code — C4 rewrite", () => {
     mockWithBypassRls.mockImplementation(
       (_prisma: unknown, fn: (tx: unknown) => unknown) =>
         fn({
+          $executeRaw: vi.fn().mockResolvedValue(1),
           extensionBridgeCode: {
             findMany: mockBridgeCodeFindMany,
             updateMany: mockBridgeCodeUpdateMany,

--- a/src/__tests__/api/passwords/attachments.test.ts
+++ b/src/__tests__/api/passwords/attachments.test.ts
@@ -30,11 +30,14 @@ const {
   mockRateLimitCheck: vi.fn(),
 }));
 
-// Tx mock — upload now wraps user.findUnique + attachment.create in a tx.
+// Tx mock — upload now wraps the advisory lock + attachment.count cap-check +
+// user.findUnique + attachment.create in a single tx. Point the tx surface at
+// the same hoists the pre-tx setup used so existing per-test .mockResolvedValue
+// calls keep driving behavior.
 const txMock = {
   $executeRaw: mockExecuteRaw,
   user: { findUnique: mockUserFindUnique },
-  attachment: { create: mockAttachmentCreate },
+  attachment: { count: mockAttachmentCount, create: mockAttachmentCreate },
 };
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
@@ -98,6 +101,14 @@ vi.mock("@/lib/quota/resource-quotas", () => ({
 
 function createParams(id: string) {
   return { params: Promise.resolve({ id }) };
+}
+
+// Asserts the per-user advisory lock ($executeRaw with pg_advisory_xact_lock)
+// was acquired inside the upload tx.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
 }
 
 vi.mock("@/lib/quota/resource-quotas", () => ({
@@ -423,6 +434,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
     const { status, json } = await parseResponse(res);
     expect(status).toBe(201);
     expect(json.filename).toBe("test.pdf");
+    expectAdvisoryLockAcquired(mockExecuteRaw);
   });
 
   it("rejects upload with malformed base64 in cekEncrypted (R19 mirror of route.test.ts) → 400", async () => {

--- a/src/__tests__/api/sends/file.test.ts
+++ b/src/__tests__/api/sends/file.test.ts
@@ -19,6 +19,9 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     passwordShare: { create: mockCreate, aggregate: mockAggregate },
     user: { findUnique: mockUserFindUnique },
+    // The aggregate+create run inside a withUserTenantRls callback that first
+    // acquires a pg_advisory_xact_lock via prisma.$executeRaw.
+    $executeRaw: vi.fn().mockResolvedValue(1),
   },
 }));
 vi.mock("@/lib/crypto/crypto-server", () => ({

--- a/src/__tests__/api/teams/team-attachments.test.ts
+++ b/src/__tests__/api/teams/team-attachments.test.ts
@@ -9,6 +9,7 @@ const {
   mockAttachmentFindMany,
   mockAttachmentCount,
   mockAttachmentCreate,
+  mockExecuteRaw,
   mockPutObject,
   mockDeleteObject,
   mockWithTeamTenantRls,
@@ -20,6 +21,7 @@ const {
   mockAttachmentFindMany: vi.fn(),
   mockAttachmentCount: vi.fn(),
   mockAttachmentCreate: vi.fn(),
+  mockExecuteRaw: vi.fn().mockResolvedValue(1),
   mockPutObject: vi.fn(),
   mockDeleteObject: vi.fn(),
   mockWithTeamTenantRls: vi.fn(async (_teamId: string, fn: () => unknown) => fn()),
@@ -47,6 +49,10 @@ vi.mock("@/lib/prisma", () => ({
       count: mockAttachmentCount,
       create: mockAttachmentCreate,
     },
+    // The cap-check + create now run under a per-entry advisory lock inside one
+    // withTeamTenantRls callback (TOCTOU fix); the route calls prisma.$executeRaw
+    // for the lock before count/create.
+    $executeRaw: mockExecuteRaw,
   },
 }));
 vi.mock("@/lib/audit/audit", () => ({
@@ -116,6 +122,14 @@ function validFormFields(): Record<string, string | Blob> {
 
 const TEAM_ENTRY = { teamId: "o1", itemKeyVersion: 1, teamKeyVersion: 1, tenantId: "t1" };
 
+// Asserts the per-entry advisory lock ($executeRaw with pg_advisory_xact_lock)
+// was acquired inside the upload callback.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
+}
+
 describe("GET /api/teams/[teamId]/passwords/[id]/attachments", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -174,6 +188,10 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRateLimitCheck.mockResolvedValue({ allowed: true });
+    // Blob is stored before the locked cap-check + create; on tx failure the
+    // route calls deleteObject(...).catch(...), so deleteObject must be a Promise.
+    mockPutObject.mockResolvedValue(Buffer.from("stored"));
+    mockDeleteObject.mockResolvedValue(undefined);
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -356,6 +374,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
     const { status, json } = await parseResponse(res);
     expect(status).toBe(201);
     expect(json.filename).toBe("test.pdf");
+    expectAdvisoryLockAcquired(mockExecuteRaw);
     expect(mockAttachmentCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({

--- a/src/__tests__/api/tenant/scim-tokens.test.ts
+++ b/src/__tests__/api/tenant/scim-tokens.test.ts
@@ -58,6 +58,9 @@ vi.mock("@/lib/prisma", () => ({
       findUnique: mockScimTokenFindUnique,
       update: mockScimTokenUpdate,
     },
+    // The cap check + create run under an advisory lock in one withTenantRls tx
+    // (TOCTOU fix); the route calls tx.$executeRaw for the lock.
+    $executeRaw: vi.fn().mockResolvedValue(1),
   },
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,

--- a/src/__tests__/db-integration/centralize-state-transitions.integration.test.ts
+++ b/src/__tests__/db-integration/centralize-state-transitions.integration.test.ts
@@ -378,12 +378,12 @@ describe("centralize-state-transitions — integration", () => {
     const [a, b] = await Promise.all([
       withBypassRls(
         ctx.app.prisma,
-        async () => autoPromoteIfElapsed({ granteeId, grantId, now, auditBase }),
+        async (tx) => autoPromoteIfElapsed({ db: tx, granteeId, grantId, now, auditBase }),
         BYPASS_PURPOSE.CROSS_TENANT_LOOKUP,
       ),
       withBypassRls(
         ctx.app.prisma,
-        async () => autoPromoteIfElapsed({ granteeId, grantId, now, auditBase }),
+        async (tx) => autoPromoteIfElapsed({ db: tx, granteeId, grantId, now, auditBase }),
         BYPASS_PURPOSE.CROSS_TENANT_LOOKUP,
       ),
     ]);

--- a/src/__tests__/db-integration/count-then-create-toctou.integration.test.ts
+++ b/src/__tests__/db-integration/count-then-create-toctou.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Real-DB proof that the per-user advisory lock closes the count-then-create
+ * TOCTOU race that C-L1 fixes (session / bridge-code / extension-token /
+ * mobile-token / file-send caps).
+ *
+ * The production sites all run `findMany(active) → evict oldest → create` (or
+ * aggregate→check→create) inside an RLS transaction. Without serialization two
+ * concurrent issues both read `count < max` and both create, exceeding the cap.
+ * The fix prepends `SELECT pg_advisory_xact_lock(hashtext(userId))` so the loser
+ * blocks until the winner commits, then sees the updated count.
+ *
+ * This test replicates the bridge-code CAS by hand (the production path is bound
+ * to the singleton prisma and cannot be raced with two injected clients) and
+ * races two distinct pooled clients. The WITHOUT-lock case is the mutation-kill:
+ * it demonstrates the race is real, so the WITH-lock pass is meaningful.
+ *
+ * Gated on DATABASE_URL — skips on the no-DB CI job, runs on test:integration.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import { randomUUID } from "node:crypto";
+import { createTestContext, type TestContext } from "./helpers";
+
+const SKIP = !process.env.DATABASE_URL;
+
+// One "issue" = the bridge-code CAS against a cap of MAX, optionally guarded by
+// the same advisory lock the production fix adds. Runs on the app role so RLS is
+// live; bypass GUC is set so the cross-user count is visible (mirrors
+// withBypassRls). A small sleep widens the count→create window to make the race
+// deterministic without the lock.
+async function issueBridgeCode(
+  client: PrismaClient,
+  userId: string,
+  tenantId: string,
+  max: number,
+  useLock: boolean,
+): Promise<void> {
+  await client.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe(`SELECT set_config('app.bypass_rls', 'on', true)`);
+    if (useLock) {
+      await tx.$executeRawUnsafe(
+        `SELECT pg_advisory_xact_lock(hashtext($1::text))`,
+        userId,
+      );
+    }
+    const active: Array<{ id: string }> = await tx.$queryRawUnsafe(
+      `SELECT id FROM extension_bridge_codes
+       WHERE user_id = $1::uuid AND expires_at > now()
+       ORDER BY created_at ASC`,
+      userId,
+    );
+    const overflow = active.length + 1 - max;
+    if (overflow > 0) {
+      const toRevoke = active.slice(0, overflow).map((r) => r.id);
+      await tx.$executeRawUnsafe(
+        `DELETE FROM extension_bridge_codes WHERE id = ANY($1::uuid[])`,
+        toRevoke,
+      );
+    }
+    // Widen the window so the un-serialized path reliably interleaves.
+    await tx.$executeRawUnsafe(`SELECT pg_sleep(0.15)`);
+    await tx.$executeRawUnsafe(
+      `INSERT INTO extension_bridge_codes
+         (id, code_hash, user_id, tenant_id, scope, expires_at, created_at, cnf_jkt)
+       VALUES ($1::uuid, $2, $3::uuid, $4::uuid, 'x', now() + interval '5 min', now(), 'jkt')`,
+      randomUUID(),
+      randomUUID().replace(/-/g, ""),
+      userId,
+      tenantId,
+    );
+  });
+}
+
+async function activeCount(ctx: TestContext, userId: string): Promise<number> {
+  const r: Array<{ n: bigint }> = await ctx.su.prisma.$queryRawUnsafe(
+    `SELECT count(*) n FROM extension_bridge_codes WHERE user_id = $1::uuid AND expires_at > now()`,
+    userId,
+  );
+  return Number(r[0].n);
+}
+
+describe.skipIf(SKIP)("count-then-create TOCTOU — advisory lock", () => {
+  let ctx: TestContext;
+  let a: { prisma: PrismaClient };
+  let b: { prisma: PrismaClient };
+  let tenantId: string;
+  let userId: string;
+  const MAX = 1; // cap of 1 makes any second concurrent insert a violation
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    a = ctx.app;
+    // A second independent app-role client/pool so the two issues race on
+    // separate connections (Promise.all on one client would serialize).
+    const { createPrismaForRole } = await import("./helpers");
+    b = createPrismaForRole("app");
+  });
+
+  afterEach(async () => {
+    if (tenantId) await ctx.deleteTestData(tenantId);
+  });
+
+  afterAll(async () => {
+    await b.prisma.$disconnect();
+    await ctx.cleanup();
+  });
+
+  async function seed(): Promise<void> {
+    tenantId = await ctx.createTenant();
+    userId = await ctx.createUser(tenantId);
+    // Pre-seed one active code so the cap of 1 is already met.
+    await ctx.su.prisma.$transaction(async (tx) => {
+      await tx.$executeRawUnsafe(`SELECT set_config('app.bypass_rls', 'on', true)`);
+      await tx.$executeRawUnsafe(
+        `INSERT INTO extension_bridge_codes
+           (id, code_hash, user_id, tenant_id, scope, expires_at, created_at, cnf_jkt)
+         VALUES ($1::uuid, $2, $3::uuid, $4::uuid, 'x', now() + interval '5 min', now(), 'jkt')`,
+        randomUUID(),
+        randomUUID().replace(/-/g, ""),
+        userId,
+        tenantId,
+      );
+    });
+  }
+
+  it("WITHOUT the lock, two concurrent issues exceed the cap (proves the race is real)", async () => {
+    await seed();
+    await Promise.all([
+      issueBridgeCode(a.prisma, userId, tenantId, MAX, false),
+      issueBridgeCode(b.prisma, userId, tenantId, MAX, false),
+    ]);
+    // Both read [1 existing], both compute overflow=1, both evict the SAME one,
+    // both insert → 2 survive, exceeding MAX=1.
+    expect(await activeCount(ctx, userId)).toBeGreaterThan(MAX);
+  });
+
+  it("WITH the lock, two concurrent issues respect the cap (race closed)", async () => {
+    await seed();
+    await Promise.all([
+      issueBridgeCode(a.prisma, userId, tenantId, MAX, true),
+      issueBridgeCode(b.prisma, userId, tenantId, MAX, true),
+    ]);
+    // Winner evicts the pre-seeded one and inserts; loser blocks, then sees the
+    // winner's row, evicts it, inserts → exactly MAX survive.
+    expect(await activeCount(ctx, userId)).toBe(MAX);
+  });
+});

--- a/src/__tests__/db-integration/count-then-create-toctou.integration.test.ts
+++ b/src/__tests__/db-integration/count-then-create-toctou.integration.test.ts
@@ -79,6 +79,55 @@ async function activeCount(ctx: TestContext, userId: string): Promise<number> {
   return Number(r[0].n);
 }
 
+// One "issue" = the api-keys CAS against a cap of MAX, mirroring the
+// api_keys route (count non-revoked → if < MAX → create), optionally guarded by
+// the same advisory lock the production fix adds. The cap in production counts
+// `revoked_at IS NULL`, so this replica does too.
+async function issueApiKey(
+  client: PrismaClient,
+  userId: string,
+  tenantId: string,
+  max: number,
+  useLock: boolean,
+): Promise<void> {
+  await client.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe(`SELECT set_config('app.bypass_rls', 'on', true)`);
+    if (useLock) {
+      await tx.$executeRawUnsafe(
+        `SELECT pg_advisory_xact_lock(hashtext($1::text))`,
+        userId,
+      );
+    }
+    const r: Array<{ n: bigint }> = await tx.$queryRawUnsafe(
+      `SELECT count(*) n FROM api_keys
+       WHERE user_id = $1::uuid AND revoked_at IS NULL`,
+      userId,
+    );
+    const existing = Number(r[0].n);
+    if (existing >= max) return; // cap reached — production throws + maps to 400
+    // Widen the window so the un-serialized path reliably interleaves.
+    await tx.$executeRawUnsafe(`SELECT pg_sleep(0.15)`);
+    await tx.$executeRawUnsafe(
+      `INSERT INTO api_keys
+         (id, user_id, tenant_id, token_hash, prefix, name, scope, expires_at, created_at)
+       VALUES ($1::uuid, $2::uuid, $3::uuid, $4, 'api_XXXX', 'k', 'passwords:read',
+               now() + interval '30 days', now())`,
+      randomUUID(),
+      userId,
+      tenantId,
+      randomUUID().replace(/-/g, ""),
+    );
+  });
+}
+
+async function activeApiKeyCount(ctx: TestContext, userId: string): Promise<number> {
+  const r: Array<{ n: bigint }> = await ctx.su.prisma.$queryRawUnsafe(
+    `SELECT count(*) n FROM api_keys WHERE user_id = $1::uuid AND revoked_at IS NULL`,
+    userId,
+  );
+  return Number(r[0].n);
+}
+
 describe.skipIf(SKIP)("count-then-create TOCTOU — advisory lock", () => {
   let ctx: TestContext;
   let a: { prisma: PrismaClient };
@@ -143,5 +192,66 @@ describe.skipIf(SKIP)("count-then-create TOCTOU — advisory lock", () => {
     // Winner evicts the pre-seeded one and inserts; loser blocks, then sees the
     // winner's row, evicts it, inserts → exactly MAX survive.
     expect(await activeCount(ctx, userId)).toBe(MAX);
+  });
+});
+
+// The api_keys route (6th count-then-create site) uses a fixed cap
+// (MAX_API_KEYS_PER_USER) and does NOT evict on overflow — it refuses the
+// create. So the WITHOUT-lock race is: both read count < cap, both insert →
+// the cap is exceeded. The WITH-lock case serializes: the loser blocks, then
+// sees the winner's row and refuses → exactly the cap survives.
+describe.skipIf(SKIP)("count-then-create TOCTOU — advisory lock (api_keys)", () => {
+  let ctx: TestContext;
+  let a: { prisma: PrismaClient };
+  let b: { prisma: PrismaClient };
+  let tenantId: string;
+  let userId: string;
+  const MAX = 1; // cap of 1 makes any second concurrent insert a violation
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    a = ctx.app;
+    // A second independent app-role client/pool so the two issues race on
+    // separate connections (Promise.all on one client would serialize).
+    const { createPrismaForRole } = await import("./helpers");
+    b = createPrismaForRole("app");
+  });
+
+  afterEach(async () => {
+    if (tenantId) await ctx.deleteTestData(tenantId);
+  });
+
+  afterAll(async () => {
+    await b.prisma.$disconnect();
+    await ctx.cleanup();
+  });
+
+  // api_keys refuses (does not evict) on overflow, so both racers must start
+  // from BELOW the cap to exhibit the race. Seed a user with zero active keys;
+  // both racers read count=0 (< MAX=1) and both attempt to insert.
+  async function seed(): Promise<void> {
+    tenantId = await ctx.createTenant();
+    userId = await ctx.createUser(tenantId);
+  }
+
+  it("WITHOUT the lock, two concurrent issues exceed the cap (proves the race is real)", async () => {
+    await seed();
+    await Promise.all([
+      issueApiKey(a.prisma, userId, tenantId, MAX, false),
+      issueApiKey(b.prisma, userId, tenantId, MAX, false),
+    ]);
+    // Both read count=0 (< MAX), both insert → 2 survive, exceeding MAX=1.
+    expect(await activeApiKeyCount(ctx, userId)).toBeGreaterThan(MAX);
+  });
+
+  it("WITH the lock, two concurrent issues respect the cap (race closed)", async () => {
+    await seed();
+    await Promise.all([
+      issueApiKey(a.prisma, userId, tenantId, MAX, true),
+      issueApiKey(b.prisma, userId, tenantId, MAX, true),
+    ]);
+    // Winner reads count=0, inserts; loser blocks, then reads count=1 >= MAX and
+    // refuses → exactly MAX survive.
+    expect(await activeApiKeyCount(ctx, userId)).toBe(MAX);
   });
 });

--- a/src/__tests__/integration/mcp-oauth-flow.test.ts
+++ b/src/__tests__/integration/mcp-oauth-flow.test.ts
@@ -97,6 +97,9 @@ vi.mock("@/lib/auth/access/tenant-auth", () => {
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     $transaction: mockPrismaTransaction,
+    // MCP-client creation runs count+existing-check+create under an advisory
+    // lock in one withTenantRls tx (TOCTOU fix); the route calls tx.$executeRaw.
+    $executeRaw: vi.fn().mockResolvedValue(1),
     mcpClient: {
       findMany: mockMcpClientFindMany,
       count: mockMcpClientCount,

--- a/src/__tests__/integration/mcp-oauth-flow.test.ts
+++ b/src/__tests__/integration/mcp-oauth-flow.test.ts
@@ -292,7 +292,7 @@ describe("Scenario 3: PKCE Token Exchange Success via /api/mcp/token", () => {
     const challenge = computeS256Challenge(verifier);
 
     // Wire up the $transaction mock to run through the real PKCE path
-    mockPrismaTransaction.mockImplementation(async (fn) => {
+    mockWithBypassRls.mockImplementation(async (_p, fn) => {
       const tx = {
         mcpAuthorizationCode: {
           findUnique: vi.fn().mockResolvedValue({
@@ -318,6 +318,11 @@ describe("Scenario 3: PKCE Token Exchange Success via /api/mcp/token", () => {
         },
         mcpAccessToken: {
           create: vi.fn().mockResolvedValue({ id: "new-token-id" }),
+        },
+        // createRefreshToken runs in its own withBypassRls scope, which the
+        // overridden mock now also drives with this tx.
+        mcpRefreshToken: {
+          create: vi.fn().mockResolvedValue({}),
         },
         // derivePasskeyState reads these inside exchangeCodeForToken
         webAuthnCredential: {
@@ -373,7 +378,7 @@ describe("Scenario 4: PKCE Failure Paths via POST /api/mcp/token", () => {
     const correctVerifier = "correct-verifier-abc123";
     const challenge = computeS256Challenge(correctVerifier);
 
-    mockPrismaTransaction.mockImplementation(async (fn) => {
+    mockWithBypassRls.mockImplementation(async (_p, fn) => {
       const tx = {
         mcpAuthorizationCode: {
           findUnique: vi.fn().mockResolvedValue({
@@ -413,7 +418,7 @@ describe("Scenario 4: PKCE Failure Paths via POST /api/mcp/token", () => {
   });
 
   it("code already used (usedAt non-null) → 400 invalid_grant", async () => {
-    mockPrismaTransaction.mockImplementation(async (fn) => {
+    mockWithBypassRls.mockImplementation(async (_p, fn) => {
       const tx = {
         mcpAuthorizationCode: {
           findUnique: vi.fn().mockResolvedValue({
@@ -453,7 +458,7 @@ describe("Scenario 4: PKCE Failure Paths via POST /api/mcp/token", () => {
   });
 
   it("code expired → 400 invalid_grant", async () => {
-    mockPrismaTransaction.mockImplementation(async (fn) => {
+    mockWithBypassRls.mockImplementation(async (_p, fn) => {
       const tx = {
         mcpAuthorizationCode: {
           findUnique: vi.fn().mockResolvedValue({
@@ -496,7 +501,7 @@ describe("Scenario 4: PKCE Failure Paths via POST /api/mcp/token", () => {
     const correctVerifier = "correct-verifier-for-secret-test";
     const challenge = computeS256Challenge(correctVerifier);
 
-    mockPrismaTransaction.mockImplementation(async (fn) => {
+    mockWithBypassRls.mockImplementation(async (_p, fn) => {
       const tx = {
         mcpAuthorizationCode: {
           findUnique: vi.fn().mockResolvedValue({
@@ -543,7 +548,7 @@ describe("Scenario 4: PKCE Failure Paths via POST /api/mcp/token", () => {
     const verifier = "correct-verifier-for-redirect-test-scenario";
     const challenge = computeS256Challenge(verifier);
 
-    mockPrismaTransaction.mockImplementation(async (fn) => {
+    mockWithBypassRls.mockImplementation(async (_p, fn) => {
       const tx = {
         mcpAuthorizationCode: {
           findUnique: vi.fn().mockResolvedValue({

--- a/src/app/api/api-keys/route.test.ts
+++ b/src/app/api/api-keys/route.test.ts
@@ -6,6 +6,7 @@ const {
   mockCheckAuth,
   mockPrismaApiKey,
   mockPrismaUser,
+  mockExecuteRaw,
   mockWithUserTenantRls,
   mockRateLimitCheck,
   mockRequireRecentSession,
@@ -17,6 +18,7 @@ const {
     count: vi.fn(),
   },
   mockPrismaUser: { findUnique: vi.fn() },
+  mockExecuteRaw: vi.fn().mockResolvedValue(1),
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
   mockRateLimitCheck: vi.fn().mockResolvedValue({ allowed: true }),
   mockRequireRecentSession: vi.fn().mockResolvedValue(null),
@@ -32,6 +34,10 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     apiKey: mockPrismaApiKey,
     user: mockPrismaUser,
+    // The cap-check + create now run under an advisory lock inside one
+    // withUserTenantRls tx (TOCTOU fix); the route calls prisma.$executeRaw
+    // for the lock before count/create.
+    $executeRaw: mockExecuteRaw,
   },
 }));
 vi.mock("@/lib/crypto/crypto-server", () => ({
@@ -69,6 +75,16 @@ function authFail(status = 401) {
     ok: false,
     response: NextResponse.json({ error: "UNAUTHORIZED" }, { status }),
   };
+}
+
+// Asserts the per-user advisory lock ($executeRaw with
+// pg_advisory_xact_lock) was acquired. Mutation-kill: deleting the lock line
+// from the production count-then-create path leaves $executeRaw uncalled with
+// that SQL, so this fails.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
 }
 
 describe("GET /api/api-keys", () => {
@@ -139,6 +155,7 @@ describe("POST /api/api-keys", () => {
     mockPrismaApiKey.count.mockReset();
     mockPrismaApiKey.create.mockReset();
     mockPrismaUser.findUnique.mockReset();
+    mockExecuteRaw.mockClear();
     mockRateLimitCheck.mockResolvedValue({ allowed: true });
     mockRequireRecentSession.mockResolvedValue(null);
   });
@@ -301,5 +318,7 @@ describe("POST /api/api-keys", () => {
     expect(json.id).toBe("new-key");
     expect(json.token).toMatch(/^api_/);
     expect(res.headers.get("Cache-Control")).toBe("no-store");
+    // The count-then-create runs under a per-user advisory lock (TOCTOU fix).
+    expectAdvisoryLockAcquired(mockExecuteRaw);
   });
 });

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -28,6 +28,10 @@ const apiKeyCreateLimiter = createRateLimiter({
   failClosedOnRedisError: true,
 });
 
+// Sentinel thrown inside the locked transaction when the re-checked per-user key
+// count is at the cap. Mapped to API_KEY_LIMIT_EXCEEDED outside the tx.
+class ApiKeyLimitError extends Error {}
+
 // GET /api/api-keys — List API keys for the current user
 async function handleGET(req: NextRequest) {
   const authed = await checkAuth(req);
@@ -87,16 +91,6 @@ async function handlePOST(req: NextRequest) {
 
   const { name, scope: scopes, expiresAt } = result.data;
 
-  // Check key limit
-  const existingCount = await withUserTenantRls(userId, async () =>
-    prisma.apiKey.count({
-      where: { userId: userId, revokedAt: null },
-    }),
-  );
-  if (existingCount >= MAX_API_KEYS_PER_USER) {
-    return errorResponse(API_ERROR.API_KEY_LIMIT_EXCEEDED);
-  }
-
   // Generate token: api_ + 43 chars base62 (256-bit entropy)
   // Use 48 bytes to ensure enough chars remain after stripping _ and -
   const rawBytes = randomBytes(48);
@@ -111,19 +105,39 @@ async function handlePOST(req: NextRequest) {
   const tokenHash = hashToken(plaintext);
   const prefix = plaintext.slice(0, API_KEY_PREFIX_LENGTH); // "api_XXXX"
 
-  const key = await withUserTenantRls(userId, async (tenantId) =>
-    prisma.apiKey.create({
-      data: {
-        userId: userId,
-        tenantId,
-        tokenHash,
-        prefix,
-        name,
-        scope: scopes.join(","),
-        expiresAt,
-      },
-    }),
-  );
+  // Serialize the cap check with the create under a per-user advisory lock so
+  // two concurrent POSTs cannot both read count < MAX and both create, blowing
+  // past MAX_API_KEYS_PER_USER (TOCTOU). The lock, count, and create fold into
+  // one tenant tx via the proxy; over-limit throws a sentinel mapped outside.
+  let key: { id: string; expiresAt: Date | null; createdAt: Date };
+  try {
+    key = await withUserTenantRls(userId, async (tenantId) => {
+      await prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`;
+      const existingCount = await prisma.apiKey.count({
+        where: { userId: userId, revokedAt: null },
+      });
+      if (existingCount >= MAX_API_KEYS_PER_USER) {
+        throw new ApiKeyLimitError();
+      }
+      return prisma.apiKey.create({
+        data: {
+          userId: userId,
+          tenantId,
+          tokenHash,
+          prefix,
+          name,
+          scope: scopes.join(","),
+          expiresAt,
+        },
+        select: { id: true, expiresAt: true, createdAt: true },
+      });
+    });
+  } catch (e) {
+    if (e instanceof ApiKeyLimitError) {
+      return errorResponse(API_ERROR.API_KEY_LIMIT_EXCEEDED);
+    }
+    throw e;
+  }
 
   await logAuditAsync({
     ...personalAuditBase(req, userId),

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { randomBytes } from "node:crypto";
 import { checkAuth } from "@/lib/auth/session/check-auth";
 import { prisma } from "@/lib/prisma";
+import { advisoryXactLock } from "@/lib/tenant-rls";
 import { hashToken } from "@/lib/crypto/crypto-server";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { apiKeyCreateSchema } from "@/lib/validations";
@@ -112,7 +113,7 @@ async function handlePOST(req: NextRequest) {
   let key: { id: string; expiresAt: Date | null; createdAt: Date };
   try {
     key = await withUserTenantRls(userId, async (tenantId) => {
-      await prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`;
+      await advisoryXactLock(prisma, userId);
       const existingCount = await prisma.apiKey.count({
         where: { userId: userId, revokedAt: null },
       });

--- a/src/app/api/auth/passkey/reauth/verify/route.test.ts
+++ b/src/app/api/auth/passkey/reauth/verify/route.test.ts
@@ -51,6 +51,10 @@ vi.mock("@/lib/audit/audit", () => ({
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     $transaction: mockPrismaTransaction,
+    // The session mutation now runs directly on the withBypassRls callback's
+    // tx (redundant inner $transaction removed), so the outer tx (this prisma
+    // mock passed through by mockWithBypassRls) must carry session.update.
+    session: { update: mockSessionUpdate },
   },
 }));
 

--- a/src/app/api/auth/passkey/reauth/verify/route.ts
+++ b/src/app/api/auth/passkey/reauth/verify/route.ts
@@ -69,26 +69,25 @@ async function handlePOST(req: NextRequest) {
   const verifiedAt = new Date();
   const verification = await withBypassRls(
     prisma,
-    (tx) =>
-      prisma.$transaction(async (tx) => {
-        const assertion = await verifyAuthenticationAssertion(
-          tx,
-          session.user.id,
-          response,
-          `webauthn:challenge:reauth:${session.user.id}:${result.data.challengeId}`,
-        );
+    async (tx) => {
+      const assertion = await verifyAuthenticationAssertion(
+        tx,
+        session.user.id,
+        response,
+        `webauthn:challenge:reauth:${session.user.id}:${result.data.challengeId}`,
+      );
 
-        if (!assertion.ok) {
-          return assertion;
-        }
-
-        await tx.session.update({
-          where: { sessionToken },
-          data: { passkeyVerifiedAt: verifiedAt },
-        });
-
+      if (!assertion.ok) {
         return assertion;
-      }),
+      }
+
+      await tx.session.update({
+        where: { sessionToken },
+        data: { passkeyVerifiedAt: verifiedAt },
+      });
+
+      return assertion;
+    },
     BYPASS_PURPOSE.AUTH_FLOW,
   );
 

--- a/src/app/api/auth/passkey/verify/route.test.ts
+++ b/src/app/api/auth/passkey/verify/route.test.ts
@@ -219,7 +219,11 @@ describe("POST /api/auth/passkey/verify", () => {
     });
     await POST(req);
 
-    expect(mockPrismaTransaction).toHaveBeenCalledOnce();
+    // Session eviction + creation now run directly on the withBypassRls
+    // callback's tx (the redundant inner $transaction was removed).
+    // Atomicity is preserved by the single bypass-RLS scope: the SSO tenant
+    // guard read plus the session mutation are the two bypass scopes.
+    expect(mockWithBypassRls).toHaveBeenCalledTimes(2);
     expect(mockPrismaSessionDeleteMany).toHaveBeenCalledWith({
       where: { userId: "user-1" },
     });
@@ -534,7 +538,11 @@ describe("POST /api/auth/passkey/verify", () => {
     mockPrismaSessionFindMany.mockResolvedValue([
       { sessionToken: "old-tok-1" },
     ]);
-    mockPrismaTransaction.mockRejectedValue(new Error("tx rolled back"));
+    // The session mutation now runs directly on the withBypassRls callback's
+    // tx (inner $transaction removed). A failing tx body is simulated by a
+    // rejecting model method; the invariant is unchanged: cache invalidation
+    // must NOT run when the bypass-RLS scope throws.
+    mockPrismaSessionCreate.mockRejectedValue(new Error("tx rolled back"));
 
     const req = createRequest("POST", ROUTE_URL, {
       body: validBody,

--- a/src/app/api/auth/passkey/verify/route.ts
+++ b/src/app/api/auth/passkey/verify/route.ts
@@ -118,44 +118,41 @@ async function handlePOST(req: NextRequest) {
   // aggressive rotation is acceptable for a password manager.
   let evictedTokens: string[] = [];
   const evictedCount = await withBypassRls(prisma, async (tx) => {
-    const result = await prisma.$transaction(async (tx) => {
-      // SELECT tokens to invalidate before deleteMany — same tx so the read
-      // sees only currently-live sessions (R3 / S-6 sequencing).
-      const existing = await tx.session.findMany({
-        where: { userId: user.id },
-        select: { sessionToken: true },
-      });
-      evictedTokens = existing.map((s) => s.sessionToken);
-
-      const deleted = await tx.session.deleteMany({
-        where: { userId: user.id },
-      });
-      // Note on passkeyVerifiedAt ownership (split with auth-adapter):
-      // Initial value is set HERE because the passkey sign-in route owns
-      // session creation for the WebAuthn provider (not the Auth.js
-      // adapter). The auth-adapter's createSession sets passkeyVerifiedAt
-      // to null implicitly for OAuth/email sessions, which is correct —
-      // those flows do not establish passkey freshness.
-      // Subsequent updates: ordinary session activity in
-      // `src/lib/auth/session/auth-adapter.ts:updateSession` writes only
-      // {expires, lastActiveAt}; it MUST NOT refresh passkeyVerifiedAt
-      // (C2 invariant). Refresh happens via the dedicated reauth flow at
-      // `src/app/api/auth/passkey/reauth/verify/route.ts`.
-      await tx.session.create({
-        data: {
-          sessionToken,
-          userId: user.id,
-          tenantId: existingUser.tenantId,
-          expires,
-          ipAddress: meta.ip ?? null,
-          userAgent: meta.userAgent?.slice(0, 512) ?? null,
-          passkeyVerifiedAt: verifiedAt,
-          provider: "webauthn",
-        },
-      });
-      return deleted.count;
+    // SELECT tokens to invalidate before deleteMany — same tx so the read
+    // sees only currently-live sessions (R3 / S-6 sequencing).
+    const existing = await tx.session.findMany({
+      where: { userId: user.id },
+      select: { sessionToken: true },
     });
-    return result;
+    evictedTokens = existing.map((s) => s.sessionToken);
+
+    const deleted = await tx.session.deleteMany({
+      where: { userId: user.id },
+    });
+    // Note on passkeyVerifiedAt ownership (split with auth-adapter):
+    // Initial value is set HERE because the passkey sign-in route owns
+    // session creation for the WebAuthn provider (not the Auth.js
+    // adapter). The auth-adapter's createSession sets passkeyVerifiedAt
+    // to null implicitly for OAuth/email sessions, which is correct —
+    // those flows do not establish passkey freshness.
+    // Subsequent updates: ordinary session activity in
+    // `src/lib/auth/session/auth-adapter.ts:updateSession` writes only
+    // {expires, lastActiveAt}; it MUST NOT refresh passkeyVerifiedAt
+    // (C2 invariant). Refresh happens via the dedicated reauth flow at
+    // `src/app/api/auth/passkey/reauth/verify/route.ts`.
+    await tx.session.create({
+      data: {
+        sessionToken,
+        userId: user.id,
+        tenantId: existingUser.tenantId,
+        expires,
+        ipAddress: meta.ip ?? null,
+        userAgent: meta.userAgent?.slice(0, 512) ?? null,
+        passkeyVerifiedAt: verifiedAt,
+        provider: "webauthn",
+      },
+    });
+    return deleted.count;
   }, BYPASS_PURPOSE.AUTH_FLOW);
 
   // Invalidate cache AFTER $transaction resolves successfully (S-6).

--- a/src/app/api/emergency-access/[id]/accept/route.test.ts
+++ b/src/app/api/emergency-access/[id]/accept/route.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest, createParams } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockPrismaGrant, mockPrismaUser, mockTransaction, mockTxGrantUpdateMany, mockTxKeyPairCreate, mockRateLimiter, mockSendEmail, mockWithBypassRls } = vi.hoisted(() => ({
+const { mockAuth, mockPrismaGrant, mockPrismaUser, mockTxGrantUpdateMany, mockTxKeyPairCreate, mockRateLimiter, mockSendEmail, mockWithBypassRls } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
-  mockPrismaGrant: { findUnique: vi.fn() },
+  mockPrismaGrant: { findUnique: vi.fn(), updateMany: vi.fn() },
   mockPrismaUser: { findUnique: vi.fn() },
-  mockTransaction: vi.fn(),
   mockTxGrantUpdateMany: vi.fn(),
   mockTxKeyPairCreate: vi.fn(),
   mockRateLimiter: { check: vi.fn() },
@@ -17,8 +16,8 @@ vi.mock("@/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     emergencyAccessGrant: mockPrismaGrant,
+    emergencyAccessKeyPair: { create: mockTxKeyPairCreate },
     user: mockPrismaUser,
-    $transaction: mockTransaction,
   },
 }));
 vi.mock("@/lib/email", () => ({ sendEmail: mockSendEmail }));
@@ -61,13 +60,10 @@ describe("POST /api/emergency-access/[id]/accept", () => {
     mockRateLimiter.check.mockResolvedValue({ allowed: true });
     mockPrismaGrant.findUnique.mockResolvedValue(pendingGrant);
     mockTxGrantUpdateMany.mockResolvedValue({ count: 1 });
+    // transition({ db: tx }) runs directly on the withBypassRls callback's tx
+    // (the mocked prisma), so the CAS updateMany lands on mockPrismaGrant.
+    mockPrismaGrant.updateMany.mockImplementation((...args) => mockTxGrantUpdateMany(...args));
     mockTxKeyPairCreate.mockResolvedValue({});
-    mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
-      cb({
-        emergencyAccessGrant: { updateMany: mockTxGrantUpdateMany },
-        emergencyAccessKeyPair: { create: mockTxKeyPairCreate },
-      }),
-    );
     mockPrismaUser.findUnique.mockResolvedValue({ email: "owner@test.com", name: "Owner Name" });
   });
 
@@ -181,7 +177,9 @@ describe("POST /api/emergency-access/[id]/accept", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.status).toBe(EA_STATUS.ACCEPTED);
-    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    // Atomicity: the CAS transition + escrow keyPair.create run inside one
+    // withBypassRls scope (findUnique + CAS + owner lookup = 3 calls).
+    expect(mockWithBypassRls).toHaveBeenCalled();
     expect(mockTxGrantUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({

--- a/src/app/api/emergency-access/[id]/accept/route.ts
+++ b/src/app/api/emergency-access/[id]/accept/route.ts
@@ -67,34 +67,32 @@ async function handlePOST(
   // creates the escrow key pair if the transition actually fired. Wrapping
   // both writes in $transaction ensures the key pair never exists for a
   // grant whose status was already moved by a concurrent request.
-  const txResult = await withBypassRls(prisma, async (tx) =>
-    prisma.$transaction(async (tx) => {
-      // C6 (early-return variant): if transition() reports !ok, the surrounding
-      // tx commits but nothing follows the early return inside this callback,
-      // so the post-CAS keyPair.create is correctly gated. Equivalent to throw
-      // for atomicity purposes — see deviation log §C6 alternative pattern.
-      const transitionResult = await transition({
-        db: tx,
-        where: { id, granteeEmail: grant.granteeEmail },
-        to: EA_STATUS.ACCEPTED,
-        actor: EA_ACTOR.GRANTEE,
-        extraData: { granteeId: session.user.id, granteePublicKey },
-      });
-      if (!transitionResult.ok) {
-        return { ok: false as const };
-      }
-      await tx.emergencyAccessKeyPair.create({
-        data: {
-          grantId: id,
-          tenantId: grant.tenantId,
-          encryptedPrivateKey: encryptedPrivateKey.ciphertext,
-          privateKeyIv: encryptedPrivateKey.iv,
-          privateKeyAuthTag: encryptedPrivateKey.authTag,
-        },
-      });
-      return { ok: true as const };
-    }),
-  BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+  const txResult = await withBypassRls(prisma, async (tx) => {
+    // C6 (early-return variant): if transition() reports !ok, the surrounding
+    // tx commits but nothing follows the early return inside this callback,
+    // so the post-CAS keyPair.create is correctly gated. Equivalent to throw
+    // for atomicity purposes — see deviation log §C6 alternative pattern.
+    const transitionResult = await transition({
+      db: tx,
+      where: { id, granteeEmail: grant.granteeEmail },
+      to: EA_STATUS.ACCEPTED,
+      actor: EA_ACTOR.GRANTEE,
+      extraData: { granteeId: session.user.id, granteePublicKey },
+    });
+    if (!transitionResult.ok) {
+      return { ok: false as const };
+    }
+    await tx.emergencyAccessKeyPair.create({
+      data: {
+        grantId: id,
+        tenantId: grant.tenantId,
+        encryptedPrivateKey: encryptedPrivateKey.ciphertext,
+        privateKeyIv: encryptedPrivateKey.iv,
+        privateKeyAuthTag: encryptedPrivateKey.authTag,
+      },
+    });
+    return { ok: true as const };
+  }, BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
   if (!txResult.ok) {
     return errorResponse(API_ERROR.GRANT_NOT_PENDING);

--- a/src/app/api/emergency-access/[id]/decline/route.ts
+++ b/src/app/api/emergency-access/[id]/decline/route.ts
@@ -42,7 +42,7 @@ async function handlePOST(
   // Atomic compare-and-swap: only transitions a still-PENDING row.
   const transitionResult = await withBypassRls(prisma, async (tx) =>
     transition({
-      db: prisma,
+      db: tx,
       where: { id, granteeEmail: grant.granteeEmail },
       to: EA_STATUS.REJECTED,
       actor: EA_ACTOR.GRANTEE,

--- a/src/app/api/emergency-access/[id]/request/route.ts
+++ b/src/app/api/emergency-access/[id]/request/route.ts
@@ -51,7 +51,7 @@ async function handlePOST(
   // would otherwise race past the optimistic canTransition check.
   const transitionResult = await withBypassRls(prisma, async (tx) =>
     transition({
-      db: prisma,
+      db: tx,
       where: { id, granteeId: session.user.id },
       to: EA_STATUS.REQUESTED,
       actor: EA_ACTOR.GRANTEE,

--- a/src/app/api/emergency-access/[id]/vault/route.ts
+++ b/src/app/api/emergency-access/[id]/vault/route.ts
@@ -53,6 +53,7 @@ async function handleGET(
       prisma,
       async (tx) =>
         autoPromoteIfElapsed({
+          db: tx,
           granteeId: session.user.id,
           grantId: id,
           now: new Date(),

--- a/src/app/api/emergency-access/accept/route.test.ts
+++ b/src/app/api/emergency-access/accept/route.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockPrismaGrant, mockPrismaUser, mockTransaction, mockTxGrantUpdateMany, mockTxKeyPairCreate, mockSendEmail, mockWithBypassRls } = vi.hoisted(() => ({
+const { mockAuth, mockPrismaGrant, mockPrismaUser, mockTxGrantUpdateMany, mockTxKeyPairCreate, mockSendEmail, mockWithBypassRls } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockPrismaGrant: {
     findUnique: vi.fn(),
+    updateMany: vi.fn(),
   },
   mockPrismaUser: { findUnique: vi.fn() },
-  mockTransaction: vi.fn(),
   mockTxGrantUpdateMany: vi.fn(),
   mockTxKeyPairCreate: vi.fn(),
   mockSendEmail: vi.fn(),
@@ -18,8 +18,8 @@ vi.mock("@/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     emergencyAccessGrant: mockPrismaGrant,
+    emergencyAccessKeyPair: { create: mockTxKeyPairCreate },
     user: mockPrismaUser,
-    $transaction: mockTransaction,
   },
 }));
 vi.mock("@/lib/email", () => ({ sendEmail: mockSendEmail }));
@@ -66,13 +66,10 @@ describe("POST /api/emergency-access/accept", () => {
     mockAuth.mockResolvedValue({ user: { id: "grantee-1", email: "grantee@test.com" } });
     mockPrismaGrant.findUnique.mockResolvedValue(validGrant);
     mockTxGrantUpdateMany.mockResolvedValue({ count: 1 });
+    // transition({ db: tx }) runs directly on the withBypassRls callback's tx
+    // (the mocked prisma), so the CAS updateMany lands on mockPrismaGrant.
+    mockPrismaGrant.updateMany.mockImplementation((...args) => mockTxGrantUpdateMany(...args));
     mockTxKeyPairCreate.mockResolvedValue({});
-    mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
-      cb({
-        emergencyAccessGrant: { updateMany: mockTxGrantUpdateMany },
-        emergencyAccessKeyPair: { create: mockTxKeyPairCreate },
-      }),
-    );
     mockPrismaUser.findUnique.mockResolvedValue({ email: "owner@test.com", name: "Owner Name" });
   });
 
@@ -144,7 +141,9 @@ describe("POST /api/emergency-access/accept", () => {
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.status).toBe(EA_STATUS.ACCEPTED);
-    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    // Atomicity: the CAS transition + escrow keyPair.create run inside one
+    // withBypassRls scope (findUnique + CAS + owner lookup = 3 calls).
+    expect(mockWithBypassRls).toHaveBeenCalled();
     expect(mockTxGrantUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({

--- a/src/app/api/emergency-access/accept/route.ts
+++ b/src/app/api/emergency-access/accept/route.ts
@@ -70,34 +70,32 @@ async function handlePOST(req: NextRequest) {
 
   // Atomic compare-and-swap: only transitions a still-PENDING row, and only
   // creates the escrow key pair if the transition actually fired.
-  const txResult = await withBypassRls(prisma, async (tx) =>
-    prisma.$transaction(async (tx) => {
-      // C6 (early-return variant): if transition() reports !ok, the surrounding
-      // tx commits but nothing follows the early return inside this callback,
-      // so the post-CAS keyPair.create is correctly gated. Equivalent to throw
-      // for atomicity purposes — see deviation log §C6 alternative pattern.
-      const transitionResult = await transition({
-        db: tx,
-        where: { id: grant.id, tokenHash: grant.tokenHash },
-        to: EA_STATUS.ACCEPTED,
-        actor: EA_ACTOR.GRANTEE,
-        extraData: { granteeId: session.user.id, granteePublicKey },
-      });
-      if (!transitionResult.ok) {
-        return { ok: false as const };
-      }
-      await tx.emergencyAccessKeyPair.create({
-        data: {
-          grantId: grant.id,
-          tenantId: grant.tenantId,
-          encryptedPrivateKey: encryptedPrivateKey.ciphertext,
-          privateKeyIv: encryptedPrivateKey.iv,
-          privateKeyAuthTag: encryptedPrivateKey.authTag,
-        },
-      });
-      return { ok: true as const };
-    }),
-  BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+  const txResult = await withBypassRls(prisma, async (tx) => {
+    // C6 (early-return variant): if transition() reports !ok, the surrounding
+    // tx commits but nothing follows the early return inside this callback,
+    // so the post-CAS keyPair.create is correctly gated. Equivalent to throw
+    // for atomicity purposes — see deviation log §C6 alternative pattern.
+    const transitionResult = await transition({
+      db: tx,
+      where: { id: grant.id, tokenHash: grant.tokenHash },
+      to: EA_STATUS.ACCEPTED,
+      actor: EA_ACTOR.GRANTEE,
+      extraData: { granteeId: session.user.id, granteePublicKey },
+    });
+    if (!transitionResult.ok) {
+      return { ok: false as const };
+    }
+    await tx.emergencyAccessKeyPair.create({
+      data: {
+        grantId: grant.id,
+        tenantId: grant.tenantId,
+        encryptedPrivateKey: encryptedPrivateKey.ciphertext,
+        privateKeyIv: encryptedPrivateKey.iv,
+        privateKeyAuthTag: encryptedPrivateKey.authTag,
+      },
+    });
+    return { ok: true as const };
+  }, BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
   if (!txResult.ok) {
     return errorResponse(API_ERROR.INVITATION_ALREADY_USED);

--- a/src/app/api/emergency-access/reject/route.ts
+++ b/src/app/api/emergency-access/reject/route.ts
@@ -44,7 +44,7 @@ async function handlePOST(req: NextRequest) {
   // Atomic compare-and-swap: only transitions a still-PENDING row.
   const transitionResult = await withBypassRls(prisma, async (tx) =>
     transition({
-      db: prisma,
+      db: tx,
       where: { id: grant.id, tokenHash: grant.tokenHash },
       to: EA_STATUS.REJECTED,
       actor: EA_ACTOR.GRANTEE,

--- a/src/app/api/extension/bridge-code/route.test.ts
+++ b/src/app/api/extension/bridge-code/route.test.ts
@@ -51,6 +51,9 @@ vi.mock("@/lib/prisma", () => ({
     user: {
       findUnique: mockUserFindUnique,
     },
+    // withBypassRls passes `prisma` as the tx; the route acquires a
+    // pg_advisory_xact_lock via tx.$executeRaw before the count-then-create.
+    $executeRaw: vi.fn().mockResolvedValue(1),
   },
 }));
 vi.mock("@/lib/crypto/crypto-server", () => ({

--- a/src/app/api/extension/bridge-code/route.test.ts
+++ b/src/app/api/extension/bridge-code/route.test.ts
@@ -10,6 +10,7 @@ const {
   mockBridgeCodeFindMany,
   mockBridgeCodeUpdateMany,
   mockUserFindUnique,
+  mockExecuteRaw,
   mockCheck,
   mockCheckIpRateLimit,
   mockCheckRateLimitOrFail,
@@ -27,6 +28,7 @@ const {
   mockBridgeCodeFindMany: vi.fn(),
   mockBridgeCodeUpdateMany: vi.fn(),
   mockUserFindUnique: vi.fn(),
+  mockExecuteRaw: vi.fn().mockResolvedValue(1),
   mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
   mockCheckIpRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
   mockCheckRateLimitOrFail: vi.fn().mockResolvedValue(null),
@@ -53,7 +55,7 @@ vi.mock("@/lib/prisma", () => ({
     },
     // withBypassRls passes `prisma` as the tx; the route acquires a
     // pg_advisory_xact_lock via tx.$executeRaw before the count-then-create.
-    $executeRaw: vi.fn().mockResolvedValue(1),
+    $executeRaw: mockExecuteRaw,
   },
 }));
 vi.mock("@/lib/crypto/crypto-server", () => ({
@@ -376,6 +378,15 @@ describe("POST /api/extension/bridge-code", () => {
     expect(mockLogAudit).not.toHaveBeenCalledWith(
       expect.objectContaining({ action: "EXTENSION_BRIDGE_CODE_ISSUE_FAILURE" }),
     );
+
+    // The count-then-create runs under a per-user advisory lock (TOCTOU fix).
+    // Mutation-kill: removing the tx.$executeRaw lock line would leave
+    // $executeRaw uncalled with this SQL.
+    expect(
+      mockExecuteRaw.mock.calls.some((c) =>
+        String(c[0]).includes("pg_advisory_xact_lock"),
+      ),
+    ).toBe(true);
   });
 
   it("revokes oldest unused codes when BRIDGE_CODE_MAX_ACTIVE is exceeded", async () => {

--- a/src/app/api/extension/bridge-code/route.ts
+++ b/src/app/api/extension/bridge-code/route.ts
@@ -37,7 +37,7 @@ import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { checkIpRateLimit } from "@/lib/security/ip-rate-limit";
 import { extractClientIp } from "@/lib/auth/policy/ip-access";
 import { checkAccessRestrictionWithAudit } from "@/lib/auth/policy/access-restriction";
-import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+import { withBypassRls, BYPASS_PURPOSE, advisoryXactLock } from "@/lib/tenant-rls";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { logAuditAsync, extractRequestMeta, personalAuditBase } from "@/lib/audit/audit";
 import { emitBridgeCodeIssueFailure } from "@/lib/audit/bridge-code-failure";
@@ -274,7 +274,7 @@ async function handlePOST(req: NextRequest) {
       // (two concurrent issues both reading active.length < max). Advisory lock
       // is transaction-scoped; matches the codebase idiom (attachments, vault
       // rotate-key).
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`;
+      await advisoryXactLock(tx, userId);
       const active = await tx.extensionBridgeCode.findMany({
         where: { userId, usedAt: null, expiresAt: { gt: now } },
         orderBy: { createdAt: "asc" },

--- a/src/app/api/extension/bridge-code/route.ts
+++ b/src/app/api/extension/bridge-code/route.ts
@@ -269,6 +269,12 @@ async function handlePOST(req: NextRequest) {
 
   try {
     await withBypassRls(prisma, async (tx) => {
+      // Serialize concurrent bridge-code issuance for this user so the
+      // count-then-evict-then-create sequence cannot race past the active cap
+      // (two concurrent issues both reading active.length < max). Advisory lock
+      // is transaction-scoped; matches the codebase idiom (attachments, vault
+      // rotate-key).
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`;
       const active = await tx.extensionBridgeCode.findMany({
         where: { userId, usedAt: null, expiresAt: { gt: now } },
         orderBy: { createdAt: "asc" },

--- a/src/app/api/extension/token/exchange/route.test.ts
+++ b/src/app/api/extension/token/exchange/route.test.ts
@@ -119,6 +119,9 @@ describe("POST /api/extension/token/exchange", () => {
     // Provide a default that runs the callback against the mocked Prisma surface.
     mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
       cb({
+        // issueExtensionToken acquires a pg_advisory_xact_lock via
+        // tx.$executeRaw before the count-then-create cap enforcement.
+        $executeRaw: vi.fn().mockResolvedValue(1),
         extensionToken: {
           findMany: mockExtensionTokenFindMany,
           create: mockExtensionTokenCreate,

--- a/src/app/api/maintenance/audit-chain-verify/route.ts
+++ b/src/app/api/maintenance/audit-chain-verify/route.ts
@@ -141,7 +141,7 @@ async function handleGET(req: NextRequest) {
   const anchors = await withBypassRls(
     prisma,
     async (tx) =>
-      prisma.$queryRawUnsafe<AnchorRow[]>(
+      tx.$queryRawUnsafe<AnchorRow[]>(
         `SELECT chain_seq FROM audit_chain_anchors WHERE tenant_id = $1`,
         tenantId,
       ),
@@ -160,7 +160,7 @@ async function handleGET(req: NextRequest) {
     const fromRows = await withBypassRls(
       prisma,
       async (tx) =>
-        prisma.$queryRawUnsafe<SeqBoundRow[]>(
+        tx.$queryRawUnsafe<SeqBoundRow[]>(
           `SELECT MIN(chain_seq) AS chain_seq
            FROM audit_logs
            WHERE tenant_id = $1
@@ -183,7 +183,7 @@ async function handleGET(req: NextRequest) {
     const toRows = await withBypassRls(
       prisma,
       async (tx) =>
-        prisma.$queryRawUnsafe<SeqBoundRow[]>(
+        tx.$queryRawUnsafe<SeqBoundRow[]>(
           `SELECT MAX(chain_seq) AS chain_seq
            FROM audit_logs
            WHERE tenant_id = $1
@@ -206,7 +206,7 @@ async function handleGET(req: NextRequest) {
     const seedRows = await withBypassRls(
       prisma,
       async (tx) =>
-        prisma.$queryRawUnsafe<{ event_hash: Uint8Array }[]>(
+        tx.$queryRawUnsafe<{ event_hash: Uint8Array }[]>(
           `SELECT event_hash
            FROM audit_logs
            WHERE tenant_id = $1
@@ -234,7 +234,7 @@ async function handleGET(req: NextRequest) {
   const rows = await withBypassRls(
     prisma,
     async (tx) =>
-      prisma.$queryRawUnsafe<ChainRowRaw[]>(
+      tx.$queryRawUnsafe<ChainRowRaw[]>(
         `SELECT id, tenant_id, created_at,
                 chain_seq, event_hash, chain_prev_hash, metadata
          FROM audit_logs

--- a/src/app/api/maintenance/audit-outbox-metrics/route.ts
+++ b/src/app/api/maintenance/audit-outbox-metrics/route.ts
@@ -64,7 +64,7 @@ async function handleGET(req: NextRequest) {
   // WHERE filter, queue depth and failure counts of every other tenant
   // leak through this endpoint.
   const rows = await withBypassRls(prisma, async (tx) =>
-    prisma.$queryRaw<MetricsRow[]>`
+    tx.$queryRaw<MetricsRow[]>`
       SELECT
         COUNT(*) FILTER (WHERE status = 'PENDING')    AS pending,
         COUNT(*) FILTER (WHERE status = 'PROCESSING') AS processing,

--- a/src/app/api/maintenance/audit-outbox-purge-failed/route.ts
+++ b/src/app/api/maintenance/audit-outbox-purge-failed/route.ts
@@ -80,7 +80,7 @@ async function handlePOST(req: NextRequest) {
   const rows = await withBypassRls(
     prisma,
     async (tx) =>
-      prisma.$queryRaw<{ purged: bigint }[]>`
+      tx.$queryRaw<{ purged: bigint }[]>`
         WITH deleted AS (
           DELETE FROM audit_outbox
           WHERE status = 'FAILED'

--- a/src/app/api/mcp/register/route.test.ts
+++ b/src/app/api/mcp/register/route.test.ts
@@ -337,22 +337,20 @@ describe("POST /api/mcp/register", () => {
     expect(status).toBe(201);
   });
 
-  // C6 acceptance: deleteMany called with exact where before count (invocationCallOrder)
-  // T9: tx-side deleteMany (mockTxDeleteMany) is distinct from top-level mockPrismaDeleteMany,
-  // proving the operation executes inside the transaction.
+  // C6 acceptance: deleteMany called with exact where before count (invocationCallOrder).
+  // The lazy-cleanup deleteMany + count + create now run directly on the
+  // withBypassRls callback's tx (redundant inner $transaction removed), so the
+  // tx-scoped deleteMany is mockPrismaDeleteMany — the mcpClient method carried
+  // by the prisma mock that mockWithBypassRls passes through as `tx`.
   it("C6: calls deleteMany with expired-unclaimed where before count inside transaction", async () => {
     const req = createRequest("POST", "http://localhost/api/mcp/register", {
       body: VALID_BODY,
     });
     await POST(req);
 
-    // T9: top-level prisma.mcpClient.deleteMany must NOT have been called directly —
-    // only the tx-scoped version runs inside the transaction.
-    expect(mockPrismaDeleteMany).not.toHaveBeenCalled();
-
-    // T9 + C6: tx deleteMany must be called with the exact C6 where clause
-    expect(mockTxDeleteMany).toHaveBeenCalledOnce();
-    const deleteManyCall = mockTxDeleteMany.mock.calls[0]?.[0] as {
+    // C6: tx deleteMany must be called exactly once with the exact C6 where clause
+    expect(mockPrismaDeleteMany).toHaveBeenCalledOnce();
+    const deleteManyCall = mockPrismaDeleteMany.mock.calls[0]?.[0] as {
       where: { isDcr: boolean; tenantId: null; dcrExpiresAt: { lt: unknown } };
     };
     expect(deleteManyCall.where.isDcr).toBe(true);
@@ -360,7 +358,7 @@ describe("POST /api/mcp/register", () => {
     expect(deleteManyCall.where.dcrExpiresAt.lt).toBeInstanceOf(Date);
 
     // deleteMany must be called BEFORE count (invocationCallOrder guard)
-    const deleteManyOrder = mockTxDeleteMany.mock.invocationCallOrder[0]!;
+    const deleteManyOrder = mockPrismaDeleteMany.mock.invocationCallOrder[0]!;
     const countOrder = mockPrismaCount.mock.invocationCallOrder[0]!;
     expect(deleteManyOrder).toBeLessThan(countOrder);
   });

--- a/src/app/api/mcp/register/route.test.ts
+++ b/src/app/api/mcp/register/route.test.ts
@@ -7,6 +7,7 @@ const {
   mockPrismaDeleteMany,
   mockTxDeleteMany,
   mockWithBypassRls,
+  mockExecuteRaw,
   mockRateLimiterCheck,
   mockExtractClientIp,
   mockRateLimitKeyFromIp,
@@ -23,6 +24,7 @@ const {
     mockPrismaDeleteMany: mockDeleteMany,
     mockTxDeleteMany,
     mockWithBypassRls,
+    mockExecuteRaw: vi.fn().mockResolvedValue(1),
     mockRateLimiterCheck: vi.fn().mockResolvedValue({ allowed: true }),
     mockExtractClientIp: vi.fn().mockReturnValue("127.0.0.1"),
     mockRateLimitKeyFromIp: vi.fn((ip: string) => ip),
@@ -37,6 +39,10 @@ vi.mock("@/lib/prisma", () => ({
       create: mockPrismaCreate,
       deleteMany: mockPrismaDeleteMany,
     },
+    // The DCR-registration tx now acquires a fixed-key advisory lock as its
+    // first statement (tx.$executeRaw); mockWithBypassRls passes this prisma
+    // object through as tx.
+    $executeRaw: mockExecuteRaw,
     $transaction: vi.fn(async (fn: (tx: unknown) => unknown) =>
       fn({
         mcpClient: {
@@ -44,6 +50,7 @@ vi.mock("@/lib/prisma", () => ({
           create: mockPrismaCreate,
           deleteMany: mockTxDeleteMany,
         },
+        $executeRaw: mockExecuteRaw,
       }),
     ),
   },
@@ -82,6 +89,16 @@ const MOCK_CREATED_CLIENT = {
   clientId: "mcpc_abcdef1234567890abcdef1234567890",
   createdAt: new Date("2024-01-01T00:00:00Z"),
 };
+
+// Asserts the fixed-key advisory lock ($executeRaw with pg_advisory_xact_lock)
+// was acquired. Mutation-kill: deleting the lock line from the production
+// deleteMany-count-create tx leaves $executeRaw uncalled with that SQL, so
+// this fails.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
+}
 
 describe("POST /api/mcp/register", () => {
   beforeEach(() => {
@@ -126,6 +143,9 @@ describe("POST /api/mcp/register", () => {
       | undefined;
     expect(createCall?.data.clientSecretHash).toBe("");
     expect(createCall?.data.isDcr).toBe(true);
+
+    // Lock acquired before the deleteMany + count-cap-check + create (TOCTOU fix).
+    expectAdvisoryLockAcquired(mockExecuteRaw);
   });
 
   it("returns 400 with invalid_client_metadata when client_name is missing", async () => {

--- a/src/app/api/mcp/register/route.ts
+++ b/src/app/api/mcp/register/route.ts
@@ -138,6 +138,12 @@ async function handlePOST(req: NextRequest) {
   let client: { id: string; clientId: string; createdAt: Date };
   try {
     client = await withBypassRls(prisma, async (tx) => {
+      // Serialize the global unclaimed-DCR-client cap check with the create
+      // under a fixed-key advisory lock so concurrent registrations cannot both
+      // read count < MAX and both create, blowing past MAX_UNCLAIMED_DCR_CLIENTS
+      // (TOCTOU). A fixed key serializes all DCR registrations globally —
+      // acceptable for this rate-limited anti-DoS pre-auth endpoint.
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('mcp-dcr-register'))`;
       // Lazy cleanup: remove expired unclaimed DCR clients before counting.
       // Removes the hard dependency on dcr-cleanup-worker for cap recovery.
       await tx.mcpClient.deleteMany({

--- a/src/app/api/mcp/register/route.ts
+++ b/src/app/api/mcp/register/route.ts
@@ -137,37 +137,35 @@ async function handlePOST(req: NextRequest) {
   // Count + create atomically with bypass RLS (no tenant context for DCR)
   let client: { id: string; clientId: string; createdAt: Date };
   try {
-    client = await withBypassRls(prisma, async (tx) =>
-      prisma.$transaction(async (tx) => {
-        // Lazy cleanup: remove expired unclaimed DCR clients before counting.
-        // Removes the hard dependency on dcr-cleanup-worker for cap recovery.
-        await tx.mcpClient.deleteMany({
-          where: { isDcr: true, tenantId: null, dcrExpiresAt: { lt: new Date() } },
-        });
-        // Global cap: reject if too many unclaimed DCR clients exist
-        const unclaimedCount = await tx.mcpClient.count({
-          where: { isDcr: true, tenantId: null },
-        });
-        if (unclaimedCount >= MAX_UNCLAIMED_DCR_CLIENTS) {
-          throw new CapExceededError();
-        }
+    client = await withBypassRls(prisma, async (tx) => {
+      // Lazy cleanup: remove expired unclaimed DCR clients before counting.
+      // Removes the hard dependency on dcr-cleanup-worker for cap recovery.
+      await tx.mcpClient.deleteMany({
+        where: { isDcr: true, tenantId: null, dcrExpiresAt: { lt: new Date() } },
+      });
+      // Global cap: reject if too many unclaimed DCR clients exist
+      const unclaimedCount = await tx.mcpClient.count({
+        where: { isDcr: true, tenantId: null },
+      });
+      if (unclaimedCount >= MAX_UNCLAIMED_DCR_CLIENTS) {
+        throw new CapExceededError();
+      }
 
-        return tx.mcpClient.create({
-          data: {
-            clientId,
-            clientSecretHash,
-            name: body.client_name,
-            redirectUris: validatedUris,
-            allowedScopes: MCP_SCOPES.join(","),
-            isDcr: true,
-            dcrExpiresAt,
-            // tenantId: null (omitted)
-            // createdById: null (omitted)
-          },
-          select: { id: true, clientId: true, createdAt: true },
-        });
-      }),
-    BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+      return tx.mcpClient.create({
+        data: {
+          clientId,
+          clientSecretHash,
+          name: body.client_name,
+          redirectUris: validatedUris,
+          allowedScopes: MCP_SCOPES.join(","),
+          isDcr: true,
+          dcrExpiresAt,
+          // tenantId: null (omitted)
+          // createdById: null (omitted)
+        },
+        select: { id: true, clientId: true, createdAt: true },
+      });
+    }, BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
   } catch (err) {
     if (err instanceof CapExceededError) {
       return NextResponse.json(

--- a/src/app/api/mcp/register/route.ts
+++ b/src/app/api/mcp/register/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { randomBytes } from "node:crypto";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+import { withBypassRls, BYPASS_PURPOSE, advisoryXactLock } from "@/lib/tenant-rls";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { readJsonWithCap } from "@/lib/http/parse-body";
 import { MAX_JSON_BODY_BYTES } from "@/lib/validations/common.server";
@@ -143,7 +143,7 @@ async function handlePOST(req: NextRequest) {
       // read count < MAX and both create, blowing past MAX_UNCLAIMED_DCR_CLIENTS
       // (TOCTOU). A fixed key serializes all DCR registrations globally —
       // acceptable for this rate-limited anti-DoS pre-auth endpoint.
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('mcp-dcr-register'))`;
+      await advisoryXactLock(tx, "mcp-dcr-register");
       // Lazy cleanup: remove expired unclaimed DCR clients before counting.
       // Removes the hard dependency on dcr-cleanup-worker for cap recovery.
       await tx.mcpClient.deleteMany({

--- a/src/app/api/passwords/[id]/attachments/[attachmentId]/migrate/route.ts
+++ b/src/app/api/passwords/[id]/attachments/[attachmentId]/migrate/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { advisoryXactLock } from "@/lib/tenant-rls";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { withRequestLog } from "@/lib/http/with-request-log";
@@ -135,7 +136,7 @@ async function handlePUT(
         // keyVersion equality check is not racy against a concurrent
         // rotation that bumped the keyVersion between request boundary and
         // lock acquisition.
-        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`;
+        await advisoryXactLock(tx, userId);
 
         const u = await tx.user.findUnique({
           where: { id: userId },

--- a/src/app/api/passwords/[id]/attachments/route.test.ts
+++ b/src/app/api/passwords/[id]/attachments/route.test.ts
@@ -89,6 +89,15 @@ function createParams(id: string) {
   return { params: Promise.resolve({ id }) };
 }
 
+// Asserts the per-user advisory lock ($executeRaw with pg_advisory_xact_lock)
+// was acquired inside the upload tx. Mutation-kill: deleting the lock line from
+// the production locked-tx path leaves $executeRaw uncalled with that SQL.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
+}
+
 vi.mock("@/lib/quota/resource-quotas", () => ({
   assertQuotaAvailable: vi.fn().mockResolvedValue(undefined),
   QuotaExceededError: class extends Error {},
@@ -386,6 +395,7 @@ describe("POST /api/passwords/[id]/attachments", () => {
       createParams("pw-1")
     );
     expect(res.status).toBe(201);
+    expectAdvisoryLockAcquired(txMock.$executeRaw);
     expect(mockPrismaAttachment.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({

--- a/src/app/api/passwords/[id]/attachments/route.ts
+++ b/src/app/api/passwords/[id]/attachments/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { advisoryXactLock } from "@/lib/tenant-rls";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import {
   ALLOWED_EXTENSIONS,
@@ -270,7 +271,7 @@ async function handlePOST(
         // user.keyVersion read AND attachment.create closes the TOCTOU
         // window — a rotation that commits between our read and create
         // can no longer land a stale-cekKeyVersion mode-2 row.
-        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${session.user.id}::text))`;
+        await advisoryXactLock(tx, session.user.id);
 
         // Re-check the per-entry attachment cap under the same lock so
         // concurrent uploads cannot both pass count < MAX and both create.

--- a/src/app/api/passwords/[id]/attachments/route.ts
+++ b/src/app/api/passwords/[id]/attachments/route.ts
@@ -26,6 +26,11 @@ import { LegacyAttachmentInconsistentVersionError } from "@/lib/vault/rotate-key
 
 type RouteContext = { params: Promise<{ id: string }> };
 
+// Sentinel thrown inside the locked transaction when the re-checked per-entry
+// attachment count is at the cap. Mapped to ATTACHMENT_LIMIT_EXCEEDED outside
+// the tx.
+class AttachmentLimitError extends Error {}
+
 const attachmentUploadLimiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 30 });
 
 function getExtension(filename: string): string {
@@ -106,15 +111,10 @@ async function handlePOST(
   const rl = await attachmentUploadLimiter.check(`rl:attachment_upload:${session.user.id}`);
   if (!rl.allowed) return rateLimited(rl.retryAfterMs);
 
-  // Check attachment count limit
-  const count = await withUserTenantRls(session.user.id, async () =>
-    prisma.attachment.count({
-      where: { passwordEntryId: id },
-    }),
-  );
-  if (count >= MAX_ATTACHMENTS_PER_ENTRY) {
-    return errorResponse(API_ERROR.ATTACHMENT_LIMIT_EXCEEDED);
-  }
+  // The per-entry attachment cap is re-checked INSIDE the advisory-locked tx
+  // below (under the existing per-user lock), so two concurrent uploads cannot
+  // both read count < MAX and both create, blowing past
+  // MAX_ATTACHMENTS_PER_ENTRY (TOCTOU).
 
   // Early rejection before buffering the multipart body into memory. Requires a
   // declared Content-Length and caps it — fail-closed on a missing header so a
@@ -272,6 +272,15 @@ async function handlePOST(
         // can no longer land a stale-cekKeyVersion mode-2 row.
         await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${session.user.id}::text))`;
 
+        // Re-check the per-entry attachment cap under the same lock so
+        // concurrent uploads cannot both pass count < MAX and both create.
+        const count = await tx.attachment.count({
+          where: { passwordEntryId: id },
+        });
+        if (count >= MAX_ATTACHMENTS_PER_ENTRY) {
+          throw new AttachmentLimitError();
+        }
+
         const currentUser = await tx.user.findUnique({
           where: { id: session.user.id },
           select: { keyVersion: true },
@@ -316,6 +325,9 @@ async function handlePOST(
     );
   } catch (error) {
     await blobStore.deleteObject(storedBlob, blobContext).catch(() => {});
+    if (error instanceof AttachmentLimitError) {
+      return errorResponse(API_ERROR.ATTACHMENT_LIMIT_EXCEEDED);
+    }
     if (error instanceof LegacyAttachmentInconsistentVersionError) {
       return errorResponse(API_ERROR.ATTACHMENT_INCONSISTENT_VERSION);
     }

--- a/src/app/api/scim/v2/Groups/[id]/route.ts
+++ b/src/app/api/scim/v2/Groups/[id]/route.ts
@@ -31,7 +31,7 @@ async function handleGET(req: NextRequest, { params }: Params) {
   const { id } = await params;
 
   return withTenantRls(prisma, tenantId, async (tx) => {
-    const resource = await fetchScimGroup(tenantId, id, getScimBaseUrl());
+    const resource = await fetchScimGroup(tenantId, id, getScimBaseUrl(), tx);
     if (!resource) {
       return scimError(404, "Group not found");
     }
@@ -56,7 +56,7 @@ async function handlePUT(req: NextRequest, { params }: Params): Promise<Response
       replaceScimGroup(tenantId, id, {
         displayName: bodyResult.data.displayName,
         memberUserIds: bodyResult.data.members.map((m) => m.value),
-      }, getScimBaseUrl()),
+      }, getScimBaseUrl(), tx),
     );
   } catch (e) {
     if (e instanceof ScimGroupNotFoundError) {
@@ -115,7 +115,7 @@ async function handlePATCH(req: NextRequest, { params }: Params): Promise<Respon
   let serviceResult: Awaited<ReturnType<typeof patchScimGroup>>;
   try {
     serviceResult = await withTenantRls(prisma, tenantId, (tx) =>
-      patchScimGroup(tenantId, id, actions, getScimBaseUrl()),
+      patchScimGroup(tenantId, id, actions, getScimBaseUrl(), tx),
     );
   } catch (e) {
     if (e instanceof ScimGroupNotFoundError) {

--- a/src/app/api/scim/v2/ResourceTypes/route.ts
+++ b/src/app/api/scim/v2/ResourceTypes/route.ts
@@ -1,7 +1,5 @@
 import type { NextRequest } from "next/server";
 import { scimResponse } from "@/lib/scim/response";
-import { withTenantRls } from "@/lib/tenant-rls";
-import { prisma } from "@/lib/prisma";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { authorizeScim } from "@/lib/scim/with-scim-auth";
 
@@ -9,34 +7,31 @@ import { authorizeScim } from "@/lib/scim/with-scim-auth";
 async function handleGET(req: NextRequest) {
   const auth = await authorizeScim(req);
   if (!auth.ok) return auth.response;
-  const { tenantId } = auth.data;
 
-  return withTenantRls(prisma, tenantId, async (tx) =>
-    scimResponse([
-      {
-        schemas: ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
-        id: "User",
-        name: "User",
-        endpoint: "/Users",
-        schema: "urn:ietf:params:scim:schemas:core:2.0:User",
-        meta: {
-          resourceType: "ResourceType",
-          location: "/api/scim/v2/ResourceTypes/User",
-        },
+  return scimResponse([
+    {
+      schemas: ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+      id: "User",
+      name: "User",
+      endpoint: "/Users",
+      schema: "urn:ietf:params:scim:schemas:core:2.0:User",
+      meta: {
+        resourceType: "ResourceType",
+        location: "/api/scim/v2/ResourceTypes/User",
       },
-      {
-        schemas: ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
-        id: "Group",
-        name: "Group",
-        endpoint: "/Groups",
-        schema: "urn:ietf:params:scim:schemas:core:2.0:Group",
-        meta: {
-          resourceType: "ResourceType",
-          location: "/api/scim/v2/ResourceTypes/Group",
-        },
+    },
+    {
+      schemas: ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+      id: "Group",
+      name: "Group",
+      endpoint: "/Groups",
+      schema: "urn:ietf:params:scim:schemas:core:2.0:Group",
+      meta: {
+        resourceType: "ResourceType",
+        location: "/api/scim/v2/ResourceTypes/Group",
       },
-    ]),
-  );
+    },
+  ]);
 }
 
 export const GET = withRequestLog(handleGET);

--- a/src/app/api/scim/v2/Schemas/route.ts
+++ b/src/app/api/scim/v2/Schemas/route.ts
@@ -1,7 +1,5 @@
 import type { NextRequest } from "next/server";
 import { scimResponse } from "@/lib/scim/response";
-import { withTenantRls } from "@/lib/tenant-rls";
-import { prisma } from "@/lib/prisma";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { authorizeScim } from "@/lib/scim/with-scim-auth";
 
@@ -9,102 +7,99 @@ import { authorizeScim } from "@/lib/scim/with-scim-auth";
 async function handleGET(req: NextRequest) {
   const auth = await authorizeScim(req);
   if (!auth.ok) return auth.response;
-  const { tenantId } = auth.data;
 
-  return withTenantRls(prisma, tenantId, async (tx) =>
-    scimResponse([
-      {
-        schemas: ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
-        id: "urn:ietf:params:scim:schemas:core:2.0:User",
-        name: "User",
-        description: "User Account",
-        attributes: [
-          {
-            name: "userName",
-            type: "string",
-            multiValued: false,
-            required: true,
-            uniqueness: "server",
-            description: "Unique identifier for the User (email address)",
-          },
-          {
-            name: "name",
-            type: "complex",
-            multiValued: false,
-            required: false,
-            subAttributes: [
-              {
-                name: "formatted",
-                type: "string",
-                multiValued: false,
-                required: false,
-                description: "Display name",
-              },
-            ],
-          },
-          {
-            name: "active",
-            type: "boolean",
-            multiValued: false,
-            required: false,
-            description: "User active status in the team",
-          },
-          {
-            name: "externalId",
-            type: "string",
-            multiValued: false,
-            required: false,
-            description: "External identifier from the IdP",
-          },
-        ],
-        meta: {
-          resourceType: "Schema",
-          location: "/api/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
+  return scimResponse([
+    {
+      schemas: ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
+      id: "urn:ietf:params:scim:schemas:core:2.0:User",
+      name: "User",
+      description: "User Account",
+      attributes: [
+        {
+          name: "userName",
+          type: "string",
+          multiValued: false,
+          required: true,
+          uniqueness: "server",
+          description: "Unique identifier for the User (email address)",
         },
-      },
-      {
-        schemas: ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
-        id: "urn:ietf:params:scim:schemas:core:2.0:Group",
-        name: "Group",
-        description: "Group (role-based)",
-        attributes: [
-          {
-            name: "displayName",
-            type: "string",
-            multiValued: false,
-            required: true,
-            description: "Team role name (ADMIN, MEMBER, VIEWER)",
-          },
-          {
-            name: "members",
-            type: "complex",
-            multiValued: true,
-            required: false,
-            subAttributes: [
-              {
-                name: "value",
-                type: "string",
-                multiValued: false,
-                required: true,
-                description: "User ID",
-              },
-              {
-                name: "display",
-                type: "string",
-                multiValued: false,
-                required: false,
-                description: "User email",
-              },
-            ],
-          },
-        ],
-        meta: {
-          resourceType: "Schema",
-          location: "/api/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group",
+        {
+          name: "name",
+          type: "complex",
+          multiValued: false,
+          required: false,
+          subAttributes: [
+            {
+              name: "formatted",
+              type: "string",
+              multiValued: false,
+              required: false,
+              description: "Display name",
+            },
+          ],
         },
+        {
+          name: "active",
+          type: "boolean",
+          multiValued: false,
+          required: false,
+          description: "User active status in the team",
+        },
+        {
+          name: "externalId",
+          type: "string",
+          multiValued: false,
+          required: false,
+          description: "External identifier from the IdP",
+        },
+      ],
+      meta: {
+        resourceType: "Schema",
+        location: "/api/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
       },
-    ]),
-  );
+    },
+    {
+      schemas: ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
+      id: "urn:ietf:params:scim:schemas:core:2.0:Group",
+      name: "Group",
+      description: "Group (role-based)",
+      attributes: [
+        {
+          name: "displayName",
+          type: "string",
+          multiValued: false,
+          required: true,
+          description: "Team role name (ADMIN, MEMBER, VIEWER)",
+        },
+        {
+          name: "members",
+          type: "complex",
+          multiValued: true,
+          required: false,
+          subAttributes: [
+            {
+              name: "value",
+              type: "string",
+              multiValued: false,
+              required: true,
+              description: "User ID",
+            },
+            {
+              name: "display",
+              type: "string",
+              multiValued: false,
+              required: false,
+              description: "User email",
+            },
+          ],
+        },
+      ],
+      meta: {
+        resourceType: "Schema",
+        location: "/api/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group",
+      },
+    },
+  ]);
 }
 
 export const GET = withRequestLog(handleGET);

--- a/src/app/api/scim/v2/ServiceProviderConfig/route.ts
+++ b/src/app/api/scim/v2/ServiceProviderConfig/route.ts
@@ -1,7 +1,5 @@
 import type { NextRequest } from "next/server";
 import { scimResponse } from "@/lib/scim/response";
-import { withTenantRls } from "@/lib/tenant-rls";
-import { prisma } from "@/lib/prisma";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { authorizeScim } from "@/lib/scim/with-scim-auth";
 
@@ -9,28 +7,25 @@ import { authorizeScim } from "@/lib/scim/with-scim-auth";
 async function handleGET(req: NextRequest) {
   const auth = await authorizeScim(req);
   if (!auth.ok) return auth.response;
-  const { tenantId } = auth.data;
 
-  return withTenantRls(prisma, tenantId, async (tx) =>
-    scimResponse({
-      schemas: ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
-      documentationUri: "https://tools.ietf.org/html/rfc7644",
-      patch: { supported: true },
-      bulk: { supported: false, maxOperations: 0, maxPayloadSize: 0 },
-      filter: { supported: true, maxResults: 200 },
-      changePassword: { supported: false },
-      sort: { supported: false },
-      etag: { supported: false },
-      authenticationSchemes: [
-        {
-          type: "oauthbearertoken",
-          name: "OAuth Bearer Token",
-          description: "Authentication scheme using the OAuth Bearer Token Standard",
-          specUri: "https://tools.ietf.org/html/rfc6750",
-        },
-      ],
-    }),
-  );
+  return scimResponse({
+    schemas: ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+    documentationUri: "https://tools.ietf.org/html/rfc7644",
+    patch: { supported: true },
+    bulk: { supported: false, maxOperations: 0, maxPayloadSize: 0 },
+    filter: { supported: true, maxResults: 200 },
+    changePassword: { supported: false },
+    sort: { supported: false },
+    etag: { supported: false },
+    authenticationSchemes: [
+      {
+        type: "oauthbearertoken",
+        name: "OAuth Bearer Token",
+        description: "Authentication scheme using the OAuth Bearer Token Standard",
+        specUri: "https://tools.ietf.org/html/rfc6750",
+      },
+    ],
+  });
 }
 
 export const GET = withRequestLog(handleGET);

--- a/src/app/api/scim/v2/Users/[id]/route.ts
+++ b/src/app/api/scim/v2/Users/[id]/route.ts
@@ -37,7 +37,7 @@ async function handleGET(req: NextRequest, { params }: Params) {
 
   return withTenantRls(prisma, tenantId, async (tx) => {
     const { id } = await params;
-    const userId = await resolveUserId(tenantId, id);
+    const userId = await resolveUserId(tenantId, id, tx);
     if (!userId) {
       return scimError(404, "User not found");
     }
@@ -66,7 +66,7 @@ async function handlePUT(req: NextRequest, { params }: Params): Promise<Response
   let serviceResult;
   try {
     serviceResult = await withTenantRls(prisma, tenantId, (tx) =>
-      resolveUserId(tenantId, id).then((userId) => {
+      resolveUserId(tenantId, id, tx).then((userId) => {
         if (!userId) throw new ScimUserNotFoundError();
         return replaceScimUser(tenantId, userId, { active, externalId, name }, getScimBaseUrl());
       }),
@@ -136,7 +136,7 @@ async function handlePATCH(req: NextRequest, { params }: Params): Promise<Respon
   let serviceResult;
   try {
     serviceResult = await withTenantRls(prisma, tenantId, (tx) =>
-      resolveUserId(tenantId, id).then((userId) => {
+      resolveUserId(tenantId, id, tx).then((userId) => {
         if (!userId) throw new ScimUserNotFoundError();
         return patchScimUser(tenantId, userId, patchOps, getScimBaseUrl());
       }),
@@ -189,7 +189,7 @@ async function handleDELETE(req: NextRequest, { params }: Params): Promise<Respo
   let serviceResult;
   try {
     serviceResult = await withTenantRls(prisma, tenantId, (tx) =>
-      resolveUserId(tenantId, id).then((userId) => {
+      resolveUserId(tenantId, id, tx).then((userId) => {
         if (!userId) throw new ScimUserNotFoundError();
         return deactivateScimUser(tenantId, userId);
       }),

--- a/src/app/api/scim/v2/Users/route.test.ts
+++ b/src/app/api/scim/v2/Users/route.test.ts
@@ -9,8 +9,8 @@ const {
   mockTenantMember,
   mockUser,
   mockScimExternalMapping,
-  mockTransaction,
   mockWithTenantRls,
+  applyTxHolder,
 } = vi.hoisted(() => ({
   mockValidateScimToken: vi.fn(),
   mockCheckScimRateLimit: vi.fn(),
@@ -18,9 +18,20 @@ const {
   mockTenantMember: { findMany: vi.fn(), count: vi.fn(), findUnique: vi.fn(), create: vi.fn() },
   mockUser: { findUnique: vi.fn(), create: vi.fn() },
   mockScimExternalMapping: { findFirst: vi.fn(), findMany: vi.fn(), create: vi.fn(), deleteMany: vi.fn() },
-  mockTransaction: vi.fn(),
-  mockWithTenantRls: vi.fn(async (prisma: unknown, _tenantId: string, fn: (tx: unknown) => unknown) => fn(prisma)),
+  // Holds the rich POST tx (formerly the inner prisma.$transaction tx, now the
+  // withTenantRls callback's tx directly), or a rejection to simulate a DB
+  // constraint violation surfacing from the tx.
+  applyTxHolder: { current: null as Record<string, unknown> | null, reject: null as unknown },
+  mockWithTenantRls: vi.fn(),
 }));
+
+// withTenantRls now runs the POST body directly on its callback tx (the inner
+// prisma.$transaction fold was removed). Route the test-configured rich tx (or
+// rejection) through it; GET callbacks fall back to the top-level prisma mock.
+mockWithTenantRls.mockImplementation(async (prisma: unknown, _tenantId: string, fn: (tx: unknown) => unknown) => {
+  if (applyTxHolder.reject) throw applyTxHolder.reject;
+  return fn(applyTxHolder.current ?? prisma);
+});
 
 vi.mock("@/lib/auth/tokens/scim-token", () => ({ validateScimToken: mockValidateScimToken }));
 vi.mock("@/lib/scim/rate-limit", () => ({ checkScimRateLimit: mockCheckScimRateLimit }));
@@ -35,7 +46,6 @@ vi.mock("@/lib/prisma", () => ({
     tenantMember: mockTenantMember,
     user: mockUser,
     scimExternalMapping: mockScimExternalMapping,
-    $transaction: mockTransaction,
   },
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>, withTenantRls: mockWithTenantRls }));
@@ -69,6 +79,8 @@ describe("GET /api/scim/v2/Users", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
+    applyTxHolder.current = null;
+    applyTxHolder.reject = null;
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
     mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
@@ -188,29 +200,28 @@ describe("POST /api/scim/v2/Users", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv("AUTH_URL", "http://localhost:3000");
+    applyTxHolder.current = null;
+    applyTxHolder.reject = null;
     mockValidateScimToken.mockResolvedValue(SCIM_TOKEN_DATA);
     mockCheckScimRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it("creates tenant member", async () => {
-    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
-      const tx = {
-        user: {
-          findUnique: vi.fn().mockResolvedValue(null),
-          create: vi.fn().mockResolvedValue({ id: "new-user", tenantId: "tenant-1", email: "new@example.com", name: "New" }),
-        },
-        tenantMember: {
-          findUnique: vi.fn().mockResolvedValue(null),
-          create: vi.fn().mockResolvedValue({ id: "tm1", deactivatedAt: null }),
-        },
-        scimExternalMapping: {
-          findFirst: vi.fn().mockResolvedValue(null),
-          deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
-          create: vi.fn().mockResolvedValue({}),
-        },
-      };
-      return fn(tx);
-    });
+    applyTxHolder.current = {
+      user: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({ id: "new-user", tenantId: "tenant-1", email: "new@example.com", name: "New" }),
+      },
+      tenantMember: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({ id: "tm1", deactivatedAt: null }),
+      },
+      scimExternalMapping: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        create: vi.fn().mockResolvedValue({}),
+      },
+    };
 
     const res = await POST(
       makeReq({
@@ -228,13 +239,10 @@ describe("POST /api/scim/v2/Users", () => {
   });
 
   it("returns 409 when user already exists in tenant", async () => {
-    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
-      const tx = {
-        user: { findUnique: vi.fn().mockResolvedValue({ id: "user-1", tenantId: "tenant-1", email: "dup@example.com" }) },
-        tenantMember: { findUnique: vi.fn().mockResolvedValue({ id: "tm1" }) },
-      };
-      return fn(tx);
-    });
+    applyTxHolder.current = {
+      user: { findUnique: vi.fn().mockResolvedValue({ id: "user-1", tenantId: "tenant-1", email: "dup@example.com" }) },
+      tenantMember: { findUnique: vi.fn().mockResolvedValue({ id: "tm1" }) },
+    };
 
     const res = await POST(
       makeReq({
@@ -260,26 +268,23 @@ describe("POST /api/scim/v2/Users", () => {
   });
 
   it("returns 409 when externalId is already mapped to another user", async () => {
-    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
-      const tx = {
-        user: { findUnique: vi.fn().mockResolvedValue({ id: "user-1", tenantId: "tenant-1", email: "dup@example.com", name: "Dup" }) },
-        tenantMember: {
-          findUnique: vi.fn().mockResolvedValue(null),
-          create: vi.fn().mockResolvedValue({ id: "tm1", deactivatedAt: null }),
-        },
-        scimExternalMapping: {
-          findFirst: vi.fn().mockResolvedValue({
-            tenantId: "tenant-1",
-            externalId: "ext-1",
-            internalId: "other-user",
-            resourceType: "User",
-          }),
-          deleteMany: vi.fn(),
-          create: vi.fn(),
-        },
-      };
-      return fn(tx);
-    });
+    applyTxHolder.current = {
+      user: { findUnique: vi.fn().mockResolvedValue({ id: "user-1", tenantId: "tenant-1", email: "dup@example.com", name: "Dup" }) },
+      tenantMember: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({ id: "tm1", deactivatedAt: null }),
+      },
+      scimExternalMapping: {
+        findFirst: vi.fn().mockResolvedValue({
+          tenantId: "tenant-1",
+          externalId: "ext-1",
+          internalId: "other-user",
+          resourceType: "User",
+        }),
+        deleteMany: vi.fn(),
+        create: vi.fn(),
+      },
+    };
 
     const res = await POST(
       makeReq({
@@ -336,26 +341,23 @@ describe("POST /api/scim/v2/Users", () => {
 
   it("creates a deactivated member when active is false", async () => {
     let createdMemberData: Record<string, unknown> | undefined;
-    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
-      const tx = {
-        user: {
-          findUnique: vi.fn().mockResolvedValue({ id: "user-1", tenantId: "tenant-1", email: "inactive@example.com", name: "Inactive" }),
-        },
-        tenantMember: {
-          findUnique: vi.fn().mockResolvedValue(null),
-          create: vi.fn().mockImplementation(({ data }) => {
-            createdMemberData = data;
-            return { id: "tm1", deactivatedAt: data.deactivatedAt };
-          }),
-        },
-        scimExternalMapping: {
-          findFirst: vi.fn().mockResolvedValue(null),
-          deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
-          create: vi.fn().mockResolvedValue({}),
-        },
-      };
-      return fn(tx);
-    });
+    applyTxHolder.current = {
+      user: {
+        findUnique: vi.fn().mockResolvedValue({ id: "user-1", tenantId: "tenant-1", email: "inactive@example.com", name: "Inactive" }),
+      },
+      tenantMember: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockImplementation(({ data }) => {
+          createdMemberData = data;
+          return { id: "tm1", deactivatedAt: data.deactivatedAt };
+        }),
+      },
+      scimExternalMapping: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        create: vi.fn().mockResolvedValue({}),
+      },
+    };
 
     const res = await POST(
       makeReq({
@@ -374,26 +376,23 @@ describe("POST /api/scim/v2/Users", () => {
   it("reuses an existing externalId mapping for the same user", async () => {
     const deleteMany = vi.fn();
     const create = vi.fn();
-    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
-      const tx = {
-        user: { findUnique: vi.fn().mockResolvedValue({ id: "user-1", tenantId: "tenant-1", email: "same@example.com", name: "Same" }) },
-        tenantMember: {
-          findUnique: vi.fn().mockResolvedValue(null),
-          create: vi.fn().mockResolvedValue({ id: "tm1", deactivatedAt: null }),
-        },
-        scimExternalMapping: {
-          findFirst: vi.fn().mockResolvedValue({
-            tenantId: "tenant-1",
-            externalId: "ext-1",
-            internalId: "user-1",
-            resourceType: "User",
-          }),
-          deleteMany,
-          create,
-        },
-      };
-      return fn(tx);
-    });
+    applyTxHolder.current = {
+      user: { findUnique: vi.fn().mockResolvedValue({ id: "user-1", tenantId: "tenant-1", email: "same@example.com", name: "Same" }) },
+      tenantMember: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({ id: "tm1", deactivatedAt: null }),
+      },
+      scimExternalMapping: {
+        findFirst: vi.fn().mockResolvedValue({
+          tenantId: "tenant-1",
+          externalId: "ext-1",
+          internalId: "user-1",
+          resourceType: "User",
+        }),
+        deleteMany,
+        create,
+      },
+    };
 
     const res = await POST(
       makeReq({
@@ -415,7 +414,7 @@ describe("POST /api/scim/v2/Users", () => {
       code: "P2002",
       clientVersion: "test",
     });
-    mockTransaction.mockRejectedValue(error);
+    applyTxHolder.reject = error;
 
     const res = await POST(
       makeReq({
@@ -435,7 +434,7 @@ describe("POST /api/scim/v2/Users", () => {
       clientVersion: "test",
       meta: { modelName: "ScimExternalMapping" },
     });
-    mockTransaction.mockRejectedValue(error);
+    applyTxHolder.reject = error;
 
     const res = await POST(
       makeReq({

--- a/src/app/api/scim/v2/Users/route.ts
+++ b/src/app/api/scim/v2/Users/route.ts
@@ -130,83 +130,81 @@ async function handlePOST(req: NextRequest) {
   const { userName, name, externalId, active } = bodyResult.data;
 
   try {
-    const created = await withTenantRls(prisma, tenantId, async (tx) =>
-      prisma.$transaction(async (tx) => {
-        let user = await tx.user.findUnique({ where: { email: userName } });
-        if (!user) {
-          user = await tx.user.create({
-            data: {
-              tenantId,
-              email: userName,
-              name: name?.formatted ?? null,
-            },
-          });
-        }
-
-        // Reject if user already belongs to a different tenant (cross-tenant DoS prevention)
-        if (user.tenantId !== tenantId) {
-          const otherMembership = await tx.tenantMember.findFirst({
-            where: { userId: user.id, tenantId: { not: tenantId }, deactivatedAt: null },
-            select: { id: true },
-          });
-          if (otherMembership) {
-            throw new Error("SCIM_USER_BELONGS_TO_OTHER_TENANT");
-          }
-        }
-
-        const existingMember = await tx.tenantMember.findUnique({
-          where: { tenantId_userId: { tenantId, userId: user.id } },
-        });
-
-        if (existingMember) {
-          throw new Error("SCIM_RESOURCE_EXISTS");
-        }
-
-        const member = await tx.tenantMember.create({
+    const created = await withTenantRls(prisma, tenantId, async (tx) => {
+      let user = await tx.user.findUnique({ where: { email: userName } });
+      if (!user) {
+        user = await tx.user.create({
           data: {
             tenantId,
-            userId: user.id,
-            role: TENANT_ROLE.MEMBER,
-            deactivatedAt: active === false ? new Date() : null,
-            scimManaged: true,
-            provisioningSource: "SCIM",
-            lastScimSyncedAt: new Date(),
+            email: userName,
+            name: name?.formatted ?? null,
           },
         });
+      }
 
-        if (externalId) {
-          const existing = await tx.scimExternalMapping.findFirst({
+      // Reject if user already belongs to a different tenant (cross-tenant DoS prevention)
+      if (user.tenantId !== tenantId) {
+        const otherMembership = await tx.tenantMember.findFirst({
+          where: { userId: user.id, tenantId: { not: tenantId }, deactivatedAt: null },
+          select: { id: true },
+        });
+        if (otherMembership) {
+          throw new Error("SCIM_USER_BELONGS_TO_OTHER_TENANT");
+        }
+      }
+
+      const existingMember = await tx.tenantMember.findUnique({
+        where: { tenantId_userId: { tenantId, userId: user.id } },
+      });
+
+      if (existingMember) {
+        throw new Error("SCIM_RESOURCE_EXISTS");
+      }
+
+      const member = await tx.tenantMember.create({
+        data: {
+          tenantId,
+          userId: user.id,
+          role: TENANT_ROLE.MEMBER,
+          deactivatedAt: active === false ? new Date() : null,
+          scimManaged: true,
+          provisioningSource: "SCIM",
+          lastScimSyncedAt: new Date(),
+        },
+      });
+
+      if (externalId) {
+        const existing = await tx.scimExternalMapping.findFirst({
+          where: {
+            tenantId,
+            externalId,
+            resourceType: "User",
+          },
+        });
+        if (existing && existing.internalId !== user.id) {
+          throw new Error("SCIM_EXTERNAL_ID_CONFLICT");
+        }
+        if (!existing) {
+          await tx.scimExternalMapping.deleteMany({
             where: {
               tenantId,
-              externalId,
+              internalId: user.id,
               resourceType: "User",
             },
           });
-          if (existing && existing.internalId !== user.id) {
-            throw new Error("SCIM_EXTERNAL_ID_CONFLICT");
-          }
-          if (!existing) {
-            await tx.scimExternalMapping.deleteMany({
-              where: {
-                tenantId,
-                internalId: user.id,
-                resourceType: "User",
-              },
-            });
-            await tx.scimExternalMapping.create({
-              data: {
-                tenantId,
-                externalId,
-                resourceType: "User",
-                internalId: user.id,
-              },
-            });
-          }
+          await tx.scimExternalMapping.create({
+            data: {
+              tenantId,
+              externalId,
+              resourceType: "User",
+              internalId: user.id,
+            },
+          });
         }
+      }
 
-        return { user, member, externalId };
-      }),
-    );
+      return { user, member, externalId };
+    });
 
     await logAuditAsync({
       ...tenantAuditBase(req, auditUserId, tenantId),

--- a/src/app/api/sends/file/route.test.ts
+++ b/src/app/api/sends/file/route.test.ts
@@ -10,6 +10,7 @@ const {
   mockCheck,
   mockLogAudit,
   mockFileTypeFromBuffer,
+  mockExecuteRaw,
   mockWithUserTenantRls,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
@@ -19,6 +20,7 @@ const {
   mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
   mockLogAudit: vi.fn(),
   mockFileTypeFromBuffer: vi.fn(),
+  mockExecuteRaw: vi.fn().mockResolvedValue(1),
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
 }));
 
@@ -29,7 +31,7 @@ vi.mock("@/lib/prisma", () => ({
     user: { findUnique: mockUserFindUnique },
     // The aggregate+create run inside a withUserTenantRls callback that first
     // acquires a pg_advisory_xact_lock via prisma.$executeRaw.
-    $executeRaw: vi.fn().mockResolvedValue(1),
+    $executeRaw: mockExecuteRaw,
   },
 }));
 vi.mock("@/lib/crypto/crypto-server", () => ({
@@ -207,6 +209,15 @@ describe("POST /api/sends/file", () => {
         metadata: expect.objectContaining({ sendType: "FILE" }),
       }),
     );
+
+    // The aggregate-then-create byte-quota check runs under a per-user advisory
+    // lock (TOCTOU fix). Mutation-kill: removing the prisma.$executeRaw lock
+    // line would leave $executeRaw uncalled with this SQL.
+    expect(
+      mockExecuteRaw.mock.calls.some((c) =>
+        String(c[0]).includes("pg_advisory_xact_lock"),
+      ),
+    ).toBe(true);
   });
 
   it("includes accessPassword in response when requirePassword is set", async () => {

--- a/src/app/api/sends/file/route.test.ts
+++ b/src/app/api/sends/file/route.test.ts
@@ -27,6 +27,9 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     passwordShare: { create: mockCreate, aggregate: mockAggregate },
     user: { findUnique: mockUserFindUnique },
+    // The aggregate+create run inside a withUserTenantRls callback that first
+    // acquires a pg_advisory_xact_lock via prisma.$executeRaw.
+    $executeRaw: vi.fn().mockResolvedValue(1),
   },
 }));
 vi.mock("@/lib/crypto/crypto-server", () => ({

--- a/src/app/api/sends/file/route.ts
+++ b/src/app/api/sends/file/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { advisoryXactLock } from "@/lib/tenant-rls";
 import {
   createSendFileMetaSchema,
   SEND_MAX_FILE_SIZE,
@@ -210,7 +211,7 @@ async function handlePOST(req: NextRequest) {
   try {
     share = await withUserTenantRls(session.user.id, async () => {
       // Serialize concurrent file-send creation for this user (aggregate-then-create byte-quota race).
-      await prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${session.user.id}::text))`;
+      await advisoryXactLock(prisma, session.user.id);
 
       const activeTotal = await prisma.passwordShare.aggregate({
         where: {

--- a/src/app/api/sends/file/route.ts
+++ b/src/app/api/sends/file/route.ts
@@ -34,6 +34,11 @@ import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 
 const sendFileLimiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 5 });
 
+// Sentinel thrown inside the locked transaction when the re-checked active
+// byte-quota would be exceeded. Mapped to SEND_STORAGE_LIMIT_EXCEEDED outside
+// the tx so the over-limit path returns a proper error response, not a 500.
+class SendStorageLimitError extends Error {}
+
 // POST /api/sends/file — Create a file Send
 async function handlePOST(req: NextRequest) {
   const session = await auth();
@@ -153,33 +158,15 @@ async function handlePOST(req: NextRequest) {
   // If detected is undefined (plain-text .txt/.csv/.json with no signature),
   // we already enforced the active-content extension denylist above.
 
-  // Storage limit check and actor (tenantId) lookup are independent — run in parallel
-  const now = new Date();
-  const [activeTotal, actor] = await Promise.all([
-    withUserTenantRls(session.user.id, async () =>
-      prisma.passwordShare.aggregate({
-        where: {
-          createdById: session.user.id,
-          shareType: SHARE_TYPE.FILE,
-          revokedAt: null,
-          expiresAt: { gt: now },
-          sendSizeBytes: { not: null },
-        },
-        _sum: { sendSizeBytes: true },
-      }),
-    ),
-    withUserTenantRls(session.user.id, async () =>
-      prisma.user.findUnique({
-        where: { id: session.user.id },
-        select: { tenantId: true },
-      }),
-    ),
-  ]);
-
-  const currentTotal = activeTotal._sum.sendSizeBytes ?? 0;
-  if (currentTotal + file.size > SEND_MAX_ACTIVE_TOTAL_BYTES) {
-    return errorResponse(API_ERROR.SEND_STORAGE_LIMIT_EXCEEDED);
-  }
+  // Resolve the actor's tenantId first — needed as AAD for the (expensive)
+  // encryption below, which we keep OUTSIDE the locked transaction so the
+  // advisory lock is held only across aggregate+create, not crypto.
+  const actor = await withUserTenantRls(session.user.id, async () =>
+    prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { tenantId: true },
+    }),
+  );
   if (!actor) {
     return unauthorized();
   }
@@ -213,32 +200,65 @@ async function handlePOST(req: NextRequest) {
   // application/octet-stream anyway, so this is only used for UI display.
   const contentType = detected?.mime ?? "application/octet-stream";
 
-  const share = await withUserTenantRls(session.user.id, async () =>
-    prisma.passwordShare.create({
-      data: {
-        tokenHash,
-        shareType: SHARE_TYPE.FILE,
-        entryType: null,
-        sendName: meta.name,
-        sendFilename: filename,
-        sendContentType: contentType,
-        sendSizeBytes: file.size,
-        encryptedData: encryptedMeta.ciphertext,
-        dataIv: encryptedMeta.iv,
-        dataAuthTag: encryptedMeta.authTag,
-        encryptedFile: new Uint8Array(encryptedFile.ciphertext),
-        fileIv: encryptedFile.iv,
-        fileAuthTag: encryptedFile.authTag,
-        masterKeyVersion: encryptedMeta.masterKeyVersion,
-        expiresAt,
-        maxViews: meta.maxViews ?? null,
-        accessPasswordHash,
-        accessPasswordHashVersion,
-        createdById: session.user.id,
-        tenantId: actor.tenantId,
-      },
-    }),
-  );
+  // Serialize the byte-quota check with the create under a per-user advisory
+  // lock so two concurrent uploads cannot both read `currentTotal + size <=
+  // limit` and both create, blowing past SEND_MAX_ACTIVE_TOTAL_BYTES. The
+  // aggregate is (re-)run inside the locked tx immediately before the create;
+  // the expensive encryption above stays outside so the lock is held only
+  // across aggregate+create.
+  let share: { id: string; expiresAt: Date };
+  try {
+    share = await withUserTenantRls(session.user.id, async () => {
+      // Serialize concurrent file-send creation for this user (aggregate-then-create byte-quota race).
+      await prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${session.user.id}::text))`;
+
+      const activeTotal = await prisma.passwordShare.aggregate({
+        where: {
+          createdById: session.user.id,
+          shareType: SHARE_TYPE.FILE,
+          revokedAt: null,
+          expiresAt: { gt: new Date() },
+          sendSizeBytes: { not: null },
+        },
+        _sum: { sendSizeBytes: true },
+      });
+      const currentTotal = activeTotal._sum.sendSizeBytes ?? 0;
+      if (currentTotal + file.size > SEND_MAX_ACTIVE_TOTAL_BYTES) {
+        throw new SendStorageLimitError();
+      }
+
+      return prisma.passwordShare.create({
+        data: {
+          tokenHash,
+          shareType: SHARE_TYPE.FILE,
+          entryType: null,
+          sendName: meta.name,
+          sendFilename: filename,
+          sendContentType: contentType,
+          sendSizeBytes: file.size,
+          encryptedData: encryptedMeta.ciphertext,
+          dataIv: encryptedMeta.iv,
+          dataAuthTag: encryptedMeta.authTag,
+          encryptedFile: new Uint8Array(encryptedFile.ciphertext),
+          fileIv: encryptedFile.iv,
+          fileAuthTag: encryptedFile.authTag,
+          masterKeyVersion: encryptedMeta.masterKeyVersion,
+          expiresAt,
+          maxViews: meta.maxViews ?? null,
+          accessPasswordHash,
+          accessPasswordHashVersion,
+          createdById: session.user.id,
+          tenantId: actor.tenantId,
+        },
+        select: { id: true, expiresAt: true },
+      });
+    });
+  } catch (e) {
+    if (e instanceof SendStorageLimitError) {
+      return errorResponse(API_ERROR.SEND_STORAGE_LIMIT_EXCEEDED);
+    }
+    throw e;
+  }
 
   // Audit log
   await logAuditAsync({

--- a/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.test.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.test.ts
@@ -7,6 +7,7 @@ const {
   mockPrismaTeamPasswordEntry,
   mockPrismaAttachment,
   mockPrismaTeam,
+  mockExecuteRaw,
   MockTeamAuthError,
   mockWithTeamTenantRls,
   mockRateLimitCheck,
@@ -24,6 +25,7 @@ const {
   mockPrismaTeam: {
     findUnique: vi.fn(),
   },
+  mockExecuteRaw: vi.fn().mockResolvedValue(1),
   mockWithTeamTenantRls: vi.fn(async (_teamId: string, fn: () => unknown) => fn()),
   MockTeamAuthError: class MockTeamAuthError extends Error {
     status: number;
@@ -49,6 +51,10 @@ vi.mock("@/lib/prisma", () => ({
     teamPasswordEntry: mockPrismaTeamPasswordEntry,
     attachment: mockPrismaAttachment,
     team: mockPrismaTeam,
+    // The cap-check + create now run under a per-entry advisory lock inside one
+    // withTeamTenantRls callback (TOCTOU fix); the route calls prisma.$executeRaw
+    // for the lock before count/create.
+    $executeRaw: mockExecuteRaw,
     auditLog: { create: vi.fn().mockResolvedValue({}) },
   },
 }));
@@ -92,6 +98,15 @@ async function createFormDataRequest(
 // Valid hex strings for client-encrypted fields
 const VALID_IV = "a".repeat(24);
 const VALID_AUTH_TAG = "b".repeat(32);
+
+// Asserts the per-entry advisory lock ($executeRaw with pg_advisory_xact_lock)
+// was acquired inside the upload callback. Mutation-kill: deleting the lock line
+// from the production locked path leaves $executeRaw uncalled with that SQL.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
+}
 
 describe("GET /api/teams/[teamId]/passwords/[id]/attachments", () => {
   beforeEach(() => {
@@ -253,6 +268,9 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
   });
 
   it("returns 400 when attachment limit is exceeded", async () => {
+    // The cap check now runs INSIDE the advisory-locked callback, after all
+    // request validation and the blob store put — so the request must be fully
+    // valid (encryptionMode included) to reach it.
     mockPrismaAttachment.count.mockResolvedValue(20);
     const res = await POST(
       await createFormDataRequest("http://localhost/api/teams/team-1/passwords/pw-1/attachments", {
@@ -262,6 +280,8 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
         iv: VALID_IV,
         authTag: VALID_AUTH_TAG,
         sizeBytes: "3",
+        aadVersion: "1",
+        encryptionMode: "1",
       }),
       createParams("team-1", "pw-1"),
     );
@@ -393,6 +413,7 @@ describe("POST /api/teams/[teamId]/passwords/[id]/attachments", () => {
       createParams("team-1", "pw-1"),
     );
     expect(res.status).toBe(201);
+    expectAdvisoryLockAcquired(mockExecuteRaw);
     expect(mockPrismaAttachment.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({

--- a/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.ts
@@ -23,6 +23,11 @@ import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
 
 type RouteContext = { params: Promise<{ teamId: string; id: string }> };
 
+// Sentinel thrown inside the locked transaction when the re-checked per-entry
+// attachment count is at the cap. Mapped to ATTACHMENT_LIMIT_EXCEEDED outside
+// the tx.
+class AttachmentLimitError extends Error {}
+
 const teamAttachmentUploadLimiter = createRateLimiter({ windowMs: RATE_WINDOW_MS, max: 30 });
 
 function getExtension(filename: string): string {
@@ -113,15 +118,10 @@ async function handlePOST(
     return errorResponse(API_ERROR.ITEM_KEY_REQUIRED);
   }
 
-  // Check attachment count limit
-  const count = await withTeamTenantRls(teamId, async () =>
-    prisma.attachment.count({
-      where: { teamPasswordEntryId: id },
-    }),
-  );
-  if (count >= MAX_ATTACHMENTS_PER_ENTRY) {
-    return errorResponse(API_ERROR.ATTACHMENT_LIMIT_EXCEEDED);
-  }
+  // The per-entry attachment cap is re-checked INSIDE the advisory-locked tx
+  // below (keyed on the entry id), so two concurrent uploads to the same entry
+  // cannot both read count < MAX and both create, blowing past
+  // MAX_ATTACHMENTS_PER_ENTRY (TOCTOU).
 
   // Early rejection before buffering the multipart body into memory. Requires a
   // declared Content-Length and caps it — fail-closed on a missing header so a
@@ -219,10 +219,21 @@ async function handlePOST(
   const blobContext = { attachmentId, entryId: id, teamId };
   const storedBlob = await blobStore.putObject(buffer, blobContext);
 
+  // Serialize the cap check with the create under a per-entry advisory lock
+  // (keyed on the entry id) so concurrent uploads to the same entry cannot both
+  // read count < MAX and both create. Blob storage above stays OUTSIDE the lock;
+  // over-limit throws a sentinel mapped to ATTACHMENT_LIMIT_EXCEEDED outside.
   let attachment;
   try {
-    attachment = await withTeamTenantRls(teamId, async () =>
-      prisma.attachment.create({
+    attachment = await withTeamTenantRls(teamId, async () => {
+      await prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${id}::text))`;
+      const count = await prisma.attachment.count({
+        where: { teamPasswordEntryId: id },
+      });
+      if (count >= MAX_ATTACHMENTS_PER_ENTRY) {
+        throw new AttachmentLimitError();
+      }
+      return prisma.attachment.create({
         data: {
           id: attachmentId,
           filename: sanitizedFilename,
@@ -245,10 +256,13 @@ async function handlePOST(
           sizeBytes: true,
           createdAt: true,
         },
-      }),
-    );
+      });
+    });
   } catch (error) {
     await blobStore.deleteObject(storedBlob, blobContext).catch(() => {});
+    if (error instanceof AttachmentLimitError) {
+      return errorResponse(API_ERROR.ATTACHMENT_LIMIT_EXCEEDED);
+    }
     throw error;
   }
 

--- a/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/attachments/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { advisoryXactLock } from "@/lib/tenant-rls";
 import { logAuditAsync, teamAuditBase } from "@/lib/audit/audit";
 import { requireTeamPermission } from "@/lib/auth/access/team-auth";
 import { API_ERROR } from "@/lib/http/api-error-codes";
@@ -226,7 +227,7 @@ async function handlePOST(
   let attachment;
   try {
     attachment = await withTeamTenantRls(teamId, async () => {
-      await prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${id}::text))`;
+      await advisoryXactLock(prisma, id);
       const count = await prisma.attachment.count({
         where: { teamPasswordEntryId: id },
       });

--- a/src/app/api/teams/[teamId]/webhooks/route.test.ts
+++ b/src/app/api/teams/[teamId]/webhooks/route.test.ts
@@ -12,6 +12,7 @@ const {
   mockGetCurrentMasterKeyVersion,
   mockGetMasterKeyByVersion,
   mockRequireRecentSession,
+  mockExecuteRaw,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockPrismaTeamWebhook: {
@@ -22,6 +23,7 @@ const {
   mockPrismaTeam: {
     findUniqueOrThrow: vi.fn(),
   },
+  mockExecuteRaw: vi.fn().mockResolvedValue(1),
   mockRequireTeamPermission: vi.fn(),
   mockWithTeamTenantRls: vi.fn(
     async (_teamId: string, fn: (tenantId: string) => unknown) => fn("22222222-2222-4222-8222-222222222222"),
@@ -42,6 +44,10 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     teamWebhook: mockPrismaTeamWebhook,
     team: mockPrismaTeam,
+    // The cap-check + create now run under an advisory lock inside one
+    // withTeamTenantRls tx (TOCTOU fix); the route calls prisma.$executeRaw
+    // for the lock before count/create.
+    $executeRaw: mockExecuteRaw,
   },
 }));
 vi.mock("@/lib/auth/access/team-auth", () => ({
@@ -85,6 +91,15 @@ type Params = { params: Promise<{ teamId: string }> };
 
 function teamParams(teamId: string = "33333333-3333-4333-8333-333333333333"): Params {
   return createParams({ teamId });
+}
+
+// Asserts the advisory lock ($executeRaw with pg_advisory_xact_lock) was
+// acquired inside the count-then-create tx. Mutation-kill: deleting the lock
+// line from the production path leaves $executeRaw uncalled with that SQL.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
 }
 
 describe("GET /api/teams/[teamId]/webhooks", () => {
@@ -163,6 +178,7 @@ describe("POST /api/teams/[teamId]/webhooks", () => {
     expect(json.secret).toBeDefined();
     expect(typeof json.secret).toBe("string");
     expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expectAdvisoryLockAcquired(mockExecuteRaw);
   });
 
   it("returns 400 on invalid URL", async () => {

--- a/src/app/api/teams/[teamId]/webhooks/route.ts
+++ b/src/app/api/teams/[teamId]/webhooks/route.ts
@@ -30,6 +30,11 @@ import { isSsrfSafeWebhookUrl, SSRF_URL_VALIDATION_MESSAGE, maskUrlForDisplay } 
 
 type Params = { params: Promise<{ teamId: string }> };
 
+// Sentinel thrown inside the locked transaction when the re-checked team
+// webhook count is at the cap. Mapped to the MAX_WEBHOOKS validation error
+// outside the tx.
+class WebhookLimitError extends Error {}
+
 const createWebhookSchema = z.object({
   url: z.string().url().max(WEBHOOK_URL_MAX_LENGTH).refine(
     isSsrfSafeWebhookUrl,
@@ -96,47 +101,59 @@ async function handlePOST(req: NextRequest, { params }: Params) {
   if (!result.ok) return result.response;
   const { data } = result;
 
-  // Check webhook count limit
-  const existingCount = await withTeamTenantRls(teamId, async () =>
-    prisma.teamWebhook.count({ where: { teamId } }),
-  );
-  if (existingCount >= MAX_WEBHOOKS) {
-    return validationError({
-      limit: `Maximum ${MAX_WEBHOOKS} webhooks per team`,
-    });
-  }
-
   // Pre-allocate the webhook id so the AAD can bind to it BEFORE the row is
-  // written (see C9 design — AAD includes webhookId).
+  // written (see C9 design — AAD includes webhookId). Crypto stays OUTSIDE the
+  // locked tx below.
   const webhookId = randomUUID();
   const plainSecret = randomBytes(32).toString("hex");
   const version = getCurrentMasterKeyVersion();
   const masterKey = getMasterKeyByVersion(version);
 
-  const webhook = await withTeamTenantRls(teamId, async (tenantId) => {
-    const aad = buildWebhookSecretAAD({
-      tableName: "TeamWebhook",
-      version: WEBHOOK_SECRET_AAD_VERSION_CURRENT,
-      webhookId,
-      tenantId,
-      teamId,
-    });
-    const encrypted = encryptServerData(plainSecret, masterKey, aad);
-    return prisma.teamWebhook.create({
-      data: {
-        id: webhookId,
-        teamId,
+  // Serialize the cap check with the create under a per-team advisory lock so
+  // two concurrent POSTs cannot both read count < MAX and both create, blowing
+  // past MAX_WEBHOOKS (TOCTOU). The lock, count, and create fold into one team
+  // tenant tx via the proxy; over-limit throws a sentinel mapped outside.
+  let webhook;
+  try {
+    webhook = await withTeamTenantRls(teamId, async (tenantId) => {
+      await prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${teamId}::text))`;
+      const existingCount = await prisma.teamWebhook.count({
+        where: { teamId },
+      });
+      if (existingCount >= MAX_WEBHOOKS) {
+        throw new WebhookLimitError();
+      }
+      const aad = buildWebhookSecretAAD({
+        tableName: "TeamWebhook",
+        version: WEBHOOK_SECRET_AAD_VERSION_CURRENT,
+        webhookId,
         tenantId,
-        url: data.url,
-        secretEncrypted: encrypted.ciphertext,
-        secretIv: encrypted.iv,
-        secretAuthTag: encrypted.authTag,
-        masterKeyVersion: version,
-        secretAadVersion: WEBHOOK_SECRET_AAD_VERSION_CURRENT,
-        events: data.events,
-      },
+        teamId,
+      });
+      const encrypted = encryptServerData(plainSecret, masterKey, aad);
+      return prisma.teamWebhook.create({
+        data: {
+          id: webhookId,
+          teamId,
+          tenantId,
+          url: data.url,
+          secretEncrypted: encrypted.ciphertext,
+          secretIv: encrypted.iv,
+          secretAuthTag: encrypted.authTag,
+          masterKeyVersion: version,
+          secretAadVersion: WEBHOOK_SECRET_AAD_VERSION_CURRENT,
+          events: data.events,
+        },
+      });
     });
-  });
+  } catch (e) {
+    if (e instanceof WebhookLimitError) {
+      return validationError({
+        limit: `Maximum ${MAX_WEBHOOKS} webhooks per team`,
+      });
+    }
+    throw e;
+  }
 
   await logAuditAsync({
     ...teamAuditBase(req, session.user.id, teamId),

--- a/src/app/api/teams/[teamId]/webhooks/route.ts
+++ b/src/app/api/teams/[teamId]/webhooks/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { advisoryXactLock } from "@/lib/tenant-rls";
 import { requireTeamPermission } from "@/lib/auth/access/team-auth";
 import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 import { logAuditAsync, teamAuditBase } from "@/lib/audit/audit";
@@ -116,7 +117,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
   let webhook;
   try {
     webhook = await withTeamTenantRls(teamId, async (tenantId) => {
-      await prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${teamId}::text))`;
+      await advisoryXactLock(prisma, teamId);
       const existingCount = await prisma.teamWebhook.count({
         where: { teamId },
       });

--- a/src/app/api/tenant/access-requests/[id]/approve/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.ts
@@ -7,7 +7,7 @@ import { requireTenantPermission } from "@/lib/auth/access/tenant-auth";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
-import { withTenantRls, withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+import { withTenantRls, withBypassRls, BYPASS_PURPOSE, advisoryXactLock } from "@/lib/tenant-rls";
 import { transition, AR_STATUS, AR_ACTOR } from "@/lib/access-request/access-request-state";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { NO_STORE_HEADERS } from "@/lib/http/cache-headers";
@@ -139,7 +139,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
       // AND the direct token-create route share this lock key) so the
       // count→create limit check cannot be raced past MAX_SA_TOKENS_PER_ACCOUNT
       // under READ COMMITTED.
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${request.serviceAccountId}::text))`;
+      await advisoryXactLock(tx, request.serviceAccountId);
 
       // Enforce token limit per SA. "Active" = not revoked AND not expired,
       // matching extension/operator/SCIM token limit checks — expired-but-not-

--- a/src/app/api/tenant/access-requests/[id]/deny/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/deny/route.ts
@@ -72,7 +72,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
   // Optimistic lock: only update if still PENDING and belongs to this tenant
   const transitionResult = await withTenantRls(prisma, actor.tenantId, async (tx) =>
     transition({
-      db: prisma,
+      db: tx,
       where: { id: requestId, tenantId: actor.tenantId },
       to: AR_STATUS.DENIED,
       actor: AR_ACTOR.ADMIN,

--- a/src/app/api/tenant/audit-delivery-targets/route.test.ts
+++ b/src/app/api/tenant/audit-delivery-targets/route.test.ts
@@ -10,6 +10,7 @@ const {
   mockAuditDeliveryTargetFindMany,
   mockAuditDeliveryTargetCount,
   mockAuditDeliveryTargetCreate,
+  mockExecuteRaw,
   mockGetCurrentMasterKeyVersion,
   mockGetMasterKeyByVersion,
   mockEncryptServerData,
@@ -23,6 +24,7 @@ const {
   mockAuditDeliveryTargetFindMany: vi.fn(),
   mockAuditDeliveryTargetCount: vi.fn(),
   mockAuditDeliveryTargetCreate: vi.fn(),
+  mockExecuteRaw: vi.fn().mockResolvedValue(1),
   mockGetCurrentMasterKeyVersion: vi.fn().mockReturnValue(1),
   mockGetMasterKeyByVersion: vi.fn(() => Buffer.alloc(32)),
   mockEncryptServerData: vi.fn().mockReturnValue({
@@ -57,6 +59,10 @@ vi.mock("@/lib/prisma", () => ({
       count: mockAuditDeliveryTargetCount,
       create: mockAuditDeliveryTargetCreate,
     },
+    // The cap-check + create now run under an advisory lock inside one
+    // withTenantRls tx (TOCTOU fix); the route calls tx.$executeRaw for the
+    // lock before count/create. The mock passes prisma as tx.
+    $executeRaw: mockExecuteRaw,
   },
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
@@ -91,6 +97,15 @@ import { TenantAuthError } from "@/lib/auth/access/tenant-auth";
 import { AUDIT_ACTION } from "@/lib/constants";
 
 const ACTOR = { tenantId: "tenant-1", role: "ADMIN" };
+
+// Asserts the advisory lock ($executeRaw with pg_advisory_xact_lock) was
+// acquired inside the count-then-create tx. Mutation-kill: deleting the lock
+// line from the production path leaves $executeRaw uncalled with that SQL.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
+}
 
 const makeTargetSelectResult = (overrides: Record<string, unknown> = {}) => ({
   id: "adt-1",
@@ -371,6 +386,7 @@ describe("POST /api/tenant/audit-delivery-targets", () => {
     expect(json.target).not.toHaveProperty("configAuthTag");
     expect(json.target).not.toHaveProperty("masterKeyVersion");
     expect(json).not.toHaveProperty("secret");
+    expectAdvisoryLockAcquired(mockExecuteRaw);
   });
 
   it("calls logAuditAsync with AUDIT_DELIVERY_TARGET_CREATE", async () => {

--- a/src/app/api/tenant/audit-delivery-targets/route.ts
+++ b/src/app/api/tenant/audit-delivery-targets/route.ts
@@ -33,6 +33,11 @@ import {
 
 import { isSsrfSafeWebhookUrl as ssrfSafeUrl, SSRF_URL_VALIDATION_MESSAGE as ssrfMessage, maskUrlForDisplay } from "@/lib/url/url-validation";
 
+// Sentinel thrown inside the locked transaction when the re-checked audit
+// delivery target count is at the cap. Mapped to the MAX_AUDIT_DELIVERY_TARGETS
+// validation error outside the tx.
+class AuditDeliveryTargetLimitError extends Error {}
+
 const createDeliveryTargetSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal(AuditDeliveryTargetKind.WEBHOOK),
@@ -153,16 +158,6 @@ async function handlePOST(req: NextRequest) {
   if (!result.ok) return result.response;
   const { data } = result;
 
-  // Check delivery target count limit (all targets, regardless of isActive)
-  const existingCount = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.auditDeliveryTarget.count({ where: { tenantId: actor.tenantId } }),
-  );
-  if (existingCount >= MAX_AUDIT_DELIVERY_TARGETS) {
-    return validationError({
-      limit: `Maximum ${MAX_AUDIT_DELIVERY_TARGETS} audit delivery targets per tenant`,
-    });
-  }
-
   // Pre-generate UUID so we can build AAD before DB insert
   const targetId = randomUUID();
 
@@ -170,7 +165,8 @@ async function handlePOST(req: NextRequest) {
   const { kind: _kind, ...configFields } = data;
   const configJson = JSON.stringify(configFields);
 
-  // Encrypt with AAD = targetId + tenantId (must match worker decryption)
+  // Encrypt with AAD = targetId + tenantId (must match worker decryption).
+  // Crypto stays OUTSIDE the locked tx below.
   const version = getCurrentMasterKeyVersion();
   const masterKey = getMasterKeyByVersion(version);
   const aad = Buffer.concat([
@@ -179,19 +175,40 @@ async function handlePOST(req: NextRequest) {
   ]);
   const encrypted = encryptServerData(configJson, masterKey, aad);
 
-  const target = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.auditDeliveryTarget.create({
-      data: {
-        id: targetId,
-        tenantId: actor.tenantId,
-        kind: data.kind,
-        configEncrypted: encrypted.ciphertext,
-        configIv: encrypted.iv,
-        configAuthTag: encrypted.authTag,
-        masterKeyVersion: version,
-      },
-    }),
-  );
+  // Serialize the cap check with the create under a per-tenant advisory lock so
+  // two concurrent POSTs cannot both read count < MAX and both create, blowing
+  // past MAX_AUDIT_DELIVERY_TARGETS (TOCTOU). Lock, count, and create fold into
+  // one tenant tx; over-limit throws a sentinel mapped outside.
+  let target;
+  try {
+    target = await withTenantRls(prisma, actor.tenantId, async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      const existingCount = await tx.auditDeliveryTarget.count({
+        where: { tenantId: actor.tenantId },
+      });
+      if (existingCount >= MAX_AUDIT_DELIVERY_TARGETS) {
+        throw new AuditDeliveryTargetLimitError();
+      }
+      return tx.auditDeliveryTarget.create({
+        data: {
+          id: targetId,
+          tenantId: actor.tenantId,
+          kind: data.kind,
+          configEncrypted: encrypted.ciphertext,
+          configIv: encrypted.iv,
+          configAuthTag: encrypted.authTag,
+          masterKeyVersion: version,
+        },
+      });
+    });
+  } catch (e) {
+    if (e instanceof AuditDeliveryTargetLimitError) {
+      return validationError({
+        limit: `Maximum ${MAX_AUDIT_DELIVERY_TARGETS} audit delivery targets per tenant`,
+      });
+    }
+    throw e;
+  }
 
   await logAuditAsync({
     ...tenantAuditBase(req, session.user.id, actor.tenantId),

--- a/src/app/api/tenant/audit-delivery-targets/route.ts
+++ b/src/app/api/tenant/audit-delivery-targets/route.ts
@@ -8,7 +8,7 @@ import {
   TENANT_PERMISSION,
   AUDIT_ACTION,
 } from "@/lib/constants";
-import { withTenantRls } from "@/lib/tenant-rls";
+import { withTenantRls, advisoryXactLock } from "@/lib/tenant-rls";
 import {
   getCurrentMasterKeyVersion,
   getMasterKeyByVersion,
@@ -182,7 +182,7 @@ async function handlePOST(req: NextRequest) {
   let target;
   try {
     target = await withTenantRls(prisma, actor.tenantId, async (tx) => {
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      await advisoryXactLock(tx, actor.tenantId);
       const existingCount = await tx.auditDeliveryTarget.count({
         where: { tenantId: actor.tenantId },
       });

--- a/src/app/api/tenant/mcp-clients/route.test.ts
+++ b/src/app/api/tenant/mcp-clients/route.test.ts
@@ -12,6 +12,7 @@ const {
   mockMcpClientCount,
   mockMcpClientFindFirst,
   mockMcpClientCreate,
+  mockExecuteRaw,
   mockHashToken,
   mockUserFindMany,
   mockRequireRecentSession,
@@ -25,6 +26,7 @@ const {
   mockMcpClientCount: vi.fn(),
   mockMcpClientFindFirst: vi.fn(),
   mockMcpClientCreate: vi.fn(),
+  mockExecuteRaw: vi.fn().mockResolvedValue(1),
   mockHashToken: vi.fn((token: string) => `hashed:${token}`),
   mockUserFindMany: vi.fn().mockResolvedValue([]),
   mockRequireRecentSession: vi.fn().mockResolvedValue(null),
@@ -56,6 +58,10 @@ vi.mock("@/lib/prisma", () => ({
     user: {
       findMany: mockUserFindMany,
     },
+    // The cap-check + name-check + create now run under an advisory lock inside
+    // one withTenantRls tx (TOCTOU fix); the route calls tx.$executeRaw for the
+    // lock before count/create. The withTenantRls mock passes prisma as tx.
+    $executeRaw: mockExecuteRaw,
   },
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
@@ -88,6 +94,16 @@ import { TenantAuthError } from "@/lib/auth/access/tenant-auth";
 import { MAX_MCP_CLIENTS_PER_TENANT } from "@/lib/constants/auth/mcp";
 
 const ACTOR = { tenantId: "tenant-1", role: "ADMIN" };
+
+// Asserts the per-tenant advisory lock ($executeRaw with pg_advisory_xact_lock)
+// was acquired. Mutation-kill: deleting the lock line from the production
+// count/name-check/create path leaves $executeRaw uncalled with that SQL, so
+// this fails.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
+}
 
 const makeClient = (overrides: Record<string, unknown> = {}) => ({
   id: "client-1",
@@ -206,6 +222,8 @@ describe("POST /api/tenant/mcp-clients", () => {
         tenantId: "tenant-1",
       }),
     );
+    // The count/name-check/create runs under a per-tenant advisory lock (TOCTOU fix).
+    expectAdvisoryLockAcquired(mockExecuteRaw);
   });
 
   it.each([

--- a/src/app/api/tenant/mcp-clients/route.ts
+++ b/src/app/api/tenant/mcp-clients/route.ts
@@ -18,6 +18,12 @@ import { withRequestLog } from "@/lib/http/with-request-log";
 import { NO_STORE_HEADERS } from "@/lib/http/cache-headers";
 import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 
+// Sentinels thrown inside the locked transaction. Mapped outside the tx:
+// the limit error to MCP_CLIENT_LIMIT_EXCEEDED, the name conflict to
+// MCP_CLIENT_NAME_CONFLICT.
+class McpClientLimitError extends Error {}
+class McpClientNameConflictError extends Error {}
+
 const createSchema = z.object({
   name: z.string().min(1).max(100),
   redirectUris: z.array(
@@ -127,50 +133,59 @@ async function handlePOST(req: NextRequest) {
   if (!result.ok) return result.response;
   const { name, redirectUris, allowedScopes } = result.data;
 
-  // Enforce tenant limit
-  const count = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.mcpClient.count({ where: { tenantId: actor.tenantId } }),
-  );
-  if (count >= MAX_MCP_CLIENTS_PER_TENANT) {
-    return errorResponseWithMessage(API_ERROR.MCP_CLIENT_LIMIT_EXCEEDED, `Maximum ${MAX_MCP_CLIENTS_PER_TENANT} MCP clients per tenant`);
-  }
-
-  // Check name uniqueness
-  const existing = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.mcpClient.findFirst({ where: { tenantId: actor.tenantId, name } }),
-  );
-  if (existing) {
-    return errorResponse(API_ERROR.MCP_CLIENT_NAME_CONFLICT);
-  }
-
-  // Generate client credentials
+  // Generate client credentials outside the locked tx (like api-keys).
   const clientId = MCP_CLIENT_ID_PREFIX + randomBytes(16).toString("hex");
   const clientSecret = randomBytes(32).toString("base64url");
   const clientSecretHash = hashToken(clientSecret);
 
-  const client = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.mcpClient.create({
-      data: {
-        tenantId: actor.tenantId,
-        clientId,
-        clientSecretHash,
-        name,
-        redirectUris,
-        allowedScopes: allowedScopes.join(","),
-        createdById: session.user.id,
-      },
-      select: {
-        id: true,
-        clientId: true,
-        name: true,
-        redirectUris: true,
-        allowedScopes: true,
-        isActive: true,
-        isDcr: true,
-        createdAt: true,
-      },
-    }),
-  );
+  // Serialize the cap check + name-uniqueness check + create under a per-tenant
+  // advisory lock so two concurrent POSTs cannot both read count < MAX (or both
+  // see no name conflict) and both create, blowing past MAX_MCP_CLIENTS_PER_TENANT
+  // (TOCTOU). Lock, count, existing-check, and create fold into one tenant tx;
+  // over-limit / name-conflict throw sentinels mapped outside the tx.
+  let client;
+  try {
+    client = await withTenantRls(prisma, actor.tenantId, async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      const count = await tx.mcpClient.count({ where: { tenantId: actor.tenantId } });
+      if (count >= MAX_MCP_CLIENTS_PER_TENANT) {
+        throw new McpClientLimitError();
+      }
+      const existing = await tx.mcpClient.findFirst({ where: { tenantId: actor.tenantId, name } });
+      if (existing) {
+        throw new McpClientNameConflictError();
+      }
+      return tx.mcpClient.create({
+        data: {
+          tenantId: actor.tenantId,
+          clientId,
+          clientSecretHash,
+          name,
+          redirectUris,
+          allowedScopes: allowedScopes.join(","),
+          createdById: session.user.id,
+        },
+        select: {
+          id: true,
+          clientId: true,
+          name: true,
+          redirectUris: true,
+          allowedScopes: true,
+          isActive: true,
+          isDcr: true,
+          createdAt: true,
+        },
+      });
+    });
+  } catch (e) {
+    if (e instanceof McpClientLimitError) {
+      return errorResponseWithMessage(API_ERROR.MCP_CLIENT_LIMIT_EXCEEDED, `Maximum ${MAX_MCP_CLIENTS_PER_TENANT} MCP clients per tenant`);
+    }
+    if (e instanceof McpClientNameConflictError) {
+      return errorResponse(API_ERROR.MCP_CLIENT_NAME_CONFLICT);
+    }
+    throw e;
+  }
 
   await logAuditAsync({
     ...tenantAuditBase(req, session.user.id, actor.tenantId),

--- a/src/app/api/tenant/mcp-clients/route.ts
+++ b/src/app/api/tenant/mcp-clients/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { withTenantRls } from "@/lib/tenant-rls";
+import { withTenantRls, advisoryXactLock } from "@/lib/tenant-rls";
 import { requireTenantPermission } from "@/lib/auth/access/tenant-auth";
 import { randomBytes } from "node:crypto";
 import { hashToken } from "@/lib/crypto/crypto-server";
@@ -146,7 +146,7 @@ async function handlePOST(req: NextRequest) {
   let client;
   try {
     client = await withTenantRls(prisma, actor.tenantId, async (tx) => {
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      await advisoryXactLock(tx, actor.tenantId);
       const count = await tx.mcpClient.count({ where: { tenantId: actor.tenantId } });
       if (count >= MAX_MCP_CLIENTS_PER_TENANT) {
         throw new McpClientLimitError();

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
@@ -17,6 +17,7 @@ const {
   mockRequireTenantPermission,
   mockIsTenantRoleAbove,
   mockWithTenantRls,
+  mockExecuteRaw,
   mockNotificationTitle,
   mockNotificationBody,
   mockEncryptResetToken,
@@ -53,6 +54,7 @@ const {
     mockWithTenantRls: vi.fn(
       (p: unknown, _t: unknown, fn: (tx: unknown) => unknown) => fn(p),
     ),
+    mockExecuteRaw: vi.fn().mockResolvedValue(1),
     mockNotificationTitle: vi.fn(),
     mockNotificationBody: vi.fn(),
     mockEncryptResetToken: vi.fn(),
@@ -76,6 +78,10 @@ vi.mock("@/lib/prisma", () => ({
       create: mockPrismaAdminVaultResetCreate,
       findMany: mockPrismaAdminVaultResetFindMany,
     },
+    // The pending-reset count + create now run under an advisory lock inside one
+    // withTenantRls tx (TOCTOU fix); the route calls tx.$executeRaw for the lock
+    // before count/create. mockWithTenantRls passes this prisma object as tx.
+    $executeRaw: mockExecuteRaw,
   },
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
@@ -152,6 +158,16 @@ const TARGET_MEMBER = {
     locale: null,
   },
 };
+
+// Asserts the per-tenant advisory lock ($executeRaw with
+// pg_advisory_xact_lock) was acquired. Mutation-kill: deleting the lock line
+// from the production count-then-create path leaves $executeRaw uncalled with
+// that SQL, so this fails.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
+}
 
 describe("POST /api/tenant/members/[userId]/reset-vault", () => {
   beforeEach(() => {
@@ -422,6 +438,9 @@ describe("POST /api/tenant/members/[userId]/reset-vault", () => {
       TENANT_ID,
       expect.any(Function),
     );
+
+    // Lock acquired before the count-cap-check + create (TOCTOU fix).
+    expectAdvisoryLockAcquired(mockExecuteRaw);
   });
 
   it("notifies zero approvers when no other admins exist (T10)", async () => {

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.ts
@@ -33,6 +33,10 @@ import {
 
 export const runtime = "nodejs";
 
+// Sentinel thrown inside the locked transaction when the re-checked pending
+// reset count is at the cap. Mapped to a 429 outside the tx.
+class PendingResetLimitError extends Error {}
+
 const adminResetLimiter = createRateLimiter({
   windowMs: MS_PER_DAY,
   max: 3,
@@ -134,24 +138,9 @@ async function handlePOST(
     return rateLimited(retryAfterMs);
   }
 
-  // Check pending resets limit
-  const pendingCount = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.adminVaultReset.count({
-      where: {
-        targetUserId,
-        executedAt: null,
-        revokedAt: null,
-        expiresAt: { gt: new Date() },
-      },
-    }),
-  );
-
-  if (pendingCount >= MAX_PENDING_RESETS) {
-    return rateLimited();
-  }
-
   // Pre-allocate the reset id so it can be bound into the encrypted token's
-  // AAD before insert.
+  // AAD before insert. Token generation + encryption stay OUTSIDE the locked
+  // tx below.
   const id = randomUUID();
   const token = randomBytes(32).toString("hex");
   const tokenHash = createHash("sha256").update(token).digest("hex");
@@ -163,21 +152,45 @@ async function handlePOST(
     targetEmailAtInitiate,
   });
 
-  const resetRecord = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.adminVaultReset.create({
-      data: {
-        id,
-        tenantId: actor.tenantId,
-        teamId: null,
-        targetUserId,
-        initiatedById: session.user.id,
-        tokenHash,
-        encryptedToken,
-        targetEmailAtInitiate,
-        expiresAt,
-      },
-    }),
-  );
+  // Serialize the pending-count check with the create under a per-tenant
+  // advisory lock so two concurrent POSTs cannot both read count < MAX and both
+  // create, blowing past MAX_PENDING_RESETS (TOCTOU). Lock, count, and create
+  // fold into one tenant tx; over-limit throws a sentinel mapped to 429 outside.
+  let resetRecord;
+  try {
+    resetRecord = await withTenantRls(prisma, actor.tenantId, async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      const pendingCount = await tx.adminVaultReset.count({
+        where: {
+          targetUserId,
+          executedAt: null,
+          revokedAt: null,
+          expiresAt: { gt: new Date() },
+        },
+      });
+      if (pendingCount >= MAX_PENDING_RESETS) {
+        throw new PendingResetLimitError();
+      }
+      return tx.adminVaultReset.create({
+        data: {
+          id,
+          tenantId: actor.tenantId,
+          teamId: null,
+          targetUserId,
+          initiatedById: session.user.id,
+          tokenHash,
+          encryptedToken,
+          targetEmailAtInitiate,
+          expiresAt,
+        },
+      });
+    });
+  } catch (e) {
+    if (e instanceof PendingResetLimitError) {
+      return rateLimited();
+    }
+    throw e;
+  }
 
   // Audit log — keep `expiresAt` so the audit row is self-contained for
   // compliance queries (F23). State (`pending_approval`) is implicit in

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.ts
@@ -13,7 +13,7 @@ import {
   isTenantRoleAbove,
 } from "@/lib/auth/access/tenant-auth";
 import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
-import { withTenantRls } from "@/lib/tenant-rls";
+import { withTenantRls, advisoryXactLock } from "@/lib/tenant-rls";
 import { notificationTitle, notificationBody } from "@/lib/notification/notification-messages";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
 import { AUDIT_ACTION } from "@/lib/constants";
@@ -159,7 +159,7 @@ async function handlePOST(
   let resetRecord;
   try {
     resetRecord = await withTenantRls(prisma, actor.tenantId, async (tx) => {
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      await advisoryXactLock(tx, actor.tenantId);
       const pendingCount = await tx.adminVaultReset.count({
         where: {
           targetUserId,

--- a/src/app/api/tenant/operator-tokens/route.test.ts
+++ b/src/app/api/tenant/operator-tokens/route.test.ts
@@ -5,6 +5,7 @@ const {
   mockAuth,
   mockRequireTenantPermission,
   mockPrismaOperatorToken,
+  mockExecuteRaw,
   mockWithTenantRls,
   mockLogAudit,
   mockHashToken,
@@ -28,6 +29,7 @@ const {
       count: vi.fn(),
       create: vi.fn(),
     },
+    mockExecuteRaw: vi.fn().mockResolvedValue(1),
     mockWithTenantRls: vi.fn(async (p: unknown, _t: unknown, fn: (tx: unknown) => unknown) => fn(p)),
     mockLogAudit: vi.fn(),
     mockHashToken: vi.fn((t: string) => `hashed:${t}`),
@@ -41,6 +43,10 @@ vi.mock("@/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     operatorToken: mockPrismaOperatorToken,
+    // The cap-check + create now run under an advisory lock inside one
+    // withTenantRls tx (TOCTOU fix); the route calls tx.$executeRaw for the
+    // lock before count/create. The withTenantRls mock passes prisma as tx.
+    $executeRaw: mockExecuteRaw,
   },
 }));
 vi.mock("@/lib/auth/access/tenant-auth", () => ({
@@ -76,6 +82,15 @@ vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
 }));
 
 import { GET, POST } from "./route";
+
+// Asserts the per-tenant advisory lock ($executeRaw with pg_advisory_xact_lock)
+// was acquired. Mutation-kill: deleting the lock line from the production
+// count-then-create path leaves $executeRaw uncalled with that SQL, so this fails.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
+}
 
 const TENANT_ID = "tenant-1";
 const USER_ID = "user-1";
@@ -303,6 +318,8 @@ describe("POST /api/tenant/operator-tokens", () => {
         action: "OPERATOR_TOKEN_CREATE",
       }),
     );
+    // The count-then-create runs under a per-tenant advisory lock (TOCTOU fix).
+    expectAdvisoryLockAcquired(mockExecuteRaw);
   });
 
   it("emits audit OPERATOR_TOKEN_CREATE with tokenId and scope", async () => {

--- a/src/app/api/tenant/operator-tokens/route.ts
+++ b/src/app/api/tenant/operator-tokens/route.ts
@@ -37,6 +37,11 @@ export const runtime = "nodejs";
 
 const TOKEN_LIMIT_PER_TENANT = 50;
 
+// Sentinel thrown inside the locked transaction when the re-checked active
+// operator-token count is at the cap. Mapped to OPERATOR_TOKEN_LIMIT_EXCEEDED
+// outside the tx.
+class OperatorTokenLimitError extends Error {}
+
 const createTokenLimiter = createRateLimiter({
   windowMs: RATE_WINDOW_MS,
   max: 5,
@@ -149,20 +154,7 @@ async function handlePOST(req: NextRequest) {
   const result = await parseBody(req, createTokenSchema);
   if (!result.ok) return result.response;
 
-  // Cap active tokens per tenant
-  const tokenCount = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.operatorToken.count({
-      where: {
-        tenantId: actor.tenantId,
-        revokedAt: null,
-        expiresAt: { gt: new Date() },
-      },
-    }),
-  );
-  if (tokenCount >= TOKEN_LIMIT_PER_TENANT) {
-    return errorResponse(API_ERROR.OPERATOR_TOKEN_LIMIT_EXCEEDED);
-  }
-
+  // Token generation + hashing are done outside the locked tx (like api-keys).
   const plaintext = generateOperatorToken();
   const tokenHash = hashToken(plaintext);
   const prefix = plaintext.slice(0, 8);
@@ -170,31 +162,55 @@ async function handlePOST(req: NextRequest) {
     Date.now() + result.data.expiresInDays * MS_PER_DAY,
   );
 
+  // Serialize the cap check with the create under a per-tenant advisory lock so
+  // two concurrent POSTs cannot both read count < LIMIT and both create, blowing
+  // past TOKEN_LIMIT_PER_TENANT (TOCTOU). Lock, count, and create fold into one
+  // tenant tx; over-limit throws a sentinel mapped to a 409 outside the tx.
+  //
   // Server hard-codes subjectUserId = createdByUserId = session.userId.
   // The Zod schema is `.strict()` so a body-injected subjectUserId is rejected
   // before reaching this point.
-  const token = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.operatorToken.create({
-      data: {
-        tenantId: actor.tenantId,
-        tokenHash,
-        prefix,
-        name: result.data.name,
-        subjectUserId: session.user.id,
-        createdByUserId: session.user.id,
-        scope: result.data.scope,
-        expiresAt,
-      },
-      select: {
-        id: true,
-        prefix: true,
-        name: true,
-        scope: true,
-        expiresAt: true,
-        createdAt: true,
-      },
-    }),
-  );
+  let token;
+  try {
+    token = await withTenantRls(prisma, actor.tenantId, async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      const tokenCount = await tx.operatorToken.count({
+        where: {
+          tenantId: actor.tenantId,
+          revokedAt: null,
+          expiresAt: { gt: new Date() },
+        },
+      });
+      if (tokenCount >= TOKEN_LIMIT_PER_TENANT) {
+        throw new OperatorTokenLimitError();
+      }
+      return tx.operatorToken.create({
+        data: {
+          tenantId: actor.tenantId,
+          tokenHash,
+          prefix,
+          name: result.data.name,
+          subjectUserId: session.user.id,
+          createdByUserId: session.user.id,
+          scope: result.data.scope,
+          expiresAt,
+        },
+        select: {
+          id: true,
+          prefix: true,
+          name: true,
+          scope: true,
+          expiresAt: true,
+          createdAt: true,
+        },
+      });
+    });
+  } catch (e) {
+    if (e instanceof OperatorTokenLimitError) {
+      return errorResponse(API_ERROR.OPERATOR_TOKEN_LIMIT_EXCEEDED);
+    }
+    throw e;
+  }
 
   await logAuditAsync({
     ...tenantAuditBase(req, session.user.id, actor.tenantId),

--- a/src/app/api/tenant/operator-tokens/route.ts
+++ b/src/app/api/tenant/operator-tokens/route.ts
@@ -10,7 +10,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { parseBody } from "@/lib/http/parse-body";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
-import { withTenantRls } from "@/lib/tenant-rls";
+import { withTenantRls, advisoryXactLock } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { NO_STORE_HEADERS } from "@/lib/http/cache-headers";
 import {
@@ -173,7 +173,7 @@ async function handlePOST(req: NextRequest) {
   let token;
   try {
     token = await withTenantRls(prisma, actor.tenantId, async (tx) => {
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      await advisoryXactLock(tx, actor.tenantId);
       const tokenCount = await tx.operatorToken.count({
         where: {
           tenantId: actor.tenantId,

--- a/src/app/api/tenant/scim-tokens/route.test.ts
+++ b/src/app/api/tenant/scim-tokens/route.test.ts
@@ -5,6 +5,7 @@ import { createRequest } from "@/__tests__/helpers/request-builder";
 const {
   mockAuth,
   mockPrismaScimToken,
+  mockExecuteRaw,
   mockRequireTenantPermission,
   mockWithTenantRls,
   mockLogAudit,
@@ -29,6 +30,7 @@ const {
       count: vi.fn(),
       create: vi.fn(),
     },
+    mockExecuteRaw: vi.fn().mockResolvedValue(1),
     mockRequireTenantPermission: vi.fn(),
     mockWithTenantRls: vi.fn((p: unknown, _t: unknown, fn: (tx: unknown) => unknown) => fn(p)),
     mockLogAudit: vi.fn(),
@@ -42,7 +44,13 @@ const {
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/prisma", () => ({
-  prisma: { scimToken: mockPrismaScimToken },
+  prisma: {
+    scimToken: mockPrismaScimToken,
+    // The cap-check + create now run under an advisory lock inside one
+    // withTenantRls tx (TOCTOU fix); the route calls tx.$executeRaw for the
+    // lock before count/create. The withTenantRls mock passes prisma as tx.
+    $executeRaw: mockExecuteRaw,
+  },
 }));
 vi.mock("@/lib/auth/access/tenant-auth", () => ({
   requireTenantPermission: mockRequireTenantPermission,
@@ -82,6 +90,15 @@ import { GET, POST } from "./route";
 
 const TENANT_ID = "tenant-1";
 const ACTOR = { id: "membership-1", tenantId: TENANT_ID, userId: "user-1", role: "OWNER" };
+
+// Asserts the per-tenant advisory lock ($executeRaw with pg_advisory_xact_lock)
+// was acquired. Mutation-kill: deleting the lock line from the production
+// count-then-create path leaves $executeRaw uncalled with that SQL, so this fails.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
+}
 
 describe("GET /api/tenant/scim-tokens", () => {
   beforeEach(() => {
@@ -231,6 +248,8 @@ describe("POST /api/tenant/scim-tokens", () => {
         action: "SCIM_TOKEN_CREATE",
       }),
     );
+    // The count-then-create runs under a per-tenant advisory lock (TOCTOU fix).
+    expectAdvisoryLockAcquired(mockExecuteRaw);
   });
 
   it("returns 400 for invalid expiresInDays (below minimum)", async () => {

--- a/src/app/api/tenant/scim-tokens/route.ts
+++ b/src/app/api/tenant/scim-tokens/route.ts
@@ -31,6 +31,13 @@ const scimTokenCreateLimiter = createRateLimiter({
   failClosedOnRedisError: true,
 });
 
+// Sentinel thrown inside the locked transaction when the re-checked active
+// SCIM-token count is at the cap. Mapped to SCIM_TOKEN_LIMIT_EXCEEDED outside
+// the tx.
+class ScimTokenLimitError extends Error {}
+
+const SCIM_TOKEN_LIMIT_PER_TENANT = 10;
+
 export const runtime = "nodejs";
 
 const createTokenSchema = z.object({
@@ -110,20 +117,7 @@ async function handlePOST(req: NextRequest) {
   const result = await parseBody(req, createTokenSchema);
   if (!result.ok) return result.response;
 
-  // Limit active (non-revoked, non-expired) tokens per tenant (max 10)
-  const tokenCount = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.scimToken.count({
-      where: {
-        tenantId: actor.tenantId,
-        revokedAt: null,
-        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
-      },
-    }),
-  );
-  if (tokenCount >= 10) {
-    return errorResponse(API_ERROR.SCIM_TOKEN_LIMIT_EXCEEDED);
-  }
-
+  // Token generation + hashing are done outside the locked tx (like api-keys).
   const plaintext = generateScimToken();
   const tokenHash = hashToken(plaintext);
 
@@ -131,17 +125,40 @@ async function handlePOST(req: NextRequest) {
     ? new Date(Date.now() + result.data.expiresInDays * MS_PER_DAY)
     : null;
 
-  const token = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.scimToken.create({
-      data: {
-        tenantId: actor.tenantId,
-        tokenHash,
-        description: result.data.description ?? null,
-        expiresAt,
-        createdById: session.user.id,
-      },
-    }),
-  );
+  // Serialize the cap check with the create under a per-tenant advisory lock so
+  // two concurrent POSTs cannot both read count < LIMIT and both create, blowing
+  // past the active-token cap (TOCTOU). Lock, count, and create fold into one
+  // tenant tx; over-limit throws a sentinel mapped to a 409 outside the tx.
+  let token;
+  try {
+    token = await withTenantRls(prisma, actor.tenantId, async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      const tokenCount = await tx.scimToken.count({
+        where: {
+          tenantId: actor.tenantId,
+          revokedAt: null,
+          OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+        },
+      });
+      if (tokenCount >= SCIM_TOKEN_LIMIT_PER_TENANT) {
+        throw new ScimTokenLimitError();
+      }
+      return tx.scimToken.create({
+        data: {
+          tenantId: actor.tenantId,
+          tokenHash,
+          description: result.data.description ?? null,
+          expiresAt,
+          createdById: session.user.id,
+        },
+      });
+    });
+  } catch (e) {
+    if (e instanceof ScimTokenLimitError) {
+      return errorResponse(API_ERROR.SCIM_TOKEN_LIMIT_EXCEEDED);
+    }
+    throw e;
+  }
 
   await logAuditAsync({
     ...tenantAuditBase(req, session.user.id, actor.tenantId),

--- a/src/app/api/tenant/scim-tokens/route.ts
+++ b/src/app/api/tenant/scim-tokens/route.ts
@@ -9,7 +9,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { parseBody } from "@/lib/http/parse-body";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
-import { withTenantRls } from "@/lib/tenant-rls";
+import { withTenantRls, advisoryXactLock } from "@/lib/tenant-rls";
 import { z } from "zod";
 import { SCIM_TOKEN_DESC_MAX_LENGTH } from "@/lib/validations";
 import { withRequestLog } from "@/lib/http/with-request-log";
@@ -132,7 +132,7 @@ async function handlePOST(req: NextRequest) {
   let token;
   try {
     token = await withTenantRls(prisma, actor.tenantId, async (tx) => {
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      await advisoryXactLock(tx, actor.tenantId);
       const tokenCount = await tx.scimToken.count({
         where: {
           tenantId: actor.tenantId,

--- a/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
@@ -9,7 +9,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { parseBody } from "@/lib/http/parse-body";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
-import { withTenantRls } from "@/lib/tenant-rls";
+import { withTenantRls, advisoryXactLock } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { NO_STORE_HEADERS } from "@/lib/http/cache-headers";
 import { errorResponse, errorResponseWithMessage, handleAuthError, notFound, unauthorized } from "@/lib/http/api-response";
@@ -138,7 +138,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
       // Serialize concurrent token issuance for the same SA so the count→create
       // limit check cannot be raced past MAX_SA_TOKENS_PER_ACCOUNT under
       // READ COMMITTED (two issuers seeing the same pre-insert count).
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${id}::text))`;
+      await advisoryXactLock(tx, id);
 
       // "Active" = not revoked AND not expired, matching extension/operator/
       // SCIM token limit checks — expired-but-not-revoked tokens are unusable

--- a/src/app/api/tenant/service-accounts/route.test.ts
+++ b/src/app/api/tenant/service-accounts/route.test.ts
@@ -11,6 +11,7 @@ const {
   mockServiceAccountFindMany,
   mockServiceAccountCount,
   mockServiceAccountCreate,
+  mockExecuteRaw,
   mockDispatchTenantWebhook,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
@@ -21,6 +22,7 @@ const {
   mockServiceAccountFindMany: vi.fn(),
   mockServiceAccountCount: vi.fn(),
   mockServiceAccountCreate: vi.fn(),
+  mockExecuteRaw: vi.fn().mockResolvedValue(1),
   mockDispatchTenantWebhook: vi.fn(),
 }));
 
@@ -46,6 +48,10 @@ vi.mock("@/lib/prisma", () => ({
       count: mockServiceAccountCount,
       create: mockServiceAccountCreate,
     },
+    // The cap-check + create now run under an advisory lock inside one
+    // withTenantRls tx (TOCTOU fix); the route calls tx.$executeRaw for the
+    // lock before count/create. The withTenantRls mock passes prisma as tx.
+    $executeRaw: mockExecuteRaw,
   },
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
@@ -77,6 +83,15 @@ import { TenantAuthError } from "@/lib/auth/access/tenant-auth";
 import { MAX_SERVICE_ACCOUNTS_PER_TENANT } from "@/lib/constants/auth/service-account";
 
 const ACTOR = { tenantId: "tenant-1", role: "ADMIN" };
+
+// Asserts the per-tenant advisory lock ($executeRaw with pg_advisory_xact_lock)
+// was acquired. Mutation-kill: deleting the lock line from the production
+// count-then-create path leaves $executeRaw uncalled with that SQL, so this fails.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
+}
 
 const makeSA = (overrides: Record<string, unknown> = {}) => ({
   id: "sa-1",
@@ -158,6 +173,8 @@ describe("POST /api/tenant/service-accounts", () => {
         tenantId: "tenant-1",
       }),
     );
+    // The count-then-create runs under a per-tenant advisory lock (TOCTOU fix).
+    expectAdvisoryLockAcquired(mockExecuteRaw);
   });
 
   it("rejects when limit exceeded (MAX_SERVICE_ACCOUNTS_PER_TENANT)", async () => {

--- a/src/app/api/tenant/service-accounts/route.ts
+++ b/src/app/api/tenant/service-accounts/route.ts
@@ -23,6 +23,11 @@ const saCreateLimiter = createRateLimiter({
   failClosedOnRedisError: true,
 });
 
+// Sentinel thrown inside the locked transaction when the re-checked active
+// service-account count is at the cap. Mapped to SA_LIMIT_EXCEEDED outside
+// the tx.
+class ServiceAccountLimitError extends Error {}
+
 export const runtime = "nodejs";
 
 // GET /api/tenant/service-accounts — List service accounts for the tenant
@@ -100,19 +105,23 @@ async function handlePOST(req: NextRequest) {
   const result = await parseBody(req, serviceAccountCreateSchema);
   if (!result.ok) return result.response;
 
-  const count = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.serviceAccount.count({
-      where: { tenantId: actor.tenantId, isActive: true },
-    }),
-  );
-  if (count >= MAX_SERVICE_ACCOUNTS_PER_TENANT) {
-    return errorResponse(API_ERROR.SA_LIMIT_EXCEEDED);
-  }
-
+  // Serialize the cap check with the create under a per-tenant advisory lock so
+  // two concurrent POSTs cannot both read count < MAX and both create, blowing
+  // past MAX_SERVICE_ACCOUNTS_PER_TENANT (TOCTOU). Lock, count, and create fold
+  // into one tenant tx; over-limit throws a sentinel mapped outside. The lock
+  // guards the count cap only — the (tenantId, name) unique constraint is
+  // orthogonal and still surfaces as P2002 → SA_NAME_CONFLICT below.
   let sa;
   try {
-    sa = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-      tx.serviceAccount.create({
+    sa = await withTenantRls(prisma, actor.tenantId, async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      const count = await tx.serviceAccount.count({
+        where: { tenantId: actor.tenantId, isActive: true },
+      });
+      if (count >= MAX_SERVICE_ACCOUNTS_PER_TENANT) {
+        throw new ServiceAccountLimitError();
+      }
+      return tx.serviceAccount.create({
         data: {
           tenantId: actor.tenantId,
           name: result.data.name,
@@ -131,9 +140,12 @@ async function handlePOST(req: NextRequest) {
           updatedAt: true,
           createdBy: { select: { id: true, name: true, email: true } },
         },
-      }),
-    );
+      });
+    });
   } catch (err) {
+    if (err instanceof ServiceAccountLimitError) {
+      return errorResponse(API_ERROR.SA_LIMIT_EXCEEDED);
+    }
     if (
       err instanceof Prisma.PrismaClientKnownRequestError &&
       err.code === "P2002"

--- a/src/app/api/tenant/service-accounts/route.ts
+++ b/src/app/api/tenant/service-accounts/route.ts
@@ -8,7 +8,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { parseBody } from "@/lib/http/parse-body";
 import { TENANT_PERMISSION } from "@/lib/constants/auth/tenant-permission";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE } from "@/lib/constants";
-import { withTenantRls } from "@/lib/tenant-rls";
+import { withTenantRls, advisoryXactLock } from "@/lib/tenant-rls";
 import { withRequestLog } from "@/lib/http/with-request-log";
 import { errorResponse, handleAuthError, unauthorized } from "@/lib/http/api-response";
 import { createRateLimiter } from "@/lib/security/rate-limit";
@@ -114,7 +114,7 @@ async function handlePOST(req: NextRequest) {
   let sa;
   try {
     sa = await withTenantRls(prisma, actor.tenantId, async (tx) => {
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      await advisoryXactLock(tx, actor.tenantId);
       const count = await tx.serviceAccount.count({
         where: { tenantId: actor.tenantId, isActive: true },
       });

--- a/src/app/api/tenant/webhooks/route.test.ts
+++ b/src/app/api/tenant/webhooks/route.test.ts
@@ -10,6 +10,7 @@ const {
   mockTenantWebhookFindMany,
   mockTenantWebhookCount,
   mockTenantWebhookCreate,
+  mockExecuteRaw,
   mockGetCurrentMasterKeyVersion,
   mockGetMasterKeyByVersion,
   mockEncryptServerData,
@@ -22,6 +23,7 @@ const {
   mockTenantWebhookFindMany: vi.fn(),
   mockTenantWebhookCount: vi.fn(),
   mockTenantWebhookCreate: vi.fn(),
+  mockExecuteRaw: vi.fn().mockResolvedValue(1),
   mockGetCurrentMasterKeyVersion: vi.fn().mockReturnValue(1),
   mockGetMasterKeyByVersion: vi.fn(() => Buffer.alloc(32)),
   mockEncryptServerData: vi.fn().mockReturnValue({
@@ -54,6 +56,10 @@ vi.mock("@/lib/prisma", () => ({
       count: mockTenantWebhookCount,
       create: mockTenantWebhookCreate,
     },
+    // The cap-check + create now run under an advisory lock inside one
+    // withTenantRls tx (TOCTOU fix); the route calls tx.$executeRaw for the
+    // lock before count/create. The mock passes prisma as tx.
+    $executeRaw: mockExecuteRaw,
   },
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
@@ -96,6 +102,15 @@ vi.mock("@/lib/quota/resource-quotas", () => ({
 }));
 
 const ACTOR = { tenantId: "22222222-2222-4222-8222-222222222222", role: "ADMIN" };
+
+// Asserts the advisory lock ($executeRaw with pg_advisory_xact_lock) was
+// acquired inside the count-then-create tx. Mutation-kill: deleting the lock
+// line from the production path leaves $executeRaw uncalled with that SQL.
+function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
+  expect(
+    mock.mock.calls.some((c) => String(c[0]).includes("pg_advisory_xact_lock")),
+  ).toBe(true);
+}
 
 /**
  * Fields returned by Prisma after applying the `select` in handleGET.
@@ -249,6 +264,7 @@ describe("POST /api/tenant/webhooks", () => {
         tenantId: "22222222-2222-4222-8222-222222222222",
       }),
     );
+    expectAdvisoryLockAcquired(mockExecuteRaw);
   });
 
   it("enforces 5-webhook-per-tenant limit", async () => {

--- a/src/app/api/tenant/webhooks/route.ts
+++ b/src/app/api/tenant/webhooks/route.ts
@@ -30,6 +30,11 @@ import { MAX_WEBHOOKS, WEBHOOK_URL_MAX_LENGTH } from "@/lib/validations/common";
 import { isSsrfSafeWebhookUrl, SSRF_URL_VALIDATION_MESSAGE, maskUrlForDisplay } from "@/lib/url/url-validation";
 import { NO_STORE_HEADERS } from "@/lib/http/cache-headers";
 
+// Sentinel thrown inside the locked transaction when the re-checked tenant
+// webhook count is at the cap. Mapped to the MAX_WEBHOOKS validation error
+// outside the tx.
+class WebhookLimitError extends Error {}
+
 const createWebhookSchema = z.object({
   url: z.string().url().max(WEBHOOK_URL_MAX_LENGTH).refine(
     isSsrfSafeWebhookUrl,
@@ -112,19 +117,10 @@ async function handlePOST(req: NextRequest) {
     throw err;
   }
 
-  // Check webhook count limit
-  const existingCount = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.tenantWebhook.count({ where: { tenantId: actor.tenantId } }),
-  );
-  if (existingCount >= MAX_WEBHOOKS) {
-    return validationError({
-      limit: `Maximum ${MAX_WEBHOOKS} webhooks per tenant`,
-    });
-  }
-
   // Pre-allocate the webhook id so the AAD can bind to it BEFORE the row is
   // written. Without this, AAD construction would have a chicken-and-egg
-  // dependency on the create() call's returned id.
+  // dependency on the create() call's returned id. Crypto stays OUTSIDE the
+  // locked tx below.
   const webhookId = randomUUID();
   const plainSecret = randomBytes(32).toString("hex");
   const version = getCurrentMasterKeyVersion();
@@ -137,21 +133,42 @@ async function handlePOST(req: NextRequest) {
   });
   const encrypted = encryptServerData(plainSecret, masterKey, aad);
 
-  const webhook = await withTenantRls(prisma, actor.tenantId, async (tx) =>
-    tx.tenantWebhook.create({
-      data: {
-        id: webhookId,
-        tenantId: actor.tenantId,
-        url: data.url,
-        secretEncrypted: encrypted.ciphertext,
-        secretIv: encrypted.iv,
-        secretAuthTag: encrypted.authTag,
-        masterKeyVersion: version,
-        secretAadVersion: WEBHOOK_SECRET_AAD_VERSION_CURRENT,
-        events: data.events,
-      },
-    }),
-  );
+  // Serialize the cap check with the create under a per-tenant advisory lock so
+  // two concurrent POSTs cannot both read count < MAX and both create, blowing
+  // past MAX_WEBHOOKS (TOCTOU). Lock, count, and create fold into one tenant tx;
+  // over-limit throws a sentinel mapped to the validation error outside the tx.
+  let webhook;
+  try {
+    webhook = await withTenantRls(prisma, actor.tenantId, async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      const existingCount = await tx.tenantWebhook.count({
+        where: { tenantId: actor.tenantId },
+      });
+      if (existingCount >= MAX_WEBHOOKS) {
+        throw new WebhookLimitError();
+      }
+      return tx.tenantWebhook.create({
+        data: {
+          id: webhookId,
+          tenantId: actor.tenantId,
+          url: data.url,
+          secretEncrypted: encrypted.ciphertext,
+          secretIv: encrypted.iv,
+          secretAuthTag: encrypted.authTag,
+          masterKeyVersion: version,
+          secretAadVersion: WEBHOOK_SECRET_AAD_VERSION_CURRENT,
+          events: data.events,
+        },
+      });
+    });
+  } catch (e) {
+    if (e instanceof WebhookLimitError) {
+      return validationError({
+        limit: `Maximum ${MAX_WEBHOOKS} webhooks per tenant`,
+      });
+    }
+    throw e;
+  }
 
   await logAuditAsync({
     ...tenantAuditBase(req, session.user.id, actor.tenantId),

--- a/src/app/api/tenant/webhooks/route.ts
+++ b/src/app/api/tenant/webhooks/route.ts
@@ -10,7 +10,7 @@ import {
   AUDIT_ACTION,
   TENANT_WEBHOOK_SUBSCRIBABLE_ACTIONS,
 } from "@/lib/constants";
-import { withTenantRls } from "@/lib/tenant-rls";
+import { withTenantRls, advisoryXactLock } from "@/lib/tenant-rls";
 import {
   getCurrentMasterKeyVersion,
   getMasterKeyByVersion,
@@ -140,7 +140,7 @@ async function handlePOST(req: NextRequest) {
   let webhook;
   try {
     webhook = await withTenantRls(prisma, actor.tenantId, async (tx) => {
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${actor.tenantId}::text))`;
+      await advisoryXactLock(tx, actor.tenantId);
       const existingCount = await tx.tenantWebhook.count({
         where: { tenantId: actor.tenantId },
       });

--- a/src/app/api/user/mcp-tokens/route.test.ts
+++ b/src/app/api/user/mcp-tokens/route.test.ts
@@ -224,7 +224,10 @@ describe("DELETE /api/user/mcp-tokens", () => {
 
     expect(status).toBe(200);
     expect(json.revokedCount).toBe(0);
-    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    // The revoke body now runs directly inside the withBypassRls scope
+    // (redundant inner $transaction removed); atomicity is still asserted
+    // by requiring exactly one bypass-RLS scope.
+    expect(mockWithBypassRls).toHaveBeenCalledTimes(1);
     expect(mockMcpAccessTokenUpdateMany).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/user/mcp-tokens/route.ts
+++ b/src/app/api/user/mcp-tokens/route.ts
@@ -86,94 +86,90 @@ async function handleDELETE(_req: NextRequest) {
   const { revokedCount, delegationSessionIds } = await withBypassRls(
     prisma,
     async (tx) => {
-      const result = await prisma.$transaction(async (tx) => {
-        // 1. Find all active tokens for this user (inside transaction for consistency)
-        const activeTokens = await tx.mcpAccessToken.findMany({
-          where: { userId, tenantId, revokedAt: null, expiresAt: { gt: now } },
-          select: { id: true },
-        });
+      // 1. Find all active tokens for this user (inside transaction for consistency)
+      const activeTokens = await tx.mcpAccessToken.findMany({
+        where: { userId, tenantId, revokedAt: null, expiresAt: { gt: now } },
+        select: { id: true },
+      });
 
-        if (activeTokens.length === 0) {
-          return { revokedCount: 0, delegationSessionIds: [] as string[] };
-        }
+      if (activeTokens.length === 0) {
+        return { revokedCount: 0, delegationSessionIds: [] as string[] };
+      }
 
-        const tokenIds = activeTokens.map((t) => t.id);
+      const tokenIds = activeTokens.map((t) => t.id);
 
-        // 2. Revoke all access tokens
-        await tx.mcpAccessToken.updateMany({
-          where: { id: { in: tokenIds }, revokedAt: null },
+      // 2. Revoke all access tokens
+      await tx.mcpAccessToken.updateMany({
+        where: { id: { in: tokenIds }, revokedAt: null },
+        data: { revokedAt: now },
+      });
+
+      // 3. Revoke refresh token families
+      const refreshTokens = await tx.mcpRefreshToken.findMany({
+        where: { accessTokenId: { in: tokenIds } },
+        select: { familyId: true },
+      });
+      const familyIds = [
+        ...new Set(refreshTokens.map((rt) => rt.familyId)),
+      ];
+      if (familyIds.length > 0) {
+        await tx.mcpRefreshToken.updateMany({
+          where: { familyId: { in: familyIds }, revokedAt: null },
           data: { revokedAt: now },
         });
 
-        // 3. Revoke refresh token families
-        const refreshTokens = await tx.mcpRefreshToken.findMany({
-          where: { accessTokenId: { in: tokenIds } },
-          select: { familyId: true },
+        // Also revoke any sibling access tokens in the same families
+        const relatedRefresh = await tx.mcpRefreshToken.findMany({
+          where: { familyId: { in: familyIds } },
+          select: { accessTokenId: true },
         });
-        const familyIds = [
-          ...new Set(refreshTokens.map((rt) => rt.familyId)),
+        const relatedIds = [
+          ...new Set(relatedRefresh.map((r) => r.accessTokenId)),
         ];
-        if (familyIds.length > 0) {
-          await tx.mcpRefreshToken.updateMany({
-            where: { familyId: { in: familyIds }, revokedAt: null },
+        if (relatedIds.length > 0) {
+          await tx.mcpAccessToken.updateMany({
+            where: { id: { in: relatedIds }, userId, tenantId, revokedAt: null },
             data: { revokedAt: now },
           });
-
-          // Also revoke any sibling access tokens in the same families
-          const relatedRefresh = await tx.mcpRefreshToken.findMany({
-            where: { familyId: { in: familyIds } },
-            select: { accessTokenId: true },
-          });
-          const relatedIds = [
-            ...new Set(relatedRefresh.map((r) => r.accessTokenId)),
-          ];
-          if (relatedIds.length > 0) {
-            await tx.mcpAccessToken.updateMany({
-              where: { id: { in: relatedIds }, userId, tenantId, revokedAt: null },
-              data: { revokedAt: now },
-            });
-          }
         }
+      }
 
-        // 3. Revoke delegation sessions (with userId for defense-in-depth)
-        const sessions = await tx.delegationSession.findMany({
+      // 3. Revoke delegation sessions (with userId for defense-in-depth)
+      const sessions = await tx.delegationSession.findMany({
+        where: {
+          mcpTokenId: { in: tokenIds },
+          userId,
+          revokedAt: null,
+        },
+        select: { id: true },
+      });
+      if (sessions.length > 0) {
+        await tx.delegationSession.updateMany({
           where: {
             mcpTokenId: { in: tokenIds },
             userId,
             revokedAt: null,
           },
-          select: { id: true },
+          data: { revokedAt: now },
         });
-        if (sessions.length > 0) {
-          await tx.delegationSession.updateMany({
-            where: {
-              mcpTokenId: { in: tokenIds },
-              userId,
-              revokedAt: null,
-            },
-            data: { revokedAt: now },
-          });
-        }
+      }
 
-        // 4. Single summary audit entry
-        await tx.auditLog.create({
-          data: {
-            userId,
-            tenantId,
-            action: AUDIT_ACTION.MCP_CONNECTION_REVOKE_ALL,
-            scope: AUDIT_SCOPE.PERSONAL,
-            targetType: "McpAccessToken",
-            metadata: { revokedCount: tokenIds.length },
-          },
-        });
-
-        return {
-          revokedCount: tokenIds.length,
-          delegationSessionIds: sessions.map((s) => s.id),
-        };
+      // 4. Single summary audit entry
+      await tx.auditLog.create({
+        data: {
+          userId,
+          tenantId,
+          action: AUDIT_ACTION.MCP_CONNECTION_REVOKE_ALL,
+          scope: AUDIT_SCOPE.PERSONAL,
+          targetType: "McpAccessToken",
+          metadata: { revokedCount: tokenIds.length },
+        },
       });
 
-      return result;
+      return {
+        revokedCount: tokenIds.length,
+        delegationSessionIds: sessions.map((s) => s.id),
+      };
     },
     BYPASS_PURPOSE.CROSS_TENANT_LOOKUP,
   );

--- a/src/app/api/vault/rotate-key/route.ts
+++ b/src/app/api/vault/rotate-key/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { createHash, randomBytes, timingSafeEqual } from "crypto";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { advisoryXactLock } from "@/lib/tenant-rls";
 import { invalidateUserSessions } from "@/lib/auth/session/user-session-invalidation";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { API_ERROR } from "@/lib/http/api-error-codes";
@@ -177,7 +178,7 @@ async function handlePOST(request: NextRequest) {
     txResult = await withUserTenantRls(userId, async () =>
       prisma.$transaction(async (tx) => {
         // Advisory lock prevents concurrent key rotations for the same user (S-17 equivalent)
-        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`;
+        await advisoryXactLock(tx, userId);
 
         return applyVaultRotation(
           tx,

--- a/src/app/api/webauthn/credentials/[id]/prf/route.ts
+++ b/src/app/api/webauthn/credentials/[id]/prf/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { advisoryXactLock } from "@/lib/tenant-rls";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { API_ERROR } from "@/lib/http/api-error-codes";
 import { withRequestLog } from "@/lib/http/with-request-log";
@@ -121,7 +122,7 @@ async function handlePOST(
     outcome = await withUserTenantRls(userId, async () =>
       prisma.$transaction(async (tx) => {
         // Serialize concurrent PRF rebootstrap + rotation for the same user.
-        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`;
+        await advisoryXactLock(tx, userId);
 
         // Step-up auth + counter CAS. Helper reads challenge from the
         // PRF-dedicated Redis key, performs verifyAuthentication, and runs the

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -68,7 +68,7 @@ export async function ensureTenantMembershipForSignIn(
   }
 
   const tenant = await withBypassRls(prisma, async (tx) => {
-    const found = await findOrCreateSsoTenant(tenantClaim);
+    const found = await findOrCreateSsoTenant(tenantClaim, tx);
 
     if (!found) return null;
 

--- a/src/lib/auth/policy/account-lockout.test.ts
+++ b/src/lib/auth/policy/account-lockout.test.ts
@@ -3,8 +3,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const {
   mockPrismaUser,
   mockPrismaTenant,
-  mockPrismaTransaction,
+  mockTxState,
   mockLogAudit,
+  mockLogAuditInTx,
   mockExtractRequestMeta,
   mockGetLogger,
   mockLoggerInstance,
@@ -18,8 +19,19 @@ const {
   return {
     mockPrismaUser: { findUnique: vi.fn(), update: vi.fn() },
     mockPrismaTenant: { findUnique: vi.fn() },
-    mockPrismaTransaction: vi.fn(),
+    // Raw-SQL behavior for the inner bypass-RLS callback (the former
+    // $transaction body now runs directly on the withBypassRls tx). Model
+    // methods (user/tenant) delegate to the shared module mocks so existing
+    // assertions on mockPrismaUser/mockPrismaTenant still hold.
+    mockTxState: {
+      queryRawImpl: vi.fn(),
+      executeRawImpl: vi.fn(),
+    } as {
+      queryRawImpl: ReturnType<typeof vi.fn>;
+      executeRawImpl: ReturnType<typeof vi.fn>;
+    },
     mockLogAudit: vi.fn(),
+    mockLogAuditInTx: vi.fn(),
     mockExtractRequestMeta: vi.fn().mockReturnValue({ ip: null, userAgent: null }),
     mockGetLogger: vi.fn(() => mockLoggerInstance),
     mockLoggerInstance,
@@ -31,14 +43,29 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     user: mockPrismaUser,
     tenant: mockPrismaTenant,
-    $transaction: mockPrismaTransaction,
   },
 }));
+// The former inner prisma.$transaction was folded away: the lockout body now
+// runs directly on the tx that withBypassRls passes to its callback. So the
+// tx mock here must expose every method the body calls: $executeRaw (SET LOCAL),
+// $queryRaw (the FOR UPDATE row read), user.update (counter write), plus the
+// user.findUnique / tenant.findUnique used by the other bypass call-sites
+// (tenantId resolution, checkLockout, getLockoutThresholds). Model methods
+// delegate to the shared module mocks so existing assertions still hold.
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
-  withBypassRls: vi.fn((prisma: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
+  withBypassRls: vi.fn((_prisma: unknown, fn: (tx: unknown) => unknown) => {
+    const tx = {
+      $executeRaw: (...args: unknown[]) => mockTxState.executeRawImpl(...args),
+      $queryRaw: (...args: unknown[]) => mockTxState.queryRawImpl(...args),
+      user: mockPrismaUser,
+      tenant: mockPrismaTenant,
+    };
+    return fn(tx);
+  }),
 }));
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
+  logAuditInTx: mockLogAuditInTx,
   extractRequestMeta: mockExtractRequestMeta,
 }));
 vi.mock("@/lib/logger", () => ({
@@ -105,14 +132,9 @@ describe("recordFailure", () => {
     last_failed_unlock_at: Date | null;
     account_locked_until: Date | null;
   }) {
-    mockPrismaTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-      const tx = {
-        $executeRaw: vi.fn(),
-        $queryRaw: vi.fn().mockResolvedValue([row]),
-        user: { update: vi.fn() },
-      };
-      return fn(tx);
-    });
+    mockTxState.executeRawImpl.mockResolvedValue(undefined);
+    mockTxState.queryRawImpl.mockResolvedValue([row]);
+    mockPrismaUser.update.mockResolvedValue(undefined);
   }
 
   it("increments counter on first failure", async () => {
@@ -254,7 +276,7 @@ describe("recordFailure", () => {
     const lockTimeoutError = Object.assign(new Error("lock timeout"), {
       code: "55P03",
     });
-    mockPrismaTransaction.mockRejectedValue(lockTimeoutError);
+    mockTxState.queryRawImpl.mockRejectedValue(lockTimeoutError);
 
     const result = await recordFailure("user-1");
     expect(result).toBeNull();
@@ -269,7 +291,7 @@ describe("recordFailure", () => {
       code: "P2010",
       meta: { code: "55P03" },
     });
-    mockPrismaTransaction.mockRejectedValue(prismaError);
+    mockTxState.queryRawImpl.mockRejectedValue(prismaError);
 
     const result = await recordFailure("user-1");
     expect(result).toBeNull();
@@ -283,7 +305,7 @@ describe("recordFailure", () => {
     const wrappedError = Object.assign(new Error("transaction failed"), {
       cause: Object.assign(new Error("lock timeout"), { code: "55P03" }),
     });
-    mockPrismaTransaction.mockRejectedValue(wrappedError);
+    mockTxState.queryRawImpl.mockRejectedValue(wrappedError);
 
     const result = await recordFailure("user-1");
     expect(result).toBeNull();
@@ -293,7 +315,7 @@ describe("recordFailure", () => {
     const lockTimeoutError = Object.assign(new Error("lock timeout"), {
       code: "55P03",
     });
-    mockPrismaTransaction.mockRejectedValue(lockTimeoutError);
+    mockTxState.queryRawImpl.mockRejectedValue(lockTimeoutError);
 
     await recordFailure("user-1");
     expect(mockLogAudit).toHaveBeenCalledWith(
@@ -305,7 +327,7 @@ describe("recordFailure", () => {
   });
 
   it("rethrows unexpected errors", async () => {
-    mockPrismaTransaction.mockRejectedValue(new Error("unexpected"));
+    mockTxState.queryRawImpl.mockRejectedValue(new Error("unexpected"));
     await expect(recordFailure("user-1")).rejects.toThrow("unexpected");
   });
 
@@ -455,7 +477,7 @@ describe("recordFailure", () => {
     const lockTimeoutError = Object.assign(new Error("lock timeout"), {
       code: "55P03",
     });
-    mockPrismaTransaction.mockRejectedValue(lockTimeoutError);
+    mockTxState.queryRawImpl.mockRejectedValue(lockTimeoutError);
 
     const result = await recordFailure("user-1");
     expect(result).toBeNull();
@@ -510,14 +532,9 @@ describe("getLockoutThresholds (via recordFailure with tenantId)", () => {
     last_failed_unlock_at: Date | null;
     account_locked_until: Date | null;
   }) {
-    mockPrismaTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-      const tx = {
-        $executeRaw: vi.fn(),
-        $queryRaw: vi.fn().mockResolvedValue([row]),
-        user: { update: vi.fn() },
-      };
-      return fn(tx);
-    });
+    mockTxState.executeRawImpl.mockResolvedValue(undefined);
+    mockTxState.queryRawImpl.mockResolvedValue([row]);
+    mockPrismaUser.update.mockResolvedValue(undefined);
   }
 
   it("applies custom thresholds when getLockoutThresholds returns per-tenant config", async () => {

--- a/src/lib/auth/policy/account-lockout.test.ts
+++ b/src/lib/auth/policy/account-lockout.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 
 const {
   mockPrismaUser,
@@ -27,8 +27,8 @@ const {
       queryRawImpl: vi.fn(),
       executeRawImpl: vi.fn(),
     } as {
-      queryRawImpl: ReturnType<typeof vi.fn>;
-      executeRawImpl: ReturnType<typeof vi.fn>;
+      queryRawImpl: Mock;
+      executeRawImpl: Mock;
     },
     mockLogAudit: vi.fn(),
     mockLogAuditInTx: vi.fn(),

--- a/src/lib/auth/policy/account-lockout.ts
+++ b/src/lib/auth/policy/account-lockout.ts
@@ -187,8 +187,7 @@ export async function recordFailure(
   try {
     // withBypassRls required: called outside tenant RLS context (post-auth side effect).
     // The prisma proxy re-uses the bypass transaction for nested $transaction calls.
-    const result = await withBypassRls(prisma, async (tx) =>
-      prisma.$transaction(async (tx) => {
+    const result = await withBypassRls(prisma, async (tx) => {
       // Set lock_timeout to prevent indefinite waits
       await tx.$executeRaw`SET LOCAL lock_timeout = '200ms'`;
 
@@ -271,8 +270,7 @@ export async function recordFailure(
         lockMinutes,
         thresholdCrossed,
       };
-    }),
-    BYPASS_PURPOSE.AUTH_FLOW);
+    }, BYPASS_PURPOSE.AUTH_FLOW);
 
     // Atomic audit: VAULT_UNLOCK_FAILED (every failure)
     try {

--- a/src/lib/auth/session/auth-adapter.test.ts
+++ b/src/lib/auth/session/auth-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const { mockPrismaSession, mockPrismaUser, mockPrismaTenant, mockPrismaTenantMember, mockPrismaAccount, mockPrismaTransaction, mockSessionMetaGetStore, mockTenantClaimStoreGetStore, mockFindOrCreateSsoTenant, mockWithBypassRls, mockTxSession, mockTxTenant, mockLogAudit, mockCreateNotification, mockResolveEffectiveSessionTimeouts, mockInvalidateCachedSessions } = vi.hoisted(() => ({
+const { mockPrismaSession, mockPrismaUser, mockPrismaTenant, mockPrismaTenantMember, mockPrismaAccount, mockPrismaTransaction, mockSessionMetaGetStore, mockTenantClaimStoreGetStore, mockFindOrCreateSsoTenant, mockWithBypassRls, mockTxExecuteRaw, mockTxSession, mockTxTenant, mockLogAudit, mockCreateNotification, mockResolveEffectiveSessionTimeouts, mockInvalidateCachedSessions } = vi.hoisted(() => ({
   mockPrismaSession: {
     create: vi.fn(),
     update: vi.fn(),
@@ -32,6 +32,7 @@ const { mockPrismaSession, mockPrismaUser, mockPrismaTenant, mockPrismaTenantMem
   mockTenantClaimStoreGetStore: vi.fn(),
   mockFindOrCreateSsoTenant: vi.fn(),
   mockWithBypassRls: vi.fn(async (prisma: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
+  mockTxExecuteRaw: vi.fn().mockResolvedValue(1),
   mockTxSession: {
     create: vi.fn(),
     findMany: vi.fn(),
@@ -316,10 +317,11 @@ describe("createCustomAdapter", () => {
     // to the session/tenant tx mocks and expose $executeRaw for the
     // per-user advisory lock (SELECT pg_advisory_xact_lock(...)).
     beforeEach(() => {
+      mockTxExecuteRaw.mockClear();
       mockWithBypassRls.mockImplementation(
         async (_prisma: unknown, fn: (tx: unknown) => unknown) =>
           fn({
-            $executeRaw: vi.fn().mockResolvedValue(1),
+            $executeRaw: mockTxExecuteRaw,
             tenant: { ...mockPrismaTenant, findUnique: mockTxTenant.findUnique },
             user: mockPrismaUser,
             tenantMember: mockPrismaTenantMember,
@@ -367,6 +369,15 @@ describe("createCustomAdapter", () => {
         userId: "u-1",
         expires,
       });
+
+      // The count-then-evict-then-create (concurrent-session cap) runs under a
+      // per-user advisory lock (TOCTOU race). Mutation-kill: removing the
+      // tx.$executeRaw lock line leaves $executeRaw uncalled with this SQL.
+      expect(
+        mockTxExecuteRaw.mock.calls.some((c) =>
+          String(c[0]).includes("pg_advisory_xact_lock"),
+        ),
+      ).toBe(true);
     });
 
     it("records provider from sessionMetaStorage on the session row", async () => {

--- a/src/lib/auth/session/auth-adapter.test.ts
+++ b/src/lib/auth/session/auth-adapter.test.ts
@@ -210,7 +210,7 @@ describe("createCustomAdapter", () => {
 
       // Bootstrap tenant.create should NOT be called
       expect(mockPrismaTenant.create).not.toHaveBeenCalled();
-      expect(mockFindOrCreateSsoTenant).toHaveBeenCalledWith("acme.com");
+      expect(mockFindOrCreateSsoTenant).toHaveBeenCalledWith("acme.com", expect.anything());
       // User should be created with SSO tenant ID
       expect(mockPrismaUser.create).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/lib/auth/session/auth-adapter.test.ts
+++ b/src/lib/auth/session/auth-adapter.test.ts
@@ -100,6 +100,13 @@ describe("createCustomAdapter", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Restore the default bypass-tx passthrough (fn(prisma)). The createSession
+    // describe overrides this with a tx that exposes $executeRaw + tx session
+    // mocks; mockImplementation persists across tests, so re-assert the default
+    // here so sibling describes keep the plain prisma-passthrough tx.
+    mockWithBypassRls.mockImplementation(
+      async (prisma: unknown, fn: (tx: unknown) => unknown) => fn(prisma),
+    );
     // Default: no pending tenant claim
     mockTenantClaimStoreGetStore.mockReturnValue({ tenantClaim: null });
     mockFindOrCreateSsoTenant.mockResolvedValue(null);
@@ -304,6 +311,23 @@ describe("createCustomAdapter", () => {
   });
 
   describe("createSession", () => {
+    // createSession runs entirely on the outer withBypassRls transaction
+    // (the former inner prisma.$transaction was removed). Route the bypass tx
+    // to the session/tenant tx mocks and expose $executeRaw for the
+    // per-user advisory lock (SELECT pg_advisory_xact_lock(...)).
+    beforeEach(() => {
+      mockWithBypassRls.mockImplementation(
+        async (_prisma: unknown, fn: (tx: unknown) => unknown) =>
+          fn({
+            $executeRaw: vi.fn().mockResolvedValue(1),
+            tenant: { ...mockPrismaTenant, findUnique: mockTxTenant.findUnique },
+            user: mockPrismaUser,
+            tenantMember: mockPrismaTenantMember,
+            session: mockTxSession,
+          }),
+      );
+    });
+
     it("captures IP and userAgent from sessionMetaStorage", async () => {
       mockSessionMetaGetStore.mockReturnValue({
         ip: "192.168.1.1",
@@ -532,10 +556,13 @@ describe("createCustomAdapter", () => {
       expectNotInvalidatedOnDbThrow(mockInvalidateCachedSessions);
     });
 
-    it("does not invalidate cache when $transaction throws (sequencing invariant)", async () => {
+    it("does not invalidate cache when the bypass transaction throws (sequencing invariant)", async () => {
       mockSessionMetaGetStore.mockReturnValue({ ip: "10.0.0.1", userAgent: "x" });
       mockPrismaUser.findUnique.mockResolvedValue({ tenantId: "tenant-1" });
-      mockPrismaTransaction.mockRejectedValue(new Error("tx rolled back"));
+      // createSession now runs on the outer withBypassRls tx (inner
+      // prisma.$transaction removed). Simulate the DB write failing inside
+      // that tx so the whole bypass transaction rolls back.
+      mockTxSession.create.mockRejectedValue(new Error("tx rolled back"));
 
       const adapter = createCustomAdapter();
       await expect(

--- a/src/lib/auth/session/auth-adapter.ts
+++ b/src/lib/auth/session/auth-adapter.ts
@@ -275,67 +275,71 @@ export function createCustomAdapter(): Adapter {
       const created = await withBypassRls(prisma, async (tx) => {
         const tenantId = await resolveTenantIdForUser(session.userId);
 
-        // Serializable prevents TOCTOU in concurrent session counting
-        return prisma.$transaction(async (tx) => {
-          // Check tenant's concurrent session limit
-          const tenant = await tx.tenant.findUnique({
-            where: { id: tenantId },
-            select: { maxConcurrentSessions: true },
-          });
+        // Serialize concurrent session creation for this user so the
+        // count-then-evict-then-create sequence cannot race past the concurrent
+        // session cap (two concurrent sign-ins both reading count < max).
+        // Advisory lock is transaction-scoped; matches the codebase idiom
+        // (attachments, vault rotate-key).
+        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${session.userId}::text))`;
 
-          const maxSessions = tenant?.maxConcurrentSessions;
-          if (maxSessions != null && maxSessions > 0) {
-            // Count active sessions (ORDER BY id for consistent lock ordering)
-            const activeSessions = await tx.session.findMany({
-              where: {
-                userId: session.userId,
-                tenantId,
-                expires: { gt: new Date() },
-              },
-              select: { id: true, sessionToken: true, ipAddress: true, userAgent: true },
-              orderBy: { id: "asc" },
-            });
+        // Check tenant's concurrent session limit
+        const tenant = await tx.tenant.findUnique({
+          where: { id: tenantId },
+          select: { maxConcurrentSessions: true },
+        });
 
-            // Evict oldest sessions if at or over limit
-            if (activeSessions.length >= maxSessions) {
-              const toEvict = activeSessions.slice(0, activeSessions.length - maxSessions + 1);
-              await tx.session.deleteMany({
-                where: { id: { in: toEvict.map((s) => s.id) } },
-              });
-
-              evictionInfo = { tenantId, maxSessions, evicted: toEvict };
-            }
-          }
-
-          // Override Auth.js's default expires with the per-user resolved idle
-          // window. At createSession time `createdAt === now`, so the absolute
-          // bound does not further constrain the first expires; subsequent
-          // updateSession calls enforce `min(now + idle, createdAt + absolute)`.
-          const resolved = await resolveEffectiveSessionTimeouts(
-            session.userId,
-            meta?.provider ?? null,
-          );
-          const resolvedExpires = new Date(
-            Date.now() + resolved.idleMinutes * MS_PER_MINUTE,
-          );
-
-          return tx.session.create({
-            data: {
-              sessionToken: session.sessionToken,
+        const maxSessions = tenant?.maxConcurrentSessions;
+        if (maxSessions != null && maxSessions > 0) {
+          // Count active sessions (ORDER BY id for consistent lock ordering)
+          const activeSessions = await tx.session.findMany({
+            where: {
               userId: session.userId,
               tenantId,
-              expires: resolvedExpires,
-              ipAddress: meta?.ip ?? null,
-              userAgent: meta?.userAgent?.slice(0, USER_AGENT_MAX_LENGTH) ?? null,
-              provider: meta?.provider ?? null,
+              expires: { gt: new Date() },
             },
-            select: {
-              sessionToken: true,
-              userId: true,
-              expires: true,
-            },
+            select: { id: true, sessionToken: true, ipAddress: true, userAgent: true },
+            orderBy: { id: "asc" },
           });
-        }, { isolationLevel: "Serializable" });
+
+          // Evict oldest sessions if at or over limit
+          if (activeSessions.length >= maxSessions) {
+            const toEvict = activeSessions.slice(0, activeSessions.length - maxSessions + 1);
+            await tx.session.deleteMany({
+              where: { id: { in: toEvict.map((s) => s.id) } },
+            });
+
+            evictionInfo = { tenantId, maxSessions, evicted: toEvict };
+          }
+        }
+
+        // Override Auth.js's default expires with the per-user resolved idle
+        // window. At createSession time `createdAt === now`, so the absolute
+        // bound does not further constrain the first expires; subsequent
+        // updateSession calls enforce `min(now + idle, createdAt + absolute)`.
+        const resolved = await resolveEffectiveSessionTimeouts(
+          session.userId,
+          meta?.provider ?? null,
+        );
+        const resolvedExpires = new Date(
+          Date.now() + resolved.idleMinutes * MS_PER_MINUTE,
+        );
+
+        return tx.session.create({
+          data: {
+            sessionToken: session.sessionToken,
+            userId: session.userId,
+            tenantId,
+            expires: resolvedExpires,
+            ipAddress: meta?.ip ?? null,
+            userAgent: meta?.userAgent?.slice(0, USER_AGENT_MAX_LENGTH) ?? null,
+            provider: meta?.provider ?? null,
+          },
+          select: {
+            sessionToken: true,
+            userId: true,
+            expires: true,
+          },
+        });
       }, BYPASS_PURPOSE.AUTH_FLOW);
 
       // Fire-and-forget: check for new device and notify user

--- a/src/lib/auth/session/auth-adapter.ts
+++ b/src/lib/auth/session/auth-adapter.ts
@@ -159,7 +159,7 @@ export function createCustomAdapter(): Adapter {
         // Resolve SSO tenant inside withBypassRls (no nesting)
         let ssoTenant: { id: string } | null = null;
         if (pendingClaim) {
-          ssoTenant = await findOrCreateSsoTenant(pendingClaim);
+          ssoTenant = await findOrCreateSsoTenant(pendingClaim, tx);
         }
 
         return prisma.$transaction(async (tx) => {

--- a/src/lib/auth/session/auth-adapter.ts
+++ b/src/lib/auth/session/auth-adapter.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { sessionMetaStorage } from "@/lib/auth/session/session-meta";
 import { tenantClaimStorage } from "@/lib/tenant/tenant-claim-storage";
 import { findOrCreateSsoTenant } from "@/lib/tenant/tenant-management";
-import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+import { withBypassRls, BYPASS_PURPOSE, advisoryXactLock } from "@/lib/tenant-rls";
 import { randomUUID } from "node:crypto";
 import { checkNewDeviceAndNotify } from "@/lib/auth/policy/new-device-detection";
 import { USER_AGENT_MAX_LENGTH, BOOTSTRAP_SLUG_HASH_LENGTH } from "@/lib/validations/common.server";
@@ -279,7 +279,7 @@ export function createCustomAdapter(): Adapter {
         // session cap (two concurrent sign-ins both reading count < max).
         // Advisory lock is transaction-scoped; matches the codebase idiom
         // (attachments, vault rotate-key).
-        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${session.userId}::text))`;
+        await advisoryXactLock(tx, session.userId);
 
         // Check tenant's concurrent session limit
         const tenant = await tx.tenant.findUnique({

--- a/src/lib/auth/session/auth-adapter.ts
+++ b/src/lib/auth/session/auth-adapter.ts
@@ -156,50 +156,49 @@ export function createCustomAdapter(): Adapter {
       const pendingClaim = tenantClaimStorage.getStore()?.tenantClaim ?? null;
 
       const created = await withBypassRls(prisma, async (tx) => {
-        // Resolve SSO tenant inside withBypassRls (no nesting)
+        // Resolve SSO tenant, then create tenant/user/member — all on the single
+        // withBypassRls tx (no redundant inner $transaction).
         let ssoTenant: { id: string } | null = null;
         if (pendingClaim) {
           ssoTenant = await findOrCreateSsoTenant(pendingClaim, tx);
         }
 
-        return prisma.$transaction(async (tx) => {
-          const tenant = ssoTenant
-            ?? await tx.tenant.create({
-                data: {
-                  name: user.email ?? user.name ?? "User",
-                  slug: `bootstrap-${randomUUID().replace(/-/g, "").slice(0, BOOTSTRAP_SLUG_HASH_LENGTH)}`,
-                  isBootstrap: true,
-                },
-                select: { id: true },
-              });
+        const tenant = ssoTenant
+          ?? await tx.tenant.create({
+              data: {
+                name: user.email ?? user.name ?? "User",
+                slug: `bootstrap-${randomUUID().replace(/-/g, "").slice(0, BOOTSTRAP_SLUG_HASH_LENGTH)}`,
+                isBootstrap: true,
+              },
+              select: { id: true },
+            });
 
-          const createdUser = await tx.user.create({
-            data: {
-              name: user.name,
-              email: user.email,
-              image: user.image,
-              emailVerified: user.emailVerified,
-              tenantId: tenant.id,
-            },
-            select: {
-              id: true,
-              name: true,
-              email: true,
-              image: true,
-              emailVerified: true,
-            },
-          });
-
-          await tx.tenantMember.create({
-            data: {
-              tenantId: tenant.id,
-              userId: createdUser.id,
-              role: ssoTenant ? "MEMBER" : "OWNER",
-            },
-          });
-
-          return createdUser;
+        const createdUser = await tx.user.create({
+          data: {
+            name: user.name,
+            email: user.email,
+            image: user.image,
+            emailVerified: user.emailVerified,
+            tenantId: tenant.id,
+          },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            image: true,
+            emailVerified: true,
+          },
         });
+
+        await tx.tenantMember.create({
+          data: {
+            tenantId: tenant.id,
+            userId: createdUser.id,
+            role: ssoTenant ? "MEMBER" : "OWNER",
+          },
+        });
+
+        return createdUser;
       }, BYPASS_PURPOSE.AUTH_FLOW);
       if (!created.email) {
         throw new Error("USER_EMAIL_MISSING");

--- a/src/lib/auth/tokens/extension-token.test.ts
+++ b/src/lib/auth/tokens/extension-token.test.ts
@@ -16,12 +16,14 @@ const {
   mockCreate,
   mockUpdateMany,
   mockTransaction,
+  mockTxExecuteRaw,
   mockWithUserTenantRls,
 } = vi.hoisted(() => ({
   mockFindMany: vi.fn(),
   mockCreate: vi.fn(),
   mockUpdateMany: vi.fn(),
   mockTransaction: vi.fn(),
+  mockTxExecuteRaw: vi.fn().mockResolvedValue(1),
   mockWithUserTenantRls: vi.fn(async (_userId: string, fn: () => unknown) => fn()),
 }));
 
@@ -605,9 +607,10 @@ describe("issueExtensionToken", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockWithUserTenantRls.mockImplementation(async (_u, fn) => fn());
+    mockTxExecuteRaw.mockClear();
     mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
       cb({
-        $executeRaw: vi.fn().mockResolvedValue(1),
+        $executeRaw: mockTxExecuteRaw,
         extensionToken: {
           findMany: mockFindMany,
           create: mockCreate,
@@ -634,6 +637,14 @@ describe("issueExtensionToken", () => {
     expect(result.expiresAt).toBeInstanceOf(Date);
     expect(result.scopeCsv).toBe("passwords:read,vault:unlock-data");
     expect(result.cnfJkt).toBe(VALID_CNF_JKT);
+    // The count-then-evict-then-create runs under a per-user advisory lock
+    // (TOCTOU cap race). Mutation-kill: removing the tx.$executeRaw lock line
+    // leaves $executeRaw uncalled with this SQL.
+    expect(
+      mockTxExecuteRaw.mock.calls.some((c) =>
+        String(c[0]).includes("pg_advisory_xact_lock"),
+      ),
+    ).toBe(true);
   });
 
   it("creates the token via prisma.extensionToken.create with the hashed token and cnfJkt", async () => {

--- a/src/lib/auth/tokens/extension-token.test.ts
+++ b/src/lib/auth/tokens/extension-token.test.ts
@@ -607,6 +607,7 @@ describe("issueExtensionToken", () => {
     mockWithUserTenantRls.mockImplementation(async (_u, fn) => fn());
     mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
       cb({
+        $executeRaw: vi.fn().mockResolvedValue(1),
         extensionToken: {
           findMany: mockFindMany,
           create: mockCreate,

--- a/src/lib/auth/tokens/extension-token.ts
+++ b/src/lib/auth/tokens/extension-token.ts
@@ -218,6 +218,8 @@ export async function issueExtensionToken(params: {
 
   const created = await withUserTenantRls(userId, async () =>
     prisma.$transaction(async (tx) => {
+      // Serialize concurrent token issuance for this user (count-then-evict-then-create cap race).
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`;
       // Find active tokens (non-revoked, non-expired)
       const active = await tx.extensionToken.findMany({
         where: { userId, revokedAt: null, expiresAt: { gt: now } },

--- a/src/lib/auth/tokens/extension-token.ts
+++ b/src/lib/auth/tokens/extension-token.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { generateShareToken, hashToken } from "@/lib/crypto/crypto-server";
-import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+import { withBypassRls, BYPASS_PURPOSE, advisoryXactLock } from "@/lib/tenant-rls";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { randomUUID } from "node:crypto";
 import {
@@ -219,7 +219,7 @@ export async function issueExtensionToken(params: {
   const created = await withUserTenantRls(userId, async () =>
     prisma.$transaction(async (tx) => {
       // Serialize concurrent token issuance for this user (count-then-evict-then-create cap race).
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`;
+      await advisoryXactLock(tx, userId);
       // Find active tokens (non-revoked, non-expired)
       const active = await tx.extensionToken.findMany({
         where: { userId, revokedAt: null, expiresAt: { gt: now } },

--- a/src/lib/auth/tokens/mobile-token.test.ts
+++ b/src/lib/auth/tokens/mobile-token.test.ts
@@ -10,6 +10,7 @@ const {
   mockExtUpdate,
   mockExtUpdateMany,
   mockTransaction,
+  mockTxExecuteRaw,
   mockWithBypassRls,
   mockWithUserTenantRls,
 } = vi.hoisted(() => ({
@@ -18,6 +19,7 @@ const {
   mockExtUpdate: vi.fn(),
   mockExtUpdateMany: vi.fn(),
   mockTransaction: vi.fn(),
+  mockTxExecuteRaw: vi.fn().mockResolvedValue(1),
   mockWithBypassRls: vi.fn(async (p: unknown, fn: (tx: unknown) => unknown) => fn(p)),
   mockWithUserTenantRls: vi.fn(async (_u: string, fn: () => unknown) => fn()),
 }));
@@ -125,7 +127,7 @@ const CNF_JKT = DEVICE_JKT;
 function setupTransactionPassthrough() {
   mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
     cb({
-      $executeRaw: vi.fn().mockResolvedValue(1),
+      $executeRaw: mockTxExecuteRaw,
       extensionToken: {
         findMany: mockExtFindMany,
         create: mockExtCreate,
@@ -203,6 +205,15 @@ describe("issueIosToken", () => {
     const refreshCall = mockExtCreate.mock.calls[1][0];
     expect(refreshCall.data.clientKind).toBe("IOS_APP");
     expect(refreshCall.data.tokenHash).not.toBe(accessCall.data.tokenHash);
+
+    // The count-then-evict-then-create runs under a per-user advisory lock
+    // (TOCTOU cap race). Mutation-kill: removing the tx.$executeRaw lock line
+    // leaves $executeRaw uncalled with this SQL.
+    expect(
+      mockTxExecuteRaw.mock.calls.some((c) =>
+        String(c[0]).includes("pg_advisory_xact_lock"),
+      ),
+    ).toBe(true);
   });
 
   it("generates a new familyId when none is provided", async () => {

--- a/src/lib/auth/tokens/mobile-token.test.ts
+++ b/src/lib/auth/tokens/mobile-token.test.ts
@@ -125,6 +125,7 @@ const CNF_JKT = DEVICE_JKT;
 function setupTransactionPassthrough() {
   mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
     cb({
+      $executeRaw: vi.fn().mockResolvedValue(1),
       extensionToken: {
         findMany: mockExtFindMany,
         create: mockExtCreate,

--- a/src/lib/auth/tokens/mobile-token.ts
+++ b/src/lib/auth/tokens/mobile-token.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server";
 import { createHash, randomUUID } from "node:crypto";
 import { prisma } from "@/lib/prisma";
 import { generateShareToken, hashToken } from "@/lib/crypto/crypto-server";
-import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+import { withBypassRls, BYPASS_PURPOSE, advisoryXactLock } from "@/lib/tenant-rls";
 import { withUserTenantRls } from "@/lib/tenant-context";
 import { logAuditAsync, personalAuditBase } from "@/lib/audit/audit";
 import {
@@ -142,7 +142,7 @@ export async function issueIosToken(
   const accessRow = await withUserTenantRls(userId, async () =>
     prisma.$transaction(async (tx) => {
       // Serialize concurrent token issuance for this user (count-then-evict-then-create cap race).
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`;
+      await advisoryXactLock(tx, userId);
       // Enforce per-user active-token cap (covers BROWSER_EXTENSION + IOS_APP
       // rows; an iOS pair counts as 2 active rows). The cap is a defence
       // against issuance abuse — the host app's "one active token per device"

--- a/src/lib/auth/tokens/mobile-token.ts
+++ b/src/lib/auth/tokens/mobile-token.ts
@@ -141,6 +141,8 @@ export async function issueIosToken(
 
   const accessRow = await withUserTenantRls(userId, async () =>
     prisma.$transaction(async (tx) => {
+      // Serialize concurrent token issuance for this user (count-then-evict-then-create cap race).
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId}::text))`;
       // Enforce per-user active-token cap (covers BROWSER_EXTENSION + IOS_APP
       // rows; an iOS pair counts as 2 active rows). The cap is a defence
       // against issuance abuse — the host app's "one active token per device"

--- a/src/lib/auth/webauthn/webauthn-authorize.ts
+++ b/src/lib/auth/webauthn/webauthn-authorize.ts
@@ -173,7 +173,7 @@ export async function authorizeWebAuthn(
   // last_used_device is set to NULL here; device info is captured
   // by session metadata when Auth.js creates the session.
   const updatedRows = await withBypassRls(prisma, async (tx) =>
-    prisma.$executeRaw`
+    tx.$executeRaw`
       UPDATE "webauthn_credentials"
       SET counter = ${BigInt(newCounter)},
           "last_used_at" = ${new Date()}

--- a/src/lib/directory-sync/engine.test.ts
+++ b/src/lib/directory-sync/engine.test.ts
@@ -5,7 +5,6 @@ import { SYSTEM_ACTOR_ID } from "@/lib/constants/app";
 
 const {
   mockExecuteRaw,
-  mockTransaction,
   mockDirSyncConfig,
   mockScimMapping,
   mockTenantMember,
@@ -18,10 +17,10 @@ const {
   mockFetchAzureAdUsers,
   mockGetGoogleAccessToken,
   mockFetchGoogleUsers,
+  applyTxHolder,
 } = vi.hoisted(() => {
   return {
     mockExecuteRaw: vi.fn(),
-    mockTransaction: vi.fn(),
     mockDirSyncConfig: {
       findFirst: vi.fn(),
       findUnique: vi.fn(),
@@ -38,13 +37,17 @@ const {
     mockFetchAzureAdUsers: vi.fn(),
     mockGetGoogleAccessToken: vi.fn(),
     mockFetchGoogleUsers: vi.fn(),
+    // Holds the rich apply-phase tx a test configures. The apply body (formerly
+    // an inner prisma.$transaction folded into withTenantRls) now runs directly
+    // on the withTenantRls callback's tx, so tests inject that tx here instead
+    // of via prisma.$transaction.
+    applyTxHolder: { current: null as Record<string, unknown> | null },
   };
 });
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     $executeRaw: mockExecuteRaw,
-    $transaction: mockTransaction,
     directorySyncConfig: mockDirSyncConfig,
     scimExternalMapping: mockScimMapping,
     tenantMember: mockTenantMember,
@@ -52,8 +55,34 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
+// The apply phase now runs directly on the withTenantRls callback's tx (the
+// former inner prisma.$transaction was a no-op fold and is gone). Merge any
+// test-configured apply-phase tx over the top-level prisma model mocks +
+// $executeRaw, so every withTenantRls callback — CAS lock ($executeRaw), config
+// load, mapping/member load, log create, AND the apply phase — resolves the
+// methods it calls on tx.
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
-  withTenantRls: vi.fn((prisma, _tenantId, fn) => fn(prisma)),
+  withTenantRls: vi.fn(async (prisma, _tenantId, fn) => {
+    if (!applyTxHolder.current) return fn(prisma);
+    // Per-model deep merge: the apply-phase tx and the top-level prisma mock
+    // each supply a slice of a model's methods (e.g. the apply tx supplies
+    // scimExternalMapping.upsert / user.create; prisma supplies the load-phase
+    // scimExternalMapping.findMany / tenantMember.findMany). The top-level
+    // prisma mock is authoritative for the read/load methods it defines, so
+    // give it precedence; the apply tx fills in the write methods prisma lacks.
+    const base = prisma as Record<string, unknown>;
+    const overlay = applyTxHolder.current as Record<string, unknown>;
+    const tx: Record<string, unknown> = { ...base };
+    for (const [model, methods] of Object.entries(overlay)) {
+      const baseModel = base[model];
+      tx[model] =
+        baseModel && typeof baseModel === "object" && methods && typeof methods === "object"
+          ? { ...(methods as object), ...(baseModel as object) }
+          : methods;
+    }
+    tx.$executeRaw = mockExecuteRaw;
+    return fn(tx);
+  }),
 }));
 
 vi.mock("@/lib/audit/audit", () => ({
@@ -159,27 +188,35 @@ function setupAcquiredLock() {
   mockExecuteRaw.mockResolvedValue(1);
 }
 
-/** Set up a successful transaction that calls the callback with a mock tx */
+/** Rich apply-phase tx shape; individual tests override specific methods. */
+function makeApplyTx(overrides: Record<string, unknown> = {}) {
+  return {
+    user: {
+      findMany: vi.fn().mockResolvedValue([]),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    tenantMember: {
+      findMany: vi.fn().mockResolvedValue([]),
+      create: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    scimExternalMapping: {
+      upsert: vi.fn(),
+    },
+    ...overrides,
+  };
+}
+
+/** Register the apply-phase tx that the withTenantRls mock injects. */
+function setApplyTx(tx: Record<string, unknown>) {
+  applyTxHolder.current = tx;
+}
+
+/** Set up a successful apply phase with a default rich tx. */
 function setupTransaction() {
-  mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-    const tx = {
-      user: {
-        findMany: vi.fn().mockResolvedValue([]),
-        create: vi.fn(),
-        update: vi.fn(),
-      },
-      tenantMember: {
-        findMany: vi.fn().mockResolvedValue([]),
-        create: vi.fn(),
-        update: vi.fn(),
-        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
-      },
-      scimExternalMapping: {
-        upsert: vi.fn(),
-      },
-    };
-    return fn(tx);
-  });
+  setApplyTx(makeApplyTx());
 }
 
 // ─── Tests ───────────────────────────────────────────────────
@@ -187,6 +224,7 @@ function setupTransaction() {
 describe("runDirectorySync", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    applyTxHolder.current = null;
     mockDirSyncLog.create.mockResolvedValue({ id: "log-1" });
     mockDirSyncConfig.update.mockResolvedValue({});
     mockDecryptCredentials.mockReturnValue(OKTA_CREDS_JSON);
@@ -197,6 +235,9 @@ describe("runDirectorySync", () => {
   describe("dryRun mode", () => {
     it("returns correct counts without writing any data", async () => {
       setupAcquiredLock();
+      // Register a tracking apply-phase tx so we can assert no writes happen.
+      const applyTx = makeApplyTx();
+      setApplyTx(applyTx);
 
       mockDirSyncConfig.findUnique.mockResolvedValue(OKTA_CONFIG);
       mockFetchOktaUsers.mockResolvedValue([
@@ -219,12 +260,17 @@ describe("runDirectorySync", () => {
       expect(result.usersCreated).toBe(1);
       expect(result.usersUpdated).toBe(1);
       expect(result.usersDeactivated).toBe(0);
-      // No $transaction call in dryRun
-      expect(mockTransaction).not.toHaveBeenCalled();
+      // dryRun performs no writes: the apply-phase tx is never exercised.
+      expect(applyTx.user.create).not.toHaveBeenCalled();
+      expect(applyTx.tenantMember.create).not.toHaveBeenCalled();
+      expect(applyTx.tenantMember.update).not.toHaveBeenCalled();
+      expect(applyTx.tenantMember.updateMany).not.toHaveBeenCalled();
     });
 
     it("counts deactivations without writing", async () => {
       setupAcquiredLock();
+      const applyTx = makeApplyTx();
+      setApplyTx(applyTx);
 
       mockDirSyncConfig.findUnique.mockResolvedValue(OKTA_CONFIG);
       // Provider returns no users → all mapped members would be deactivated
@@ -242,7 +288,8 @@ describe("runDirectorySync", () => {
       expect(result.success).toBe(true);
       expect(result.dryRun).toBe(true);
       expect(result.usersDeactivated).toBe(1);
-      expect(mockTransaction).not.toHaveBeenCalled();
+      // dryRun performs no writes: the batch-deactivate updateMany is never run.
+      expect(applyTx.tenantMember.updateMany).not.toHaveBeenCalled();
     });
   });
 
@@ -252,32 +299,24 @@ describe("runDirectorySync", () => {
     it("calls tx.user.create and tx.tenantMember.create for a new provider user", async () => {
       setupAcquiredLock();
 
-      let capturedTx: {
+      const capturedTx = makeApplyTx({
+        user: {
+          findMany: vi.fn().mockResolvedValue([]), // no pre-existing users by email
+          create: vi.fn().mockResolvedValue({ id: "new-user-1", email: "newuser@example.com" }),
+          update: vi.fn(),
+        },
+        tenantMember: {
+          findMany: vi.fn().mockResolvedValue([]), // no pre-existing tenant members
+          create: vi.fn().mockResolvedValue({}),
+          update: vi.fn(),
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+        },
+      }) as {
         user: { create: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> };
         tenantMember: { create: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn>; updateMany: ReturnType<typeof vi.fn> };
         scimExternalMapping: { upsert: ReturnType<typeof vi.fn> };
-      } | undefined;
-
-      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const tx = {
-          user: {
-            findMany: vi.fn().mockResolvedValue([]), // no pre-existing users by email
-            create: vi.fn().mockResolvedValue({ id: "new-user-1", email: "newuser@example.com" }),
-            update: vi.fn(),
-          },
-          tenantMember: {
-            findMany: vi.fn().mockResolvedValue([]), // no pre-existing tenant members
-            create: vi.fn().mockResolvedValue({}),
-            update: vi.fn(),
-            updateMany: vi.fn().mockResolvedValue({ count: 0 }),
-          },
-          scimExternalMapping: {
-            upsert: vi.fn(),
-          },
-        };
-        capturedTx = tx;
-        return fn(tx);
-      });
+      };
+      setApplyTx(capturedTx);
 
       mockDirSyncConfig.findUnique.mockResolvedValue(OKTA_CONFIG);
       // Provider returns one new user not yet in the system
@@ -291,15 +330,14 @@ describe("runDirectorySync", () => {
       const result = await runDirectorySync(BASE_OPTIONS);
 
       expect(result.success).toBe(true);
-      expect(capturedTx).toBeDefined();
       // user.create must be called to create the new user
-      expect(capturedTx!.user.create).toHaveBeenCalledWith(
+      expect(capturedTx.user.create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({ email: "newuser@example.com" }),
         }),
       );
       // tenantMember.create must be called to add the user to the tenant
-      expect(capturedTx!.tenantMember.create).toHaveBeenCalledWith(
+      expect(capturedTx.tenantMember.create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({ tenantId: TENANT_ID }),
         }),
@@ -312,6 +350,8 @@ describe("runDirectorySync", () => {
   describe("safety guard", () => {
     it("aborts when deactivations exceed 20% and force=false", async () => {
       setupAcquiredLock();
+      const applyTx = makeApplyTx();
+      setApplyTx(applyTx);
 
       mockDirSyncConfig.findUnique.mockResolvedValue(OKTA_CONFIG);
       // Provider returns 1 user, 6 currently active → 5 would be deactivated (83%)
@@ -338,7 +378,10 @@ describe("runDirectorySync", () => {
       expect(result.abortedSafety).toBe(true);
       expect(result.errorMessage).toMatch(/20%/);
       expect(result.logId).toBe("log-1");
-      expect(mockTransaction).not.toHaveBeenCalled();
+      // Aborting before the apply phase means no member writes occur.
+      expect(applyTx.tenantMember.updateMany).not.toHaveBeenCalled();
+      expect(applyTx.tenantMember.update).not.toHaveBeenCalled();
+      expect(applyTx.user.create).not.toHaveBeenCalled();
     });
 
     it("proceeds normally when force=true despite exceeding 20%", async () => {
@@ -460,22 +503,17 @@ describe("runDirectorySync", () => {
 
       // Capture the updateMany call to verify OWNER is excluded
       let updateManyWhere: unknown;
-      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const tx = {
-          user: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn(), update: vi.fn() },
-          tenantMember: {
-            findMany: vi.fn().mockResolvedValue([]),
-            create: vi.fn(),
-            update: vi.fn(),
-            updateMany: vi.fn().mockImplementation((args: unknown) => {
-              updateManyWhere = args;
-              return Promise.resolve({ count: 1 });
-            }),
-          },
-          scimExternalMapping: { upsert: vi.fn() },
-        };
-        return fn(tx);
-      });
+      setApplyTx(makeApplyTx({
+        tenantMember: {
+          findMany: vi.fn().mockResolvedValue([]),
+          create: vi.fn(),
+          update: vi.fn(),
+          updateMany: vi.fn().mockImplementation((args: unknown) => {
+            updateManyWhere = args;
+            return Promise.resolve({ count: 1 });
+          }),
+        },
+      }));
 
       const result = await runDirectorySync({ ...BASE_OPTIONS, force: true });
 
@@ -498,29 +536,25 @@ describe("runDirectorySync", () => {
       let userUpdateArgs: unknown;
       let tenantMemberUpdateArgs: unknown;
 
-      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const tx = {
-          user: {
-            findMany: vi.fn().mockResolvedValue([]),
-            create: vi.fn(),
-            update: vi.fn().mockImplementation((args: unknown) => {
-              userUpdateArgs = args;
-              return Promise.resolve({});
-            }),
-          },
-          tenantMember: {
-            findMany: vi.fn().mockResolvedValue([]),
-            create: vi.fn(),
-            update: vi.fn().mockImplementation((args: unknown) => {
-              tenantMemberUpdateArgs = args;
-              return Promise.resolve({});
-            }),
-            updateMany: vi.fn().mockResolvedValue({ count: 0 }),
-          },
-          scimExternalMapping: { upsert: vi.fn() },
-        };
-        return fn(tx);
-      });
+      setApplyTx(makeApplyTx({
+        user: {
+          findMany: vi.fn().mockResolvedValue([]),
+          create: vi.fn(),
+          update: vi.fn().mockImplementation((args: unknown) => {
+            userUpdateArgs = args;
+            return Promise.resolve({});
+          }),
+        },
+        tenantMember: {
+          findMany: vi.fn().mockResolvedValue([]),
+          create: vi.fn(),
+          update: vi.fn().mockImplementation((args: unknown) => {
+            tenantMemberUpdateArgs = args;
+            return Promise.resolve({});
+          }),
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+        },
+      }));
 
       mockDirSyncConfig.findUnique.mockResolvedValue(OKTA_CONFIG);
 
@@ -576,26 +610,17 @@ describe("runDirectorySync", () => {
 
       let tenantMemberUpdateArgs: unknown;
 
-      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const tx = {
-          user: {
-            findMany: vi.fn().mockResolvedValue([]),
-            create: vi.fn(),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          tenantMember: {
-            findMany: vi.fn().mockResolvedValue([]),
-            create: vi.fn(),
-            update: vi.fn().mockImplementation((args: unknown) => {
-              tenantMemberUpdateArgs = args;
-              return Promise.resolve({});
-            }),
-            updateMany: vi.fn().mockResolvedValue({ count: 0 }),
-          },
-          scimExternalMapping: { upsert: vi.fn() },
-        };
-        return fn(tx);
-      });
+      setApplyTx(makeApplyTx({
+        tenantMember: {
+          findMany: vi.fn().mockResolvedValue([]),
+          create: vi.fn(),
+          update: vi.fn().mockImplementation((args: unknown) => {
+            tenantMemberUpdateArgs = args;
+            return Promise.resolve({});
+          }),
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+        },
+      }));
 
       mockDirSyncConfig.findUnique.mockResolvedValue(OKTA_CONFIG);
 

--- a/src/lib/directory-sync/engine.ts
+++ b/src/lib/directory-sync/engine.ts
@@ -181,7 +181,7 @@ export async function runDirectorySync(
       preCheck.lastSyncAt < staleThreshold;
 
     const updated = await withTenantRls(prisma, tenantId, (tx) =>
-      prisma.$executeRaw`
+      tx.$executeRaw`
         UPDATE "directory_sync_configs"
         SET status = 'RUNNING'::"DirectorySyncStatus",
             "last_sync_at" = ${startedAt}

--- a/src/lib/directory-sync/engine.ts
+++ b/src/lib/directory-sync/engine.ts
@@ -409,134 +409,132 @@ export async function runDirectorySync(
 
     // 7. Apply changes (if not dryRun)
     if (!dryRun) {
-      await withTenantRls(prisma, tenantId, (tx) =>
-        prisma.$transaction(async (tx) => {
-          // Create new users
-          // Batch pre-fetch: all users by email for toCreate
-          const createEmails = toCreate.map((pu) => pu.email.toLowerCase());
-          const existingUsers = await tx.user.findMany({
-            where: { email: { in: createEmails, mode: "insensitive" } },
-            select: { id: true, email: true },
-          });
-          const userByEmail = new Map(existingUsers.map((u) => [u.email!.toLowerCase(), u]));
+      await withTenantRls(prisma, tenantId, async (tx) => {
+        // Create new users
+        // Batch pre-fetch: all users by email for toCreate
+        const createEmails = toCreate.map((pu) => pu.email.toLowerCase());
+        const existingUsers = await tx.user.findMany({
+          where: { email: { in: createEmails, mode: "insensitive" } },
+          select: { id: true, email: true },
+        });
+        const userByEmail = new Map(existingUsers.map((u) => [u.email!.toLowerCase(), u]));
 
-          // Create missing users individually (need IDs back)
-          for (const pu of toCreate) {
-            const emailKey = pu.email.toLowerCase();
-            if (!userByEmail.has(emailKey)) {
-              const newUser = await tx.user.create({
-                data: { tenantId, email: pu.email, name: pu.displayName },
-              });
-              userByEmail.set(emailKey, newUser);
-            }
-          }
-
-          // Batch pre-fetch: tenantMembers for all users in toCreate
-          const allUserIds = toCreate.map((pu) => userByEmail.get(pu.email.toLowerCase())!.id);
-          const existingTenantMembers = await tx.tenantMember.findMany({
-            where: { tenantId, userId: { in: allUserIds } },
-            select: { id: true, userId: true, deactivatedAt: true },
-          });
-          const tmByUserId = new Map(existingTenantMembers.map((m) => [m.userId, m]));
-
-          // Process each user: create/reactivate tenantMember + upsert mapping
-          for (const pu of toCreate) {
-            const user = userByEmail.get(pu.email.toLowerCase())!;
-            const existing = tmByUserId.get(user.id);
-
-            if (!existing) {
-              await tx.tenantMember.create({
-                data: {
-                  tenantId,
-                  userId: user.id,
-                  role: TENANT_ROLE.MEMBER,
-                  deactivatedAt: pu.active ? null : new Date(),
-                  scimManaged: true,
-                  provisioningSource: "SCIM",
-                  lastScimSyncedAt: new Date(),
-                },
-              });
-            } else if (existing.deactivatedAt && pu.active) {
-              // Reactivate
-              await tx.tenantMember.update({
-                where: { id: existing.id },
-                data: { deactivatedAt: null, lastScimSyncedAt: new Date() },
-              });
-            }
-
-            // Create or update external mapping
-            await tx.scimExternalMapping.upsert({
-              where: {
-                tenantId_externalId_resourceType: {
-                  tenantId,
-                  externalId: pu.externalId,
-                  resourceType: "User",
-                },
-              },
-              create: {
-                tenantId,
-                externalId: pu.externalId,
-                resourceType: "User",
-                internalId: user.id,
-              },
-              update: {
-                internalId: user.id,
-              },
+        // Create missing users individually (need IDs back)
+        for (const pu of toCreate) {
+          const emailKey = pu.email.toLowerCase();
+          if (!userByEmail.has(emailKey)) {
+            const newUser = await tx.user.create({
+              data: { tenantId, email: pu.email, name: pu.displayName },
             });
-
-            usersCreated++;
+            userByEmail.set(emailKey, newUser);
           }
+        }
 
-          // Update existing users
-          for (const { user: pu, internalId } of toUpdate) {
-            const member = memberByUserId.get(internalId);
-            if (!member) continue;
+        // Batch pre-fetch: tenantMembers for all users in toCreate
+        const allUserIds = toCreate.map((pu) => userByEmail.get(pu.email.toLowerCase())!.id);
+        const existingTenantMembers = await tx.tenantMember.findMany({
+          where: { tenantId, userId: { in: allUserIds } },
+          select: { id: true, userId: true, deactivatedAt: true },
+        });
+        const tmByUserId = new Map(existingTenantMembers.map((m) => [m.userId, m]));
 
-            await tx.user.update({
-              where: { id: internalId },
-              data: { name: pu.displayName },
-            });
+        // Process each user: create/reactivate tenantMember + upsert mapping
+        for (const pu of toCreate) {
+          const user = userByEmail.get(pu.email.toLowerCase())!;
+          const existing = tmByUserId.get(user.id);
 
-            // OWNER protection: skip deactivation for OWNER role
-            if (member.role === TENANT_ROLE.OWNER && !pu.active) {
-              usersUpdated++;
-              continue;
-            }
-
-            await tx.tenantMember.update({
-              where: { id: member.id },
+          if (!existing) {
+            await tx.tenantMember.create({
               data: {
+                tenantId,
+                userId: user.id,
+                role: TENANT_ROLE.MEMBER,
                 deactivatedAt: pu.active ? null : new Date(),
+                scimManaged: true,
+                provisioningSource: "SCIM",
                 lastScimSyncedAt: new Date(),
               },
             });
+          } else if (existing.deactivatedAt && pu.active) {
+            // Reactivate
+            await tx.tenantMember.update({
+              where: { id: existing.id },
+              data: { deactivatedAt: null, lastScimSyncedAt: new Date() },
+            });
+          }
 
+          // Create or update external mapping
+          await tx.scimExternalMapping.upsert({
+            where: {
+              tenantId_externalId_resourceType: {
+                tenantId,
+                externalId: pu.externalId,
+                resourceType: "User",
+              },
+            },
+            create: {
+              tenantId,
+              externalId: pu.externalId,
+              resourceType: "User",
+              internalId: user.id,
+            },
+            update: {
+              internalId: user.id,
+            },
+          });
+
+          usersCreated++;
+        }
+
+        // Update existing users
+        for (const { user: pu, internalId } of toUpdate) {
+          const member = memberByUserId.get(internalId);
+          if (!member) continue;
+
+          await tx.user.update({
+            where: { id: internalId },
+            data: { name: pu.displayName },
+          });
+
+          // OWNER protection: skip deactivation for OWNER role
+          if (member.role === TENANT_ROLE.OWNER && !pu.active) {
             usersUpdated++;
+            continue;
           }
 
-          // Deactivate users no longer in provider (batch, OWNER-safe)
-          if (toDeactivate.length > 0) {
-            const memberIds = toDeactivate
-              .map((userId) => memberByUserId.get(userId)?.id)
-              .filter((id): id is string => id != null);
+          await tx.tenantMember.update({
+            where: { id: member.id },
+            data: {
+              deactivatedAt: pu.active ? null : new Date(),
+              lastScimSyncedAt: new Date(),
+            },
+          });
 
-            if (memberIds.length > 0) {
-              const result = await tx.tenantMember.updateMany({
-                where: {
-                  id: { in: memberIds },
-                  tenantId,
-                  role: { not: TENANT_ROLE.OWNER },
-                },
-                data: {
-                  deactivatedAt: new Date(),
-                  lastScimSyncedAt: new Date(),
-                },
-              });
-              usersDeactivated = result.count;
-            }
+          usersUpdated++;
+        }
+
+        // Deactivate users no longer in provider (batch, OWNER-safe)
+        if (toDeactivate.length > 0) {
+          const memberIds = toDeactivate
+            .map((userId) => memberByUserId.get(userId)?.id)
+            .filter((id): id is string => id != null);
+
+          if (memberIds.length > 0) {
+            const result = await tx.tenantMember.updateMany({
+              where: {
+                id: { in: memberIds },
+                tenantId,
+                role: { not: TENANT_ROLE.OWNER },
+              },
+              data: {
+                deactivatedAt: new Date(),
+                lastScimSyncedAt: new Date(),
+              },
+            });
+            usersDeactivated = result.count;
           }
-        }),
-      );
+        }
+      });
     } else {
       // Dry run: count what would happen
       usersCreated = toCreate.length;

--- a/src/lib/emergency-access/vault-auto-promote.ts
+++ b/src/lib/emergency-access/vault-auto-promote.ts
@@ -14,7 +14,7 @@
  * review boundary — see scripts/checks/check-bypass-rls.mjs ALLOWED_USAGE.
  */
 
-import { prisma } from "@/lib/prisma";
+import type { TxOrPrisma } from "@/lib/prisma";
 import { transition } from "./emergency-access-state";
 import { logAuditAsync, type AuditLogParams } from "@/lib/audit/audit";
 import { AUDIT_ACTION, AUDIT_TARGET_TYPE, EA_STATUS, EA_ACTOR } from "@/lib/constants";
@@ -70,6 +70,7 @@ export type AutoPromoteResult =
  * "not_eligible" and the route falls through to the NOT_ACTIVATED 403 check.
  */
 export async function autoPromoteIfElapsed(args: {
+  db: TxOrPrisma;
   granteeId: string;
   grantId: string;
   now: Date;
@@ -77,13 +78,12 @@ export async function autoPromoteIfElapsed(args: {
   // Matches the shape returned by personalAuditBase(req, userId).
   auditBase: Omit<AuditLogParams, "action" | "targetType" | "targetId" | "metadata" | "actorType">;
 }): Promise<AutoPromoteResult> {
-  const { granteeId, grantId, now, auditBase } = args;
+  const { db, granteeId, grantId, now, auditBase } = args;
 
-  // Caller MUST wrap in withBypassRls — see file header. The prisma proxy
-  // re-targets all queries below to the active bypass-tx via AsyncLocalStorage.
+  // Caller MUST wrap in withBypassRls and pass its tx as `db` — see file header.
 
   // Step 1: fetch current grant state to check eligibility
-  const current = await prisma.emergencyAccessGrant.findUnique({
+  const current = await db.emergencyAccessGrant.findUnique({
     where: { id: grantId },
     select: { status: true, waitExpiresAt: true, granteeId: true },
   });
@@ -101,7 +101,7 @@ export async function autoPromoteIfElapsed(args: {
 
   // Step 3: CAS-protected transition (closes race window)
   const promoted = await transition({
-    db: prisma,
+    db,
     where: { id: grantId, granteeId },
     to: EA_STATUS.ACTIVATED,
     actor: EA_ACTOR.SYSTEM,
@@ -114,7 +114,7 @@ export async function autoPromoteIfElapsed(args: {
   }
 
   // Step 4: re-fetch to get the authoritative post-promotion state
-  const updated = await prisma.emergencyAccessGrant.findUnique({
+  const updated = await db.emergencyAccessGrant.findUnique({
     where: { id: grantId },
     include: {
       granteeKeyPair: true,

--- a/src/lib/mcp/oauth-server.ts
+++ b/src/lib/mcp/oauth-server.ts
@@ -165,109 +165,107 @@ export async function exchangeCodeForToken(
 ): Promise<TokenExchangeOutcome> {
   const codeHash = hashToken(params.code);
 
-  const result = await withBypassRls(prisma, async (tx) =>
-    prisma.$transaction(async (tx) => {
-      const authCode = await tx.mcpAuthorizationCode.findUnique({
-        where: { codeHash },
-        include: { mcpClient: true },
+  const result = await withBypassRls(prisma, async (tx) => {
+    const authCode = await tx.mcpAuthorizationCode.findUnique({
+      where: { codeHash },
+      include: { mcpClient: true },
+    });
+
+    if (!authCode) return { error: "invalid_grant" as const };
+    if (authCode.usedAt) return { error: "invalid_grant" as const };
+    if (authCode.expiresAt < new Date()) return { error: "invalid_grant" as const };
+
+    // Verify client identity (public clients have empty clientSecretHash)
+    if (authCode.mcpClient.clientId !== params.clientId)
+      return { error: "invalid_client" as const };
+    const isPublicClient = authCode.mcpClient.clientSecretHash === "";
+    if (!isPublicClient && !safeEqual(authCode.mcpClient.clientSecretHash, params.clientSecretHash))
+      return { error: "invalid_client" as const };
+    if (!authCode.mcpClient.isActive) return { error: "invalid_client" as const };
+
+    // Null guard for DCR clients (must be claimed before token exchange)
+    if (!authCode.tenantId || !authCode.mcpClient.tenantId) {
+      return { error: "invalid_client" as const };
+    }
+
+    // Tenant boundary guard
+    if (authCode.tenantId !== authCode.mcpClient.tenantId)
+      return { error: "invalid_grant" as const };
+
+    // Verify redirect_uri matches
+    if (authCode.redirectUri !== params.redirectUri)
+      return { error: "invalid_grant" as const };
+
+    // PKCE S256 verification
+    if (authCode.codeChallengeMethod !== "S256")
+      return { error: "invalid_request" as const };
+    if (!verifyPkceS256(authCode.codeChallenge, params.codeVerifier))
+      return { error: "invalid_grant" as const };
+
+    // Mark code as used via compare-and-swap. The findUnique above takes no
+    // row lock (Read Committed), so two concurrent exchanges can both observe
+    // usedAt === null; gating the consume on `usedAt: null` makes the loser's
+    // count === 0 and aborts it, preventing double-redemption of one code into
+    // multiple independent token families. Mirrors the refresh-token CAS below.
+    const consumed = await tx.mcpAuthorizationCode.updateMany({
+      where: { id: authCode.id, usedAt: null },
+      data: { usedAt: new Date() },
+    });
+    if (consumed.count === 0) return { error: "invalid_grant" as const };
+
+    // Passkey enforcement at the auth_code → token MINT point. The code was
+    // gated at consent creation, but enforcement can flip (or a passkey be
+    // removed) within the code TTL, so re-derive here before minting. AFTER
+    // code validation + consume; BEFORE the access-token create. SA-bound
+    // (userId null) skip.
+    if (authCode.userId !== null) {
+      const pk = await derivePasskeyState({
+        userId: authCode.userId,
+        tenantId: authCode.tenantId,
+        tx,
       });
-
-      if (!authCode) return { error: "invalid_grant" as const };
-      if (authCode.usedAt) return { error: "invalid_grant" as const };
-      if (authCode.expiresAt < new Date()) return { error: "invalid_grant" as const };
-
-      // Verify client identity (public clients have empty clientSecretHash)
-      if (authCode.mcpClient.clientId !== params.clientId)
-        return { error: "invalid_client" as const };
-      const isPublicClient = authCode.mcpClient.clientSecretHash === "";
-      if (!isPublicClient && !safeEqual(authCode.mcpClient.clientSecretHash, params.clientSecretHash))
-        return { error: "invalid_client" as const };
-      if (!authCode.mcpClient.isActive) return { error: "invalid_client" as const };
-
-      // Null guard for DCR clients (must be claimed before token exchange)
-      if (!authCode.tenantId || !authCode.mcpClient.tenantId) {
-        return { error: "invalid_client" as const };
-      }
-
-      // Tenant boundary guard
-      if (authCode.tenantId !== authCode.mcpClient.tenantId)
-        return { error: "invalid_grant" as const };
-
-      // Verify redirect_uri matches
-      if (authCode.redirectUri !== params.redirectUri)
-        return { error: "invalid_grant" as const };
-
-      // PKCE S256 verification
-      if (authCode.codeChallengeMethod !== "S256")
-        return { error: "invalid_request" as const };
-      if (!verifyPkceS256(authCode.codeChallenge, params.codeVerifier))
-        return { error: "invalid_grant" as const };
-
-      // Mark code as used via compare-and-swap. The findUnique above takes no
-      // row lock (Read Committed), so two concurrent exchanges can both observe
-      // usedAt === null; gating the consume on `usedAt: null` makes the loser's
-      // count === 0 and aborts it, preventing double-redemption of one code into
-      // multiple independent token families. Mirrors the refresh-token CAS below.
-      const consumed = await tx.mcpAuthorizationCode.updateMany({
-        where: { id: authCode.id, usedAt: null },
-        data: { usedAt: new Date() },
-      });
-      if (consumed.count === 0) return { error: "invalid_grant" as const };
-
-      // Passkey enforcement at the auth_code → token MINT point. The code was
-      // gated at consent creation, but enforcement can flip (or a passkey be
-      // removed) within the code TTL, so re-derive here before minting. AFTER
-      // code validation + consume; BEFORE the access-token create. SA-bound
-      // (userId null) skip.
-      if (authCode.userId !== null) {
-        const pk = await derivePasskeyState({
+      if (passkeyEnforcementBlocks(pk)) {
+        return {
+          error: "access_denied" as const,
           userId: authCode.userId,
           tenantId: authCode.tenantId,
-          tx,
-        });
-        if (passkeyEnforcementBlocks(pk)) {
-          return {
-            error: "access_denied" as const,
-            userId: authCode.userId,
-            tenantId: authCode.tenantId,
-          };
-        }
+        };
       }
+    }
 
-      // Issue access token
-      const plainToken = MCP_TOKEN_PREFIX + randomBytes(32).toString("base64url");
-      const tokenHash = hashToken(plainToken);
-      const expirySeconds = Math.min(
-        params.tokenExpirySeconds ?? MCP_TOKEN_EXPIRY_SEC,
-        MCP_TOKEN_EXPIRY_SEC,
-      );
-      const expiresAt = new Date(Date.now() + expirySeconds * MS_PER_SECOND);
+    // Issue access token
+    const plainToken = MCP_TOKEN_PREFIX + randomBytes(32).toString("base64url");
+    const tokenHash = hashToken(plainToken);
+    const expirySeconds = Math.min(
+      params.tokenExpirySeconds ?? MCP_TOKEN_EXPIRY_SEC,
+      MCP_TOKEN_EXPIRY_SEC,
+    );
+    const expiresAt = new Date(Date.now() + expirySeconds * MS_PER_SECOND);
 
-      const newAccessToken = await tx.mcpAccessToken.create({
-        data: {
-          tokenHash,
-          clientId: authCode.clientId,
-          tenantId: authCode.tenantId,
-          userId: authCode.userId,
-          serviceAccountId: authCode.serviceAccountId,
-          scope: authCode.scope,
-          expiresAt,
-        },
-      });
-
-      return {
-        ok: true as const,
-        accessToken: plainToken,
-        expiresIn: expirySeconds,
-        scope: authCode.scope,
-        tokenId: newAccessToken.id,
-        clientDbId: authCode.clientId,
+    const newAccessToken = await tx.mcpAccessToken.create({
+      data: {
+        tokenHash,
+        clientId: authCode.clientId,
         tenantId: authCode.tenantId,
         userId: authCode.userId,
         serviceAccountId: authCode.serviceAccountId,
-      };
-    }),
-  BYPASS_PURPOSE.TOKEN_LIFECYCLE);
+        scope: authCode.scope,
+        expiresAt,
+      },
+    });
+
+    return {
+      ok: true as const,
+      accessToken: plainToken,
+      expiresIn: expirySeconds,
+      scope: authCode.scope,
+      tokenId: newAccessToken.id,
+      clientDbId: authCode.clientId,
+      tenantId: authCode.tenantId,
+      userId: authCode.userId,
+      serviceAccountId: authCode.serviceAccountId,
+    };
+  }, BYPASS_PURPOSE.TOKEN_LIFECYCLE);
 
   if ("error" in result) {
     return {
@@ -777,53 +775,51 @@ export async function revokeToken(params: {
 }): Promise<void> {
   const tokenHash = hashToken(params.token);
 
-  await withBypassRls(prisma, async (tx) =>
-    prisma.$transaction(async (tx) => {
-      // Try refresh token first (if hint says so or no hint)
-      if (params.tokenTypeHint !== "access_token") {
-        const rt = await tx.mcpRefreshToken.findUnique({
-          where: { tokenHash },
-          include: { mcpClient: { select: { clientId: true, clientSecretHash: true } } },
-        });
-
-        if (rt && rt.mcpClient.clientId === params.clientId) {
-          if (!verifyRevokeClientAuth(rt.mcpClient.clientSecretHash, params.clientSecretHash)) return;
-          // Revoke entire rotation family
-          await tx.mcpRefreshToken.updateMany({
-            where: { familyId: rt.familyId, tenantId: rt.tenantId, revokedAt: null },
-            data: { revokedAt: new Date() },
-          });
-          // Revoke all associated access tokens in the family
-          const familyTokens = await tx.mcpRefreshToken.findMany({
-            where: { familyId: rt.familyId, tenantId: rt.tenantId },
-            select: { accessTokenId: true },
-          });
-          const accessTokenIds = [...new Set(familyTokens.map((t) => t.accessTokenId))];
-          if (accessTokenIds.length > 0) {
-            await tx.mcpAccessToken.updateMany({
-              where: { id: { in: accessTokenIds }, tenantId: rt.tenantId, revokedAt: null },
-              data: { revokedAt: new Date() },
-            });
-          }
-          return;
-        }
-      }
-
-      // Try access token
-      const at = await tx.mcpAccessToken.findUnique({
+  await withBypassRls(prisma, async (tx) => {
+    // Try refresh token first (if hint says so or no hint)
+    if (params.tokenTypeHint !== "access_token") {
+      const rt = await tx.mcpRefreshToken.findUnique({
         where: { tokenHash },
         include: { mcpClient: { select: { clientId: true, clientSecretHash: true } } },
       });
 
-      if (at && at.mcpClient.clientId === params.clientId) {
-        if (!verifyRevokeClientAuth(at.mcpClient.clientSecretHash, params.clientSecretHash)) return;
-        await tx.mcpAccessToken.update({
-          where: { id: at.id, tenantId: at.tenantId },
+      if (rt && rt.mcpClient.clientId === params.clientId) {
+        if (!verifyRevokeClientAuth(rt.mcpClient.clientSecretHash, params.clientSecretHash)) return;
+        // Revoke entire rotation family
+        await tx.mcpRefreshToken.updateMany({
+          where: { familyId: rt.familyId, tenantId: rt.tenantId, revokedAt: null },
           data: { revokedAt: new Date() },
         });
+        // Revoke all associated access tokens in the family
+        const familyTokens = await tx.mcpRefreshToken.findMany({
+          where: { familyId: rt.familyId, tenantId: rt.tenantId },
+          select: { accessTokenId: true },
+        });
+        const accessTokenIds = [...new Set(familyTokens.map((t) => t.accessTokenId))];
+        if (accessTokenIds.length > 0) {
+          await tx.mcpAccessToken.updateMany({
+            where: { id: { in: accessTokenIds }, tenantId: rt.tenantId, revokedAt: null },
+            data: { revokedAt: new Date() },
+          });
+        }
+        return;
       }
+    }
 
-      // Unknown/already revoked token → silent success per RFC 7009
-    }),
-  BYPASS_PURPOSE.TOKEN_LIFECYCLE);
+    // Try access token
+    const at = await tx.mcpAccessToken.findUnique({
+      where: { tokenHash },
+      include: { mcpClient: { select: { clientId: true, clientSecretHash: true } } },
+    });
+
+    if (at && at.mcpClient.clientId === params.clientId) {
+      if (!verifyRevokeClientAuth(at.mcpClient.clientSecretHash, params.clientSecretHash)) return;
+      await tx.mcpAccessToken.update({
+        where: { id: at.id, tenantId: at.tenantId },
+        data: { revokedAt: new Date() },
+      });
+    }
+
+    // Unknown/already revoked token → silent success per RFC 7009
+  }, BYPASS_PURPOSE.TOKEN_LIFECYCLE);
 }

--- a/src/lib/services/scim-group-service.test.ts
+++ b/src/lib/services/scim-group-service.test.ts
@@ -56,6 +56,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
+import type { TxOrPrisma } from "@/lib/prisma";
 import {
   replaceScimGroup,
   patchScimGroup,
@@ -64,6 +65,11 @@ import {
   ScimNoSuchMemberError,
   ScimDisplayNameMismatchError,
 } from "./scim-group-service";
+
+// A plain client with no `$transaction` — the production tenant-tx shape that
+// drives the flatten (else) branch. Cast at construction so call sites read
+// clean; the service only touches scimGroupMapping/teamMember/tenantMember.
+type FlattenDb = TxOrPrisma;
 
 const BASE_URL = "http://localhost:3000/api/scim/v2";
 const TENANT_ID = "tenant-1";
@@ -567,5 +573,172 @@ describe("patchScimGroup", () => {
     expect(createCall.data[0].teamId).toBe(TEAM_ID);
     expect(createCall.data[0].role).toBe("ADMIN");
     expect(mockTeamMemberUpdateMany).not.toHaveBeenCalled();
+  });
+});
+
+// ── Flatten branch: db WITHOUT $transaction (production tenant-tx path) ───────
+//
+// Production ALWAYS calls these with a tenant `tx` that has no `$transaction`,
+// so `"$transaction" in db` is false and the else branch (`await run(db)`)
+// runs. The tests above pass/default a client that HAS `$transaction`, only
+// exercising the `db.$transaction(run)` branch. These tests inject an explicit
+// db mock with no `$transaction` and assert the add/remove happen directly on
+// it — no nested transaction opened.
+describe("replaceScimGroup — flatten branch (db has no $transaction)", () => {
+  beforeEach(() => {
+    // Prior describes called mockTransaction; clear so the "flatten branch did
+    // NOT open a nested tx" assertion below is meaningful.
+    mockTransaction.mockClear();
+  });
+
+  function makeFlattenDb() {
+    const findMany = vi.fn();
+    const createMany = vi.fn().mockResolvedValue({ count: 0 });
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const tenantMemberFindMany = vi.fn().mockResolvedValue([]);
+    const scimGroupMappingFindUnique = vi.fn();
+    const db = {
+      scimGroupMapping: { findUnique: scimGroupMappingFindUnique },
+      teamMember: { findMany, createMany, updateMany },
+      tenantMember: { findMany: tenantMemberFindMany },
+    } as unknown as FlattenDb;
+    return { db, findMany, createMany, updateMany, tenantMemberFindMany, scimGroupMappingFindUnique };
+  }
+
+  it("adds members directly on the passed db (no nested $transaction)", async () => {
+    const { db, findMany, createMany, tenantMemberFindMany, scimGroupMappingFindUnique } =
+      makeFlattenDb();
+    scimGroupMappingFindUnique.mockResolvedValue(DEFAULT_MAPPING);
+    findMany
+      .mockResolvedValueOnce([]) // currentMembers (runReplace)
+      .mockResolvedValueOnce([]) // existingMembers (applyAddOperations)
+      .mockResolvedValueOnce([]); // loadGroupMembers (after run, on db)
+    tenantMemberFindMany.mockResolvedValue([{ userId: "user-a" }, { userId: "user-b" }]);
+    createMany.mockResolvedValue({ count: 2 });
+
+    const result = await replaceScimGroup(
+      TENANT_ID,
+      SCIM_ID,
+      { displayName: "core:ADMIN", memberUserIds: ["user-a", "user-b"] },
+      BASE_URL,
+      db,
+    );
+
+    // The batch createMany fired on the passed db, not via a nested tx.
+    expect(createMany).toHaveBeenCalledOnce();
+    expect(createMany.mock.calls[0][0].data).toHaveLength(2);
+    // No $transaction on this db → the flatten (else) branch ran.
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(result.added).toBe(2);
+    expect(result.removed).toBe(0);
+  });
+
+  it("removes members directly on the passed db and returns correct counts", async () => {
+    const { db, findMany, updateMany, scimGroupMappingFindUnique } = makeFlattenDb();
+    scimGroupMappingFindUnique.mockResolvedValue(DEFAULT_MAPPING);
+    const currentMembers = [
+      { id: "m-1", userId: "user-a", role: "ADMIN" },
+      { id: "m-2", userId: "user-b", role: "ADMIN" },
+    ];
+    findMany
+      .mockResolvedValueOnce(currentMembers) // currentMembers (runReplace)
+      .mockResolvedValueOnce(currentMembers) // freshMembers (applyRemoveOperations)
+      .mockResolvedValueOnce([]); // loadGroupMembers (after run, on db)
+    updateMany.mockResolvedValue({ count: 2 });
+
+    const result = await replaceScimGroup(
+      TENANT_ID,
+      SCIM_ID,
+      { displayName: "core:ADMIN", memberUserIds: [] },
+      BASE_URL,
+      db,
+    );
+
+    expect(updateMany).toHaveBeenCalledOnce();
+    expect(updateMany.mock.calls[0][0].where.id.in).toEqual(
+      expect.arrayContaining(["m-1", "m-2"]),
+    );
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(result.removed).toBe(2);
+    expect(result.added).toBe(0);
+  });
+});
+
+describe("patchScimGroup — flatten branch (db has no $transaction)", () => {
+  beforeEach(() => {
+    mockTransaction.mockClear();
+  });
+
+  function makeFlattenDb() {
+    const findMany = vi.fn();
+    const createMany = vi.fn().mockResolvedValue({ count: 0 });
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const tenantMemberFindMany = vi.fn().mockResolvedValue([]);
+    const scimGroupMappingFindUnique = vi.fn();
+    const db = {
+      scimGroupMapping: { findUnique: scimGroupMappingFindUnique },
+      teamMember: { findMany, createMany, updateMany },
+      tenantMember: { findMany: tenantMemberFindMany },
+    } as unknown as FlattenDb;
+    return { db, findMany, createMany, updateMany, tenantMemberFindMany, scimGroupMappingFindUnique };
+  }
+
+  it("adds members directly on the passed db (no nested $transaction)", async () => {
+    const { db, findMany, createMany, tenantMemberFindMany, scimGroupMappingFindUnique } =
+      makeFlattenDb();
+    scimGroupMappingFindUnique.mockResolvedValue(DEFAULT_MAPPING);
+    findMany
+      .mockResolvedValueOnce([]) // existingMembers (applyAddOperations)
+      .mockResolvedValueOnce([]); // loadGroupMembers (after run, on db)
+    tenantMemberFindMany.mockResolvedValue([{ userId: "user-a" }, { userId: "user-b" }]);
+    createMany.mockResolvedValue({ count: 2 });
+
+    const result = await patchScimGroup(
+      TENANT_ID,
+      SCIM_ID,
+      [
+        { op: "add", userId: "user-a" },
+        { op: "add", userId: "user-b" },
+      ],
+      BASE_URL,
+      db,
+    );
+
+    expect(createMany).toHaveBeenCalledOnce();
+    expect(createMany.mock.calls[0][0].data).toHaveLength(2);
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(result.teamId).toBe(TEAM_ID);
+    expect(result.role).toBe("ADMIN");
+  });
+
+  it("removes members directly on the passed db (no nested $transaction)", async () => {
+    const { db, findMany, updateMany, scimGroupMappingFindUnique } = makeFlattenDb();
+    scimGroupMappingFindUnique.mockResolvedValue(DEFAULT_MAPPING);
+    const existingMembers = [
+      { id: "m-1", userId: "user-a", role: "ADMIN" },
+      { id: "m-2", userId: "user-b", role: "ADMIN" },
+    ];
+    findMany
+      .mockResolvedValueOnce(existingMembers) // validate existence (runPatch)
+      .mockResolvedValueOnce(existingMembers) // freshMembers (applyRemoveOperations)
+      .mockResolvedValueOnce([]); // loadGroupMembers (after run, on db)
+    updateMany.mockResolvedValue({ count: 2 });
+
+    await patchScimGroup(
+      TENANT_ID,
+      SCIM_ID,
+      [
+        { op: "remove", userId: "user-a" },
+        { op: "remove", userId: "user-b" },
+      ],
+      BASE_URL,
+      db,
+    );
+
+    expect(updateMany).toHaveBeenCalledOnce();
+    expect(updateMany.mock.calls[0][0].where.id.in).toEqual(
+      expect.arrayContaining(["m-1", "m-2"]),
+    );
+    expect(mockTransaction).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/services/scim-group-service.ts
+++ b/src/lib/services/scim-group-service.ts
@@ -4,7 +4,7 @@
  * All functions must be called within a `withTenantRls()` context.
  */
 
-import { prisma } from "@/lib/prisma";
+import { prisma, type TxOrPrisma } from "@/lib/prisma";
 import type { TeamRole } from "@prisma/client";
 import type { ScimGroupMemberInput, ScimGroupResource } from "@/lib/scim/serializers";
 import type { GroupMemberAction } from "@/lib/scim/patch-parser";
@@ -109,8 +109,12 @@ function buildGroupResource(
   };
 }
 
-async function loadGroupMembers(teamId: string, role: TeamRole): Promise<ScimGroupMemberInput[]> {
-  const members = await prisma.teamMember.findMany({
+async function loadGroupMembers(
+  db: TxOrPrisma,
+  teamId: string,
+  role: TeamRole,
+): Promise<ScimGroupMemberInput[]> {
+  const members = await db.teamMember.findMany({
     where: { teamId, role, deactivatedAt: null },
     include: { user: { select: { id: true, email: true } } },
   });
@@ -234,8 +238,9 @@ export async function fetchScimGroup(
   tenantId: string,
   scimId: string,
   baseUrl: string,
+  db: TxOrPrisma = prisma,
 ): Promise<ScimGroupResource | null> {
-  const mapping = await prisma.scimGroupMapping.findUnique({
+  const mapping = await db.scimGroupMapping.findUnique({
     where: {
       tenantId_externalGroupId: {
         tenantId,
@@ -251,7 +256,7 @@ export async function fetchScimGroup(
   });
   if (!mapping) return null;
 
-  const members = await loadGroupMembers(mapping.teamId, mapping.role);
+  const members = await loadGroupMembers(db, mapping.teamId, mapping.role);
   return buildGroupResource(
     mapping.externalGroupId,
     toDisplayName(mapping.team.slug, mapping.role),
@@ -277,8 +282,9 @@ export async function replaceScimGroup(
   scimId: string,
   data: ScimGroupReplaceInput,
   baseUrl: string,
+  db: TxOrPrisma = prisma,
 ): Promise<ScimGroupReplaceResult> {
-  const mapping = await prisma.scimGroupMapping.findUnique({
+  const mapping = await db.scimGroupMapping.findUnique({
     where: {
       tenantId_externalGroupId: {
         tenantId,
@@ -308,30 +314,34 @@ export async function replaceScimGroup(
   let addedCount = 0;
   let removedCount = 0;
 
-  try {
-    const counts = await prisma.$transaction(async (tx) => {
-      // Compute delta inside transaction to avoid TOCTOU race
-      const currentMembers = await tx.teamMember.findMany({
-        where: { teamId: mapping.teamId, role: mapping.role, deactivatedAt: null },
-        select: { id: true, userId: true, role: true },
-      });
-      const currentUserIds = new Set(currentMembers.map((m) => m.userId));
-
-      const toAdd = [...requestedUserIds].filter((uid) => !currentUserIds.has(uid));
-      const toRemove = currentMembers.filter((m) => !requestedUserIds.has(m.userId));
-
-      await applyAddOperations(tx, mapping.teamId, tenantId, mapping.role, toAdd);
-      await applyRemoveOperations(tx, mapping.teamId, mapping.role, toRemove.map((m) => m.id));
-
-      return { added: toAdd.length, removed: toRemove.length };
+  const runReplace = async (tx: TxClient) => {
+    // Compute delta inside transaction to avoid TOCTOU race
+    const currentMembers = await tx.teamMember.findMany({
+      where: { teamId: mapping.teamId, role: mapping.role, deactivatedAt: null },
+      select: { id: true, userId: true, role: true },
     });
+    const currentUserIds = new Set(currentMembers.map((m) => m.userId));
+
+    const toAdd = [...requestedUserIds].filter((uid) => !currentUserIds.has(uid));
+    const toRemove = currentMembers.filter((m) => !requestedUserIds.has(m.userId));
+
+    await applyAddOperations(tx, mapping.teamId, tenantId, mapping.role, toAdd);
+    await applyRemoveOperations(tx, mapping.teamId, mapping.role, toRemove.map((m) => m.id));
+
+    return { added: toAdd.length, removed: toRemove.length };
+  };
+
+  try {
+    // Already inside a tenant tx → reuse it (flatten). Given a plain client →
+    // open a real transaction so the add/remove writes stay atomic.
+    const counts = "$transaction" in db ? await db.$transaction(runReplace) : await runReplace(db);
     addedCount = counts.added;
     removedCount = counts.removed;
   } catch (e) {
     rethrowScimGroupErrors(e);
   }
 
-  const members = await loadGroupMembers(mapping.teamId, mapping.role);
+  const members = await loadGroupMembers(db, mapping.teamId, mapping.role);
   const resource = buildGroupResource(
     mapping.externalGroupId,
     toDisplayName(mapping.team.slug, mapping.role),
@@ -365,8 +375,9 @@ export async function patchScimGroup(
   scimId: string,
   operations: GroupMemberAction[],
   baseUrl: string,
+  db: TxOrPrisma = prisma,
 ): Promise<ScimGroupPatchResult> {
-  const mapping = await prisma.scimGroupMapping.findUnique({
+  const mapping = await db.scimGroupMapping.findUnique({
     where: {
       tenantId_externalGroupId: {
         tenantId,
@@ -382,36 +393,44 @@ export async function patchScimGroup(
   });
   if (!mapping) throw new ScimGroupNotFoundError();
 
-  try {
-    await prisma.$transaction(async (tx) => {
-      const addOps = operations.filter((a) => a.op === "add");
-      const removeOps = operations.filter((a) => a.op === "remove");
+  const runPatch = async (tx: TxClient) => {
+    const addOps = operations.filter((a) => a.op === "add");
+    const removeOps = operations.filter((a) => a.op === "remove");
 
-      await applyAddOperations(tx, mapping.teamId, tenantId, mapping.role, addOps.map((a) => a.userId));
+    await applyAddOperations(tx, mapping.teamId, tenantId, mapping.role, addOps.map((a) => a.userId));
 
-      // Remove: validate existence before delegating
-      if (removeOps.length > 0) {
-        const removeUserIds = removeOps.map((a) => a.userId);
-        const members = await tx.teamMember.findMany({
-          where: { teamId: mapping.teamId, userId: { in: removeUserIds } },
-          select: { id: true, userId: true, role: true },
-        });
-        const memberByUserId = new Map(members.map((m) => [m.userId, m]));
+    // Remove: validate existence before delegating
+    if (removeOps.length > 0) {
+      const removeUserIds = removeOps.map((a) => a.userId);
+      const members = await tx.teamMember.findMany({
+        where: { teamId: mapping.teamId, userId: { in: removeUserIds } },
+        select: { id: true, userId: true, role: true },
+      });
+      const memberByUserId = new Map(members.map((m) => [m.userId, m]));
 
-        for (const uid of removeUserIds) {
-          if (!memberByUserId.has(uid)) {
-            throw new Error(`SCIM_NO_SUCH_MEMBER:${uid}`);
-          }
+      for (const uid of removeUserIds) {
+        if (!memberByUserId.has(uid)) {
+          throw new Error(`SCIM_NO_SUCH_MEMBER:${uid}`);
         }
-
-        await applyRemoveOperations(tx, mapping.teamId, mapping.role, members.map((m) => m.id));
       }
-    });
+
+      await applyRemoveOperations(tx, mapping.teamId, mapping.role, members.map((m) => m.id));
+    }
+  };
+
+  try {
+    // Already inside a tenant tx → reuse it (flatten). Given a plain client →
+    // open a real transaction so the add/remove writes stay atomic.
+    if ("$transaction" in db) {
+      await db.$transaction(runPatch);
+    } else {
+      await runPatch(db);
+    }
   } catch (e) {
     rethrowScimGroupErrors(e);
   }
 
-  const members = await loadGroupMembers(mapping.teamId, mapping.role);
+  const members = await loadGroupMembers(db, mapping.teamId, mapping.role);
   const resource = buildGroupResource(
     mapping.externalGroupId,
     toDisplayName(mapping.team.slug, mapping.role),

--- a/src/lib/services/scim-user-service.ts
+++ b/src/lib/services/scim-user-service.ts
@@ -5,7 +5,7 @@
  */
 
 import { Prisma } from "@prisma/client";
-import { prisma } from "@/lib/prisma";
+import { prisma, type TxOrPrisma } from "@/lib/prisma";
 import type { AuditAction } from "@prisma/client";
 import { AUDIT_ACTION } from "@/lib/constants";
 import { userToScimUser, type ScimUserInput, type ScimUserResource } from "@/lib/scim/serializers";
@@ -82,16 +82,20 @@ export class ScimDeleteConflictError extends Error {
  *
  * Returns `null` if the user cannot be found.
  */
-export async function resolveUserId(tenantId: string, scimId: string): Promise<string | null> {
+export async function resolveUserId(
+  tenantId: string,
+  scimId: string,
+  db: TxOrPrisma = prisma,
+): Promise<string | null> {
   if (scimId.length > 255) return null;
 
-  const member = await prisma.tenantMember.findUnique({
+  const member = await db.tenantMember.findUnique({
     where: { tenantId_userId: { tenantId, userId: scimId } },
     select: { userId: true },
   });
   if (member) return member.userId;
 
-  const mapping = await prisma.scimExternalMapping.findFirst({
+  const mapping = await db.scimExternalMapping.findFirst({
     where: {
       tenantId,
       externalId: scimId,

--- a/src/lib/tenant-context.ts
+++ b/src/lib/tenant-context.ts
@@ -21,7 +21,7 @@ export async function resolveUserTenantIdFromClient(
 
 export async function resolveUserTenantId(userId: string): Promise<string | null> {
   return withBypassRls(prisma, async (tx) =>
-    resolveUserTenantIdFromClient(prisma, userId),
+    resolveUserTenantIdFromClient(tx, userId),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 }
 
@@ -51,6 +51,12 @@ export async function withUserTenantRls<T>(
   if (!tenantId) {
     throw new Error("TENANT_NOT_RESOLVED");
   }
+  // check-bypass-rls requires the (tx) callback form, but this thin wrapper
+  // delegates to a caller-supplied fn(tenantId) that takes no client — fn's own
+  // queries run inside this tenant tx via the ambient ALS/proxy. tx is therefore
+  // structurally required yet genuinely unused here. Threading tx would change
+  // the public withUserTenantRls contract (SC1 deferral, bypass-rls-tx plan).
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   return withTenantRls(prisma, tenantId, (tx) => (fn as (tenantId: string) => Promise<T>)(tenantId));
 }
 
@@ -70,5 +76,8 @@ export async function withTeamTenantRls<T>(
   if (!tenantId) {
     throw new Error("TENANT_NOT_RESOLVED");
   }
+  // See withUserTenantRls above: same fn(tenantId) delegation, tx unthreadable
+  // without a public-contract change (SC1 deferral).
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   return withTenantRls(prisma, tenantId, (tx) => (fn as (tenantId: string) => Promise<T>)(tenantId));
 }

--- a/src/lib/tenant-rls.ts
+++ b/src/lib/tenant-rls.ts
@@ -69,3 +69,25 @@ export async function withBypassRls<T>(
     return tenantRlsStorage.run({ tx, tenantId: null, bypass: true }, () => fn(tx));
   });
 }
+
+/**
+ * Acquire a transaction-scoped PostgreSQL advisory lock keyed by an arbitrary
+ * string. MUST be called inside an open transaction (withTenantRls /
+ * withBypassRls / prisma.$transaction) — the lock auto-releases at tx end. Used
+ * to serialize concurrent "count/aggregate → check cap → create" sequences for
+ * the same key so two requests cannot both read count < cap and both create
+ * (TOCTOU). See scripts/checks/check-count-then-create-lock.mjs.
+ *
+ * SECURITY: `key` is bound as a Prisma tagged-template parameter, so the emitted
+ * SQL is `SELECT pg_advisory_xact_lock(hashtext($1::text))` — `key` is NEVER
+ * string-concatenated into SQL and cannot inject. Extracting this single verbatim
+ * statement (previously inlined at every call site) keeps the injection-safety
+ * reasoning in one reviewed place; the emitted SQL and thus the lock identity are
+ * byte-identical to the inlined form.
+ */
+export async function advisoryXactLock(
+  client: Pick<Prisma.TransactionClient, "$executeRaw">,
+  key: string,
+): Promise<void> {
+  await client.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${key}::text))`;
+}

--- a/src/lib/tenant/tenant-management.ts
+++ b/src/lib/tenant/tenant-management.ts
@@ -1,5 +1,5 @@
 import { Prisma } from "@prisma/client";
-import { prisma } from "@/lib/prisma";
+import { prisma, type TxOrPrisma } from "@/lib/prisma";
 import { slugifyTenant } from "@/lib/tenant/tenant-claim";
 import { randomBytes } from "node:crypto";
 import { SLUG_MAX_LENGTH } from "@/lib/validations/common";
@@ -13,18 +13,19 @@ import { SLUG_MAX_LENGTH } from "@/lib/validations/common";
  */
 export async function findOrCreateSsoTenant(
   tenantClaim: string,
+  db: TxOrPrisma = prisma,
 ): Promise<{ id: string } | null> {
   const tenantSlug = slugifyTenant(tenantClaim);
   if (!tenantSlug) return null;
 
-  let found = await prisma.tenant.findUnique({
+  let found = await db.tenant.findUnique({
     where: { externalId: tenantClaim },
     select: { id: true },
   });
 
   if (!found) {
     try {
-      found = await prisma.tenant.create({
+      found = await db.tenant.create({
         data: {
           externalId: tenantClaim,
           name: tenantClaim,
@@ -37,7 +38,7 @@ export async function findOrCreateSsoTenant(
         e instanceof Prisma.PrismaClientKnownRequestError &&
         e.code === "P2002"
       ) {
-        found = await prisma.tenant.findUnique({
+        found = await db.tenant.findUnique({
           where: { externalId: tenantClaim },
           select: { id: true },
         });
@@ -45,7 +46,7 @@ export async function findOrCreateSsoTenant(
         if (!found) {
           try {
             const suffix = randomBytes(4).toString("hex");
-            found = await prisma.tenant.create({
+            found = await db.tenant.create({
               data: {
                 externalId: tenantClaim,
                 name: tenantClaim,

--- a/src/lib/vault/vault-reset.test.ts
+++ b/src/lib/vault/vault-reset.test.ts
@@ -4,7 +4,7 @@ const {
   mockPrismaUser, mockPrismaPasswordEntry, mockPrismaAttachment,
   mockPrismaPasswordShare, mockPrismaVaultKey, mockPrismaTag, mockPrismaFolder,
   mockPrismaEmergencyGrant, mockPrismaTeamMemberKey, mockPrismaTeamMember,
-  mockPrismaTransaction,
+  mockPrismaTransaction, mockWithBypassRls,
 } = vi.hoisted(() => {
   // Shared tx client mock — used inside the $transaction callback
   const txClient = {
@@ -34,6 +34,9 @@ const {
     // Execute the callback with the tx client so individual model mocks are invoked
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockPrismaTransaction: vi.fn((cb: any) => cb(txClient)),
+    // withBypassRls invokes the callback directly with the passed-in tx (the prisma mock),
+    // which carries all the model-method mocks the reset body calls.
+    mockWithBypassRls: vi.fn((prismaArg: unknown, fn: (tx: unknown) => unknown) => fn(prismaArg)),
   };
 });
 
@@ -53,7 +56,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOriginal()) as Record<string, unknown>,
-  withBypassRls: vi.fn((prisma: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
+  withBypassRls: mockWithBypassRls,
 }));
 vi.mock("@/lib/logger", () => ({
   default: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) },
@@ -79,6 +82,10 @@ describe("executeVaultReset", () => {
     mockPrismaTeamMemberKey.deleteMany.mockResolvedValue({ count: 1 });
     mockPrismaTeamMember.updateMany.mockResolvedValue({ count: 1 });
     mockPrismaUser.update.mockResolvedValue({});
+    // Re-bind withBypassRls to invoke its callback (cleared by clearAllMocks)
+    mockWithBypassRls.mockImplementation(
+      (prismaArg: unknown, fn: (tx: unknown) => unknown) => fn(prismaArg),
+    );
     // Re-bind the transaction mock to execute the callback (cleared by clearAllMocks)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockPrismaTransaction.mockImplementation((cb: any) => cb({
@@ -103,10 +110,14 @@ describe("executeVaultReset", () => {
 
   it("runs a single transaction", async () => {
     await executeVaultReset("user-1");
-    expect(mockPrismaTransaction).toHaveBeenCalledTimes(1);
-    // Callback form: the argument is a function, not an array
-    const txArg = mockPrismaTransaction.mock.calls[0][0];
-    expect(typeof txArg).toBe("function");
+    // Atomicity is now provided by the outer withBypassRls callback (the redundant
+    // inner prisma.$transaction was folded away). The mutating body runs in a single
+    // withBypassRls call: one count pass + one delete/update pass = 2 invocations,
+    // and the delete/update body must be driven via the callback form (required for
+    // bulkTransition — S4).
+    expect(mockWithBypassRls).toHaveBeenCalledTimes(2);
+    const bodyCallback = mockWithBypassRls.mock.calls[1][1];
+    expect(typeof bodyCallback).toBe("function");
   });
 
   it("deletes attachments for the target user", async () => {
@@ -216,6 +227,9 @@ describe("executeVaultReset", () => {
     mockPrismaTeamMemberKey.deleteMany.mockResolvedValue({ count: 1 });
     mockPrismaTeamMember.updateMany.mockResolvedValue({ count: 1 });
     mockPrismaUser.update.mockResolvedValue({});
+    mockWithBypassRls.mockImplementation(
+      (prismaArg: unknown, fn: (tx: unknown) => unknown) => fn(prismaArg),
+    );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockPrismaTransaction.mockImplementation((cb: any) => cb({
         attachment: mockPrismaAttachment,
@@ -234,8 +248,9 @@ describe("executeVaultReset", () => {
     const resultB = await executeVaultReset("admin-target-user");
     expect(resultB).toEqual({ deletedEntries: 10, deletedAttachments: 3 });
 
-    // Callback form: argument is a function
-    const txArg = mockPrismaTransaction.mock.calls[0][0];
-    expect(typeof txArg).toBe("function");
+    // Same atomicity path regardless of caller: mutating body driven via the
+    // withBypassRls callback form (the second withBypassRls call).
+    const bodyCallback = mockWithBypassRls.mock.calls[1][1];
+    expect(typeof bodyCallback).toBe("function");
   });
 });

--- a/src/lib/vault/vault-reset.ts
+++ b/src/lib/vault/vault-reset.ts
@@ -50,82 +50,80 @@ export async function executeVaultReset(
   );
 
   // Single transaction: delete all vault data (callback form required for bulkTransition — S4).
-  const attachmentRefs = await withBypassRls(prisma, async (tx) =>
-    prisma.$transaction(async (tx) => {
-      // Attachments: rows are bytea in DB, but external blob backends store the
-      // ciphertext out-of-band — capture refs before delete so they aren't
-      // orphaned, then purge after the transaction commits.
-      const refs = await collectAttachmentRefsByCreator(tx, targetUserId);
-      await tx.attachment.deleteMany({ where: { createdById: targetUserId } });
-      // Share links
-      await tx.passwordShare.deleteMany({ where: { createdById: targetUserId } });
-      // Password entries
-      await tx.passwordEntry.deleteMany({ where: { userId: targetUserId } });
-      // Vault keys
-      await tx.vaultKey.deleteMany({ where: { userId: targetUserId } });
-      // Tags (all entries deleted, tags are now orphaned)
-      await tx.tag.deleteMany({ where: { userId: targetUserId } });
-      // Folders (user-owned, not cascade-deleted by PasswordEntry removal)
-      await tx.folder.deleteMany({ where: { userId: targetUserId } });
-      // Emergency access grants (revoke as owner — matrix-validated via bulkTransition).
-      // actor: "OWNER" because the matrix models vault-reset as the owner's own revocation
-      // (the user's grants as owner are wiped; SYSTEM has no REVOKED matrix entry).
-      await bulkTransition({
-        db: tx,
-        where: { ownerId: targetUserId },
-        to: EA_STATUS.REVOKED,
-        actor: EA_ACTOR.OWNER,
-        extraData: { revokedAt: new Date() },
-      });
-      // Team E2E: delete all TeamMemberKey records for this user
-      await tx.teamMemberKey.deleteMany({ where: { userId: targetUserId } });
-      // Team E2E: reset keyDistributed on all TeamMember records for this user
-      await tx.teamMember.updateMany({
-        where: { userId: targetUserId },
-        data: { keyDistributed: false },
-      });
-      // Null out vault + recovery + lockout + ECDH fields on User
-      await tx.user.update({
-        where: { id: targetUserId },
-        data: {
-          vaultSetupAt: null,
-          accountSalt: null,
-          encryptedSecretKey: null,
-          secretKeyIv: null,
-          secretKeyAuthTag: null,
-          masterPasswordServerHash: null,
-          masterPasswordServerSalt: null,
-          keyVersion: 0,
-          passphraseVerifierHmac: null,
-          passphraseVerifierVersion: VERIFIER_VERSION,
-          // Recovery key fields
-          recoveryEncryptedSecretKey: null,
-          recoverySecretKeyIv: null,
-          recoverySecretKeyAuthTag: null,
-          recoveryHkdfSalt: null,
-          recoveryVerifierHmac: null,
-          recoveryVerifierVersion: VERIFIER_VERSION,
-          recoveryKeySetAt: null,
-          // Lockout fields
-          failedUnlockAttempts: 0,
-          lastFailedUnlockAt: null,
-          accountLockedUntil: null,
-          // ECDH key pair (team E2E)
-          ecdhPublicKey: null,
-          encryptedEcdhPrivateKey: null,
-          ecdhPrivateKeyIv: null,
-          ecdhPrivateKeyAuthTag: null,
-        },
-      });
+  const attachmentRefs = await withBypassRls(prisma, async (tx) => {
+    // Attachments: rows are bytea in DB, but external blob backends store the
+    // ciphertext out-of-band — capture refs before delete so they aren't
+    // orphaned, then purge after the transaction commits.
+    const refs = await collectAttachmentRefsByCreator(tx, targetUserId);
+    await tx.attachment.deleteMany({ where: { createdById: targetUserId } });
+    // Share links
+    await tx.passwordShare.deleteMany({ where: { createdById: targetUserId } });
+    // Password entries
+    await tx.passwordEntry.deleteMany({ where: { userId: targetUserId } });
+    // Vault keys
+    await tx.vaultKey.deleteMany({ where: { userId: targetUserId } });
+    // Tags (all entries deleted, tags are now orphaned)
+    await tx.tag.deleteMany({ where: { userId: targetUserId } });
+    // Folders (user-owned, not cascade-deleted by PasswordEntry removal)
+    await tx.folder.deleteMany({ where: { userId: targetUserId } });
+    // Emergency access grants (revoke as owner — matrix-validated via bulkTransition).
+    // actor: "OWNER" because the matrix models vault-reset as the owner's own revocation
+    // (the user's grants as owner are wiped; SYSTEM has no REVOKED matrix entry).
+    await bulkTransition({
+      db: tx,
+      where: { ownerId: targetUserId },
+      to: EA_STATUS.REVOKED,
+      actor: EA_ACTOR.OWNER,
+      extraData: { revokedAt: new Date() },
+    });
+    // Team E2E: delete all TeamMemberKey records for this user
+    await tx.teamMemberKey.deleteMany({ where: { userId: targetUserId } });
+    // Team E2E: reset keyDistributed on all TeamMember records for this user
+    await tx.teamMember.updateMany({
+      where: { userId: targetUserId },
+      data: { keyDistributed: false },
+    });
+    // Null out vault + recovery + lockout + ECDH fields on User
+    await tx.user.update({
+      where: { id: targetUserId },
+      data: {
+        vaultSetupAt: null,
+        accountSalt: null,
+        encryptedSecretKey: null,
+        secretKeyIv: null,
+        secretKeyAuthTag: null,
+        masterPasswordServerHash: null,
+        masterPasswordServerSalt: null,
+        keyVersion: 0,
+        passphraseVerifierHmac: null,
+        passphraseVerifierVersion: VERIFIER_VERSION,
+        // Recovery key fields
+        recoveryEncryptedSecretKey: null,
+        recoverySecretKeyIv: null,
+        recoverySecretKeyAuthTag: null,
+        recoveryHkdfSalt: null,
+        recoveryVerifierHmac: null,
+        recoveryVerifierVersion: VERIFIER_VERSION,
+        recoveryKeySetAt: null,
+        // Lockout fields
+        failedUnlockAttempts: 0,
+        lastFailedUnlockAt: null,
+        accountLockedUntil: null,
+        // ECDH key pair (team E2E)
+        ecdhPublicKey: null,
+        encryptedEcdhPrivateKey: null,
+        ecdhPrivateKeyIv: null,
+        ecdhPrivateKeyAuthTag: null,
+      },
+    });
 
-      // TEST-ONLY: failure-injection hook (T16 / S4 atomicity). Never runs in production.
-      if (process.env.NODE_ENV === "test" && __testHook) {
-        await __testHook(tx);
-      }
+    // TEST-ONLY: failure-injection hook (T16 / S4 atomicity). Never runs in production.
+    if (process.env.NODE_ENV === "test" && __testHook) {
+      await __testHook(tx);
+    }
 
-      return refs;
-    }),
-  BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
+    return refs;
+  }, BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
   // Purge external blob objects only after the DB transaction commits
   // (best-effort; no-op on the DB backend).


### PR DESCRIPTION
## Summary

What started as clearing two non-fatal `pre-pr.sh` warnings surfaced a **confirmed pre-existing TOCTOU race class of 17 count-then-create cap sites**, plus a hardening of 41 RLS transaction callbacks. The primary work is the security fix; the callback hardening and WARN cleanup ride along.

## Primary: count-then-create TOCTOU (17 sites)

Every per-scope cap enforcer ran `count()/aggregate() → if (n >= MAX) reject → create()` where the count and create were in **separate** RLS transactions (or one transaction without serialization). Two concurrent requests both read `n < MAX`, both create, and the cap is exceeded.

The seed instance (session limit in `auth-adapter`) even *tried* to prevent this with a nested `prisma.$transaction(fn, { isolationLevel: "Serializable" })` — but the Prisma singleton **Proxy** folds a nested `$transaction` into the ambient RLS transaction and **silently drops its options**, so it ran at read committed, not serializable (proven against the real DB: `current_setting('transaction_isolation')` returned `read committed`).

**Fix** — the codebase's own advisory-lock idiom (7 existing precedents like `attachments`, `vault/rotate-key`, `service-accounts/[id]/tokens`), **not** Serializable (which needs `40001`/`P2034` retry infrastructure the codebase lacks — a real Serializable would turn a silent over-count into a user-facing login 500). Each site now unifies count + cap-check + create into **one** RLS transaction with `SELECT pg_advisory_xact_lock(hashtext(<scope-id>))` as the first statement, keyed by the cap's scope (user / tenant / team / entry, or a fixed key for the global anti-DoS DCR cap). Over-limit throws a sentinel caught outside the tx → the existing error response. Expensive crypto stays outside the lock window.

The 17 sites: session limit, api-keys, bridge-code, extension-token, mobile-token, Send byte-quota, operator-tokens, service-accounts, scim-tokens, mcp-clients, tenant + team webhooks, audit-delivery-targets, personal + team attachments, reset-vault, mcp-register.

## Mechanized completeness (the durable fix)

The member-set was enumerated by hand across review rounds and expanded four times (1 → 5 → 6 → 10 → 17) because early passes anchored on a *symptom* (an `isolationLevel` grep) rather than the *primitive* (`count() + create() + cap`). To stop it silently regrowing, `scripts/checks/check-count-then-create-lock.mjs` flags any RLS-wrapped `count → cap-check → create` file lacking `pg_advisory_xact_lock`, with a reviewed soft-cap allowlist (`resource-quotas.ts`) and stale-exemption anti-drift. It's a floor (it cannot prove the lock is in the same tx — that stays review-enforced and pinned by per-site mutation-kill unit assertions), runs in the `static-checks` CI job, is mutation-verified, and ships with a self-test.

## Secondary: RLS callback-form hardening (41 sites)

`check-bypass-rls.mjs` mandates the `(tx) => tx.x` callback form (robust under DI / raw client) over `(tx) => prisma.x` (which depends on the Proxy's AsyncLocalStorage fold); eslint flagged the unused `tx`. All 41 were brought into the tx-form — behavior-preserving, since `prisma.x` and `tx.x` resolve to the same transaction under the active RLS context. Buckets: raw-SQL (`prisma.$` → `tx.$`), helper `db:` threading, removal of redundant nested `$transaction` wrappers, static-SCIM wrapper drops, and helper `tx` threading. The two `withUserTenantRls`/`withTeamTenantRls` sites that delegate to a public `fn(tenantId)` contract are the one documented exception (eslint-disable with rationale). `tx`-unused warnings: 41 → 0.

## Tertiary: two non-fatal pre-pr WARNs

- `security-doc-exists`: named the existing overview section in `audit-anchor-verification.md` with `## Overview`.
- CLI `--tag-secret`: silenced the intentional shell-history warning in tests that only exercise the tag-secret path to reach downstream validation.

## Test plan

- `npx vitest run` — 933 files, 11,988 tests pass
- `scripts/pre-pr.sh` — 43/43 (the new guard is +1)
- Real-DB integration test proves the race is real WITHOUT the lock (count > cap) and closed WITH it (count == cap), for bridge-code + api-keys; DATABASE_URL-gated
- Per-site mutation-kill unit assertions at every lock site; the new guard is mutation-verified + self-tested

## Scope contracts (deferred, documented)

- **SC1**: `withUserTenantRls`/`withTeamTenantRls` still delegate to a client-less `fn(tenantId)` public contract — threading `tx` requires a contract change, tracked separately.
- **SC2**: `resource-quotas.ts` is a documented pre-1.0 soft-cap (overshoot accepted); it is the sole entry in the new guard's soft-cap allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
