### PR TITLE
fix(security): lock DCR-consent tenant cap + broaden TOCTOU guard to findMany/updateMany/byte shapes

### DIFF
--- a/docs/archive/review/pr637-toctou-cap-triangulate-code-review.md
+++ b/docs/archive/review/pr637-toctou-cap-triangulate-code-review.md
@@ -1,0 +1,146 @@
+# Code Review: PR #637 TOCTOU cap-race hardening — triangulate independent verification
+
+Date: 2026-07-06
+Review round: 1
+Target: HEAD `2bf38259` (already merged to main) — `git diff HEAD~1...HEAD`
+Trigger: user `/triangulate` on top of a human "Approve, 90/100" review.
+
+## Summary
+
+Three expert agents (functionality / security / testing) independently verified the human
+review. The human review's headline — "no new Critical/High/Medium" — **does not hold**.
+Two mutually-reinforcing findings, both confirmed by the orchestrator with direct evidence:
+
+- **[S1] Critical**: a real per-tenant cap-bypass in `mcp/authorize/consent` (unlocked
+  `count → cap-check → updateMany`-claim). A genuine member of the very TOCTOU class the PR
+  set out to close, invisible to the guard because the claim write is `updateMany`, not `.create`.
+- **[T1/T2] Major**: the CI guard is a **lexical floor**, not a mutation-verified convergence
+  artifact. It is structurally blind to the *dominant* production cap shape (`findMany().length`)
+  and to byte-aggregate caps. Orchestrator mutation-proof: removing the real `advisoryXactLock`
+  from `bridge-code` (a security-critical token-issuance site) leaves the guard **green**.
+
+Per triangulate Step 3-8, a class whose member-set expanded ≥2× (here 1→5→6→10→17) is only
+"closed" when a mutation-verified guard goes red on a real omission. This guard cannot.
+**The R42 class is NOT closed.**
+
+## Orchestrator-verified evidence
+
+```
+# S1 — consent route: count + cap, NO .create (claims via updateMany), NO lock
+src/app/api/mcp/authorize/consent/route.ts
+  :131  count(mcpClient, tenantId)      # COUNT present
+  :134  >= MAX_MCP_CLIENTS_PER_TENANT   # CAP present
+  :171  updateMany(...tenantId: null->userTenantId)  # claim = create-equivalent
+  grep .create( => 0  |  grep advisoryXactLock => 0
+# mirror IS locked:
+src/app/api/tenant/mcp-clients/route.ts:149  advisoryXactLock(tx, actor.tenantId)
+
+# T1 — guard blindness, mutation-proven
+$ node scripts/checks/check-count-then-create-lock.mjs                 -> OK (exit 0)
+$ sed 's/await advisoryXactLock(tx, userId);/\/\/ removed/' bridge-code/route.ts
+$ node scripts/checks/check-count-then-create-lock.mjs                 -> OK (exit 0)  # SURVIVED
+# bridge-code uses findMany().length + BRIDGE_CODE_MAX_ACTIVE:
+  grep -cE '\.(count|aggregate)\(' bridge-code/route.ts => 0   # COUNT_RE never matches
+```
+
+Guard-invisible real lock sites (findMany().length or byte-aggregate shape):
+`extension/bridge-code`, `auth/tokens/extension-token.ts`, `auth/tokens/mobile-token.ts`,
+`auth/session/auth-adapter.ts`, `sends/file` (aggregate + `SEND_MAX_ACTIVE_TOTAL_BYTES`,
+excluded by the `MAX_…BYTES` negative-lookahead).
+
+## Security Findings
+
+### [S1] Critical: unlocked per-tenant cap in DCR-consent claim — TOCTOU cap bypass (A\B member)
+- File: `src/app/api/mcp/authorize/consent/route.ts:128-181`
+- Problem: `withBypassRls` callback does `count(tenantId) → if >= MAX_MCP_CLIENTS_PER_TENANT →
+  updateMany` (claim `tenantId: null → userTenantId`) with no advisory lock. The claim
+  increments the tenant's client count exactly like the locked mirror in
+  `tenant/mcp-clients/route.ts:148-158`. Symmetric-counterpart gap (R42 clause ③ mirror):
+  cap enforced on two mirrored surfaces, only one locked. The two surfaces can also race each other.
+- Impact: A tenant at `MAX-1` clients exceeds `MAX_MCP_CLIENTS_PER_TENANT` (=10). Register N
+  unclaimed DCR clients (distinct names) via `/api/mcp/register`, fire N concurrent consent
+  "Allow" POSTs; each reads `count < MAX`, each CAS `updateMany` succeeds (distinct ids → no P2002).
+- Fix: `await advisoryXactLock(tx, userTenantId)` as the first statement in the `withBypassRls`
+  callback (before the `:131` count). Key on `userTenantId` so it shares lock identity with the
+  `tenant/mcp-clients` mirror (which locks on `actor.tenantId`) — serializing both surfaces.
+- escalate: true (exploitable per-tenant cap bypass; guard structurally blind to it)
+
+### [S2] Major: guard cannot detect `updateMany`/`upsert`-based cap enforcers
+- File: `scripts/checks/check-count-then-create-lock.mjs:49` (`CREATE_RE = /\.create\s*\(/`)
+- Problem: create-detector matches only `.create(`; a claim/CAS via `updateMany`/`upsert` that
+  bumps the counted set is create-equivalent but invisible. S1 slipped past for exactly this reason.
+- Fix: broaden create-detection to include `updateMany`/`upsert` that sets a scoping FK; add S1's
+  site as a mutation-kill fixture.
+
+## Testing Findings
+
+### [T1] Major: guard blind to `findMany().length` and byte-aggregate cap shapes (mutation-proven)
+- File: `scripts/checks/check-count-then-create-lock.mjs:47-48`
+- Problem: `COUNT_RE` matches only `.count(`/`.aggregate(`; the prevailing "evict-oldest"
+  `findMany().length` shape and byte caps (`MAX_…BYTES`, negative-lookahead-excluded) never match.
+  5 real production sites' locks can be removed with the guard staying green — incl. the
+  security-critical `bridge-code`, `extension-token`, `mobile-token`, session `auth-adapter`.
+- Fix: add `findMany(` to a count-like alternation; broaden the cap heuristic beyond `MAX_*`/`*_LIMIT`
+  name-spelling (better: key on "reads a per-scope table then writes it under an RLS wrapper").
+
+### [T2] Major: guard regression test never proves it catches a real evasion shape (RT7 shape b)
+- File: `scripts/__tests__/check-count-then-create-lock.test.mjs:42-49,74-79`
+- Problem: the only failing fixture (`CAP_THEN_CREATE_NO_LOCK`) uses `.count()`+`MAX_WIDGETS_PER_TENANT`
+  — reverse-engineered from the guard's own regex. No fixture in the real `findMany().length`/byte shapes.
+- Fix: add failing fixtures mirroring the real shapes; require exit 1.
+
+### [T3] Major: sole real-DB concurrency proof races a hand-written replica, and runs in NO CI job
+- File: `src/__tests__/db-integration/count-then-create-toctou.integration.test.ts:12-72`; CI wiring
+- Problem: the test re-implements bridge-code/api-key CAS in raw SQL (its own header admits the
+  production path "cannot be raced"), so it proves *a* lock serializes — not that production call
+  sites are wired right. And no `.github/workflows/ci.yml` step runs `test:integration`.
+- Fix: drive real route handlers / issuers concurrently; wire `test:integration` into a CI job
+  (the Postgres service already exists at ci.yml:521).
+
+### [T4] Major: new F3 unused-tx drift guard (48 LOC) has zero regression test
+- File: `scripts/checks/check-bypass-rls.mjs:197-211,300-333`
+- Problem: no `check-bypass-rls` test exists; the intricate `[\s\S]{0,120}?`-window regex is unproven
+  and will silently stop matching after a refactor.
+- Fix: add `scripts/__tests__/check-bypass-rls.test.mjs` (non-allowlisted disable+`(tx)=>` → exit 1;
+  `tenant-context.ts`-shaped allowlisted → exit 0).
+
+### [T5] Minor: stale-exemption detection asymmetric — F3 allowlist can rot
+- Fix: mirror `raw-sql-usage.mjs:376` stale-entry detection into the F3 scan.
+
+### [T6] Minor: `check-raw-sql-usage` lacks a STALE_EXEMPT regression case for the 22-file drop
+- Fix: add an `it()` asserting a listed-but-clean file → exit 1 with `STALE_EXEMPT`.
+
+## Functionality Findings
+
+Verdict: the refactor is behavior-preserving in the `.create()`-shaped covered paths. No new
+Critical/Major from the correctness angle — BUT the functionality expert derived its member-set
+from `.create()` only, so it reported "no missed site" and did NOT flag S1/T1. This is the
+triangulation split: security+testing caught what functionality's primitive choice hid.
+
+### [F1] Minor [Adjacent]: 4 lock calls rely on the Prisma-proxy ALS fold, not an explicit `tx`
+- Files: `api-keys/route.ts:116`, `sends/file/route.ts:214`, `teams/[teamId]/webhooks/route.ts:120`,
+  `teams/[teamId]/passwords/[id]/attachments/route.ts:230`
+- Problem: pass bare `prisma` to `advisoryXactLock` inside `withUserTenantRls`/`withTeamTenantRls`;
+  the lock lands in the tenant tx only via the ALS re-target — the fragility the PR otherwise removes.
+  Pre-existing (SC1-deferred F3 disposition). Future fix: thread `tx` through the wrapper signature.
+### [F2] Nit: `service-accounts/[id]/tokens/route.ts` sentinel is a message-matched `Error`, not a class.
+### [F3] Nit: `mcp/register/route.ts` `CapExceededError` used at :157/:176, declared at :214 (no TDZ at runtime).
+
+## Adjacent Findings
+- Testing [Adjacent]: api-keys lock target on singleton prisma — confirm lock+count+create share one
+  connection/tx (advisory *xact* locks release at tx end). Orchestrator note: verified elsewhere
+  that `withUserTenantRls` folds `prisma.$executeRaw` into the ambient tx via ALS; correct today,
+  but the F1 fragility applies.
+
+## Recurring Issue Check (key rules)
+- R42 (class-membership derivation): **Finding S1/S2/T1/T2** — member-set was derived from the
+  symptom-ish `.create()` shape (clause ①a violation: the true primitive is "a write that bumps
+  the counted set", which includes `updateMany`-claim and the `findMany().length` read shape).
+  Accretion signature 1→5→6→10→17 present; clause ①b says a ≥2×-expanded class must re-derive
+  from the corrected primitive, not append-and-continue. A\B non-empty (consent). Class NOT closed.
+- R38 (fail-open by omission): S1 is fail-open-by-omission (cap not enforced) — Critical floor.
+- RT7 shape b (authored-but-unproven gate): T2/T4 — guard/test green without proving red on real shapes.
+
+## Resolution Status
+Pending user decision (see orchestrator message). No fixes applied yet — S1 is a security-boundary
+change requiring impact analysis + real-flow verification before applying.

--- a/scripts/__tests__/check-bypass-rls.test.mjs
+++ b/scripts/__tests__/check-bypass-rls.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for check-bypass-rls.mjs — specifically the F3 anti-drift
+ * scan (scripts/checks/check-bypass-rls.mjs:300-333), which flags any file that
+ * suppresses an unused `tx` on a with*Rls (tx) => callback with an
+ * eslint-disable-next-line no-unused-vars, outside the F3 allowlist.
+ *
+ * The guard reads its source tree from `src/` relative to the process cwd
+ * (`readdirSync("src", ...)`), so each case runs the real CLI with cwd set to an
+ * isolated fixture tree — mirroring the file layout the guard keys off of.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CHECKER = fileURLToPath(new URL("../checks/check-bypass-rls.mjs", import.meta.url));
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "bypass-rls-check-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function run(relPath, source) {
+  mkdirSync(join(dir, relPath.split("/").slice(0, -1).join("/")), { recursive: true });
+  writeFileSync(join(dir, relPath), source, "utf8");
+  try {
+    const stdout = execFileSync("node", [CHECKER], {
+      cwd: dir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, stderr: "", stdout };
+  } catch (e) {
+    return { code: e.status, stderr: e.stderr?.toString() ?? "", stdout: e.stdout?.toString() ?? "" };
+  }
+}
+
+// F3 violation, isolated: the file IS on the model allowlist (audit-outbox.ts,
+// models: auditOutbox) so it does NOT trip the "not on the allowlist" check —
+// the ONLY thing wrong is the eslint-disable(no-unused-vars) on an unused `tx`.
+// This pins that F3 fires on its own, not just as a side effect of an
+// unallowlisted file.
+const F3_UNUSED_TX_ON_ALLOWLISTED_FILE = `
+import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+async function h() {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return withBypassRls(prisma, BYPASS_PURPOSE.AUDIT, async (tx) => drain());
+}`;
+
+// The sanctioned shape: tenant-context.ts is in F3_UNUSED_TX_DISABLE_ALLOWLIST,
+// so its unused-tx delegating wrapper (fn(tenantId) public contract) is allowed.
+// A sibling real (tx) => tx.x callback confirms the file still passes the model
+// allowlist (tenantMember, team).
+const TENANT_CONTEXT_ALLOWED = `
+import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+export async function withTenantContext(tenantId) {
+  return withBypassRls(prisma, BYPASS_PURPOSE.CTX, async (tx) => {
+    return tx.tenantMember.findFirst({ where: { tenantId } });
+  });
+}
+export async function withTeamContext(tenantId, fn) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return withBypassRls(prisma, BYPASS_PURPOSE.CTX, async (tx) => fn(tenantId));
+}`;
+
+// A brand-new (non-allowlisted) file that suppresses an unused tx — trips BOTH
+// the model-allowlist check and F3. Confirms F3 detects the drift even on a file
+// the guard would reject for other reasons.
+const F3_UNUSED_TX_ON_NEW_FILE = `
+import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+async function h() {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return withBypassRls(prisma, BYPASS_PURPOSE.X, async (tx) => doThing());
+}`;
+
+describe("check-bypass-rls F3 unused-tx anti-drift", () => {
+  it("fails an allowlisted file that suppresses an unused tx on a with*Rls callback", () => {
+    const r = run("src/lib/audit/audit-outbox.ts", F3_UNUSED_TX_ON_ALLOWLISTED_FILE);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("no-unused-vars");
+    expect(r.stderr).toContain("src/lib/audit/audit-outbox.ts");
+  });
+
+  it("passes the tenant-context.ts delegating wrappers (F3 allowlisted)", () => {
+    const r = run("src/lib/tenant-context.ts", TENANT_CONTEXT_ALLOWED);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("check-bypass-rls: OK");
+  });
+
+  it("flags a new non-allowlisted file that suppresses an unused tx", () => {
+    const r = run("src/app/api/y/route.ts", F3_UNUSED_TX_ON_NEW_FILE);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("no-unused-vars");
+    expect(r.stderr).toContain("src/app/api/y/route.ts");
+  });
+});

--- a/scripts/__tests__/check-count-then-create-lock.test.mjs
+++ b/scripts/__tests__/check-count-then-create-lock.test.mjs
@@ -70,6 +70,85 @@ async function handlePOST(name, size) {
   return withTenantRls(prisma, t, async (tx) => tx.widget.create({ data: {} }));
 }`;
 
+// The broadened-primitive shapes. The class is "read a per-scope table → gate on
+// a cap → write it", NOT the .count()+MAX_ spelling. These four real-code shapes
+// were invisible to the count()+.create() guard and must all go RED without a lock.
+
+// evict-oldest: findMany().length + N - CAP > 0, then updateMany (revoke) + create.
+const EVICT_OLDEST_NO_LOCK = `
+import { withTenantRls } from "@/lib/tenant-rls";
+import { WIDGET_MAX_ACTIVE } from "@/lib/constants";
+async function h() {
+  return withTenantRls(prisma, t, async (tx) => {
+    const active = await tx.widget.findMany({ where: { t } });
+    const overflow = active.length + 1 - WIDGET_MAX_ACTIVE;
+    if (overflow > 0) await tx.widget.updateMany({ where: {}, data: { revoked: true } });
+    return tx.widget.create({ data: {} });
+  });
+}`;
+
+// byte-quota: aggregate()._sum vs *_TOTAL_BYTES, then create.
+const BYTE_QUOTA_NO_LOCK = `
+import { withTenantRls } from "@/lib/tenant-rls";
+import { SEND_MAX_ACTIVE_TOTAL_BYTES } from "@/lib/constants";
+async function h() {
+  return withTenantRls(prisma, t, async (tx) => {
+    const agg = await tx.send.aggregate({ _sum: { bytes: true } });
+    if ((agg._sum.bytes ?? 0) >= SEND_MAX_ACTIVE_TOTAL_BYTES) throw new Err();
+    return tx.send.create({ data: {} });
+  });
+}`;
+
+// DCR-consent claim: count vs MAX_, then updateMany claim (flips FK) — NO .create.
+const CLAIM_UPDATEMANY_NO_LOCK = `
+import { withBypassRls } from "@/lib/tenant-rls";
+import { MAX_CLIENTS_PER_TENANT } from "@/lib/constants";
+async function h() {
+  return withBypassRls(prisma, async (tx) => {
+    const n = await tx.mcpClient.count({ where: { tenantId } });
+    if (n >= MAX_CLIENTS_PER_TENANT) throw new Err();
+    return tx.mcpClient.updateMany({ where: { id }, data: { tenantId } });
+  });
+}`;
+
+// dynamic per-tenant cap in a lowercase var (maxSessions) — matches no naming rule.
+const DYNAMIC_SESSION_CAP_NO_LOCK = `
+import { withTenantRls } from "@/lib/tenant-rls";
+async function h(maxSessions) {
+  return withTenantRls(prisma, t, async (tx) => {
+    const sessions = await tx.session.findMany({ where: { t } });
+    if (sessions.length >= maxSessions) throw new Err();
+    return tx.session.create({ data: {} });
+  });
+}`;
+
+// False-cap decoys that MUST stay exit 0: a bare rows.length > 20 pagination check,
+// MAX_CACHE_ENTRIES (in-memory Map size cap), a *_THROTTLE_MS interval, and an
+// unrelated updateMany — none of these gate a per-scope table count.
+const NON_CAP_LENGTH_AND_UPDATEMANY = `
+import { withTenantRls } from "@/lib/tenant-rls";
+import { MAX_CACHE_ENTRIES, MAX_MCP_TOKEN_LAST_USED_THROTTLE_MS } from "@/lib/constants";
+async function h() {
+  const rows = await withTenantRls(prisma, t, async (tx) => tx.widget.findMany());
+  if (rows.length > 20) return err();
+  if (cache.size > MAX_CACHE_ENTRIES) cache.clear();
+  if (now - last > MAX_MCP_TOKEN_LAST_USED_THROTTLE_MS) throttle();
+  return withTenantRls(prisma, t, async (tx) => tx.widget.updateMany({ where: {}, data: {} }));
+}`;
+
+// A broadened shape WITH the lock present — must pass.
+const EVICT_OLDEST_WITH_LOCK = `
+import { withTenantRls } from "@/lib/tenant-rls";
+import { WIDGET_MAX_ACTIVE } from "@/lib/constants";
+async function h() {
+  return withTenantRls(prisma, t, async (tx) => {
+    await tx.$executeRaw\`SELECT pg_advisory_xact_lock(hashtext(\${t}::text))\`;
+    const active = await tx.widget.findMany({ where: { t } });
+    if (active.length + 1 - WIDGET_MAX_ACTIVE > 0) await tx.widget.updateMany({ where: {}, data: {} });
+    return tx.widget.create({ data: {} });
+  });
+}`;
+
 describe("check-count-then-create-lock", () => {
   it("fails a cap-then-create site with no advisory lock", () => {
     const r = run("src/app/api/x/route.ts", CAP_THEN_CREATE_NO_LOCK);
@@ -96,5 +175,40 @@ describe("check-count-then-create-lock", () => {
        async function h() { return withTenantRls(prisma, t, async (tx) => tx.widget.create({})); }`,
     );
     expect(r.code).toBe(0);
+  });
+
+  it("fails the evict-oldest findMany().length cap shape with no lock", () => {
+    const r = run("src/app/api/x/route.ts", EVICT_OLDEST_NO_LOCK);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("missing a pg_advisory_xact_lock");
+  });
+
+  it("fails the byte-quota aggregate vs *_TOTAL_BYTES cap shape with no lock", () => {
+    const r = run("src/app/api/x/route.ts", BYTE_QUOTA_NO_LOCK);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("missing a pg_advisory_xact_lock");
+  });
+
+  it("fails the claim-style updateMany cap shape (no .create) with no lock", () => {
+    const r = run("src/app/api/x/route.ts", CLAIM_UPDATEMANY_NO_LOCK);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("missing a pg_advisory_xact_lock");
+  });
+
+  it("fails the dynamic maxSessions cap shape with no lock", () => {
+    const r = run("src/app/api/x/route.ts", DYNAMIC_SESSION_CAP_NO_LOCK);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("missing a pg_advisory_xact_lock");
+  });
+
+  it("does not flag false-cap decoys (pagination length, Map-size cap, throttle interval)", () => {
+    const r = run("src/app/api/x/route.ts", NON_CAP_LENGTH_AND_UPDATEMANY);
+    expect(r.code).toBe(0);
+  });
+
+  it("passes a broadened cap shape that has the advisory lock", () => {
+    const r = run("src/app/api/x/route.ts", EVICT_OLDEST_WITH_LOCK);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("check-count-then-create-lock: OK");
   });
 });

--- a/scripts/checks/check-count-then-create-lock.mjs
+++ b/scripts/checks/check-count-then-create-lock.mjs
@@ -10,10 +10,21 @@
  *
  * Detection is lexical-with-context (no AST dependency needed — cheap, runs in
  * the static-checks job): a file is a "cap-then-create site" when it contains ALL
- * of: (a) a `.count(` or `.aggregate(` call, (b) a cap comparison against a MAX_*
- * / *_LIMIT* constant (`>= MAX_…`, `> …_LIMIT`, etc.), and (c) a `.create(` call.
- * Every such file MUST also contain `pg_advisory_xact_lock`, OR appear in
- * SOFT_CAP_EXEMPTIONS with a reviewed reason.
+ * of: (a) a per-scope READ — `.count(`, `.aggregate(`, or `.findMany(` (the
+ * "evict-oldest" family reads with findMany then compares `.length`), (b) a cap
+ * comparison — either a MAX_* / *_LIMIT* / *_TOTAL_BYTES constant threshold, a
+ * `.length … > /`>=` overflow check, or a `maxConcurrentSessions`/`maxSessions`
+ * dynamic cap, and (c) a WRITE that bumps the counted set — `.create(`,
+ * `.createMany(`, `.upsert(`, or a claim-style `.updateMany(` (flips a scoping FK
+ * on an existing row, e.g. DCR claim `tenantId: null → tenantId`). Every such file
+ * MUST also contain `pg_advisory_xact_lock`, OR appear in SOFT_CAP_EXEMPTIONS.
+ *
+ * The read/cap/write alternations are deliberately broad because the class's real
+ * defining primitive is "read a per-scope table → gate on a cap → write it", NOT
+ * the `.count()+MAX_` spelling. Keying on that spelling let bridge-code / token /
+ * session caps (findMany().length), the byte-quota send cap (_TOTAL_BYTES), and
+ * the DCR-consent claim (updateMany, no .create) ship or mutate without the guard
+ * seeing them. See the triangulate review pr637-toctou-cap-*.
  *
  * This is a floor, not a proof of correctness — it cannot verify the lock is in
  * the SAME tx as the count+create (that's review-enforced, and pinned by the
@@ -39,14 +50,41 @@ const SOFT_CAP_EXEMPTIONS = new Map([
   ],
 ]);
 
-// A cap comparison: a >= or > against a MAX_* / *_LIMIT* / LIMIT_PER_* constant,
-// or a bare numeric cap next to such a name. Deliberately excludes length/size
-// guards (MAX_LENGTH, MAX_FILE_SIZE, MAX_BYTES, MAX_DAYS, …) which are validation
-// bounds, not count caps — those never pair a count() with a create() on a cap.
-const CAP_COMPARISON_RE =
-  />=?\s*(MAX_(?!LENGTH|FILE_SIZE|BYTES|JSON|DAYS|AGE|DEPTH|EXPIRY|EXPIRES|DIMENSION|IMPORT_FOLDERS|CIDRS|BULK|ATTEMPTS|CONCURRENT_SESSIONS_(?:MIN|MAX))[A-Z_]*|[A-Z_]+_LIMIT(?:_PER_[A-Z]+)?|TOKEN_LIMIT[A-Z_]*)\b/;
-const COUNT_RE = /\.(count|aggregate)\s*\(/;
-const CREATE_RE = /\.create\s*\(/;
+// A cap comparison. Three shapes are accepted (the class uses all three):
+//  1. A >= / > against a named UPPER_SNAKE cap constant: MAX_* / *_LIMIT* /
+//     *_TOTAL_BYTES. Length/size VALIDATION bounds (MAX_LENGTH, MAX_FILE_SIZE,
+//     MAX_BYTES, MAX_DAYS, …) are excluded — they never gate a table count.
+//     *_TOTAL_BYTES is the one _BYTES form that IS a count cap (a byte-quota over
+//     an aggregated table, e.g. SEND_MAX_ACTIVE_TOTAL_BYTES), so it is allowed
+//     while the generic _BYTES / _FILE_SIZE validation bounds stay excluded.
+//  2. A `.length`-based overflow check in the findMany().length "evict-oldest"
+//     family. Matched narrowly as `<name>.length + N - CAP_CONSTANT` (the exact
+//     shape used by the bridge-code / extension-token / mobile-token caps) so a
+//     bare `xs.length > 0` / `> limit` / `> 20` pagination or presence check is
+//     NOT mistaken for a cap.
+//  3. A dynamic per-tenant session cap held in a lowercase var
+//     (maxSessions / maxConcurrentSessions), which matches no naming convention.
+// Excluded MAX_ forms are not per-scope DB caps: validation length/size bounds
+// (LENGTH, FILE_SIZE, BYTES, DIMENSION, …), time/interval constants (…_THROTTLE_MS
+// and other THROTTLE intervals, AGE, DAYS, EXPIRY/EXPIRES), traversal bounds
+// (DEPTH), and the in-memory Map size cap (CACHE_ENTRIES) used by per-process
+// throttle caches. *_TOTAL_BYTES is re-admitted below — it IS a byte-quota cap.
+const CAP_NAMED_RE =
+  />=?\s*(MAX_(?!LENGTH|FILE_SIZE|BYTES|JSON|DAYS|AGE|DEPTH|EXPIRY|EXPIRES|DIMENSION|IMPORT_FOLDERS|CIDRS|BULK|ATTEMPTS|CACHE_ENTRIES|[A-Z_]*THROTTLE[A-Z_]*|CONCURRENT_SESSIONS_(?:MIN|MAX))[A-Z_]*|[A-Z_]+_TOTAL_BYTES|[A-Z_]+_LIMIT(?:_PER_[A-Z]+)?|TOKEN_LIMIT[A-Z_]*)\b/;
+// `active.length + 1 - BRIDGE_CODE_MAX_ACTIVE` — length, then arithmetic against
+// an UPPER_SNAKE cap constant. Anchored on the `- CONSTANT` so presence checks
+// (`xs.length > 0`) and numeric-literal bounds (`all.length > 20`) do not match.
+const CAP_LENGTH_OVERFLOW_RE = /\.length\s*[-+][^;\n]*?[-+]\s*[A-Z][A-Z0-9_]*[A-Z0-9]\b/;
+const CAP_DYNAMIC_SESSION_RE = /\.length\s*>=?\s*maxSessions\b|>=?\s*maxConcurrentSessions\b/;
+const CAP_COMPARISON_RE = new RegExp(
+  `${CAP_NAMED_RE.source}|${CAP_LENGTH_OVERFLOW_RE.source}|${CAP_DYNAMIC_SESSION_RE.source}`,
+);
+// A per-scope read that establishes the current count.
+const COUNT_RE = /\.(count|aggregate|findMany)\s*\(/;
+// A write that bumps the counted set: a plain create, or a claim/CAS updateMany
+// (flips a scoping FK on an existing row — the DCR-consent claim increments a
+// tenant's client count with no `.create` at all), or upsert.
+const CREATE_RE = /\.(create|createMany|updateMany|upsert)\s*\(/;
 const LOCK_RE = /pg_advisory_xact_lock|advisoryXactLock\s*\(/;
 const RLS_WRAPPER_RE = /with(?:Bypass|Tenant|UserTenant|TeamTenant)Rls\s*\(/;
 

--- a/src/app/api/mcp/authorize/consent/route.test.ts
+++ b/src/app/api/mcp/authorize/consent/route.test.ts
@@ -12,6 +12,7 @@ const {
   mockMcpClientFindUnique,
   mockTxFindFirst,
   mockTxDelete,
+  mockExecuteRaw,
   mockRequireRecentSession,
   mockDerivePasskeyState,
 } = vi.hoisted(() => ({
@@ -26,6 +27,7 @@ const {
   mockMcpClientFindUnique: vi.fn(),
   mockTxFindFirst: vi.fn().mockResolvedValue(null),
   mockTxDelete: vi.fn().mockResolvedValue({}),
+  mockExecuteRaw: vi.fn().mockResolvedValue(0),
   mockRequireRecentSession: vi.fn().mockResolvedValue(null),
   mockDerivePasskeyState: vi.fn(),
 }));
@@ -66,6 +68,10 @@ vi.mock("@/lib/prisma", () => ({
 // because vi.clearAllMocks() wipes mock implementations between tests).
 function bypassRlsImpl(_p: unknown, fn: (tx: unknown) => unknown) {
   return fn({
+    // The claim callback acquires a per-tenant advisory lock (advisoryXactLock)
+    // before the count → cap → updateMany-claim sequence, so the bypass tx must
+    // serve $executeRaw. Captured by mockExecuteRaw to assert the lock is taken.
+    $executeRaw: mockExecuteRaw,
     mcpClient: {
       // The route issues two distinct findFirst shapes on the bypass tx: the
       // initial client lookup keys on `clientId`; the DCR claim-exclusion
@@ -420,6 +426,20 @@ describe("POST /api/mcp/authorize/consent", () => {
     expect(res.status).toBe(302);
     const location = res.headers.get("location") ?? "";
     expect(location).toContain("code=");
+
+    // S1: the claim must serialize under a per-tenant advisory lock, taken
+    // BEFORE the count→cap→updateMany-claim, keyed on the user's tenantId (so it
+    // shares lock identity with the admin-create mirror). Without this ordering
+    // two concurrent Allow POSTs can both read count < MAX and both claim.
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    const lockArgs = mockExecuteRaw.mock.calls[0];
+    expect(lockArgs.slice(1)).toContain(VALID_USER.tenantId);
+    expect(mockExecuteRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      mockMcpClientCount.mock.invocationCallOrder[0],
+    );
+    expect(mockExecuteRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      mockMcpClientUpdateMany.mock.invocationCallOrder[0],
+    );
   });
 
   it("redirects with error=access_denied and calls logAuditAsync on deny action", async () => {

--- a/src/app/api/mcp/authorize/consent/route.ts
+++ b/src/app/api/mcp/authorize/consent/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
+import { withBypassRls, BYPASS_PURPOSE, advisoryXactLock } from "@/lib/tenant-rls";
 import { createAuthorizationCode } from "@/lib/mcp/oauth-server";
 import { MCP_SCOPES, MAX_MCP_CLIENTS_PER_TENANT } from "@/lib/constants/auth/mcp";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
@@ -128,6 +128,15 @@ export async function POST(req: NextRequest) {
       claimResult = await withBypassRls(
         prisma,
         async (tx) => {
+          // Serialize count → cap-check → claim under a per-tenant advisory
+          // lock. The claim below is a create-equivalent (it flips an unclaimed
+          // client's tenantId null → userTenantId, bumping this tenant's client
+          // count), so without the lock two concurrent Allow POSTs can both read
+          // count < MAX and both claim, exceeding MAX_MCP_CLIENTS_PER_TENANT.
+          // Keyed on userTenantId so it shares lock identity with the admin-create
+          // mirror in api/tenant/mcp-clients (locks on actor.tenantId) — the two
+          // surfaces enforce the same per-tenant cap and must serialize together.
+          await advisoryXactLock(tx, userTenantId);
           const tenantClientCount = await tx.mcpClient.count({
             where: { tenantId: userTenantId },
           });


### PR DESCRIPTION
Follow-up to `#637`. A triangulate review of that PR surfaced one live Critical and a structural blind spot in the guard that was supposed to close the cap-bypass class.

## S1 — DCR-consent tenant cap TOCTOU (Critical)

`POST /api/mcp/authorize/consent` claims an unclaimed DCR MCP client by flipping its `tenantId` from `null` to the consenting user's tenant — a create-equivalent that bumps the tenant's client count. The `count → cap-check → updateMany`-claim ran inside `withBypassRls` **without an advisory lock**, so two concurrent Allow POSTs could both read `count < MAX_MCP_CLIENTS_PER_TENANT` and both claim, exceeding the cap.

Fix: take `advisoryXactLock(tx, userTenantId)` as the first statement of the claim callback, before the count. Keyed on `userTenantId` so it shares lock identity with the admin-create mirror in `api/tenant/mcp-clients` (which locks on `actor.tenantId`) — both surfaces enforce the same per-tenant cap and must serialize together.

This site was invisible to the human review and to the count-then-create guard because it uses `updateMany` (a claim), not `.create()`.

## S2/T1 — broaden the count-then-create-lock guard

The guard keyed on the `.count()` + `MAX_` spelling. The class's real defining primitive is **"read a per-scope table → gate on a cap → write it"**, not that spelling. Keying on the spelling let three shapes ship or mutate unseen:

- `findMany().length` "evict-oldest" family (bridge-code / extension-token / mobile-token / session caps)
- byte-quota send cap (`aggregate()._sum` vs `*_TOTAL_BYTES`)
- the DCR-consent claim above (`updateMany`, no `.create`)

The read / cap / write alternations are broadened to cover all three, while excluding non-cap decoys: pagination `.length` checks, in-memory `Map`-size caps (`MAX_CACHE_ENTRIES`), and throttle intervals (`*_THROTTLE_MS`). Verified green on a clean tree (zero false positives) and mutation-red across the representative real sites (consent, mcp-clients, bridge-code, sends/file).

## Tests

- `scripts/__tests__/check-count-then-create-lock.test.mjs` — real-shape fixtures for each broadened shape (evict-oldest, byte-quota, claim-updateMany, dynamic `maxSessions`) plus false-cap decoys, all mutation-verified.
- `scripts/__tests__/check-bypass-rls.test.mjs` (new) — pins the F3 unused-`tx` anti-drift scan: fires on an allowlisted file suppressing an unused `tx`, passes the sanctioned `tenant-context.ts` delegating wrappers.
- `consent/route.test.ts` — asserts the advisory lock is taken before the count/updateMany-claim, keyed on the user's tenant. Mutation-verified: removing the lock fails the assertion.

`docs/archive/review/pr637-toctou-cap-triangulate-code-review.md` records the full finding evidence (S1/S2, T1-T6, F1-F3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)