### PR TITLE
feat(ios): search on category screens, sort with direction toggle, app version

### DIFF
--- a/docs/archive/review/ios-search-sort-and-version-plan.md
+++ b/docs/archive/review/ios-search-sort-and-version-plan.md
@@ -355,3 +355,49 @@ Phase 2 obligation: re-run the grep, diff against this list, and for each **pers
 | C10 | Localization strings (en/ja)                                  | locked |
 
 All contracts are `locked` after Round-1 plan review: the Round-1 findings (F1/F2 web-parity + nil/empty semantics, F6/S5/T5 ISO parser reuse, T1 version seam, T2 injected store, T3 per-key favorites, T4 stability + both-key nil-last, T7 e2e date test, S1 screen-recording gate, F4 sort-menu location) were all reflected into the contracts above.
+
+## Implementation Checklist
+
+### Files to create
+- `ios/Shared/ISO8601.swift` — free func `parseISO8601(_:) -> Date?` (relocated dual-variant parser).
+- `ios/Shared/Models/EntrySortOption.swift` — enum + `sorted(_:)` (C1).
+- `ios/Shared/AppVersion.swift` — string-seam version provider (C9).
+- `ios/PasswdSSOTests/EntrySortOptionTests.swift` — T-SORT.
+- `ios/PasswdSSOTests/AppVersionTests.swift` — T-VERSION.
+
+### Files to modify
+- `ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift` — replace body of `parseISO8601` with forwarding shim to `Shared.parseISO8601` (R2-T1; keep the static method so `Self.parseISO8601` @ line 41 and tests @ 86/114/115/116 still compile).
+- `ios/Shared/Models/VaultEntrySummary.swift` — add `createdAt/updatedAt: Date?` + defaulted init params (C2).
+- `ios/Shared/AutoFill/CredentialResolver.swift` — `CacheEntry`: add optional `createdAt/updatedAt` + defaulted init params (C3).
+- `ios/PasswdSSOApp/Vault/EntryFetcher.swift` — `EncryptedEntry`: add optional date `String` wire fields + `CodingKeys` + convert in `toPersonalCacheEntry()` via `Shared.parseISO8601` (C4). Team `toCacheEntry` passes nil (SC3).
+- `ios/Shared/Models/EntryBlobDecoder.swift` — `summary(...)`: add `createdAt/updatedAt: Date? = nil` params, set on returned `VaultEntrySummary` (C5).
+- `ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift` — `init(settings:)`, `sortOption` property (read/write AppSettingsStore), `filteredSummaries` final sort step, `decryptOverview` passes `entry.createdAt/updatedAt` to `summary` (C6).
+- `ios/Shared/Storage/AppSettingsStore.swift` — `entrySortOption` fail-closed getter/setter + `entrySortOptionKey` (C7).
+- `ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift` — `.searchable()` on outer container of `VaultCategoryListView`; rows stay in `!isScreenRecording` else branch (C8).
+- `ios/PasswdSSOApp/Views/Vault/VaultListView.swift` — Sort menu in top-level toolbar setting `viewModel.sortOption` (C6/F4).
+- `ios/PasswdSSOApp/Views/SettingsView.swift` — Version `LabeledContent` row (C9).
+- `ios/PasswdSSOApp/Localizable.xcstrings` — new keys: `Sort`, `Title`, `Created date`, `Updated date`, `Website`, `Version` (en+ja) (C10).
+- Test extensions: `VaultFilterTests.swift` (T-VM-SORT), `AppSettingsStoreTests.swift` (T-PERSIST), `CacheEntryPropagationTests.swift` (T-DATE, T-DATE-COMPAT), `VaultViewModelTests.swift` (T-DATE-E2E), `EntryBlobDecoderTests.swift` (T-BLOB).
+
+### Reusable code (MUST reuse, do not reimplement)
+- `AutofillTokenRefresher.parseISO8601` dual-variant parse (`AutofillTokenRefresher.swift:57-64`) → relocate to Shared, reuse everywhere.
+- `AppSettingsStore` fail-closed getter pattern (`appLanguage`/`vaultTimeoutAction`, lines 190-200) → mirror for `entrySortOption`.
+- `AppSettingsStore(defaults:)` injection (line 80) + `AppSettingsStoreTests` per-suite pattern → reuse for T-PERSIST.
+- `injectSummaries` (VaultViewModelTests.swift:838) + `makeCacheData` (line 849) → reuse for sort/e2e tests.
+- `EntryBlobDecoder.summary`/`toPersonalCacheEntry` established metadata-on-cache-row pattern (entryType/isFavorite) → dates follow the same shape.
+
+### Member-set (R42) — CacheEntry( sites, verified
+- Personal sync: `HostSyncService.swift:95` → `toPersonalCacheEntry()` (MUST carry dates).
+- Team: `EntryFetcher.swift:129 toCacheEntry` (nil — SC3).
+- Passkey registration append: `CredentialProviderViewController.swift:449` (nil — new local entry, no server date; next host sync backfills).
+- Debug/Demo: `DebugVaultLoader.swift:237`, `DemoVaultFactory.swift:449` (nil ok; may set for realism).
+
+### Test-tree enumeration (R19) — symbols with changed signatures
+- `EntryBlobDecoder.summary`: tests in `CacheEntryPropagationTests`, `EntryBlobDecoderTests`, `PasskeyEntryBlobBuilderTests` — all use defaulted params, no update needed unless asserting dates.
+- `VaultEntrySummary.init`: constructed in `EntryBlobDecoder.swift` + 7 test files — defaulted params, no update needed.
+- `VaultViewModel.init`: 22 call sites all zero-arg — `init(settings:)` default arg keeps them compiling; keep `@MainActor`.
+- `parseISO8601`: `AutofillTokenRefresher.swift:41` + `AutofillTokenRefresherTests.swift:86/114/115/116` — forwarding shim preserves all.
+
+### Mandatory checks (memory)
+- `xcodegen generate` (commit regenerated pbxproj — new files must be added to targets via project.yml/xcodegen).
+- `xcodebuild test -scheme PasswdSSOApp -destination 'id=<sim udid>'` — all tests pass + build succeeds.

--- a/docs/archive/review/ios-search-sort-and-version-plan.md
+++ b/docs/archive/review/ios-search-sort-and-version-plan.md
@@ -1,0 +1,357 @@
+# Plan: iOS Search Enablement, Sort Keys, and Settings Version Row
+
+## Project context
+
+- **Type**: mixed — this PR is iOS-only (SwiftUI app in `ios/`), but plumbs two new fields through a wire model that mirrors a server response shape in `src/`.
+- **Test infrastructure**: unit tests (`ios/PasswdSSOTests`, XCTest) + UI tests (`ios/PasswdSSOUITests`) + CI (xcodegen → xcodebuild). Build env is available locally (`xcodebuild`, Xcode 26.4.1); `xcodegen generate` regenerates the pbxproj.
+- **Verification environment constraints**:
+  - **VC1** — `xcodebuild test` on the iOS simulator is available locally (see memory `ios-build-env-available`). All new unit tests are `verifiable-local`. The three feature behaviors (search on category screens, sort menu, version row) are `verifiable-local` via unit tests over `VaultViewModel`/`AppSettingsStore` plus a manual simulator run.
+  - **VC2** — Real end-to-end date-sort correctness (createdAt/updatedAt values actually arriving from a live server through sync) requires a running passwd-sso server with real entries. This is `verifiable-local` only if a dev server is reachable; otherwise the date-plumbing is `verifiable-CI`/unit via a fixture `CacheEntry` carrying known dates. We do NOT require a live server: the golden-fixture test (T-DATE) exercises decode→summary→sort with fixed dates and is the authoritative check.
+  - **VC3** — Bundle version string (`CFBundleShortVersionString`) resolves to the xcodegen-substituted `MARKETING_VERSION` only in a real build, not in unit-test host bundles reliably. The version-row logic is tested against an **injected** provider (not `Bundle.main` directly) so the test is `verifiable-local`; the real substituted value is confirmed by the manual simulator run.
+
+## Objective
+
+Three user-requested iOS improvements, mirroring existing web behavior where one exists:
+
+1. **Search on every category screen.** Today the search field lives only on the top-level `VaultListView` bottom bar; category screens (`VaultCategoryListView` — Logins, Passkeys, tag screens, etc.) inherit the query but offer no way to *enter* or *edit* a search while inside them. Add a search affordance to the category screens, scoped to the current category.
+2. **Sort key selection.** Add a sort menu with four keys — Title, Created date, Updated date, Website — selectable on the list screens, with the selected key persisted across launches. iOS currently has no sort at all. **Parity note (F1):** the web app's `EntrySortOption` (`src/lib/vault/entry-sort.ts:1`) has only THREE keys — `title`/`createdAt`/`updatedAt`; there is **no `website` key on web**. This plan mirrors web semantics for those three keys (direction, favorites-first) and adds `website` as an **iOS-only** key sorting on `urlHost` ascending. `website` therefore has no web reference implementation and its semantics are defined fully in C1 below. Created/Updated dates are not yet carried to iOS; this plan plumbs them through the sync pipeline.
+3. **App version in Settings.** Display the app marketing version (and build number) in the Settings screen. Not shown anywhere today.
+
+## Requirements
+
+### Functional
+
+- **FR1** Search is enterable/editable on category screens and filters within the current category only (confirmed with user: "現在のカテゴリ内のみ"). The top-level global search behavior is unchanged.
+- **FR2** A sort menu offers exactly four keys: Title, Created date, Updated date, Website. Direction is fixed per key: title & website ascending (case-insensitive via `localizedCaseInsensitiveCompare`), created & updated descending (newest first) — the three shared keys match web `entry-sort.ts`. Favorites-first ordering is **preserved** as the primary sort (matching web `compareEntriesWithFavorite`). Nil/empty sort values (nil dates on team/legacy entries; empty `urlHost`) sort AFTER all populated values on that key (see C1). The overall sort is **stable** (equal-key ties preserve prior/input order) — enforced via an index tie-break, because Swift's `sorted(by:)` is not guaranteed stable (F/T finding T4).
+- **FR3** The selected sort key persists across app launches (confirmed with user: "永続化する") via `AppSettingsStore` (App Group UserDefaults), fail-closed to `.title`. **Default is deliberately `.title`, NOT web's `.updatedAt`** (F3): date keys are `nil` for team/legacy entries and for ALL personal entries until the first post-upgrade sync backfills them, so a date default would present an apparently-unsorted list on first launch; `.title` is the one key with a value on every entry. This divergence from web is intentional, not an oversight.
+- **FR4** Created/Updated timestamps flow from the server `/api/passwords` GET response (which already returns `createdAt`/`updatedAt` as ISO-8601 strings — `src/app/api/passwords/route.ts:95-96`) through `EncryptedEntry` → `CacheEntry` → `VaultEntrySummary`. Team entries have no created/updated in their wire model; they decode to `nil` and sort last on date keys (documented, not a bug).
+- **FR5** Settings shows the app version. Format: marketing version and build number, e.g. `0.4.65 (0.4.65)`.
+
+### Non-functional
+
+- **NFR1** No change to the E2E encryption contract. `createdAt`/`updatedAt` are **non-secret server metadata** carried on the cache row alongside the existing `entryType`/`isFavorite` — NOT inside the encrypted blob. This exactly mirrors how `entryType`/`isFavorite` are already threaded (`EntryBlobDecoder.summary` sets `lastAccessedAt: nil` and takes metadata as separate params).
+- **NFR2** Backward/forward-compatible cache: `CacheEntry` is a `Codable` persisted to disk. New date fields MUST be `Optional` so an older cache (written before this change) still decodes (nil dates). This mirrors the `entryType`/`isFavorite` optionality rationale documented on `CacheEntry`.
+- **NFR3** All new UI strings go through the localization catalog (`.xcstrings`) — both `en` and `ja`. See memory `ios-string-catalog-notes` for the extraction pitfalls.
+
+## Technical approach
+
+### Data flow for dates (FR4)
+
+Server GET `/api/passwords` already returns `createdAt`/`updatedAt`. The iOS `EncryptedEntry` wire model (`ios/PasswdSSOApp/Vault/EntryFetcher.swift`) has an **explicit `CodingKeys`** whitelist that currently drops them. The plumbing:
+
+```
+/api/passwords GET (createdAt, updatedAt: ISO strings)
+  └─> EncryptedEntry (add optional Date fields + CodingKeys entries)
+        └─> EncryptedEntry.toPersonalCacheEntry() (pass dates through)
+              └─> CacheEntry (add optional Date fields; persisted to App Group cache)
+                    └─> VaultViewModel.decryptOverview (pass dates into decoder)
+                          └─> EntryBlobDecoder.summary(...createdAt:updatedAt:) (set on summary)
+                                └─> VaultEntrySummary (add optional Date fields)
+                                      └─> sort comparator reads them
+```
+
+Decoding ISO-8601 strings → `Date`: **Decision**: decode as optional `String` on the wire model and convert with the EXISTING dual-variant parser, because the existing `fetchEntries` decoder (`MobileAPIClient.fetchEntries`, a bare `JSONDecoder()` with no `dateDecodingStrategy`) is shared and changing its global strategy could affect other fields. Keeping the raw string local and converting at the `toPersonalCacheEntry()` boundary avoids a global decoder-strategy change. `CacheEntry`/`VaultEntrySummary` store `Date?`.
+
+**REUSE, do not reimplement (F6/S5/T5)**: `AutofillTokenRefresher.parseISO8601(_:)` (`ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift:57-64`) ALREADY implements the required tolerant parse — it tries a fractional-seconds `ISO8601DateFormatter` first, then falls back to the plain one. A single formatter with `.withFractionalSeconds` FAILS on non-fractional strings (and vice versa); the dual attempt is mandatory. Because `EncryptedEntry`/`EntryFetcher` (host-app target) and any Shared consumer need it, **relocate the parse logic into `Shared`** (e.g. a `Shared/ISO8601.swift` free function `parseISO8601(_:) -> Date?`) — do NOT copy it (DRY) and do NOT move the whole `AutofillTokenRefresher` type into Shared (R10: it pulls app-target deps; Shared has no deps, app→Shared is the correct direction, so a free function is safe).
+
+**Preserve existing call sites (R2-T1)**: `AutofillTokenRefresher.parseISO8601` is called directly as a static method by production code (`AutofillTokenRefresher.swift:41` via `Self.parseISO8601`) AND by existing tests (`AutofillTokenRefresherTests.swift:86/114/115/116`). To avoid breaking those, keep a thin **forwarding shim** `static func parseISO8601(_ s: String) -> Date? { Shared.parseISO8601(s) }` on `AutofillTokenRefresher` — DRY at the implementation, zero call-site churn. Do NOT delete the static method outright.
+
+Team entries (`TeamEncryptedEntry.toCacheEntry`) have no createdAt/updatedAt on their wire model → pass `nil` (documented in FR4).
+
+### Sort (FR2/FR3)
+
+- New shared enum `EntrySortOption` in `Shared` (mirrors web `entry-sort.ts` type). Cases: `.title`, `.createdAt`, `.updatedAt`, `.website`. `String`-backed rawValues for persistence.
+- New pure comparator `EntrySortOption.compare(_:_:) -> Bool` (or a `sorted(_:)` helper) applying favorites-first then the key, matching `compareEntriesWithFavorite`.
+- `VaultViewModel.filteredSummaries` applies the sort as the final step (after scope + search filter). Sort key read from a new `sortOption` property, initialized from `AppSettingsStore`.
+- Persistence: new `AppSettingsStore.entrySortOption: EntrySortOption` fail-closed getter/setter (default `.title` — chosen because it is the one key with data guaranteed present on every entry, personal and team; date keys are nil for team/legacy entries).
+
+### Search on category screens (FR1)
+
+- `VaultCategoryListView` gains a `.searchable(text: $viewModel.searchQuery, ...)` modifier (or a bottom search field consistent with `VaultListView`). Since `viewModel.searchQuery` is shared state and `entries` already composes `filteredSummaries.filter { matches($0, category) }`, wiring a search binding into the category screen filters within the category automatically.
+- **Decision**: use `.searchable()` on the category screen (the pushed nav view) rather than replicating the custom bottom bar, because a pushed view with a nav bar is the idiomatic place for `.searchable()` and `DemoVaultView` already uses this exact pattern (`DemoVaultView.swift:45`). The top-level `VaultListView` keeps its bottom-bar field unchanged.
+- **Screen-recording invariant (S1)**: `.searchable()` attaches to the outer container (`Group`/nav chrome — the search *bar* itself shows no secrets, only the query the user typed). Entry-row rendering MUST stay inside the existing `else` (`!isScreenRecording`) branch of `VaultCategoryListView.body` (`VaultCategoryLanding.swift:92-135`) — exactly as `DemoVaultView.swift:45` does. Never render filtered result rows outside the `if isScreenRecording` gate, or entry titles/usernames leak into a screen recording / AirPlay mirror.
+- **Cross-screen query UX (F5)**: the category `.searchable` and the top-level bottom-bar field both write the SAME shared `viewModel.searchQuery`. Consequences to verify in the manual sim run: (a) a query typed at top level carries into the category `.searchable` pre-populated; (b) `.searchable`'s system Cancel clears the shared query, emptying the top-level field too; (c) on returning from a category with a non-empty query, the top-level view is in `entryList` mode (not the category grid), because `VaultListView` switches on `searchQuery.isEmpty` (`VaultListView.swift:43-47`). These are consistent with "search is global state" and are acceptable, but MUST be confirmed on-device/sim (VC1), not assumed.
+- **Search query lifecycle**: `VaultListView` clears `searchQuery` on scope change (`VaultListView.swift:186`). Entering a category does NOT clear it — a query typed at top level carries in. Verify this is acceptable UX (it is: the category screen shows the same filtered set the count promised). On leaving the category, the query persists back to the top-level field (shared state) — this matches "search is global state" and is not a regression.
+
+### Version row (FR5)
+
+- Add a `LabeledContent("Version")` row to `SettingsView` (new bottom section or in the existing Server section footer area).
+- **Testable seam is a closure/protocol, NOT `Bundle` injection (T1)**: `Bundle` has no public initializer accepting an arbitrary `infoDictionary`, so a synthetic `Bundle` with known version keys cannot be built in XCTest — a `Bundle(for:)` test bundle carries the xcodegen-substituted `MARKETING_VERSION`, not a fixed test value, making a `Bundle`-injected version test either uncompilable or vacuous. Instead inject the raw lookups:
+  ```swift
+  public struct AppVersion {
+    public static func display(
+      marketing: String? = Self.infoValue("CFBundleShortVersionString"),
+      build: String? = Self.infoValue("CFBundleVersion")
+    ) -> String
+    private static func infoValue(_ key: String) -> String? {
+      Bundle.main.object(forInfoDictionaryKey: key) as? String
+    }
+  }
+  ```
+  The default arguments read the real `Bundle.main` Info.plist in production; tests call `AppVersion.display(marketing: "0.4.65", build: "42")` → `"0.4.65 (42)"` and `AppVersion.display(marketing: nil, build: nil)` → fallback (e.g. `"—"`). `Bundle.main` is class-swizzled by `LanguageBundle` but only `localizedString(forKey:)` is overridden, so `object(forInfoDictionaryKey:)` returns the real Info.plist values (confirmed in exploration). The real substituted `MARKETING_VERSION` display is confirmed by the manual sim run (VC3), not a unit test.
+
+## Contracts
+
+### C1 — `EntrySortOption` shared enum + comparator
+
+- **Signature**:
+  ```swift
+  // ios/Shared/Models/EntrySortOption.swift (new)
+  public enum EntrySortOption: String, CaseIterable, Sendable {
+    case title
+    case createdAt
+    case updatedAt
+    case website
+  }
+  extension EntrySortOption {
+    /// Favorites-first, then the selected key. Mirrors web compareEntriesWithFavorite.
+    public func sorted(_ summaries: [VaultEntrySummary]) -> [VaultEntrySummary]
+  }
+  ```
+- **Invariants**:
+  - **app-enforced**: `sorted` is favorites-first — favorites always precede non-favorites **regardless of key** (matches `compareEntriesWithFavorite`: `if a.isFavorite !== b.isFavorite return a.isFavorite ? -1 : 1`). The favorite split is applied BEFORE the per-key comparison, never inside a single key's branch (the porting mistake T3 guards against).
+  - **app-enforced**: date keys sort descending (newest first); `title`/`website` ascending, case-insensitive, using `localizedCaseInsensitiveCompare` (the Swift analogue of JS `localeCompare`).
+  - **app-enforced (nil/empty sort-last)**: a `nil` date on a date key sorts AFTER all non-nil entries on that key; an empty (`""`) `urlHost` on the `website` key sorts AFTER all non-empty hosts. `urlHost` is a non-optional `String` that is `""` (never `nil`) for non-web entry types (secure notes, identities, …) — so `""` is treated as the "empty" sort-last sentinel for `website`, exactly as `nil` is for date keys (F2). Team/legacy entries and non-web entries therefore never jump to the top.
+  - **app-enforced (stability, T4)**: the sort is **stable** — equal-key ties (including nil-vs-nil and `""`-vs-`""`) preserve input order. Swift's `sorted(by:)` is NOT guaranteed stable, so `sorted` MUST enforce stability explicitly, e.g. sort `summaries.enumerated()` with the original index as the final tie-breaker. Do NOT rely on `sorted(by:)` being stable.
+  - **app-enforced**: `website` key sorts on `urlHost` (the summary field), ascending, non-empty-first.
+- **Forbidden patterns**:
+  - `pattern: dateDecodingStrategy\s*=\s*\.iso8601` in the shared `fetchEntries` decoder path — reason: a global strategy change risks other fields; dates are converted locally (see C4).
+  - `pattern: Locale\.current` in EntrySortOption — reason: sorting must not depend on ambient locale for test determinism; use `localizedCaseInsensitiveCompare` on the String directly.
+- **Acceptance criteria**:
+  - `EntrySortOption.title.sorted([b:"Beta", a:"Alpha"])` → `[a, b]`.
+  - **Favorites-first holds for EVERY key** (T3): a favorite entry that would sort last on the key precedes an alphabetically/chronologically-first non-favorite, tested under `.title`, `.createdAt`, `.updatedAt`, AND `.website`.
+  - Under `.createdAt` AND `.updatedAt` (both keys, T4): an entry with a later timestamp precedes an earlier one; a `nil`-date entry sorts last on that key.
+  - Under `.website`: an entry with `urlHost=""` sorts after entries with a non-empty host.
+  - **Stability (T4)**: two entries with equal keys (e.g. same title, or both nil createdAt) preserve their input relative order.
+  - `.allCases.count == 4`.
+
+### C2 — `VaultEntrySummary` gains `createdAt`/`updatedAt`
+
+- **Signature**: add to `ios/Shared/Models/VaultEntrySummary.swift`:
+  ```swift
+  public let createdAt: Date?
+  public let updatedAt: Date?
+  ```
+  plus init params `createdAt: Date? = nil, updatedAt: Date? = nil` (defaulted so all existing call sites — AutoFill, decoders, tests — compile unchanged).
+- **Invariants**:
+  - **app-enforced**: both fields default to `nil`; a summary constructed without them is valid (all AutoFill/test call sites rely on this).
+  - **schema-enforced (Codable)**: `Codable` conformance still round-trips; both being `Optional` means an older encoded summary (if any is persisted) still decodes.
+- **Forbidden patterns**:
+  - `pattern: createdAt: Date\b` (non-optional) in VaultEntrySummary — reason: must be `Date?` for backward-compat (NFR2).
+- **Acceptance criteria**: existing `VaultEntrySummary(...)` calls with no date args still compile; new fields default `nil`.
+- **Consumer-flow walkthrough** (VaultEntrySummary is a consumed shape):
+  - **Consumer: sort comparator** (path: `EntrySortOption.sorted`) reads `{ createdAt, updatedAt, urlHost, title, isFavorite }` and uses `createdAt`/`updatedAt` for date-key ordering, `urlHost` for website key, `title` for title key, `isFavorite` for the primary favorites-first split. All fields present on the summary. ✓
+  - **Consumer: `EntrySummaryRow`** (path: `VaultCategoryLanding.swift:40`) reads `{ title, username, entryType, urlHost }` — unchanged; does not read the new date fields. ✓
+  - **Consumer: AutoFill call sites** (path: `CredentialResolver`, `CredentialPickerView`) construct summaries via decoders that will pass `nil` for the new fields (defaulted). They do not read the date fields. ✓
+  - No consumer needs a field absent from the extended shape.
+
+### C3 — `CacheEntry` gains optional `createdAt`/`updatedAt`
+
+- **Signature**: add to `CacheEntry` (`ios/Shared/AutoFill/CredentialResolver.swift:758`):
+  ```swift
+  public let createdAt: Date?
+  public let updatedAt: Date?
+  ```
+  plus defaulted init params (`= nil`).
+- **Invariants**:
+  - **schema-enforced (Codable, NFR2)**: both `Optional` → an on-disk cache written before this change decodes with `nil` dates (no crash, no re-sync forced). This is the same optionality contract already documented for `entryType`/`isFavorite` on `CacheEntry`.
+- **Forbidden patterns**:
+  - `pattern: let createdAt: Date\b` (non-optional) in CacheEntry — reason: NFR2 backward-compat.
+- **Acceptance criteria**: decoding a JSON `CacheEntry` fixture that omits `createdAt`/`updatedAt` succeeds with `nil` (regression test in `CacheEntryPropagationTests`).
+- **Consumer-flow walkthrough** (CacheEntry is a consumed persisted shape):
+  - **Consumer: `VaultViewModel.decryptOverview`** (path: `VaultViewModel.swift:169`) reads the whole `CacheEntry` and now additionally passes `entry.createdAt`/`entry.updatedAt` into `EntryBlobDecoder.summary`. Fields present. ✓
+  - **Consumer: `VaultViewModel.loadDetail`/`decryptBlob`/`rawPlaintexts`** read the entry for decryption; they do NOT need the dates (detail view does not sort). Unchanged. ✓
+  - **Consumer: AutoFill `CredentialResolver`** decodes `[CacheEntry]` for QuickType; does not read dates. Optional fields decode to nil harmlessly. ✓
+  - **Consumer: `HostSyncService`/`DebugVaultLoader`/tests** construct `CacheEntry` via `toPersonalCacheEntry()` / `toCacheEntry()` / literals — all use defaulted params so unchanged sites compile. ✓
+
+### C4 — `EncryptedEntry` decodes dates + `toPersonalCacheEntry` passes them through
+
+- **Signature**: add to `EncryptedEntry` (`EntryFetcher.swift`):
+  ```swift
+  public let createdAt: Date?   // decoded from ISO-8601 string on the wire
+  public let updatedAt: Date?
+  ```
+  add `createdAt`/`updatedAt` to `CodingKeys`. `toPersonalCacheEntry()` passes them into `CacheEntry`.
+- **Invariants**:
+  - **app-enforced**: ISO-8601 string → `Date` conversion uses the RELOCATED `parseISO8601` (moved to `Shared` per the Technical-approach note — F6), which tries a fractional-seconds formatter then falls back to the plain one; a missing/unparseable value → `nil` (never throws; a date parse failure must not fail the whole sync). A single formatter with only `.withFractionalSeconds` would silently drop non-fractional dates — hence the reused dual-attempt.
+  - **app-enforced**: the conversion is local to `EncryptedEntry` decoding; the shared `fetchEntries` `JSONDecoder` global `dateDecodingStrategy` is NOT changed (forbidden pattern in C1).
+- **Forbidden patterns**:
+  - `pattern: try container.decode\(Date.self, forKey: .createdAt\)` (non-optional, throwing) — reason: must be `decodeIfPresent` + tolerant parse so a bad/absent date never breaks sync.
+- **Acceptance criteria**:
+  - Decoding a `/api/passwords`-shaped JSON with `"createdAt":"2024-01-02T03:04:05.000Z"` yields a non-nil `Date`; `toPersonalCacheEntry()` carries it to `CacheEntry.createdAt`.
+  - Decoding JSON omitting the dates yields `nil` (no throw).
+- **Consumer-flow walkthrough**:
+  - **Consumer: `HostSyncService`** (path: `ios/PasswdSSOApp/Vault/HostSyncService.swift`) maps fetched `EncryptedEntry` → `CacheEntry` via `toPersonalCacheEntry()`. It reads no date field directly; the mapping helper carries them. Verify HostSyncService uses `toPersonalCacheEntry()` (not a hand-rolled `CacheEntry(...)` that would drop the dates) — if it constructs `CacheEntry` inline, that site must be updated. **[Phase-2 must confirm the actual mapping site.]** ✓ pending confirmation
+
+### C5 — `EntryBlobDecoder.summary` accepts and sets dates
+
+- **Signature**: extend `EntryBlobDecoder.summary` (`EntryBlobDecoder.swift:248`):
+  ```swift
+  public static func summary(
+    plaintext: Data, entryId: String, teamId: String?,
+    entryType: String? = nil, isFavorite: Bool = false,
+    createdAt: Date? = nil, updatedAt: Date? = nil   // new, defaulted
+  ) -> VaultEntrySummary?
+  ```
+  Sets `createdAt`/`updatedAt` on the returned `VaultEntrySummary` (dates are cache-row metadata, NOT from the blob — same pattern as `entryType`/`isFavorite`; `lastAccessedAt` stays `nil`).
+- **Invariants**:
+  - **app-enforced**: defaulted params → AutoFill call sites (`CredentialResolver`) that don't pass dates compile unchanged and get `nil`.
+- **Forbidden patterns**:
+  - `pattern: createdAt = p\.` / decoding createdAt from the OverviewBlobPayload — reason: dates are server metadata, NOT in the encrypted overview blob; reading them from the blob is wrong (they aren't there).
+- **Acceptance criteria**: `EntryBlobDecoder.summary(plaintext:…, createdAt: d1, updatedAt: d2)` returns a summary with those exact dates; called without them → `nil` dates.
+- **Consumer-flow walkthrough**: sole producer is `VaultViewModel.decryptOverview`, which now passes `entry.createdAt`/`entry.updatedAt`. Team decryptor (`TeamEntryDecryptor.decryptTeamSummary`) does not pass dates → team summaries get `nil` (FR4). ✓
+
+### C6 — `VaultViewModel` applies sort + threads dates
+
+- **Signature**: on `VaultViewModel` (`VaultViewModel.swift`):
+  ```swift
+  // Injected store so tests use a clean per-test suite, not the shared App Group (T2).
+  public init(settings: AppSettingsStore = AppSettingsStore())
+  public var sortOption: EntrySortOption   // initialized from `settings` at init; writes back to `settings` on set
+  ```
+  `filteredSummaries` gains a final `sortOption.sorted(...)` step. `decryptOverview` passes `entry.createdAt`/`entry.updatedAt` into `EntryBlobDecoder.summary`.
+- **Sort menu UI location (F4)**: the Sort menu is presented in the **top-level `VaultListView` toolbar** (alongside the existing "⋯" menu, or as a second toolbar item). It sets `viewModel.sortOption`. Because the sort is applied inside `filteredSummaries` (shared VM state), the pushed `VaultCategoryListView` screens automatically reflect the globally-chosen key with no additional UI. Changing sort from within a category screen is OUT of scope for this PR (SC5) — the menu lives at top level only.
+- **Invariants**:
+  - **app-enforced**: sort is the LAST transform in `filteredSummaries` (after scope filter + search filter) so search results are also sorted.
+  - **app-enforced**: setting `sortOption` persists to the injected `settings.entrySortOption`; the initial value is read from it at VM init (fail-closed default `.title`).
+- **Forbidden patterns**:
+  - `pattern: allSummaries\.sorted` outside `filteredSummaries` — reason: single sort point.
+- **Acceptance criteria**:
+  - `filteredSummaries` returns entries in the order dictated by `sortOption` (unit test via `injectSummaries` with explicit dates on the injected summaries).
+  - A VM built with `VaultViewModel(settings: AppSettingsStore(defaults: <per-test suite>))` reads its initial `sortOption` from that suite; setting `sortOption` writes it back to that suite (no shared-App-Group pollution — T2).
+  - Default sort when nothing persisted is `.title`.
+  - **End-to-end date threading (T7)**: a `CacheEntry` seeded with known createdAt/updatedAt, run through the real `loadFromCache`/`decryptOverview` path (using `makeCacheData` infra in `VaultViewModelTests`), yields `vm.allSummaries.first?.createdAt == expected` — proving `decryptOverview` actually passes the dates to `summary` (not merely that the two seams work in isolation).
+
+### C7 — `AppSettingsStore.entrySortOption` persistence
+
+- **Signature**: add to `AppSettingsStore` (`ios/Shared/Storage/AppSettingsStore.swift`):
+  ```swift
+  public var entrySortOption: EntrySortOption { get; nonmutating set }
+  public static let entrySortOptionKey: String   // exposed for tests (mirrors fetchFaviconsCachedKey)
+  ```
+  Default `.title` (documented rationale: only key with data present on every entry). Fail-closed: absent/garbage rawValue → `.title`.
+- **Invariants**:
+  - **app-enforced**: getter fail-closed to `.title` on absent/unrecognized value (mirrors `appLanguage`/`vaultTimeoutAction` pattern).
+- **Forbidden patterns**: none specific.
+- **Acceptance criteria**: set `.updatedAt`, re-read via a fresh `AppSettingsStore(defaults:)` → `.updatedAt`; writing garbage to the key then reading → `.title`.
+
+### C8 — Category-screen search wiring
+
+- **Signature**: `VaultCategoryListView.body` gains `.searchable(text: $viewModel.searchQuery, prompt: Text("Search"))` (bound to shared VM state).
+- **Invariants**:
+  - **app-enforced**: `entries` remains `filteredSummaries.filter { matches($0, category) }` — search filters WITHIN the category (FR1), because `filteredSummaries` already applies the query and category membership is applied after.
+  - **app-enforced**: typing in the category search updates the same `viewModel.searchQuery` the top-level bar uses (shared state) — no divergent second query.
+  - **app-enforced (screen-recording, S1)**: `.searchable()` attaches to the outer container (nav chrome); the filtered entry `List` MUST remain inside the existing `else` (`!isScreenRecording`) branch of `VaultCategoryListView.body`. Entry rows never render while `isScreenRecording` is true. Mirror `DemoVaultView.swift:45`.
+- **Forbidden patterns**:
+  - `pattern: @State.*searchText` inside `VaultCategoryListView` — reason: must bind shared `viewModel.searchQuery`, not a local state (a local state would filter globally-then-category but not sync back, causing a stale top-level bar).
+  - `pattern: List\(entries` OUTSIDE the `else`/`!isScreenRecording` branch in `VaultCategoryListView` — reason: S1 — result rows must stay gated behind the screen-recording overlay.
+- **Acceptance criteria**: with a non-empty query, a category screen shows only entries that both match the query AND belong to the category (unit-level: assert `filteredSummaries.filter{matches}` semantics; UI-level: manual simulator check).
+- **Consumer-flow walkthrough**: n/a (UI wiring, not a data shape). The consumed state is `viewModel.searchQuery`, already contract-tested by `VaultFilterTests`.
+
+### C9 — `AppVersion` provider + Settings row
+
+- **Signature** (string-lookup seam, NOT `Bundle` injection — T1):
+  ```swift
+  // ios/Shared/AppVersion.swift (new)
+  public struct AppVersion {
+    /// Defaults read the real Bundle.main Info.plist; tests pass explicit values.
+    public static func display(
+      marketing: String? = infoValue("CFBundleShortVersionString"),
+      build: String? = infoValue("CFBundleVersion")
+    ) -> String   // "0.4.65 (42)"; fallback "—" when both nil
+    public static func infoValue(_ key: String) -> String? {
+      Bundle.main.object(forInfoDictionaryKey: key) as? String
+    }
+  }
+  ```
+  `SettingsView` renders `LabeledContent("Version") { Text(AppVersion.display()) }`.
+- **Invariants**:
+  - **app-enforced**: reads `CFBundleShortVersionString` / `CFBundleVersion`; when a value is missing → a stable fallback string (`"—"`), never a crash.
+  - **app-enforced (testability, T1)**: the seam is the injectable `marketing`/`build` STRING parameters, not a `Bundle` — because `Bundle` has no public `infoDictionary` initializer and a `Bundle(for:)` test bundle carries the xcodegen-substituted version, not a fixed test value. Tests inject strings directly.
+- **Forbidden patterns**:
+  - `pattern: Shared\.frameworkVersion` in SettingsView — reason: `frameworkVersion` is a hardcoded `"0.1.0"` unrelated to the marketing version; do not display it.
+  - `pattern: display\(bundle:` — reason: T1 — a `Bundle`-injection signature yields an uncompilable/vacuous test; the seam must be the string parameters.
+- **Acceptance criteria**:
+  - `AppVersion.display(marketing: "0.4.65", build: "42")` → `"0.4.65 (42)"`.
+  - `AppVersion.display(marketing: nil, build: nil)` → `"—"` (fallback), no crash.
+  - `AppVersion.display(marketing: "0.4.65", build: nil)` → a sensible partial (e.g. `"0.4.65"`), no crash.
+
+### C10 — Localization strings
+
+- **Signature**: new catalog keys in `Localizable.xcstrings` (both `en`/`ja`): `"Sort"`, sort key labels (`"Title"`, `"Created date"`, `"Updated date"`, `"Website"`), `"Version"`. (`"Search"`/`"No matches"`/`"No entries"` already exist.)
+- **Invariants**:
+  - **schema-enforced (catalog)**: every new user-facing string has both `en` and `ja` translations (NFR3). `LocalizationCatalogTests` (existing) enforces catalog completeness — verify new keys are covered.
+- **Forbidden patterns**:
+  - `pattern: Text\("Sort"\)` without a corresponding catalog entry — reason: NFR3; but note per memory `ios-string-catalog-notes`, xcodebuild does not write back extraction, so keys are added manually.
+- **Acceptance criteria**: `LocalizationCatalogTests` passes; both locales resolve every new key. See memory `ios-string-catalog-notes` for the `String` variable vs `LocalizedStringKey` binding pitfall (use string literals in `Text(...)`/`.searchable(prompt:)`, not `String` variables, so keys extract).
+
+## Considerations & constraints
+
+### Scope contract
+
+- **SC1** — Sort direction toggle (ascending/descending per key) is out of scope. Web has fixed direction per key; iOS mirrors that. Owner: future enhancement if requested. (The screenshot's iOS-native passwords menu shows a 降順/昇順 toggle, but the web app — our parity target — does not; we mirror web semantics, not the OS Passwords app.)
+- **SC2** — Sorting the AutoFill extension pickers (`CredentialPickerView`, `OneTimeCodePickerView`) is out of scope; those have their own local search and ranking (`URLMatcher.sortByURLMatch`). This PR touches only the host-app list.
+- **SC3** — Adding `createdAt`/`updatedAt` to the **team** entry wire model (`TeamEncryptedEntry`) is out of scope; team date-sort keys resolve to `nil` (sort-last). Owner: future team-parity work (see memory `ios-extension-parity-roadmap`).
+- **SC4** — Sorting/searching the trash view (if any) is out of scope; this PR targets the active vault list.
+- **SC5** — Changing the sort key from within a pushed category screen is out of scope; the Sort menu lives only on the top-level `VaultListView` toolbar (C6). Category screens reflect the globally-chosen key automatically. Owner: future enhancement if requested.
+
+### Known risks
+
+- **R-A** Changing `EncryptedEntry`/`CacheEntry` shape risks breaking existing decode of on-disk caches. Mitigated by NFR2 (all new fields optional) + a regression test decoding a date-less fixture (T-DATE-COMPAT).
+- **R-B** `HostSyncService` might construct `CacheEntry` inline rather than via `toPersonalCacheEntry()`, silently dropping the dates. Phase 2 MUST grep for `CacheEntry(` construction sites and confirm the personal-sync path routes through `toPersonalCacheEntry()` (C4 walkthrough). Member-set below.
+- **R-C** `.searchable()` on a pushed category view plus the top-level bottom-bar field both writing `viewModel.searchQuery` could produce surprising cross-screen query persistence. Documented as intended (shared state); verified in manual run.
+
+### Member-set derivation (R42) — `CacheEntry(` construction sites
+
+Universally-quantified concern: "**every** personal-sync path that builds a `CacheEntry` from a fetched entry MUST carry the new dates." Defining primitive: literal `CacheEntry(` construction + the `toPersonalCacheEntry()`/`toCacheEntry()` mappers.
+
+```
+grep -rn "CacheEntry(" ios/ | grep -v Tests
+```
+Code-derived member list (from exploration):
+- `ios/PasswdSSOApp/Vault/EntryFetcher.swift` — `toPersonalCacheEntry()` (personal; MUST carry dates — C4) and `toCacheEntry(teamId:)` (team; dates `nil` — SC3).
+- `ios/PasswdSSOAutofillExtension/CredentialProviderViewController.swift` — Phase 2 confirm whether it builds cache entries on a sync path (if it re-syncs, must route through the mapper; if it only reads, no change).
+- `ios/PasswdSSOApp/Debug/DebugVaultLoader.swift` — debug fixture writer; may set dates for realistic debug data (optional).
+- `ios/Shared/Demo/DemoVaultFactory.swift` — demo data; dates optional.
+- Test files (excluded from the control; they may set dates as fixtures).
+
+Phase 2 obligation: re-run the grep, diff against this list, and for each **personal production sync** member confirm it routes through `toPersonalCacheEntry()` (carrying dates) — any inline personal `CacheEntry(` on a sync path that omits dates is a finding.
+
+## User operation scenarios
+
+1. **Search inside a category**: user taps "ログイン" (Logins) → sees the login list → pulls down / taps the search bar → types "git" → sees only login entries whose title/username/urlHost contains "git". Back out → top-level search bar shows "git" (shared state); clearing it there clears everywhere.
+2. **Sort by updated date**: user opens the sort menu → picks "Updated date" → list reorders newest-first, favorites still on top → force-quits and relaunches → sort is still "Updated date". A team vault entry (no updatedAt) sorts below all personal entries under this key.
+3. **Sort by title on a fresh install**: no persisted preference → defaults to Title, ascending, case-insensitive, favorites first.
+4. **Check version**: user opens Settings → scrolls to the Version row → sees `0.4.65 (0.4.65)`.
+5. **Legacy cache**: user upgrades the app; the on-disk cache predates the date fields → entries decode with nil dates → date sorts put them last, title/website sorts unaffected → next sync backfills real dates.
+
+## Testing strategy
+
+- **T-SORT** (`EntrySortOptionTests.swift`, new): title ascending case-insensitive; date descending; `website` ascending non-empty-first; `.allCases.count == 4`. **Favorites-first asserted for ALL FOUR keys** (T3), not just `.title`. **nil-date-last asserted for BOTH `.createdAt` and `.updatedAt`** (T4). **`""`-urlHost-last asserted for `.website`** (F2). **Stability asserted** (T4): equal-key ties (same title; both-nil dates) preserve input order — this test FAILS if `sorted` relies on Swift's non-stable `sorted(by:)` without an index tie-break.
+- **T-VM-SORT** (extend `VaultFilterTests.swift`): `filteredSummaries` applies `sortOption` after scope+search; changing key reorders; default `.title`. Uses a VM built with an injected per-test `UserDefaults` suite (T2).
+- **T-PERSIST** (extend `AppSettingsStoreTests.swift`): `entrySortOption` round-trips through an injected `UserDefaults(suiteName: UUID)` + `removePersistentDomain` teardown (T2 isolation); garbage rawValue → `.title`; absent → `.title`.
+- **T-DATE** (extend `CacheEntryPropagationTests.swift`): `EncryptedEntry` decodes ISO dates in THREE forms — fractional (`.000Z`), non-fractional (`05Z`), and garbage/absent → `nil` with no throw (T5); `toPersonalCacheEntry()` carries them into `CacheEntry`.
+- **T-DATE-E2E** (extend `VaultViewModelTests.swift`, new — T7): seed a `CacheEntry` with known dates, run the real `loadFromCache`/`decryptOverview` via `makeCacheData`, assert `vm.allSummaries.first?.createdAt/updatedAt` equal the seeded values — proves the threading step inside `decryptOverview`, which the isolated seam tests do not cover.
+- **T-DATE-COMPAT** (extend `CacheEntryPropagationTests.swift`): a `CacheEntry` JSON fixture OMITTING the date fields decodes with `nil` (NFR2 regression) — clone of the existing `testCacheEntryDecodesNilIsFavoriteFromLegacyJSON`.
+- **T-BLOB** (extend `EntryBlobDecoder` tests): `summary(...createdAt:updatedAt:)` sets the dates; called without → `nil`; dates are NOT read from the blob payload.
+- **T-VERSION** (`AppVersionTests.swift`, new): `display(marketing:"0.4.65", build:"42")` → `"0.4.65 (42)"`; `display(marketing:nil, build:nil)` → `"—"`; partial (build nil) → sensible fallback, no crash (T1 — string seam, no `Bundle`).
+- **T-SEARCH-CAT**: the genuinely-new C8 binding is verified by asserting the category-scoped `entries` computed property reflects `viewModel.searchQuery` (not a re-test of `filteredSummaries` — T6). The `.searchable` field's visual presence and the screen-recording gate (S1) are verified manually in the simulator (VC1). Do NOT add a `#file`-based source-grep gate for `.searchable` presence (vacuous — memory `ios-swift6-file-vacuous-gate`); if a grep gate is used at all, use `#filePath` + non-swallowing `try` and prove-red.
+- **T-L10N** (existing `LocalizationCatalogTests`): passes with the new keys in both locales (`ja`/`en`). Uses string literals in `Text(...)`/`.searchable(prompt:)`, never `String` variables (memory `ios-string-catalog-notes`).
+- **Mandatory checks** (memory): `xcodegen generate` (commit pbxproj), then `xcodebuild test -scheme PasswdSSOApp -destination 'id=<sim udid>'` — all tests pass. Build must succeed.
+
+## Go/No-Go Gate
+
+| ID  | Subject                                                        | Status |
+|-----|---------------------------------------------------------------|--------|
+| C1  | `EntrySortOption` shared enum + comparator (4 keys, stable, nil/empty-last) | locked |
+| C2  | `VaultEntrySummary` gains createdAt/updatedAt                  | locked |
+| C3  | `CacheEntry` gains optional createdAt/updatedAt (compat)       | locked |
+| C4  | `EncryptedEntry` decodes dates + toPersonalCacheEntry passthru (reuse parseISO8601) | locked |
+| C5  | `EntryBlobDecoder.summary` accepts/sets dates                 | locked |
+| C6  | `VaultViewModel` applies sort + threads dates (injected store, top-level menu) | locked |
+| C7  | `AppSettingsStore.entrySortOption` persistence                | locked |
+| C8  | Category-screen search wiring (screen-recording gated)        | locked |
+| C9  | `AppVersion` string-seam provider + Settings row              | locked |
+| C10 | Localization strings (en/ja)                                  | locked |
+
+All contracts are `locked` after Round-1 plan review: the Round-1 findings (F1/F2 web-parity + nil/empty semantics, F6/S5/T5 ISO parser reuse, T1 version seam, T2 injected store, T3 per-key favorites, T4 stability + both-key nil-last, T7 e2e date test, S1 screen-recording gate, F4 sort-menu location) were all reflected into the contracts above.

--- a/docs/archive/review/ios-search-sort-and-version-review.md
+++ b/docs/archive/review/ios-search-sort-and-version-review.md
@@ -1,0 +1,71 @@
+# Plan Review: ios-search-sort-and-version
+
+Date: 2026-07-07
+Review rounds: 2 (converged)
+
+## Changes from Previous Round
+
+Round 1: initial three-expert review (Functionality, Security, Testing) against the initial plan.
+Round 2: incremental verification of all Round-1 fixes + six new design cross-checks; one new minor finding (R2-T1), fixed.
+
+## Functionality Findings (Round 1)
+
+- **F1 [Major] — RESOLVED**: Plan claimed the sort "mirrors web `EntrySortOption`" with four keys, but web (`src/lib/vault/entry-sort.ts:1`) has only THREE (`title`/`createdAt`/`updatedAt`); there is no `website` key on web. Fix: reframed `website` as an iOS-only key with fully-specified local semantics (Objective §2, FR2, C1); removed all "4 keys mirror web" claims.
+- **F2 [Major] — RESOLVED**: nil dates are not a rare team/legacy edge — they are the state for ALL personal entries until the first post-upgrade sync backfills them; and `urlHost` is `""` (never `nil`) for non-web entries. Fix: C1 now specifies nil-date-last for date keys AND `""`-urlHost-last for `website`; user-scenario 5 documents the post-upgrade window.
+- **F3 [Minor] — RESOLVED**: default sort `.title` diverges from web's `.updatedAt`. Fix: FR3 documents this as a deliberate divergence (date keys are nil until first sync), not an oversight.
+- **F4 [Minor] — RESOLVED**: sort-menu UI location was unspecified. Fix: C6 places it in the top-level `VaultListView` toolbar; SC5 defers in-category sort control.
+- **F5 [Minor] — RESOLVED (documented)**: two search surfaces (top bottom-bar + category `.searchable`) write the same shared `viewModel.searchQuery`. Fix: cross-screen query UX consequences enumerated as manual-sim (VC1) verification items.
+- **F6 [Minor] — RESOLVED**: an existing dual-variant ISO parser (`AutofillTokenRefresher.parseISO8601`) already does what C4 needs; a single-formatter reimplementation would drop non-fractional dates. Fix: C4/Technical-approach mandate REUSE + relocate-to-Shared (free function), not reimplement.
+
+## Security Findings (Round 1)
+
+- **S1 [Low] — RESOLVED**: category-screen `.searchable` must not render entry rows outside the `isScreenRecording` gate. Fix: C8 invariant + forbidden-pattern (`List(entries` outside the `!isScreenRecording` else branch); mirror `DemoVaultView.swift:45`.
+- **S2–S6 [Info]**: createdAt/updatedAt confirmed non-secret (server already stores/returns them, not in the encrypted blob); sort-key persistence carries no PII; version disclosure benign; ISO parse-to-nil is DoS/ReDoS-safe (`ISO8601DateFormatter` is fixed-grammar); missed `CacheEntry(` date sites degrade sort order only, never confidentiality. No action.
+- **No Critical/High security findings.** No escalation to Opus warranted.
+
+## Testing Findings (Round 1)
+
+- **T1 [High] — RESOLVED**: `AppVersion.display(bundle:)` is untestable — `Bundle` has no synthetic-infoDictionary initializer. Fix: C9 uses a string-parameter seam `display(marketing:build:)`; forbidden-pattern bans `display(bundle:`.
+- **T2 [Medium] — RESOLVED**: C6's VM persistence test would pollute the shared App Group suite. Fix: `VaultViewModel.init(settings: AppSettingsStore = AppSettingsStore())`; tests inject a per-test `UserDefaults(suiteName: UUID)`.
+- **T3 [Medium] — RESOLVED**: favorites-first tested under only one key. Fix: C1 acceptance + T-SORT assert favorites-first for ALL four keys.
+- **T4 [Medium] — RESOLVED**: nil-last tested one key; "nil-vs-nil stable" invariant likely false under Swift's non-stable `sorted(by:)`. Fix: C1 mandates stability via an `enumerated()` index tie-break; T-SORT asserts nil-last for both date keys AND stability.
+- **T5 [Low] — RESOLVED**: ISO tolerance (fractional/non-fractional) tested one form. Fix: T-DATE asserts three forms (fractional, non-fractional, garbage→nil).
+- **T6 [Low] — RESOLVED**: proposed category-search assert re-tested existing `filteredSummaries` behavior, not the new binding. Fix: T-SEARCH-CAT targets the category-scoped `entries` computed property; no vacuous `#file` grep gate.
+- **T7 [Low] — RESOLVED**: no end-to-end test that `decryptOverview` actually threads the dates. Fix: T-DATE-E2E in `VaultViewModelTests` drives the real decrypt path.
+
+## Round 2 Findings
+
+- **R2-T1 [Minor] — RESOLVED**: relocating `parseISO8601` out of `AutofillTokenRefresher` would break existing callers — production `Self.parseISO8601` (`AutofillTokenRefresher.swift:41`) and tests (`AutofillTokenRefresherTests.swift:86/114/115/116`). Fix: C4 mandates a thin forwarding static shim on `AutofillTokenRefresher` delegating to the Shared free function (DRY, zero call-site churn).
+- **Round-2 design cross-checks (all PASS)**: (1) index tie-break does not conflict with the favorites-first primary split; (2) `VaultListView`'s zero-arg `VaultViewModel()` correctly uses the default (real) store in prod, injected store in tests — no leakage; (3) no stale "four keys mirror web"; (4) `init(settings:)` default arg keeps all ~20 existing `VaultViewModel()` call sites compiling; (5) Swift evaluates `display()` default args per-call, so no static-init ordering hazard; (6) R10: Shared has no deps → the relocated free function is safe.
+
+## Adjacent Findings
+
+- T4 flagged the "nil-vs-nil preserves input order" invariant as partly a correctness issue (Swift `sorted(by:)` not stable) — routed into C1 as the mandatory index tie-break, not left as a testing-only note.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R9 (async-in-tx): N/A (no DB, pure sync date conversion).
+- R10 (circular import): checked — relocating only the static parser to Shared (which has no deps) is safe; do not move the whole `AutofillTokenRefresher` type.
+- R12 (enum consumers / i18n): `EntrySortOption` new enum — C10 adds en/ja catalog keys for all labels; `LocalizationCatalogTests` enforces coverage; no exhaustive-switch consumers to break.
+- R42 (member-set): `CacheEntry(` construction sites enumerated and verified accurate; only the personal `toPersonalCacheEntry()` mapper carries dates; team mapper + passkey-registration append + debug/demo sites correctly pass nil.
+
+### Security expert
+- RS1 (secrets in persistence/logs): PASS — dates non-secret, sort-key non-PII, nothing logged.
+- RS2 (E2E boundary): PASS — new fields are cache-row metadata, forbidden from the encrypted blob (C5).
+- RS3 (info disclosure via new UI): WATCH → addressed by S1 (screen-recording gate).
+- RS4 (auth/authz on new endpoints): N/A — no server change.
+- RS5 (input validation/injection): PASS — ISO parse fail→nil, no throw, no ReDoS.
+
+### Testing expert
+- RT1 (vacuous gates): addressed — no `#file` grep gate; T-L10N uses `#filePath`.
+- RT2 (test isolation): addressed by T2 (injected per-test UserDefaults suite).
+- RT3 (mock-at-boundary): addressed by T1 (string seam, not `Bundle`).
+- RT4 (fail-for-a-real-reason): addressed across T1/T3/T4/T5/T6/T7.
+- RT5 (real-boundary not mocked away): golden-fixture date test avoids a live server (VC2).
+- RT6 (per-member coverage): addressed by T3/T4 (per-key assertions).
+- RT7 (assert behavior not restatement): addressed by T6.
+
+## Outcome
+
+All Round-1 findings (F1–F6, S1, T1–T7) and the single Round-2 finding (R2-T1) are resolved and reflected in the plan's contracts. All 10 contracts are `locked`. No Critical/Major findings remain. Ready for Phase 2 (implementation).

--- a/ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift
+++ b/ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift
@@ -54,12 +54,20 @@ public struct AutofillTokenRefresher: Sendable {
     }
   }
 
-  /// Server emits `Date.toISOString()` (fractional seconds); a plain
-  /// ISO8601DateFormatter does NOT parse those, so try both variants.
+  /// Forwards to the relocated `parseISO8601(_:)` free function in `Shared`
+  /// (dual fractional/plain ISO-8601 parse). Kept as a static method so
+  /// existing call sites (`Self.parseISO8601` above, and tests) don't need to
+  /// change; delegates to the file-scope `callSharedParseISO8601` shim below
+  /// because a same-named static method shadows the free function for
+  /// unqualified lookup within its own body, and `Shared` also declares a
+  /// type named `Shared` that shadows the module name for qualified lookup.
   static func parseISO8601(_ string: String) -> Date? {
-    let fractional = ISO8601DateFormatter()
-    fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    if let date = fractional.date(from: string) { return date }
-    return ISO8601DateFormatter().date(from: string)
+    callSharedParseISO8601(string)
   }
+}
+
+/// File-scope shim resolving the `Shared` module's free function unambiguously
+/// (see comment on `AutofillTokenRefresher.parseISO8601` above).
+private func callSharedParseISO8601(_ string: String) -> Date? {
+  parseISO8601(string)
 }

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -219,6 +219,23 @@
         }
       }
     },
+    "Ascending" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ascending"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "昇順"
+          }
+        }
+      }
+    },
     "Auto-Clear" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -805,6 +822,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デモモード"
+          }
+        }
+      }
+    },
+    "Descending" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descending"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "降順"
           }
         }
       }

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -1,46 +1,46 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "%@" : {
-      "comment" : "Xcode-editor extraction placeholder for the TOTP countdown Int; the compiler emits the %lld key. Pure number — not translated.",
-      "shouldTranslate" : false
+  "sourceLanguage": "en",
+  "strings": {
+    "%@": {
+      "comment": "Xcode-editor extraction placeholder for the TOTP countdown Int; the compiler emits the %lld key. Pure number — not translated.",
+      "shouldTranslate": false
     },
-    "%@ minutes" : {
-      "comment" : "Xcode-editor extraction placeholder; the compiler emits the %lld minutes plural key (translated). Not translated to avoid a duplicate.",
-      "shouldTranslate" : false
+    "%@ minutes": {
+      "comment": "Xcode-editor extraction placeholder; the compiler emits the %lld minutes plural key (translated). Not translated to avoid a duplicate.",
+      "shouldTranslate": false
     },
-    "%@ seconds" : {
-      "comment" : "Xcode-editor extraction placeholder; the compiler emits the %lld seconds plural key (translated). Not translated to avoid a duplicate.",
-      "shouldTranslate" : false
+    "%@ seconds": {
+      "comment": "Xcode-editor extraction placeholder; the compiler emits the %lld seconds plural key (translated). Not translated to avoid a duplicate.",
+      "shouldTranslate": false
     },
-    "%lld minutes" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld minute"
+    "%lld minutes": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld minute"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld minutes"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld minutes"
                 }
               }
             }
           }
         },
-        "ja" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld 分"
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 分"
                 }
               }
             }
@@ -48,34 +48,34 @@
         }
       }
     },
-    "%lld seconds" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld second"
+    "%lld seconds": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld second"
                 }
               },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld seconds"
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld seconds"
                 }
               }
             }
           }
         },
-        "ja" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld 秒"
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 秒"
                 }
               }
             }
@@ -83,2744 +83,2748 @@
         }
       }
     },
-    "Account Holder Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Account Holder Name"
+    "Account Holder Name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Account Holder Name"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "口座名義人"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "口座名義人"
           }
         }
       }
     },
-    "Account Number" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Account Number"
+    "Account Number": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Account Number"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "口座番号"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "口座番号"
           }
         }
       }
     },
-    "Account Type" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Account Type"
+    "Account Type": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Account Type"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "口座種別"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "口座種別"
           }
         }
       }
     },
-    "Address" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Address"
+    "Address": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Address"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "住所"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "住所"
           }
         }
       }
     },
-    "Address Line 1" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Address Line 1"
+    "Address Line 1": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Address Line 1"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "住所1"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "住所1"
           }
         }
       }
     },
-    "Address Line 2" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Address Line 2"
+    "Address Line 2": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Address Line 2"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "住所2"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "住所2"
           }
         }
       }
     },
-    "All" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All"
+    "All": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべて"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて"
           }
         }
       }
     },
-    "Appearance" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Appearance"
+    "Appearance": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appearance"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "外観"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外観"
           }
         }
       }
     },
-    "Ascending" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ascending"
+    "Ascending": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ascending"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "昇順"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "昇順"
           }
         }
       }
     },
-    "Auto-Clear" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-Clear"
+    "Auto-Clear": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Clear"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動消去"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動消去"
           }
         }
       }
     },
-    "Auto-copy custom field after fill" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-copy custom field after fill"
+    "Auto-Lock": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Lock"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "入力後にカスタムフィールドを自動コピー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動ロック"
           }
         }
       }
     },
-    "Auto-copy TOTP after fill" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-copy TOTP after fill"
+    "Auto-copy TOTP after fill": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-copy TOTP after fill"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "入力後にTOTPを自動コピー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "入力後にTOTPを自動コピー"
           }
         }
       }
     },
-    "Auto-Lock" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-Lock"
+    "Auto-copy custom field after fill": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-copy custom field after fill"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動ロック"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "入力後にカスタムフィールドを自動コピー"
           }
         }
       }
     },
-    "Bank Accounts" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bank Accounts"
+    "Bank Accounts": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bank Accounts"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "銀行口座"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "銀行口座"
           }
         }
       }
     },
-    "Bank Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bank Name"
+    "Bank Name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bank Name"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "銀行名"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "銀行名"
           }
         }
       }
     },
-    "biometrics" : {
-      "comment" : "Fallback biometry name when neither Face ID nor Touch ID is detected.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "biometrics"
+    "Branch Name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Branch Name"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "生体認証"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支店名"
           }
         }
       }
     },
-    "Branch Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Branch Name"
+    "Brand": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brand"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "支店名"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブランド"
           }
         }
       }
     },
-    "Brand" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brand"
+    "CVV": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CVV"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ブランド"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セキュリティコード"
           }
         }
       }
     },
-    "Cancel" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "Cancel": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャンセル"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
           }
         }
       }
     },
-    "Card Number" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Card Number"
+    "Card Number": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Card Number"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カード番号"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カード番号"
           }
         }
       }
     },
-    "Cardholder Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cardholder Name"
+    "Cardholder Name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cardholder Name"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カード名義人"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カード名義人"
           }
         }
       }
     },
-    "City" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "City"
+    "City": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "City"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "市区町村"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "市区町村"
           }
         }
       }
     },
-    "Clear search" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear search"
+    "Clear search": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear search"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "検索をクリア"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索をクリア"
           }
         }
       }
     },
-    "Clipboard" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clipboard"
+    "Clipboard": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clipboard"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "クリップボード"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリップボード"
           }
         }
       }
     },
-    "Codes" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Codes"
+    "Codes": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codes"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コード"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コード"
           }
         }
       }
     },
-    "Comment" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comment"
+    "Comment": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comment"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コメント"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コメント"
           }
         }
       }
     },
-    "Continue" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
+    "Continue": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "続ける"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "続ける"
           }
         }
       }
     },
-    "Copied!" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copied!"
+    "Copied!": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied!"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コピーしました！"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピーしました！"
           }
         }
       }
     },
-    "Copy" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy"
+    "Copy": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コピー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピー"
           }
         }
       }
     },
-    "Could not reach %@. Check the URL and your network." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Could not reach %@. Check the URL and your network."
+    "Could not reach %@. Check the URL and your network.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not reach %@. Check the URL and your network."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ に接続できませんでした。URL とネットワークを確認してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ に接続できませんでした。URL とネットワークを確認してください。"
           }
         }
       }
     },
-    "Could not save. Please try again." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Could not save. Please try again."
+    "Could not save. Please try again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not save. Please try again."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存できませんでした。もう一度お試しください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存できませんでした。もう一度お試しください。"
           }
         }
       }
     },
-    "Couldn't decrypt this entry." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't decrypt this entry."
+    "Couldn't decrypt this entry.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't decrypt this entry."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このエントリを復号できませんでした。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このエントリを復号できませんでした。"
           }
         }
       }
     },
-    "Couldn't sync. Check your connection and try again." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't sync. Check your connection and try again."
+    "Couldn't sync. Check your connection and try again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't sync. Check your connection and try again."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "同期できませんでした。接続を確認して再試行してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同期できませんでした。接続を確認して再試行してください。"
           }
         }
       }
     },
-    "Country" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Country"
+    "Country": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Country"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "国"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "国"
           }
         }
       }
     },
-    "Create entry" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create entry"
+    "Create entry": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create entry"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エントリを作成"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エントリを作成"
           }
         }
       }
     },
-    "Created date" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Created date"
+    "Created date": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Created date"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "作成日"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成日"
           }
         }
       }
     },
-    "Creation Date" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creation Date"
+    "Creation Date": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creation Date"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "作成日"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成日"
           }
         }
       }
     },
-    "Credential ID" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Credential ID"
+    "Credential ID": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credential ID"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "クレデンシャルID"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クレデンシャルID"
           }
         }
       }
     },
-    "Credit Cards" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Credit Cards"
+    "Credit Cards": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credit Cards"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "クレジットカード"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クレジットカード"
           }
         }
       }
     },
-    "CVV" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CVV"
+    "Dark": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セキュリティコード"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダーク"
           }
         }
       }
     },
-    "Dark" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dark"
+    "Date of Birth": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date of Birth"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダーク"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生年月日"
           }
         }
       }
     },
-    "Date of Birth" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date of Birth"
+    "Decrypting…": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrypting…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "生年月日"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "復号しています…"
           }
         }
       }
     },
-    "Decrypting…" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Decrypting…"
+    "Demo Mode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demo Mode"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "復号しています…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デモモード"
           }
         }
       }
     },
-    "Demo Mode" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demo Mode"
+    "Descending": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descending"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "デモモード"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "降順"
           }
         }
       }
     },
-    "Descending" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descending"
+    "Device Info": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Device Info"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "降順"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバイス情報"
           }
         }
       }
     },
-    "Device Info" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Device Info"
+    "Done": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "デバイス情報"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
           }
         }
       }
     },
-    "Done" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
+    "Edit": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完了"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編集"
           }
         }
       }
     },
-    "Edit" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit"
+    "Edit Entry": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Entry"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "編集"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エントリを編集"
           }
         }
       }
     },
-    "Edit Entry" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit Entry"
+    "Edit this entry in the web app.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit this entry in the web app."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エントリを編集"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この項目の編集はWebアプリで行ってください。"
           }
         }
       }
     },
-    "Edit this entry in the web app." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit this entry in the web app."
+    "Email": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "この項目の編集はWebアプリで行ってください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メールアドレス"
           }
         }
       }
     },
-    "Email" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Email"
+    "Enter a valid https:// URL (http:// allowed for localhost).": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a valid https:// URL (http:// allowed for localhost)."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メールアドレス"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効な https:// URL を入力してください（localhost のみ http:// が使用できます）。"
           }
         }
       }
     },
-    "Enter a valid https:// URL (http:// allowed for localhost)." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter a valid https:// URL (http:// allowed for localhost)."
+    "Enter your master passphrase to unlock the vault.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter your master passphrase to unlock the vault."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効な https:// URL を入力してください（localhost のみ http:// が使用できます）。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マスターパスフレーズを入力して保管庫のロックを解除します。"
           }
         }
       }
     },
-    "Enter your master passphrase to unlock the vault." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter your master passphrase to unlock the vault."
+    "Enter your passwd-sso server URL to get started.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter your passwd-sso server URL to get started."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "マスターパスフレーズを入力して保管庫のロックを解除します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passwd-sso サーバーの URL を入力して開始します。"
           }
         }
       }
     },
-    "Enter your passwd-sso server URL to get started." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter your passwd-sso server URL to get started."
+    "Exit Demo": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exit Demo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "passwd-sso サーバーの URL を入力して開始します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デモを終了"
           }
         }
       }
     },
-    "Exit Demo" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exit Demo"
+    "Expiration Date": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration Date"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "デモを終了"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効期限"
           }
         }
       }
     },
-    "Expiration Date" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expiration Date"
+    "Expiry Date": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiry Date"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効期限"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効期限"
           }
         }
       }
     },
-    "Expiry Date" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expiry Date"
+    "Expiry Month": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiry Month"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効期限"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効期限(月)"
           }
         }
       }
     },
-    "Expiry Month" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expiry Month"
+    "Expiry Year": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiry Year"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効期限(月)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効期限(年)"
           }
         }
       }
     },
-    "Expiry Year" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expiry Year"
+    "Family Name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Family Name"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効期限(年)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "姓"
           }
         }
       }
     },
-    "Family Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Family Name"
+    "Family Name (Kana)": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Family Name (Kana)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "姓"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "姓(カナ)"
           }
         }
       }
     },
-    "Family Name (Kana)" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Family Name (Kana)"
+    "Favorites": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favorites"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "姓(カナ)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お気に入り"
           }
         }
       }
     },
-    "Favorites" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Favorites"
+    "Fingerprint": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fingerprint"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "お気に入り"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィンガープリント"
           }
         }
       }
     },
-    "Fingerprint" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fingerprint"
+    "Full Name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Name"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フィンガープリント"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "氏名"
           }
         }
       }
     },
-    "Full Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Full Name"
+    "Given Name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Given Name"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "氏名"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名"
           }
         }
       }
     },
-    "Given Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Given Name"
+    "Given Name (Kana)": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Given Name (Kana)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "名"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名(カナ)"
           }
         }
       }
     },
-    "Given Name (Kana)" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Given Name (Kana)"
+    "IBAN": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IBAN"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "名(カナ)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IBAN"
           }
         }
       }
     },
-    "IBAN" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "IBAN"
+    "ID Number": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID Number"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "IBAN"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID番号"
           }
         }
       }
     },
-    "Icons" : {
-      "comment" : "A section of the settings that controls whether site icons are shown.",
-      "extractionState" : "translated",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Icons"
+    "Icons": {
+      "comment": "A section of the settings that controls whether site icons are shown.",
+      "isCommentAutoGenerated": true,
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icons"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アイコン"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイコン"
           }
         }
       }
     },
-    "ID Number" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID Number"
+    "Identities": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identities"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID番号"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "個人情報"
           }
         }
       }
     },
-    "Identities" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Identities"
+    "Incorrect passphrase. Please try again.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incorrect passphrase. Please try again."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "個人情報"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パスフレーズが正しくありません。もう一度お試しください。"
           }
         }
       }
     },
-    "Incorrect passphrase. Please try again." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incorrect passphrase. Please try again."
+    "Issue Date": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Issue Date"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パスフレーズが正しくありません。もう一度お試しください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "発行日"
           }
         }
       }
     },
-    "Issue Date" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Issue Date"
+    "Key Size": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key Size"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "発行日"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鍵サイズ"
           }
         }
       }
     },
-    "Key Size" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Key Size"
+    "Key Type": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key Type"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鍵サイズ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鍵タイプ"
           }
         }
       }
     },
-    "Key Type" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Key Type"
+    "Language": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鍵タイプ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語"
           }
         }
       }
     },
-    "Language" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Language"
+    "License Key": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "License Key"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "言語"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライセンスキー"
           }
         }
       }
     },
-    "License Key" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "License Key"
+    "Licensee": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licensee"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ライセンスキー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライセンシー"
           }
         }
       }
     },
-    "Licensee" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Licensee"
+    "Light": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ライセンシー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライト"
           }
         }
       }
     },
-    "Light" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Light"
+    "Lock": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lock"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ライト"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ロック"
           }
         }
       }
     },
-    "Lock" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lock"
+    "Log Out": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Log Out"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ロック"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログアウト"
           }
         }
       }
     },
-    "Log Out" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log Out"
+    "Logins": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logins"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログアウト"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログイン"
           }
         }
       }
     },
-    "Logins" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Logins"
+    "Master passphrase": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Master passphrase"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログイン"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マスターパスフレーズ"
           }
         }
       }
     },
-    "Master passphrase" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Master passphrase"
+    "Middle Name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Middle Name"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "マスターパスフレーズ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ミドルネーム"
           }
         }
       }
     },
-    "Middle Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Middle Name"
+    "More": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ミドルネーム"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "その他"
           }
         }
       }
     },
-    "More" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "More"
+    "Nationality": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nationality"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "その他"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "国籍"
           }
         }
       }
     },
-    "Nationality" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nationality"
+    "New Entry": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Entry"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "国籍"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規エントリ"
           }
         }
       }
     },
-    "New Entry" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New Entry"
+    "No": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新規エントリ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "いいえ"
           }
         }
       }
     },
-    "No" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No"
+    "No entries": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No entries"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "いいえ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エントリがありません"
           }
         }
       }
     },
-    "No entries" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No entries"
+    "No matches": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matches"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エントリがありません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致する項目がありません"
           }
         }
       }
     },
-    "No matches" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No matches"
+    "Not configured": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not configured"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一致する項目がありません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未設定"
           }
         }
       }
     },
-    "Not configured" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not configured"
+    "Not set": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not set"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未設定"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未設定"
           }
         }
       }
     },
-    "Not set" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not set"
+    "Note": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未設定"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ノート"
           }
         }
       }
     },
-    "Note" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Note"
+    "Notes": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notes"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ノート"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メモ"
           }
         }
       }
     },
-    "Notes" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notes"
+    "OK": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メモ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         }
       }
     },
-    "OK" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+    "On Timeout": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On Timeout"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイムアウト時"
           }
         }
       }
     },
-    "On Timeout" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "On Timeout"
+    "One-Time Code": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "One-Time Code"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "タイムアウト時"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワンタイムコード"
           }
         }
       }
     },
-    "One-Time Code" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "One-Time Code"
+    "Passkeys": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passkeys"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ワンタイムコード"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パスキー"
           }
         }
       }
     },
-    "Passkeys" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passkeys"
+    "Passphrase": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passphrase"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パスキー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パスフレーズ"
           }
         }
       }
     },
-    "Passphrase" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passphrase"
+    "Password": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パスフレーズ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パスワード"
           }
         }
       }
     },
-    "passwd-sso" : {
-      "comment" : "Brand name — never translated.",
-      "shouldTranslate" : false
-    },
-    "Password" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password"
+    "Personal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personal"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パスワード"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "個人"
           }
         }
       }
     },
-    "Personal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personal"
+    "Phone": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phone"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "個人"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電話番号"
           }
         }
       }
     },
-    "Phone" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phone"
+    "Postal Code": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postal Code"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "電話番号"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "郵便番号"
           }
         }
       }
     },
-    "Postal Code" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Postal Code"
+    "Private Key": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private Key"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "郵便番号"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "秘密鍵"
           }
         }
       }
     },
-    "Private Key" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Private Key"
+    "Public Key": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public Key"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "秘密鍵"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公開鍵"
           }
         }
       }
     },
-    "Public Key" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Public Key"
+    "Purchase Date": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Purchase Date"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "公開鍵"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "購入日"
           }
         }
       }
     },
-    "Purchase Date" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Purchase Date"
+    "Recording — content hidden": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording — content hidden"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "購入日"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録画中 — 内容を非表示にしています"
           }
         }
       }
     },
-    "Recording — content hidden" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording — content hidden"
+    "Relying Party ID": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relying Party ID"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録画中 — 内容を非表示にしています"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リライングパーティID"
           }
         }
       }
     },
-    "Relying Party ID" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relying Party ID"
+    "Relying Party Name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relying Party Name"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リライングパーティID"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リライングパーティ名"
           }
         }
       }
     },
-    "Relying Party Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relying Party Name"
+    "Retry": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リライングパーティ名"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再試行"
           }
         }
       }
     },
-    "Retry" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry"
+    "Routing Number": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Routing Number"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再試行"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ルーティング番号"
           }
         }
       }
     },
-    "Routing Number" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Routing Number"
+    "SSH Keys": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH Keys"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ルーティング番号"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSHキー"
           }
         }
       }
     },
-    "Save" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+    "SWIFT / BIC": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SWIFT / BIC"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SWIFT / BIC"
           }
         }
       }
     },
-    "Search" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search"
+    "Save": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "検索"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
           }
         }
       }
     },
-    "Secure Notes" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Secure Notes"
+    "Search": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セキュアメモ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索"
           }
         }
       }
     },
-    "Security" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Security"
+    "Secure Notes": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secure Notes"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セキュリティ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セキュアメモ"
           }
         }
       }
     },
-    "Server" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server"
+    "Security": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Security"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サーバー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セキュリティ"
           }
         }
       }
     },
-    "Server Setup" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server Setup"
+    "Server": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サーバー設定"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーバー"
           }
         }
       }
     },
-    "Set by your organization." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set by your organization."
+    "Server Setup": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server Setup"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "組織によって設定されています。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーバー設定"
           }
         }
       }
     },
-    "Settings" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+    "Set by your organization.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set by your organization."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "組織によって設定されています。"
           }
         }
       }
-    },
-    "Shared framework v%@" : {
-      "comment" : "Unused scaffold view (ContentView, not in the live UI). Not translated.",
-      "shouldTranslate" : false
     },
-    "Show site icons" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show site icons"
+    "Settings": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サイトアイコンを表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
           }
         }
       }
     },
-    "Sign in again" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in again"
+    "Shared framework v%@": {
+      "comment": "Unused scaffold view (ContentView, not in the live UI). Not translated.",
+      "shouldTranslate": false
+    },
+    "Show site icons": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show site icons"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再度サインイン"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイトアイコンを表示"
           }
         }
       }
     },
-    "Sign in to passwd-sso" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in to passwd-sso"
+    "Sign Out": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign Out"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "passwd-sso にサインイン"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サインアウト"
           }
         }
       }
     },
-    "Sign Out" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign Out"
+    "Sign in again": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in again"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サインアウト"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再度サインイン"
           }
         }
       }
     },
-    "Sign out of passwd-sso?" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign out of passwd-sso?"
+    "Sign in to passwd-sso": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in to passwd-sso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "passwd-sso からサインアウトしますか？"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passwd-sso にサインイン"
           }
         }
       }
     },
-    "Signing in…" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signing in…"
+    "Sign out of passwd-sso?": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign out of passwd-sso?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サインインしています…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passwd-sso からサインアウトしますか？"
           }
         }
       }
     },
-    "Software Licenses" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Software Licenses"
+    "Signing in…": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signing in…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ソフトウェアライセンス"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サインインしています…"
           }
         }
       }
     },
-    "Software Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Software Name"
+    "Software Licenses": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Software Licenses"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ソフトウェア名"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソフトウェアライセンス"
           }
         }
       }
     },
-    "Sort" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sort"
+    "Software Name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Software Name"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "並び替え"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソフトウェア名"
           }
         }
       }
     },
-    "SSH Keys" : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSH Keys"
+    "Sort": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSHキー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "並び替え"
           }
         }
       }
     },
-    "State" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "State"
+    "State": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "State"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "都道府県"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "都道府県"
           }
         }
       }
     },
-    "SWIFT / BIC" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SWIFT / BIC"
+    "Sync failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync failed"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SWIFT / BIC"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同期に失敗しました"
           }
         }
       }
     },
-    "Sync failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync failed"
+    "Sync now": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync now"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "同期に失敗しました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今すぐ同期"
           }
         }
       }
     },
-    "Sync now" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync now"
+    "System": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今すぐ同期"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム"
           }
         }
       }
     },
-    "System" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System"
+    "TOTP Secret": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TOTP Secret"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システム"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TOTP シークレット"
           }
         }
       }
     },
-    "Tags" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tags"
+    "TOTP secret (optional)": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TOTP secret (optional)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "タグ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TOTP シークレット（任意）"
           }
         }
       }
     },
-    "Tags, custom fields, generator settings, and password history are kept on save — edit those in the web app." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tags, custom fields, generator settings, and password history are kept on save — edit those in the web app."
+    "Tags": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tags"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "タグ、カスタムフィールド、ジェネレーター設定、パスワード履歴は保存時に保持されます。これらは Web アプリで編集してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タグ"
           }
         }
       }
     },
-    "Tags, custom fields, generator settings, and password history are kept when you save an edit here — edit those in the web app." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tags, custom fields, generator settings, and password history are kept when you save an edit here — edit those in the web app."
+    "Tags, custom fields, generator settings, and password history are kept on save — edit those in the web app.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tags, custom fields, generator settings, and password history are kept on save — edit those in the web app."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ここで編集を保存しても、タグ、カスタムフィールド、ジェネレーター設定、パスワード履歴は保持されます。これらは Web アプリで編集してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タグ、カスタムフィールド、ジェネレーター設定、パスワード履歴は保存時に保持されます。これらは Web アプリで編集してください。"
           }
         }
       }
     },
-    "The vault locks after this much idle time (\"Log Out\" also clears the session). AutoFill needs the app unlocked within this window; each fill still requires Face ID." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The vault locks after this much idle time (\"Log Out\" also clears the session). AutoFill needs the app unlocked within this window; each fill still requires Face ID."
+    "Tags, custom fields, generator settings, and password history are kept when you save an edit here — edit those in the web app.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tags, custom fields, generator settings, and password history are kept when you save an edit here — edit those in the web app."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "この時間アイドル状態が続くと保管庫がロックされます（「ログアウト」を選ぶとセッションも消去されます）。AutoFill はこの時間内にアプリのロックが解除されている必要があり、各入力には Face ID が必要です。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ここで編集を保存しても、タグ、カスタムフィールド、ジェネレーター設定、パスワード履歴は保持されます。これらは Web アプリで編集してください。"
           }
         }
       }
     },
-    "Theme" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Theme"
+    "The vault locks after this much idle time (\"Log Out\" also clears the session). AutoFill needs the app unlocked within this window; each fill still requires Face ID.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The vault locks after this much idle time (\"Log Out\" also clears the session). AutoFill needs the app unlocked within this window; each fill still requires Face ID."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "テーマ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この時間アイドル状態が続くと保管庫がロックされます（「ログアウト」を選ぶとセッションも消去されます）。AutoFill はこの時間内にアプリのロックが解除されている必要があり、各入力には Face ID が必要です。"
           }
         }
       }
     },
-    "This clears the local session. You'll need to sign in and unlock again." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This clears the local session. You'll need to sign in and unlock again."
+    "Theme": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ローカルセッションが消去されます。再度サインインしてロックを解除する必要があります。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テーマ"
           }
         }
       }
     },
-    "Title" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Title"
+    "This clears the local session. You'll need to sign in and unlock again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This clears the local session. You'll need to sign in and unlock again."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "タイトル"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカルセッションが消去されます。再度サインインしてロックを解除する必要があります。"
           }
         }
       }
     },
-    "To use a different server, sign out and set up again." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To use a different server, sign out and set up again."
+    "Title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Title"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "別のサーバーを使うには、サインアウトして設定し直してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイトル"
           }
         }
       }
     },
-    "TOTP Secret" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TOTP Secret"
+    "To use a different server, sign out and set up again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To use a different server, sign out and set up again."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TOTP シークレット"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別のサーバーを使うには、サインアウトして設定し直してください。"
           }
         }
       }
     },
-    "TOTP secret (optional)" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TOTP secret (optional)"
+    "Try Demo Mode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try Demo Mode"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TOTP シークレット（任意）"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デモを試す"
           }
         }
       }
     },
-    "Try Demo Mode" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try Demo Mode"
+    "URL": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "デモを試す"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL"
           }
         }
       }
     },
-    "Unable to unlock vault. Check your connection and try again." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to unlock vault. Check your connection and try again."
+    "Unable to unlock vault. Check your connection and try again.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to unlock vault. Check your connection and try again."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保管庫のロックを解除できません。接続を確認してもう一度お試しください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保管庫のロックを解除できません。接続を確認してもう一度お試しください。"
           }
         }
       }
     },
-    "Unlock" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unlock"
+    "Unlock": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ロック解除"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ロック解除"
           }
         }
       }
     },
-    "Unlock with %@" : {
-      "comment" : "%@ is a biometry name (Face ID / Touch ID / biometrics).",
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unlock with %@"
+    "Unlock with %@": {
+      "comment": "%@ is a biometry name (Face ID / Touch ID / biometrics).",
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock with %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ でロック解除"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ でロック解除"
           }
         }
       }
     },
-    "Unlock your passwd-sso vault." : {
-      "comment" : "LAContext biometric prompt reason.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unlock your passwd-sso vault."
+    "Unlock your passwd-sso vault.": {
+      "comment": "LAContext biometric prompt reason.",
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock your passwd-sso vault."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "passwd-sso の保管庫をロック解除します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passwd-sso の保管庫をロック解除します。"
           }
         }
       }
     },
-    "Updated date" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updated date"
+    "Updated date": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updated date"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新日"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新日"
           }
         }
       }
     },
-    "URL" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+    "Username": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Username"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ユーザー名"
           }
         }
       }
     },
-    "Username" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Username"
+    "Vault": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vault"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ユーザー名"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保管庫"
           }
         }
       }
     },
-    "Vault" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vault"
+    "Version": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保管庫"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン"
           }
         }
       }
     },
-    "Version" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
+    "Website": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バージョン"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webサイト"
           }
         }
       }
     },
-    "Website" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website"
+    "When on, entry domain names are sent to the passwd-sso server to fetch site icons.": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When on, entry domain names are sent to the passwd-sso server to fetch site icons."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Webサイト"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オンにすると、エントリのドメイン名がサイトアイコン取得のためにpasswd-ssoサーバーに送信されます。"
           }
         }
       }
     },
-    "When on, entry domain names are sent to the passwd-sso server to fetch site icons." : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, entry domain names are sent to the passwd-sso server to fetch site icons."
+    "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices.": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オンにすると、エントリのドメイン名がサイトアイコン取得のためにpasswd-ssoサーバーに送信されます。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オンにすると、ワンタイムコードを持つログインを入力した際に、現在のコードをクリップボードにコピーします。クリップボードは上記の時間が経過すると消去され、ほかのデバイスには同期されません。"
           }
         }
       }
     },
-    "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices." : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices."
+    "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices.\n\nCustom-field auto-copy copies a single non-hidden custom field after a fill; hidden fields are never auto-copied (copy them from the entry instead). A one-time-code takes priority for the clipboard.": {
+      "extractionState": "translated",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices.\n\nCustom-field auto-copy copies a single non-hidden custom field after a fill; hidden fields are never auto-copied (copy them from the entry instead). A one-time-code takes priority for the clipboard."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オンにすると、ワンタイムコードを持つログインを入力した際に、現在のコードをクリップボードにコピーします。クリップボードは上記の時間が経過すると消去され、ほかのデバイスには同期されません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オンにすると、ワンタイムコードを持つログインを入力する際に現在のコードをクリップボードにコピーして貼り付けられます。クリップボードは上記の時間が経過すると消去され、他のデバイスには同期されません。\n\nカスタムフィールドの自動コピーは、入力後に非表示でないカスタムフィールドが1つだけのときにコピーします。非表示フィールドは自動コピーされません（エントリーからコピーしてください）。ワンタイムコードがある場合はそちらが優先されます。"
           }
         }
       }
     },
-    "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices.\n\nCustom-field auto-copy copies a single non-hidden custom field after a fill; hidden fields are never auto-copied (copy them from the entry instead). A one-time-code takes priority for the clipboard." : {
-      "extractionState" : "translated",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices.\n\nCustom-field auto-copy copies a single non-hidden custom field after a fill; hidden fields are never auto-copied (copy them from the entry instead). A one-time-code takes priority for the clipboard."
+    "Yes": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yes"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オンにすると、ワンタイムコードを持つログインを入力する際に現在のコードをクリップボードにコピーして貼り付けられます。クリップボードは上記の時間が経過すると消去され、他のデバイスには同期されません。\n\nカスタムフィールドの自動コピーは、入力後に非表示でないカスタムフィールドが1つだけのときにコピーします。非表示フィールドは自動コピーされません（エントリーからコピーしてください）。ワンタイムコードがある場合はそちらが優先されます。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "はい"
           }
         }
       }
     },
-    "Yes" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yes"
+    "You've reached your vault's item limit. Remove unused items and try again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You've reached your vault's item limit. Remove unused items and try again."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保管庫の項目数が上限に達しました。不要な項目を削除してから、もう一度お試しください。"
           }
         }
       }
     },
-    "You've reached your vault's item limit. Remove unused items and try again." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You've reached your vault's item limit. Remove unused items and try again."
+    "Your session expired. Lock and unlock to sign in again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your session expired. Lock and unlock to sign in again."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保管庫の項目数が上限に達しました。不要な項目を削除してから、もう一度お試しください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッションの有効期限が切れました。一度ロックして解除し、サインインし直してください。"
           }
         }
       }
     },
-    "Your session expired. Lock and unlock to sign in again." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your session expired. Lock and unlock to sign in again."
+    "Your session has expired. Please sign in again.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your session has expired. Please sign in again."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セッションの有効期限が切れました。一度ロックして解除し、サインインし直してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッションの有効期限が切れました。もう一度サインインしてください。"
           }
         }
       }
     },
-    "Your session has expired. Please sign in again." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your session has expired. Please sign in again."
+    "Your session is out of date. Enter your passphrase to unlock.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your session is out of date. Enter your passphrase to unlock."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セッションの有効期限が切れました。もう一度サインインしてください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッション情報が古くなっています。パスフレーズを入力して解錠してください。"
           }
         }
       }
     },
-    "Your session is out of date. Enter your passphrase to unlock." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your session is out of date. Enter your passphrase to unlock."
+    "biometrics": {
+      "comment": "Fallback biometry name when neither Face ID nor Touch ID is detected.",
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "biometrics"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セッション情報が古くなっています。パスフレーズを入力して解錠してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生体認証"
           }
         }
       }
+    },
+    "passwd-sso": {
+      "comment": "Brand name — never translated.",
+      "shouldTranslate": false
     }
   },
-  "version" : "1.1"
+  "version": "1.1"
 }

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -657,6 +657,22 @@
         }
       }
     },
+    "Created date": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Created date"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成日"
+          }
+        }
+      }
+    },
     "Creation Date": {
       "extractionState": "stale",
       "localizations": {
@@ -1940,6 +1956,22 @@
         }
       }
     },
+    "Sort": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "並び替え"
+          }
+        }
+      }
+    },
     "Secure Notes": {
       "extractionState": "translated",
       "localizations": {
@@ -2531,6 +2563,22 @@
         }
       }
     },
+    "Updated date": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updated date"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新日"
+          }
+        }
+      }
+    },
     "Vault": {
       "extractionState": "manual",
       "localizations": {
@@ -2697,6 +2745,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "セッション情報が古くなっています。パスフレーズを入力して解錠してください。"
+          }
+        }
+      }
+    },
+    "Website": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webサイト"
           }
         }
       }

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -1,46 +1,46 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "%@": {
-      "comment": "Xcode-editor extraction placeholder for the TOTP countdown Int; the compiler emits the %lld key. Pure number — not translated.",
-      "shouldTranslate": false
+  "sourceLanguage" : "en",
+  "strings" : {
+    "%@" : {
+      "comment" : "Xcode-editor extraction placeholder for the TOTP countdown Int; the compiler emits the %lld key. Pure number — not translated.",
+      "shouldTranslate" : false
     },
-    "%@ minutes": {
-      "comment": "Xcode-editor extraction placeholder; the compiler emits the %lld minutes plural key (translated). Not translated to avoid a duplicate.",
-      "shouldTranslate": false
+    "%@ minutes" : {
+      "comment" : "Xcode-editor extraction placeholder; the compiler emits the %lld minutes plural key (translated). Not translated to avoid a duplicate.",
+      "shouldTranslate" : false
     },
-    "%@ seconds": {
-      "comment": "Xcode-editor extraction placeholder; the compiler emits the %lld seconds plural key (translated). Not translated to avoid a duplicate.",
-      "shouldTranslate": false
+    "%@ seconds" : {
+      "comment" : "Xcode-editor extraction placeholder; the compiler emits the %lld seconds plural key (translated). Not translated to avoid a duplicate.",
+      "shouldTranslate" : false
     },
-    "%lld minutes": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "variations": {
-            "plural": {
-              "one": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%lld minute"
+    "%lld minutes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld minute"
                 }
               },
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%lld minutes"
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld minutes"
                 }
               }
             }
           }
         },
-        "ja": {
-          "variations": {
-            "plural": {
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%lld 分"
+        "ja" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld 分"
                 }
               }
             }
@@ -48,34 +48,34 @@
         }
       }
     },
-    "%lld seconds": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "variations": {
-            "plural": {
-              "one": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%lld second"
+    "%lld seconds" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld second"
                 }
               },
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%lld seconds"
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld seconds"
                 }
               }
             }
           }
         },
-        "ja": {
-          "variations": {
-            "plural": {
-              "other": {
-                "stringUnit": {
-                  "state": "translated",
-                  "value": "%lld 秒"
+        "ja" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld 秒"
                 }
               }
             }
@@ -83,2710 +83,2710 @@
         }
       }
     },
-    "Account Holder Name": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Account Holder Name"
+    "Account Holder Name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account Holder Name"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "口座名義人"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "口座名義人"
           }
         }
       }
     },
-    "Account Number": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Account Number"
+    "Account Number" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account Number"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "口座番号"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "口座番号"
           }
         }
       }
     },
-    "Account Type": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Account Type"
+    "Account Type" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account Type"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "口座種別"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "口座種別"
           }
         }
       }
     },
-    "Address": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Address"
+    "Address" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "住所"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "住所"
           }
         }
       }
     },
-    "Address Line 1": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Address Line 1"
+    "Address Line 1" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address Line 1"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "住所1"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "住所1"
           }
         }
       }
     },
-    "Address Line 2": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Address Line 2"
+    "Address Line 2" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address Line 2"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "住所2"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "住所2"
           }
         }
       }
     },
-    "All": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All"
+    "All" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべて"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて"
           }
         }
       }
     },
-    "Appearance": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Appearance"
+    "Appearance" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appearance"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "外観"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外観"
           }
         }
       }
     },
-    "Auto-Clear": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-Clear"
+    "Auto-Clear" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-Clear"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動消去"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動消去"
           }
         }
       }
     },
-    "Auto-Lock": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-Lock"
+    "Auto-copy custom field after fill" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-copy custom field after fill"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動ロック"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "入力後にカスタムフィールドを自動コピー"
           }
         }
       }
     },
-    "Auto-copy TOTP after fill": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-copy TOTP after fill"
+    "Auto-copy TOTP after fill" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-copy TOTP after fill"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "入力後にTOTPを自動コピー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "入力後にTOTPを自動コピー"
           }
         }
       }
     },
-    "Auto-copy custom field after fill": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-copy custom field after fill"
+    "Auto-Lock" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-Lock"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "入力後にカスタムフィールドを自動コピー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動ロック"
           }
         }
       }
     },
-    "Bank Accounts": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bank Accounts"
+    "Bank Accounts" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bank Accounts"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "銀行口座"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "銀行口座"
           }
         }
       }
     },
-    "Bank Name": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bank Name"
+    "Bank Name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bank Name"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "銀行名"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "銀行名"
           }
         }
       }
     },
-    "Branch Name": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Branch Name"
+    "biometrics" : {
+      "comment" : "Fallback biometry name when neither Face ID nor Touch ID is detected.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "biometrics"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "支店名"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生体認証"
           }
         }
       }
     },
-    "Brand": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Brand"
+    "Branch Name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Branch Name"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブランド"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支店名"
           }
         }
       }
     },
-    "CVV": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CVV"
+    "Brand" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brand"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セキュリティコード"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ブランド"
           }
         }
       }
     },
-    "Cancel": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
+    "Cancel" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンセル"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
           }
         }
       }
     },
-    "Card Number": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Card Number"
+    "Card Number" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Card Number"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カード番号"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カード番号"
           }
         }
       }
     },
-    "Cardholder Name": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cardholder Name"
+    "Cardholder Name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cardholder Name"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カード名義人"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カード名義人"
           }
         }
       }
     },
-    "City": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "City"
+    "City" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "City"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "市区町村"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "市区町村"
           }
         }
       }
     },
-    "Clear search": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear search"
+    "Clear search" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear search"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検索をクリア"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索をクリア"
           }
         }
       }
     },
-    "Clipboard": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clipboard"
+    "Clipboard" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clipboard"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クリップボード"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボード"
           }
         }
       }
     },
-    "Codes": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Codes"
+    "Codes" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codes"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コード"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コード"
           }
         }
       }
     },
-    "Comment": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Comment"
+    "Comment" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comment"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コメント"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コメント"
           }
         }
       }
     },
-    "Continue": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue"
+    "Continue" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "続ける"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "続ける"
           }
         }
       }
     },
-    "Copied!": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copied!"
+    "Copied!" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copied!"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コピーしました！"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピーしました！"
           }
         }
       }
     },
-    "Copy": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy"
+    "Copy" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コピー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピー"
           }
         }
       }
     },
-    "Could not reach %@. Check the URL and your network.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Could not reach %@. Check the URL and your network."
+    "Could not reach %@. Check the URL and your network." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not reach %@. Check the URL and your network."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ に接続できませんでした。URL とネットワークを確認してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ に接続できませんでした。URL とネットワークを確認してください。"
           }
         }
       }
     },
-    "Could not save. Please try again.": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Could not save. Please try again."
+    "Could not save. Please try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not save. Please try again."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保存できませんでした。もう一度お試しください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存できませんでした。もう一度お試しください。"
           }
         }
       }
     },
-    "Couldn't decrypt this entry.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't decrypt this entry."
+    "Couldn't decrypt this entry." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't decrypt this entry."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このエントリを復号できませんでした。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このエントリを復号できませんでした。"
           }
         }
       }
     },
-    "Couldn't sync. Check your connection and try again.": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't sync. Check your connection and try again."
+    "Couldn't sync. Check your connection and try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't sync. Check your connection and try again."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "同期できませんでした。接続を確認して再試行してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同期できませんでした。接続を確認して再試行してください。"
           }
         }
       }
     },
-    "Country": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Country"
+    "Country" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Country"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "国"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "国"
           }
         }
       }
     },
-    "Create entry": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create entry"
+    "Create entry" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create entry"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エントリを作成"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エントリを作成"
           }
         }
       }
     },
-    "Created date": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Created date"
+    "Created date" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Created date"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "作成日"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作成日"
           }
         }
       }
     },
-    "Creation Date": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Creation Date"
+    "Creation Date" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creation Date"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "作成日"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作成日"
           }
         }
       }
     },
-    "Credential ID": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credential ID"
+    "Credential ID" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credential ID"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クレデンシャルID"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クレデンシャルID"
           }
         }
       }
     },
-    "Credit Cards": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credit Cards"
+    "Credit Cards" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credit Cards"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クレジットカード"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クレジットカード"
           }
         }
       }
     },
-    "Dark": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dark"
+    "CVV" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CVV"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダーク"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュリティコード"
           }
         }
       }
     },
-    "Date of Birth": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Date of Birth"
+    "Dark" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dark"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "生年月日"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダーク"
           }
         }
       }
     },
-    "Decrypting…": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Decrypting…"
+    "Date of Birth" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date of Birth"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "復号しています…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生年月日"
           }
         }
       }
     },
-    "Demo Mode": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Demo Mode"
+    "Decrypting…" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decrypting…"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "デモモード"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復号しています…"
           }
         }
       }
     },
-    "Device Info": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Device Info"
+    "Demo Mode" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Demo Mode"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "デバイス情報"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デモモード"
           }
         }
       }
     },
-    "Done": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Done"
+    "Device Info" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Device Info"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完了"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバイス情報"
           }
         }
       }
     },
-    "Edit": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit"
+    "Done" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "編集"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
           }
         }
       }
     },
-    "Edit Entry": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit Entry"
+    "Edit" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エントリを編集"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編集"
           }
         }
       }
     },
-    "Edit this entry in the web app.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit this entry in the web app."
+    "Edit Entry" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Entry"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この項目の編集はWebアプリで行ってください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エントリを編集"
           }
         }
       }
     },
-    "Email": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Email"
+    "Edit this entry in the web app." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit this entry in the web app."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メールアドレス"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この項目の編集はWebアプリで行ってください。"
           }
         }
       }
     },
-    "Enter a valid https:// URL (http:// allowed for localhost).": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter a valid https:// URL (http:// allowed for localhost)."
+    "Email" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効な https:// URL を入力してください（localhost のみ http:// が使用できます）。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メールアドレス"
           }
         }
       }
     },
-    "Enter your master passphrase to unlock the vault.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter your master passphrase to unlock the vault."
+    "Enter a valid https:// URL (http:// allowed for localhost)." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter a valid https:// URL (http:// allowed for localhost)."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "マスターパスフレーズを入力して保管庫のロックを解除します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効な https:// URL を入力してください（localhost のみ http:// が使用できます）。"
           }
         }
       }
     },
-    "Enter your passwd-sso server URL to get started.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter your passwd-sso server URL to get started."
+    "Enter your master passphrase to unlock the vault." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter your master passphrase to unlock the vault."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "passwd-sso サーバーの URL を入力して開始します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マスターパスフレーズを入力して保管庫のロックを解除します。"
           }
         }
       }
     },
-    "Exit Demo": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exit Demo"
+    "Enter your passwd-sso server URL to get started." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter your passwd-sso server URL to get started."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "デモを終了"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "passwd-sso サーバーの URL を入力して開始します。"
           }
         }
       }
     },
-    "Expiration Date": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expiration Date"
+    "Exit Demo" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exit Demo"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効期限"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デモを終了"
           }
         }
       }
     },
-    "Expiry Date": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expiry Date"
+    "Expiration Date" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiration Date"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効期限"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限"
           }
         }
       }
     },
-    "Expiry Month": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expiry Month"
+    "Expiry Date" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiry Date"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効期限(月)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限"
           }
         }
       }
     },
-    "Expiry Year": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expiry Year"
+    "Expiry Month" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiry Month"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効期限(年)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限(月)"
           }
         }
       }
     },
-    "Family Name": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Family Name"
+    "Expiry Year" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiry Year"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "姓"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限(年)"
           }
         }
       }
     },
-    "Family Name (Kana)": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Family Name (Kana)"
+    "Family Name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Family Name"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "姓(カナ)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "姓"
           }
         }
       }
     },
-    "Favorites": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Favorites"
+    "Family Name (Kana)" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Family Name (Kana)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "お気に入り"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "姓(カナ)"
           }
         }
       }
     },
-    "Fingerprint": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fingerprint"
+    "Favorites" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favorites"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィンガープリント"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お気に入り"
           }
         }
       }
     },
-    "Full Name": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Full Name"
+    "Fingerprint" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fingerprint"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "氏名"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィンガープリント"
           }
         }
       }
     },
-    "Given Name": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Given Name"
+    "Full Name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Full Name"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "名"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "氏名"
           }
         }
       }
     },
-    "Given Name (Kana)": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Given Name (Kana)"
+    "Given Name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Given Name"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "名(カナ)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名"
           }
         }
       }
     },
-    "IBAN": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IBAN"
+    "Given Name (Kana)" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Given Name (Kana)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IBAN"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名(カナ)"
           }
         }
       }
     },
-    "ID Number": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ID Number"
+    "IBAN" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IBAN"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ID番号"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IBAN"
           }
         }
       }
     },
-    "Icons": {
-      "comment": "A section of the settings that controls whether site icons are shown.",
-      "isCommentAutoGenerated": true,
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Icons"
+    "Icons" : {
+      "comment" : "A section of the settings that controls whether site icons are shown.",
+      "extractionState" : "translated",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Icons"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アイコン"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アイコン"
           }
         }
       }
     },
-    "Identities": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identities"
+    "ID Number" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID Number"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "個人情報"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID番号"
           }
         }
       }
     },
-    "Incorrect passphrase. Please try again.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incorrect passphrase. Please try again."
+    "Identities" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Identities"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パスフレーズが正しくありません。もう一度お試しください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "個人情報"
           }
         }
       }
     },
-    "Issue Date": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issue Date"
+    "Incorrect passphrase. Please try again." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incorrect passphrase. Please try again."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "発行日"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスフレーズが正しくありません。もう一度お試しください。"
           }
         }
       }
     },
-    "Key Size": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Key Size"
+    "Issue Date" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Issue Date"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "鍵サイズ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "発行日"
           }
         }
       }
     },
-    "Key Type": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Key Type"
+    "Key Size" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Key Size"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "鍵タイプ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵サイズ"
           }
         }
       }
     },
-    "Language": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Language"
+    "Key Type" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Key Type"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "言語"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵タイプ"
           }
         }
       }
     },
-    "License Key": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "License Key"
+    "Language" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Language"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライセンスキー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語"
           }
         }
       }
     },
-    "Licensee": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licensee"
+    "License Key" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "License Key"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライセンシー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライセンスキー"
           }
         }
       }
     },
-    "Light": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Light"
+    "Licensee" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Licensee"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライト"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライセンシー"
           }
         }
       }
     },
-    "Lock": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lock"
+    "Light" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ロック"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライト"
           }
         }
       }
     },
-    "Log Out": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log Out"
+    "Lock" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lock"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ログアウト"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロック"
           }
         }
       }
     },
-    "Logins": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Logins"
+    "Log Out" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Log Out"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ログイン"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログアウト"
           }
         }
       }
     },
-    "Master passphrase": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Master passphrase"
+    "Logins" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logins"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "マスターパスフレーズ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログイン"
           }
         }
       }
     },
-    "Middle Name": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Middle Name"
+    "Master passphrase" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Master passphrase"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ミドルネーム"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マスターパスフレーズ"
           }
         }
       }
     },
-    "More": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "More"
+    "Middle Name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Middle Name"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "その他"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ミドルネーム"
           }
         }
       }
     },
-    "Nationality": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nationality"
+    "More" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "国籍"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他"
           }
         }
       }
     },
-    "New Entry": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New Entry"
+    "Nationality" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nationality"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新規エントリ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "国籍"
           }
         }
       }
     },
-    "No": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No"
+    "New Entry" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Entry"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "いいえ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新規エントリ"
           }
         }
       }
     },
-    "No entries": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No entries"
+    "No" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エントリがありません"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "いいえ"
           }
         }
       }
     },
-    "No matches": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No matches"
+    "No entries" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No entries"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一致する項目がありません"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エントリがありません"
           }
         }
       }
     },
-    "Not configured": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not configured"
+    "No matches" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No matches"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未設定"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一致する項目がありません"
           }
         }
       }
     },
-    "Not set": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not set"
+    "Not configured" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not configured"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未設定"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未設定"
           }
         }
       }
     },
-    "Note": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Note"
+    "Not set" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not set"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ノート"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未設定"
           }
         }
       }
     },
-    "Notes": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notes"
+    "Note" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メモ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ノート"
           }
         }
       }
     },
-    "OK": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+    "Notes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notes"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモ"
           }
         }
       }
     },
-    "On Timeout": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "On Timeout"
+    "OK" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タイムアウト時"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         }
       }
     },
-    "One-Time Code": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "One-Time Code"
+    "On Timeout" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On Timeout"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワンタイムコード"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイムアウト時"
           }
         }
       }
     },
-    "Passkeys": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passkeys"
+    "One-Time Code" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "One-Time Code"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パスキー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ワンタイムコード"
           }
         }
       }
     },
-    "Passphrase": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passphrase"
+    "Passkeys" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passkeys"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パスフレーズ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスキー"
           }
         }
       }
     },
-    "Password": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Password"
+    "Passphrase" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passphrase"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パスワード"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスフレーズ"
           }
         }
       }
     },
-    "Personal": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personal"
+    "passwd-sso" : {
+      "comment" : "Brand name — never translated.",
+      "shouldTranslate" : false
+    },
+    "Password" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Password"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "個人"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスワード"
           }
         }
       }
     },
-    "Phone": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phone"
+    "Personal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personal"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "電話番号"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "個人"
           }
         }
       }
     },
-    "Postal Code": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Postal Code"
+    "Phone" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phone"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "郵便番号"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電話番号"
           }
         }
       }
     },
-    "Private Key": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Private Key"
+    "Postal Code" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postal Code"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "秘密鍵"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "郵便番号"
           }
         }
       }
     },
-    "Public Key": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Public Key"
+    "Private Key" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Private Key"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "公開鍵"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "秘密鍵"
           }
         }
       }
     },
-    "Purchase Date": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Purchase Date"
+    "Public Key" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Public Key"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "購入日"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公開鍵"
           }
         }
       }
     },
-    "Recording — content hidden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recording — content hidden"
+    "Purchase Date" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purchase Date"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "録画中 — 内容を非表示にしています"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購入日"
           }
         }
       }
     },
-    "Relying Party ID": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relying Party ID"
+    "Recording — content hidden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recording — content hidden"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リライングパーティID"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画中 — 内容を非表示にしています"
           }
         }
       }
     },
-    "Relying Party Name": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relying Party Name"
+    "Relying Party ID" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relying Party ID"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リライングパーティ名"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リライングパーティID"
           }
         }
       }
     },
-    "Retry": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retry"
+    "Relying Party Name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relying Party Name"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "再試行"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リライングパーティ名"
           }
         }
       }
     },
-    "Routing Number": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Routing Number"
+    "Retry" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ルーティング番号"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再試行"
           }
         }
       }
     },
-    "SSH Keys": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH Keys"
+    "Routing Number" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Routing Number"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSHキー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ルーティング番号"
           }
         }
       }
     },
-    "SWIFT / BIC": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SWIFT / BIC"
+    "Save" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SWIFT / BIC"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
           }
         }
       }
     },
-    "Save": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save"
+    "Search" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保存"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索"
           }
         }
       }
     },
-    "Search": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search"
+    "Secure Notes" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secure Notes"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検索"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュアメモ"
           }
         }
       }
     },
-    "Sort": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sort"
+    "Security" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Security"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "並び替え"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュリティ"
           }
         }
       }
     },
-    "Secure Notes": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Secure Notes"
+    "Server" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セキュアメモ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サーバー"
           }
         }
       }
     },
-    "Security": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Security"
+    "Server Setup" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server Setup"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セキュリティ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サーバー設定"
           }
         }
       }
     },
-    "Server": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server"
+    "Set by your organization." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set by your organization."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サーバー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "組織によって設定されています。"
           }
         }
       }
     },
-    "Server Setup": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server Setup"
+    "Settings" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サーバー設定"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
           }
         }
       }
+    },
+    "Shared framework v%@" : {
+      "comment" : "Unused scaffold view (ContentView, not in the live UI). Not translated.",
+      "shouldTranslate" : false
     },
-    "Set by your organization.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Set by your organization."
+    "Show site icons" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show site icons"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "組織によって設定されています。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サイトアイコンを表示"
           }
         }
       }
     },
-    "Settings": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Settings"
+    "Sign in again" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in again"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再度サインイン"
           }
         }
       }
     },
-    "Shared framework v%@": {
-      "comment": "Unused scaffold view (ContentView, not in the live UI). Not translated.",
-      "shouldTranslate": false
-    },
-    "Show site icons": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show site icons"
+    "Sign in to passwd-sso" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in to passwd-sso"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サイトアイコンを表示"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "passwd-sso にサインイン"
           }
         }
       }
     },
-    "Sign Out": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sign Out"
+    "Sign Out" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign Out"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サインアウト"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サインアウト"
           }
         }
       }
     },
-    "Sign in again": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sign in again"
+    "Sign out of passwd-sso?" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign out of passwd-sso?"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "再度サインイン"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "passwd-sso からサインアウトしますか？"
           }
         }
       }
     },
-    "Sign in to passwd-sso": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sign in to passwd-sso"
+    "Signing in…" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signing in…"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "passwd-sso にサインイン"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サインインしています…"
           }
         }
       }
     },
-    "Sign out of passwd-sso?": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sign out of passwd-sso?"
+    "Software Licenses" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Software Licenses"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "passwd-sso からサインアウトしますか？"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソフトウェアライセンス"
           }
         }
       }
     },
-    "Signing in…": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Signing in…"
+    "Software Name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Software Name"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サインインしています…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソフトウェア名"
           }
         }
       }
     },
-    "Software Licenses": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Software Licenses"
+    "Sort" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sort"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソフトウェアライセンス"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "並び替え"
           }
         }
       }
     },
-    "Software Name": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Software Name"
+    "SSH Keys" : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH Keys"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソフトウェア名"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSHキー"
           }
         }
       }
     },
-    "State": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "State"
+    "State" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "State"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "都道府県"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "都道府県"
           }
         }
       }
     },
-    "Sync failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync failed"
+    "SWIFT / BIC" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SWIFT / BIC"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "同期に失敗しました"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SWIFT / BIC"
           }
         }
       }
     },
-    "Sync now": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync now"
+    "Sync failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync failed"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "今すぐ同期"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同期に失敗しました"
           }
         }
       }
     },
-    "System": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "System"
+    "Sync now" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync now"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "システム"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今すぐ同期"
           }
         }
       }
     },
-    "TOTP Secret": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TOTP Secret"
+    "System" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TOTP シークレット"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム"
           }
         }
       }
     },
-    "TOTP secret (optional)": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TOTP secret (optional)"
+    "Tags" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tags"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TOTP シークレット（任意）"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグ"
           }
         }
       }
     },
-    "Tags": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tags"
+    "Tags, custom fields, generator settings, and password history are kept on save — edit those in the web app." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tags, custom fields, generator settings, and password history are kept on save — edit those in the web app."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タグ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグ、カスタムフィールド、ジェネレーター設定、パスワード履歴は保存時に保持されます。これらは Web アプリで編集してください。"
           }
         }
       }
     },
-    "Tags, custom fields, generator settings, and password history are kept on save — edit those in the web app.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tags, custom fields, generator settings, and password history are kept on save — edit those in the web app."
+    "Tags, custom fields, generator settings, and password history are kept when you save an edit here — edit those in the web app." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tags, custom fields, generator settings, and password history are kept when you save an edit here — edit those in the web app."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タグ、カスタムフィールド、ジェネレーター設定、パスワード履歴は保存時に保持されます。これらは Web アプリで編集してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ここで編集を保存しても、タグ、カスタムフィールド、ジェネレーター設定、パスワード履歴は保持されます。これらは Web アプリで編集してください。"
           }
         }
       }
     },
-    "Tags, custom fields, generator settings, and password history are kept when you save an edit here — edit those in the web app.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tags, custom fields, generator settings, and password history are kept when you save an edit here — edit those in the web app."
+    "The vault locks after this much idle time (\"Log Out\" also clears the session). AutoFill needs the app unlocked within this window; each fill still requires Face ID." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The vault locks after this much idle time (\"Log Out\" also clears the session). AutoFill needs the app unlocked within this window; each fill still requires Face ID."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ここで編集を保存しても、タグ、カスタムフィールド、ジェネレーター設定、パスワード履歴は保持されます。これらは Web アプリで編集してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この時間アイドル状態が続くと保管庫がロックされます（「ログアウト」を選ぶとセッションも消去されます）。AutoFill はこの時間内にアプリのロックが解除されている必要があり、各入力には Face ID が必要です。"
           }
         }
       }
     },
-    "The vault locks after this much idle time (\"Log Out\" also clears the session). AutoFill needs the app unlocked within this window; each fill still requires Face ID.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The vault locks after this much idle time (\"Log Out\" also clears the session). AutoFill needs the app unlocked within this window; each fill still requires Face ID."
+    "Theme" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Theme"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この時間アイドル状態が続くと保管庫がロックされます（「ログアウト」を選ぶとセッションも消去されます）。AutoFill はこの時間内にアプリのロックが解除されている必要があり、各入力には Face ID が必要です。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テーマ"
           }
         }
       }
     },
-    "Theme": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Theme"
+    "This clears the local session. You'll need to sign in and unlock again." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This clears the local session. You'll need to sign in and unlock again."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テーマ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローカルセッションが消去されます。再度サインインしてロックを解除する必要があります。"
           }
         }
       }
     },
-    "This clears the local session. You'll need to sign in and unlock again.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This clears the local session. You'll need to sign in and unlock again."
+    "Title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカルセッションが消去されます。再度サインインしてロックを解除する必要があります。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトル"
           }
         }
       }
     },
-    "Title": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Title"
+    "To use a different server, sign out and set up again." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To use a different server, sign out and set up again."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タイトル"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "別のサーバーを使うには、サインアウトして設定し直してください。"
           }
         }
       }
     },
-    "To use a different server, sign out and set up again.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To use a different server, sign out and set up again."
+    "TOTP Secret" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TOTP Secret"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "別のサーバーを使うには、サインアウトして設定し直してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TOTP シークレット"
           }
         }
       }
     },
-    "Try Demo Mode": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try Demo Mode"
+    "TOTP secret (optional)" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TOTP secret (optional)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "デモを試す"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TOTP シークレット（任意）"
           }
         }
       }
     },
-    "URL": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL"
+    "Try Demo Mode" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try Demo Mode"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デモを試す"
           }
         }
       }
     },
-    "Unable to unlock vault. Check your connection and try again.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unable to unlock vault. Check your connection and try again."
+    "Unable to unlock vault. Check your connection and try again." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to unlock vault. Check your connection and try again."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保管庫のロックを解除できません。接続を確認してもう一度お試しください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保管庫のロックを解除できません。接続を確認してもう一度お試しください。"
           }
         }
       }
     },
-    "Unlock": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unlock"
+    "Unlock" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unlock"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ロック解除"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロック解除"
           }
         }
       }
     },
-    "Unlock with %@": {
-      "comment": "%@ is a biometry name (Face ID / Touch ID / biometrics).",
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unlock with %@"
+    "Unlock with %@" : {
+      "comment" : "%@ is a biometry name (Face ID / Touch ID / biometrics).",
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unlock with %@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ でロック解除"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ でロック解除"
           }
         }
       }
     },
-    "Unlock your passwd-sso vault.": {
-      "comment": "LAContext biometric prompt reason.",
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unlock your passwd-sso vault."
+    "Unlock your passwd-sso vault." : {
+      "comment" : "LAContext biometric prompt reason.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unlock your passwd-sso vault."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "passwd-sso の保管庫をロック解除します。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "passwd-sso の保管庫をロック解除します。"
           }
         }
       }
     },
-    "Username": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Username"
+    "Updated date" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Updated date"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ユーザー名"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新日"
           }
         }
       }
     },
-    "Updated date": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updated date"
+    "URL" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更新日"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL"
           }
         }
       }
     },
-    "Vault": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vault"
+    "Username" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Username"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保管庫"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザー名"
           }
         }
       }
     },
-    "Version": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
+    "Vault" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vault"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バージョン"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保管庫"
           }
         }
       }
     },
-    "When on, entry domain names are sent to the passwd-sso server to fetch site icons.": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "When on, entry domain names are sent to the passwd-sso server to fetch site icons."
+    "Version" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "オンにすると、エントリのドメイン名がサイトアイコン取得のためにpasswd-ssoサーバーに送信されます。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バージョン"
           }
         }
       }
     },
-    "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices.": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices."
+    "Website" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Website"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "オンにすると、ワンタイムコードを持つログインを入力した際に、現在のコードをクリップボードにコピーします。クリップボードは上記の時間が経過すると消去され、ほかのデバイスには同期されません。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webサイト"
           }
         }
       }
     },
-    "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices.\n\nCustom-field auto-copy copies a single non-hidden custom field after a fill; hidden fields are never auto-copied (copy them from the entry instead). A one-time-code takes priority for the clipboard.": {
-      "extractionState": "translated",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices.\n\nCustom-field auto-copy copies a single non-hidden custom field after a fill; hidden fields are never auto-copied (copy them from the entry instead). A one-time-code takes priority for the clipboard."
+    "When on, entry domain names are sent to the passwd-sso server to fetch site icons." : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, entry domain names are sent to the passwd-sso server to fetch site icons."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "オンにすると、ワンタイムコードを持つログインを入力する際に現在のコードをクリップボードにコピーして貼り付けられます。クリップボードは上記の時間が経過すると消去され、他のデバイスには同期されません。\n\nカスタムフィールドの自動コピーは、入力後に非表示でないカスタムフィールドが1つだけのときにコピーします。非表示フィールドは自動コピーされません（エントリーからコピーしてください）。ワンタイムコードがある場合はそちらが優先されます。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンにすると、エントリのドメイン名がサイトアイコン取得のためにpasswd-ssoサーバーに送信されます。"
           }
         }
       }
     },
-    "Yes": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Yes"
+    "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices." : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "はい"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンにすると、ワンタイムコードを持つログインを入力した際に、現在のコードをクリップボードにコピーします。クリップボードは上記の時間が経過すると消去され、ほかのデバイスには同期されません。"
           }
         }
       }
     },
-    "You've reached your vault's item limit. Remove unused items and try again.": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You've reached your vault's item limit. Remove unused items and try again."
+    "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices.\n\nCustom-field auto-copy copies a single non-hidden custom field after a fill; hidden fields are never auto-copied (copy them from the entry instead). A one-time-code takes priority for the clipboard." : {
+      "extractionState" : "translated",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, filling a login that has a one-time-code copies the current code to the clipboard so you can paste it. The clipboard clears after the time above and never syncs to your other devices.\n\nCustom-field auto-copy copies a single non-hidden custom field after a fill; hidden fields are never auto-copied (copy them from the entry instead). A one-time-code takes priority for the clipboard."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保管庫の項目数が上限に達しました。不要な項目を削除してから、もう一度お試しください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンにすると、ワンタイムコードを持つログインを入力する際に現在のコードをクリップボードにコピーして貼り付けられます。クリップボードは上記の時間が経過すると消去され、他のデバイスには同期されません。\n\nカスタムフィールドの自動コピーは、入力後に非表示でないカスタムフィールドが1つだけのときにコピーします。非表示フィールドは自動コピーされません（エントリーからコピーしてください）。ワンタイムコードがある場合はそちらが優先されます。"
           }
         }
       }
     },
-    "Your session expired. Lock and unlock to sign in again.": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your session expired. Lock and unlock to sign in again."
+    "Yes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yes"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セッションの有効期限が切れました。一度ロックして解除し、サインインし直してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "はい"
           }
         }
       }
     },
-    "Your session has expired. Please sign in again.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your session has expired. Please sign in again."
+    "You've reached your vault's item limit. Remove unused items and try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You've reached your vault's item limit. Remove unused items and try again."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セッションの有効期限が切れました。もう一度サインインしてください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保管庫の項目数が上限に達しました。不要な項目を削除してから、もう一度お試しください。"
           }
         }
       }
     },
-    "Your session is out of date. Enter your passphrase to unlock.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your session is out of date. Enter your passphrase to unlock."
+    "Your session expired. Lock and unlock to sign in again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your session expired. Lock and unlock to sign in again."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セッション情報が古くなっています。パスフレーズを入力して解錠してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セッションの有効期限が切れました。一度ロックして解除し、サインインし直してください。"
           }
         }
       }
     },
-    "Website": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Website"
+    "Your session has expired. Please sign in again." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your session has expired. Please sign in again."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Webサイト"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セッションの有効期限が切れました。もう一度サインインしてください。"
           }
         }
       }
     },
-    "biometrics": {
-      "comment": "Fallback biometry name when neither Face ID nor Touch ID is detected.",
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "biometrics"
+    "Your session is out of date. Enter your passphrase to unlock." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your session is out of date. Enter your passphrase to unlock."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "生体認証"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セッション情報が古くなっています。パスフレーズを入力して解錠してください。"
           }
         }
       }
-    },
-    "passwd-sso": {
-      "comment": "Brand name — never translated.",
-      "shouldTranslate": false
     }
   },
-  "version": "1.1"
+  "version" : "1.1"
 }

--- a/ios/PasswdSSOApp/Vault/EntryFetcher.swift
+++ b/ios/PasswdSSOApp/Vault/EntryFetcher.swift
@@ -17,6 +17,13 @@ public struct EncryptedEntry: Sendable, Codable, Equatable {
   public let tagIds: [String]?
   public let folderId: String?
   public let requireReprompt: Bool?
+  /// ISO-8601 strings on the wire (server `Date.toISOString()`); converted to
+  /// `Date` locally in `toPersonalCacheEntry()` via `Shared`'s `parseISO8601`
+  /// free function — the shared `fetchEntries` `JSONDecoder` global strategy
+  /// is NOT changed (a global change risks other fields; see plan C4/C1
+  /// forbidden pattern).
+  public let createdAt: String?
+  public let updatedAt: String?
 
   public init(
     id: String,
@@ -30,7 +37,9 @@ public struct EncryptedEntry: Sendable, Codable, Equatable {
     teamId: String? = nil,
     tagIds: [String]? = nil,
     folderId: String? = nil,
-    requireReprompt: Bool? = nil
+    requireReprompt: Bool? = nil,
+    createdAt: String? = nil,
+    updatedAt: String? = nil
   ) {
     self.id = id
     self.encryptedOverview = encryptedOverview
@@ -44,6 +53,8 @@ public struct EncryptedEntry: Sendable, Codable, Equatable {
     self.tagIds = tagIds
     self.folderId = folderId
     self.requireReprompt = requireReprompt
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
   }
 
   enum CodingKeys: String, CodingKey {
@@ -59,6 +70,8 @@ public struct EncryptedEntry: Sendable, Codable, Equatable {
     case tagIds
     case folderId
     case requireReprompt
+    case createdAt
+    case updatedAt
   }
 
   /// Convert a personal entry to a CacheEntry for the App Group cache. Single
@@ -76,7 +89,9 @@ public struct EncryptedEntry: Sendable, Codable, Equatable {
       encryptedBlob: encryptedBlob,
       encryptedOverview: encryptedOverview,
       entryType: entryType,
-      isFavorite: isFavorite
+      isFavorite: isFavorite,
+      createdAt: createdAt.flatMap(parseISO8601),
+      updatedAt: updatedAt.flatMap(parseISO8601)
     )
   }
 }

--- a/ios/PasswdSSOApp/Views/SettingsView.swift
+++ b/ios/PasswdSSOApp/Views/SettingsView.swift
@@ -234,6 +234,13 @@ struct SettingsView: View {
         } footer: {
           Text("To use a different server, sign out and set up again.")
         }
+
+        Section {
+          LabeledContent("Version") {
+            Text(AppVersion.display())
+              .foregroundStyle(.secondary)
+          }
+        }
       }
       .navigationTitle("Settings")
       .navigationBarTitleDisplayMode(.inline)

--- a/ios/PasswdSSOApp/Views/Vault/DemoVaultView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/DemoVaultView.swift
@@ -25,7 +25,9 @@ struct DemoVaultView: View {
   let demo: DemoVault
   let onExit: () -> Void
 
-  @State private var viewModel = VaultViewModel()
+  // Ephemeral settings-backed VM: Demo Mode must not read/write the real
+  // App Group sort preference (isolation contract — see DemoModeStateTests).
+  @State private var viewModel = VaultViewModel.makeEphemeral()
   @State private var isScreenRecording: Bool = UIScreen.main.isCaptured
 
   private let presentation = DemoVaultPresentation()

--- a/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
@@ -83,6 +83,7 @@ struct VaultCategoryListView: View {
   // Seed synchronously so an already-active recording never shows a frame of
   // entries before onAppear flips the flag.
   @State private var isScreenRecording = UIScreen.main.isCaptured
+  @FocusState private var searchFocused: Bool
 
   // Compose with the live search query (filteredSummaries) then the category.
   private var entries: [VaultEntrySummary] {
@@ -126,13 +127,101 @@ struct VaultCategoryListView: View {
     }
     .navigationTitle(navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
-    .searchable(text: $viewModel.searchQuery, prompt: Text("Search"))
+    // Self-built bottom bar (not `.searchable`) so a sort control can sit on the
+    // SAME row, left of the search field — like the iOS Passwords app. The
+    // system `.searchable` field is system-managed with no adjacent slot on
+    // iOS 17/18; this HStack works identically on all supported versions. The
+    // whole bar is hidden during screen recording (rows are already gated
+    // above), so no entry-derived UI renders while capturing.
+    .safeAreaInset(edge: .bottom) {
+      if !isScreenRecording {
+        categoryBottomBar
+      }
+    }
     .onAppear { isScreenRecording = UIScreen.main.isCaptured }
     .onReceive(
       NotificationCenter.default.publisher(for: UIScreen.capturedDidChangeNotification)
     ) { _ in
       isScreenRecording = UIScreen.main.isCaptured
     }
+  }
+
+  /// Bottom bar: a sort Menu (↑↓) on the leading edge, then the search field —
+  /// mirrors the iOS Passwords app category screen. Binds the shared
+  /// `viewModel.searchQuery` / `sortOption` / `sortDirection`.
+  private var categoryBottomBar: some View {
+    HStack(spacing: 12) {
+      EntrySortMenu(
+        sortOption: $viewModel.sortOption,
+        sortDirection: $viewModel.sortDirection,
+        onChange: { autoLockService?.recordActivity() }
+      )
+      HStack(spacing: 6) {
+        Image(systemName: "magnifyingglass")
+          .foregroundStyle(.secondary)
+        TextField("Search", text: $viewModel.searchQuery)
+          .textFieldStyle(.plain)
+          .textInputAutocapitalization(.never)
+          .autocorrectionDisabled()
+          .focused($searchFocused)
+          .submitLabel(.search)
+        if !viewModel.searchQuery.isEmpty {
+          Button {
+            viewModel.searchQuery = ""
+          } label: {
+            Image(systemName: "xmark.circle.fill")
+              .foregroundStyle(.secondary)
+          }
+          .buttonStyle(.plain)
+          .accessibilityLabel("Clear search")
+        }
+      }
+      .padding(.horizontal, 12)
+      .frame(minHeight: 44)
+      .background(Color(.secondarySystemBackground), in: Capsule())
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 8)
+    .background(.bar)
+  }
+}
+
+/// Sort control shared by the category screens: a Menu showing an
+/// ascending/descending toggle and the four sort keys, matching the iOS
+/// Passwords app. Bindings write the shared VaultViewModel state (persisted).
+struct EntrySortMenu: View {
+  @Binding var sortOption: EntrySortOption
+  @Binding var sortDirection: EntrySortDirection
+  var onChange: () -> Void = {}
+
+  var body: some View {
+    Menu {
+      Picker("Direction", selection: directionBinding) {
+        Label("Descending", systemImage: "arrow.down").tag(EntrySortDirection.descending)
+        Label("Ascending", systemImage: "arrow.up").tag(EntrySortDirection.ascending)
+      }
+      Picker("Sort by", selection: optionBinding) {
+        Text("Title").tag(EntrySortOption.title)
+        Text("Created date").tag(EntrySortOption.createdAt)
+        Text("Updated date").tag(EntrySortOption.updatedAt)
+        Text("Website").tag(EntrySortOption.website)
+      }
+    } label: {
+      Image(systemName: "arrow.up.arrow.down")
+        .font(.body)
+        .frame(width: 44, height: 44)
+        .background(Color(.secondarySystemBackground), in: Circle())
+    }
+    .accessibilityLabel("Sort")
+    // Stable, non-localized handle for UI tests (the label is localized).
+    .accessibilityIdentifier("category-sort-button")
+  }
+
+  private var optionBinding: Binding<EntrySortOption> {
+    Binding(get: { sortOption }, set: { sortOption = $0; onChange() })
+  }
+  private var directionBinding: Binding<EntrySortDirection> {
+    Binding(get: { sortDirection }, set: { sortDirection = $0; onChange() })
   }
 }
 

--- a/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultCategoryLanding.swift
@@ -126,6 +126,7 @@ struct VaultCategoryListView: View {
     }
     .navigationTitle(navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
+    .searchable(text: $viewModel.searchQuery, prompt: Text("Search"))
     .onAppear { isScreenRecording = UIScreen.main.isCaptured }
     .onReceive(
       NotificationCenter.default.publisher(for: UIScreen.capturedDidChangeNotification)

--- a/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
@@ -65,14 +65,6 @@ struct VaultListView: View {
               Label("Sync now", systemImage: "arrow.clockwise")
             }
             .disabled(isSyncing)
-            Picker(selection: $viewModel.sortOption) {
-              Text("Title").tag(EntrySortOption.title)
-              Text("Created date").tag(EntrySortOption.createdAt)
-              Text("Updated date").tag(EntrySortOption.updatedAt)
-              Text("Website").tag(EntrySortOption.website)
-            } label: {
-              Label("Sort", systemImage: "arrow.up.arrow.down")
-            }
             Button {
               autoLockService.recordActivity()
               isShowingSettings = true

--- a/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
@@ -65,6 +65,14 @@ struct VaultListView: View {
               Label("Sync now", systemImage: "arrow.clockwise")
             }
             .disabled(isSyncing)
+            Picker(selection: $viewModel.sortOption) {
+              Text("Title").tag(EntrySortOption.title)
+              Text("Created date").tag(EntrySortOption.createdAt)
+              Text("Updated date").tag(EntrySortOption.updatedAt)
+              Text("Website").tag(EntrySortOption.website)
+            } label: {
+              Label("Sort", systemImage: "arrow.up.arrow.down")
+            }
             Button {
               autoLockService.recordActivity()
               isShowingSettings = true

--- a/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
@@ -41,16 +41,20 @@ public enum VaultScope: Hashable, Sendable {
   /// Injected so tests use a clean per-test suite, not the shared App Group.
   private let settings: AppSettingsStore
 
-  /// Selected sort key (FR2/FR3), read from `settings` at init and written
-  /// back to it on every change. Presented via the top-level toolbar only
-  /// (SC5); category screens inherit it through `filteredSummaries`.
+  /// Selected sort key + direction, read from `settings` at init and written
+  /// back on every change. The sort control lives on the category screens'
+  /// bottom bar; all screens reflect the same choice through `filteredSummaries`.
   public var sortOption: EntrySortOption {
     didSet { settings.entrySortOption = sortOption }
+  }
+  public var sortDirection: EntrySortDirection {
+    didSet { settings.entrySortDirection = sortDirection }
   }
 
   public init(settings: AppSettingsStore = AppSettingsStore()) {
     self.settings = settings
     self.sortOption = settings.entrySortOption
+    self.sortDirection = settings.entrySortDirection
   }
 
   /// A view-model whose settings are backed by a throwaway in-memory suite,
@@ -102,7 +106,7 @@ public enum VaultScope: Hashable, Sendable {
     // Sort is the LAST transform (after scope + search) so search results are
     // also sorted, and every screen (top-level + category) reflects the same
     // globally-chosen key (single sort point — C6 forbidden pattern).
-    return sortOption.sorted(result)
+    return sortOption.sorted(result, direction: sortDirection)
   }
 
   /// True when the currently selected scope is a team vault (create is disabled).

--- a/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
@@ -38,6 +38,32 @@ public enum VaultScope: Hashable, Sendable {
 
   var allSummaries: [VaultEntrySummary] = []
 
+  /// Injected so tests use a clean per-test suite, not the shared App Group.
+  private let settings: AppSettingsStore
+
+  /// Selected sort key (FR2/FR3), read from `settings` at init and written
+  /// back to it on every change. Presented via the top-level toolbar only
+  /// (SC5); category screens inherit it through `filteredSummaries`.
+  public var sortOption: EntrySortOption {
+    didSet { settings.entrySortOption = sortOption }
+  }
+
+  public init(settings: AppSettingsStore = AppSettingsStore()) {
+    self.settings = settings
+    self.sortOption = settings.entrySortOption
+  }
+
+  /// A view-model whose settings are backed by a throwaway in-memory suite,
+  /// touching NO shared App Group state. Demo Mode uses this so browsing the
+  /// demo vault never reads or writes the real persisted sort preference —
+  /// preserving the demo isolation contract without `DemoVaultView` naming
+  /// `AppSettingsStore` (see DemoModeStateTests grep gate).
+  public static func makeEphemeral() -> VaultViewModel {
+    let suite = UserDefaults(suiteName: "demo.ephemeral") ?? .standard
+    suite.removePersistentDomain(forName: "demo.ephemeral")
+    return VaultViewModel(settings: AppSettingsStore(defaults: suite))
+  }
+
   /// cacheKey from the last `loadFromCache`, retained so `loadDetail` can decrypt
   /// team entries without re-threading it from every call site.
   private var loadedCacheKey: SymmetricKey?
@@ -64,7 +90,10 @@ public enum VaultScope: Hashable, Sendable {
         $0.urlHost.lowercased().contains(q)
       }
     }
-    return result
+    // Sort is the LAST transform (after scope + search) so search results are
+    // also sorted, and every screen (top-level + category) reflects the same
+    // globally-chosen key (single sort point — C6 forbidden pattern).
+    return sortOption.sorted(result)
   }
 
   /// True when the currently selected scope is a team vault (create is disabled).
@@ -185,7 +214,9 @@ public enum VaultScope: Hashable, Sendable {
         entryId: entry.id,
         teamId: entry.teamId,
         entryType: entry.entryType,
-        isFavorite: entry.isFavorite ?? false
+        isFavorite: entry.isFavorite ?? false,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt
       )
     } catch {
       return nil

--- a/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultViewModel.swift
@@ -59,8 +59,17 @@ public enum VaultScope: Hashable, Sendable {
   /// preserving the demo isolation contract without `DemoVaultView` naming
   /// `AppSettingsStore` (see DemoModeStateTests grep gate).
   public static func makeEphemeral() -> VaultViewModel {
-    let suite = UserDefaults(suiteName: "demo.ephemeral") ?? .standard
-    suite.removePersistentDomain(forName: "demo.ephemeral")
+    // Per-instance suite name so two concurrent demo VMs never share or wipe
+    // each other's store, and never fall back to `.standard` (which would leak
+    // the demo sort key into the app's real defaults, defeating "ephemeral").
+    let suiteName = "demo.ephemeral.\(UUID().uuidString)"
+    guard let suite = UserDefaults(suiteName: suiteName) else {
+      // A fresh, unique suite name does not collide with the bundle id, so this
+      // is unreachable in practice; if it ever happens, prefer an in-memory
+      // volatile store over `.standard` so nothing persists to real defaults.
+      return VaultViewModel(settings: AppSettingsStore(defaults: UserDefaults()))
+    }
+    suite.removePersistentDomain(forName: suiteName)
     return VaultViewModel(settings: AppSettingsStore(defaults: suite))
   }
 

--- a/ios/PasswdSSOTests/AppSettingsStoreTests.swift
+++ b/ios/PasswdSSOTests/AppSettingsStoreTests.swift
@@ -452,4 +452,36 @@ final class AppSettingsStoreTests: XCTestCase {
       defaults.string(forKey: "entrySortOption"), "website",
       "setter must write to the literal key the public constant names")
   }
+
+  // MARK: - Entry sort direction (T-PERSIST)
+
+  func testEntrySortDirectionAbsentFollowsKeyDefault() {
+    let store = AppSettingsStore(defaults: defaults)
+    // Default key is .title → ascending; a date key → descending.
+    store.entrySortOption = .title
+    XCTAssertEqual(AppSettingsStore(defaults: defaults).entrySortDirection, .ascending)
+    store.entrySortOption = .updatedAt
+    XCTAssertEqual(AppSettingsStore(defaults: defaults).entrySortDirection, .descending)
+  }
+
+  func testEntrySortDirectionRoundTrip() {
+    let store = AppSettingsStore(defaults: defaults)
+    store.entrySortOption = .title  // natural default ascending
+    store.entrySortDirection = .descending  // explicit override
+    XCTAssertEqual(AppSettingsStore(defaults: defaults).entrySortDirection, .descending)
+  }
+
+  func testEntrySortDirectionInvalidRawValueFollowsKeyDefault() {
+    defaults.set("garbage", forKey: "entrySortDirection")
+    let store = AppSettingsStore(defaults: defaults)
+    store.entrySortOption = .title
+    XCTAssertEqual(AppSettingsStore(defaults: defaults).entrySortDirection, .ascending)
+  }
+
+  func testEntrySortDirectionKeyConsistency() {
+    XCTAssertEqual(AppSettingsStore.entrySortDirectionKey, "entrySortDirection")
+    let store = AppSettingsStore(defaults: defaults)
+    store.entrySortDirection = .ascending
+    XCTAssertEqual(defaults.string(forKey: "entrySortDirection"), "ascending")
+  }
 }

--- a/ios/PasswdSSOTests/AppSettingsStoreTests.swift
+++ b/ios/PasswdSSOTests/AppSettingsStoreTests.swift
@@ -425,4 +425,31 @@ final class AppSettingsStoreTests: XCTestCase {
       defaults.bool(forKey: "autoCopyCustomField"),
       "setter must write to the literal key the public constant names")
   }
+
+  // MARK: - Entry sort option (T-PERSIST)
+
+  func testEntrySortOptionAbsentReturnsTitle() {
+    XCTAssertEqual(AppSettingsStore(defaults: defaults).entrySortOption, .title)
+  }
+
+  func testEntrySortOptionRoundTrip() {
+    let store = AppSettingsStore(defaults: defaults)
+    store.entrySortOption = .updatedAt
+    // Re-read via a fresh AppSettingsStore instance over the same suite.
+    XCTAssertEqual(AppSettingsStore(defaults: defaults).entrySortOption, .updatedAt)
+  }
+
+  func testEntrySortOptionInvalidRawValueReturnsTitle() {
+    defaults.set("garbage", forKey: "entrySortOption")
+    XCTAssertEqual(AppSettingsStore(defaults: defaults).entrySortOption, .title)
+  }
+
+  func testEntrySortOptionKeyConsistency() {
+    XCTAssertEqual(AppSettingsStore.entrySortOptionKey, "entrySortOption")
+    let store = AppSettingsStore(defaults: defaults)
+    store.entrySortOption = .website
+    XCTAssertEqual(
+      defaults.string(forKey: "entrySortOption"), "website",
+      "setter must write to the literal key the public constant names")
+  }
 }

--- a/ios/PasswdSSOTests/AppVersionTests.swift
+++ b/ios/PasswdSSOTests/AppVersionTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Shared
+
+/// T-VERSION: AppVersion.display uses the injectable string seam (T1), not
+/// Bundle — Bundle has no public infoDictionary initializer, so a synthetic
+/// test bundle can't carry a fixed test version.
+final class AppVersionTests: XCTestCase {
+  func testDisplayWithMarketingAndBuild() {
+    XCTAssertEqual(AppVersion.display(marketing: "0.4.65", build: "42"), "0.4.65 (42)")
+  }
+
+  func testDisplayWithBothNilReturnsFallback() {
+    XCTAssertEqual(AppVersion.display(marketing: nil, build: nil), "—")
+  }
+
+  func testDisplayWithBuildNilReturnsMarketingOnly() {
+    XCTAssertEqual(AppVersion.display(marketing: "0.4.65", build: nil), "0.4.65")
+  }
+
+  func testDisplayWithMarketingNilReturnsBuildOnly() {
+    XCTAssertEqual(AppVersion.display(marketing: nil, build: "42"), "42")
+  }
+}

--- a/ios/PasswdSSOTests/CacheEntryPropagationTests.swift
+++ b/ios/PasswdSSOTests/CacheEntryPropagationTests.swift
@@ -75,16 +75,19 @@ final class CacheEntryPropagationTests: XCTestCase {
     return try JSONDecoder().decode(EncryptedEntry.self, from: Data(json.utf8))
   }
 
+  // 2024-01-02T03:04:05Z == 1704164645 epoch seconds. Assert the exact instant
+  // so a wrong-but-non-nil parse (bad TZ, wrong component) is caught, not just
+  // "some Date".
+  private let expectedInstant = Date(timeIntervalSince1970: 1_704_164_645)
+
   func testEncryptedEntryDecodesFractionalISODate() throws {
     let entry = try decodeEncryptedEntry(createdAt: "2024-01-02T03:04:05.000Z", updatedAt: nil)
-    let cache = entry.toPersonalCacheEntry()
-    XCTAssertNotNil(cache.createdAt)
+    XCTAssertEqual(entry.toPersonalCacheEntry().createdAt, expectedInstant)
   }
 
   func testEncryptedEntryDecodesNonFractionalISODate() throws {
     let entry = try decodeEncryptedEntry(createdAt: "2024-01-02T03:04:05Z", updatedAt: nil)
-    let cache = entry.toPersonalCacheEntry()
-    XCTAssertNotNil(cache.createdAt)
+    XCTAssertEqual(entry.toPersonalCacheEntry().createdAt, expectedInstant)
   }
 
   func testEncryptedEntryGarbageOrAbsentDateYieldsNilWithoutThrow() throws {

--- a/ios/PasswdSSOTests/CacheEntryPropagationTests.swift
+++ b/ios/PasswdSSOTests/CacheEntryPropagationTests.swift
@@ -58,4 +58,63 @@ final class CacheEntryPropagationTests: XCTestCase {
     XCTAssertNil(summary.entryType)
     XCTAssertFalse(summary.isFavorite)
   }
+
+  // MARK: - T-DATE: EncryptedEntry decodes ISO dates, toPersonalCacheEntry carries them
+
+  private func decodeEncryptedEntry(createdAt: String?, updatedAt: String?) throws -> EncryptedEntry {
+    func field(_ name: String, _ value: String?) -> String {
+      guard let value else { return "" }
+      return #","\#(name)":"\#(value)""#
+    }
+    let json = """
+    {"id":"e10","encryptedOverview":{"ciphertext":"aa","iv":"aabbccddeeff001122334455","authTag":"00112233445566778899aabbccddeeff"},
+     "encryptedBlob":{"ciphertext":"aa","iv":"aabbccddeeff001122334455","authTag":"00112233445566778899aabbccddeeff"},
+     "keyVersion":1,"aadVersion":1,"entryType":"LOGIN","isFavorite":false,"isArchived":false\
+    \(field("createdAt", createdAt))\(field("updatedAt", updatedAt))}
+    """
+    return try JSONDecoder().decode(EncryptedEntry.self, from: Data(json.utf8))
+  }
+
+  func testEncryptedEntryDecodesFractionalISODate() throws {
+    let entry = try decodeEncryptedEntry(createdAt: "2024-01-02T03:04:05.000Z", updatedAt: nil)
+    let cache = entry.toPersonalCacheEntry()
+    XCTAssertNotNil(cache.createdAt)
+  }
+
+  func testEncryptedEntryDecodesNonFractionalISODate() throws {
+    let entry = try decodeEncryptedEntry(createdAt: "2024-01-02T03:04:05Z", updatedAt: nil)
+    let cache = entry.toPersonalCacheEntry()
+    XCTAssertNotNil(cache.createdAt)
+  }
+
+  func testEncryptedEntryGarbageOrAbsentDateYieldsNilWithoutThrow() throws {
+    let garbage = try decodeEncryptedEntry(createdAt: "not-a-date", updatedAt: nil)
+    XCTAssertNil(garbage.toPersonalCacheEntry().createdAt)
+
+    let absent = try decodeEncryptedEntry(createdAt: nil, updatedAt: nil)
+    XCTAssertNil(absent.toPersonalCacheEntry().createdAt)
+    XCTAssertNil(absent.toPersonalCacheEntry().updatedAt)
+  }
+
+  func testToPersonalCacheEntryCarriesBothDates() throws {
+    let entry = try decodeEncryptedEntry(
+      createdAt: "2024-01-02T03:04:05.000Z", updatedAt: "2024-06-07T08:09:10.000Z")
+    let cache = entry.toPersonalCacheEntry()
+    XCTAssertNotNil(cache.createdAt)
+    XCTAssertNotNil(cache.updatedAt)
+    XCTAssertNotEqual(cache.createdAt, cache.updatedAt)
+  }
+
+  // MARK: - T-DATE-COMPAT: CacheEntry JSON omitting dates decodes with nil
+
+  func testCacheEntryDecodesNilDatesFromLegacyJSON() throws {
+    let json = #"""
+    {"id":"e11","aadVersion":0,"keyVersion":0,
+     "encryptedBlob":{"ciphertext":"aa","iv":"bb","authTag":"cc"},
+     "encryptedOverview":{"ciphertext":"aa","iv":"bb","authTag":"cc"}}
+    """#
+    let entry = try JSONDecoder().decode(CacheEntry.self, from: Data(json.utf8))
+    XCTAssertNil(entry.createdAt)
+    XCTAssertNil(entry.updatedAt)
+  }
 }

--- a/ios/PasswdSSOTests/DemoModeStateTests.swift
+++ b/ios/PasswdSSOTests/DemoModeStateTests.swift
@@ -77,6 +77,32 @@ final class DemoModeStateTests: XCTestCase {
     }
   }
 
+  // MARK: - Demo settings isolation (behavioral, complements the grep gate)
+
+  /// The grep gate forbids the `AppSettingsStore` token in DemoVaultView.swift,
+  /// but `VaultViewModel()`'s default arg would bind the real App Group suite
+  /// transitively. `makeEphemeral()` is the isolation seam; this test proves it
+  /// neither reads nor writes the shared persisted sort preference.
+  ///
+  /// Prove-red (RT7): change `makeEphemeral()` to `VaultViewModel()` → this fails
+  /// (the ephemeral VM would then reflect and pollute the shared suite).
+  func testDemoViewModelDoesNotTouchSharedSortPreference() {
+    let shared = AppSettingsStore()
+    let original = shared.entrySortOption
+    defer { shared.entrySortOption = original }
+
+    // A value the ephemeral VM must NOT observe.
+    shared.entrySortOption = .website
+
+    let demoVM = VaultViewModel.makeEphemeral()
+    // Ephemeral VM starts at the fail-closed default, not the shared .website.
+    XCTAssertEqual(demoVM.sortOption, .title)
+
+    // Mutating the demo VM must not leak into the shared suite.
+    demoVM.sortOption = .createdAt
+    XCTAssertEqual(shared.entrySortOption, .website)
+  }
+
   /// Prove-red (RT7): temporarily add `MobileAPIClient` to DemoVaultView.swift → test fails.
   // See the #filePath rationale on testForbiddenPatternsAbsent_inDemoVaultFactory.
   func testForbiddenPatternsAbsent_inDemoVaultView() throws {

--- a/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
+++ b/ios/PasswdSSOTests/EntryBlobDecoderTests.swift
@@ -551,4 +551,39 @@ final class EntryBlobDecoderTests: XCTestCase {
     let entry = try JSONDecoder().decode(CacheEntry.self, from: data(json))
     XCTAssertEqual(entry.entryType, "PASSKEY")
   }
+
+  // MARK: - summary() createdAt/updatedAt (T-BLOB)
+
+  func testSummarySetsCreatedAtAndUpdatedAtWhenPassed() throws {
+    let json = #"{"title":"T","tags":[]}"#
+    let created = Date(timeIntervalSince1970: 1000)
+    let updated = Date(timeIntervalSince1970: 2000)
+    let summary = try XCTUnwrap(
+      EntryBlobDecoder.summary(
+        plaintext: data(json), entryId: "d1", teamId: nil,
+        createdAt: created, updatedAt: updated
+      )
+    )
+    XCTAssertEqual(summary.createdAt, created)
+    XCTAssertEqual(summary.updatedAt, updated)
+  }
+
+  func testSummaryDatesDefaultToNilWhenNotPassed() throws {
+    let json = #"{"title":"T","tags":[]}"#
+    let summary = try XCTUnwrap(
+      EntryBlobDecoder.summary(plaintext: data(json), entryId: "d2", teamId: nil)
+    )
+    XCTAssertNil(summary.createdAt)
+    XCTAssertNil(summary.updatedAt)
+  }
+
+  func testSummaryDoesNotReadDatesFromBlobPayload() throws {
+    // Even if the blob JSON happened to carry createdAt/updatedAt-looking keys,
+    // they must be ignored — dates are cache-row metadata only.
+    let json = #"{"title":"T","tags":[],"createdAt":"2024-01-01T00:00:00.000Z"}"#
+    let summary = try XCTUnwrap(
+      EntryBlobDecoder.summary(plaintext: data(json), entryId: "d3", teamId: nil)
+    )
+    XCTAssertNil(summary.createdAt)
+  }
 }

--- a/ios/PasswdSSOTests/EntrySortOptionTests.swift
+++ b/ios/PasswdSSOTests/EntrySortOptionTests.swift
@@ -3,7 +3,8 @@ import XCTest
 @testable import Shared
 
 /// T-SORT: EntrySortOption's 4-key comparator — favorites-first (all keys),
-/// per-key direction, nil/empty sort-last, and stability (index tie-break).
+/// per-key direction toggle, nil/empty sort-last (regardless of direction),
+/// and stability (index tie-break).
 final class EntrySortOptionTests: XCTestCase {
   private func s(
     _ id: String,
@@ -25,73 +26,128 @@ final class EntrySortOptionTests: XCTestCase {
     XCTAssertEqual(EntrySortOption.allCases.count, 4)
   }
 
-  // MARK: - title (ascending, case-insensitive)
+  func testDirectionAllCasesCountIsTwo() {
+    XCTAssertEqual(EntrySortDirection.allCases.count, 2)
+  }
+
+  // MARK: - default direction per key
+
+  func testDefaultDirectionIsAscendingForTitleAndWebsite() {
+    XCTAssertEqual(EntrySortOption.title.defaultDirection, .ascending)
+    XCTAssertEqual(EntrySortOption.website.defaultDirection, .ascending)
+  }
+
+  func testDefaultDirectionIsDescendingForDates() {
+    XCTAssertEqual(EntrySortOption.createdAt.defaultDirection, .descending)
+    XCTAssertEqual(EntrySortOption.updatedAt.defaultDirection, .descending)
+  }
+
+  // MARK: - title (ascending / descending)
 
   func testTitleSortsAscendingCaseInsensitive() {
     let a = s("a", title: "alpha")
     let b = s("b", title: "Beta")
-    let result = EntrySortOption.title.sorted([b, a])
+    let result = EntrySortOption.title.sorted([b, a], direction: .ascending)
     XCTAssertEqual(result.map(\.id), ["a", "b"])
   }
 
-  // MARK: - website (ascending, empty-last)
+  func testTitleSortsDescendingWhenRequested() {
+    let a = s("a", title: "alpha")
+    let b = s("b", title: "Beta")
+    let result = EntrySortOption.title.sorted([a, b], direction: .descending)
+    XCTAssertEqual(result.map(\.id), ["b", "a"])
+  }
+
+  // MARK: - website (ascending / descending, empty-last both ways)
 
   func testWebsiteSortsAscendingAndEmptyHostLast() {
     let empty = s("empty", urlHost: "")
     let z = s("z", urlHost: "zeta.com")
     let a = s("a", urlHost: "alpha.com")
-    let result = EntrySortOption.website.sorted([empty, z, a])
+    let result = EntrySortOption.website.sorted([empty, z, a], direction: .ascending)
     XCTAssertEqual(result.map(\.id), ["a", "z", "empty"])
   }
 
-  // MARK: - createdAt / updatedAt (descending, nil-last)
+  func testWebsiteDescendingStillSortsEmptyHostLast() {
+    let empty = s("empty", urlHost: "")
+    let z = s("z", urlHost: "zeta.com")
+    let a = s("a", urlHost: "alpha.com")
+    let result = EntrySortOption.website.sorted([empty, z, a], direction: .descending)
+    // Populated hosts reverse (z before a); empty STILL sorts last, not first.
+    XCTAssertEqual(result.map(\.id), ["z", "a", "empty"])
+  }
+
+  // MARK: - createdAt / updatedAt (descending / ascending, nil-last both ways)
 
   func testCreatedAtSortsDescendingNewestFirstAndNilLast() {
     let older = s("older", createdAt: Date(timeIntervalSince1970: 1000))
     let newer = s("newer", createdAt: Date(timeIntervalSince1970: 2000))
     let noDate = s("noDate", createdAt: nil)
-    let result = EntrySortOption.createdAt.sorted([older, noDate, newer])
+    let result = EntrySortOption.createdAt.sorted([older, noDate, newer], direction: .descending)
     XCTAssertEqual(result.map(\.id), ["newer", "older", "noDate"])
+  }
+
+  func testCreatedAtAscendingOldestFirstButNilStillLast() {
+    let older = s("older", createdAt: Date(timeIntervalSince1970: 1000))
+    let newer = s("newer", createdAt: Date(timeIntervalSince1970: 2000))
+    let noDate = s("noDate", createdAt: nil)
+    let result = EntrySortOption.createdAt.sorted([newer, noDate, older], direction: .ascending)
+    // Oldest first when ascending, but nil NEVER bubbles to the top.
+    XCTAssertEqual(result.map(\.id), ["older", "newer", "noDate"])
   }
 
   func testUpdatedAtSortsDescendingNewestFirstAndNilLast() {
     let older = s("older", updatedAt: Date(timeIntervalSince1970: 1000))
     let newer = s("newer", updatedAt: Date(timeIntervalSince1970: 2000))
     let noDate = s("noDate", updatedAt: nil)
-    let result = EntrySortOption.updatedAt.sorted([older, noDate, newer])
+    let result = EntrySortOption.updatedAt.sorted([older, noDate, newer], direction: .descending)
     XCTAssertEqual(result.map(\.id), ["newer", "older", "noDate"])
   }
 
-  // MARK: - favorites-first for ALL FOUR keys (T3)
+  func testUpdatedAtAscendingOldestFirstButNilStillLast() {
+    let older = s("older", updatedAt: Date(timeIntervalSince1970: 1000))
+    let newer = s("newer", updatedAt: Date(timeIntervalSince1970: 2000))
+    let noDate = s("noDate", updatedAt: nil)
+    let result = EntrySortOption.updatedAt.sorted([newer, noDate, older], direction: .ascending)
+    XCTAssertEqual(result.map(\.id), ["older", "newer", "noDate"])
+  }
 
-  func testFavoritesFirstUnderTitle() {
-    // "zzz" would sort last alphabetically, but it's a favorite.
+  // MARK: - favorites-first for ALL FOUR keys, BOTH directions (T3)
+
+  func testFavoritesFirstUnderTitleBothDirections() {
     let favorite = s("fav", title: "zzz", isFavorite: true)
     let nonFavorite = s("nonfav", title: "aaa", isFavorite: false)
-    let result = EntrySortOption.title.sorted([nonFavorite, favorite])
-    XCTAssertEqual(result.map(\.id), ["fav", "nonfav"])
+    for direction in EntrySortDirection.allCases {
+      let result = EntrySortOption.title.sorted([nonFavorite, favorite], direction: direction)
+      XCTAssertEqual(result.map(\.id), ["fav", "nonfav"], "direction \(direction)")
+    }
   }
 
-  func testFavoritesFirstUnderWebsite() {
+  func testFavoritesFirstUnderWebsiteBothDirections() {
     let favorite = s("fav", urlHost: "", isFavorite: true)  // empty host would sort last
     let nonFavorite = s("nonfav", urlHost: "alpha.com", isFavorite: false)
-    let result = EntrySortOption.website.sorted([nonFavorite, favorite])
-    XCTAssertEqual(result.map(\.id), ["fav", "nonfav"])
+    for direction in EntrySortDirection.allCases {
+      let result = EntrySortOption.website.sorted([nonFavorite, favorite], direction: direction)
+      XCTAssertEqual(result.map(\.id), ["fav", "nonfav"], "direction \(direction)")
+    }
   }
 
-  func testFavoritesFirstUnderCreatedAt() {
-    // Favorite has the OLDER date (would sort last on this key), but favorites-first wins.
+  func testFavoritesFirstUnderCreatedAtBothDirections() {
     let favorite = s("fav", isFavorite: true, createdAt: Date(timeIntervalSince1970: 100))
     let nonFavorite = s("nonfav", isFavorite: false, createdAt: Date(timeIntervalSince1970: 9999))
-    let result = EntrySortOption.createdAt.sorted([nonFavorite, favorite])
-    XCTAssertEqual(result.map(\.id), ["fav", "nonfav"])
+    for direction in EntrySortDirection.allCases {
+      let result = EntrySortOption.createdAt.sorted([nonFavorite, favorite], direction: direction)
+      XCTAssertEqual(result.map(\.id), ["fav", "nonfav"], "direction \(direction)")
+    }
   }
 
-  func testFavoritesFirstUnderUpdatedAt() {
+  func testFavoritesFirstUnderUpdatedAtBothDirections() {
     let favorite = s("fav", isFavorite: true, updatedAt: nil)  // nil would sort last
     let nonFavorite = s("nonfav", isFavorite: false, updatedAt: Date(timeIntervalSince1970: 100))
-    let result = EntrySortOption.updatedAt.sorted([nonFavorite, favorite])
-    XCTAssertEqual(result.map(\.id), ["fav", "nonfav"])
+    for direction in EntrySortDirection.allCases {
+      let result = EntrySortOption.updatedAt.sorted([nonFavorite, favorite], direction: direction)
+      XCTAssertEqual(result.map(\.id), ["fav", "nonfav"], "direction \(direction)")
+    }
   }
 
   // MARK: - stability (T4)
@@ -100,7 +156,7 @@ final class EntrySortOptionTests: XCTestCase {
     let first = s("first", title: "Same")
     let second = s("second", title: "Same")
     let third = s("third", title: "Same")
-    let result = EntrySortOption.title.sorted([first, second, third])
+    let result = EntrySortOption.title.sorted([first, second, third], direction: .ascending)
     XCTAssertEqual(result.map(\.id), ["first", "second", "third"])
   }
 
@@ -108,14 +164,14 @@ final class EntrySortOptionTests: XCTestCase {
     let first = s("first", createdAt: nil)
     let second = s("second", createdAt: nil)
     let third = s("third", createdAt: nil)
-    let result = EntrySortOption.createdAt.sorted([first, second, third])
+    let result = EntrySortOption.createdAt.sorted([first, second, third], direction: .descending)
     XCTAssertEqual(result.map(\.id), ["first", "second", "third"])
   }
 
   func testStabilityPreservesInputOrderForBothEmptyHosts() {
     let first = s("first", urlHost: "")
     let second = s("second", urlHost: "")
-    let result = EntrySortOption.website.sorted([first, second])
+    let result = EntrySortOption.website.sorted([first, second], direction: .ascending)
     XCTAssertEqual(result.map(\.id), ["first", "second"])
   }
 }

--- a/ios/PasswdSSOTests/EntrySortOptionTests.swift
+++ b/ios/PasswdSSOTests/EntrySortOptionTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import XCTest
+@testable import Shared
+
+/// T-SORT: EntrySortOption's 4-key comparator — favorites-first (all keys),
+/// per-key direction, nil/empty sort-last, and stability (index tie-break).
+final class EntrySortOptionTests: XCTestCase {
+  private func s(
+    _ id: String,
+    title: String = "T",
+    urlHost: String = "x.com",
+    isFavorite: Bool = false,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil
+  ) -> VaultEntrySummary {
+    VaultEntrySummary(
+      id: id, title: title, username: "u", urlHost: urlHost,
+      isFavorite: isFavorite, createdAt: createdAt, updatedAt: updatedAt
+    )
+  }
+
+  // MARK: - allCases
+
+  func testAllCasesCountIsFour() {
+    XCTAssertEqual(EntrySortOption.allCases.count, 4)
+  }
+
+  // MARK: - title (ascending, case-insensitive)
+
+  func testTitleSortsAscendingCaseInsensitive() {
+    let a = s("a", title: "alpha")
+    let b = s("b", title: "Beta")
+    let result = EntrySortOption.title.sorted([b, a])
+    XCTAssertEqual(result.map(\.id), ["a", "b"])
+  }
+
+  // MARK: - website (ascending, empty-last)
+
+  func testWebsiteSortsAscendingAndEmptyHostLast() {
+    let empty = s("empty", urlHost: "")
+    let z = s("z", urlHost: "zeta.com")
+    let a = s("a", urlHost: "alpha.com")
+    let result = EntrySortOption.website.sorted([empty, z, a])
+    XCTAssertEqual(result.map(\.id), ["a", "z", "empty"])
+  }
+
+  // MARK: - createdAt / updatedAt (descending, nil-last)
+
+  func testCreatedAtSortsDescendingNewestFirstAndNilLast() {
+    let older = s("older", createdAt: Date(timeIntervalSince1970: 1000))
+    let newer = s("newer", createdAt: Date(timeIntervalSince1970: 2000))
+    let noDate = s("noDate", createdAt: nil)
+    let result = EntrySortOption.createdAt.sorted([older, noDate, newer])
+    XCTAssertEqual(result.map(\.id), ["newer", "older", "noDate"])
+  }
+
+  func testUpdatedAtSortsDescendingNewestFirstAndNilLast() {
+    let older = s("older", updatedAt: Date(timeIntervalSince1970: 1000))
+    let newer = s("newer", updatedAt: Date(timeIntervalSince1970: 2000))
+    let noDate = s("noDate", updatedAt: nil)
+    let result = EntrySortOption.updatedAt.sorted([older, noDate, newer])
+    XCTAssertEqual(result.map(\.id), ["newer", "older", "noDate"])
+  }
+
+  // MARK: - favorites-first for ALL FOUR keys (T3)
+
+  func testFavoritesFirstUnderTitle() {
+    // "zzz" would sort last alphabetically, but it's a favorite.
+    let favorite = s("fav", title: "zzz", isFavorite: true)
+    let nonFavorite = s("nonfav", title: "aaa", isFavorite: false)
+    let result = EntrySortOption.title.sorted([nonFavorite, favorite])
+    XCTAssertEqual(result.map(\.id), ["fav", "nonfav"])
+  }
+
+  func testFavoritesFirstUnderWebsite() {
+    let favorite = s("fav", urlHost: "", isFavorite: true)  // empty host would sort last
+    let nonFavorite = s("nonfav", urlHost: "alpha.com", isFavorite: false)
+    let result = EntrySortOption.website.sorted([nonFavorite, favorite])
+    XCTAssertEqual(result.map(\.id), ["fav", "nonfav"])
+  }
+
+  func testFavoritesFirstUnderCreatedAt() {
+    // Favorite has the OLDER date (would sort last on this key), but favorites-first wins.
+    let favorite = s("fav", isFavorite: true, createdAt: Date(timeIntervalSince1970: 100))
+    let nonFavorite = s("nonfav", isFavorite: false, createdAt: Date(timeIntervalSince1970: 9999))
+    let result = EntrySortOption.createdAt.sorted([nonFavorite, favorite])
+    XCTAssertEqual(result.map(\.id), ["fav", "nonfav"])
+  }
+
+  func testFavoritesFirstUnderUpdatedAt() {
+    let favorite = s("fav", isFavorite: true, updatedAt: nil)  // nil would sort last
+    let nonFavorite = s("nonfav", isFavorite: false, updatedAt: Date(timeIntervalSince1970: 100))
+    let result = EntrySortOption.updatedAt.sorted([nonFavorite, favorite])
+    XCTAssertEqual(result.map(\.id), ["fav", "nonfav"])
+  }
+
+  // MARK: - stability (T4)
+
+  func testStabilityPreservesInputOrderForEqualTitles() {
+    let first = s("first", title: "Same")
+    let second = s("second", title: "Same")
+    let third = s("third", title: "Same")
+    let result = EntrySortOption.title.sorted([first, second, third])
+    XCTAssertEqual(result.map(\.id), ["first", "second", "third"])
+  }
+
+  func testStabilityPreservesInputOrderForBothNilDates() {
+    let first = s("first", createdAt: nil)
+    let second = s("second", createdAt: nil)
+    let third = s("third", createdAt: nil)
+    let result = EntrySortOption.createdAt.sorted([first, second, third])
+    XCTAssertEqual(result.map(\.id), ["first", "second", "third"])
+  }
+
+  func testStabilityPreservesInputOrderForBothEmptyHosts() {
+    let first = s("first", urlHost: "")
+    let second = s("second", urlHost: "")
+    let result = EntrySortOption.website.sorted([first, second])
+    XCTAssertEqual(result.map(\.id), ["first", "second"])
+  }
+}

--- a/ios/PasswdSSOTests/VaultFilterTests.swift
+++ b/ios/PasswdSSOTests/VaultFilterTests.swift
@@ -57,15 +57,17 @@ final class VaultFilterTests: XCTestCase {
 
   func testChangingSortOptionReordersFilteredSummaries() {
     let vm = VaultViewModel(settings: AppSettingsStore(defaults: makeSuiteDefaults()))
+    // Distinct hosts so .website produces a genuine host-based reorder that is
+    // the INVERSE of the title order — proving the VM applies the website key,
+    // not merely preserving input order via stability.
     vm.injectSummaries([
-      s("b", title: "Beta"),
-      s("a", title: "Alpha"),
+      s("b", title: "Beta", urlHost: "alpha.com"),
+      s("a", title: "Alpha", urlHost: "zeta.com"),
     ])
     vm.sortOption = .title
-    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["a", "b"])
+    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["a", "b"])  // Alpha < Beta
 
     vm.sortOption = .website
-    // Both entries default to urlHost "x.com" (equal keys) → stable, input order.
-    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["b", "a"])
+    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["b", "a"])  // alpha.com < zeta.com
   }
 }

--- a/ios/PasswdSSOTests/VaultFilterTests.swift
+++ b/ios/PasswdSSOTests/VaultFilterTests.swift
@@ -6,7 +6,9 @@ import Shared
 /// flat search list) keeps today's behavior after the landing refactor.
 @MainActor
 final class VaultFilterTests: XCTestCase {
-  private func s(_ id: String, title: String, username: String = "u", urlHost: String = "x.com") -> VaultEntrySummary {
+  private func s(
+    _ id: String, title: String, username: String = "u", urlHost: String = "x.com"
+  ) -> VaultEntrySummary {
     VaultEntrySummary(id: id, title: title, username: username, urlHost: urlHost)
   }
 
@@ -28,5 +30,42 @@ final class VaultFilterTests: XCTestCase {
     XCTAssertEqual(vm.filteredSummaries.map(\.id), ["b"])
     vm.searchQuery = "gitlab.com"
     XCTAssertEqual(vm.filteredSummaries.map(\.id), ["b"])
+  }
+
+  // MARK: - T-VM-SORT (sortOption applied as filteredSummaries' final step)
+
+  private func makeSuiteDefaults() -> UserDefaults {
+    let suiteName = "test.vaultfilter.\(UUID().uuidString)"
+    return UserDefaults(suiteName: suiteName)!
+  }
+
+  func testDefaultSortIsTitle() {
+    let vm = VaultViewModel(settings: AppSettingsStore(defaults: makeSuiteDefaults()))
+    XCTAssertEqual(vm.sortOption, .title)
+  }
+
+  func testFilteredSummariesAppliesSortAfterScopeAndSearch() {
+    let vm = VaultViewModel(settings: AppSettingsStore(defaults: makeSuiteDefaults()))
+    vm.injectSummaries([
+      s("b", title: "Beta", username: "bob", urlHost: "beta.com"),
+      s("a", title: "Alpha", username: "alice", urlHost: "alpha.com"),
+    ])
+    vm.searchQuery = "" // no search filter, but sort must still apply
+    vm.sortOption = .title
+    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["a", "b"])
+  }
+
+  func testChangingSortOptionReordersFilteredSummaries() {
+    let vm = VaultViewModel(settings: AppSettingsStore(defaults: makeSuiteDefaults()))
+    vm.injectSummaries([
+      s("b", title: "Beta"),
+      s("a", title: "Alpha"),
+    ])
+    vm.sortOption = .title
+    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["a", "b"])
+
+    vm.sortOption = .website
+    // Both entries default to urlHost "x.com" (equal keys) → stable, input order.
+    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["b", "a"])
   }
 }

--- a/ios/PasswdSSOTests/VaultFilterTests.swift
+++ b/ios/PasswdSSOTests/VaultFilterTests.swift
@@ -70,4 +70,24 @@ final class VaultFilterTests: XCTestCase {
     vm.sortOption = .website
     XCTAssertEqual(vm.filteredSummaries.map(\.id), ["b", "a"])  // alpha.com < zeta.com
   }
+
+  func testChangingSortDirectionReordersFilteredSummaries() {
+    let vm = VaultViewModel(settings: AppSettingsStore(defaults: makeSuiteDefaults()))
+    vm.injectSummaries([
+      s("b", title: "Beta"),
+      s("a", title: "Alpha"),
+    ])
+    vm.sortOption = .title
+    vm.sortDirection = .ascending
+    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["a", "b"])
+
+    vm.sortDirection = .descending
+    XCTAssertEqual(vm.filteredSummaries.map(\.id), ["b", "a"])
+  }
+
+  func testDefaultSortDirectionFollowsKey() {
+    let vm = VaultViewModel(settings: AppSettingsStore(defaults: makeSuiteDefaults()))
+    // Default key .title → natural ascending direction.
+    XCTAssertEqual(vm.sortDirection, .ascending)
+  }
 }

--- a/ios/PasswdSSOTests/VaultViewModelTests.swift
+++ b/ios/PasswdSSOTests/VaultViewModelTests.swift
@@ -566,6 +566,35 @@ final class VaultViewModelTests: XCTestCase {
       "Personal entry must still appear in allSummaries")
   }
 
+  // MARK: - T-DATE-E2E: decryptOverview threads CacheEntry dates into the summary
+
+  /// Proves `decryptOverview` actually passes `entry.createdAt`/`updatedAt` to
+  /// `EntryBlobDecoder.summary` (not merely that the two seams work in
+  /// isolation) — runs the real loadFromCache path over a seeded CacheEntry.
+  func testLoadFromCache_threadsCreatedAtAndUpdatedAtIntoSummary() async throws {
+    let blobJSON = #"{"title":"T","username":"u","password":"p","url":"","notes":"","tags":[]}"#
+    let overviewJSON = #"{"title":"T","username":"u","urlHost":"example.com"}"#
+    let expectedCreated = Date(timeIntervalSince1970: 1_700_000_000)
+    let expectedUpdated = Date(timeIntervalSince1970: 1_800_000_000)
+
+    let vm = await VaultViewModel()
+    let localVaultKey = vaultKey
+    let localUserId = userId
+    let seedData = try makeCacheData(
+      entryId: entryId, userId: userId, vaultKey: vaultKey,
+      blobJSON: blobJSON, overviewJSON: overviewJSON, aadVersion: 1,
+      createdAt: expectedCreated, updatedAt: expectedUpdated
+    )
+    await MainActor.run {
+      vm.loadFromCache(cacheData: seedData, vaultKey: localVaultKey, userId: localUserId)
+    }
+
+    let first = await MainActor.run { vm.allSummaries.first }
+    let summary = try XCTUnwrap(first)
+    XCTAssertEqual(summary.createdAt, expectedCreated)
+    XCTAssertEqual(summary.updatedAt, expectedUpdated)
+  }
+
   // MARK: - VaultScope filtering
 
   func testLoadFromCache_personalScopeFiltersToTeamIdNil() async throws {
@@ -852,7 +881,9 @@ func makeCacheData(
   vaultKey: SymmetricKey,
   blobJSON: String,
   overviewJSON: String,
-  aadVersion: Int
+  aadVersion: Int,
+  createdAt: Date? = nil,
+  updatedAt: Date? = nil
 ) throws -> CacheData {
   let blobData = Data(blobJSON.utf8)
   let overviewData = Data(overviewJSON.utf8)
@@ -877,7 +908,9 @@ func makeCacheData(
     aadVersion: aadVersion,
     keyVersion: 1,
     encryptedBlob: encBlob,
-    encryptedOverview: encOverview
+    encryptedOverview: encOverview,
+    createdAt: createdAt,
+    updatedAt: updatedAt
   )
 
   let entriesData = try JSONEncoder().encode([entry])

--- a/ios/PasswdSSOUITests/PasswdSSOUITests.swift
+++ b/ios/PasswdSSOUITests/PasswdSSOUITests.swift
@@ -38,4 +38,43 @@ final class PasswdSSOUITests: XCTestCase {
       XCTAssertTrue(signInButton.isHittable, "Sign-in primary button is not hittable")
     }
   }
+
+  /// Drives Demo Mode → a category screen → confirms the new bottom-bar sort
+  /// control is present and hittable. Verifies the search+sort UI wiring
+  /// end-to-end (unit tests cover the comparator; this covers the SwiftUI
+  /// surface). Captures a screenshot attachment for visual review.
+  func testCategoryScreenHasSortControl() {
+    let app = XCUIApplication()
+    app.launch()
+    XCTAssertTrue(app.staticTexts["passwd-sso"].waitForExistence(timeout: 5))
+
+    // Enter Demo Mode (available from either the server-setup or sign-in screen).
+    let demoFromSetup = app.buttons["server-setup-demo-button"]
+    let demoFromSignIn = app.buttons["sign-in-demo-button"]
+    if demoFromSetup.waitForExistence(timeout: 2) {
+      demoFromSetup.tap()
+    } else if demoFromSignIn.waitForExistence(timeout: 2) {
+      demoFromSignIn.tap()
+    } else {
+      XCTFail("No demo entry point found")
+      return
+    }
+
+    // The demo landing shows category cards; tap the first tappable card to push
+    // the category list (which owns the new sort bottom bar).
+    let card = app.buttons.element(boundBy: 1)
+    XCTAssertTrue(card.waitForExistence(timeout: 5), "No category card to tap")
+    card.tap()
+
+    // The sort control must exist on the category screen. Matched by a stable
+    // identifier (the visible label is localized, e.g. "並び替え" in Japanese).
+    let sortButton = app.buttons["category-sort-button"]
+    XCTAssertTrue(sortButton.waitForExistence(timeout: 5), "Sort control missing on category screen")
+    XCTAssertTrue(sortButton.isHittable, "Sort control not hittable")
+
+    let shot = XCTAttachment(screenshot: app.screenshot())
+    shot.name = "category-screen-with-sort-bar"
+    shot.lifetime = .keepAlways
+    add(shot)
+  }
 }

--- a/ios/Shared/AppVersion.swift
+++ b/ios/Shared/AppVersion.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// App marketing-version display for the Settings screen (FR5).
+///
+/// The testable seam is the injectable `marketing`/`build` STRING parameters,
+/// NOT a `Bundle` (T1): `Bundle` has no public initializer accepting an
+/// arbitrary `infoDictionary`, so a synthetic `Bundle` with known version keys
+/// cannot be built in XCTest. The default arguments read the real
+/// `Bundle.main` Info.plist in production; tests pass explicit strings.
+public struct AppVersion {
+  /// Defaults read the real Bundle.main Info.plist; tests pass explicit values.
+  public static func display(
+    marketing: String? = infoValue("CFBundleShortVersionString"),
+    build: String? = infoValue("CFBundleVersion")
+  ) -> String {
+    switch (marketing, build) {
+    case let (m?, b?): return "\(m) (\(b))"
+    case let (m?, nil): return m
+    case let (nil, b?): return b
+    case (nil, nil): return "—"
+    }
+  }
+
+  public static func infoValue(_ key: String) -> String? {
+    Bundle.main.object(forInfoDictionaryKey: key) as? String
+  }
+}

--- a/ios/Shared/AutoFill/CredentialResolver.swift
+++ b/ios/Shared/AutoFill/CredentialResolver.swift
@@ -780,6 +780,11 @@ public struct CacheEntry: Codable, Sendable {
   /// nil-tolerant: caches written before this field existed, and team rows,
   /// decode to nil → treated as not-favorite.
   public let isFavorite: Bool?
+  /// Server-side creation/update timestamps (non-secret metadata, like
+  /// `entryType`/`isFavorite`). Optional/nil-tolerant: caches written before
+  /// this field existed, and all team rows (SC3), decode to nil.
+  public let createdAt: Date?
+  public let updatedAt: Date?
 
   public init(
     id: String,
@@ -792,7 +797,9 @@ public struct CacheEntry: Codable, Sendable {
     encryptedBlob: EncryptedData,
     encryptedOverview: EncryptedData,
     entryType: String? = nil,
-    isFavorite: Bool? = nil
+    isFavorite: Bool? = nil,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil
   ) {
     self.id = id
     self.teamId = teamId
@@ -805,5 +812,7 @@ public struct CacheEntry: Codable, Sendable {
     self.encryptedOverview = encryptedOverview
     self.entryType = entryType
     self.isFavorite = isFavorite
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
   }
 }

--- a/ios/Shared/ISO8601.swift
+++ b/ios/Shared/ISO8601.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Server emits `Date.toISOString()` (fractional seconds); a plain
+/// ISO8601DateFormatter does NOT parse those, so try both variants. Never
+/// throws — an unparseable string returns nil so a bad date can never break a
+/// decode/sync pipeline.
+public func parseISO8601(_ string: String) -> Date? {
+  let fractional = ISO8601DateFormatter()
+  fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+  if let date = fractional.date(from: string) { return date }
+  return ISO8601DateFormatter().date(from: string)
+}

--- a/ios/Shared/Models/EntryBlobDecoder.swift
+++ b/ios/Shared/Models/EntryBlobDecoder.swift
@@ -250,7 +250,9 @@ public enum EntryBlobDecoder {
     entryId: String,
     teamId: String?,
     entryType: String? = nil,
-    isFavorite: Bool = false
+    isFavorite: Bool = false,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil
   ) -> VaultEntrySummary? {
     guard let p = try? JSONDecoder().decode(OverviewBlobPayload.self, from: plaintext) else {
       return nil
@@ -271,7 +273,11 @@ public enum EntryBlobDecoder {
       relyingPartyId: p.relyingPartyId,
       credentialId: p.credentialId,
       entryType: entryType,
-      isFavorite: isFavorite
+      isFavorite: isFavorite,
+      // createdAt/updatedAt are cache-row metadata (like entryType/isFavorite),
+      // NOT read from the overview blob — the blob never carries them.
+      createdAt: createdAt,
+      updatedAt: updatedAt
     )
   }
 

--- a/ios/Shared/Models/EntrySortOption.swift
+++ b/ios/Shared/Models/EntrySortOption.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Sort key for the vault list. Mirrors web `entry-sort.ts` (`title`/
+/// `createdAt`/`updatedAt`); `website` is iOS-only (no web reference — see
+/// plan F1). String-backed for persistence in `AppSettingsStore`.
+public enum EntrySortOption: String, CaseIterable, Sendable {
+  case title
+  case createdAt
+  case updatedAt
+  case website
+}
+
+extension EntrySortOption {
+  /// Favorites-first, then the selected key. Mirrors web
+  /// `compareEntriesWithFavorite`: favorites always precede non-favorites,
+  /// regardless of key, applied BEFORE the per-key comparison.
+  ///
+  /// - title/website: ascending, case-insensitive (`localizedCaseInsensitiveCompare`).
+  /// - createdAt/updatedAt: descending (newest first); nil sorts last.
+  /// - website: empty (`""`) urlHost sorts last (never nil — see VaultEntrySummary).
+  ///
+  /// Swift's `sorted(by:)` is not guaranteed stable, so ties (including the
+  /// nil/nil and ""/""cases) are broken by the original index to preserve
+  /// input order.
+  public func sorted(_ summaries: [VaultEntrySummary]) -> [VaultEntrySummary] {
+    let indexed = Array(summaries.enumerated())
+    let result = indexed.sorted { lhs, rhs in
+      let (li, l) = lhs
+      let (ri, r) = rhs
+      if l.isFavorite != r.isFavorite {
+        return l.isFavorite
+      }
+      switch keyCompare(l, r) {
+      case .orderedAscending: return true
+      case .orderedDescending: return false
+      case .orderedSame: return li < ri
+      }
+    }
+    return result.map(\.1)
+  }
+
+  private func keyCompare(_ l: VaultEntrySummary, _ r: VaultEntrySummary) -> ComparisonResult {
+    switch self {
+    case .title:
+      return l.title.localizedCaseInsensitiveCompare(r.title)
+    case .website:
+      return compareSortLast(l.urlHost, r.urlHost, isEmpty: { $0.isEmpty }) {
+        $0.localizedCaseInsensitiveCompare($1)
+      }
+    case .createdAt:
+      return compareDateDescending(l.createdAt, r.createdAt)
+    case .updatedAt:
+      return compareDateDescending(l.updatedAt, r.updatedAt)
+    }
+  }
+
+  /// Descending date compare (newest first); nil sorts after all non-nil dates.
+  private func compareDateDescending(_ l: Date?, _ r: Date?) -> ComparisonResult {
+    switch (l, r) {
+    case (nil, nil): return .orderedSame
+    case (nil, _): return .orderedDescending  // l sorts after r
+    case (_, nil): return .orderedAscending   // l sorts before r
+    case let (lv?, rv?):
+      if lv == rv { return .orderedSame }
+      return lv > rv ? .orderedAscending : .orderedDescending
+    }
+  }
+
+  /// Ascending compare where the "empty" sentinel sorts last (used for
+  /// website's `""` urlHost, the non-optional analogue of nil-last dates).
+  private func compareSortLast<T>(
+    _ l: T, _ r: T, isEmpty: (T) -> Bool, compare: (T, T) -> ComparisonResult
+  ) -> ComparisonResult {
+    switch (isEmpty(l), isEmpty(r)) {
+    case (true, true): return .orderedSame
+    case (true, false): return .orderedDescending
+    case (false, true): return .orderedAscending
+    case (false, false): return compare(l, r)
+    }
+  }
+}

--- a/ios/Shared/Models/EntrySortOption.swift
+++ b/ios/Shared/Models/EntrySortOption.swift
@@ -10,19 +10,40 @@ public enum EntrySortOption: String, CaseIterable, Sendable {
   case website
 }
 
+/// Sort direction, independent of the key (matches the iOS Passwords app's
+/// 昇順/降順 toggle). String-backed for persistence.
+public enum EntrySortDirection: String, CaseIterable, Sendable {
+  case ascending
+  case descending
+}
+
 extension EntrySortOption {
-  /// Favorites-first, then the selected key. Mirrors web
-  /// `compareEntriesWithFavorite`: favorites always precede non-favorites,
-  /// regardless of key, applied BEFORE the per-key comparison.
+  /// The natural direction for this key when the user has expressed no
+  /// preference. Titles/websites read best A→Z (ascending); dates read best
+  /// newest-first (descending). Used only as the persisted default.
+  public var defaultDirection: EntrySortDirection {
+    switch self {
+    case .title, .website: return .ascending
+    case .createdAt, .updatedAt: return .descending
+    }
+  }
+}
+
+extension EntrySortOption {
+  /// Favorites-first, then the selected key in the given direction.
   ///
-  /// - title/website: ascending, case-insensitive (`localizedCaseInsensitiveCompare`).
-  /// - createdAt/updatedAt: descending (newest first); nil sorts last.
-  /// - website: empty (`""`) urlHost sorts last (never nil — see VaultEntrySummary).
+  /// Invariants (independent of `direction`):
+  /// - favorites always precede non-favorites (applied BEFORE the per-key compare);
+  /// - entries with no value on the key (nil date, empty `""` urlHost) always
+  ///   sort LAST — they never bubble to the top when the direction flips;
+  /// - ties are broken by original index, so the sort is STABLE (Swift's
+  ///   `sorted(by:)` is not guaranteed stable).
   ///
-  /// Swift's `sorted(by:)` is not guaranteed stable, so ties (including the
-  /// nil/nil and ""/""cases) are broken by the original index to preserve
-  /// input order.
-  public func sorted(_ summaries: [VaultEntrySummary]) -> [VaultEntrySummary] {
+  /// `direction` flips only the ordering AMONG populated values.
+  public func sorted(
+    _ summaries: [VaultEntrySummary],
+    direction: EntrySortDirection
+  ) -> [VaultEntrySummary] {
     let indexed = Array(summaries.enumerated())
     let result = indexed.sorted { lhs, rhs in
       let (li, l) = lhs
@@ -30,7 +51,7 @@ extension EntrySortOption {
       if l.isFavorite != r.isFavorite {
         return l.isFavorite
       }
-      switch keyCompare(l, r) {
+      switch keyCompare(l, r, direction: direction) {
       case .orderedAscending: return true
       case .orderedDescending: return false
       case .orderedSame: return li < ri
@@ -39,35 +60,54 @@ extension EntrySortOption {
     return result.map(\.1)
   }
 
-  private func keyCompare(_ l: VaultEntrySummary, _ r: VaultEntrySummary) -> ComparisonResult {
+  private func keyCompare(
+    _ l: VaultEntrySummary, _ r: VaultEntrySummary, direction: EntrySortDirection
+  ) -> ComparisonResult {
     switch self {
     case .title:
-      return l.title.localizedCaseInsensitiveCompare(r.title)
+      return applyDirection(l.title.localizedCaseInsensitiveCompare(r.title), direction)
     case .website:
       return compareSortLast(l.urlHost, r.urlHost, isEmpty: { $0.isEmpty }) {
-        $0.localizedCaseInsensitiveCompare($1)
+        applyDirection($0.localizedCaseInsensitiveCompare($1), direction)
       }
     case .createdAt:
-      return compareDateDescending(l.createdAt, r.createdAt)
+      return compareDate(l.createdAt, r.createdAt, direction: direction)
     case .updatedAt:
-      return compareDateDescending(l.updatedAt, r.updatedAt)
+      return compareDate(l.updatedAt, r.updatedAt, direction: direction)
     }
   }
 
-  /// Descending date compare (newest first); nil sorts after all non-nil dates.
-  private func compareDateDescending(_ l: Date?, _ r: Date?) -> ComparisonResult {
+  /// Flip an ascending-by-value comparison to descending when requested.
+  private func applyDirection(
+    _ result: ComparisonResult, _ direction: EntrySortDirection
+  ) -> ComparisonResult {
+    guard direction == .descending else { return result }
+    switch result {
+    case .orderedAscending: return .orderedDescending
+    case .orderedDescending: return .orderedAscending
+    case .orderedSame: return .orderedSame
+    }
+  }
+
+  /// Date compare honoring `direction`; nil sorts last regardless of direction.
+  private func compareDate(
+    _ l: Date?, _ r: Date?, direction: EntrySortDirection
+  ) -> ComparisonResult {
     switch (l, r) {
     case (nil, nil): return .orderedSame
-    case (nil, _): return .orderedDescending  // l sorts after r
-    case (_, nil): return .orderedAscending   // l sorts before r
+    case (nil, _): return .orderedDescending  // l (nil) sorts after r
+    case (_, nil): return .orderedAscending   // l sorts before r (nil)
     case let (lv?, rv?):
       if lv == rv { return .orderedSame }
-      return lv > rv ? .orderedAscending : .orderedDescending
+      // Ascending = oldest first; direction flips to newest first.
+      let ascending: ComparisonResult = lv < rv ? .orderedAscending : .orderedDescending
+      return applyDirection(ascending, direction)
     }
   }
 
-  /// Ascending compare where the "empty" sentinel sorts last (used for
-  /// website's `""` urlHost, the non-optional analogue of nil-last dates).
+  /// Compare where the "empty" sentinel always sorts last (used for website's
+  /// `""` urlHost), independent of `direction` — the populated-value compare
+  /// (passed in) already carries the direction.
   private func compareSortLast<T>(
     _ l: T, _ r: T, isEmpty: (T) -> Bool, compare: (T, T) -> ComparisonResult
   ) -> ComparisonResult {

--- a/ios/Shared/Models/VaultEntrySummary.swift
+++ b/ios/Shared/Models/VaultEntrySummary.swift
@@ -33,6 +33,11 @@ public struct VaultEntrySummary: Codable, Sendable, Equatable, Identifiable {
   public let entryType: String?
   /// Server favorite flag (cache-row metadata, not in the encrypted blob).
   public let isFavorite: Bool
+  /// Server-side creation/update timestamps (cache-row metadata, not in the
+  /// encrypted blob — same pattern as entryType/isFavorite). nil for team/
+  /// legacy entries (see EncryptedEntry/CacheEntry); drives date-key sort.
+  public let createdAt: Date?
+  public let updatedAt: Date?
 
   public init(
     id: String,
@@ -49,7 +54,9 @@ public struct VaultEntrySummary: Codable, Sendable, Equatable, Identifiable {
     relyingPartyId: String? = nil,
     credentialId: String? = nil,
     entryType: String? = nil,
-    isFavorite: Bool = false
+    isFavorite: Bool = false,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil
   ) {
     self.id = id
     self.title = title
@@ -66,5 +73,7 @@ public struct VaultEntrySummary: Codable, Sendable, Equatable, Identifiable {
     self.credentialId = credentialId
     self.entryType = entryType
     self.isFavorite = isFavorite
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
   }
 }

--- a/ios/Shared/Storage/AppSettingsStore.swift
+++ b/ios/Shared/Storage/AppSettingsStore.swift
@@ -69,6 +69,7 @@ public struct AppSettingsStore {
     static let fetchFaviconsCached = "fetchFaviconsCached"
     static let autoCopyCustomField = "autoCopyCustomField"
     static let entrySortOption = "entrySortOption"
+    static let entrySortDirection = "entrySortDirection"
   }
 
   /// Public key constant for `fetchFaviconsCached` so tests (which import Shared
@@ -76,6 +77,7 @@ public struct AppSettingsStore {
   public static let fetchFaviconsCachedKey = Key.fetchFaviconsCached
   public static let autoCopyCustomFieldKey = Key.autoCopyCustomField
   public static let entrySortOptionKey = Key.entrySortOption
+  public static let entrySortDirectionKey = Key.entrySortDirection
 
   private let defaults: UserDefaults
 
@@ -230,6 +232,22 @@ public struct AppSettingsStore {
     }
     nonmutating set {
       defaults.set(newValue.rawValue, forKey: Key.entrySortOption)
+    }
+  }
+
+  /// Selected sort direction, persisted across launches. When never set, falls
+  /// back to the current key's natural direction (`title`/`website` ascending,
+  /// dates descending) so the first display reads naturally. Garbage → same
+  /// fallback (fail-closed).
+  public var entrySortDirection: EntrySortDirection {
+    get {
+      guard let raw = defaults.string(forKey: Key.entrySortDirection),
+        let direction = EntrySortDirection(rawValue: raw)
+      else { return entrySortOption.defaultDirection }
+      return direction
+    }
+    nonmutating set {
+      defaults.set(newValue.rawValue, forKey: Key.entrySortDirection)
     }
   }
 

--- a/ios/Shared/Storage/AppSettingsStore.swift
+++ b/ios/Shared/Storage/AppSettingsStore.swift
@@ -68,12 +68,14 @@ public struct AppSettingsStore {
     static let appLanguage = "appLanguage"
     static let fetchFaviconsCached = "fetchFaviconsCached"
     static let autoCopyCustomField = "autoCopyCustomField"
+    static let entrySortOption = "entrySortOption"
   }
 
   /// Public key constant for `fetchFaviconsCached` so tests (which import Shared
   /// without @testable) can verify the raw UserDefaults key (T5/T11).
   public static let fetchFaviconsCachedKey = Key.fetchFaviconsCached
   public static let autoCopyCustomFieldKey = Key.autoCopyCustomField
+  public static let entrySortOptionKey = Key.entrySortOption
 
   private let defaults: UserDefaults
 
@@ -213,6 +215,22 @@ public struct AppSettingsStore {
   public var autoCopyCustomField: Bool {
     get { defaults.bool(forKey: Key.autoCopyCustomField) }
     nonmutating set { defaults.set(newValue, forKey: Key.autoCopyCustomField) }
+  }
+
+  /// Selected vault list sort key, persisted across launches (FR3). Absent/
+  /// garbage → `.title` (fail-closed): it is the one key with data present on
+  /// every entry — date keys are nil for team/legacy entries until backfilled
+  /// by a sync, so defaulting to a date key would look unsorted on first launch.
+  public var entrySortOption: EntrySortOption {
+    get {
+      guard let raw = defaults.string(forKey: Key.entrySortOption),
+        let option = EntrySortOption(rawValue: raw)
+      else { return .title }
+      return option
+    }
+    nonmutating set {
+      defaults.set(newValue.rawValue, forKey: Key.entrySortOption)
+    }
   }
 
   /// Apply the persisted language to the process's string lookup via


### PR DESCRIPTION
## Summary

Three iOS improvements, developed plan-first with a three-perspective review (functionality / security / testing) recorded under `docs/archive/review/`:

1. **Search on every category screen** — search was only enterable on the top screen; each category screen (Logins, Passkeys, "All", tags, …) now has its own search field, scoped within the category.
2. **Sort with an ascending/descending toggle** — a sort control on the category screens' bottom bar (left of the search field, like the iOS Passwords app) offering **Title / Created date / Updated date / Website** plus a **降順/昇順 (descending/ascending)** toggle. Key + direction are persisted across launches.
3. **App version in Settings** — the marketing version + build number are shown in a Settings row.

To support date sorting, `createdAt`/`updatedAt` are plumbed through the sync pipeline (`EncryptedEntry → CacheEntry → VaultEntrySummary`) as **non-secret cache-row metadata** — never inside the encrypted blob, mirroring how `entryType`/`isFavorite` are already carried. New fields are optional for backward-compatible cache decoding.

## UI design

- **Top screen**: simple search only, no sort (unchanged behavior).
- **Category screens** (incl. "All"): a self-built bottom bar (search field + a leading ↑↓ sort menu). This replaces the system `.searchable` on those screens because iOS 17/18 has no public API to place a control on the same row as the system search field (that is iOS 26-only); the self-built bar works identically on all supported versions (deployment target iOS 17).
- Sort semantics mirror the web app for the three shared keys; `website` is an iOS-only key. Favorites always sort first; nil dates / empty hosts always sort last regardless of direction; the sort is stable (index tie-break).

## Key changes

- `EntrySortOption` + `EntrySortDirection` (Shared) with a stable `sorted(_:direction:)` comparator.
- `createdAt`/`updatedAt` on `VaultEntrySummary` / `CacheEntry` / `EncryptedEntry`, converted from ISO-8601 via a relocated shared `parseISO8601` (reused, not reimplemented).
- Sort key + direction persisted in `AppSettingsStore` (fail-closed; direction defaults to the key's natural direction).
- `AppVersion` version-string provider with a testable string seam (not `Bundle` injection).
- Demo Mode uses an ephemeral settings suite so browsing never touches the real persisted sort preference (isolation contract preserved, with a regression test).

## Testing

- 740 unit tests + 3 UI tests pass (`xcodebuild test`, iOS 17.2 simulator).
- New coverage: sort comparator (favorites-first per key, nil/empty-last both directions, stability), direction persistence, ISO date decode (fractional / non-fractional / garbage→nil), end-to-end date threading through `decryptOverview`, version formatting, demo isolation, and a UI test driving Demo Mode → category → sort control (with a screenshot attachment).
- Localization: `en` + `ja` for all new strings (並び替え / 昇順 / 降順 / 作成日 / 更新日 / Webサイト / バージョン).

🤖 Generated with [Claude Code](https://claude.com/claude-code)