### PR TITLE
fix: keep touched custom fields on save, drop only untouched rows

### DIFF
--- a/docs/archive/review/fix-custom-field-label-optional-code-review.md
+++ b/docs/archive/review/fix-custom-field-label-optional-code-review.md
@@ -1,0 +1,46 @@
+# Code Review: fix-custom-field-label-optional
+Date: 2026-07-07
+Review round: 1 (converged — zero findings)
+
+## Changes from Previous Round
+Initial review of the implemented fix (commit f6a85fa1).
+
+## Functionality Findings
+**No findings.** The implemented predicate at `src/lib/vault/entry-form-helpers.ts:38-42` is byte-for-byte the plan's C1 "Resolved rule" and satisfies INV-C1.1–C1.7. Boolean branch (`field.value === "true"`) is safe: the UI writes boolean values only via `String(checked)` (`entry-custom-fields-totp-section.tsx:140`), so the domain is strictly `{"true","false"}`. Both callers still pass `EntryCustomField[]` (required `type`); the `type?` widening does not compile-break (`tsc --noEmit` clean on touched files). `parseUrlHost || null` change inert at all three consumers. No downstream code assumes labelled-only custom fields (`map-detail-fields.ts:37` passes through verbatim). Fix reaches both the reported bug (value-only) and the mirror (label-only) on both personal and team login paths.
+
+## Security Findings
+**No findings.** The `parseUrlHost` `|| null` change is a net security improvement (empty-string hosts from `javascript:`/`data:`/`mailto:` no longer reach `additionalUrlHosts`). `isSafeHref` gate is label-independent (`login-section.tsx:130-141`, `share-entry-view.tsx:152-169`) — label-less dangerous-scheme URL fields still render as inert text. Share plaintext path (`shareDataSchema`) already tolerated empty labels; the new client behavior is consistent, no bypass. No length-cap/DoS bypass (opaque blob capped at `CIPHERTEXT_MAX`). No auth/authz path touched. Escalation: none.
+
+## Testing Findings
+**No findings.** All 12 C1 acceptance rows have tests. The label-less URL repro test is a genuine failing-first regression guard (verified: old `label.trim() && value.trim()` predicate returns `[]` for the repro input). `personal-entry-payload.test.ts` asserts length 2 + the `additionalUrlHosts` side-effect with a host distinct from the main URL host (non-vacuous). `team-entry-payload.test.ts` rewritten to `.toEqual` with an untouched-row drop proof. `parseUrlHost` C2 tests cover dangerous schemes → null. No old-behavior assertions left behind. Detail-render test acceptably deferred (optional per plan T7).
+
+## Adjacent Findings
+- [Testing, non-blocking] An optional lightweight `login-section` render test of a label-less URL field would close the only untested link (detail-render tolerance), but is not required — the render path was verified by inspection and the fix is pure client logic fully unit-covered.
+
+## Quality Warnings
+None.
+
+## Recurring Issue Check
+### Functionality expert
+- R42 (member-set completeness): PASS — re-grepped `filterNonEmptyCustomFields`; 2 callers (personal + team), import path correctly excluded, no raw-SQL/aliased writers. Centralized-helper fix covers full set.
+- R1-R41: N/A (pure-logic client-side change; no migrations, i18n strings, routes, tokens).
+
+### Security expert
+- R1 (injection): clear (share `type` enum-validated; no SQL/command surface).
+- R5 (XSS): clear (`isSafeHref` allowlist gate label-independent).
+- R6 (SSRF): clear/improved (empty hosts no longer reach `additionalUrlHosts`; favicon proxy retains `normalizeFaviconHost`).
+- R42: N/A to a security defect; `|| null` applied at the single primitive shared by both call sites.
+- RS1-RS5: no new secret-response / no-store / plaintext-leak / auth-enumeration surface.
+
+### Testing expert
+- RT4 (regression-fails-before-fix): PASS (repro test provably red against old predicate).
+- RT6 (write-read / vacuous-assertion): PASS (`additionalUrlHosts` test uses a distinct host, avoiding the dedup-vacuity trap).
+- R42 (test member-set): PASS (both caller tests updated; import path excluded; every `CUSTOM_FIELD_TYPE` value appears ≥ once).
+
+## Environment Verification Report
+- C1 (keep-if-touched predicate): `verified-local` — `npx vitest run` (12033 passed, 0 failed); the repro row confirmed failing-first against the old predicate.
+- C2 (parseUrlHost empty→null): `verified-local` — dangerous-scheme unit tests pass; `npx next build` succeeds.
+No Phase-1 `Verification environment constraints` entries were `blocked-deferred` (all paths were `verifiable-local`).
+
+## Resolution Status
+All three experts returned **No findings** in Round 1. Phase 1's F1/F2/F3/F4/S1/T1-T7 findings were all resolved in the plan + implementation before Phase 3 (see `-review.md` Resolution Status). No new findings to fix. Review converged in one round.

--- a/docs/archive/review/fix-custom-field-label-optional-plan.md
+++ b/docs/archive/review/fix-custom-field-label-optional-plan.md
@@ -1,0 +1,178 @@
+# Plan: fix-custom-field-label-optional
+
+## Project context
+
+- **Type**: web app (Next.js 16 App Router, E2E-encrypted password manager)
+- **Test infrastructure**: unit + integration (`vitest`) + E2E (Playwright) + CI/CD
+- **Verification environment constraints**:
+  - `verifiable-local`: the payload-builder round-trip (build → JSON shape) is a pure function testable in `vitest` with no external service. This is the core of the fix and is fully verifiable locally.
+  - `verifiable-local`: detail-render + edit-rehydrate of a label-less custom field is testable via component render / `mapDecryptedBlobToDetailFields` unit test.
+  - `blocked-deferred`: none. The bug and fix are entirely client-side pure logic; no paid-tier API, no hardware attestation, no cross-tenant billing needed.
+
+## Objective
+
+**Re-scoped (essence shift, 2026-07-07):** the reported symptom was "a label-less URL custom field disappears on update," but the user identified the true problem as broader — **any content the user typed into a custom field is silently discarded on save** (no error, success toast shown). The objective is therefore: **never silently drop user-entered custom-field content on save.** A field is persisted whenever the user has entered anything into it (a label OR a value); only a completely **untouched** row (the phantom row created by clicking "Add field" and never filling it) is dropped.
+
+Original framing → new framing:
+- Was: "make the field label optional so a value-only field is kept."
+- Now: "keep any touched field; drop only untouched rows." This subsumes the original bug (value present, label absent → kept) AND the mirror case (label present, value absent → kept), eliminating silent data loss in both directions.
+
+## Root cause (verified)
+
+`filterNonEmptyCustomFields` in [entry-form-helpers.ts:26-30](../../../src/lib/vault/entry-form-helpers.ts#L26-L30):
+
+```ts
+export function filterNonEmptyCustomFields<T extends CustomFieldLike>(
+  fields: T[]
+): T[] {
+  return fields.filter((field) => field.label.trim() && field.value.trim());
+}
+```
+
+The predicate requires **both** `label.trim()` AND `value.trim()`. A URL (or any-type) field with a filled value but empty label fails the `label.trim()` conjunct → it is stripped from `validCustomFields` → never serialized into the encrypted blob → absent from detail and edit.
+
+**Verification performed:**
+- Full E2E crypto round-trip test (build payload → encrypt overview with AAD → decrypt via `decryptPersonalOverview` → sort/search) confirmed the *entry* does NOT disappear and nothing throws — the overview blob is `{"title":...,"urlHost":null,"tags":[],...}` and is benign. This ruled out the decrypt-skip / sort-crash hypotheses.
+- User confirmed the symptom is **the URL field itself is missing**, not the entry — consistent with the field being filtered out at save.
+- Confirmed the detail renderer [login-section.tsx:123-142](../../../src/components/passwords/detail/sections/login-section.tsx#L123-L142) renders a field with an empty `label` correctly (empty `<label>` + value/URL anchor), so a label-less field is fully displayable once persisted.
+
+## Member-set derivation (R42)
+
+The class is "every save path that drops user-entered custom-field data." Defining primitive: callers of `filterNonEmptyCustomFields`.
+
+```
+grep -rn "filterNonEmptyCustomFields" src/ | grep -iv test
+```
+
+Result (set A):
+- `src/lib/vault/personal-entry-payload.ts:47` — personal login payload builder
+- `src/lib/team/team-entry-payload.ts:182` — team login payload builder
+- `src/lib/vault/entry-form-helpers.ts:26` — the definition itself
+
+Both consumer call sites (personal + team) use the identical helper, so fixing the helper fixes both. **The fix is centralized in the helper** — no per-caller change needed. Indirect members checked:
+- Import path (`password-import-payload.ts:225`) writes `customFields` **without** this filter (it passes through parser output), so import is not affected and not in scope.
+- No raw-SQL or aliased-wrapper writers of custom fields exist.
+
+## Field-type analysis (all CUSTOM_FIELD_TYPE values considered)
+
+Per user instruction, the emptiness predicate must be correct for **every** type in [custom-field.ts](../../../src/lib/constants/vault/custom-field.ts):
+
+| Type | value domain | "has data" predicate | Notes |
+|------|-------------|---------------------|-------|
+| TEXT | free string | `value.trim() !== ""` | |
+| HIDDEN | free string (masked) | `value.trim() !== ""` | |
+| URL | free string | `value.trim() !== ""` | the reported case |
+| DATE | `"YYYY-MM-DD"` or `""` | `value.trim() !== ""` | UI clears value to `""` on type-switch |
+| MONTH_YEAR | `"YYYY-MM"` or `""` | `value.trim() !== ""` | same |
+| BOOLEAN | always `"true"` \| `"false"` | **special** — see below | UI defaults value to `"false"` on add / type-switch ([entry-custom-fields-totp-section.tsx:97-98](../../../src/components/passwords/entry/entry-custom-fields-totp-section.tsx#L97-L98)) |
+
+**"Touched" is the unifying predicate.** A row is *touched* if the user entered anything into it. Drop only *untouched* rows.
+
+**Non-boolean types** (text/hidden/url/date/monthYear): touched iff `label.trim() !== "" || value.trim() !== ""`. A value-only field (the reported bug) is kept; a label-only field (mirror case) is kept; a blank row is dropped.
+
+**BOOLEAN**: `value` is never empty (`"false"` by default), so `value.trim()` cannot distinguish touched from untouched. A boolean is *touched* iff the user labelled it OR turned it on: `label.trim() !== "" || value === "true"`. A freshly-added, unlabelled, still-`false` boolean is the untouched/noise case and is dropped. (A label-less boolean would render as an empty-caption "はい/いいえ" with no meaning — dropping the untouched one avoids that; a user who turns it on without a label has still expressed intent and it is kept, accepting the empty caption as the cost of not losing their input.)
+
+**Resolved rule (single predicate):**
+
+```
+keep(field) :=
+  type === BOOLEAN
+    ? (label.trim() !== "" || value === "true")     // boolean: touched = labelled or turned on
+    : (label.trim() !== "" || value.trim() !== "")  // others: touched = has label or value
+```
+
+This is the user-confirmed design (2026-07-07): "入力があれば保存、未入力行のみ破棄" — keep if there is any input, drop only untouched rows. It fixes the reported bug and eliminates silent data loss in both directions, while still discarding the phantom empty row from clicking "Add field".
+
+## Technical approach
+
+Replace the single-predicate filter with a type-aware predicate. The helper is generic over `CustomFieldLike` (`{label, value}`) but the type-aware rule needs `type`. Options:
+
+- **A (chosen)**: widen `CustomFieldLike` consumers to pass `type`. The two real callers already pass `EntryCustomField[]` (which has `type: CustomFieldType`). Extend `CustomFieldLike` to `{ label: string; value: string; type?: CustomFieldType }` and branch on `type`. When `type` is absent (defensive), fall back to the non-boolean rule (`value.trim() !== ""`).
+- B: keep `filterNonEmptyCustomFields` label-agnostic (`value.trim()` only) and handle boolean noise elsewhere. Rejected: scatters the rule.
+
+Chosen: A — one function, one rule, both callers fixed.
+
+## Contracts
+
+### C1 — `filterNonEmptyCustomFields` "keep-if-touched" predicate
+
+- **Signature**: `filterNonEmptyCustomFields<T extends CustomFieldLike>(fields: T[]): T[]` (unchanged). `CustomFieldLike` becomes `{ label: string; value: string; type?: CustomFieldType }`.
+- **Invariants** (app-enforced):
+  - INV-C1.1: a non-boolean field with non-empty `value.trim()` is **kept** regardless of `label`. (Fixes the reported bug.)
+  - INV-C1.2: a non-boolean field with non-empty `label.trim()` is **kept** regardless of `value`. (Fixes the mirror case — no silent loss of a label-only field.)
+  - INV-C1.3: a non-boolean field with empty `label.trim()` AND empty `value.trim()` is **dropped** (untouched phantom row).
+  - INV-C1.4: a boolean field is kept iff `label.trim() !== "" || value === "true"`; dropped iff empty label AND `value === "false"` (untouched).
+  - INV-C1.5: field ordering is preserved (filter, not reorder).
+  - INV-C1.6: no field object is mutated (pure filter; same references returned).
+  - INV-C1.7: when `type` is absent (defensive — no production caller omits it), fall back to the non-boolean branch.
+- **Forbidden patterns**:
+  - pattern: `field.label.trim() && field.value.trim()` — reason: the exact both-required (AND) predicate that caused the data loss must not remain.
+- **Acceptance criteria** (each is one unit test; every type appears ≥ once; whitespace + ordering covered):
+  - `[{label:"", value:"https://example.com", type:"url"}]` → **kept** ← reported repro; MUST fail against current predicate.
+  - `[{label:"note", value:"", type:"text"}]` → **kept** (label-only, mirror case).
+  - `[{label:"", value:"secret", type:"hidden"}]` → **kept** (HIDDEN with value).
+  - `[{label:"", value:"2026-01-01", type:"date"}]` → **kept**.
+  - `[{label:"", value:"2026-03", type:"monthYear"}]` → **kept**.
+  - `[{label:"", value:"", type:"text"}]` → **dropped** (untouched).
+  - `[{label:"   ", value:"   ", type:"text"}]` → **dropped** (whitespace-only both → untouched).
+  - `[{label:"", value:"   ", type:"text"}]` → **dropped** (whitespace-only value, no label; guards `value.trim()` vs `value !== ""`).
+  - `[{label:"", value:"true", type:"boolean"}]` → **kept** (turned on).
+  - `[{label:"", value:"false", type:"boolean"}]` → **dropped** (untouched boolean).
+  - `[{label:"agreed", value:"false", type:"boolean"}]` → **kept** (labelled).
+  - `[{label:"a", value:"1"}, {label:"", value:"", type:"text"}, {label:"", value:"2", type:"url"}]` → returns `[{label:"a",...}, {label:"",value:"2",...}]` in that ORDER (mixed keep/drop, survivor order asserted, INV-C1.5).
+- **Consumer-flow walkthrough**:
+  - Consumer `buildPersonalEntryPayload` (path: `src/lib/vault/personal-entry-payload.ts:47`) reads the returned `validCustomFields` and (a) serializes them into `fullBlob.customFields` when length>0, and (b) derives `additionalUrlHosts` from those whose `type==="url" && value`. After the fix, a label-less URL field is now in `validCustomFields`, so it correctly appears in the blob AND newly contributes to `additionalUrlHosts` (desirable — the host becomes searchable/iconable). No field the consumer reads is removed; only `type` is now consulted, which `EntryCustomField` already carries.
+  - Consumer `buildTeamEntryPayload` (path: `src/lib/team/team-entry-payload.ts:182`) reads `validFields` and serializes into `entryFields.customFields` when length>0. Same shape; `type` already present on `EntryCustomField`. Label-less value fields now persist identically to the personal path.
+  - Consumer (read-back) `mapDecryptedBlobToDetailFields` (path: `src/lib/vault/map-detail-fields.ts:37`) and `login-section.tsx` render each field's `{label, value, type}`; an empty `label` renders an empty `<label>` element — already tolerated. No consumer requires a non-empty label.
+
+### C2 — `parseUrlHost` returns `null` for empty hostname (security S1)
+
+- **Signature**: `parseUrlHost(value: string): string | null` (unchanged).
+- **Invariants**:
+  - INV-C2.1: a URL whose parsed `hostname` is `""` (e.g. `javascript:alert(1)`, `data:...`, `mailto:x`) returns `null`, not `""`.
+  - INV-C2.2: well-formed http(s) URLs return their hostname unchanged.
+- **Forbidden patterns**:
+  - pattern: `return new URL(value).hostname;` — reason: must not return the bare hostname without the empty-string→null guard.
+- **Acceptance criteria**:
+  - `parseUrlHost("javascript:alert(1)")` → `null` (was `""`).
+  - `parseUrlHost("https://example.com")` → `"example.com"`.
+  - `parseUrlHost("")` → `null` (unchanged).
+- **Rationale**: with C1 now keeping label-less URL fields, a dangerous-scheme URL value reaches `additionalUrlHosts` derivation (`personal-entry-payload.ts:49-56`). Today that would push `""` into the array. Inert at every consumer (verified by security review) but a data-hygiene wart; this is the correct normalization regardless. Low cost, folded in here.
+
+## Testing strategy
+
+- **Unit tests for `filterNonEmptyCustomFields`** covering every C1 acceptance row (one behavioral assertion per test). The repro row (`{label:"", value:"https://example.com", type:"url"} → kept`) is the failing-first regression guard — it MUST be verified to FAIL against the current `label.trim() && value.trim()` predicate before implementing (per common/testing "regression test fails before the fix").
+- **Rewrite existing tests that encode the OLD drop-on-empty-label behavior** (these WILL go red — enumerated from review, R42 test member-set):
+  - `src/lib/vault/entry-form-helpers.test.ts:52-62` — asserts `{label:"",value:"456"}` and `{label:"  ",value:"trimmed"}` dropped; both now KEPT (label-only "  " trims to empty but value present → kept; `{label:"",value:"456"}` value present → kept). Rewrite `.toEqual` to the new contract.
+  - `src/lib/vault/personal-entry-payload.test.ts:80-96` — `{label:"",value:"skip",type:"text"}` now KEPT → `customFields.length` becomes 2 (was 1). Update.
+  - `src/lib/team/team-entry-payload.test.ts:6-35` — `{label:"",value:"c",type:"text"}` now KEPT → `customFields` length 2 (was 1). Update + assert the kept field is present.
+- **Payload-level test** (`buildPersonalEntryPayload`): a label-less URL field whose host ≠ the entry's main `url` host → assert `fullBlob.customFields` contains it AND `overviewBlob.additionalUrlHosts` contains the new host. (Host must differ from the main URL host — equal hosts are excluded at `personal-entry-payload.ts:54`, else the assertion vacuously passes.)
+- **Team payload parallel test**: `buildTeamEntryPayload` (login) with a label-less value field persists it in `fullBlob.customFields`.
+- **`parseUrlHost` C2 tests**: dangerous-scheme → null; http(s) → hostname; empty → null.
+- **No E2E** (T7): pure logic is fully unit-covered. Optional lightweight `login-section` render test asserting a `{label:"", value:"https://…", type:"url"}` field renders its URL anchor — closes the only untested link (detail-render of a label-less field); acceptable to defer.
+
+## Considerations & constraints
+
+- **Scope contract**:
+  - SC1 — Import path custom-field handling (`password-import-payload.ts`) is out of scope; it does not use `filterNonEmptyCustomFields` and has no reported defect. Owned by any future import-validation work.
+  - SC2 — Adding a "required label" affordance to the UI is explicitly NOT the chosen direction (user chose label-optional); not in scope.
+  - SC3 — Migration/backfill of already-lost data is impossible (the data never reached the server — E2E, client-dropped before encryption). No backfill contract; nothing to migrate. Users must re-enter previously-dropped fields.
+- **Boolean default noise**: the boolean rule (INV-C1.4) is a deliberate behavior refinement, not strictly part of the reported bug. Included because (a) the user asked to consider all types, and (b) a naive "keep if value non-empty" would persist every default-`false` boolean row as noise. User-confirmed direction: keep only touched booleans (labelled or turned on).
+- **Essence-shift record (2026-07-07)**: original scope was "fix label-less URL field disappearing"; re-scoped mid-plan to "no silent discard of user-entered custom-field content" after the user clarified the underlying objection. Trigger: the fix's true class is broader than the seed instance (the reported URL case is one member of "any touched field silently dropped"). Both callers and both empty-directions (value-only, label-only) are now in scope. This is why the diff (predicate + boolean handling + 3 test rewrites + parseUrlHost) is larger than a one-line URL fix.
+
+## User operation scenarios
+
+1. Edit a personal login → add additional field, type URL, leave label(名称) blank, paste `https://example.com` → Update → re-open: the URL field is present in detail and edit. (The reported bug.)
+2. Add a text additional field with a value but no label → persists.
+3. Add a text field, type a label, leave value blank → persists (mirror case; no silent loss of a labelled-but-unfilled row).
+4. Add a boolean field, leave it off (false) and unlabeled → dropped (untouched noise row).
+5. Add a boolean field, turn it on (true), no label → persists.
+6. Add a field and touch nothing (blank label + blank value) → dropped (unchanged from today).
+7. Same scenarios in a team login entry → identical behavior.
+
+## Go/No-Go Gate
+
+| ID  | Subject                                              | Status |
+|-----|------------------------------------------------------|--------|
+| C1  | `filterNonEmptyCustomFields` keep-if-touched predicate | locked |
+| C2  | `parseUrlHost` empty-hostname → null (S1)             | locked |

--- a/docs/archive/review/fix-custom-field-label-optional-review.md
+++ b/docs/archive/review/fix-custom-field-label-optional-review.md
@@ -1,0 +1,75 @@
+# Plan Review: fix-custom-field-label-optional
+Date: 2026-07-07
+Review round: 1
+
+## Changes from Previous Round
+Initial review.
+
+## Functionality Findings
+
+**[F1] Minor — pre-existing**: `additionalUrlHosts` derivation (`personal-entry-payload.ts:52-54`) uses `f.value` (truthy) not `f.value.trim()`; a URL value with surrounding whitespace is serialized untrimmed. Pre-existing for labelled URL fields; not introduced by this fix. Note only.
+
+**[F2] Minor — needs user sign-off**: The chosen rule DROPS label-only-empty-value non-boolean fields (`value.trim() !== ""` only). A user who adds a field, types a label, saves without a value, then re-opens → the row vanishes (mirror of the reported bug). NOT a new regression vs. today (today also drops it), but a persistent papercut the plan chose not to fix. Trade-off: dropping avoids persisting blank "added-and-forgotten" rows. Surface to user.
+
+**[F3] Minor — needs user sign-off**: Boolean predicate `label.trim() !== "" || value === "true"` newly KEEPS an unlabeled `value==="true"` boolean (today both unlabeled true/false booleans are dropped). Correct and well-defined (boolean value is always `"true"`/`"false"`, verified), but a behavior addition beyond the literal reported URL bug. Surface to user per "no unrequested spec changes."
+
+**[F4] Minor — non-blocking**: `CustomFieldLike` widening to `type?: CustomFieldType` makes the `type`-absent fallback branch unreachable from production (both callers pass required-`type` `EntryCustomField[]`). Mild YAGNI; optional to make `type` required. Harmless as-is.
+
+Verified clean: member-set complete (only 2 callers, both LOGIN; non-login forms pass `customFields: []`; import path bypasses filter, correctly out of scope); read/edit-rehydrate needs no change; per-type predicate correct for all 6 types.
+
+## Security Findings
+
+**[S1] Minor — optional defensive fix**: `parseUrlHost("javascript:alert(1)")` returns `""` (not `null`), so a label-less dangerous-scheme URL field lands `additionalUrlHosts: ["", ...]` in the overview blob. Inert at every consumer (web favicon guards `!host` → Globe, no fetch; `normalizeFaviconHost("")` → null → server rejects; iOS `isHostMatch("", realhost)` → no false match). Pre-fix a label-less URL field was dropped, so the fix broadens reachability of an already-existing labelled-field class. Fix: `parseUrlHost` returns `null` for empty hostname (`return h || null`). Correct normalization regardless of this plan.
+
+Cleared: no XSS/open-redirect (`isSafeHref` allowlist per-type, label-independent, `login-section.tsx:131`); no SSRF (favicon proxy allowlist + IP rejection + opt-in); no length-cap/DoS bypass (blob-level `CIPHERTEXT_MAX`/`MAX_JSON_BODY_BYTES` unchanged); no masquerade (value renderer keyed on `type`, not label); no authz path touched (pure client-side pre-encryption filter). Escalation: none.
+
+## Testing Findings
+
+**[T1] Critical**: `entry-form-helpers.test.ts:52-62` (`"keeps fields with non-empty label and value"`) asserts `{label:"",value:"456"}` AND `{label:"  ",value:"trimmed"}` are DROPPED. Both are KEPT under the new predicate → test goes red. Must be rewritten to the new contract (not just extended). The whitespace-label-with-value case is a distinct case absent from the plan's C1 table.
+
+**[T2] Critical**: No failing-first regression test exists yet. The current test passes against the buggy predicate, so it is not a guard. Add a dedicated `it("keeps a label-less URL field (reported repro)")` asserting `{label:"", value:"https://example.com", type:"url"}` is kept; verify it FAILS on current `main` before implementing.
+
+**[T3] Major**: C1 acceptance table gaps: (1) whitespace-only VALUE (`{label:"", value:"   ", type:"text"}` → drop; guards `value.trim()` vs `value !==""`); (2) HIDDEN type with value → keep (type absent from table); (3) multi-field mixed kept/dropped asserting survivor ORDER (INV-C1.4). Add these tests.
+
+**[T4] Major**: `personal-entry-payload.test.ts:80-96` uses `{label:"",value:"skip",type:"text"}` and asserts `customFields.length === 1` (old behavior) → becomes 2 after fix; must update. New payload test must use a URL host ≠ the entry's main URL host or the `additionalUrlHosts` assertion vacuously passes (host equal to main is excluded, `personal-entry-payload.ts:54`).
+
+**[T5] Major**: `team-entry-payload.test.ts:6-35` (`"builds login blobs ... non-empty custom fields only"`) feeds `{label:"",value:"c",type:"text"}` and asserts `customFields.toHaveLength(1)` → becomes 2 after fix; must update + add positive presence assertion. Each caller (personal + team) needs its own updated payload test — the shared helper test alone is insufficient for the serialization path.
+
+**[T6] Minor — positive**: `filterNonEmptyCustomFields` is a pure exported function; `buildPersonalEntryPayload`/`buildTeamEntryPayload` return JSON synchronously with no crypto/DB deps. Directly unit-testable with plain literals; type widening preserves ergonomics.
+
+**[T7] Minor**: No E2E for custom fields. Do NOT add E2E (over-investment for pure logic). Optional lightweight `login-section` render test with a label-less URL field to close the only untested link (detail-render of label-less field). Acceptable to defer.
+
+## Adjacent Findings
+- (F, adjacent → testing) regression guard must assert against old predicate — already covered by T1/T2, plan handles it.
+
+## Quality Warnings
+None flagged.
+
+## Recurring Issue Check
+### Functionality expert
+- R42: PASS (key check) — member-set derived from `grep filterNonEmptyCustomFields` → 2 LOGIN callers, non-login forms pass `[]`, import bypasses filter. Complete.
+- R1-R41: N/A (pure client-side logic; no DB/RLS/TOCTOU/AAD/migration/i18n/Bearer-route).
+- Norm note: "no unrequested spec changes" — F2/F3 bundle behavior changes; user sign-off recommended.
+
+### Security expert
+- R1 injection: clear. R2 authz: N/A. R3 secrets-in-logs: clear. R4 length-cap: clear. R5 XSS/dangerous-scheme: clear (isSafeHref per-type). R6 SSRF: clear (favicon proxy allowlist; S1 empty-host rejected). R7-R41: N/A. R42: satisfied.
+- RS1-RS5: N/A. Escalation: none.
+
+### Testing expert
+- R42 (test member-set): source callers enumerated (3 to fix) but existing tests asserting old behavior initially under-counted; now complete (3 tests: T1/T4/T5).
+- RT4 / "regression test fails before fix": at risk → T2 adds it.
+- RT1-RT3, RT5-RT7: no additional issues.
+
+## Resolution Status (post-review + user re-scope)
+
+**Essence shift (2026-07-07)**: The user re-scoped the objective from "keep label-less URL fields" to "never silently discard user-entered custom-field content." Confirmed design: keep any *touched* field (label OR value present, or boolean labelled/turned-on); drop only fully-untouched rows. This resolves F2 and F3 by user decision rather than deferral.
+
+- **F1** (whitespace in URL value, pre-existing) — Skipped (pre-existing, unchanged file behavior for labelled fields too). Anti-Deferral: pre-existing in a file that IS in the diff. Justification: the field-value trimming is a separate cosmetic behavior; the fix does not touch value normalization. Cost to fix: low but out of the "no silent data loss" objective. **Orchestrator sign-off**: recorded as TODO(fix-custom-field-label-optional): trim URL custom-field value on save. Not blocking; no data loss.
+- **F2** (drops label-only-empty-value) — **RESOLVED by re-scope**: INV-C1.2 now KEEPS label-only fields. The "symmetric surprise" the finding warned about is eliminated.
+- **F3** (keeps unlabelled true boolean — unrequested spec change) — **RESOLVED by user sign-off**: user explicitly chose "入力があれば保存、未入力行のみ破棄," which includes keeping a turned-on boolean. INV-C1.4 encodes it. No longer an unrequested change.
+- **F4** (`type?` fallback dead code) — Accepted as-is. Anti-Deferral (acceptable): worst case = one unreachable branch; likelihood = production callers always pass `type`; cost to fix (make `type` required) = trivial but removes defensive ergonomics for the generic. Kept optional per INV-C1.7. Non-blocking.
+- **S1** (parseUrlHost empty-host) — **FIXED**: promoted to contract C2 (`return h || null`).
+- **T1/T4/T5** (existing tests encode old behavior) — **Addressed in plan**: testing strategy now enumerates all three files with exact line refs and required updates.
+- **T2** (failing-first regression test) — **Addressed**: the repro acceptance row is designated the failing-first guard; plan requires verifying it fails on current `main`.
+- **T3** (whitespace-value / HIDDEN / order gaps) — **Addressed**: C1 acceptance table expanded with whitespace-only-value, whitespace-both, HIDDEN, and a mixed keep/drop order-asserting case.
+- **T6** (testability positive) / **T7** (no E2E) — Accepted; T7 optional render test noted in strategy.

--- a/src/lib/team/team-entry-payload.test.ts
+++ b/src/lib/team/team-entry-payload.test.ts
@@ -3,7 +3,7 @@ import { ENTRY_TYPE } from "@/lib/constants";
 import { buildTeamEntryPayload } from "@/lib/team/team-entry-payload";
 
 describe("buildTeamEntryPayload", () => {
-  it("builds login blobs with totp null and non-empty custom fields only", () => {
+  it("builds login blobs with totp null, keeping touched custom fields (incl. label-less)", () => {
     const { fullBlob, overviewBlob } = buildTeamEntryPayload({
       entryType: ENTRY_TYPE.LOGIN,
       title: "  A  ",
@@ -13,7 +13,10 @@ describe("buildTeamEntryPayload", () => {
       url: " https://example.com ",
       customFields: [
         { label: "a", value: "b", type: "text" },
+        // Label-less value field: touched, so kept (previously dropped).
         { label: "", value: "c", type: "text" },
+        // Fully-empty row: untouched, dropped.
+        { label: "", value: "", type: "text" },
       ],
       totp: null,
       tagNames: [{ name: "t1", color: "#f00" }],
@@ -24,7 +27,10 @@ describe("buildTeamEntryPayload", () => {
     expect(blob.username).toBe("user");
     expect(blob.password).toBe("pw");
     expect(blob.url).toBe("https://example.com");
-    expect(blob.customFields).toHaveLength(1);
+    expect(blob.customFields).toEqual([
+      { label: "a", value: "b", type: "text" },
+      { label: "", value: "c", type: "text" },
+    ]);
     expect(blob.notes).toBeNull();
 
     const overview = JSON.parse(overviewBlob);

--- a/src/lib/vault/entry-form-helpers.test.ts
+++ b/src/lib/vault/entry-form-helpers.test.ts
@@ -49,47 +49,84 @@ describe("toTagNameColor", () => {
 // ─── filterNonEmptyCustomFields ──────────────────────────────
 
 describe("filterNonEmptyCustomFields", () => {
-  it("keeps fields with non-empty label and value", () => {
-    const fields = [
-      { label: "api_key", value: "123" },
-      { label: "", value: "456" },
-      { label: "name", value: "" },
-      { label: "  ", value: "trimmed" },
-    ];
-    expect(filterNonEmptyCustomFields(fields)).toEqual([
-      { label: "api_key", value: "123" },
-    ]);
+  // Keep any touched field (label OR value present); drop only untouched rows.
+
+  it("keeps a label-less URL field (reported repro — was silently dropped)", () => {
+    const fields = [{ label: "", value: "https://example.com", type: "url" as const }];
+    expect(filterNonEmptyCustomFields(fields)).toEqual(fields);
   });
 
-  it("returns empty array when all fields are empty", () => {
-    expect(filterNonEmptyCustomFields([{ label: "", value: "" }])).toEqual([]);
+  it("keeps a value-only text field regardless of label", () => {
+    const fields = [{ label: "", value: "456", type: "text" as const }];
+    expect(filterNonEmptyCustomFields(fields)).toEqual(fields);
+  });
+
+  it("keeps a label-only field with empty value (no silent loss of a titled row)", () => {
+    const fields = [{ label: "note", value: "", type: "text" as const }];
+    expect(filterNonEmptyCustomFields(fields)).toEqual(fields);
+  });
+
+  it("keeps a HIDDEN field with a value and no label", () => {
+    const fields = [{ label: "", value: "secret", type: "hidden" as const }];
+    expect(filterNonEmptyCustomFields(fields)).toEqual(fields);
+  });
+
+  it("keeps DATE and MONTH_YEAR fields with values and no label", () => {
+    const fields = [
+      { label: "", value: "2026-01-01", type: "date" as const },
+      { label: "", value: "2026-03", type: "monthYear" as const },
+    ];
+    expect(filterNonEmptyCustomFields(fields)).toHaveLength(2);
+  });
+
+  it("drops a fully-empty row (untouched)", () => {
+    expect(
+      filterNonEmptyCustomFields([{ label: "", value: "", type: "text" as const }])
+    ).toEqual([]);
+  });
+
+  it("drops a whitespace-only label + whitespace-only value row (untouched)", () => {
+    expect(
+      filterNonEmptyCustomFields([{ label: "   ", value: "   ", type: "text" as const }])
+    ).toEqual([]);
+  });
+
+  it("drops a whitespace-only value with no label (guards value.trim not value !== '')", () => {
+    expect(
+      filterNonEmptyCustomFields([{ label: "", value: "   ", type: "text" as const }])
+    ).toEqual([]);
+  });
+
+  it("keeps a turned-on boolean with no label", () => {
+    const fields = [{ label: "", value: "true", type: "boolean" as const }];
+    expect(filterNonEmptyCustomFields(fields)).toEqual(fields);
+  });
+
+  it("drops an untouched (off, unlabelled) boolean", () => {
+    expect(
+      filterNonEmptyCustomFields([{ label: "", value: "false", type: "boolean" as const }])
+    ).toEqual([]);
+  });
+
+  it("keeps a labelled off boolean", () => {
+    const fields = [{ label: "agreed", value: "false", type: "boolean" as const }];
+    expect(filterNonEmptyCustomFields(fields)).toEqual(fields);
+  });
+
+  it("preserves the order of surviving fields in a mixed keep/drop array", () => {
+    const fields = [
+      { label: "a", value: "1", type: "text" as const },
+      { label: "", value: "", type: "text" as const },
+      { label: "", value: "2", type: "url" as const },
+    ];
+    expect(filterNonEmptyCustomFields(fields)).toEqual([
+      { label: "a", value: "1", type: "text" },
+      { label: "", value: "2", type: "url" },
+    ]);
   });
 
   it("returns empty array for empty input", () => {
     expect(filterNonEmptyCustomFields([])).toEqual([]);
-  });
-
-  it("keeps BOOLEAN field with value 'false' (non-empty)", () => {
-    const fields = [
-      { label: "toggle", value: "false", type: "boolean" },
-    ];
-    expect(filterNonEmptyCustomFields(fields)).toHaveLength(1);
-    expect(filterNonEmptyCustomFields(fields)[0].value).toBe("false");
-  });
-
-  it("filters out BOOLEAN field with empty value", () => {
-    const fields = [
-      { label: "toggle", value: "", type: "boolean" },
-    ];
-    expect(filterNonEmptyCustomFields(fields)).toHaveLength(0);
-  });
-
-  it("keeps DATE and MONTH_YEAR fields with values", () => {
-    const fields = [
-      { label: "birthday", value: "2000-01-01", type: "date" },
-      { label: "expiry", value: "2026-03", type: "monthYear" },
-    ];
-    expect(filterNonEmptyCustomFields(fields)).toHaveLength(2);
   });
 });
 
@@ -114,5 +151,13 @@ describe("parseUrlHost", () => {
 
   it("extracts hostname from URL with subdomain", () => {
     expect(parseUrlHost("https://app.example.com")).toBe("app.example.com");
+  });
+
+  it("returns null for authority-less schemes whose hostname is empty", () => {
+    // javascript:/data:/mailto: parse successfully but have an empty hostname;
+    // normalize to null so "" never lands in a urlHost field.
+    expect(parseUrlHost("javascript:alert(1)")).toBeNull();
+    expect(parseUrlHost("data:text/plain,hi")).toBeNull();
+    expect(parseUrlHost("mailto:a@b.com")).toBeNull();
   });
 });

--- a/src/lib/vault/entry-form-helpers.ts
+++ b/src/lib/vault/entry-form-helpers.ts
@@ -7,9 +7,13 @@ export interface TagNameColor {
   color: string | null;
 }
 
+import { CUSTOM_FIELD_TYPE } from "@/lib/constants";
+import type { CustomFieldType } from "@/lib/constants";
+
 export interface CustomFieldLike {
   label: string;
   value: string;
+  type?: CustomFieldType;
 }
 
 export function extractTagIds(tags: TagWithId[]): string[] {
@@ -23,16 +27,27 @@ export function toTagNameColor(tags: TagNameColor[]): TagNameColor[] {
   }));
 }
 
+// Keep any field the user touched; drop only untouched rows (the phantom row
+// created by "Add field" and never filled). A field is touched when it carries
+// a label or a value. Booleans always carry a value ("true"/"false"), so their
+// "untouched" state is the default-off, unlabelled toggle — dropped; a labelled
+// or turned-on boolean is kept. This prevents silently discarding user input.
 export function filterNonEmptyCustomFields<T extends CustomFieldLike>(
   fields: T[]
 ): T[] {
-  return fields.filter((field) => field.label.trim() && field.value.trim());
+  return fields.filter((field) =>
+    field.type === CUSTOM_FIELD_TYPE.BOOLEAN
+      ? field.label.trim() !== "" || field.value === "true"
+      : field.label.trim() !== "" || field.value.trim() !== ""
+  );
 }
 
 export function parseUrlHost(value: string): string | null {
   if (!value) return null;
   try {
-    return new URL(value).hostname;
+    // hostname is "" for schemes without an authority (javascript:, data:,
+    // mailto:) — normalize those to null so they never reach urlHost fields.
+    return new URL(value).hostname || null;
   } catch {
     return null;
   }

--- a/src/lib/vault/personal-entry-payload.test.ts
+++ b/src/lib/vault/personal-entry-payload.test.ts
@@ -79,7 +79,10 @@ describe("buildPersonalEntryPayload", () => {
       },
       customFields: [
         { label: "env", value: "prod", type: "text" },
+        // Label-less value field: touched, so kept (previously dropped).
         { label: "", value: "skip", type: "text" },
+        // Fully-empty row: untouched, dropped.
+        { label: "", value: "", type: "text" },
       ],
       totp: null,
       requireReprompt: true,
@@ -93,11 +96,40 @@ describe("buildPersonalEntryPayload", () => {
     expect(full.url).toBe("https://example.com/path");
     expect(full.notes).toBeNull();
     expect(Array.isArray(full.customFields)).toBe(true);
-    expect((full.customFields as unknown[]).length).toBe(1);
+    // "env"/"prod" and label-less "skip" survive; the fully-empty row is dropped.
+    expect((full.customFields as unknown[]).length).toBe(2);
     expect(overview.urlHost).toBe("example.com");
     expect(overview.requireReprompt).toBe(true);
     // No TOTP → marker absent from overview (iOS reads absent as hasTOTP=false).
     expect(overview).not.toHaveProperty("hasTOTP");
+  });
+
+  it("keeps a label-less URL custom field and derives its host into additionalUrlHosts", () => {
+    const { fullBlob, overviewBlob } = buildPersonalEntryPayload({
+      title: "Repro",
+      username: "u",
+      password: "pw",
+      // Main URL host differs from the custom-field host so the custom host is
+      // not deduped away (personal-entry-payload excludes hosts equal to urlHost).
+      url: "https://main.example.com",
+      notes: "",
+      selectedTags: [],
+      generatorSettings: BASE_GENERATOR_SETTINGS,
+      customFields: [
+        { label: "", value: "https://extra.example.org", type: "url" },
+      ],
+      totp: null,
+      requireReprompt: false,
+      existingHistory: [],
+    });
+
+    const full = JSON.parse(fullBlob) as Record<string, unknown>;
+    const overview = JSON.parse(overviewBlob) as Record<string, unknown>;
+
+    expect(full.customFields).toEqual([
+      { label: "", value: "https://extra.example.org", type: "url" },
+    ]);
+    expect(overview.additionalUrlHosts).toEqual(["extra.example.org"]);
   });
 
   it("marks the overview blob with hasTOTP when a TOTP secret is present", () => {


### PR DESCRIPTION
## Summary
Fixes silent data loss where a custom ("additional") field with a user-entered value but an empty label was silently discarded on save — the reported symptom being a label-less URL field vanishing from the detail and edit views after a successful-looking update.

- Replaces the strict `label && value` (AND) predicate in `filterNonEmptyCustomFields` with a **"keep-if-touched"** rule: keep any field carrying a label or a value; drop only fully-untouched rows.
- Booleans always carry a value, so their untouched state is the default-off, unlabelled toggle — dropped; a labelled or turned-on boolean is kept.
- Normalizes `parseUrlHost` to return `null` (not `""`) for authority-less schemes (`javascript:`/`data:`/`mailto:`) so empty hosts never leak into `urlHost` / `additionalUrlHosts`.

## Motivation
The reported bug was one instance of a broader class: **any** custom-field content the user typed was silently dropped when the label was empty, with a success toast and no error. Custom fields live inside the client-side E2E-encrypted blob, so the server never sees them in plaintext — this is necessarily a client-side fix. The objective was re-scoped from "keep label-less URL fields" to "never silently discard user-entered content," fixing both the value-only case and its label-only mirror. Both the personal (`src/lib/vault/personal-entry-payload.ts`) and team (`src/lib/team/team-entry-payload.ts`) login save paths share the fixed helper.

## Trade-offs
- A turned-on boolean with no label is kept (renders an empty caption) rather than silently dropped — accepting the empty caption as the cost of not losing user input.
- Whitespace-in-URL-value trimming is pre-existing and left out of scope for this data-loss fix.

## Verification (completed)
- `npx vitest run` — 12033 passed, 0 failed. The label-less URL repro test is a genuine failing-first guard (returns `[]` under the old predicate).
- `npx next build` — succeeds. `scripts/pre-pr.sh` — 35 checks pass.
- triangulate 3-expert review (plan + code): converged with **No findings**.

## Review artifacts
- [plan](./docs/archive/review/fix-custom-field-label-optional-plan.md) · [plan review](./docs/archive/review/fix-custom-field-label-optional-review.md) · [code review](./docs/archive/review/fix-custom-field-label-optional-code-review.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)