### PR TITLE
fix(security): handle SESSION_STEP_UP_REQUIRED 403 in all mutating UI callers

### DIFF
--- a/docs/archive/review/step-up-client-policy-card-code-review.md
+++ b/docs/archive/review/step-up-client-policy-card-code-review.md
@@ -1,0 +1,115 @@
+# Code Review: step-up-client-policy-card
+Date: 2026-07-08
+Review round: 1 (triangulate Phase 3)
+
+## Changes from Previous Round
+Initial code review of the committed Phase 2 implementation (037765fe), on top of the
+Phase 2 self-R-check baseline and two prior external review passes (F1/F2, already fixed
+and committed).
+
+## Functionality Findings
+No novel findings survived verification. The functionality expert verified: discriminated
+retry replay targets the correct handler+arg for every multi-mutation component; the
+permanent-delete rollback (reload before reauth) is correct and empty-trash/bulk-purge
+have no analogous phantom-state risk; base-webhook stacked markers replay create vs delete
+correctly; every client `@stepup` marker has its branch token within the adjacency window;
+the guard exits 0 and its logic has no false-PASS beyond the two documented limits; all
+Implementation-Checklist files appear in the diff.
+
+Seed dispositions:
+- `use-bulk-action.ts:128` silent-swallow (Ollama Major) — Rejected as a live bug
+  (unreachable: the sole consumer always passes `onStepUpRequired`), but re-tagged
+  **[Adjacent] Minor** as an API-design latent trap. → **Fixed** (see Resolution T3).
+- `mcp-client-card / api-key-manager / access-request-card` "bypasses shared helper"
+  (Ollama Minor ×3) — Rejected: intentional raw-literal branches where the parsed body is
+  reused for other error codes (a `handleStepUpError` swap would double-consume
+  `res.json()`); documented in deviation D2; each still carries a correct marker+branch.
+
+## Security Findings
+**No findings.** The security expert verified all six focus areas: no guard false-PASS
+surface beyond the two documented limits (`.test.` exclusion anchored, `is_exempt` exact
+match, adjacency window has no real bleed-through, multi-line calls anchor correctly); no
+step-up bypass introduced (every marker is a pure comment above an unchanged
+`requireRecentCurrentAuthMethod` call with its `if (stepUp) return` intact); passwords &
+team-passwords DELETE gated only inside `if (permanent)`, soft-delete frictionless; the
+phantom-delete fix uses a genuine server re-fetch and has no residual leak; all 3 exempt
+ids are legitimately custom-recovery / non-interactive (operator-tokens uses a custom
+`errorCode` override so it structurally never emits the standard code); no info leak in the
+typed error or helper.
+
+## Testing Findings
+- **[T1] [Major] bulk-purge hook step-up branch has no direct unit test** —
+  `src/hooks/bulk/use-bulk-action.ts` executeAction's step-up branch was proven only by
+  proxy through a fully-mocked consumer. → **Fixed** (Resolution T1).
+- **[T2] [Major] team-scope permanent-delete / empty-trash step-up untested at every
+  level** — the personal & team vault-list adapters' `throwIfStepUp` had zero direct
+  coverage; the team-scope path was untested at unit/integration/E2E despite guard
+  satisfaction. → **Fixed** (Resolution T2).
+
+Seed dispositions (all refuted / disclosed): the E2E shared-session mutation is handled by
+an `afterAll refreshSessionRecency`; tenant-members-card mocks reset in `beforeEach`;
+fixture viii's existence-level pairing is a documented tradeoff. The expert empirically
+reverted the adjacency check to a whole-file grep and confirmed ONLY fixture vii flips —
+proving it is the sole regression lock for the file-scoped-grep bug class.
+
+## Adjacent Findings
+- **[T3 / Adjacent] [Minor] use-bulk-action `onStepUpRequired` optional-field trap** — an
+  omitted `onStepUpRequired` would let the no-op `?.()` make `handleStepUpError` return
+  true, silently closing the dialog with no toast. → **Fixed** (Resolution T3).
+
+## Recurring Issue Check
+- R1/R2 (reuse): shared helper extracted per user steer; no duplicated step-up block. Clean.
+- R19 (all test trees): every touched component's co-located test updated; full suite green. Clean.
+- R42 (class member-set): 45 members derived from the defining primitive; closed by the
+  mutation-verified CI guard (see Environment Verification Report). Clean.
+- Forbidden patterns (plan): step-up branch in `!res.ok` not catch; no hardcoded "cancel";
+  no `@prisma/client` in guard. Grep-verified clean.
+- RS1 (timing-safe), R36 (suppression), RT4 (race-vacuous): N/A to this diff.
+
+## Environment Verification Report
+Phase 1 declared the step-up 403 path unit-testable (mock fetchApi → 403) and the
+browser/E2E stale-window path as `verifiable-local`.
+- Unit denial tests (per component × gated method) + helper test + adapter/hook step-up
+  tests: **verified-local** — `npx vitest run` 12086 pass.
+- C1 guard: **verified-local** — `bash scripts/checks/check-step-up-client-coverage.sh`
+  exit 0; 10-fixture self-test pass; mutation-proven (reverting adjacency→file-scope flips
+  only fixture vii; removing a client marker goes RED via S\C).
+- E2E `step-up-stale-window.spec.ts` + existing `trash.spec.ts`: **blocked-deferred** —
+  the full E2E stack (Postgres+Redis+Jackson+Next server, seeded via global-setup) is not
+  up in this environment and E2E is outside pre-pr's default gate
+  (project_ci_gates_beyond_pre_pr, declared in Phase 1 / plan §Verification). Spec authored
+  and type-consistent with the page objects; run when the stack is available. Deviation
+  D5 records the justification.
+- **R42 class `step-up-client-coverage`: member-set expanded ~24→45 (≥2×) — closed by
+  mutation-verified CI guard `scripts/checks/check-step-up-client-coverage.sh` (red-proven:
+  remove a client `@stepup` marker → MISSING_CLIENT_MARKER; revert adjacency→file-scope →
+  fixture vii FAILs), wired in `scripts/pre-pr.sh:166` → CI `static-checks` job
+  (`PRE_PR_STATIC_ONLY=1`).**
+
+## Resolution Status
+
+### T1 [Major] bulk-purge hook step-up branch untested — Fixed
+- Action: added a `describe("step-up handling")` block to use-bulk-action.test.ts (3 tests):
+  deletePermanently+403+handler → onStepUpRequired called, dialog closed, no error toast;
+  deletePermanently+403 with handler omitted → generic error toast (not swallowed);
+  non-purge action+403 → onStepUpRequired NOT called.
+- Modified file: src/hooks/bulk/use-bulk-action.test.ts
+
+### T2 [Major] team-scope adapter step-up untested — Fixed
+- Action: added 3 tests each to personal- and team-vault-list-adapter.test.ts:
+  deletePermanently & emptyTrash on 403 → reject with StepUpRequiredError
+  (isStepUpRequiredError true); an ungated method (restore) on 403 → plain Error.
+- Modified files: src/lib/vault/personal-vault-list-adapter.test.ts,
+  src/lib/vault/team-vault-list-adapter.test.ts
+
+### T3 [Adjacent Minor] use-bulk-action onStepUpRequired optional-field trap — Fixed
+- Action: gated the step-up branch on `pendingAction === "deletePermanently" &&
+  onStepUpRequired` so an omitted handler falls through to the generic error toast instead
+  of silently closing the dialog. Regression-locked by the T1 "handler omitted" test.
+- Modified file: src/hooks/bulk/use-bulk-action.ts
+
+### R35 Tier-2 manual-test artifact — Added
+- Action: admin-IA pages (C3) trigger the R35 Tier-1 pre-pr gate; authored a Tier-2
+  manual-test plan (Pre-conditions / per-surface scenarios / 4 Adversarial scenarios incl.
+  the phantom-delete ADV-1 and reauth-replay-target ADV-4 / Rollback).
+- Added file: docs/archive/review/step-up-client-policy-card-manual-test.md

--- a/docs/archive/review/step-up-client-policy-card-deviation.md
+++ b/docs/archive/review/step-up-client-policy-card-deviation.md
@@ -1,0 +1,61 @@
+# Coding Deviation Log: step-up-client-policy-card
+
+## D1 — Member-set is 45 gated (route, method) server call sites, not the plan's ~24
+The plan estimated ~24 members and warned of ≥2× expansion. The authoritative
+`grep -rnE '(^|[^A-Za-z0-9_])requireRecentCurrentAuthMethod\(' src/app` yields **45**
+server call sites across 35 route files. This is the expected R42 expansion, not a
+re-scope: the guard-first marker scheme is the convergence artifact the plan mandated
+for exactly this. Classification: 3 EXEMPT + ~19 already-HANDLED (marker-only) + 23 FIX
+(new client branch). Full table in the plan's Implementation Checklist.
+
+## D2 — Shared client helper extracted (reverses the handoff's "do not extract a wrapper")
+The handoff doc (docs/archive/review/step-up-client-handoff.md §"Per-component fix
+recipe") said "Convention is INLINE per-component ... do NOT extract a shared wrapper."
+That convention was OVERRIDDEN by an explicit user instruction on 2026-07-08:
+「共通処理にできる箇所は？を意識してコーディングしてください」. Extracted
+`src/lib/http/handle-step-up-error.ts`: `handleStepUpError(res, trigger, arg?)`,
+`isStepUpRequired(body)`, plus a typed-error layer for non-hook adapters
+(`StepUpRequiredError`, `isStepUpRequiredError`, `throwIfStepUp`). ~23 FIX sites and the
+~19 HANDLED sites use it (a few keep the raw-literal branch where the parsed body is
+reused for other error codes — a clean handleStepUpError swap there would double-consume
+`res.json()`). The C1 guard's client-branch token set accepts the helper tokens
+(`handleStepUpError(`, `throwIfStepUp(`, `isStepUpRequiredError(`) in addition to the raw
+`SESSION_STEP_UP_REQUIRED` literal.
+
+## D3 — C4 uses a typed error, not just the fetch helper (F4 contract)
+The vault-list adapters (`personal`/`team-vault-list-adapter.ts`) are non-hook async
+methods that cannot open a dialog. Their two gated methods (deletePermanently,
+emptyTrash) call `throwIfStepUp(res)` → throw `StepUpRequiredError`; the sole consumer
+`entry-list-view.tsx` catches it with `isStepUpRequiredError(e)` and opens reauth. Bulk-
+purge goes through `use-bulk-action.ts` (a hook) via a new `onStepUpRequired` option.
+
+## D4 — Review-round fixes (2026-07-08, two external review passes)
+- **F1 (Medium, security-UX)**: entry-list-view optimistically removed the row BEFORE
+  the permanent-delete server call and, on step-up 403, opened reauth and returned
+  WITHOUT rollback — a purged-looking-but-still-alive secret. Fixed: `reload()` rolls
+  back the optimistic removal before opening reauth; the reauth-success retry commits the
+  removal (onEntryRemoved + notifyDataChanged + onDataChange) for real. Regression test
+  added (asserts the entry is still visible after a step-up denial).
+- **F2 (Low/Med, guard strength)**: `throwIfStepUp(` alone satisfied the client-branch
+  check without proving any consumer catches it. Added a `STEPUP_THROWER_WITHOUT_CATCHER`
+  existence-level pairing check (thrower present ⇒ `isStepUpRequiredError(` catcher must
+  exist) + self-test fixture (viii). Documented the residual limitations honestly in the
+  guard header: coverage is a set comparison (a shared route-id like `tenant-policy-patch`
+  is satisfied by ONE of its 8 cards; all 8 are wired here, review-verified), and the
+  thrower↔catcher pairing is existence-level not per-call-site (call-site ids are the
+  escalation if that becomes a real regression).
+- **E2E hygiene note**: the new stale-window spec mutates the shared `vaultReady` session;
+  added `afterAll` → `refreshSessionRecency` so a later-ordered spec isn't left stale.
+
+## D5 — E2E authored but not executed (verifiable-local gate)
+`e2e/tests/step-up-stale-window.spec.ts` (+ `makeSessionStale` helper in e2e/helpers/db.ts)
+is authored and type-consistent with the page objects, but NOT run: the full E2E stack
+(Postgres + Redis + Jackson + Next.js server, seeded via global-setup) is not up, and E2E
+is outside pre-pr's default gate (project_ci_gates_beyond_pre_pr). Existing
+`e2e/tests/trash.spec.ts` (empty-trash on a refreshed session) is unchanged and covered by
+the same infra. Run both when the stack is available.
+
+## D6 — Stray test file removed
+A sub-agent created a misnamed duplicate `src/components/settings/security/debug-token.test.tsx`
+that actually rendered `TenantTokenPolicyCard` (duplicate of tenant-token-policy-card.test.tsx).
+Deleted — coverage already lives in the correctly-named file.

--- a/docs/archive/review/step-up-client-policy-card-manual-test.md
+++ b/docs/archive/review/step-up-client-policy-card-manual-test.md
@@ -1,0 +1,102 @@
+# Manual Test Plan: step-up client reauth — close the class
+
+**R35 tier**: 2 (Critical) — change touches the session step-up (re-authentication)
+lifecycle for every mutating-UI caller of a `requireRecentCurrentAuthMethod`-gated
+route, including admin-IA pages (team member management, ownership transfer, team
+deletion). A regression re-opens a UX dead-end on a stale session and (for the vault
+permanent-delete flow) a purged-looking-but-still-alive secret.
+
+**Boot signal (R32)**: not applicable — no new long-running runtime artifact.
+
+**Branch**: `fix/step-up-client-policy-card`
+
+## Pre-conditions
+
+- Local dev stack up (`npm run docker:up`), migrations applied.
+- A tenant admin/owner user with vault set up and at least one password entry.
+- The step-up window is 15 minutes. To force a STALE window without waiting, run in
+  the dev DB: `UPDATE sessions SET created_at = now() - interval '1 hour' WHERE session_token = '<token>';`
+  (mirrors the E2E `makeSessionStale` helper). To restore: `... SET created_at = now() ...`.
+- A test user WITHOUT a passkey (so the RecentSessionRequiredDialog / "sign in again"
+  path shows) and, separately, a user WITH a PRF passkey (so the PasskeyReauthDialog path
+  shows) — both reauth surfaces should be exercised.
+- For team scenarios: a team with the admin as owner plus one other member.
+
+## Scenarios
+
+Each scenario: (1) with a FRESH session the mutation succeeds; (2) with a STALE session
+the reauth prompt appears (NOT a generic error toast / silent reload); (3) after
+completing reauth the original mutation replays and succeeds.
+
+### A — Tenant security policy cards (8 cards, shared route)
+- Steps: with a stale session, open Settings → Security, change any field on each policy
+  card (session / passkey / token / lockout / access-restriction / password / delegation /
+  retention) and click Save.
+- Expected: the reauth prompt opens; no generic "save failed" toast; after reauth the
+  save completes and the value persists.
+
+### B — Developer / credential cards
+- **api-key**: create (POST) and revoke (DELETE) each open reauth on a stale session.
+- **mcp-client**: create (POST), edit (PUT), delete (DELETE) — all three.
+- **service-account**: edit (PUT), delete (DELETE), revoke token (token DELETE).
+- **scim-token**: create (POST) and revoke (DELETE).
+- **access-request**: approve (POST) and deny (POST).
+- Expected: each opens the reauth prompt on a stale session and replays on success.
+
+### C — Admin IA pages (the R35 Tier-1 trigger)
+- **members/list**: change a member's role (PUT) and remove a member (DELETE).
+- **transfer-ownership**: transfer ownership to another member (PUT).
+- **general/delete**: delete the team (DELETE).
+- Expected: each mutation, on a stale session, opens the reauth prompt in the page (dialogs
+  render in page JSX) and replays the correct mutation after reauth. Editing the team
+  profile (PUT, NOT gated) does NOT prompt reauth.
+
+### D — Webhooks (shared base component, tenant + team)
+- Create (POST) and delete (DELETE) a tenant webhook AND a team webhook.
+- Expected: all four (2 consumers × 2 methods) open reauth on a stale session.
+
+### E — Vault permanent-delete / empty-trash / bulk-purge
+- **permanent-delete** a single trashed entry, **empty-trash**, and **bulk-purge** selected
+  trashed entries — personal AND team vault.
+- Expected: each opens reauth on a stale session and purges after reauth.
+
+## Adversarial scenarios (R35 Tier-2)
+
+### ADV-1 — Permanent-delete phantom state (the F1 fix)
+- Pre: stale session, one trashed personal entry visible.
+- Steps: permanently delete it. When the reauth prompt appears, **cancel it** (or fail the
+  passkey ceremony). Then reload the trash view.
+- Expected: the entry is STILL VISIBLE (the optimistic removal was rolled back via reload
+  before reauth opened) and STILL EXISTS server-side. It must NOT read as deleted while
+  alive. Repeat for team vault. Repeat for empty-trash and bulk-purge (these never
+  optimistically remove, so the row must simply remain).
+
+### ADV-2 — Soft-delete stays frictionless
+- Pre: stale session.
+- Steps: move an entry to trash (soft-delete, NOT permanent) — personal and team.
+- Expected: NO reauth prompt (soft-delete is not step-up-gated); the entry moves to trash
+  normally. Only the `?permanent=true` path is gated.
+
+### ADV-3 — Exempt / custom-recovery surfaces still recover
+- **operator-token** issuance on a stale session: shows its bespoke stale-session flow
+  (`OPERATOR_TOKEN_STALE_SESSION`), not a dead-end.
+- **auto-extension connect** on a stale session: surfaces via the extension-connect error
+  channel, not a silent failure.
+- Expected: these exempted surfaces still give the user a recovery path (they are exempt
+  from the standard dialog only because they own a custom one).
+
+### ADV-4 — Reauth-replay targets the correct mutation
+- Pre: stale session, a multi-mutation component (e.g. mcp-client-card with create/edit/
+  delete, or admin members with role-change/remove).
+- Steps: trigger DELETE, complete reauth.
+- Expected: the DELETE (not create/edit) replays — the discriminated retry target must not
+  replay the wrong mutation.
+
+## Expected result (summary)
+Every gated mutation, on a stale session, opens a reauth prompt and replays on success; no
+gated mutation surfaces a generic error/silent reload; no permanent-delete leaves a
+purged-looking-but-alive secret; ungated paths (soft-delete, profile edit) are unaffected.
+
+## Rollback
+Revert the branch. No migration, no persisted-state change — the change is client wiring +
+comment markers + a CI guard, so rollback is a pure code revert with no data cleanup.

--- a/docs/archive/review/step-up-client-policy-card-plan.md
+++ b/docs/archive/review/step-up-client-policy-card-plan.md
@@ -1,0 +1,306 @@
+# Plan: step-up client reauth — close the class (guard-first) per (route, method)
+
+## Project context
+- Type: web app (Next.js App Router + React client components)
+- Test infrastructure: unit + integration + E2E (vitest, @testing-library/react, Playwright)
+- Verification environment constraints: none blocking. The step-up 403 path is
+  unit-testable by mocking `fetchApi` to return a 403 `SESSION_STEP_UP_REQUIRED`
+  body. Manual browser and E2E (let step-up window lapse → mutate → reauth
+  prompt) are `verifiable-local`. E2E is outside pre-pr.sh's default gate
+  (project_ci_gates_beyond_pre_pr) — call it out explicitly.
+
+## Objective
+Close the entire "mutating UI caller whose server route enforces session step-up
+but whose client does not handle the `SESSION_STEP_UP_REQUIRED` 403" class.
+The class boundary is **(route, method, param-condition)**, NOT per-component:
+Phase-1 review (F1 Critical) found that several components already on the
+"handled" list wire step-up on only SOME of their gated mutations (e.g.
+mcp-client-card handles POST create but not PUT/DELETE; even the reference
+api-key-manager handles POST but not DELETE). A per-component enumeration
+repeats the prior PR's under-enumeration.
+
+**Guard-first strategy** (user-approved): implement the C1 CI guard FIRST so it
+mechanically enumerates the (route, method)→caller class and lists every unhandled
+member. The guard's output is the single source of truth for the fix set; we then
+fix members until the guard is green. This structurally prevents the hand-list
+miss that produced the 8→24+ expansion.
+
+## Background — the primitive and the handling marker
+`requireRecentCurrentAuthMethod` (src/lib/auth/session/recent-current-auth-method.ts:26)
+is the class-defining server primitive; on a stale window it emits
+`API_ERROR.SESSION_STEP_UP_REQUIRED`. A client HANDLES a specific gated mutation
+iff the handler for THAT (path, method) branches on
+`API_ERROR.SESSION_STEP_UP_REQUIRED` (read via `readApiErrorBody`) and invokes
+`useInlineReauth().triggerOnStaleError(...)`. Recipe: api-key-manager.tsx
+(:91 hook, :159-160 branch, :212-218 dialogs); handoff doc
+docs/archive/review/step-up-client-handoff.md §"Per-component fix recipe".
+
+Sibling guard to model C1 on: `scripts/checks/check-permanent-delete-stepup.sh`
++ its self-test `scripts/__tests__/check-permanent-delete-stepup.test.mjs`, wired
+at pre-pr.sh:165 (`run_step "Static: permanent-delete-stepup"`). It is a pure
+text/filesystem scan (no `@prisma/client` import — required so it survives the
+static-checks CI job that runs without prisma generate,
+per project_static_check_ci_no_prisma_generate).
+
+## Contracts
+
+### C1 — Marker-verified client-coverage guard (IMPLEMENT FIRST)
+`scripts/checks/check-step-up-client-coverage.sh` (+ exempt allowlist +
+`scripts/__tests__/check-step-up-client-coverage.test.mjs`).
+
+**Why marker-based, not inference-based (F7):** a pure grep cannot reliably
+resolve a client `fetchApi` call to its gated (route, method). Round-2 review
+found three caller path-spellings among NAMED members that defeat token grep:
+raw template literals (`team-policy-settings.tsx` uses `` `/api/teams/${teamId}/policy` ``,
+no `apiPath` token), prop-indirection (`base-webhook-card.tsx` calls
+`fetchApi(createEndpoint, …)` with the path token in a DIFFERENT file), and
+helper→canonical-path semantic gaps (`apiPath.tenantMemberById(userId)` has no
+`:userId` textual marker). An inference guard would go GREEN while structurally
+blind to these members — defeating the guard-first premise. So the guard verifies
+an explicit **marker at each end** instead of inferring coverage. Markers make
+coverage self-declaring, so the guard needs no path resolution.
+
+- **Two-sided marker scheme**:
+  - **Server side** — each gated handler already calls `requireRecentCurrentAuthMethod`.
+    Add a one-line marker comment on that call: `// @stepup id:<STABLE_ID> method:<M>`
+    where `<STABLE_ID>` is a short stable slug for the (route, method) pair (e.g.
+    `tenant-mcp-clients-id-put`). Mechanical to add — the routes are already known.
+  - **Client side** — each client call site that invokes a gated (route, method)
+    gets `// @stepup id:<STABLE_ID>` immediately above the `fetchApi(` line, and the
+    enclosing handler MUST contain a `SESSION_STEP_UP_REQUIRED` branch.
+- **Guard checks (pure text+filesystem scan, no `@prisma/client` import)**:
+  1. **Coverage (server→client)**: collect all server `@stepup id:X` markers (set S)
+     and all client `@stepup id:X` markers (set C). Every id in S MUST appear in C,
+     unless id is exempt-allowlisted. `S \ C` (a gated server mutation with no client
+     marker = the付け漏れ/missed-member case) → FAIL. This is the completeness gate
+     that closes F7: it does not need to resolve paths, only to match stable ids.
+  2. **Handling (client marker → branch, ADJACENCY-scoped — C1-R3-2/3)**: bash cannot
+     reliably scope to "the enclosing handler function body" (brace-matching across
+     nested arrow callbacks is not grep-able), and a whole-FILE grep false-PASSes the
+     live F1 case — mcp-client-card contains `SESSION_STEP_UP_REQUIRED` once (handleCreate)
+     but its handleEdit/PUT and handleDelete/DELETE lack it, yet a file grep returns TRUE
+     for all three. So instead: for each client `@stepup id:X` marker on line L (placed
+     immediately above the `fetchApi(` call), a `SESSION_STEP_UP_REQUIRED` reference MUST
+     appear within N lines below L (N≈40; pick by measuring the largest real
+     marker→branch gap in the fixed set and adding margin; document N in the header).
+     Mechanism: `awk -v L=<line> 'NR>=L && NR<=L+N && /SESSION_STEP_UP_REQUIRED/{f=1}
+     END{exit !f}'`. A marker with no branch in its window → FAIL. This is parser-free,
+     deterministic, and fails in the SAFE direction (a too-far branch forces a real fix
+     or a documented restructure). Escalation if adjacency proves noisy: rewrite the
+     guard in Node with ts-morph (already used parser-free in ast-guards.ts per
+     project_ast_guard_tsmorph_no_program) for true function-scoping — but adjacency is
+     the default.
+  3. **Anti-orphan (client→server)**: every client `@stepup id:X` MUST match a server
+     id (else the client marks a stale/renamed id) → FAIL. `C \ S` with no exempt → FAIL.
+  4. **Server marker completeness (LINE-BOUND, per call — C1-R3-4)**: every
+     `requireRecentCurrentAuthMethod(` call (matched with the sibling's boundary regex
+     `(^|[^A-Za-z0-9_])requireRecentCurrentAuthMethod\(` so `DISABLED_…`/imports don't
+     match) on line H MUST carry a `@stepup id:… method:…` marker on line H or H-1.
+     Do NOT use a file-level call-count==marker-count check — a route file with two gated
+     calls (e.g. mcp-clients/[id] PUT:92 + DELETE:161) needs TWO distinct-id markers, and
+     a count check would let one marker cover both. Require each marker to carry a
+     `method:` token and assert per-file id uniqueness. Header note (mirroring sibling):
+     a commented-out call still matches the call regex — left to code review by design.
+  - Param-conditional gating (`passwords/[id]` DELETE gated only inside `if (permanent)`)
+    needs no special handling now: the marker sits on the `requireRecentCurrentAuthMethod`
+    call inside the `if (permanent)` branch, and the client permanent-delete call carries
+    the matching id. The ungated soft-delete caller simply has no marker — nothing to resolve.
+- **Exempt allowlist** (`stepup-client-exempt.txt`): a server `@stepup` id may be
+  exempted from requiring a client marker (custom-recovery or non-interactive members)
+  with a ≥10-char reason. Per S4 hardening, each exempt entry names the custom marker
+  its handler file must still contain (operator-token → `OPERATOR_TOKEN_STALE_SESSION`;
+  auto-extension → `EXTENSION_CONNECT_ERROR_CODE.SESSION_STEP_UP_REQUIRED`;
+  team-vault-core poller → a documented "background poller" marker); anti-drift fails
+  if the named marker disappears. Exempt these 3.
+- **Self-test** (`.test.mjs`, mandatory — T1, expanded per T8/T9/C1-R3-5 to 7 fixtures):
+  (i) server id + matching client marker + branch within window → PASS;
+  (ii) server id with NO client marker (付け漏れ) → FAIL (coverage gate, the F7 case);
+  (iii) client marker present but NO `SESSION_STEP_UP_REQUIRED` within the adjacency window → FAIL;
+  (iv) exempt entry whose named custom marker is absent → FAIL (S4 anti-drift);
+  (v) a `requireRecentCurrentAuthMethod(` call with NO server `@stepup` marker on line H/H-1 → FAIL (server completeness);
+  (vi) a client `@stepup id:X` whose id has no server match (renamed/stale) → FAIL (anti-orphan);
+  (vii) **ONE file, TWO marked handlers — handler A has `SESSION_STEP_UP_REQUIRED` in its
+  window, handler B (also marked) does NOT — guard FAILs pointing at B (C1-R3-5).** This is
+  the ONLY fixture that passes under file-scoping and fails under adjacency-scoping; it is
+  the direct regression lock for the live mcp-client-card gap (model it on POST-handled /
+  DELETE-unhandled). Without it a refactor back to file-scoped grep passes all other fixtures
+  while silently reopening F1.
+  Use `STEPUP_CLIENT_GUARD_*` env overrides to point at fixtures (mirror the sibling's `STEPUP_GUARD_*`).
+- **Wiring (T2)**: add `run_step "Static: step-up-client-coverage" bash
+  scripts/checks/check-step-up-client-coverage.sh` in pre-pr.sh next to the
+  permanent-delete-stepup entry; and to the CI static-checks job. Confirm it runs
+  with NO prisma generate.
+- **Mutation-verified (T1)**: demonstrate RED two ways — (a) remove the client
+  `@stepup` marker from one member (coverage gate goes RED via `S \ C`), and (b)
+  keep the marker but delete its `SESSION_STEP_UP_REQUIRED` branch on a MULTI-mutation
+  component (mcp-client-card) so the handling check goes RED — proving both gates
+  fire independently — then restore.
+- **Acceptance**: after server markers are added to all gated handlers, the guard's
+  coverage gate (S\C) emits EXACTLY the set of gated mutations lacking a client
+  marker — this list IS the C2-C4 work-list. Guard green after C2-C4 fixes; guard
+  RED under each of the 6 self-test fixtures.
+
+### C2 — Fix all standard card/dialog + hook callers the guard lists
+Apply the recipe to every (component, method) the C1 coverage gate reports as
+lacking a client marker. The Phase-1 re-derivation below is the EXPECTED work-list;
+the guard's `S \ C` output is authoritative. Note (F6): the full gated-route universe
+is ~2× this list — the difference is the ~15 already-handled (route, method) pairs
+(directory-sync-card, audit-delivery-target-card, team-rotate-key-button, breakglass-*,
+tenant-vault-reset-button, team-add-from-tenant-section, passkey-credentials-card DELETE,
+service-account token-POST, scim-token POST, access-request approve, api-key create).
+Those already carry (or will carry) a client marker, so they correctly do NOT appear in
+`S \ C`. Their absence from the work-list is expected, NOT a guard miss.
+
+Members to fix (per gated method):
+
+Fully-unhandled or partially-unhandled components (per gated method):
+- Tenant policy PATCH (8 cards): tenant-session-policy-card, tenant-passkey-policy-card,
+  tenant-token-policy-card, tenant-lockout-policy-card, tenant-access-restriction-card,
+  tenant-password-policy-card, tenant-delegation-policy-card, tenant-retention-policy-card.
+- tenant-members-card — PUT member role.
+- team-policy-settings — PUT team policy.
+- base-webhook-card — POST create + DELETE (shared; covers tenant AND team webhooks).
+- **Partial gaps in "handled" components (F1)**: mcp-client-card PUT + DELETE;
+  service-account-card SA-PUT + SA-DELETE + token-DELETE; team-scim-token-manager
+  DELETE; access-request-card POST-deny; api-key-manager DELETE.
+
+For each: `useInlineReauth(() => handler())` (or a per-target discriminator when a
+component has multiple gated mutations — e.g. mcp-client-card needs create/edit/
+delete replay targets, like access-request-card's retry-target state). Add the
+`SESSION_STEP_UP_REQUIRED` branch inside the `!res.ok` block (NOT the catch — the
+forbidden bare-catch pattern must not trip on pre-existing catches). Render both
+dialogs with `cancelLabel` from the component's existing i18n namespace (verify
+the key exists).
+
+Exclusions confirmed by re-derivation (do NOT add branches — over-inclusion guard):
+- passkey-credentials-card PATCH (rename) — route PATCH NOT gated (only DELETE).
+- service-account POST create — NOT gated.
+- access-request-card POST create, vault/delegation — NOT gated.
+
+**Marker obligation covers the ALREADY-handled members too (F6):** the ~15
+already-handled (route, method) pairs must ALSO receive their server `@stepup`
+marker and a client `@stepup` marker on the existing handled call site — otherwise
+the coverage gate would flag them as `S \ C` (server marked, client unmarked). So
+the marker rollout spans every gated mutation, not only the newly-fixed ones. The
+already-handled call sites already have the `SESSION_STEP_UP_REQUIRED` branch, so
+adding their client marker is a one-line comment each; no logic change.
+
+### C3 — Admin full-page callers (pages, not cards)
+- src/app/[locale]/admin/teams/[teamId]/members/list/page.tsx — PUT role + DELETE remove (two gated mutations).
+- src/app/[locale]/admin/teams/[teamId]/members/transfer-ownership/page.tsx — PUT member.
+- src/app/[locale]/admin/teams/[teamId]/general/delete/page.tsx — DELETE team (PUT profile NOT gated).
+Render the two dialogs in page JSX (mirrors vault-reset/page.tsx). Multi-mutation
+pages use a retry-target discriminator.
+
+### C4 — Vault permanent-delete / empty-trash / bulk-purge (G15/G16)
+- G15 `src/hooks/bulk/use-bulk-action.ts` — CAN use the hook; wire the 403 branch
+  for the `deletePermanently` bulk action (bulk-purge, personal + team).
+- G16 adapters `src/lib/vault/{personal,team}-vault-list-adapter.ts`
+  `deletePermanently` (:216/:256) + `emptyTrash` (:223/:261) throw bare
+  `new Error(text)`, LOSING the code. Sole consumer (F4-verified):
+  `src/components/passwords/detail/entry-list-view.tsx` (:418 deletePermanently,
+  :430 emptyTrash), which today `catch { reload() }`.
+  - **Consumer-flow walkthrough (locked)**: entry-list-view needs the `error` code
+    string to branch on step-up; the adapter currently discards it. Contract: the
+    two gated adapter throw-sites throw a typed error exposing
+    `.code === "SESSION_STEP_UP_REQUIRED"`; entry-list-view's catch reads `.code`
+    and calls `triggerOnStaleError` instead of a silent reload. The ungated
+    adapter methods (restore/softDelete/setFavorite/setArchived) keep throwing
+    plain Error — only the two gated sites change (F4).
+  - entry-list-view wires `useInlineReauth` for both flows (or reuses the G15 hook
+    where applicable).
+
+### C5 — Base-webhook shared wiring (locked, F3)
+base-webhook-card.tsx OWNS both gated fetchApi calls (create :155, delete :191);
+tenant-webhook-card/team-webhook-card only inject endpoint strings. Wire once in
+base. (This is a member of C2's list; called out separately because it closes two
+route families with one edit.)
+
+## Forbidden patterns
+- pattern: a `catch\s*\{` block that contains the NEW step-up branch — reason:
+  the 403 branch must live in the `!res.ok` block; `res.ok===false` is not a throw.
+- pattern: hardcoded `"cancel"` literal as cancelLabel — reason: use i18n key.
+- pattern: `import .*@prisma/client` in check-step-up-client-coverage.sh/.mjs —
+  reason: must survive the no-prisma-generate static-checks CI job.
+
+## Testing strategy
+- **Per standalone (component, method)**: a step-up denial unit test (RT8) — mock
+  `fetchApi` → 403 `SESSION_STEP_UP_REQUIRED`; assert the reauth dialog opens and
+  the mutation is not reported as generic failure. ~14 standalone components/pages
+  (do NOT collapse the 8 policy cards — each has its own handler). Multi-mutation
+  components (mcp-client-card, service-account-card, admin members page) get one
+  test PER gated method.
+- **Test-count reconciliation (T7)**: fix-granularity is per (component, method).
+  Test count = one denial test per gated method, NOT per component. Explicit total:
+  8 policy cards (1 each) + tenant-members PUT + team-policy PUT + mcp-client
+  {PUT, DELETE} (2) + service-account {PUT, DELETE, token-DELETE} (3) + scim-token
+  DELETE + access-request deny + api-key DELETE + admin members {PUT, DELETE} (2) +
+  transfer-ownership PUT + team-delete DELETE + base-webhook {POST, DELETE} per
+  consumer (see below) + vault {permanent-delete, empty-trash, bulk-purge}. A
+  multi-mutation member gets one test per gated method — do not collapse.
+- **Shared abstractions need per-consumer, per-method tests (T3)**:
+  - base-webhook-card: 403 tests in BOTH tenant-webhook-card.test.tsx AND
+    team-webhook-card.test.tsx, each covering BOTH gated methods (POST create AND
+    DELETE) — DELETE-webhook is a distinct F1-class gap from POST-create (T7). The
+    two card tests diverge on the next-intl `useLocale` mock — a base-only test
+    misses a variant that fails to supply dialog context.
+  - G15/G16: an entry-list-view.test.tsx test that overrides use-bulk-action /
+    adapter to return 403 for permanent-delete + empty-trash and asserts the dialog
+    renders. entry-list-view.test.tsx currently mocks next-intl WITHOUT `useLocale`
+    (:41) — either reuse `setupPasskeyReauthDialogMocks()` (stubs dialogs, sidesteps
+    the gotcha) OR add `useLocale: () => "en"`; state which per new test file (T4).
+- **C1 guard**: the `.test.mjs` self-test (7 fixtures in C1) IS the guard's
+  regression proof (T1/T8/T9/C1-R3-5): handled-PASS, no-client-marker-FAIL,
+  marker-without-adjacent-branch-FAIL, exempt-marker-absent-FAIL,
+  server-call-without-marker-FAIL, orphan-client-marker-FAIL, and the
+  two-handlers-one-file fixture (F1 regression lock). Plus the two-way mutation demo
+  (remove marker → coverage RED; remove branch → handling RED on the multi-mutation
+  mcp-client-card, which now goes RED correctly under adjacency-scoping).
+- **E2E (T6)**: (a) run `e2e/tests/trash.spec.ts` after C4 — it already exercises
+  empty-trash step-up via `refreshSessionRecency` and could regress on the happy
+  path. (b) Add one E2E asserting the reauth dialog appears when empty-trash /
+  permanent-delete runs on a STALE window (omit `refreshSessionRecency`), mirroring
+  vault-reset.spec.ts. E2E is outside pre-pr default gate — run explicitly.
+- Full `npx vitest run`, `npx next build`, `bash scripts/pre-pr.sh`.
+
+## Considerations & constraints
+
+### Scope contract
+- SC1: OAuth/mobile direct-`requireRecentSession` routes (mcp/authorize,
+  mcp/authorize/consent, mobile/authorize) — out of scope; not mutating-UI cards.
+- SC2: S1 null-vaultAutoLock cross-bound gap (auto-lock PR) — separate PR
+  `TODO(vault-null-autolock-default)`.
+- SC3: team-vault-core background confirm-key poller — allowlisted in C1, not
+  user-facing (no awaiting gesture).
+- SC4: operator-token-card — uses `OPERATOR_TOKEN_STALE_SESSION` custom recovery;
+  allowlisted, not a `SESSION_STEP_UP_REQUIRED` consumer. Not unifying in this PR.
+
+### Risk
+- Large blast radius (~24 (component,method) fixes + a marker on every gated
+  mutation across ~16+ files). Mitigation: guard-first with a MARKER-based coverage
+  gate (not path-inference — F7). The gate matches stable `@stepup id:X` markers
+  between server and client, so it needs no fragile path resolution and cannot go
+  blind to raw-literal / prop-indirection / helper callers. "Did we get them all"
+  = the coverage gate's `S \ C` is empty. R42 ①b: member-set expanded ≥2×
+  (8→16→24+), so a mutation-verified CI guard is the REQUIRED convergence artifact.
+- Marker-scheme cost: adding a server marker to every gated handler and a client
+  marker to every gated call site is one comment line each (no logic change for the
+  ~15 already-handled members). This up-front cost buys the fail-closed coverage gate.
+
+## User operation scenarios
+1. Admin edits any tenant security policy / mcp-client / service-account / api-key /
+   webhook / scim-token after the 15-min step-up window lapses → expects a reauth
+   prompt, not a silent/generic error.
+2. Admin permanently deletes a trashed entry / empties trash / bulk-purges after
+   the window lapses → expects reauth, not a silent list reload.
+3. Team owner transfers ownership / removes a member / deletes a team from the admin
+   pages after the window lapses → expects reauth.
+
+## Go/No-Go Gate
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | Marker-verified client-coverage guard (adjacency-scoped, implement FIRST) | locked (Round 3: adjacency-window + line-bound server marker + fixture vii) |
+| C2 | Fix all card/dialog/hook callers + marker rollout | locked (member-set verified; guard S\C authoritative) |
+| C3 | Admin full-page callers | locked |
+| C4 | Vault permanent-delete / empty-trash / bulk-purge | locked (F4 typed-error contract) |
+| C5 | Base-webhook shared wiring | locked (F3 base owns fetchApi) |

--- a/docs/archive/review/step-up-client-policy-card-plan.md
+++ b/docs/archive/review/step-up-client-policy-card-plan.md
@@ -304,3 +304,95 @@ route families with one edit.)
 | C3 | Admin full-page callers | locked |
 | C4 | Vault permanent-delete / empty-trash / bulk-purge | locked (F4 typed-error contract) |
 | C5 | Base-webhook shared wiring | locked (F3 base owns fetchApi) |
+
+## Implementation Checklist (Phase 2 — derived from code, R42)
+
+### Member-set derivation (authoritative, from the defining primitive)
+`grep -rnE '(^|[^A-Za-z0-9_])requireRecentCurrentAuthMethod\(' src/app --include=route.ts`
+yields **45 gated (route, method) server call sites** across 35 route files — nearly
+**2× the plan's ~24 estimate**. This is the expected R42 expansion; the guard-first
+marker scheme is exactly the convergence artifact for it (no re-scope needed — the
+plan anticipated ≥2× expansion). Full classification below. `id` is the stable slug
+placed in `// @stepup id:<id> method:<M>`.
+
+**Legend**: FIX = client currently unhandled → needs branch + client marker.
+HANDLED = client already branches → marker-only (1 comment each). EXEMPT = allowlisted.
+
+| id | route:line | method | client consumer | disposition |
+|----|-----------|--------|-----------------|-------------|
+| api-keys-post | api-keys/route.ts:77 | POST | api-key-manager.tsx | HANDLED |
+| api-keys-id-delete | api-keys/[id]/route.ts:21 | DELETE | api-key-manager.tsx (handleRevoke) | **FIX** |
+| directory-sync-post | directory-sync/route.ts:104 | POST | directory-sync-card.tsx | HANDLED |
+| directory-sync-id-put | directory-sync/[id]/route.ts:119 | PUT | directory-sync-card.tsx | HANDLED |
+| directory-sync-id-delete | directory-sync/[id]/route.ts:201 | DELETE | directory-sync-card.tsx | HANDLED |
+| ext-bridge-code-post | extension/bridge-code/route.ts:194 | POST | auto-extension-connect.tsx | EXEMPT (EXTENSION_CONNECT_ERROR_CODE.SESSION_STEP_UP_REQUIRED) |
+| passwords-id-delete-permanent | passwords/[id]/route.ts:301 | DELETE(?permanent) | entry-list-view via personal adapter | **FIX (C4)** |
+| passwords-bulk-purge | passwords/bulk-purge/route.ts:29 | POST | use-bulk-action.ts | **FIX (C4)** |
+| passwords-empty-trash | passwords/empty-trash/route.ts:26 | POST | entry-list-view via personal adapter | **FIX (C4)** |
+| team-confirm-key-post | teams/[teamId]/members/[memberId]/confirm-key/route.ts:39 | POST | team-vault-core.tsx (setInterval poller) | EXEMPT (SC3 background poller) |
+| team-member-put | teams/[teamId]/members/[memberId]/route.ts:66 | PUT | admin members/list/page.tsx | **FIX (C3)** |
+| team-member-delete | teams/[teamId]/members/[memberId]/route.ts:177 | DELETE | admin members/list/page.tsx | **FIX (C3)** |
+| team-members-post | teams/[teamId]/members/route.ts:64 | POST | team-add-from-tenant-section.tsx | HANDLED |
+| team-password-id-delete-permanent | teams/[teamId]/passwords/[id]/route.ts:181 | DELETE(?permanent) | entry-list-view via team adapter | **FIX (C4)** |
+| team-password-bulk-purge | teams/[teamId]/passwords/bulk-purge/route.ts:42 | POST | use-bulk-action.ts (team) | **FIX (C4)** |
+| team-password-empty-trash | teams/[teamId]/passwords/empty-trash/route.ts:39 | POST | entry-list-view via team adapter | **FIX (C4)** |
+| team-policy-put | teams/[teamId]/policy/route.ts:89 | PUT | team-policy-settings.tsx | **FIX** |
+| team-rotate-key-post | teams/[teamId]/rotate-key/route.ts:83 | POST | team-rotate-key-button.tsx | HANDLED |
+| team-delete | teams/[teamId]/route.ts:150 | DELETE | admin general/delete/page.tsx | **FIX (C3)** |
+| team-webhook-delete | teams/[teamId]/webhooks/[webhookId]/route.ts:44 | DELETE | base-webhook-card.tsx (team) | **FIX (C5)** |
+| team-webhook-post | teams/[teamId]/webhooks/route.ts:98 | POST | base-webhook-card.tsx (team) | **FIX (C5)** |
+| access-request-approve | tenant/access-requests/[id]/approve/route.ts:52 | POST | access-request-card.tsx | HANDLED |
+| access-request-deny | tenant/access-requests/[id]/deny/route.ts:45 | POST | access-request-card.tsx | **FIX** |
+| audit-delivery-target-id-patch | tenant/audit-delivery-targets/[id]/route.ts:50 | PATCH | audit-delivery-target-card.tsx | HANDLED |
+| audit-delivery-target-post | tenant/audit-delivery-targets/route.ts:154 | POST | audit-delivery-target-card.tsx | HANDLED |
+| breakglass-id-delete | tenant/breakglass/[id]/route.ts:53 | DELETE | breakglass-grant-list.tsx | HANDLED |
+| breakglass-post | tenant/breakglass/route.ts:52 | POST | breakglass-dialog.tsx | HANDLED |
+| mcp-client-id-put | tenant/mcp-clients/[id]/route.ts:92 | PUT | mcp-client-card.tsx | **FIX** |
+| mcp-client-id-delete | tenant/mcp-clients/[id]/route.ts:161 | DELETE | mcp-client-card.tsx | **FIX** |
+| mcp-client-post | tenant/mcp-clients/route.ts:129 | POST | mcp-client-card.tsx | HANDLED |
+| reset-vault-approve | tenant/members/[userId]/reset-vault/[resetId]/approve/route.ts:157 | POST | tenant-reset-history-dialog.tsx | HANDLED |
+| reset-vault-post | tenant/members/[userId]/reset-vault/route.ts:116 | POST | tenant-vault-reset-button.tsx | HANDLED |
+| tenant-member-put | tenant/members/[userId]/route.ts:46 | PUT | tenant-members-card.tsx | **FIX** |
+| operator-tokens-post | tenant/operator-tokens/route.ts:139 | POST | operator-token-card.tsx | EXEMPT (OPERATOR_TOKEN_STALE_SESSION, SC4) |
+| tenant-policy-patch | tenant/policy/route.ts:193 | PATCH | 8 policy cards (session/passkey/token/lockout/access-restriction/password/delegation/retention) | **FIX** (8 cards, one shared route id) |
+| scim-token-id-delete | tenant/scim-tokens/[tokenId]/route.ts:48 | DELETE | team-scim-token-manager.tsx | **FIX** |
+| scim-token-post | tenant/scim-tokens/route.ts:104 | POST | team-scim-token-manager.tsx | HANDLED |
+| service-account-id-put | tenant/service-accounts/[id]/route.ts:102 | PUT | service-account-card.tsx | **FIX** |
+| service-account-id-delete | tenant/service-accounts/[id]/route.ts:182 | DELETE | service-account-card.tsx | **FIX** |
+| sa-token-id-delete | tenant/service-accounts/[id]/tokens/[tokenId]/route.ts:59 | DELETE | service-account-card.tsx | **FIX** |
+| sa-token-post | tenant/service-accounts/[id]/tokens/route.ts:97 | POST | service-account-card.tsx | HANDLED |
+| tenant-webhook-delete | tenant/webhooks/[webhookId]/route.ts:45 | DELETE | base-webhook-card.tsx (tenant) | **FIX (C5)** |
+| tenant-webhook-post | tenant/webhooks/route.ts:97 | POST | base-webhook-card.tsx (tenant) | **FIX (C5)** |
+| vault-reset-post | vault/reset/route.ts:57 | POST | vault-reset/page.tsx | HANDLED |
+| webauthn-credential-delete | webauthn/credentials/[id]/route.ts:38 | DELETE | passkey-credentials-card.tsx | HANDLED |
+
+**Tally**: 45 sites = 3 EXEMPT + ~19 HANDLED (marker-only) + 23 FIX (client work).
+The tenant-policy-patch id is shared by 8 client cards (all `fetchApi(API_PATH.TENANT_POLICY, {method:PATCH})` — the F7 helper-token case), so the client-side marker+branch obligation is per-card even though the server id is one.
+
+### Shared-helper commonization (user steer 2026-07-08: 共通処理にできる箇所は意識)
+Every consumer today inlines `const body = await readApiErrorBody(res); if (body?.error
+=== API_ERROR.SESSION_STEP_UP_REQUIRED) { await inlineReauth.triggerOnStaleError(arg); return; }`.
+Extract a single helper in `src/lib/http/` — `handleStepUpError(res, trigger, arg?): Promise<boolean>`
+(reads body, if step-up calls trigger and returns true; else false). Collapses the 3–4 line
+block to one line at ~23 FIX sites AND the ~19 HANDLED sites (refactor those too for uniformity).
+**Guard interaction**: extracting the helper removes the literal `SESSION_STEP_UP_REQUIRED`
+from call sites. The C1 client-side adjacency check MUST therefore accept EITHER the raw
+constant OR the helper-call token (`handleStepUpError`) as the "branch present" signal.
+Document the accepted token set in the guard header. The helper's own definition file is the
+one place the constant literal still lives.
+
+### C1 guard files
+- `scripts/checks/check-step-up-client-coverage.sh` (model: check-permanent-delete-stepup.sh)
+- `scripts/checks/stepup-client-exempt.txt` (3 entries: ext-bridge-code-post, team-confirm-key-post, operator-tokens-post — each names its custom recovery marker)
+- `scripts/__tests__/check-step-up-client-coverage.test.mjs` (7 fixtures i–vii)
+- Wire: pre-pr.sh next to permanent-delete-stepup (line ~165) + CI static-checks job
+
+### All-test-tree enumeration (R19)
+Each FIXed component has a co-located `*.test.tsx`. base-webhook shared → BOTH
+tenant-webhook-card.test.tsx AND team-webhook-card.test.tsx. C4 → entry-list-view.test.tsx.
+E2E: e2e/tests/trash.spec.ts (existing) + new stale-window spec.
+
+### CI gate parity
+Guard must run under static-checks CI job WITHOUT `prisma generate` — no `@prisma/client`
+import (pure text/fs scan, per project_static_check_ci_no_prisma_generate). Verify by
+displacing node_modules/.prisma/client before running.

--- a/docs/archive/review/step-up-client-policy-card-review.md
+++ b/docs/archive/review/step-up-client-policy-card-review.md
@@ -1,0 +1,77 @@
+# Plan Review: step-up-client-policy-card
+Date: 2026-07-08
+Review rounds: 3 (converged)
+
+## Summary
+Triangulate plan review across functionality / security / testing, 3 rounds. The
+plan evolved substantially under review — the headline outcome is that the initial
+"fix the one policy card" framing was wrong on two axes, both caught pre-implementation:
+
+1. **Member-set was under-enumerated (F1, Critical, Round 1)** — set membership is
+   per (route, method), not per component; several "already handled" components
+   (mcp-client-card, service-account-card, even the reference api-key-manager) wire
+   step-up on only SOME of their gated mutations. Re-derived the full ~24-member set
+   from `requireRecentCurrentAuthMethod` callers.
+2. **The CI guard could not be a grep-inference guard (F7, Major, Round 2)** — three
+   caller path-spellings (raw template literals, prop-indirection, apiPath helpers)
+   defeat token grep, so an inference guard goes GREEN while blind to real members.
+   Pivoted to a marker-verified guard.
+3. **The marker guard's handling-check was file-scoped (C1-R3-2, Critical, Round 3)** —
+   whole-file grep false-PASSes the live mcp-client-card F1 case. Fixed with an
+   adjacency-window mechanism + a two-handlers-one-file self-test fixture.
+
+## Round 1 findings (initial plan)
+- **F1 [Critical]** member-set per-component not per-(route,method); partial gaps in
+  mcp-client-card, service-account-card, team-scim-token-manager, access-request-card,
+  api-key-manager. → RESOLVED: re-derived per-method; C2 lists all.
+- **F2 [Major]** param-conditional gating (`?permanent=true`). → RESOLVED (marker on the
+  in-branch call; ungated soft-delete simply unmarked).
+- **F3/F4 [Minor]** base-webhook owns fetchApi; adapter typed-error feasible, single
+  consumer. → RESOLVED, C5/C4 locked.
+- **F5 [Major]** guard route→API_PATH→caller mapping hand-wavy. → superseded by F7 pivot.
+- **S1-S3 [Confirm]** fix is UX-completeness, fail-CLOSED, reauth is genuine. No finding.
+- **S4 [Minor]** allowlist should assert custom-marker presence. → RESOLVED in C1.
+- **T1 [Major]** guard needs checked-in `.test.mjs`. → RESOLVED.
+- **T2 [Major]** wire into pre-pr.sh run_step + no `@prisma/client`. → RESOLVED.
+- **T3 [Major]** shared abstractions need per-consumer tests. → RESOLVED.
+- **T4/T6 [Minor]** useLocale mock; trash.spec re-run + stale-window E2E. → RESOLVED.
+
+## Round 2 findings (updated plan)
+- **F6 [Minor]** "guard reproduces this set exactly / any delta is a bug" framing wrong —
+  the ~15 already-handled gated routes correctly don't appear in S\C. → RESOLVED (framing
+  corrected; already-handled members also get markers).
+- **F7 [Major]** grep-inference guard cannot resolve raw-literal / prop-indirection /
+  helper callers → blind spot on named members (team-policy-settings, base-webhook). →
+  RESOLVED: pivot to two-sided `@stepup id:X` marker scheme (no path resolution).
+- **T7 [Major]** test-count not reconciled with per-method fix granularity; base-webhook
+  needs both methods per consumer. → RESOLVED (explicit count).
+- **T8 [Major]** self-test fixtures don't exercise the hardest resolution logic. →
+  superseded by marker pivot; fixtures expanded.
+- **T9 [Minor]** param-conditional allowlist untested. → RESOLVED (marker sits on
+  in-branch call; no allowlist needed).
+
+## Round 3 findings (marker-guard design)
+- **C1-R3-1 [Minor]** marker scheme confirmed to eliminate F7 path-resolution. Sound.
+- **C1-R3-2 [Critical]** "enclosing handler function body" not bash-achievable; file-scoped
+  grep false-PASSes live mcp-client-card (SESSION_STEP_UP_REQUIRED once, 3 gated handlers).
+  → RESOLVED: adjacency-window (`awk` N-lines-below-marker), not file grep.
+- **C1-R3-3 [Major]** recommend adjacency (bash, no parser) over ts-morph; ts-morph as
+  escalation. → ADOPTED (adjacency default).
+- **C1-R3-4 [Major]** server-marker completeness must be line-bound (H/H-1) per call, not
+  a file-level count. → RESOLVED.
+- **C1-R3-5 [Major]** add fixture (vii): two marked handlers in one file, one branched one
+  not → FAIL. Only fixture that distinguishes adjacency- from file-scoping. → RESOLVED.
+
+## Convergence
+All contracts locked at end of Round 3. C1 is implementable as pure bash+grep+awk+filesystem
+(no `@prisma/client`), adjacency-scoped, with a 7-fixture self-test including the F1
+regression lock. Member-set is code-derived per (route, method); the marker coverage gate
+(S\C) is the R42 ①b convergence artifact for a class that expanded 8→16→24+.
+
+## Recurring Issue Check (key rules for this plan)
+- R42 (member-set derivation): CENTRAL — derived from `requireRecentCurrentAuthMethod`
+  primitive per (route, method); guard mechanizes the invariant. ✓
+- RT7 shape b (authored-but-unproven gate): addressed — 7-fixture self-test + mutation demo
+  + pre-pr.sh wiring. ✓
+- project_static_check_ci_no_prisma_generate: guard forbidden from importing @prisma/client. ✓
+- project_ci_gates_beyond_pre_pr: E2E called out as outside default gate. ✓

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -313,6 +313,19 @@ export async function refreshSessionRecency(sessionToken: string): Promise<void>
   );
 }
 
+/**
+ * Force a session outside the step-up recency window so a gated mutation returns
+ * SESSION_STEP_UP_REQUIRED. Inverse of refreshSessionRecency; the interval is far
+ * past the 15-minute window so the test is robust to clock jitter.
+ */
+export async function makeSessionStale(sessionToken: string): Promise<void> {
+  const p = getPool();
+  await p.query(
+    `UPDATE sessions SET created_at = now() - interval '1 hour' WHERE session_token = $1`,
+    [sessionToken]
+  );
+}
+
 export async function seedVaultKey(
   userId: string,
   verificationArtifact: {

--- a/e2e/tests/step-up-stale-window.spec.ts
+++ b/e2e/tests/step-up-stale-window.spec.ts
@@ -65,14 +65,21 @@ test.describe("Step-up reauth on stale window", () => {
     // Push the session outside the step-up window so empty-trash returns 403.
     await makeSessionStale(vaultReady.sessionToken);
 
-    // Click "Empty Trash" and confirm; the mutation now 403s.
+    // Click "Empty Trash" and confirm; the mutation now 403s. The confirm
+    // dialog is a plain Dialog (role='dialog'); the reauth prompt below is an
+    // AlertDialog (role='alertdialog').
     await trashPage.emptyTrashButton.click();
     await page.locator("[role='dialog']").waitFor({ timeout: 5_000 });
     await trashPage.emptyTrashConfirmButton.click();
 
-    // The reauth prompt (sign-in-again) must appear — NOT a silent reload.
+    // A reauth prompt must appear — NOT a silent reload. Which reauth dialog
+    // opens depends on canUsePasskeyRecovery() (PasskeyReauthDialog vs
+    // RecentSessionRequiredDialog), but BOTH are AlertDialogs (role=alertdialog)
+    // while the empty-trash confirm above is a plain Dialog (role=dialog) — so
+    // asserting on the alertdialog role is robust to which dialog opens and to
+    // i18n text rendering.
     await expect(
-      page.getByText(/Sign in again to continue|続行するには再サインインが必要です/),
+      page.locator("[role='alertdialog']"),
     ).toBeVisible({ timeout: 10_000 });
 
     // And the trashed entry must still be present (the purge was blocked).

--- a/e2e/tests/step-up-stale-window.spec.ts
+++ b/e2e/tests/step-up-stale-window.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, type BrowserContext, type Page } from "@playwright/test";
+import { getAuthState } from "../helpers/fixtures";
+import { injectSession } from "../helpers/auth";
+import { makeSessionStale, refreshSessionRecency } from "../helpers/db";
+import { VaultLockPage } from "../page-objects/vault-lock.page";
+import { DashboardPage } from "../page-objects/dashboard.page";
+import { PasswordEntryPage } from "../page-objects/password-entry.page";
+import { SidebarNavPage } from "../page-objects/sidebar-nav.page";
+import { TrashPage } from "../page-objects/trash.page";
+
+/**
+ * Step-up client reauth on a STALE window (companion to trash.spec.ts, which
+ * runs empty-trash on a REFRESHED session). Here the session is deliberately
+ * pushed outside the 15-minute step-up window so the empty-trash mutation
+ * returns SESSION_STEP_UP_REQUIRED; the client must open the reauth prompt
+ * instead of silently reloading. The seeded user has no passkey, so the
+ * RecentSessionRequiredDialog (sign-in-again) path is exercised.
+ */
+test.describe("Step-up reauth on stale window", () => {
+  let context: BrowserContext;
+  let page: Page;
+
+  const ts = Date.now();
+  const entryTitle = `E2E StaleStepUp ${ts}`;
+
+  test.beforeAll(async ({ browser }) => {
+    const { vaultReady } = getAuthState();
+    context = await browser.newContext();
+    await injectSession(context, vaultReady.sessionToken);
+    page = await context.newPage();
+
+    await page.goto("/ja/dashboard");
+    const lockPage = new VaultLockPage(page);
+    await expect(lockPage.passphraseInput).toBeVisible({ timeout: 20_000 });
+    await lockPage.unlockAndWait(vaultReady.passphrase!);
+
+    // Create one entry and move it to trash so empty-trash has something to do.
+    const dashboard = new DashboardPage(page);
+    const entryPage = new PasswordEntryPage(page);
+    await dashboard.createNewPassword();
+    await entryPage.fill({ title: entryTitle, password: "E2EStaleP@ss1" });
+    await entryPage.save();
+    await expect(dashboard.entryByTitle(entryTitle)).toBeVisible({ timeout: 10_000 });
+
+    // Move it to trash (soft-delete) so empty-trash has something to purge.
+    await entryPage.deleteEntry(entryTitle);
+  });
+
+  test.afterAll(async () => {
+    // This spec mutates the SHARED vaultReady session (makeSessionStale). Restore
+    // its recency so a later-ordered spec reusing this session isn't left stale.
+    const { vaultReady } = getAuthState();
+    await refreshSessionRecency(vaultReady.sessionToken);
+    await context.close();
+  });
+
+  test("empty-trash on a stale session opens the reauth prompt", async () => {
+    const { vaultReady } = getAuthState();
+    const sidebar = new SidebarNavPage(page);
+    const trashPage = new TrashPage(page);
+
+    await sidebar.navigateTo("trash");
+    await expect(page.getByText(entryTitle)).toBeVisible({ timeout: 10_000 });
+
+    // Push the session outside the step-up window so empty-trash returns 403.
+    await makeSessionStale(vaultReady.sessionToken);
+
+    // Click "Empty Trash" and confirm; the mutation now 403s.
+    await trashPage.emptyTrashButton.click();
+    await page.locator("[role='dialog']").waitFor({ timeout: 5_000 });
+    await trashPage.emptyTrashConfirmButton.click();
+
+    // The reauth prompt (sign-in-again) must appear — NOT a silent reload.
+    await expect(
+      page.getByText(/Sign in again to continue|続行するには再サインインが必要です/),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // And the trashed entry must still be present (the purge was blocked).
+    await expect(page.getByText(entryTitle)).toBeVisible();
+  });
+});

--- a/scripts/__tests__/check-step-up-client-coverage.test.mjs
+++ b/scripts/__tests__/check-step-up-client-coverage.test.mjs
@@ -1,0 +1,301 @@
+/**
+ * Self-test for scripts/checks/check-step-up-client-coverage.sh — the CI guard
+ * that requires every step-up-gated server route to have a client caller which
+ * handles the SESSION_STEP_UP_REQUIRED 403.
+ *
+ * The guard is the completeness backstop for an enumeration class (plan F7:
+ * per-component enumeration under-counts because a component can handle POST but
+ * not its DELETE). A regression in its detection would silently reopen that
+ * class, so it gets its own test asserting it catches each failure mode.
+ *
+ * Driven against fixtures via STEPUP_CLIENT_GUARD_* env overrides so the test
+ * never mutates tracked files.
+ *
+ * Fixtures (plan C1 self-test i–vii):
+ *   (i)   server id + client marker + branch in window            → PASS
+ *   (ii)  server id, NO client marker (付け漏れ)                   → FAIL (coverage S\C)
+ *   (iii) client marker, NO branch within adjacency window        → FAIL (handling)
+ *   (iv)  exempt entry whose named custom marker is absent         → FAIL (anti-drift)
+ *   (v)   requireRecentCurrentAuthMethod call with NO marker       → FAIL (server completeness)
+ *   (vi)  client id with no server match (renamed/stale)           → FAIL (anti-orphan)
+ *   (vii) ONE file, TWO marked handlers, only A branches           → FAIL pointing at B
+ *         (the ONLY fixture that passes under file-scoping and fails under
+ *          adjacency-scoping — the direct regression lock for the live
+ *          mcp-client-card POST-handled / DELETE-unhandled gap).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const GUARD = join(REPO_ROOT, "scripts/checks/check-step-up-client-coverage.sh");
+
+const STEPUP_CALL =
+  "  const stepUp = await requireRecentCurrentAuthMethod(req); if (stepUp) return stepUp;";
+
+let root;
+let apiDir;
+let clientDir;
+let exemptFile;
+
+function runGuard() {
+  const r = spawnSync("bash", [GUARD], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      STEPUP_CLIENT_GUARD_API_DIR: apiDir,
+      STEPUP_CLIENT_GUARD_CLIENT_DIR: clientDir,
+      STEPUP_CLIENT_GUARD_PATH_ROOT: root,
+      STEPUP_CLIENT_GUARD_EXEMPT_FILE: exemptFile,
+    },
+  });
+  return { exitCode: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+
+/** Write a server route fixture at api/<rel>/route.ts. */
+function writeRoute(rel, body) {
+  const dir = join(apiDir, rel);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "route.ts"), body, "utf8");
+}
+
+/** Write a client component fixture under src/<rel>. */
+function writeClient(rel, body) {
+  const full = join(clientDir, rel);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, body, "utf8");
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "stepup-client-guard-"));
+  apiDir = join(root, "src", "app", "api");
+  clientDir = join(root, "src");
+  exemptFile = join(root, "exempt.txt");
+  mkdirSync(apiDir, { recursive: true });
+  mkdirSync(clientDir, { recursive: true });
+  writeFileSync(exemptFile, "# fixture exempt list\n", "utf8");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("check-step-up-client-coverage.sh", () => {
+  it("(i) PASSES: server marker + client marker + branch in window", () => {
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "async function handleSave() {",
+        "  // @stepup id:widget-put",
+        '  const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        "  if (!res.ok) {",
+        "    if (await handleStepUpError(res, trigger)) return;",
+        "  }",
+        "}",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode, stdout).toBe(0);
+  });
+
+  it("(ii) FAILS (MISSING_CLIENT_MARKER): server marker, no client marker", () => {
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    // No client marker anywhere.
+    writeClient(
+      "components/widget-card.tsx",
+      'const res = await fetchApi("/api/widgets/x", { method: "PUT" });\n',
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("MISSING_CLIENT_MARKER");
+    expect(stdout).toContain("widget-put");
+  });
+
+  it("(iii) FAILS (CLIENT_BRANCH_MISSING): marker present, no branch in window", () => {
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "// @stepup id:widget-put",
+        'const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        "if (!res.ok) {",
+        '  toast.error("generic");', // no step-up branch
+        "}",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("CLIENT_BRANCH_MISSING");
+  });
+
+  it("(iv) FAILS (EXEMPT_MARKER_ABSENT): exempt entry's custom marker missing", () => {
+    writeRoute(
+      "extension/bridge-code",
+      `// @stepup id:ext-post method:POST\n${STEPUP_CALL}\n`,
+    );
+    // Exempt it, naming a custom marker that does NOT exist in the client tree.
+    writeFileSync(
+      exemptFile,
+      "ext-post  CUSTOM_MARKER_THAT_DOES_NOT_EXIST  # auto-extension custom recovery\n",
+      "utf8",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("EXEMPT_MARKER_ABSENT");
+  });
+
+  it("(iv-pass) PASSES: exempt entry whose custom marker IS present", () => {
+    writeRoute(
+      "extension/bridge-code",
+      `// @stepup id:ext-post method:POST\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "components/auto-extension.tsx",
+      "if (x === CUSTOM_MARKER) doThing();\n",
+    );
+    writeFileSync(
+      exemptFile,
+      "ext-post  CUSTOM_MARKER  # auto-extension custom recovery channel\n",
+      "utf8",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode, stdout).toBe(0);
+  });
+
+  it("(v) FAILS (SERVER_MARKER_MISSING): gated call with no server marker", () => {
+    writeRoute("widgets/[id]", `${STEPUP_CALL}\n`); // no marker line
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("SERVER_MARKER_MISSING");
+  });
+
+  it("(vi) FAILS (ORPHAN_CLIENT_MARKER): client id with no server match", () => {
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "// @stepup id:widget-put",
+        'const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        "if (await handleStepUpError(res, trigger)) return;",
+        "// @stepup id:renamed-stale-id",
+        'const res2 = await fetchApi("/api/widgets/y", { method: "DELETE" });',
+        "if (await handleStepUpError(res2, trigger)) return;",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("ORPHAN_CLIENT_MARKER");
+    expect(stdout).toContain("renamed-stale-id");
+  });
+
+  it("(vii) FAILS at handler B: one file, two marked handlers, only A branches", () => {
+    // Two distinct gated server ids, both with markers.
+    writeRoute(
+      "mcp-clients/[id]",
+      [
+        "// @stepup id:mcp-put method:PUT",
+        STEPUP_CALL,
+        "// filler ".repeat(1),
+        "// @stepup id:mcp-delete method:DELETE",
+        STEPUP_CALL,
+      ].join("\n") + "\n",
+    );
+    // Client: handler A (mcp-put) branches; handler B (mcp-delete) does NOT.
+    // A whole-FILE grep sees SESSION_STEP_UP_REQUIRED once and would PASS both;
+    // adjacency scoping fails B because its marker has no branch in-window.
+    const filler = Array.from({ length: 45 }, (_, i) => `  // pad ${i}`).join(
+      "\n",
+    );
+    writeClient(
+      "components/mcp-client-card.tsx",
+      [
+        "async function handleEdit() {",
+        "  // @stepup id:mcp-put",
+        '  const res = await fetchApi("/api/mcp-clients/x", { method: "PUT" });',
+        "  if (!res.ok) {",
+        "    if (await handleStepUpError(res, trigger)) return;",
+        "  }",
+        "}",
+        filler, // push handler B's marker far from A's branch
+        "async function handleDelete() {",
+        "  // @stepup id:mcp-delete",
+        '  const res = await fetchApi("/api/mcp-clients/x", { method: "DELETE" });',
+        "  if (!res.ok) {",
+        '    toast.error("generic"); // NO step-up branch — the live gap',
+        "  }",
+        "}",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("CLIENT_BRANCH_MISSING");
+    expect(stdout).toContain("mcp-delete");
+    // And crucially NOT a false MISSING_CLIENT_MARKER for mcp-delete (the marker
+    // IS present — the defect is the missing branch, caught by adjacency).
+    expect(stdout).not.toContain("MISSING_CLIENT_MARKER");
+  });
+
+  it("(viii) FAILS (THROWER_WITHOUT_CATCHER): throwIfStepUp with no isStepUpRequiredError consumer", () => {
+    writeRoute(
+      "passwords/[id]",
+      `// @stepup id:pw-delete method:DELETE\n${STEPUP_CALL}\n`,
+    );
+    // Adapter throws the typed error (counts as a branch for the marker)...
+    writeClient(
+      "lib/vault/adapter.ts",
+      [
+        "// @stepup id:pw-delete",
+        'const res = await fetchApi("/api/passwords/x?permanent=true", { method: "DELETE" });',
+        "await throwIfStepUp(res);",
+        'if (!res.ok) throw new Error("deletePermanently failed");',
+      ].join("\n") + "\n",
+    );
+    // ...but NO consumer anywhere catches it with isStepUpRequiredError.
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("STEPUP_THROWER_WITHOUT_CATCHER");
+  });
+
+  it("(viii-pass) PASSES: throwIfStepUp WITH an isStepUpRequiredError consumer", () => {
+    writeRoute(
+      "passwords/[id]",
+      `// @stepup id:pw-delete method:DELETE\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "lib/vault/adapter.ts",
+      [
+        "// @stepup id:pw-delete",
+        'const res = await fetchApi("/api/passwords/x?permanent=true", { method: "DELETE" });',
+        "await throwIfStepUp(res);",
+        'if (!res.ok) throw new Error("deletePermanently failed");',
+      ].join("\n") + "\n",
+    );
+    writeClient(
+      "components/entry-list.tsx",
+      [
+        "try { await adapter.deletePermanently(entry); }",
+        "catch (e) { if (isStepUpRequiredError(e)) { reload(); await trigger(); return; } reload(); }",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode, stdout).toBe(0);
+  });
+});

--- a/scripts/checks/check-step-up-client-coverage.sh
+++ b/scripts/checks/check-step-up-client-coverage.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# CI gate: every mutating-UI caller of a step-up-gated API route MUST handle the
+# SESSION_STEP_UP_REQUIRED 403 by opening the reauth flow — not by surfacing a
+# generic error. This closes the "server enforces step-up, client swallows it"
+# class (a UX dead-end on a stale session, and the direct symptom that started
+# docs/archive/review/step-up-client-policy-card-plan.md).
+#
+# WHY MARKER-BASED, NOT INFERENCE-BASED (plan F7):
+# A pure grep cannot reliably resolve a client `fetchApi(...)` call to the gated
+# (route, method) it hits — real callers use raw template literals
+# (`/api/teams/${teamId}/policy`), prop-indirection (the path token lives in a
+# DIFFERENT file), and helper→canonical-path gaps (`API_PATH.TENANT_POLICY`,
+# `apiPath.tenantMemberById(id)`), none of which carry a textual route+method
+# token. So coverage is declared explicitly with a stable id on BOTH ends:
+#
+#   Server (each gated handler, on the requireRecentCurrentAuthMethod call line
+#           H or H-1):        // @stepup id:<STABLE_ID> method:<M>
+#   Client (immediately above the gated fetchApi call):  // @stepup id:<STABLE_ID>
+#           ...and a step-up "branch" must appear within ADJACENCY_WINDOW lines
+#           below that client marker.
+#
+# The guard matches ids between the two sets; it never resolves a path. A gated
+# server mutation with no client marker (`S \ C`) is the 付け漏れ/missed-member
+# case and FAILS — that failure list IS the fix work-list.
+#
+# ACCEPTED CLIENT "BRANCH" TOKENS (adjacency check): the raw error constant
+# `SESSION_STEP_UP_REQUIRED`, OR a call to the shared helper `handleStepUpError(`.
+# After the commonization refactor (src/lib/http/handle-step-up-error.ts) most
+# call sites use the helper and no longer contain the raw literal; the helper's
+# own definition file is the one place the literal still lives. Both tokens count
+# as "the client handles step-up here".
+#
+# Model: scripts/checks/check-permanent-delete-stepup.sh (pure text/filesystem
+# scan, NO @prisma/client import — required so it survives the static-checks CI
+# job that runs without `prisma generate`).
+#
+# CHECKS:
+#   1. Coverage (server→client): every server id ∈ S must appear in client set C,
+#      unless exempt-allowlisted. `S \ C` → FAIL (the付け漏れ case).
+#   2. Handling (client marker → branch, ADJACENCY-scoped): for each client
+#      `@stepup id:X` on line L, a branch token must appear within
+#      ADJACENCY_WINDOW lines below L. A whole-FILE grep would false-PASS the live
+#      mcp-client-card case (one handler branches, siblings do not) — so this is
+#      strictly line-adjacency, parser-free, failing in the SAFE direction.
+#   3. Anti-orphan (client→server): every client id must match a server id
+#      (`C \ S` with no exempt) → FAIL (client marks a stale/renamed id).
+#   4. Server marker completeness (LINE-BOUND, per call): every
+#      requireRecentCurrentAuthMethod( call on line H must carry a
+#      `@stepup id:… method:…` marker on line H or H-1. Per-file id uniqueness is
+#      required so a two-gated-call file (e.g. mcp-clients/[id] PUT+DELETE) needs
+#      two distinct-id markers, not one shared marker. (A commented-out call still
+#      matches the call regex — left to code review, same as the sibling guard.)
+#
+# EXEMPT (scripts/checks/stepup-client-exempt.txt): a server id may be exempted
+# from requiring a client marker when its recovery is custom / non-interactive.
+# Each entry names the custom marker its handler file must still contain, and the
+# guard fails (EXEMPT_MARKER_ABSENT) if that marker disappears (anti-drift).
+#
+# KNOWN LIMITATIONS (coverage granularity — same class as the sibling guards):
+#   - Coverage is a SET comparison of server-ids vs client-ids. When several UI
+#     call sites share ONE server id (e.g. 8 policy cards all hit tenant/policy
+#     PATCH → id `tenant-policy-patch`), a marker+branch on ONLY ONE of them
+#     satisfies `S \ C`. The guard proves "at least one UI handles this route",
+#     not "every UI that calls it does". All 8 are wired in this PR (review-
+#     verified) and the adjacency check still catches a marked-but-unbranched
+#     site; per-call-site ids are the escalation if a future un-branched Nth
+#     consumer of a shared id becomes a real regression.
+#   - THROWER_WITHOUT_CATCHER (below) pairs `throwIfStepUp(` to a catcher only at
+#     the EXISTENCE level, not per-call-site.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Scan roots / exempt file are overridable so the self-test
+# (scripts/__tests__/check-step-up-client-coverage.test.mjs) can point the guard
+# at fixtures. Production CI uses the defaults.
+API_DIR="${STEPUP_CLIENT_GUARD_API_DIR:-$REPO_ROOT/src/app/api}"
+CLIENT_DIR="${STEPUP_CLIENT_GUARD_CLIENT_DIR:-$REPO_ROOT/src}"
+PATH_ROOT="${STEPUP_CLIENT_GUARD_PATH_ROOT:-$REPO_ROOT}"
+EXEMPT_FILE="${STEPUP_CLIENT_GUARD_EXEMPT_FILE:-$REPO_ROOT/scripts/checks/stepup-client-exempt.txt}"
+
+# The number of lines below a client `@stepup id:X` marker within which a branch
+# token must appear. After the helper refactor the branch sits 0–1 lines below
+# the marked fetchApi call; the largest real marker→branch gap in the fixed set
+# is well under 20 (a fetchApi with a multi-line options object, then the
+# `!res.ok` block). 40 is that measured max plus generous margin.
+ADJACENCY_WINDOW="${STEPUP_CLIENT_GUARD_WINDOW:-40}"
+
+# Client "branch present" tokens (extended regex, OR-joined). The paren is a
+# bracket-expression `[(]` not `\(` so it survives awk's -v un-escaping (a `\(`
+# passed via -v becomes a bare `(` = invalid regex group-open in awk).
+#   SESSION_STEP_UP_REQUIRED — raw constant (body-reuse call sites)
+#   handleStepUpError(       — shared Response→reauth helper (most call sites)
+#   throwIfStepUp(           — non-hook adapter layer: converts the 403 into a
+#                              typed StepUpRequiredError for a component to catch
+#   isStepUpRequiredError(   — component consumer catching that typed error
+BRANCH_TOKEN_RE='SESSION_STEP_UP_REQUIRED|handleStepUpError[(]|throwIfStepUp[(]|isStepUpRequiredError[(]'
+
+fail=0
+
+# ── Exempt allowlist ────────────────────────────────────────────────────────
+# Format per line:  <server-id>  <custom-marker-token>  # reason (>=10 chars)
+# The custom-marker-token must appear somewhere in CLIENT_DIR (anti-drift). bash
+# 3.2 has no associative arrays — keep parallel newline-delimited lists.
+EXEMPT_IDS=""
+EXEMPT_MARKERS=""
+EXEMPT_PARSE_FAIL=0
+if [ -f "$EXEMPT_FILE" ]; then
+  while IFS= read -r raw; do
+    raw="${raw%$'\r'}"
+    trimmed="${raw#"${raw%%[![:space:]]*}"}"
+    [ -z "$trimmed" ] && continue
+    case "$trimmed" in \#*) continue ;; esac
+
+    # id = first field; marker = second field; reason = text after `#`.
+    body="${raw%%#*}"
+    id="$(printf '%s' "$body" | awk '{print $1}')"
+    marker="$(printf '%s' "$body" | awk '{print $2}')"
+    reason=""
+    case "$raw" in *#*) reason="${raw#*#}" ;; esac
+    reason="${reason#"${reason%%[![:space:]]*}"}"
+    reason="${reason%"${reason##*[![:space:]]}"}"
+
+    if [ -z "$id" ] || [ -z "$marker" ]; then
+      echo "EXEMPT_MALFORMED: '$raw' — each entry needs '<id> <custom-marker> # reason'."
+      EXEMPT_PARSE_FAIL=1
+      continue
+    fi
+    if [ "${#reason}" -lt 10 ]; then
+      echo "EXEMPT_NO_REASON: $id has no (or too short) justification — every exemption MUST state why a standard client marker does not apply."
+      EXEMPT_PARSE_FAIL=1
+    fi
+    EXEMPT_IDS="${EXEMPT_IDS}${id}
+"
+    EXEMPT_MARKERS="${EXEMPT_MARKERS}${id} ${marker}
+"
+  done < "$EXEMPT_FILE"
+fi
+if [ "$EXEMPT_PARSE_FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+is_exempt() {
+  printf '%s' "$EXEMPT_IDS" | grep -qxF "$1"
+}
+
+# ── Collect SERVER markers (set S) and enforce completeness ──────────────────
+# Server marker line:  // @stepup id:<id> method:<M>
+# For every requireRecentCurrentAuthMethod( call on line H, require a marker on
+# line H or H-1 carrying an id and a method:. Also collect id → S.
+SERVER_IDS=""
+declare_ids_seen=""
+
+while IFS= read -r route; do
+  [ -z "$route" ] && continue
+  abs="$PATH_ROOT/$route"
+  [ -f "$abs" ] || continue
+
+  # Per-file id-uniqueness set (reset per file).
+  file_ids=""
+
+  # Each call line H (boundary regex rejects DISABLED_… / bare identifiers).
+  while IFS= read -r H; do
+    [ -z "$H" ] && continue
+    # Look at line H and H-1 for a server marker with id: and method:.
+    marker_line="$(awk -v h="$H" 'NR==h-1 || NR==h' "$abs" \
+      | grep -oE '@stepup[[:space:]]+id:[A-Za-z0-9_-]+[[:space:]]+method:[A-Za-z]+' \
+      | head -n1 || true)"
+    if [ -z "$marker_line" ]; then
+      echo "SERVER_MARKER_MISSING: $route:$H — requireRecentCurrentAuthMethod call has no '// @stepup id:… method:…' marker on its line or the line above."
+      fail=1
+      continue
+    fi
+    sid="$(printf '%s' "$marker_line" | sed -E 's/.*id:([A-Za-z0-9_-]+).*/\1/')"
+
+    # Per-file id uniqueness (a marker must not cover two distinct calls).
+    if printf '%s' "$file_ids" | grep -qxF "$sid"; then
+      echo "SERVER_MARKER_DUP_ID: $route:$H — id '$sid' is used by more than one requireRecentCurrentAuthMethod call in this file; each gated call needs a distinct id."
+      fail=1
+    fi
+    file_ids="${file_ids}${sid}
+"
+
+    # Global id uniqueness across all server files.
+    if printf '%s' "$declare_ids_seen" | grep -qxF "$sid"; then
+      echo "SERVER_MARKER_DUP_ID_GLOBAL: $route:$H — id '$sid' is already declared by another route file; ids must be globally unique."
+      fail=1
+    fi
+    declare_ids_seen="${declare_ids_seen}${sid}
+"
+
+    SERVER_IDS="${SERVER_IDS}${sid}
+"
+  done < <(grep -nE '(^|[^A-Za-z0-9_])requireRecentCurrentAuthMethod\(' "$abs" | cut -d: -f1)
+
+done < <(
+  grep -rlE '(^|[^A-Za-z0-9_])requireRecentCurrentAuthMethod\(' "$API_DIR" --include='route.ts' 2>/dev/null \
+    | sed "s|^$PATH_ROOT/||" \
+    | sort
+)
+
+# ── Collect CLIENT markers (set C) and enforce adjacency handling ────────────
+# Client marker line:  // @stepup id:<id>   (no method: — that's the server form)
+# Grep every `@stepup id:X` in client .tsx/.ts that is NOT a server marker (no
+# `method:`), across CLIENT_DIR excluding the api route tree and test files.
+CLIENT_IDS=""
+
+while IFS= read -r hit; do
+  [ -z "$hit" ] && continue
+  # hit format: <file>:<lineno>:<content>
+  cfile="${hit%%:*}"
+  rest="${hit#*:}"
+  clineno="${rest%%:*}"
+  content="${rest#*:}"
+
+  # Skip server-form markers (they carry method:) — those belong to set S.
+  case "$content" in *method:*) continue ;; esac
+
+  cid="$(printf '%s' "$content" | grep -oE '@stepup[[:space:]]+id:[A-Za-z0-9_-]+' | sed -E 's/.*id:([A-Za-z0-9_-]+).*/\1/' | head -n1)"
+  [ -z "$cid" ] && continue
+
+  CLIENT_IDS="${CLIENT_IDS}${cid}
+"
+
+  # Adjacency: a branch token within ADJACENCY_WINDOW lines below the marker.
+  if ! awk -v L="$clineno" -v W="$ADJACENCY_WINDOW" -v re="$BRANCH_TOKEN_RE" \
+      'NR>L && NR<=L+W && $0 ~ re {found=1} END{exit !found}' "$cfile"; then
+    rel="${cfile#"$PATH_ROOT/"}"
+    echo "CLIENT_BRANCH_MISSING: $rel:$clineno — '@stepup id:$cid' has no step-up branch (SESSION_STEP_UP_REQUIRED or handleStepUpError()) within $ADJACENCY_WINDOW lines below it."
+    fail=1
+  fi
+done < <(
+  grep -rnE '@stepup[[:space:]]+id:' "$CLIENT_DIR" \
+    --include='*.tsx' --include='*.ts' 2>/dev/null \
+    | grep -v "$API_DIR/" \
+    | grep -vE '\.test\.(tsx?|mjs):' \
+    || true
+)
+
+# ── Check 1: Coverage (S \ C) ────────────────────────────────────────────────
+while IFS= read -r sid; do
+  [ -z "$sid" ] && continue
+  if printf '%s' "$CLIENT_IDS" | grep -qxF "$sid"; then
+    continue
+  fi
+  if is_exempt "$sid"; then
+    continue
+  fi
+  echo "MISSING_CLIENT_MARKER: server id '$sid' is a step-up-gated mutation with no client @stepup marker — its UI caller does not handle the SESSION_STEP_UP_REQUIRED 403 (or the marker is missing). Add the client branch + marker, or exempt with reason."
+  fail=1
+done < <(printf '%s' "$SERVER_IDS" | sort -u)
+
+# ── Check 3: Anti-orphan (C \ S) ─────────────────────────────────────────────
+while IFS= read -r cid; do
+  [ -z "$cid" ] && continue
+  if printf '%s' "$SERVER_IDS" | grep -qxF "$cid"; then
+    continue
+  fi
+  if is_exempt "$cid"; then
+    continue
+  fi
+  echo "ORPHAN_CLIENT_MARKER: client id '$cid' has no matching server @stepup marker (renamed/stale route id, or a typo). Remove or correct it."
+  fail=1
+done < <(printf '%s' "$CLIENT_IDS" | sort -u)
+
+# ── Thrower↔catcher pairing (typed-error adapter layer) ──────────────────────
+# `throwIfStepUp(` counts as a client "branch" token, but on its own it only
+# RAISES a StepUpRequiredError — it does not prove any consumer catches it and
+# opens reauth. A gated adapter that throws with no catcher would reopen the
+# phantom-delete class (row optimistically removed, error swallowed). So: if the
+# thrower token appears anywhere in the client tree, at least one catcher
+# (`isStepUpRequiredError(`) MUST also appear. This is an existence-level pairing
+# (not per-call-site), which is the proportionate guard against "throws but
+# nobody catches". Per-call-site pairing would need call-site ids — deferred.
+if grep -rqE 'throwIfStepUp[(]' "$CLIENT_DIR" --include='*.tsx' --include='*.ts' 2>/dev/null; then
+  if ! grep -rqE 'isStepUpRequiredError[(]' "$CLIENT_DIR" --include='*.tsx' --include='*.ts' 2>/dev/null; then
+    echo "STEPUP_THROWER_WITHOUT_CATCHER: throwIfStepUp() is used (a layer raises StepUpRequiredError) but no consumer catches it with isStepUpRequiredError() — the typed step-up error would surface as a generic failure. Add an isStepUpRequiredError() branch that opens reauth."
+    fail=1
+  fi
+fi
+
+# ── Exempt anti-drift: each exempt id's named custom marker must still exist ──
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  eid="$(printf '%s' "$line" | awk '{print $1}')"
+  emarker="$(printf '%s' "$line" | awk '{print $2}')"
+  [ -z "$eid" ] && continue
+
+  # The exempt id must still be a real server id (else the exemption is stale).
+  if ! printf '%s' "$SERVER_IDS" | grep -qxF "$eid"; then
+    echo "STALE_EXEMPT: exempt id '$eid' has no matching server @stepup marker — remove it from stepup-client-exempt.txt."
+    fail=1
+    continue
+  fi
+  # The named custom recovery marker must still appear in the client tree.
+  if ! grep -rqF "$emarker" "$CLIENT_DIR" --include='*.tsx' --include='*.ts' 2>/dev/null; then
+    echo "EXEMPT_MARKER_ABSENT: exempt id '$eid' names custom marker '$emarker' but it is not present anywhere in the client tree — the custom recovery flow was removed or renamed."
+    fail=1
+  fi
+done < <(printf '%s' "$EXEMPT_MARKERS")
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "step-up client-coverage guard FAILED. See docs/archive/review/step-up-client-policy-card-plan.md (C1)."
+  echo "Server: add '// @stepup id:<slug> method:<M>' on the requireRecentCurrentAuthMethod line."
+  echo "Client: add '// @stepup id:<slug>' above the gated fetchApi and handle the 403 via"
+  echo "        handleStepUpError(res, inlineReauth.triggerOnStaleError) (or the raw branch)."
+  exit 1
+fi
+
+exit 0

--- a/scripts/checks/stepup-client-exempt.txt
+++ b/scripts/checks/stepup-client-exempt.txt
@@ -1,0 +1,13 @@
+# Step-up client-coverage exempt allowlist.
+#
+# Format:  <server-id>  <custom-marker-token>  # reason (>= 10 chars)
+#
+# A server @stepup id listed here does NOT require a standard client `@stepup`
+# marker + SESSION_STEP_UP_REQUIRED branch, because its stale-session recovery is
+# custom or non-interactive. The named <custom-marker-token> must still appear
+# somewhere in the client tree — the guard fails (EXEMPT_MARKER_ABSENT) if it
+# disappears, so the exemption cannot silently rot into a real coverage gap.
+
+ext-bridge-code-post   EXTENSION_CONNECT_ERROR_CODE.SESSION_STEP_UP_REQUIRED  # auto-extension-connect.tsx surfaces step-up via the extension-connect error channel, not the standard API error body
+team-confirm-key-post  KEY_DISTRIBUTE_INTERVAL_MS  # team-vault-core.tsx background setInterval poller; no awaiting user gesture, retries on next poll (SC3)
+operator-tokens-post   OPERATOR_TOKEN_STALE_SESSION  # operator-token-card.tsx has a bespoke multi-state reauth flow (limit-exceeded vs stale vs generic retry) and does not use the shared inline-reauth hook (SC4)

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -163,6 +163,7 @@ run_step "Static: api-error-codes" bash scripts/checks/check-api-error-codes.sh
 run_step "Static: api-error-body-drift" bash scripts/checks/check-api-error-body-drift.sh
 run_step "Static: fail-closed-routes-have-test" bash scripts/checks/check-fail-closed-routes-have-test.sh
 run_step "Static: permanent-delete-stepup" bash scripts/checks/check-permanent-delete-stepup.sh
+run_step "Static: step-up-client-coverage" bash scripts/checks/check-step-up-client-coverage.sh
 run_step "Static: passkey-mint-gate" bash scripts/checks/check-passkey-mint-gate.sh
 run_step "Static: raw-body-read" bash scripts/checks/check-raw-body-read.sh
 run_step "Static: actions-sha-pinned" bash scripts/checks/check-actions-sha-pinned.sh

--- a/src/app/[locale]/admin/teams/[teamId]/general/delete/page.test.tsx
+++ b/src/app/[locale]/admin/teams/[teamId]/general/delete/page.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey, mockPush, mockNotifyTeamDataChanged } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
+  mockPush: vi.fn(),
+  mockNotifyTeamDataChanged: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
+}));
+
+vi.mock("sonner", () => ({ toast: mockToast }));
+
+vi.mock("@/lib/url-helpers", () => ({
+  fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+vi.mock("@/lib/events", () => ({
+  notifyTeamDataChanged: mockNotifyTeamDataChanged,
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogTrigger: ({ children }: { children: ReactNode; asChild?: boolean }) => (
+    <div data-testid="alert-trigger">{children}</div>
+  ),
+  AlertDialogContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="alert-content">{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogCancel: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+  AlertDialogAction: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button data-testid="alert-action" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+import TeamGeneralDeletePage from "./page";
+
+function setupFetchReady({
+  team = { id: "team-1", name: "Team One", role: "OWNER" },
+}: {
+  team?: Record<string, unknown>;
+} = {}) {
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    if (url === "/api/teams/team-1" && (!init?.method || init.method === "GET")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(team) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+describe("TeamGeneralDeletePage (admin full-page, step-up denial)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true, verifiedAt: "2026-05-10T00:00:00Z" });
+  });
+
+  it("delete team — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    setupFetchReady();
+
+    const baseImpl = mockFetch.getMockImplementation()!;
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === "DELETE") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return baseImpl(url, init);
+    });
+
+    await act(async () => {
+      render(<TeamGeneralDeletePage params={Promise.resolve({ teamId: "team-1" })} />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("alert-action")).toBeInTheDocument();
+    });
+
+    // The confirm action is disabled until the confirmation text matches the
+    // team name exactly, so type it into the confirm input first.
+    const input = screen.getByLabelText("deleteTeamTypeLabel");
+    fireEvent.change(input, { target: { value: "Team One" } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("alert-action"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/[locale]/admin/teams/[teamId]/general/delete/page.tsx
+++ b/src/app/[locale]/admin/teams/[teamId]/general/delete/page.tsx
@@ -19,12 +19,16 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import { Link } from "@/i18n/navigation";
 import { AlertTriangle, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { TEAM_ROLE, apiPath } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
 import { notifyTeamDataChanged } from "@/lib/events";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 
 interface TeamInfo {
   id: string;
@@ -39,6 +43,7 @@ export default function TeamGeneralDeletePage({
 }) {
   const { teamId } = use(params);
   const t = useTranslations("Team");
+  const tCommon = useTranslations("Common");
   const router = useRouter();
 
   const [team, setTeam] = useState<TeamInfo | null>(null);
@@ -63,10 +68,17 @@ export default function TeamGeneralDeletePage({
 
   const isOwner = team?.role === TEAM_ROLE.OWNER;
 
+  // Inline step-up reauth — team deletion is server-side step-up-gated.
+  const inlineReauth = useInlineReauth(() => handleDeleteTeam());
+
   const handleDeleteTeam = async () => {
     try {
+      // @stepup id:team-delete
       const res = await fetchApi(apiPath.teamById(teamId), { method: "DELETE" });
-      if (!res.ok) throw new Error("Failed");
+      if (!res.ok) {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError)) return;
+        throw new Error("Failed");
+      }
       toast.success(t("deleted"));
       notifyTeamDataChanged();
       router.push("/dashboard");
@@ -109,72 +121,83 @@ export default function TeamGeneralDeletePage({
   }
 
   return (
-    <Card>
-      <SectionCardHeader
-        icon={Trash2}
-        title={t("generalDeleteTitle")}
-        description={t("generalDeleteDesc")}
-      />
-      <CardContent className="space-y-4">
-        <div className="rounded-md border border-destructive/30 bg-destructive/5 p-4 space-y-3">
-          <h3 className="flex items-center gap-2 text-sm font-medium text-destructive">
-            <AlertTriangle className="h-4 w-4" />
-            {t("generalDeleteWarningTitle")}
-          </h3>
-          <p className="text-sm text-muted-foreground">
-            {t("generalDeleteWarningBody", { name: team.name })}
-          </p>
-          <ul className="text-sm text-muted-foreground list-disc pl-5 space-y-1">
-            <li>{t("generalDeleteImpactVault")}</li>
-            <li>{t("generalDeleteImpactMembers")}</li>
-            <li>{t("generalDeleteImpactAuditLogs")}</li>
-            <li>{t("generalDeleteImpactPolicies")}</li>
-          </ul>
-        </div>
-        <AlertDialog
-          open={deleteDialogOpen}
-          onOpenChange={(open) => {
-            setDeleteDialogOpen(open);
-            if (!open) setDeleteConfirmText("");
-          }}
-        >
-          <AlertDialogTrigger asChild>
-            <Button variant="destructive">
-              <Trash2 className="h-4 w-4 mr-2" />
-              {t("deleteTeam")}
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>{t("deleteTeam")}</AlertDialogTitle>
-              <AlertDialogDescription>
-                {t("deleteTeamConfirm", { name: team.name })}
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <div className="space-y-2">
-              <Label htmlFor="delete-confirm-input">{t("deleteTeamTypeLabel")}</Label>
-              <Input
-                id="delete-confirm-input"
-                value={deleteConfirmText}
-                onChange={(e) => setDeleteConfirmText(e.target.value)}
-                placeholder={t("deleteTeamTypePlaceholder", { name: team.name })}
-              />
-              <p className="text-xs text-muted-foreground">
-                {t("deleteTeamTypeHint", { name: team.name })}
-              </p>
-            </div>
-            <AlertDialogFooter>
-              <AlertDialogCancel>{t("cancelInvitation")}</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={handleDeleteTeam}
-                disabled={deleteConfirmText !== team.name}
-              >
+    <>
+      <Card>
+        <SectionCardHeader
+          icon={Trash2}
+          title={t("generalDeleteTitle")}
+          description={t("generalDeleteDesc")}
+        />
+        <CardContent className="space-y-4">
+          <div className="rounded-md border border-destructive/30 bg-destructive/5 p-4 space-y-3">
+            <h3 className="flex items-center gap-2 text-sm font-medium text-destructive">
+              <AlertTriangle className="h-4 w-4" />
+              {t("generalDeleteWarningTitle")}
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              {t("generalDeleteWarningBody", { name: team.name })}
+            </p>
+            <ul className="text-sm text-muted-foreground list-disc pl-5 space-y-1">
+              <li>{t("generalDeleteImpactVault")}</li>
+              <li>{t("generalDeleteImpactMembers")}</li>
+              <li>{t("generalDeleteImpactAuditLogs")}</li>
+              <li>{t("generalDeleteImpactPolicies")}</li>
+            </ul>
+          </div>
+          <AlertDialog
+            open={deleteDialogOpen}
+            onOpenChange={(open) => {
+              setDeleteDialogOpen(open);
+              if (!open) setDeleteConfirmText("");
+            }}
+          >
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive">
+                <Trash2 className="h-4 w-4 mr-2" />
                 {t("deleteTeam")}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-      </CardContent>
-    </Card>
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>{t("deleteTeam")}</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {t("deleteTeamConfirm", { name: team.name })}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <div className="space-y-2">
+                <Label htmlFor="delete-confirm-input">{t("deleteTeamTypeLabel")}</Label>
+                <Input
+                  id="delete-confirm-input"
+                  value={deleteConfirmText}
+                  onChange={(e) => setDeleteConfirmText(e.target.value)}
+                  placeholder={t("deleteTeamTypePlaceholder", { name: team.name })}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {t("deleteTeamTypeHint", { name: team.name })}
+                </p>
+              </div>
+              <AlertDialogFooter>
+                <AlertDialogCancel>{t("cancelInvitation")}</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleDeleteTeam}
+                  disabled={deleteConfirmText !== team.name}
+                >
+                  {t("deleteTeam")}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </CardContent>
+      </Card>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
+    </>
   );
 }

--- a/src/app/[locale]/admin/teams/[teamId]/members/list/page.test.tsx
+++ b/src/app/[locale]/admin/teams/[teamId]/members/list/page.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
+}));
+
+vi.mock("sonner", () => ({ toast: mockToast }));
+
+vi.mock("@/lib/url-helpers", () => ({
+  fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
+}));
+
+// Dialog (Add Member) is not exercised by the step-up tests — mock it away so
+// TeamAddFromTenantSection / TeamInviteByEmailSection don't need real wiring.
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children: ReactNode; open?: boolean }) => (
+    open ? <>{children}</> : null
+  ),
+  DialogContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogTrigger: ({ children }: { children: ReactNode; asChild?: boolean }) => (
+    <div data-testid="alert-trigger">{children}</div>
+  ),
+  AlertDialogContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="alert-content">{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogCancel: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+  AlertDialogAction: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button data-testid="alert-action" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    children,
+    value,
+    onValueChange,
+  }: {
+    children: ReactNode;
+    value?: string;
+    onValueChange?: (v: string) => void;
+  }) => (
+    <div data-testid="select" data-value={value}>
+      {children}
+      <button
+        data-testid={`select-change-${value}`}
+        onClick={() => onValueChange?.("ADMIN")}
+      >
+        ChangeRole
+      </button>
+    </div>
+  ),
+  SelectTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectValue: () => <span />,
+  SelectContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children, value }: { children: ReactNode; value: string }) => (
+    <div data-testid={`select-item-${value}`}>{children}</div>
+  ),
+}));
+
+import TeamMembersPage from "./page";
+
+function makeMember(overrides: Partial<{
+  id: string;
+  userId: string;
+  role: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  tenantName: string | null;
+}> = {}) {
+  return {
+    id: "mem-1",
+    userId: "user-member",
+    role: "MEMBER",
+    name: "Alice",
+    email: "alice@example.com",
+    image: null,
+    tenantName: null,
+    ...overrides,
+  };
+}
+
+function setupFetchReady({
+  team = { id: "team-1", name: "Team One", slug: "team-one", description: null, role: "OWNER" },
+  members = [makeMember()],
+  invitations = [] as unknown[],
+  currentUserId = "current-owner",
+}: {
+  team?: Record<string, unknown>;
+  members?: ReturnType<typeof makeMember>[];
+  invitations?: unknown[];
+  currentUserId?: string;
+} = {}) {
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    if (url === "/api/auth/session") {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ user: { id: currentUserId } }) });
+    }
+    if (url === "/api/teams/team-1" && (!init?.method || init.method === "GET")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(team) });
+    }
+    if (url === "/api/teams/team-1/members" && (!init?.method || init.method === "GET")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(members) });
+    }
+    if (url === "/api/teams/team-1/invitations") {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(invitations) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+describe("TeamMembersPage (admin full-page, step-up denial)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true, verifiedAt: "2026-05-10T00:00:00Z" });
+  });
+
+  it("role change — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    const member = makeMember({ id: "mem-1", userId: "user-member", role: "MEMBER" });
+    setupFetchReady({ members: [member] });
+
+    // Override the PUT response with a step-up denial (GET responses stay as configured above).
+    const baseImpl = mockFetch.getMockImplementation()!;
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return baseImpl(url, init);
+    });
+
+    await act(async () => {
+      render(<TeamMembersPage params={Promise.resolve({ teamId: "team-1" })} />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("select-change-MEMBER")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("select-change-MEMBER"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it("remove member — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    const member = makeMember({ id: "mem-1", userId: "user-member", role: "MEMBER" });
+    setupFetchReady({ members: [member] });
+
+    const baseImpl = mockFetch.getMockImplementation()!;
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === "DELETE") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return baseImpl(url, init);
+    });
+
+    await act(async () => {
+      render(<TeamMembersPage params={Promise.resolve({ teamId: "team-1" })} />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("alert-action").length).toBeGreaterThanOrEqual(1);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByTestId("alert-action")[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/[locale]/admin/teams/[teamId]/members/list/page.tsx
+++ b/src/app/[locale]/admin/teams/[teamId]/members/list/page.tsx
@@ -37,12 +37,16 @@ import {
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { MemberInfo } from "@/components/member-info";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import { Link } from "@/i18n/navigation";
 import { Trash2, Users, Search, UserPlus } from "lucide-react";
 import { toast } from "sonner";
 import { TEAM_ROLE, API_PATH, apiPath } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
 import { filterMembers } from "@/lib/filter-members";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 import type { TeamMemberDisplayApiItem as Member } from "@/lib/team/team-member-display";
 
 interface TeamInfo {
@@ -62,6 +66,7 @@ export default function TeamMembersPage({
   const { teamId } = use(params);
   const t = useTranslations("Team");
   const tAdmin = useTranslations("AdminConsole");
+  const tCommon = useTranslations("Common");
 
   const [team, setTeam] = useState<TeamInfo | null>(null);
   const [loadError, setLoadError] = useState(false);
@@ -136,14 +141,29 @@ export default function TeamMembersPage({
   const isOwner = team?.role === TEAM_ROLE.OWNER;
   const isAdmin = team?.role === TEAM_ROLE.ADMIN || isOwner;
 
+  // Inline step-up reauth — both role change and member removal are
+  // server-side step-up-gated. The retry arg records which mutation was in
+  // flight so the post-reauth retry replays the same one.
+  type ReauthRetry =
+    | { type: "role"; memberId: string; role: string }
+    | { type: "remove"; memberId: string };
+  const inlineReauth = useInlineReauth<ReauthRetry>(async (retry) => {
+    if (retry.type === "role") await handleChangeRole(retry.memberId, retry.role);
+    else if (retry.type === "remove") await handleRemoveMember(retry.memberId);
+  });
+
   const handleChangeRole = async (memberId: string, role: string) => {
     try {
+      // @stepup id:team-member-put
       const res = await fetchApi(apiPath.teamMemberById(teamId, memberId), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ role }),
       });
-      if (!res.ok) throw new Error("Failed");
+      if (!res.ok) {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { type: "role", memberId, role })) return;
+        throw new Error("Failed");
+      }
       toast.success(t("roleChanged"));
       fetchAll();
     } catch {
@@ -153,10 +173,14 @@ export default function TeamMembersPage({
 
   const handleRemoveMember = async (memberId: string) => {
     try {
+      // @stepup id:team-member-delete
       const res = await fetchApi(apiPath.teamMemberById(teamId, memberId), {
         method: "DELETE",
       });
-      if (!res.ok) throw new Error("Failed");
+      if (!res.ok) {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { type: "remove", memberId })) return;
+        throw new Error("Failed");
+      }
       toast.success(t("memberRemoved"));
       fetchAll();
     } catch {
@@ -308,6 +332,15 @@ export default function TeamMembersPage({
           </div>
         </DialogContent>
       </Dialog>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
     </div>
   );
 }

--- a/src/app/[locale]/admin/teams/[teamId]/members/transfer-ownership/page.test.tsx
+++ b/src/app/[locale]/admin/teams/[teamId]/members/transfer-ownership/page.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
+}));
+
+vi.mock("sonner", () => ({ toast: mockToast }));
+
+vi.mock("@/lib/url-helpers", () => ({
+  fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogTrigger: ({ children }: { children: ReactNode; asChild?: boolean }) => (
+    <div data-testid="alert-trigger">{children}</div>
+  ),
+  AlertDialogContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="alert-content">{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogCancel: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+  AlertDialogAction: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button data-testid="alert-action" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+import TeamTransferOwnershipPage from "./page";
+
+function makeMember(overrides: Partial<{
+  id: string;
+  userId: string;
+  role: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  tenantName: string | null;
+}> = {}) {
+  return {
+    id: "mem-1",
+    userId: "user-member",
+    role: "MEMBER",
+    name: "Alice",
+    email: "alice@example.com",
+    image: null,
+    tenantName: null,
+    ...overrides,
+  };
+}
+
+function setupFetchReady({
+  team = { id: "team-1", name: "Team One", slug: "team-one", description: null, role: "OWNER" },
+  members = [makeMember()],
+}: {
+  team?: Record<string, unknown>;
+  members?: ReturnType<typeof makeMember>[];
+} = {}) {
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    if (url === "/api/teams/team-1" && (!init?.method || init.method === "GET")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(team) });
+    }
+    if (url === "/api/teams/team-1/members" && (!init?.method || init.method === "GET")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(members) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+describe("TeamTransferOwnershipPage (admin full-page, step-up denial)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true, verifiedAt: "2026-05-10T00:00:00Z" });
+  });
+
+  it("transfer — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    const member = makeMember({ id: "mem-1", userId: "user-member", role: "MEMBER" });
+    setupFetchReady({ members: [member] });
+
+    const baseImpl = mockFetch.getMockImplementation()!;
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return baseImpl(url, init);
+    });
+
+    await act(async () => {
+      render(<TeamTransferOwnershipPage params={Promise.resolve({ teamId: "team-1" })} />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("alert-action").length).toBeGreaterThanOrEqual(1);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByTestId("alert-action")[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/[locale]/admin/teams/[teamId]/members/transfer-ownership/page.tsx
+++ b/src/app/[locale]/admin/teams/[teamId]/members/transfer-ownership/page.tsx
@@ -19,12 +19,16 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { MemberInfo } from "@/components/member-info";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import { Link } from "@/i18n/navigation";
 import { Crown, Search } from "lucide-react";
 import { toast } from "sonner";
 import { TEAM_ROLE, apiPath } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
 import { filterMembers } from "@/lib/filter-members";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 import type { TeamMemberDisplayApiItem as Member } from "@/lib/team/team-member-display";
 
 interface TeamInfo {
@@ -43,6 +47,7 @@ export default function TeamTransferOwnershipPage({
 }) {
   const { teamId } = use(params);
   const t = useTranslations("Team");
+  const tCommon = useTranslations("Common");
 
   const [team, setTeam] = useState<TeamInfo | null>(null);
   const [loadError, setLoadError] = useState(false);
@@ -88,14 +93,23 @@ export default function TeamTransferOwnershipPage({
 
   const isOwner = team?.role === TEAM_ROLE.OWNER;
 
+  // Inline step-up reauth — ownership transfer is server-side step-up-gated.
+  // The retry arg records the target memberId so the post-reauth retry
+  // replays the transfer for the same member.
+  const inlineReauth = useInlineReauth<string>((memberId) => handleTransferOwnership(memberId));
+
   const handleTransferOwnership = async (memberId: string) => {
     try {
+      // @stepup id:team-member-put
       const res = await fetchApi(apiPath.teamMemberById(teamId, memberId), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ role: TEAM_ROLE.OWNER }),
       });
-      if (!res.ok) throw new Error("Failed");
+      if (!res.ok) {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, memberId)) return;
+        throw new Error("Failed");
+      }
       toast.success(t("ownershipTransferred"));
       fetchAll();
     } catch {
@@ -137,69 +151,80 @@ export default function TeamTransferOwnershipPage({
   }
 
   return (
-    <Card>
-      <SectionCardHeader icon={Crown} title={t("transferTitle")} description={t("transferDescription")} />
-      <CardContent className="space-y-4">
-        {members.length > 1 && (
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              placeholder={t("searchMembers")}
-              value={transferSearch}
-              onChange={(e) => setTransferSearch(e.target.value)}
-              className="pl-9"
-            />
-          </div>
-        )}
-        {transferCandidates.length === 0 ? (
-          <p className="py-4 text-center text-sm text-muted-foreground">
-            {transferSearch.trim()
-              ? t("noMatchingMembers")
-              : t("noTransferCandidates")}
-          </p>
-        ) : (
-          <div className="max-h-96 space-y-2 overflow-y-auto">
-            {transferCandidates.map((m) => (
-              <div
-                key={m.id}
-                className="flex items-center gap-3 rounded-xl border bg-card/80 p-3 transition-colors hover:bg-accent/30 dark:hover:bg-accent/50"
-              >
-                <MemberInfo
-                  name={m.name}
-                  email={m.email}
-                  image={m.image}
-                  tenantName={m.tenantName}
-                  viewerTenantName={viewerTenantName}
+    <>
+      <Card>
+        <SectionCardHeader icon={Crown} title={t("transferTitle")} description={t("transferDescription")} />
+        <CardContent className="space-y-4">
+          {members.length > 1 && (
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder={t("searchMembers")}
+                value={transferSearch}
+                onChange={(e) => setTransferSearch(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+          )}
+          {transferCandidates.length === 0 ? (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              {transferSearch.trim()
+                ? t("noMatchingMembers")
+                : t("noTransferCandidates")}
+            </p>
+          ) : (
+            <div className="max-h-96 space-y-2 overflow-y-auto">
+              {transferCandidates.map((m) => (
+                <div
+                  key={m.id}
+                  className="flex items-center gap-3 rounded-xl border bg-card/80 p-3 transition-colors hover:bg-accent/30 dark:hover:bg-accent/50"
                 >
-                  <TeamRoleBadge role={m.role} />
-                </MemberInfo>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button variant="outline" size="sm">
-                      <Crown className="h-3.5 w-3.5 mr-1" />
-                      {t("transferButton")}
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>{t("transferOwnership")}</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        {t("transferOwnershipConfirm", { name: m.name ?? m.email ?? "" })}
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>{t("cancelInvitation")}</AlertDialogCancel>
-                      <AlertDialogAction onClick={() => handleTransferOwnership(m.id)}>
+                  <MemberInfo
+                    name={m.name}
+                    email={m.email}
+                    image={m.image}
+                    tenantName={m.tenantName}
+                    viewerTenantName={viewerTenantName}
+                  >
+                    <TeamRoleBadge role={m.role} />
+                  </MemberInfo>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button variant="outline" size="sm">
+                        <Crown className="h-3.5 w-3.5 mr-1" />
                         {t("transferButton")}
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </div>
-            ))}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>{t("transferOwnership")}</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          {t("transferOwnershipConfirm", { name: m.name ?? m.email ?? "" })}
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>{t("cancelInvitation")}</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => handleTransferOwnership(m.id)}>
+                          {t("transferButton")}
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
+    </>
   );
 }

--- a/src/app/[locale]/vault-reset/page.tsx
+++ b/src/app/[locale]/vault-reset/page.tsx
@@ -42,6 +42,7 @@ export default function VaultResetPage() {
     setError("");
 
     try {
+      // @stepup id:vault-reset-post
       const res = await fetchApi(API_PATH.VAULT_RESET, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -18,6 +18,7 @@ async function handleDELETE(
   if (!authed.ok) return authed.response;
   // Step-up parity with POST: API-key revocation is a management op affecting
   // availability, so require the same recent re-auth bar as issuance.
+  // @stepup id:api-keys-id-delete method:DELETE
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
   const { userId } = authed.auth;

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -74,6 +74,7 @@ async function handleGET(req: NextRequest) {
 async function handlePOST(req: NextRequest) {
   const authed = await checkAuth(req);
   if (!authed.ok) return authed.response;
+  // @stepup id:api-keys-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
   const { userId } = authed.auth;

--- a/src/app/api/directory-sync/[id]/route.ts
+++ b/src/app/api/directory-sync/[id]/route.ts
@@ -116,6 +116,7 @@ async function handlePUT(req: NextRequest, ctx: RouteContext) {
     return notFound();
   }
 
+  // @stepup id:directory-sync-id-put method:PUT
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 
@@ -198,6 +199,7 @@ async function handleDELETE(req: NextRequest, ctx: RouteContext) {
     return notFound();
   }
 
+  // @stepup id:directory-sync-id-delete method:DELETE
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/directory-sync/route.ts
+++ b/src/app/api/directory-sync/route.ts
@@ -101,6 +101,7 @@ async function handlePOST(req: NextRequest) {
   }
   const tenantId = member.tenantId;
 
+  // @stepup id:directory-sync-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/extension/bridge-code/route.ts
+++ b/src/app/api/extension/bridge-code/route.ts
@@ -191,6 +191,7 @@ async function handlePOST(req: NextRequest) {
   }
 
   // 5) Step-up gate.
+  // @stepup id:ext-bridge-code-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) {
     await emitBridgeCodeIssueFailure({

--- a/src/app/api/passwords/[id]/route.ts
+++ b/src/app/api/passwords/[id]/route.ts
@@ -298,6 +298,7 @@ async function handleDELETE(
         "Permanent deletion requires step-up authentication and is not available via token.",
       );
     }
+    // @stepup id:passwords-id-delete-permanent method:DELETE
     const stepUp = await requireRecentCurrentAuthMethod(req);
     if (stepUp) return stepUp;
   }

--- a/src/app/api/passwords/bulk-purge/route.ts
+++ b/src/app/api/passwords/bulk-purge/route.ts
@@ -26,6 +26,7 @@ async function handlePOST(req: NextRequest) {
 
   // Irreversible bulk permanent delete — require a recent session (step-up),
   // matching DELETE /api/passwords/[id]?permanent=true.
+  // @stepup id:passwords-bulk-purge method:POST
   const stepUp = await requireRecentCurrentAuthMethod(req);
   if (stepUp) return stepUp;
 

--- a/src/app/api/passwords/empty-trash/route.ts
+++ b/src/app/api/passwords/empty-trash/route.ts
@@ -23,6 +23,7 @@ async function handlePOST(req: NextRequest) {
   // Irreversible bulk permanent delete — require a recent session (step-up),
   // matching DELETE /api/passwords/[id]?permanent=true. A leaked session cookie
   // alone must not wipe trash.
+  // @stepup id:passwords-empty-trash method:POST
   const stepUp = await requireRecentCurrentAuthMethod(req);
   if (stepUp) return stepUp;
 

--- a/src/app/api/teams/[teamId]/members/[memberId]/confirm-key/route.ts
+++ b/src/app/api/teams/[teamId]/members/[memberId]/confirm-key/route.ts
@@ -36,6 +36,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     return handleAuthError(e);
   }
 
+  // @stepup id:team-confirm-key-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/teams/[teamId]/members/[memberId]/route.ts
+++ b/src/app/api/teams/[teamId]/members/[memberId]/route.ts
@@ -63,6 +63,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
     return handleAuthError(e);
   }
 
+  // @stepup id:team-member-put method:PUT
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 
@@ -174,6 +175,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     return handleAuthError(e);
   }
 
+  // @stepup id:team-member-delete method:DELETE
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/teams/[teamId]/members/route.ts
+++ b/src/app/api/teams/[teamId]/members/route.ts
@@ -61,6 +61,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     return handleAuthError(e);
   }
 
+  // @stepup id:team-members-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/teams/[teamId]/passwords/[id]/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/[id]/route.ts
@@ -178,6 +178,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
   // Soft-delete (trash) stays frictionless. No token-type guard needed: this
   // handler is auth()-only (no Bearer path).
   if (permanent) {
+    // @stepup id:team-password-id-delete-permanent method:DELETE
     const stepUp = await requireRecentCurrentAuthMethod(req);
     if (stepUp) return stepUp;
   }

--- a/src/app/api/teams/[teamId]/passwords/bulk-purge/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/bulk-purge/route.ts
@@ -39,6 +39,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
   }
 
   // Irreversible bulk permanent delete — require a recent session (step-up).
+  // @stepup id:team-password-bulk-purge method:POST
   const stepUp = await requireRecentCurrentAuthMethod(req);
   if (stepUp) return stepUp;
 

--- a/src/app/api/teams/[teamId]/passwords/empty-trash/route.ts
+++ b/src/app/api/teams/[teamId]/passwords/empty-trash/route.ts
@@ -36,6 +36,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
   }
 
   // Irreversible bulk permanent delete — require a recent session (step-up).
+  // @stepup id:team-password-empty-trash method:POST
   const stepUp = await requireRecentCurrentAuthMethod(req);
   if (stepUp) return stepUp;
 

--- a/src/app/api/teams/[teamId]/policy/route.ts
+++ b/src/app/api/teams/[teamId]/policy/route.ts
@@ -86,6 +86,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
     throw e;
   }
 
+  // @stepup id:team-policy-put method:PUT
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/teams/[teamId]/rotate-key/route.ts
+++ b/src/app/api/teams/[teamId]/rotate-key/route.ts
@@ -80,6 +80,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     return handleAuthError(e);
   }
 
+  // @stepup id:team-rotate-key-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/teams/[teamId]/route.ts
+++ b/src/app/api/teams/[teamId]/route.ts
@@ -147,6 +147,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     throw e;
   }
 
+  // @stepup id:team-delete method:DELETE
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/teams/[teamId]/webhooks/[webhookId]/route.ts
+++ b/src/app/api/teams/[teamId]/webhooks/[webhookId]/route.ts
@@ -41,6 +41,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     return notFound();
   }
 
+  // @stepup id:team-webhook-delete method:DELETE
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/teams/[teamId]/webhooks/route.ts
+++ b/src/app/api/teams/[teamId]/webhooks/route.ts
@@ -95,6 +95,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     return handleAuthError(e);
   }
 
+  // @stepup id:team-webhook-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/access-requests/[id]/approve/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/approve/route.ts
@@ -49,6 +49,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     return handleAuthError(err);
   }
 
+  // @stepup id:access-request-approve method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/access-requests/[id]/deny/route.ts
+++ b/src/app/api/tenant/access-requests/[id]/deny/route.ts
@@ -42,6 +42,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     return handleAuthError(err);
   }
 
+  // @stepup id:access-request-deny method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/audit-delivery-targets/[id]/route.ts
+++ b/src/app/api/tenant/audit-delivery-targets/[id]/route.ts
@@ -47,6 +47,7 @@ async function handlePATCH(req: NextRequest, { params }: Params) {
     return notFound();
   }
 
+  // @stepup id:audit-delivery-target-id-patch method:PATCH
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/audit-delivery-targets/route.ts
+++ b/src/app/api/tenant/audit-delivery-targets/route.ts
@@ -151,6 +151,7 @@ async function handlePOST(req: NextRequest) {
     return handleAuthError(e);
   }
 
+  // @stepup id:audit-delivery-target-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/breakglass/[id]/route.ts
+++ b/src/app/api/tenant/breakglass/[id]/route.ts
@@ -50,6 +50,7 @@ async function handleDELETE(
     return notFound();
   }
 
+  // @stepup id:breakglass-id-delete method:DELETE
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/breakglass/route.ts
+++ b/src/app/api/tenant/breakglass/route.ts
@@ -49,6 +49,7 @@ async function handlePOST(req: NextRequest) {
     return handleAuthError(err);
   }
 
+  // @stepup id:breakglass-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/mcp-clients/[id]/route.ts
+++ b/src/app/api/tenant/mcp-clients/[id]/route.ts
@@ -89,6 +89,7 @@ async function handlePUT(
   );
   if (!existing) return notFound();
 
+  // @stepup id:mcp-client-id-put method:PUT
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 
@@ -158,6 +159,7 @@ async function handleDELETE(
   );
   if (!existing) return notFound();
 
+  // @stepup id:mcp-client-id-delete method:DELETE
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/mcp-clients/route.ts
+++ b/src/app/api/tenant/mcp-clients/route.ts
@@ -126,6 +126,7 @@ async function handlePOST(req: NextRequest) {
     return handleAuthError(err);
   }
 
+  // @stepup id:mcp-client-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/approve/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/[resetId]/approve/route.ts
@@ -154,6 +154,7 @@ async function handlePOST(
   // self-approval attempt still 403s without prompting reauth, and BEFORE the
   // rate-limit block so a stale session is rejected without burning the
   // per-target limiter (a low cap that would otherwise be a griefing lever).
+  // @stepup id:reset-vault-approve method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.ts
@@ -113,6 +113,7 @@ async function handlePOST(
     return notFound();
   }
 
+  // @stepup id:reset-vault-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/members/[userId]/route.ts
+++ b/src/app/api/tenant/members/[userId]/route.ts
@@ -43,6 +43,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
     return errorResponse(API_ERROR.OWNER_ONLY);
   }
 
+  // @stepup id:tenant-member-put method:PUT
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/operator-tokens/route.ts
+++ b/src/app/api/tenant/operator-tokens/route.ts
@@ -136,6 +136,7 @@ async function handlePOST(req: NextRequest) {
     return handleAuthError(err);
   }
 
+  // @stepup id:operator-tokens-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req, {
     errorCode: API_ERROR.OPERATOR_TOKEN_STALE_SESSION,
   });

--- a/src/app/api/tenant/policy/route.ts
+++ b/src/app/api/tenant/policy/route.ts
@@ -190,6 +190,7 @@ async function handlePATCH(req: NextRequest) {
     return handleAuthError(e);
   }
 
+  // @stepup id:tenant-policy-patch method:PATCH
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/scim-tokens/[tokenId]/route.ts
+++ b/src/app/api/tenant/scim-tokens/[tokenId]/route.ts
@@ -45,6 +45,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     return notFound();
   }
 
+  // @stepup id:scim-token-id-delete method:DELETE
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/scim-tokens/route.ts
+++ b/src/app/api/tenant/scim-tokens/route.ts
@@ -101,6 +101,7 @@ async function handlePOST(req: NextRequest) {
     return handleAuthError(err);
   }
 
+  // @stepup id:scim-token-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/service-accounts/[id]/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/route.ts
@@ -99,6 +99,7 @@ async function handlePUT(req: NextRequest, { params }: Params) {
     return notFound();
   }
 
+  // @stepup id:service-account-id-put method:PUT
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 
@@ -179,6 +180,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     return notFound();
   }
 
+  // @stepup id:service-account-id-delete method:DELETE
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/service-accounts/[id]/tokens/[tokenId]/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/[tokenId]/route.ts
@@ -56,6 +56,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     return notFound();
   }
 
+  // @stepup id:sa-token-id-delete method:DELETE
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
+++ b/src/app/api/tenant/service-accounts/[id]/tokens/route.ts
@@ -94,6 +94,7 @@ async function handlePOST(req: NextRequest, { params }: Params) {
     return handleAuthError(err);
   }
 
+  // @stepup id:sa-token-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/webhooks/[webhookId]/route.ts
+++ b/src/app/api/tenant/webhooks/[webhookId]/route.ts
@@ -42,6 +42,7 @@ async function handleDELETE(req: NextRequest, { params }: Params) {
     return notFound();
   }
 
+  // @stepup id:tenant-webhook-delete method:DELETE
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/tenant/webhooks/route.ts
+++ b/src/app/api/tenant/webhooks/route.ts
@@ -94,6 +94,7 @@ async function handlePOST(req: NextRequest) {
     return handleAuthError(e);
   }
 
+  // @stepup id:tenant-webhook-post method:POST
   const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) return stepUpError;
 

--- a/src/app/api/vault/reset/route.ts
+++ b/src/app/api/vault/reset/route.ts
@@ -54,6 +54,7 @@ async function handlePOST(request: NextRequest) {
   // checks session recency only (not the passphrase), so it is compatible with
   // the lost-passphrase/recovery-key last-resort purpose — the user still has a
   // valid recent session.
+  // @stepup id:vault-reset-post method:POST
   const stepUp = await requireRecentCurrentAuthMethod(request);
   if (stepUp) return stepUp;
 

--- a/src/app/api/webauthn/credentials/[id]/route.ts
+++ b/src/app/api/webauthn/credentials/[id]/route.ts
@@ -35,6 +35,7 @@ async function handleDELETE(
   // (passkey users re-prove passkey; password users re-prove password)
   // within the last 15 minutes, preventing a password-based session
   // from being used to delete a passkey.
+  // @stepup id:webauthn-credential-delete method:DELETE
   const stepUp = await requireRecentCurrentAuthMethod(req);
   if (stepUp) return stepUp;
 

--- a/src/components/breakglass/breakglass-dialog.tsx
+++ b/src/components/breakglass/breakglass-dialog.tsx
@@ -95,6 +95,7 @@ export function BreakGlassDialog({ onGrantCreated, trigger }: BreakGlassDialogPr
 
     setSubmitting(true);
     try {
+      // @stepup id:breakglass-post
       const res = await fetchApi(apiPath.tenantBreakglass(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/components/breakglass/breakglass-grant-list.tsx
+++ b/src/components/breakglass/breakglass-grant-list.tsx
@@ -87,6 +87,7 @@ export function BreakGlassGrantList({ refreshTrigger }: BreakGlassGrantListProps
   const handleRevoke = async (grantId: string) => {
     setRevoking(grantId);
     try {
+      // @stepup id:breakglass-id-delete
       const res = await fetchApi(apiPath.tenantBreakglassById(grantId), {
         method: "DELETE",
       });

--- a/src/components/passwords/detail/entry-list-view.test.tsx
+++ b/src/components/passwords/detail/entry-list-view.test.tsx
@@ -23,11 +23,13 @@ if (typeof globalThis.ResizeObserver === "undefined") {
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
-const { mockFetchApi, mockDecryptData, mockBuildAAD, STABLE_KEY } = vi.hoisted(() => ({
+const { mockFetchApi, mockDecryptData, mockBuildAAD, STABLE_KEY, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetchApi: vi.fn(),
   mockDecryptData: vi.fn(),
   mockBuildAAD: vi.fn(),
   STABLE_KEY: {} as CryptoKey,
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 // Per-test callbacks. C2: manage actions (restore / delete-permanently / soft-delete)
@@ -37,10 +39,12 @@ let capturedPaneRestore: (() => void) | undefined;
 let capturedPaneDeletePermanently: (() => void) | undefined;
 let capturedPaneDelete: (() => void) | undefined;
 let capturedBulkOnSuccess: (() => void) | undefined;
+let capturedBulkOnStepUpRequired: (() => Promise<void> | void) | undefined;
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
     params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("@/lib/url-helpers", () => ({
@@ -69,6 +73,17 @@ vi.mock("@/hooks/use-travel-mode", () => ({
 
 vi.mock("@/lib/events", () => ({
   notifyVaultDataChanged: vi.fn(),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 // Layout mode is mutable so a test can exercise the accordion (PasswordCard) path.
@@ -195,10 +210,18 @@ vi.mock("@/hooks/vault/use-entry-actions", () => ({
   }),
 }));
 
-// Capture bulk onSuccess so tests can invoke it directly.
+// Capture bulk onSuccess/onStepUpRequired so tests can invoke them directly.
 vi.mock("@/hooks/bulk/use-bulk-action", () => ({
-  useBulkAction: ({ onSuccess }: { onSuccess: () => void; scope: unknown }) => {
+  useBulkAction: ({
+    onSuccess,
+    onStepUpRequired,
+  }: {
+    onSuccess: () => void;
+    onStepUpRequired?: () => Promise<void> | void;
+    scope: unknown;
+  }) => {
     capturedBulkOnSuccess = onSuccess;
+    capturedBulkOnStepUpRequired = onStepUpRequired;
     return {
       dialogOpen: false,
       setDialogOpen: vi.fn(),
@@ -253,6 +276,10 @@ describe("EntryListView — TRASH_VIEW (T2 coverage migration + NET-NEW)", () =>
     capturedPaneDeletePermanently = undefined;
     capturedPaneDelete = undefined;
     capturedBulkOnSuccess = undefined;
+    capturedBulkOnStepUpRequired = undefined;
+    // Default: user has no passkey → the recent-session dialog opens.
+    mockCanUsePasskeyRecovery.mockReset().mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockReset().mockResolvedValue({ ok: true, verifiedAt: "2026-05-10T00:00:00Z" });
   });
 
   // ── (a) T2 migration: trash empty-state (trash-list.test.tsx line 56) ───────
@@ -334,6 +361,38 @@ describe("EntryListView — TRASH_VIEW (T2 coverage migration + NET-NEW)", () =>
     });
   });
 
+  // ── (c-stepup) C4: bulk-purge denial opens the reauth dialog ────────────────
+  // useBulkAction is mocked in this file; entry-list-view wires
+  // onStepUpRequired: () => inlineReauth.triggerOnStaleError({ type: "bulkPurge" }).
+  // Precondition: bulkOnStepUpRequired was captured (proves the wiring exists).
+  // Trigger: invoke onStepUpRequired (simulates a 403 SESSION_STEP_UP_REQUIRED on
+  //   the bulk-purge fetchApi call inside the real hook).
+  // Assert: the reauth dialog opens (not a silent failure).
+  it("bulk-purge denial (onStepUpRequired) opens the reauth dialog (T2-c-stepup)", async () => {
+    mockFetchApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [makeServerEntry("entry-1")],
+    });
+    mockDecryptData.mockResolvedValueOnce(makeDecryptedOverview("GitHub"));
+
+    render(<PasswordList searchQuery="" tagId={null} refreshKey={0} trashOnly />);
+
+    await waitFor(() => { expect(screen.getByText("GitHub")).toBeInTheDocument(); });
+
+    // Precondition: entry-list-view passed onStepUpRequired to useBulkAction.
+    expect(capturedBulkOnStepUpRequired).toBeDefined();
+
+    // Trigger: invoke onStepUpRequired (simulates the hook's SESSION_STEP_UP_REQUIRED branch).
+    await act(async () => {
+      await capturedBulkOnStepUpRequired?.();
+    });
+
+    // Assert: the recent-session reauth dialog opens.
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+  });
+
   // ── (d) NET-NEW: delete-permanently confirm dialog (R30) ────────────────────
   // Precondition: trash entry rendered; PasswordRow exposes onDeletePermanently.
   // Trigger: click delete-permanently → dialog appears.
@@ -382,6 +441,58 @@ describe("EntryListView — TRASH_VIEW (T2 coverage migration + NET-NEW)", () =>
         },
       );
       expect(deleteCall).toBeDefined();
+    });
+  });
+
+  // ── (d-stepup) C4: delete-permanently denial opens the reauth dialog ────────
+  // Precondition: trash entry rendered; confirm dialog opened.
+  // Trigger: confirm → adapter.deletePermanently 403s with SESSION_STEP_UP_REQUIRED
+  //   → throwIfStepUp throws StepUpRequiredError → entry-list-view catches it.
+  // Assert: recent-session reauth dialog opens (NOT a silent reload).
+  it("NET-NEW: delete-permanently denial (SESSION_STEP_UP_REQUIRED) opens the reauth dialog", async () => {
+    mockFetchApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [makeServerEntry("entry-1")],
+    });
+    mockDecryptData.mockResolvedValueOnce(makeDecryptedOverview("GitHub"));
+
+    render(<PasswordList searchQuery="" tagId={null} refreshKey={0} trashOnly />);
+
+    await waitFor(() => { expect(screen.getByText("GitHub")).toBeInTheDocument(); });
+
+    act(() => { fireEvent.click(screen.getByTestId("row-entry-1")); });
+    act(() => { capturedPaneDeletePermanently?.(); });
+
+    await waitFor(() => {
+      expect(screen.getByText("deleteConfirm:{\"title\":\"GitHub\"}")).toBeInTheDocument();
+    });
+
+    // Setup: the permanent DELETE call is denied with a step-up 403, then the
+    // rollback reload() re-fetches the (still-alive) entry.
+    mockFetchApi.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: "SESSION_STEP_UP_REQUIRED" }),
+    });
+    mockFetchApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [makeServerEntry("entry-1")],
+    });
+    mockDecryptData.mockResolvedValueOnce(makeDecryptedOverview("GitHub"));
+
+    const confirmBtn = screen.getByRole("button", { name: "deletePermanently" });
+    await act(async () => { fireEvent.click(confirmBtn); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+
+    // Regression (security-UX): the row was optimistically removed before the
+    // server call; on step-up denial the entry is still ALIVE server-side, so
+    // the UI must roll back (reload) and keep showing it — never leave a
+    // purged-looking-but-alive secret. Assert the entry is still visible.
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
   });
 
@@ -488,6 +599,45 @@ describe("EntryListView — TRASH_VIEW (T2 coverage migration + NET-NEW)", () =>
         return url === "/api/passwords/empty-trash" && opts?.method === "POST";
       });
       expect(postCall).toBeDefined();
+    });
+  });
+
+  // ── (e-stepup) C4: empty-trash denial opens the reauth dialog ───────────────
+  // Precondition: showEmptyTrashButton=true; confirm dialog opened.
+  // Trigger: confirm → adapter.emptyTrash 403s with SESSION_STEP_UP_REQUIRED
+  //   → throwIfStepUp throws StepUpRequiredError → entry-list-view catches it.
+  // Assert: recent-session reauth dialog opens (NOT a silent reload).
+  it("NET-NEW: empty-trash denial (SESSION_STEP_UP_REQUIRED) opens the reauth dialog", async () => {
+    mockFetchApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [makeServerEntry("entry-1")],
+    });
+    mockDecryptData.mockResolvedValueOnce(makeDecryptedOverview("OldEntry"));
+
+    render(<PasswordList searchQuery="" tagId={null} refreshKey={0} trashOnly />);
+
+    await waitFor(() => { expect(screen.getByText("OldEntry")).toBeInTheDocument(); });
+
+    const emptyTrashBtn = screen.getByRole("button", { name: "emptyTrash" });
+    fireEvent.click(emptyTrashBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("emptyTrashConfirm")).toBeInTheDocument();
+    });
+
+    // Setup: the empty-trash POST is denied with a step-up 403.
+    mockFetchApi.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: "SESSION_STEP_UP_REQUIRED" }),
+    });
+
+    const dialogConfirmBtns = screen.getAllByRole("button", { name: "emptyTrash" });
+    const dialogConfirmBtn = dialogConfirmBtns[dialogConfirmBtns.length - 1];
+    await act(async () => { fireEvent.click(dialogConfirmBtn); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
     });
   });
 

--- a/src/components/passwords/detail/entry-list-view.tsx
+++ b/src/components/passwords/detail/entry-list-view.tsx
@@ -38,6 +38,10 @@ import { usePasswordEntryDetail } from "@/hooks/vault/use-password-entry-detail"
 import { useEntryActions } from "@/hooks/vault/use-entry-actions";
 import { useBulkSelection } from "@/hooks/bulk/use-bulk-selection";
 import { useBulkAction } from "@/hooks/bulk/use-bulk-action";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { isStepUpRequiredError } from "@/lib/http/handle-step-up-error";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import { MasterDetailShell } from "@/components/passwords/detail/master-detail-shell";
 import type { EntryCardData } from "@/types/entry-card";
 import { PasswordDetailPane } from "@/components/passwords/detail/password-detail-pane";
@@ -58,6 +62,18 @@ export interface EntryListHandle {
   exitSelectionMode(): void;
   toggleSelectAll(checked: boolean): void;
 }
+
+// ---------------------------------------------------------------------------
+// C4 — step-up reauth retry target
+//
+// Three distinct mutations are step-up-gated: single-entry permanent delete,
+// empty-trash, and bulk-purge. The retry arg records which one to replay
+// after a successful reauth.
+// ---------------------------------------------------------------------------
+type StepUpRetryTarget<E> =
+  | { type: "permanentDelete"; entry: E }
+  | { type: "emptyTrash" }
+  | { type: "bulkPurge" };
 
 // ---------------------------------------------------------------------------
 // EntryListView props
@@ -314,6 +330,30 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
     [toggleSelectAll],
   );
 
+  // C4 — inline step-up reauth for permanent-delete / empty-trash / bulk-purge.
+  // The retry arg records which of the three gated mutations to replay after
+  // a successful reauth. `executeActionRef` breaks the circular dependency
+  // between this hook and useBulkAction below (bulk-purge retry needs
+  // executeAction; useBulkAction's onStepUpRequired needs inlineReauth).
+  const executeActionRef = useRef<() => Promise<void>>(async () => {});
+  const inlineReauth = useInlineReauth<StepUpRetryTarget<E>>(async (retry) => {
+    if (retry.type === "permanentDelete") {
+      await adapter.deletePermanently(retry.entry);
+      // Success after reauth: commit the removal for real (the initial
+      // optimistic remove was rolled back by reload() when step-up fired).
+      onEntryRemoved?.(retry.entry.id);
+      adapter.notifyDataChanged();
+      onDataChange?.();
+    } else if (retry.type === "emptyTrash") {
+      await adapter.emptyTrash();
+      adapter.notifyDataChanged();
+      onDataChange?.();
+      reload();
+    } else if (retry.type === "bulkPurge") {
+      await executeActionRef.current();
+    }
+  });
+
   // Bulk action hook.
   const {
     dialogOpen: bulkDialogOpen,
@@ -331,7 +371,9 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
       reload();
       onDataChange?.();
     },
+    onStepUpRequired: () => inlineReauth.triggerOnStaleError({ type: "bulkPurge" }),
   });
+  executeActionRef.current = executeAction;
 
   // ── Single-entry mutation handlers (INV-C1.4) ──────────────────────────────
   // Each: (1) optimistic remove, (2) adapter call, (3) rollback on reject, (4) notify on success.
@@ -418,10 +460,20 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
       await adapter.deletePermanently(entry);
       adapter.notifyDataChanged();
       onDataChange?.();
-    } catch {
+    } catch (e) {
+      if (isStepUpRequiredError(e)) {
+        // The row was optimistically removed above, but the server rejected the
+        // purge (stale step-up window) — the entry is still ALIVE. Roll back the
+        // optimistic removal so it does not falsely read as permanently deleted,
+        // THEN open the reauth prompt. On reauth success the retry handler
+        // commits the removal for real.
+        reload();
+        await inlineReauth.triggerOnStaleError({ type: "permanentDelete", entry });
+        return;
+      }
       reload();
     }
-  }, [adapter, deletePermanentlyPending, onDataChange, onEntryRemoved, reload]);
+  }, [adapter, deletePermanentlyPending, inlineReauth, onDataChange, onEntryRemoved, reload]);
 
   // Empty-trash: clears all trash entries; gated by descriptor.showEmptyTrashButton + canDelete.
   const handleEmptyTrashConfirmed = useCallback(async () => {
@@ -432,13 +484,18 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
       adapter.notifyDataChanged();
       onDataChange?.();
       reload();
-    } catch {
+    } catch (e) {
+      if (isStepUpRequiredError(e)) {
+        setEmptyTrashConfirmOpen(false);
+        await inlineReauth.triggerOnStaleError({ type: "emptyTrash" });
+        return;
+      }
       // Reload to show remaining entries on failure.
       reload();
     } finally {
       setIsEmptyingTrash(false);
     }
-  }, [adapter, onDataChange, reload]);
+  }, [adapter, inlineReauth, onDataChange, reload]);
 
   // ── Accordion toggle callbacks (legacy PasswordCard interface) ─────────────
 
@@ -875,6 +932,9 @@ export function EntryListView<E extends PasswordRowEntry & PasswordDetailPaneEnt
           teamId={adapter.teamId}
         />
       )}
+      {/* C4 — inline step-up reauth dialogs for permanent-delete / empty-trash / bulk-purge. */}
+      <RecentSessionRequiredDialog {...inlineReauth.recentSessionDialogProps} cancelLabel={tc("cancel")} />
+      <PasskeyReauthDialog {...inlineReauth.reauthDialogProps} cancelLabel={tc("cancel")} />
     </>
   );
 }

--- a/src/components/passwords/detail/password-list.test.tsx
+++ b/src/components/passwords/detail/password-list.test.tsx
@@ -26,6 +26,7 @@ let capturedBulkOnSuccess: (() => void) | undefined;
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
     params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("@/lib/vault/vault-context", () => ({

--- a/src/components/passwords/password-list-search.test.tsx
+++ b/src/components/passwords/password-list-search.test.tsx
@@ -15,6 +15,7 @@ const { mockFetchApi, mockDecryptData, mockEncryptionKey } = vi.hoisted(() => ({
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
 }));
 
 vi.mock("@/lib/vault/vault-context", () => ({

--- a/src/components/settings/account/tenant-members-card.test.tsx
+++ b/src/components/settings/account/tenant-members-card.test.tsx
@@ -16,11 +16,13 @@ import type { ReactNode } from "react";
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
-const { mockFetch, mockToast, mockUseTenantRole, mockFilterMembers } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockUseTenantRole, mockFilterMembers, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { error: vi.fn(), success: vi.fn() },
   mockUseTenantRole: vi.fn(),
   mockFilterMembers: vi.fn(),
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -28,6 +30,7 @@ const { mockFetch, mockToast, mockUseTenantRole, mockFilterMembers } = vi.hoiste
 // ---------------------------------------------------------------------------
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({
@@ -40,6 +43,17 @@ vi.mock("@/lib/url-helpers", () => ({
 
 vi.mock("@/hooks/use-tenant-role", () => ({
   useTenantRole: () => mockUseTenantRole(),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 vi.mock("@/lib/filter-members", () => ({
@@ -251,6 +265,7 @@ describe("TenantMembersCard", () => {
     mockFilterMembers.mockImplementation(
       (members: unknown[], _query: string) => members,
     );
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
   });
 
   // -------------------------------------------------------------------------
@@ -529,6 +544,56 @@ describe("TenantMembersCard", () => {
   });
 
   // -------------------------------------------------------------------------
+  // 7b. Role change: SESSION_STEP_UP_REQUIRED denial
+  // -------------------------------------------------------------------------
+  it("opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned on role change", async () => {
+    const member = makeMember({
+      id: "mem-1",
+      userId: "user-member",
+      role: "MEMBER",
+      scimManaged: false,
+    });
+
+    mockUseTenantRole.mockReturnValue({
+      role: "OWNER",
+      isAdmin: true,
+      loading: false,
+    });
+
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "/api/auth/session") {
+        return Promise.resolve({ json: () => Promise.resolve({ user: { id: "current-owner" } }) });
+      }
+      if (url === "/api/tenant/members" && (!init?.method || init.method === "GET")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([member]) });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+
+    await act(async () => {
+      render(<TenantMembersCard />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("member-info")).toBeInTheDocument();
+    });
+
+    const changeButton = screen.getByTestId("select-change-MEMBER");
+    await act(async () => {
+      fireEvent.click(changeButton);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
   // 8. Role change error: 409 (scimManaged conflict)
   // -------------------------------------------------------------------------
   it("shows scimManagedRoleError toast on 409 response", async () => {
@@ -553,7 +618,7 @@ describe("TenantMembersCard", () => {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([member]) });
       }
       // PUT returns 409
-      return Promise.resolve({ ok: false, status: 409 });
+      return Promise.resolve({ ok: false, status: 409, json: () => Promise.resolve({ error: "SCIM_MANAGED_CONFLICT" }) });
     });
 
     await act(async () => {
@@ -599,7 +664,7 @@ describe("TenantMembersCard", () => {
       if (url === "/api/tenant/members" && (!init?.method || init.method === "GET")) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([member]) });
       }
-      return Promise.resolve({ ok: false, status: 500 });
+      return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({ error: "INTERNAL_ERROR" }) });
     });
 
     await act(async () => {

--- a/src/components/settings/account/tenant-members-card.tsx
+++ b/src/components/settings/account/tenant-members-card.tsx
@@ -22,6 +22,10 @@ import { API_PATH, apiPath } from "@/lib/constants";
 import { useTenantRole } from "@/hooks/use-tenant-role";
 import { TenantVaultResetButton } from "../security/tenant-vault-reset-button";
 import { TenantResetHistoryDialog } from "../security/tenant-reset-history-dialog";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 
 interface TenantMember {
   id: string;
@@ -56,6 +60,7 @@ const ROLE_LEVEL: Record<string, number> = {
 
 export function TenantMembersCard() {
   const t = useTranslations("TenantAdmin");
+  const tCommon = useTranslations("Common");
   const { role: myRole, isAdmin, loading: roleLoading } = useTenantRole();
   const isOwner = myRole === "OWNER";
   const [members, setMembers] = useState<TenantMember[]>([]);
@@ -98,14 +103,24 @@ export function TenantMembersCard() {
     }
   }, [isAdmin, fetchMembers]);
 
-  const handleChangeRole = useCallback(async (userId: string, newRole: string) => {
+  // Retry target carries (userId, newRole) so a step-up interruption replays
+  // the same role change after reauth.
+  const inlineReauth = useInlineReauth<{ userId: string; newRole: string }>(
+    async ({ userId, newRole }): Promise<void> => {
+      await handleChangeRole(userId, newRole);
+    },
+  );
+
+  const handleChangeRole = useCallback(async (userId: string, newRole: string): Promise<void> => {
     try {
+      // @stepup id:tenant-member-put
       const res = await fetchApi(apiPath.tenantMemberById(userId), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ role: newRole }),
       });
       if (!res.ok) {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { userId, newRole })) return;
         if (res.status === 409) {
           toast.error(t("scimManagedRoleError"));
         } else {
@@ -118,7 +133,7 @@ export function TenantMembersCard() {
     } catch {
       toast.error(t("roleChangeFailed"));
     }
-  }, [t, fetchMembers]);
+  }, [t, fetchMembers, inlineReauth]);
 
   if (roleLoading || loading) {
     return (
@@ -230,6 +245,15 @@ export function TenantMembersCard() {
             )}
           </>
         )}
+
+        <RecentSessionRequiredDialog
+          {...inlineReauth.recentSessionDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
+        <PasskeyReauthDialog
+          {...inlineReauth.reauthDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/settings/account/tenant-retention-policy-card.test.tsx
+++ b/src/components/settings/account/tenant-retention-policy-card.test.tsx
@@ -9,21 +9,35 @@ import {
   RETENTION_DAYS_MAX,
 } from "@/lib/validations/common";
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () =>
     (key: string, params?: Record<string, string | number>) =>
       params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({ toast: mockToast }));
 
 vi.mock("@/lib/url-helpers", () => ({
   fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import { TenantRetentionPolicyCard } from "./tenant-retention-policy-card";
@@ -48,6 +62,7 @@ function setupGet(data: Record<string, unknown>) {
 describe("TenantRetentionPolicyCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
   });
 
   it("disables save button when no changes (R26)", async () => {
@@ -148,6 +163,33 @@ describe("TenantRetentionPolicyCard", () => {
     await waitFor(() => {
       expect(mockToast.error).toHaveBeenCalledWith("retentionPolicySaveFailed");
     });
+  });
+
+  it("shows the recent-session dialog on a SESSION_STEP_UP_REQUIRED save denial, without a generic error toast", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ auditLogRetentionDays: 365 }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+    render(<TenantRetentionPolicyCard />);
+    const save = await screen.findByRole("button", {
+      name: "retentionPolicySave",
+    });
+
+    fireEvent.click(screen.getByLabelText("auditLogRetentionEnabled"));
+    fireEvent.click(save);
+
+    expect(await screen.findByTestId("recent-session-dialog")).toBeInTheDocument();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 
   describe("generic retention fields", () => {

--- a/src/components/settings/account/tenant-retention-policy-card.tsx
+++ b/src/components/settings/account/tenant-retention-policy-card.tsx
@@ -25,6 +25,10 @@ import { useFormDirty } from "@/hooks/form/use-form-dirty";
 import { useBeforeUnloadGuard } from "@/hooks/form/use-before-unload-guard";
 import { FormDirtyBadge } from "@/components/settings/account/form-dirty-badge";
 import { bindRangeInput } from "@/lib/ui/input-range";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 
 // The 5 generic retention fields share a single [min, max] bound and the
 // "toggle on → integer days, off → null (never auto-delete)" pattern.
@@ -161,6 +165,8 @@ export function TenantRetentionPolicyCard() {
     return null;
   };
 
+  const inlineReauth = useInlineReauth(() => handleSave());
+
   const handleSave = async () => {
     const validationError = validate();
     if (validationError) {
@@ -176,6 +182,7 @@ export function TenantRetentionPolicyCard() {
       for (const { key } of GENERIC_FIELDS) {
         body[key] = generic.enabled[key] ? Number(generic.days[key]) : null;
       }
+      // @stepup id:tenant-policy-patch
       const res = await fetchApi(API_PATH.TENANT_POLICY, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -190,6 +197,7 @@ export function TenantRetentionPolicyCard() {
           days: { ...generic.days },
         });
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError)) return;
         toast.error(t("retentionPolicySaveFailed"));
       }
     } catch {
@@ -314,6 +322,15 @@ export function TenantRetentionPolicyCard() {
             {t("retentionPolicySave")}
           </Button>
         </div>
+
+        <RecentSessionRequiredDialog
+          {...inlineReauth.recentSessionDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
+        <PasskeyReauthDialog
+          {...inlineReauth.reauthDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/settings/developer/access-request-card.test.tsx
+++ b/src/components/settings/developer/access-request-card.test.tsx
@@ -630,6 +630,46 @@ describe("AccessRequestCard", () => {
     });
   });
 
+  it("opens RecentSessionRequiredDialog on 403 SESSION_STEP_UP_REQUIRED deny response", async () => {
+    setupFetchRequests();
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ requests: sampleRequests }),
+        });
+      }
+      if (init.method === "POST" && String(url).includes("/deny")) {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 500 });
+    });
+
+    await act(async () => {
+      render(<AccessRequestCard />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("deploy-bot")).toBeInTheDocument();
+    });
+
+    const alertActions = screen.getAllByTestId("alert-action");
+    expect(alertActions.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      fireEvent.click(alertActions[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
   it("opens create dialog and submits POST to access requests endpoint", async () => {
     mockFetch.mockImplementation((url: string, init?: RequestInit) => {
       if (!init?.method || init.method === "GET") {

--- a/src/components/settings/developer/access-request-card.tsx
+++ b/src/components/settings/developer/access-request-card.tsx
@@ -49,6 +49,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
 import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
 import { tokenMintApiErrorKey } from "@/lib/http/token-mint-error";
 
 import type { AccessRequestStatus } from "@prisma/client";
@@ -91,9 +92,13 @@ export function AccessRequestCard() {
   const [approving, setApproving] = useState<string | null>(null);
   const [jitToken, setJitToken] = useState<string | null>(null);
   const [jitTokenOpen, setJitTokenOpen] = useState(false);
-  // The retry arg (owned by the hook) carries the request id so the post-reauth
-  // retry approves the same request the operator was acting on.
-  const inlineReauth = useInlineReauth<string>((requestId) => handleApprove(requestId));
+  // The retry arg (owned by the hook) carries which mutation and request id so
+  // the post-reauth retry replays the same action on the same request.
+  type ReauthRetry = { type: "approve"; requestId: string } | { type: "deny"; requestId: string };
+  const inlineReauth = useInlineReauth<ReauthRetry>(async (retry) => {
+    if (retry.type === "approve") await handleApprove(retry.requestId);
+    else if (retry.type === "deny") await handleDeny(retry.requestId);
+  });
 
   // Create dialog state
   const [createOpen, setCreateOpen] = useState(false);
@@ -189,6 +194,7 @@ export function AccessRequestCard() {
   const handleApprove = async (requestId: string) => {
     setApproving(requestId);
     try {
+      // @stepup id:access-request-approve
       const res = await fetchApi(apiPath.tenantAccessRequestApprove(requestId), {
         method: "POST",
         cache: "no-store",
@@ -198,7 +204,7 @@ export function AccessRequestCard() {
         const code = body?.error ?? "";
         if (code === API_ERROR.SESSION_STEP_UP_REQUIRED) {
           // Pass the request id so the post-reauth retry approves the same one.
-          await inlineReauth.triggerOnStaleError(requestId);
+          await inlineReauth.triggerOnStaleError({ type: "approve", requestId });
         } else if (res.status === 409 && code === API_ERROR.SA_TOKEN_LIMIT_EXCEEDED) {
           toast.error(t("arTokenLimitExceeded"));
         } else if (res.status === 409 && code === API_ERROR.SA_INACTIVE) {
@@ -233,6 +239,7 @@ export function AccessRequestCard() {
 
   const handleDeny = async (requestId: string) => {
     try {
+      // @stepup id:access-request-deny
       const res = await fetchApi(apiPath.tenantAccessRequestDeny(requestId), {
         method: "POST",
       });
@@ -240,6 +247,7 @@ export function AccessRequestCard() {
         toast.success(t("arDenied"));
         fetchRequests();
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { type: "deny", requestId })) return;
         toast.error(t("arDenyFailed"));
       }
     } catch {

--- a/src/components/settings/developer/api-key-manager.test.tsx
+++ b/src/components/settings/developer/api-key-manager.test.tsx
@@ -188,6 +188,51 @@ describe("ApiKeyManager", () => {
     expect(mockToast.error).not.toHaveBeenCalled();
   });
 
+  it("opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned on revoke", async () => {
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (
+        String(url).includes("/api/api-keys") &&
+        (!init || init.method === undefined || init.method === "GET")
+      ) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve([
+            {
+              id: "k1",
+              prefix: "abc1",
+              name: "ProdKey",
+              scopes: ["passwords:read"],
+              expiresAt: new Date(Date.now() + 60_000).toISOString(),
+              createdAt: new Date().toISOString(),
+              revokedAt: null,
+              lastUsedAt: null,
+            },
+          ]),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+
+    render(<ApiKeyManager />);
+    await waitFor(() => {
+      expect(screen.getByText("ProdKey")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /revoke/ }));
+    const confirmButtons = screen.getAllByRole("button", { name: /revoke/ });
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
   it("falls back to local createError for an unrecognized API error code", async () => {
     mockFetch.mockImplementation((url: string, init?: RequestInit) => {
       if (

--- a/src/components/settings/developer/api-key-manager.tsx
+++ b/src/components/settings/developer/api-key-manager.tsx
@@ -46,6 +46,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
 import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
 import { tokenMintApiErrorKey } from "@/lib/http/token-mint-error";
 
 interface ApiKeyEntry {
@@ -88,7 +89,14 @@ export function ApiKeyManager() {
     new Set([API_KEY_SCOPE.PASSWORDS_READ]),
   );
   const [expiryDays, setExpiryDays] = useState("90");
-  const inlineReauth = useInlineReauth(() => handleCreate());
+  // Inline step-up reauth — creating a key and revoking one are both
+  // server-side step-up-gated. The retry arg (owned by the hook) records
+  // which mutation was in flight so the post-reauth retry replays the same one.
+  type ReauthRetry = { type: "create" } | { type: "revoke"; keyId: string };
+  const inlineReauth = useInlineReauth<ReauthRetry>(async (retry) => {
+    if (retry.type === "create") await handleCreate();
+    else if (retry.type === "revoke") await handleRevoke(retry.keyId);
+  });
 
   const fetchKeys = useCallback(async () => {
     try {
@@ -136,6 +144,7 @@ export function ApiKeyManager() {
       const expiresAt = new Date();
       expiresAt.setDate(expiresAt.getDate() + parseInt(expiryDays, 10));
 
+      // @stepup id:api-keys-post
       const res = await fetchApi("/api/api-keys", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -157,7 +166,7 @@ export function ApiKeyManager() {
       } else {
         const err = await res.json().catch(() => ({}));
         if (err.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-          await inlineReauth.triggerOnStaleError();
+          await inlineReauth.triggerOnStaleError({ type: "create" });
         } else if (err.error === API_ERROR.API_KEY_LIMIT_EXCEEDED) {
           toast.error(t("limitExceeded", { max: MAX_API_KEYS_PER_USER }));
         } else if (res.status === 400) {
@@ -176,6 +185,7 @@ export function ApiKeyManager() {
 
   const handleRevoke = async (keyId: string) => {
     try {
+      // @stepup id:api-keys-id-delete
       const res = await fetchApi(`/api/api-keys/${keyId}`, {
         method: "DELETE",
       });
@@ -183,6 +193,7 @@ export function ApiKeyManager() {
         toast.success(t("revoked_toast"));
         fetchKeys();
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { type: "revoke", keyId })) return;
         toast.error(t("revokeError"));
       }
     } catch {

--- a/src/components/settings/developer/audit-delivery-target-card.tsx
+++ b/src/components/settings/developer/audit-delivery-target-card.tsx
@@ -194,6 +194,7 @@ export function AuditDeliveryTargetCard() {
     setCreating(true);
     setUrlError("");
     try {
+      // @stepup id:audit-delivery-target-post
       const res = await fetchApi(apiPath.tenantAuditDeliveryTargets(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -222,6 +223,7 @@ export function AuditDeliveryTargetCard() {
 
   const handleToggleActive = async (target: TargetItem) => {
     try {
+      // @stepup id:audit-delivery-target-id-patch
       const res = await fetchApi(apiPath.tenantAuditDeliveryTargetById(target.id), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },

--- a/src/components/settings/developer/base-webhook-card.test.tsx
+++ b/src/components/settings/developer/base-webhook-card.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
 if (typeof globalThis.ResizeObserver === "undefined") {
@@ -11,21 +11,36 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   } as unknown as typeof ResizeObserver;
 }
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () =>
     (key: string, params?: Record<string, string | number>) =>
       params ? `${key}:${JSON.stringify(params)}` : key,
+  // RecentSessionRequiredDialog (step-up reauth flow) calls useLocale.
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({ toast: mockToast }));
 
 vi.mock("@/lib/url-helpers", () => ({
   fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 vi.mock("@/lib/format/format-datetime", () => ({
@@ -36,6 +51,32 @@ vi.mock("@/components/passwords/shared/copy-button", () => ({
   CopyButton: ({ getValue }: { getValue: () => string }) => (
     <button type="button" data-testid="copy-button" data-value={getValue()}>
       copy
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
+    <div data-testid="alert-trigger">{children}</div>
+  ),
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="alert-content">{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  AlertDialogAction: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button data-testid="alert-action" onClick={onClick}>
+      {children}
     </button>
   ),
 }));
@@ -82,6 +123,9 @@ function setupList(webhooks: Array<Record<string, unknown>>) {
 describe("BaseWebhookCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: user has no passkey → the recent-session dialog opens.
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true, verifiedAt: "2026-05-10T00:00:00Z" });
   });
 
   it("renders the empty state when no webhooks", async () => {
@@ -146,9 +190,96 @@ describe("BaseWebhookCard", () => {
     render(<BaseWebhookCard config={config} />);
     await waitFor(() => {
       expect(
-        screen.getByText("https://example.com/hook"),
-      ).toBeInTheDocument();
+        screen.getAllByText("https://example.com/hook").length,
+      ).toBeGreaterThanOrEqual(1);
     });
     expect(screen.getByText("active")).toBeInTheDocument();
+  });
+
+  it("create — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ webhooks: [] }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+
+    render(<BaseWebhookCard config={config} />);
+    await waitFor(() =>
+      expect(screen.getByText("noWebhooks")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /addWebhook/ }));
+    fireEvent.change(screen.getByPlaceholderText("urlPlaceholder"), {
+      target: { value: "https://example.com/hook" },
+    });
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+
+    const buttons = screen.getAllByRole("button", { name: /addWebhook/ });
+    const submitBtn = buttons[buttons.length - 1];
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it("delete — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            webhooks: [
+              {
+                id: "w1",
+                url: "https://example.com/hook",
+                events: ["a.action.1"],
+                isActive: true,
+                failCount: 0,
+                lastDeliveredAt: null,
+                lastFailedAt: null,
+                lastError: null,
+                createdAt: new Date().toISOString(),
+              },
+            ],
+          }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+
+    render(<BaseWebhookCard config={config} />);
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("https://example.com/hook").length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    const alertActions = screen.getAllByTestId("alert-action");
+    await act(async () => {
+      fireEvent.click(alertActions[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/developer/base-webhook-card.tsx
+++ b/src/components/settings/developer/base-webhook-card.tsx
@@ -43,6 +43,10 @@ import { toast } from "sonner";
 import { formatDateTime } from "@/lib/format/format-datetime";
 import { fetchApi } from "@/lib/url-helpers";
 import { readApiErrorBody, getApiErrorFieldErrors } from "@/lib/http/read-api-error-body";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 import { MAX_WEBHOOKS } from "@/lib/validations/common";
 
 export interface WebhookItem {
@@ -99,6 +103,15 @@ export function BaseWebhookCard({ config }: Props) {
   const [selectedEvents, setSelectedEvents] = useState<Set<string>>(new Set());
   const [newSecret, setNewSecret] = useState<string | null>(null);
 
+  // Inline step-up reauth — create and delete are both server-side step-up-gated.
+  // The retry arg records which mutation was attempted so the post-reauth retry
+  // replays the same one.
+  type ReauthRetry = { type: "create" } | { type: "delete"; webhookId: string };
+  const inlineReauth = useInlineReauth<ReauthRetry>(async (retry) => {
+    if (retry.type === "create") await handleCreate();
+    else if (retry.type === "delete") await handleDelete(retry.webhookId);
+  });
+
   // listEndpoint already encodes all dynamic identifiers (e.g. teamId is baked into
   // apiPath.teamWebhooks(teamId)), so depending on listEndpoint alone is sufficient.
   const fetchWebhooks = useCallback(async () => {
@@ -152,6 +165,8 @@ export function BaseWebhookCard({ config }: Props) {
     setCreating(true);
     setUrlError("");
     try {
+      // @stepup id:tenant-webhook-post
+      // @stepup id:team-webhook-post
       const res = await fetchApi(createEndpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -170,6 +185,7 @@ export function BaseWebhookCard({ config }: Props) {
         return;
       }
       if (!res.ok) {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { type: "create" })) return;
         toast.error(t("createFailed"));
         return;
       }
@@ -188,6 +204,8 @@ export function BaseWebhookCard({ config }: Props) {
 
   const handleDelete = async (webhookId: string) => {
     try {
+      // @stepup id:tenant-webhook-delete
+      // @stepup id:team-webhook-delete
       const res = await fetchApi(deleteEndpointRef.current(webhookId), {
         method: "DELETE",
       });
@@ -195,6 +213,7 @@ export function BaseWebhookCard({ config }: Props) {
         toast.success(t("deleted"));
         fetchWebhooks();
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { type: "delete", webhookId })) return;
         toast.error(t("deleteFailed"));
       }
     } catch {
@@ -468,6 +487,15 @@ export function BaseWebhookCard({ config }: Props) {
           )}
         </DialogContent>
       </Dialog>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
     </Card>
   );
 }

--- a/src/components/settings/developer/directory-sync-card.tsx
+++ b/src/components/settings/developer/directory-sync-card.tsx
@@ -212,6 +212,7 @@ export function DirectorySyncCard() {
         if (Object.keys(formCredentials).some((k) => formCredentials[k])) {
           body.credentials = formCredentials;
         }
+        // @stepup id:directory-sync-id-put
         const res = await fetchApi(apiPath.directorySyncById(editingConfig.id), {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
@@ -236,6 +237,7 @@ export function DirectorySyncCard() {
         }
       } else {
         // Create
+        // @stepup id:directory-sync-post
         const res = await fetchApi(API_PATH.DIRECTORY_SYNC, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -277,6 +279,7 @@ export function DirectorySyncCard() {
 
   async function handleDelete(id: string) {
     try {
+      // @stepup id:directory-sync-id-delete
       const res = await fetchApi(apiPath.directorySyncById(id), {
         method: "DELETE",
       });

--- a/src/components/settings/developer/mcp-client-card.test.tsx
+++ b/src/components/settings/developer/mcp-client-card.test.tsx
@@ -724,6 +724,43 @@ describe("McpClientCard", () => {
     });
   });
 
+  it("delete client — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ clients: sampleClients }),
+        });
+      }
+      if (init.method === "DELETE") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    });
+
+    await act(async () => {
+      render(<McpClientCard />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("My MCP Agent")).toBeInTheDocument();
+    });
+
+    const alertActions = screen.getAllByTestId("alert-action");
+    await act(async () => {
+      fireEvent.click(alertActions[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
   it("delete client — confirm dialog, verify DELETE called", async () => {
     setupFetchClients();
 
@@ -803,5 +840,67 @@ describe("McpClientCard", () => {
       );
       expect(putCalls.length).toBe(1);
     });
+  });
+
+  it("edit client — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ clients: sampleClients }),
+        });
+      }
+      if (init.method === "PUT") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    });
+
+    await act(async () => {
+      render(<McpClientCard />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("My MCP Agent")).toBeInTheDocument();
+    });
+
+    const allButtons = screen.getAllByRole("button");
+    const editButtons = allButtons.filter((b) => {
+      const testId = b.getAttribute("data-testid");
+      return !testId && b.closest("[data-testid='alert-trigger']") === null &&
+        !b.textContent?.includes("registerMcpClient") &&
+        !b.textContent?.includes("cancel") &&
+        !b.textContent?.includes("delete") &&
+        b.textContent?.trim() === "";
+    });
+    expect(editButtons.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      fireEvent.click(editButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("editMcpClient")).toBeInTheDocument();
+    });
+
+    const nameInput = screen.getByDisplayValue("My MCP Agent");
+    fireEvent.change(nameInput, { target: { value: "Renamed Agent" } });
+
+    const saveBtn = screen.getAllByRole("button").find(
+      (b) => b.textContent?.includes("save")
+    );
+    expect(saveBtn).toBeDefined();
+    await act(async () => {
+      fireEvent.click(saveBtn!);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/developer/mcp-client-card.tsx
+++ b/src/components/settings/developer/mcp-client-card.tsx
@@ -47,6 +47,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
 import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
 
 interface McpClient {
   id: string;
@@ -120,7 +121,18 @@ export function McpClientCard() {
   const [createUriError, setCreateUriError] = useState("");
   const [createScopeError, setCreateScopeError] = useState("");
   const [newCredentials, setNewCredentials] = useState<NewClientCredentials | null>(null);
-  const inlineReauth = useInlineReauth(() => handleCreate());
+  // Inline step-up reauth — create/edit/delete are all server-side
+  // step-up-gated. The retry arg (owned by the hook) records which mutation
+  // was in flight so the post-reauth retry replays the same one.
+  type ReauthRetry =
+    | { type: "create" }
+    | { type: "edit" }
+    | { type: "delete"; clientId: string };
+  const inlineReauth = useInlineReauth<ReauthRetry>(async (retry) => {
+    if (retry.type === "create") await handleCreate();
+    else if (retry.type === "edit") await handleEdit();
+    else if (retry.type === "delete") await handleDelete(retry.clientId);
+  });
 
   // Edit dialog
   const [editOpen, setEditOpen] = useState(false);
@@ -206,6 +218,7 @@ const toastUpdateApiError = (errorCode: unknown) => {
 
     setCreating(true);
     try {
+      // @stepup id:mcp-client-post
       const res = await fetchApi(apiPath.tenantMcpClients(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -218,7 +231,7 @@ const toastUpdateApiError = (errorCode: unknown) => {
       if (!res.ok) {
         const body = await readApiErrorBody(res);
         if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-          await inlineReauth.triggerOnStaleError();
+          await inlineReauth.triggerOnStaleError({ type: "create" });
         } else if (res.status === 409 && body?.error === API_ERROR.MCP_CLIENT_NAME_CONFLICT) {
           setCreateNameError(t("mcpNameConflict"));
         } else if (res.status === 400 && body?.error === API_ERROR.VALIDATION_ERROR) {
@@ -310,6 +323,7 @@ const toastUpdateApiError = (errorCode: unknown) => {
       if (!editClient.isDcr) {
         body.redirectUris = uris;
       }
+      // @stepup id:mcp-client-id-put
       const res = await fetchApi(apiPath.tenantMcpClientById(editClient.id), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -317,6 +331,10 @@ const toastUpdateApiError = (errorCode: unknown) => {
       });
       if (!res.ok) {
         const body = await readApiErrorBody(res);
+        if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          await inlineReauth.triggerOnStaleError({ type: "edit" });
+          return;
+        }
         if (res.status === 409) {
           setEditNameError(t("mcpNameConflict"));
           return;
@@ -357,6 +375,7 @@ const toastUpdateApiError = (errorCode: unknown) => {
 
   const handleDelete = async (clientId: string) => {
     try {
+      // @stepup id:mcp-client-id-delete
       const res = await fetchApi(apiPath.tenantMcpClientById(clientId), {
         method: "DELETE",
       });
@@ -364,6 +383,7 @@ const toastUpdateApiError = (errorCode: unknown) => {
         toast.success(t("mcpDeleted"));
         fetchClients();
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { type: "delete", clientId })) return;
         toast.error(t("mcpDeleteFailed"));
       }
     } catch {

--- a/src/components/settings/developer/service-account-card.test.tsx
+++ b/src/components/settings/developer/service-account-card.test.tsx
@@ -705,6 +705,169 @@ describe("ServiceAccountCard", () => {
     });
   });
 
+  it("edits SA — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ serviceAccounts: sampleAccounts }),
+        });
+      }
+      if (init.method === "PUT") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    });
+
+    await act(async () => {
+      render(<ServiceAccountCard />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("deploy-bot")).toBeInTheDocument();
+    });
+
+    // Pencil (edit) button is the first icon-only button per SA row.
+    const allButtons = screen.getAllByRole("button");
+    const editButtons = allButtons.filter((b) => {
+      const testId = b.getAttribute("data-testid");
+      return !testId && b.closest("[data-testid='alert-trigger']") === null &&
+        !b.textContent?.includes("createServiceAccount") &&
+        !b.textContent?.includes("cancel") &&
+        !b.textContent?.includes("delete") &&
+        b.textContent?.trim() === "";
+    });
+    expect(editButtons.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      fireEvent.click(editButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("editServiceAccount")).toBeInTheDocument();
+    });
+
+    const nameInput = screen.getByDisplayValue("deploy-bot");
+    fireEvent.change(nameInput, { target: { value: "renamed-bot" } });
+
+    const saveBtn = screen.getAllByRole("button").find(
+      (b) => b.textContent?.includes("save")
+    );
+    expect(saveBtn).toBeDefined();
+    await act(async () => {
+      fireEvent.click(saveBtn!);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it("deletes SA — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ serviceAccounts: sampleAccounts }),
+        });
+      }
+      if (init.method === "DELETE") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    });
+
+    await act(async () => {
+      render(<ServiceAccountCard />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("deploy-bot")).toBeInTheDocument();
+    });
+
+    const alertActions = screen.getAllByTestId("alert-action");
+    expect(alertActions.length).toBeGreaterThan(0);
+    await act(async () => {
+      fireEvent.click(alertActions[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it("revokes token — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET") {
+        if (url.includes("/tokens")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ tokens: sampleTokens }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            serviceAccounts: [
+              {
+                id: "sa-active",
+                name: "active-sa",
+                description: null,
+                isActive: true,
+                createdAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          }),
+        });
+      }
+      if (init.method === "DELETE" && url.includes("/tokens/")) {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    });
+
+    await act(async () => {
+      render(<ServiceAccountCard />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("active-sa")).toBeInTheDocument();
+    });
+
+    await expandSa("active-sa");
+
+    await waitFor(() => {
+      expect(screen.getByText("prod-token")).toBeInTheDocument();
+    });
+
+    // The revoke-token AlertDialogAction is the confirm button inside the
+    // token row's own AlertDialog (distinct from the SA-level delete one).
+    const alertActions = screen.getAllByTestId("alert-action");
+    expect(alertActions.length).toBeGreaterThan(0);
+    await act(async () => {
+      fireEvent.click(alertActions[alertActions.length - 1]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
   it("deletes SA — click delete, confirm in AlertDialog, verifies DELETE call", async () => {
     setupFetchAccounts();
 

--- a/src/components/settings/developer/service-account-card.tsx
+++ b/src/components/settings/developer/service-account-card.tsx
@@ -52,6 +52,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
 import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
 import { MS_PER_DAY } from "@/lib/constants/time";
 
 interface ServiceAccount {
@@ -120,7 +121,20 @@ export function ServiceAccountCard() {
   const [tokenNameError, setTokenNameError] = useState("");
   const [tokenScopeError, setTokenScopeError] = useState("");
   const [newTokenSecret, setNewTokenSecret] = useState<string | null>(null);
-  const inlineReauth = useInlineReauth(() => handleCreateToken());
+  // Inline step-up reauth — SA edit/delete and token create/revoke are all
+  // server-side step-up-gated. The retry arg (owned by the hook) records
+  // which mutation was in flight so the post-reauth retry replays the same one.
+  type ReauthRetry =
+    | { type: "edit" }
+    | { type: "delete"; saId: string }
+    | { type: "createToken" }
+    | { type: "revokeToken"; saId: string; tokenId: string };
+  const inlineReauth = useInlineReauth<ReauthRetry>(async (retry) => {
+    if (retry.type === "edit") await handleEdit();
+    else if (retry.type === "delete") await handleDelete(retry.saId);
+    else if (retry.type === "createToken") await handleCreateToken();
+    else if (retry.type === "revokeToken") await handleRevokeToken(retry.saId, retry.tokenId);
+  });
 
   const fetchAccounts = useCallback(async () => {
     try {
@@ -247,6 +261,7 @@ export function ServiceAccountCard() {
     setEditing(true);
     setEditNameError("");
     try {
+      // @stepup id:service-account-id-put
       const res = await fetchApi(apiPath.tenantServiceAccountById(editSa.id), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -261,6 +276,7 @@ export function ServiceAccountCard() {
         return;
       }
       if (!res.ok) {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { type: "edit" })) return;
         toast.error(t("saUpdateFailed"));
         return;
       }
@@ -277,6 +293,7 @@ export function ServiceAccountCard() {
 
   const handleDelete = async (saId: string) => {
     try {
+      // @stepup id:service-account-id-delete
       const res = await fetchApi(apiPath.tenantServiceAccountById(saId), {
         method: "DELETE",
       });
@@ -284,6 +301,7 @@ export function ServiceAccountCard() {
         toast.success(t("saDeleted"));
         fetchAccounts();
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { type: "delete", saId })) return;
         toast.error(t("saDeleteFailed"));
       }
     } catch {
@@ -328,6 +346,7 @@ export function ServiceAccountCard() {
         scope: Array.from(tokenSelectedScopes),
         expiresAt: expiryDate.toISOString(),
       };
+      // @stepup id:sa-token-post
       const res = await fetchApi(
         apiPath.tenantServiceAccountTokens(tokenForSaId),
         {
@@ -340,7 +359,7 @@ export function ServiceAccountCard() {
         const body = await readApiErrorBody(res);
         const code = body?.error;
         if (code === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-          await inlineReauth.triggerOnStaleError();
+          await inlineReauth.triggerOnStaleError({ type: "createToken" });
         } else if (res.status === 409 && code === API_ERROR.SA_TOKEN_LIMIT_EXCEEDED) {
           toast.error(t("tokenLimitReached"));
         } else if (res.status === 409) {
@@ -366,6 +385,7 @@ export function ServiceAccountCard() {
 
   const handleRevokeToken = async (saId: string, tokenId: string) => {
     try {
+      // @stepup id:sa-token-id-delete
       const res = await fetchApi(
         apiPath.tenantServiceAccountTokenById(saId, tokenId),
         { method: "DELETE" }
@@ -374,6 +394,7 @@ export function ServiceAccountCard() {
         toast.success(t("tokenRevoked2"));
         fetchTokens(saId);
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { type: "revokeToken", saId, tokenId })) return;
         toast.error(t("tokenRevokeFailed"));
       }
     } catch {

--- a/src/components/settings/developer/tenant-webhook-card.test.tsx
+++ b/src/components/settings/developer/tenant-webhook-card.test.tsx
@@ -10,16 +10,19 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   } as unknown as typeof ResizeObserver;
 }
 
-import { render, screen, act, waitFor } from "@testing-library/react";
+import { render, screen, act, waitFor, fireEvent, within } from "@testing-library/react";
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { error: vi.fn(), success: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 // Tenant requires useLocale in addition to useTranslations
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
+  // RecentSessionRequiredDialog (step-up reauth flow) calls useLocale.
   useLocale: () => "en",
 }));
 
@@ -31,6 +34,17 @@ vi.mock("sonner", () => ({
 
 vi.mock("@/lib/url-helpers", () => ({
   fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import {
@@ -69,6 +83,9 @@ createWebhookCardTests(mockFetch, mockToast, {
 describe("TenantWebhookCard (tenant-specific)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: user has no passkey → the recent-session dialog opens.
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true, verifiedAt: "2026-05-10T00:00:00Z" });
   });
 
   it("excludes group:tenantWebhook actions from event selector", async () => {
@@ -171,5 +188,91 @@ describe("TenantWebhookCard (tenant-specific)", () => {
 
     // Delegation actions
     expect(screen.getByText("DELEGATION_CREATE")).toBeInTheDocument();
+  });
+
+  it("create — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ webhooks: [] }),
+        });
+      }
+      if (init.method === "POST") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 500 });
+    });
+
+    await act(async () => {
+      render(<TenantWebhookCard />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("noWebhooks")).toBeInTheDocument();
+    });
+
+    const urlInput = screen.getByPlaceholderText("urlPlaceholder");
+    fireEvent.change(urlInput, {
+      target: { value: "https://valid.example.com/hook" },
+    });
+
+    const checkboxes = screen.getAllByTestId("checkbox");
+    fireEvent.click(checkboxes[0]);
+
+    const submitBtn = within(screen.getByTestId("dialog-content"))
+      .getAllByRole("button")
+      .find((b) => b.textContent?.includes("addWebhook"))!;
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it("delete — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ webhooks: sampleWebhooks }),
+        });
+      }
+      if (init.method === "DELETE") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 500 });
+    });
+
+    await act(async () => {
+      render(<TenantWebhookCard />);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("https://example.com/tenant-hook1").length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    const alertActions = screen.getAllByTestId("alert-action");
+    await act(async () => {
+      fireEvent.click(alertActions[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/security/passkey-credentials-card.tsx
+++ b/src/components/settings/security/passkey-credentials-card.tsx
@@ -266,6 +266,7 @@ export function PasskeyCredentialsCard() {
 
   const handleDelete = async (credentialId: string) => {
     try {
+      // @stepup id:webauthn-credential-delete
       const res = await fetchApi(apiPath.webauthnCredentialById(credentialId), {
         method: "DELETE",
       });

--- a/src/components/settings/security/tenant-access-restriction-card.test.tsx
+++ b/src/components/settings/security/tenant-access-restriction-card.test.tsx
@@ -4,21 +4,35 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { MAX_CIDRS } from "@/lib/validations/common";
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () =>
     (key: string, params?: Record<string, string | number>) =>
       params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({ toast: mockToast }));
 
 vi.mock("@/lib/url-helpers", () => ({
   fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import { TenantAccessRestrictionCard } from "./tenant-access-restriction-card";
@@ -43,6 +57,7 @@ function setupGet(data: Record<string, unknown>) {
 describe("TenantAccessRestrictionCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
   });
 
   it("disables save when no changes (R26)", async () => {
@@ -124,5 +139,34 @@ describe("TenantAccessRestrictionCard", () => {
     await waitFor(() => {
       expect(screen.getByText("selfLockoutWarning")).toBeInTheDocument();
     });
+  });
+
+  it("shows the recent-session dialog on a SESSION_STEP_UP_REQUIRED save denial, without a generic error toast", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({ allowedCidrs: [], tailscaleEnabled: false }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+    render(<TenantAccessRestrictionCard />);
+    const save = await screen.findByRole("button", {
+      name: "accessRestrictionSave",
+    });
+
+    const cidrs = screen.getByLabelText("allowedCidrsLabel");
+    fireEvent.change(cidrs, { target: { value: "10.0.0.0/24" } });
+    fireEvent.click(save);
+
+    expect(await screen.findByTestId("recent-session-dialog")).toBeInTheDocument();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/security/tenant-access-restriction-card.tsx
+++ b/src/components/settings/security/tenant-access-restriction-card.tsx
@@ -27,10 +27,15 @@ import {
 } from "@/components/ui/alert-dialog";
 import { API_PATH } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
+import { readApiErrorBody } from "@/lib/http/read-api-error-body";
 import { TAILNET_NAME_MAX_LENGTH, MAX_CIDRS } from "@/lib/validations";
 import { useFormDirty } from "@/hooks/form/use-form-dirty";
 import { useBeforeUnloadGuard } from "@/hooks/form/use-before-unload-guard";
 import { FormDirtyBadge } from "@/components/settings/account/form-dirty-badge";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
+import { API_ERROR } from "@/lib/http/api-error-codes";
 
 const CIDR_REGEX = /^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$/;
 const CIDR_V6_REGEX = /^[0-9a-fA-F:]*:[0-9a-fA-F:]*\/\d{1,3}$/;
@@ -110,6 +115,11 @@ export function TenantAccessRestrictionCard() {
     return null;
   };
 
+  // Discriminator carries `confirmLockout` so a step-up interruption on
+  // either the initial save or the self-lockout confirm replays the same
+  // request shape after reauth.
+  const inlineReauth = useInlineReauth<boolean>((confirmLockout) => doSave(confirmLockout));
+
   const doSave = async (confirmLockout: boolean) => {
     const validationError = validate();
     if (validationError) {
@@ -128,6 +138,7 @@ export function TenantAccessRestrictionCard() {
       if (confirmLockout) {
         body.confirmLockout = true;
       }
+      // @stepup id:tenant-policy-patch
       const res = await fetchApi(API_PATH.TENANT_POLICY, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -138,8 +149,12 @@ export function TenantAccessRestrictionCard() {
         setInitialRestriction({ ...currentRestriction });
         setShowLockoutDialog(false);
       } else {
-        const data = await res.json().catch(() => null);
-        if (res.status === 409 && data?.error === "SELF_LOCKOUT") {
+        // Single read of the response body — shared between the step-up
+        // check and the SELF_LOCKOUT check below (res.json() is one-shot).
+        const data = await readApiErrorBody(res);
+        if (data?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          await inlineReauth.triggerOnStaleError(confirmLockout);
+        } else if (res.status === 409 && data?.error === "SELF_LOCKOUT") {
           setShowLockoutDialog(true);
         } else {
           toast.error(t("accessRestrictionSaveFailed"));
@@ -262,6 +277,15 @@ export function TenantAccessRestrictionCard() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
     </>
   );
 }

--- a/src/components/settings/security/tenant-delegation-policy-card.test.tsx
+++ b/src/components/settings/security/tenant-delegation-policy-card.test.tsx
@@ -7,21 +7,35 @@ import {
   DELEGATION_TTL_MAX,
 } from "@/lib/validations/common";
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () =>
     (key: string, params?: Record<string, string | number>) =>
       params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({ toast: mockToast }));
 
 vi.mock("@/lib/url-helpers", () => ({
   fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import { TenantDelegationPolicyCard } from "./tenant-delegation-policy-card";
@@ -46,6 +60,7 @@ function setupGet(data: Record<string, unknown>) {
 describe("TenantDelegationPolicyCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
   });
 
   it("disables save button when no changes (R26)", async () => {
@@ -139,5 +154,40 @@ describe("TenantDelegationPolicyCard", () => {
         screen.getByText("delegationDefaultExceedsMax"),
       ).toBeInTheDocument();
     });
+  });
+
+  it("shows the recent-session dialog on a SESSION_STEP_UP_REQUIRED save denial, without a generic error toast", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({ delegationDefaultTtlSec: null, delegationMaxTtlSec: null }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+    render(<TenantDelegationPolicyCard />);
+    const save = await screen.findByRole("button", {
+      name: "delegationPolicySave",
+    });
+
+    // No `await` between the toggle and the save click: the revealed field
+    // renders synchronously off the same state update, and yielding here
+    // would let the test's unstable-`t` mock retrigger fetchPolicy's
+    // `useEffect` (its useCallback deps include `t`) and clobber the toggle
+    // before save fires — a mock-only race (real next-intl memoizes `t`).
+    fireEvent.click(screen.getByLabelText("delegationDefaultEnabled"));
+    const input = screen.getByLabelText("delegationDefaultTtlSec");
+    fireEvent.change(input, { target: { value: "3600" } });
+    fireEvent.click(save);
+
+    expect(await screen.findByTestId("recent-session-dialog")).toBeInTheDocument();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/security/tenant-delegation-policy-card.tsx
+++ b/src/components/settings/security/tenant-delegation-policy-card.tsx
@@ -23,6 +23,10 @@ import { useFormDirty } from "@/hooks/form/use-form-dirty";
 import { useBeforeUnloadGuard } from "@/hooks/form/use-before-unload-guard";
 import { FormDirtyBadge } from "@/components/settings/account/form-dirty-badge";
 import { bindRangeInput } from "@/lib/ui/input-range";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 
 export function TenantDelegationPolicyCard() {
   const t = useTranslations("TenantAdmin");
@@ -108,6 +112,8 @@ export function TenantDelegationPolicyCard() {
     return null;
   };
 
+  const inlineReauth = useInlineReauth(() => handleSave());
+
   const handleSave = async () => {
     const validationError = validate();
     if (validationError) {
@@ -121,6 +127,7 @@ export function TenantDelegationPolicyCard() {
         delegationDefaultTtlSec: delegationDefaultEnabled ? Number(delegationDefaultTtlSec) : null,
         delegationMaxTtlSec: delegationMaxEnabled ? Number(delegationMaxTtlSec) : null,
       };
+      // @stepup id:tenant-policy-patch
       const res = await fetchApi(API_PATH.TENANT_POLICY, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -130,6 +137,7 @@ export function TenantDelegationPolicyCard() {
         toast.success(t("delegationPolicySaved"));
         setInitialPolicy({ ...currentPolicy });
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError)) return;
         toast.error(t("delegationPolicySaveFailed"));
       }
     } catch {
@@ -236,6 +244,15 @@ export function TenantDelegationPolicyCard() {
             {t("delegationPolicySave")}
           </Button>
         </div>
+
+        <RecentSessionRequiredDialog
+          {...inlineReauth.recentSessionDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
+        <PasskeyReauthDialog
+          {...inlineReauth.reauthDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/settings/security/tenant-lockout-policy-card.test.tsx
+++ b/src/components/settings/security/tenant-lockout-policy-card.test.tsx
@@ -7,21 +7,35 @@ import {
   LOCKOUT_THRESHOLD_MAX,
 } from "@/lib/validations/common";
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () =>
     (key: string, params?: Record<string, string | number>) =>
       params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({ toast: mockToast }));
 
 vi.mock("@/lib/url-helpers", () => ({
   fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import { TenantLockoutPolicyCard } from "./tenant-lockout-policy-card";
@@ -46,6 +60,7 @@ function setupGet(data: Record<string, unknown>) {
 describe("TenantLockoutPolicyCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
   });
 
   it("disables save button when no changes (R26)", async () => {
@@ -111,5 +126,33 @@ describe("TenantLockoutPolicyCard", () => {
         screen.getByText("lockoutThresholdAscending"),
       ).toBeInTheDocument();
     });
+  });
+
+  it("shows the recent-session dialog on a SESSION_STEP_UP_REQUIRED save denial, without a generic error toast", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({}),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+    render(<TenantLockoutPolicyCard />);
+    const save = await screen.findByRole("button", {
+      name: "lockoutPolicySave",
+    });
+
+    const t1 = document.getElementById("lockout-threshold-1") as HTMLInputElement;
+    fireEvent.change(t1, { target: { value: String(LOCKOUT_THRESHOLD_MIN) } });
+    fireEvent.click(save);
+
+    expect(await screen.findByTestId("recent-session-dialog")).toBeInTheDocument();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/security/tenant-lockout-policy-card.tsx
+++ b/src/components/settings/security/tenant-lockout-policy-card.tsx
@@ -25,6 +25,10 @@ import { useFormDirty } from "@/hooks/form/use-form-dirty";
 import { useBeforeUnloadGuard } from "@/hooks/form/use-before-unload-guard";
 import { FormDirtyBadge } from "@/components/settings/account/form-dirty-badge";
 import { bindRangeInput } from "@/lib/ui/input-range";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 
 export function TenantLockoutPolicyCard() {
   const t = useTranslations("TenantAdmin");
@@ -113,6 +117,8 @@ export function TenantLockoutPolicyCard() {
     return null;
   };
 
+  const inlineReauth = useInlineReauth(() => handleSave());
+
   const handleSave = async () => {
     const validationError = validate();
     if (validationError) {
@@ -130,6 +136,7 @@ export function TenantLockoutPolicyCard() {
         lockoutThreshold3: threshold3 !== "" ? Number(threshold3) : null,
         lockoutDuration3Minutes: duration3 !== "" ? Number(duration3) : null,
       };
+      // @stepup id:tenant-policy-patch
       const res = await fetchApi(API_PATH.TENANT_POLICY, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -139,6 +146,7 @@ export function TenantLockoutPolicyCard() {
         toast.success(t("lockoutPolicySaved"));
         setInitialPolicy({ ...currentPolicy });
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError)) return;
         toast.error(t("lockoutPolicySaveFailed"));
       }
     } catch {
@@ -224,6 +232,15 @@ export function TenantLockoutPolicyCard() {
             {t("lockoutPolicySave")}
           </Button>
         </div>
+
+        <RecentSessionRequiredDialog
+          {...inlineReauth.recentSessionDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
+        <PasskeyReauthDialog
+          {...inlineReauth.reauthDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/settings/security/tenant-passkey-policy-card.test.tsx
+++ b/src/components/settings/security/tenant-passkey-policy-card.test.tsx
@@ -7,21 +7,35 @@ import {
   PIN_LENGTH_MAX,
 } from "@/lib/validations/common";
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () =>
     (key: string, params?: Record<string, string | number>) =>
       params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({ toast: mockToast }));
 
 vi.mock("@/lib/url-helpers", () => ({
   fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import { TenantPasskeyPolicyCard } from "./tenant-passkey-policy-card";
@@ -46,6 +60,7 @@ function setupGet(data: Record<string, unknown>) {
 describe("TenantPasskeyPolicyCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
   });
 
   it("disables save button when no changes (R26)", async () => {
@@ -103,5 +118,32 @@ describe("TenantPasskeyPolicyCard", () => {
       expect(body.requirePasskey).toBe(true);
       expect(body.passkeyGracePeriodDays).toBeNull();
     });
+  });
+
+  it("shows the recent-session dialog on a SESSION_STEP_UP_REQUIRED save denial, without a generic error toast", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ requirePasskey: false, requireMinPinLength: null }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+    render(<TenantPasskeyPolicyCard />);
+    const save = await screen.findByRole("button", {
+      name: "passkeyPolicySave",
+    });
+
+    fireEvent.click(screen.getByLabelText("requirePasskey"));
+    fireEvent.click(save);
+
+    expect(await screen.findByTestId("recent-session-dialog")).toBeInTheDocument();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/security/tenant-passkey-policy-card.tsx
+++ b/src/components/settings/security/tenant-passkey-policy-card.tsx
@@ -25,6 +25,10 @@ import { useFormDirty } from "@/hooks/form/use-form-dirty";
 import { useBeforeUnloadGuard } from "@/hooks/form/use-before-unload-guard";
 import { FormDirtyBadge } from "@/components/settings/account/form-dirty-badge";
 import { bindRangeInput } from "@/lib/ui/input-range";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 
 export function TenantPasskeyPolicyCard() {
   const t = useTranslations("TenantAdmin");
@@ -95,6 +99,8 @@ export function TenantPasskeyPolicyCard() {
     return null;
   };
 
+  const inlineReauth = useInlineReauth(() => handleSave());
+
   const handleSave = async () => {
     const validationError = validate();
     if (validationError) {
@@ -109,6 +115,7 @@ export function TenantPasskeyPolicyCard() {
         passkeyGracePeriodDays: requirePasskey && gracePeriodDays !== "" ? Number(gracePeriodDays) : null,
         requireMinPinLength: requireMinPinLength !== "" ? Number(requireMinPinLength) : null,
       };
+      // @stepup id:tenant-policy-patch
       const res = await fetchApi(API_PATH.TENANT_POLICY, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -118,6 +125,7 @@ export function TenantPasskeyPolicyCard() {
         toast.success(t("passkeyPolicySaved"));
         setInitialPolicy({ ...currentPolicy });
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError)) return;
         toast.error(t("passkeyPolicySaveFailed"));
       }
     } catch {
@@ -208,6 +216,15 @@ export function TenantPasskeyPolicyCard() {
             {t("passkeyPolicySave")}
           </Button>
         </div>
+
+        <RecentSessionRequiredDialog
+          {...inlineReauth.recentSessionDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
+        <PasskeyReauthDialog
+          {...inlineReauth.reauthDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/settings/security/tenant-password-policy-card.test.tsx
+++ b/src/components/settings/security/tenant-password-policy-card.test.tsx
@@ -7,21 +7,35 @@ import {
   POLICY_MIN_PW_LENGTH_MAX,
 } from "@/lib/validations/common";
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () =>
     (key: string, params?: Record<string, string | number>) =>
       params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({ toast: mockToast }));
 
 vi.mock("@/lib/url-helpers", () => ({
   fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import { TenantPasswordPolicyCard } from "./tenant-password-policy-card";
@@ -46,6 +60,7 @@ function setupGet(data: Record<string, unknown>) {
 describe("TenantPasswordPolicyCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
   });
 
   it("disables save button when no changes (R26)", async () => {
@@ -114,5 +129,32 @@ describe("TenantPasswordPolicyCard", () => {
       const body = JSON.parse(String((patchCalls[0][1] as RequestInit).body));
       expect(body.tenantRequireUppercase).toBe(true);
     });
+  });
+
+  it("shows the recent-session dialog on a SESSION_STEP_UP_REQUIRED save denial, without a generic error toast", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({}),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+    render(<TenantPasswordPolicyCard />);
+    const save = await screen.findByRole("button", {
+      name: "passwordPolicySave",
+    });
+
+    fireEvent.click(screen.getByLabelText("tenantRequireUppercase"));
+    fireEvent.click(save);
+
+    expect(await screen.findByTestId("recent-session-dialog")).toBeInTheDocument();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/security/tenant-password-policy-card.tsx
+++ b/src/components/settings/security/tenant-password-policy-card.tsx
@@ -28,6 +28,10 @@ import { useFormDirty } from "@/hooks/form/use-form-dirty";
 import { useBeforeUnloadGuard } from "@/hooks/form/use-before-unload-guard";
 import { FormDirtyBadge } from "@/components/settings/account/form-dirty-badge";
 import { bindRangeInput } from "@/lib/ui/input-range";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 
 export function TenantPasswordPolicyCard() {
   const t = useTranslations("TenantAdmin");
@@ -129,6 +133,8 @@ export function TenantPasswordPolicyCard() {
     return null;
   };
 
+  const inlineReauth = useInlineReauth(() => handleSave());
+
   const handleSave = async () => {
     const validationError = validate();
     if (validationError) {
@@ -147,6 +153,7 @@ export function TenantPasswordPolicyCard() {
         passwordMaxAgeDays: passwordMaxAgeEnabled ? Number(passwordMaxAgeDays) : null,
         passwordExpiryWarningDays: passwordExpiryWarningDays !== "" ? Number(passwordExpiryWarningDays) : null,
       };
+      // @stepup id:tenant-policy-patch
       const res = await fetchApi(API_PATH.TENANT_POLICY, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -156,6 +163,7 @@ export function TenantPasswordPolicyCard() {
         toast.success(t("passwordPolicySaved"));
         setInitialPolicy({ ...currentPolicy });
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError)) return;
         toast.error(t("passwordPolicySaveFailed"));
       }
     } catch {
@@ -308,6 +316,15 @@ export function TenantPasswordPolicyCard() {
             {t("passwordPolicySave")}
           </Button>
         </div>
+
+        <RecentSessionRequiredDialog
+          {...inlineReauth.recentSessionDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
+        <PasskeyReauthDialog
+          {...inlineReauth.reauthDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/settings/security/tenant-reset-history-dialog.tsx
+++ b/src/components/settings/security/tenant-reset-history-dialog.tsx
@@ -171,6 +171,7 @@ export function TenantResetHistoryDialog({
     setApproving(true);
     setApproveError(null);
     try {
+      // @stepup id:reset-vault-approve
       const res = await fetchApi(
         `${apiPath.tenantMemberResetVault(userId)}/${approveTarget.id}/approve`,
         { method: "POST", headers: { "Content-Type": "application/json" } },

--- a/src/components/settings/security/tenant-session-policy-card.test.tsx
+++ b/src/components/settings/security/tenant-session-policy-card.test.tsx
@@ -7,21 +7,35 @@ import {
   SESSION_IDLE_TIMEOUT_MAX,
 } from "@/lib/validations/common";
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () =>
     (key: string, params?: Record<string, string | number>) =>
       params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({ toast: mockToast }));
 
 vi.mock("@/lib/url-helpers", () => ({
   fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import { TenantSessionPolicyCard } from "./tenant-session-policy-card";
@@ -55,6 +69,7 @@ function setupGet(data: Record<string, unknown> = DEFAULT_DATA) {
 describe("TenantSessionPolicyCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
   });
 
   it("disables save button when no changes (R26)", async () => {
@@ -116,5 +131,33 @@ describe("TenantSessionPolicyCard", () => {
       const body = JSON.parse(String((patchCalls[0][1] as RequestInit).body));
       expect(body.sessionIdleTimeoutMinutes).toBe(120);
     });
+  });
+
+  it("shows the recent-session dialog on a SESSION_STEP_UP_REQUIRED save denial, without a generic error toast", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(DEFAULT_DATA),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+    render(<TenantSessionPolicyCard />);
+    const save = await screen.findByRole("button", {
+      name: "sessionPolicySave",
+    });
+
+    const idle = document.getElementById("idle-timeout") as HTMLInputElement;
+    fireEvent.change(idle, { target: { value: "120" } });
+    fireEvent.click(save);
+
+    expect(await screen.findByTestId("recent-session-dialog")).toBeInTheDocument();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/security/tenant-session-policy-card.tsx
+++ b/src/components/settings/security/tenant-session-policy-card.tsx
@@ -17,6 +17,10 @@ import { Separator } from "@/components/ui/separator";
 import { API_PATH } from "@/lib/constants";
 import { fetchApi } from "@/lib/url-helpers";
 import { readApiErrorBody, getApiErrorMessage } from "@/lib/http/read-api-error-body";
+import { API_ERROR } from "@/lib/http/api-error-codes";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import {
   MAX_CONCURRENT_SESSIONS_MIN,
   MAX_CONCURRENT_SESSIONS_MAX,
@@ -218,6 +222,8 @@ export function TenantSessionPolicyCard() {
     return null;
   };
 
+  const inlineReauth = useInlineReauth(() => handleSave());
+
   const handleSave = async () => {
     const validationError = validate();
     if (validationError) {
@@ -235,6 +241,7 @@ export function TenantSessionPolicyCard() {
         extensionTokenAbsoluteTimeoutMinutes: Number(extensionAbsoluteMinutes),
         vaultAutoLockMinutes: vaultAutoLockEnabled ? Number(vaultAutoLockMinutes) : null,
       };
+      // @stepup id:tenant-policy-patch
       const res = await fetchApi(API_PATH.TENANT_POLICY, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -244,13 +251,21 @@ export function TenantSessionPolicyCard() {
         toast.success(t("sessionPolicySaved"));
         setInitialPolicy({ ...currentPolicy });
       } else {
+        // Single read of the response body — it shares the parsed envelope
+        // between the step-up check and the cross-field message extraction
+        // below, since `res.json()` can only be consumed once.
+        const errBody = await readApiErrorBody(res);
+        if (errBody?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+          await inlineReauth.triggerOnStaleError();
+          return;
+        }
         // Surface the server-side validation message so cross-field
         // errors (e.g. "vaultAutoLockMinutes (60) must be <= ...") are
         // visible instead of a generic "failed to update".
         // C2/C4 envelope: error context is wrapped under `details: { message }`.
         // `getApiErrorMessage` walks the typed envelope safely; accessing
         // `body.message` directly would be a TypeScript error.
-        const detail = getApiErrorMessage(await readApiErrorBody(res));
+        const detail = getApiErrorMessage(errBody);
         setError(detail ?? t("sessionPolicySaveFailed"));
         toast.error(detail ?? t("sessionPolicySaveFailed"));
       }
@@ -450,6 +465,15 @@ export function TenantSessionPolicyCard() {
             {t("sessionPolicySave")}
           </Button>
         </div>
+
+        <RecentSessionRequiredDialog
+          {...inlineReauth.recentSessionDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
+        <PasskeyReauthDialog
+          {...inlineReauth.reauthDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/settings/security/tenant-token-policy-card.test.tsx
+++ b/src/components/settings/security/tenant-token-policy-card.test.tsx
@@ -7,21 +7,35 @@ import {
   JIT_TOKEN_TTL_MAX,
 } from "@/lib/validations/common";
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
   useTranslations: () =>
     (key: string, params?: Record<string, string | number>) =>
       params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
 }));
 
 vi.mock("sonner", () => ({ toast: mockToast }));
 
 vi.mock("@/lib/url-helpers", () => ({
   fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import { TenantTokenPolicyCard } from "./tenant-token-policy-card";
@@ -46,6 +60,7 @@ function setupGet(data: Record<string, unknown>) {
 describe("TenantTokenPolicyCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
   });
 
   it("disables save button when no changes (R26)", async () => {
@@ -120,5 +135,44 @@ describe("TenantTokenPolicyCard", () => {
         screen.getByText("jitTokenDefaultExceedsMax"),
       ).toBeInTheDocument();
     });
+  });
+
+  it("shows the recent-session dialog on a SESSION_STEP_UP_REQUIRED save denial, without a generic error toast", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              saTokenMaxExpiryDays: null,
+              jitTokenDefaultTtlSec: null,
+              jitTokenMaxTtlSec: null,
+            }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+    render(<TenantTokenPolicyCard />);
+    const save = await screen.findByRole("button", {
+      name: "tokenPolicySave",
+    });
+
+    // No `await` between the toggle and the save click: the revealed field
+    // renders synchronously off the same state update, and yielding here
+    // would let the test's unstable-`t` mock retrigger fetchPolicy's
+    // `useEffect` (its useCallback deps include `t`) and clobber the toggle
+    // before save fires — a mock-only race (real next-intl memoizes `t`).
+    fireEvent.click(screen.getByLabelText("saTokenMaxExpiryEnabled"));
+    const daysInput = screen.getByLabelText("saTokenMaxExpiryDays");
+    fireEvent.change(daysInput, { target: { value: "365" } });
+    fireEvent.click(save);
+
+    expect(await screen.findByTestId("recent-session-dialog")).toBeInTheDocument();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/settings/security/tenant-token-policy-card.tsx
+++ b/src/components/settings/security/tenant-token-policy-card.tsx
@@ -25,6 +25,10 @@ import { useFormDirty } from "@/hooks/form/use-form-dirty";
 import { useBeforeUnloadGuard } from "@/hooks/form/use-before-unload-guard";
 import { bindRangeInput } from "@/lib/ui/input-range";
 import { FormDirtyBadge } from "@/components/settings/account/form-dirty-badge";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 
 export function TenantTokenPolicyCard() {
   const t = useTranslations("TenantAdmin");
@@ -129,6 +133,8 @@ export function TenantTokenPolicyCard() {
     return null;
   };
 
+  const inlineReauth = useInlineReauth(() => handleSave());
+
   const handleSave = async () => {
     const validationError = validate();
     if (validationError) {
@@ -143,6 +149,7 @@ export function TenantTokenPolicyCard() {
         jitTokenDefaultTtlSec: jitTokenDefaultEnabled ? Number(jitTokenDefaultTtlSec) : null,
         jitTokenMaxTtlSec: jitTokenMaxEnabled ? Number(jitTokenMaxTtlSec) : null,
       };
+      // @stepup id:tenant-policy-patch
       const res = await fetchApi(API_PATH.TENANT_POLICY, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -152,6 +159,7 @@ export function TenantTokenPolicyCard() {
         toast.success(t("tokenPolicySaved"));
         setInitialPolicy({ ...currentPolicy });
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError)) return;
         toast.error(t("tokenPolicySaveFailed"));
       }
     } catch {
@@ -295,6 +303,15 @@ export function TenantTokenPolicyCard() {
             {t("tokenPolicySave")}
           </Button>
         </div>
+
+        <RecentSessionRequiredDialog
+          {...inlineReauth.recentSessionDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
+        <PasskeyReauthDialog
+          {...inlineReauth.reauthDialogProps}
+          cancelLabel={tCommon("cancel")}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/settings/security/tenant-vault-reset-button.tsx
+++ b/src/components/settings/security/tenant-vault-reset-button.tsx
@@ -52,6 +52,7 @@ export function TenantVaultResetButton({
   const handleReset = async () => {
     setLoading(true);
     try {
+      // @stepup id:reset-vault-post
       const res = await fetchApi(
         apiPath.tenantMemberResetVault(userId),
         {

--- a/src/components/team/members/team-add-from-tenant-section.tsx
+++ b/src/components/team/members/team-add-from-tenant-section.tsx
@@ -90,6 +90,7 @@ export function TeamAddFromTenantSection({ teamId, onSuccess, teamTenantName }: 
   const handleAddMember = async (userId: string) => {
     setAdding(userId);
     try {
+      // @stepup id:team-members-post
       const res = await fetchApi(apiPath.teamMembers(teamId), {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/components/team/security/team-policy-settings.test.tsx
+++ b/src/components/team/security/team-policy-settings.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () =>
+    (key: string, params?: Record<string, string | number>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => "en",
+}));
+
+vi.mock("sonner", () => ({ toast: mockToast }));
+
+vi.mock("@/lib/url-helpers", () => ({
+  fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
+}));
+
+import { TeamPolicySettings } from "./team-policy-settings";
+
+const DEFAULT_DATA = {
+  minPasswordLength: 8,
+  requireUppercase: false,
+  requireLowercase: false,
+  requireNumbers: false,
+  requireSymbols: false,
+  sessionIdleTimeoutMinutes: null,
+  sessionAbsoluteTimeoutMinutes: null,
+  requireRepromptForAll: false,
+  allowExport: true,
+  allowSharing: true,
+  requireSharePassword: false,
+  passwordHistoryCount: 0,
+  inheritTenantCidrs: true,
+  teamAllowedCidrs: [],
+};
+
+describe("TeamPolicySettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+  });
+
+  it("shows the recent-session dialog on a SESSION_STEP_UP_REQUIRED save denial, without a generic error toast", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(DEFAULT_DATA),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+    });
+
+    render(<TeamPolicySettings teamId="team-1" />);
+    const save = await screen.findByRole("button", { name: "save" });
+
+    // No htmlFor/id pairing on this field, so query by role order:
+    // minPasswordLength is the first spinbutton rendered (password section).
+    const minLength = screen.getAllByRole("spinbutton")[0];
+    fireEvent.change(minLength, { target: { value: "12" } });
+    fireEvent.click(save);
+
+    expect(await screen.findByTestId("recent-session-dialog")).toBeInTheDocument();
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/team/security/team-policy-settings.tsx
+++ b/src/components/team/security/team-policy-settings.tsx
@@ -17,6 +17,10 @@ import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { fetchApi } from "@/lib/url-helpers";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
+import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
+import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
+import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
 import {
   POLICY_MIN_PW_LENGTH_MIN,
   POLICY_MIN_PW_LENGTH_MAX,
@@ -139,6 +143,10 @@ export function TeamPolicySettings({ teamId, section }: TeamPolicySettingsProps)
   // Internal text representation for teamAllowedCidrs textarea
   const [teamCidrsText, setTeamCidrsText] = useState("");
 
+  const inlineReauth = useInlineReauth(async () => {
+    await handleSave();
+  });
+
   const hasChanges = useFormDirty(policy as unknown as Record<string, unknown>, initialPolicy);
   useBeforeUnloadGuard(hasChanges);
 
@@ -188,6 +196,7 @@ export function TeamPolicySettings({ teamId, section }: TeamPolicySettingsProps)
         .map((line) => line.trim())
         .filter((line) => line.length > 0);
       const payload = { ...policy, teamAllowedCidrs };
+      // @stepup id:team-policy-put
       const res = await fetchApi(`/api/teams/${teamId}/policy`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -204,6 +213,7 @@ export function TeamPolicySettings({ teamId, section }: TeamPolicySettingsProps)
       } else if (res.status === 400) {
         toast.error(t("validationError"));
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError)) return;
         toast.error(t("saveError"));
       }
     } catch {
@@ -474,6 +484,15 @@ export function TeamPolicySettings({ teamId, section }: TeamPolicySettingsProps)
           </Button>
         </div>
       </CardContent>
+
+      <RecentSessionRequiredDialog
+        {...inlineReauth.recentSessionDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
+      <PasskeyReauthDialog
+        {...inlineReauth.reauthDialogProps}
+        cancelLabel={tCommon("cancel")}
+      />
     </Card>
   );
 }

--- a/src/components/team/security/team-rotate-key-button.tsx
+++ b/src/components/team/security/team-rotate-key-button.tsx
@@ -246,6 +246,7 @@ export function TeamRotateKeyButton({ teamId, onSuccess }: TeamRotateKeyButtonPr
       // 6. POST rotation to server
       setPhase("submitting");
 
+      // @stepup id:team-rotate-key-post
       const res = await fetchApi(apiPath.teamRotateKey(teamId), {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/components/team/security/team-scim-token-manager.test.tsx
+++ b/src/components/team/security/team-scim-token-manager.test.tsx
@@ -225,6 +225,41 @@ describe("ScimTokenManager", () => {
     expect(mockToast.error).not.toHaveBeenCalled();
   });
 
+  it("opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned on revoke", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([ACTIVE_TOKEN]) });
+      }
+      if (init.method === "DELETE") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    });
+
+    await act(async () => {
+      render(<ScimTokenManager locale="en" />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Production")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "scimTokenRevoke" }));
+    const confirmButtons = screen.getAllByRole("button", { name: "scimTokenRevoke" });
+    await act(async () => {
+      fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
   it("falls back to local networkError for an unrecognized API error code", async () => {
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) })

--- a/src/components/team/security/team-scim-token-manager.tsx
+++ b/src/components/team/security/team-scim-token-manager.tsx
@@ -47,6 +47,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
 import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
 import { tokenMintApiErrorKey } from "@/lib/http/token-mint-error";
 
 const TOKEN_STATUS_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
@@ -80,7 +81,14 @@ export function ScimTokenManager({ locale }: Props) {
   const [newToken, setNewToken] = useState<string | null>(null);
   const [description, setDescription] = useState("");
   const [expiresInDays, setExpiresInDays] = useState<string>("365");
-  const inlineReauth = useInlineReauth(() => handleCreate());
+  // Inline step-up reauth — creating a token and revoking one are both
+  // server-side step-up-gated. The retry arg (owned by the hook) records
+  // which mutation was in flight so the post-reauth retry replays the same one.
+  type ReauthRetry = { type: "create" } | { type: "revoke"; tokenId: string };
+  const inlineReauth = useInlineReauth<ReauthRetry>(async (retry) => {
+    if (retry.type === "create") await handleCreate();
+    else if (retry.type === "revoke") await handleRevoke(retry.tokenId);
+  });
 
   const scimEndpoint =
     typeof window !== "undefined"
@@ -117,6 +125,7 @@ export function ScimTokenManager({ locale }: Props) {
   const handleCreate = async () => {
     setCreating(true);
     try {
+      // @stepup id:scim-token-post
       const res = await fetchApi(apiPath.tenantScimTokens(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -135,7 +144,7 @@ export function ScimTokenManager({ locale }: Props) {
       } else {
         const err = await res.json().catch(() => ({}));
         if (err.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
-          await inlineReauth.triggerOnStaleError();
+          await inlineReauth.triggerOnStaleError({ type: "create" });
         } else {
           const apiKey = tokenMintApiErrorKey(err.error);
           toast.error(apiKey ? tApi(apiKey) : t("networkError"));
@@ -150,6 +159,7 @@ export function ScimTokenManager({ locale }: Props) {
 
   const handleRevoke = async (tokenId: string) => {
     try {
+      // @stepup id:scim-token-id-delete
       const res = await fetchApi(apiPath.tenantScimTokenById(tokenId), {
         method: "DELETE",
       });
@@ -157,6 +167,7 @@ export function ScimTokenManager({ locale }: Props) {
         toast.success(t("scimTokenRevoked"));
         fetchTokens();
       } else {
+        if (await handleStepUpError(res, inlineReauth.triggerOnStaleError, { type: "revoke", tokenId })) return;
         toast.error(t("networkError"));
       }
     } catch {

--- a/src/components/team/security/team-webhook-card.test.tsx
+++ b/src/components/team/security/team-webhook-card.test.tsx
@@ -10,16 +10,19 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   } as unknown as typeof ResizeObserver;
 }
 
-import { render, screen, act, waitFor } from "@testing-library/react";
+import { render, screen, act, waitFor, fireEvent, within } from "@testing-library/react";
 
-const { mockFetch, mockToast } = vi.hoisted(() => ({
+const { mockFetch, mockToast, mockCanUsePasskeyRecovery, mockReauthenticateWithPasskey } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
   mockToast: { error: vi.fn(), success: vi.fn() },
+  mockCanUsePasskeyRecovery: vi.fn(),
+  mockReauthenticateWithPasskey: vi.fn(),
 }));
 
-// Team only needs useTranslations (no useLocale)
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
+  // RecentSessionRequiredDialog (step-up reauth flow) calls useLocale.
+  useLocale: () => "en",
 }));
 
 // Override the generic mocks registered by setupWebhookCardMocks with the
@@ -30,6 +33,17 @@ vi.mock("sonner", () => ({
 
 vi.mock("@/lib/url-helpers", () => ({
   fetchApi: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { setupPasskeyReauthDialogMocks } from "@/__tests__/helpers/passkey-reauth-mocks";
+setupPasskeyReauthDialogMocks();
+
+vi.mock("@/lib/auth/webauthn/can-use-passkey-recovery", () => ({
+  canUsePasskeyRecovery: mockCanUsePasskeyRecovery,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
 }));
 
 import {
@@ -68,6 +82,9 @@ createWebhookCardTests(mockFetch, mockToast, {
 describe("TeamWebhookCard (team-specific)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: user has no passkey → the recent-session dialog opens.
+    mockCanUsePasskeyRecovery.mockResolvedValue(false);
+    mockReauthenticateWithPasskey.mockResolvedValue({ ok: true, verifiedAt: "2026-05-10T00:00:00Z" });
   });
 
   it("does not include group:webhook actions", async () => {
@@ -125,5 +142,91 @@ describe("TeamWebhookCard (team-specific)", () => {
     expect(screen.queryByText("MASTER_KEY_ROTATION")).not.toBeInTheDocument();
     expect(screen.queryByText("ADMIN_VAULT_RESET_INITIATE")).not.toBeInTheDocument();
     expect(screen.queryByText("ADMIN_VAULT_RESET_APPROVE")).not.toBeInTheDocument();
+  });
+
+  it("create — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ webhooks: [] }),
+        });
+      }
+      if (init.method === "POST") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 500 });
+    });
+
+    await act(async () => {
+      render(<TeamWebhookCard teamId="team-1" locale="en" />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("noWebhooks")).toBeInTheDocument();
+    });
+
+    const urlInput = screen.getByPlaceholderText("urlPlaceholder");
+    fireEvent.change(urlInput, {
+      target: { value: "https://valid.example.com/hook" },
+    });
+
+    const checkboxes = screen.getAllByTestId("checkbox");
+    fireEvent.click(checkboxes[0]);
+
+    const submitBtn = within(screen.getByTestId("dialog-content"))
+      .getAllByRole("button")
+      .find((b) => b.textContent?.includes("addWebhook"))!;
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it("delete — opens RecentSessionRequiredDialog when SESSION_STEP_UP_REQUIRED is returned", async () => {
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init?.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ webhooks: sampleWebhooks }),
+        });
+      }
+      if (init.method === "DELETE") {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 500 });
+    });
+
+    await act(async () => {
+      render(<TeamWebhookCard teamId="team-1" locale="en" />);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("https://example.com/hook1").length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    const alertActions = screen.getAllByTestId("alert-action");
+    await act(async () => {
+      fireEvent.click(alertActions[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-session-dialog")).toBeInTheDocument();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/bulk/use-bulk-action.test.ts
+++ b/src/hooks/bulk/use-bulk-action.test.ts
@@ -388,4 +388,72 @@ describe("useBulkAction", () => {
     expect(teamEvents).toHaveLength(0);
     dispatchSpy.mockRestore();
   });
+
+  // ---------------------------------------------------------------------------
+  // Step-up (SESSION_STEP_UP_REQUIRED) handling — bulk-purge only
+  // ---------------------------------------------------------------------------
+  describe("step-up handling", () => {
+    function setupWithStepUp(
+      onStepUpRequired: (() => Promise<void> | void) | undefined,
+      selectedIds = new Set(["a", "b"]),
+      scope: BulkScope = { type: "personal" },
+    ) {
+      return renderHook(() =>
+        useBulkAction({ selectedIds, scope, t, onSuccess, onStepUpRequired }),
+      );
+    }
+
+    it("deletePermanently + 403 SESSION_STEP_UP_REQUIRED + onStepUpRequired provided: calls onStepUpRequired, closes dialog, no error toast, no throw", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+      const onStepUpRequired = vi.fn().mockResolvedValue(undefined);
+
+      const { result } = setupWithStepUp(onStepUpRequired);
+      act(() => result.current.requestAction("deletePermanently"));
+
+      await expect(act(() => result.current.executeAction())).resolves.toBeUndefined();
+
+      expect(onStepUpRequired).toHaveBeenCalledTimes(1);
+      expect(result.current.dialogOpen).toBe(false);
+      expect(mockError).not.toHaveBeenCalled();
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it("deletePermanently + 403 SESSION_STEP_UP_REQUIRED but onStepUpRequired omitted: falls through to generic error toast (mutation not silently swallowed)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+
+      const { result } = setupWithStepUp(undefined);
+      act(() => result.current.requestAction("deletePermanently"));
+      await act(() => result.current.executeAction());
+
+      expect(mockError).toHaveBeenCalled();
+      expect(onSuccess).not.toHaveBeenCalled();
+      // Dialog stays open on generic error so the user can retry.
+      expect(result.current.dialogOpen).toBe(true);
+    });
+
+    it("non-deletePermanently action (trash) + 403: does NOT call onStepUpRequired, falls through to error toast", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: "SESSION_STEP_UP_REQUIRED" }),
+      });
+      const onStepUpRequired = vi.fn().mockResolvedValue(undefined);
+
+      const { result } = setupWithStepUp(onStepUpRequired);
+      act(() => result.current.requestAction("trash"));
+      await act(() => result.current.executeAction());
+
+      expect(onStepUpRequired).not.toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalled();
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/hooks/bulk/use-bulk-action.ts
+++ b/src/hooks/bulk/use-bulk-action.ts
@@ -160,8 +160,13 @@ export function useBulkAction({
       });
 
       if (!res.ok) {
-        if (pendingAction === "deletePermanently") {
-          if (await handleStepUpError(res, async () => { await onStepUpRequired?.(); })) {
+        // Only the permanent-purge action is step-up-gated. Route the 403 to
+        // reauth ONLY when a handler is wired; otherwise fall through to the
+        // generic error toast rather than silently closing the dialog — an
+        // omitted onStepUpRequired must not swallow the mutation.
+        if (pendingAction === "deletePermanently" && onStepUpRequired) {
+          const reauth = onStepUpRequired;
+          if (await handleStepUpError(res, async () => { await reauth(); })) {
             setDialogOpen(false);
             return;
           }

--- a/src/hooks/bulk/use-bulk-action.ts
+++ b/src/hooks/bulk/use-bulk-action.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { apiPath } from "@/lib/constants/auth/api-path";
 import { fetchApi } from "@/lib/url-helpers";
 import { notifyTeamDataChanged } from "@/lib/events";
+import { handleStepUpError } from "@/lib/http/handle-step-up-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -31,6 +32,14 @@ export interface UseBulkActionOptions {
    * after onSuccess — no manual dispatch needed.
    */
   onSuccess: () => void;
+  /**
+   * Called when the `deletePermanently` bulk action (bulk-purge) hits a
+   * `SESSION_STEP_UP_REQUIRED` 403 — only this action is step-up-gated.
+   * The caller opens its reauth dialog (typically
+   * `inlineReauth.triggerOnStaleError`); the hook closes the confirm dialog
+   * and does not surface a generic error toast for this case.
+   */
+  onStepUpRequired?: () => Promise<void> | void;
 }
 
 export interface UseBulkActionReturn {
@@ -119,6 +128,7 @@ export function useBulkAction({
   scope,
   t,
   onSuccess,
+  onStepUpRequired,
 }: UseBulkActionOptions): UseBulkActionReturn {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<BulkActionType | null>(
@@ -141,6 +151,8 @@ export function useBulkAction({
       const endpoint = resolveEndpoint(scope, pendingAction);
       const body = buildBody(pendingAction, ids);
 
+      // @stepup id:passwords-bulk-purge
+      // @stepup id:team-password-bulk-purge
       const res = await fetchApi(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -148,6 +160,12 @@ export function useBulkAction({
       });
 
       if (!res.ok) {
+        if (pendingAction === "deletePermanently") {
+          if (await handleStepUpError(res, async () => { await onStepUpRequired?.(); })) {
+            setDialogOpen(false);
+            return;
+          }
+        }
         throw new Error("bulk action failed");
       }
 
@@ -165,7 +183,7 @@ export function useBulkAction({
     } finally {
       setProcessing(false);
     }
-  }, [selectedIds, pendingAction, scope, t, onSuccess]);
+  }, [selectedIds, pendingAction, scope, t, onSuccess, onStepUpRequired]);
 
   return {
     dialogOpen,

--- a/src/lib/http/handle-step-up-error.test.ts
+++ b/src/lib/http/handle-step-up-error.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  isStepUpRequired,
+  handleStepUpError,
+  StepUpRequiredError,
+  isStepUpRequiredError,
+  throwIfStepUp,
+} from "@/lib/http/handle-step-up-error";
+import { API_ERROR } from "@/lib/http/api-error-codes";
+
+function stepUp403(): Response {
+  return {
+    ok: false,
+    status: 403,
+    json: () => Promise.resolve({ error: API_ERROR.SESSION_STEP_UP_REQUIRED }),
+  } as unknown as Response;
+}
+
+function otherError(status: number, error?: string): Response {
+  return {
+    ok: false,
+    status,
+    json: () => Promise.resolve(error ? { error } : {}),
+  } as unknown as Response;
+}
+
+describe("isStepUpRequired", () => {
+  it("returns true for a step-up error body", () => {
+    expect(isStepUpRequired({ error: API_ERROR.SESSION_STEP_UP_REQUIRED })).toBe(
+      true,
+    );
+  });
+
+  it("returns false for a different error code", () => {
+    expect(isStepUpRequired({ error: API_ERROR.FORBIDDEN })).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isStepUpRequired(null)).toBe(false);
+  });
+});
+
+describe("handleStepUpError", () => {
+  it("triggers reauth and returns true on a step-up 403", async () => {
+    const trigger = vi.fn().mockResolvedValue(undefined);
+    const handled = await handleStepUpError(stepUp403(), trigger);
+    expect(handled).toBe(true);
+    expect(trigger).toHaveBeenCalledOnce();
+  });
+
+  it("passes the retry arg through to the trigger", async () => {
+    const trigger = vi.fn().mockResolvedValue(undefined);
+    await handleStepUpError(stepUp403(), trigger, { type: "delete", id: "x" });
+    expect(trigger).toHaveBeenCalledWith({ type: "delete", id: "x" });
+  });
+
+  it("returns false and does NOT trigger on a non-step-up error", async () => {
+    const trigger = vi.fn().mockResolvedValue(undefined);
+    const handled = await handleStepUpError(otherError(409, "NAME_CONFLICT"), trigger);
+    expect(handled).toBe(false);
+    expect(trigger).not.toHaveBeenCalled();
+  });
+
+  it("returns false on an error body that is not the envelope shape", async () => {
+    const trigger = vi.fn().mockResolvedValue(undefined);
+    const handled = await handleStepUpError(otherError(500), trigger);
+    expect(handled).toBe(false);
+    expect(trigger).not.toHaveBeenCalled();
+  });
+});
+
+describe("throwIfStepUp / StepUpRequiredError", () => {
+  it("throws StepUpRequiredError on a step-up 403", async () => {
+    await expect(throwIfStepUp(stepUp403())).rejects.toBeInstanceOf(
+      StepUpRequiredError,
+    );
+  });
+
+  it("does not throw on an ok response", async () => {
+    await expect(
+      throwIfStepUp({ ok: true } as unknown as Response),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw on a non-step-up error (caller throws its own)", async () => {
+    await expect(
+      throwIfStepUp(otherError(500)),
+    ).resolves.toBeUndefined();
+  });
+
+  it("isStepUpRequiredError narrows the thrown error", () => {
+    const e: unknown = new StepUpRequiredError();
+    expect(isStepUpRequiredError(e)).toBe(true);
+    expect(isStepUpRequiredError(new Error("other"))).toBe(false);
+  });
+
+  it("StepUpRequiredError carries the canonical code", () => {
+    expect(new StepUpRequiredError().code).toBe(
+      API_ERROR.SESSION_STEP_UP_REQUIRED,
+    );
+  });
+});

--- a/src/lib/http/handle-step-up-error.ts
+++ b/src/lib/http/handle-step-up-error.ts
@@ -1,0 +1,96 @@
+import { API_ERROR } from "@/lib/http/api-error-codes";
+import { readApiErrorBody } from "@/lib/http/read-api-error-body";
+import type { MainApiErrorBody } from "@/lib/http/api-response";
+
+/**
+ * Shared client handler for the `SESSION_STEP_UP_REQUIRED` 403.
+ *
+ * Every mutating-UI caller of a step-up-gated route (a route that calls
+ * `requireRecentCurrentAuthMethod` server-side) must, on a stale window, open the
+ * reauth dialog instead of surfacing a generic error. Before this helper each
+ * caller inlined the same 3–4 lines:
+ *
+ *   const body = await readApiErrorBody(res);
+ *   if (body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED) {
+ *     await trigger(arg);
+ *     return;
+ *   }
+ *
+ * `handleStepUpError` centralizes that block. Call it from the `!res.ok` branch;
+ * if it returns `true` the caller should return early (reauth is in flight),
+ * otherwise fall through to its existing error handling.
+ *
+ * The predicate `isStepUpRequired` exists for callers that have already parsed
+ * the body (or received the error code some other way) and only need the check.
+ *
+ * NOTE for the coverage guard (scripts/checks/check-step-up-client-coverage.sh):
+ * this file is the single place the raw `SESSION_STEP_UP_REQUIRED` literal lives
+ * on the client after commonization. The guard's client-side adjacency check
+ * accepts a `handleStepUpError(` call token as an equivalent "branch present"
+ * signal — see the guard header for the accepted token set.
+ */
+export function isStepUpRequired(body: MainApiErrorBody | null): boolean {
+  return body?.error === API_ERROR.SESSION_STEP_UP_REQUIRED;
+}
+
+/**
+ * Read the error body from a non-ok `Response`; if it is a step-up 403, invoke
+ * `trigger(arg)` (typically `useInlineReauth().triggerOnStaleError`) and return
+ * `true`. Returns `false` for every other error so the caller can continue its
+ * own handling.
+ *
+ * Single-target callers use `T = void` and pass no `arg`. Multi-target callers
+ * (a component with several distinct gated mutations) pass a discriminator so
+ * the post-reauth retry replays the correct mutation.
+ */
+export async function handleStepUpError<T = void>(
+  res: Response,
+  trigger: (arg: T) => Promise<void>,
+  arg: T = undefined as T,
+): Promise<boolean> {
+  const body = await readApiErrorBody(res);
+  if (!isStepUpRequired(body)) {
+    return false;
+  }
+  await trigger(arg);
+  return true;
+}
+
+/**
+ * Error thrown by non-hook layers (e.g. the vault-list adapters) that cannot
+ * open the reauth dialog themselves but must NOT swallow a step-up 403 into a
+ * generic failure. A component consumer catches it, recognises `.code`, and
+ * routes to `triggerOnStaleError` instead of a silent reload.
+ *
+ * Only the step-up-gated adapter methods throw this; ungated methods keep
+ * throwing a plain `Error` so their consumers' generic handling is unchanged.
+ */
+export class StepUpRequiredError extends Error {
+  readonly code = API_ERROR.SESSION_STEP_UP_REQUIRED;
+  constructor() {
+    super("SESSION_STEP_UP_REQUIRED");
+    this.name = "StepUpRequiredError";
+  }
+}
+
+export function isStepUpRequiredError(e: unknown): e is StepUpRequiredError {
+  return e instanceof StepUpRequiredError;
+}
+
+/**
+ * For non-hook async layers: if `res` is a step-up 403, throw
+ * `StepUpRequiredError` (so a component consumer can catch and reauth);
+ * otherwise return so the caller can throw its own domain error. Use in a
+ * gated adapter method:
+ *
+ *   const res = await fetchApi(url, { method: "DELETE" });
+ *   await throwIfStepUp(res);
+ *   if (!res.ok) throw new Error("deletePermanently failed");
+ */
+export async function throwIfStepUp(res: Response): Promise<void> {
+  if (res.ok) return;
+  const body = await readApiErrorBody(res);
+  if (isStepUpRequired(body)) {
+    throw new StepUpRequiredError();
+  }
+}

--- a/src/lib/vault/personal-vault-list-adapter.test.ts
+++ b/src/lib/vault/personal-vault-list-adapter.test.ts
@@ -56,6 +56,7 @@ vi.mock("@/hooks/use-travel-mode", () => ({
 
 import { renderHook } from "@testing-library/react";
 import { decryptPersonalOverview, usePersonalVaultListAdapter } from "./personal-vault-list-adapter";
+import { isStepUpRequiredError } from "@/lib/http/handle-step-up-error";
 import type { DisplayEntry } from "@/types/display-entry";
 
 const STABLE_KEY = {} as CryptoKey;
@@ -404,6 +405,52 @@ describe("usePersonalVaultListAdapter", () => {
     await expect(result.current.restore(entry)).rejects.toThrow("restore failed");
     await expect(result.current.deletePermanently(entry)).rejects.toThrow("deletePermanently failed");
     await expect(result.current.emptyTrash()).rejects.toThrow("emptyTrash failed");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Step-up (SESSION_STEP_UP_REQUIRED) handling — deletePermanently/emptyTrash only
+  // ---------------------------------------------------------------------------
+  it("deletePermanently rejects with StepUpRequiredError on a 403 SESSION_STEP_UP_REQUIRED", async () => {
+    mockFetchApi.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+    });
+
+    const { result } = renderHook(() => usePersonalVaultListAdapter());
+    const entry = { id: "e1" } as DisplayEntry;
+
+    const caught = await result.current.deletePermanently(entry).catch((e: unknown) => e);
+    expect(isStepUpRequiredError(caught)).toBe(true);
+  });
+
+  it("emptyTrash rejects with StepUpRequiredError on a 403 SESSION_STEP_UP_REQUIRED", async () => {
+    mockFetchApi.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+    });
+
+    const { result } = renderHook(() => usePersonalVaultListAdapter());
+
+    const caught = await result.current.emptyTrash().catch((e: unknown) => e);
+    expect(isStepUpRequiredError(caught)).toBe(true);
+  });
+
+  it("an ungated mutation (restore) rejects with a plain Error (not StepUpRequiredError) on the same 403 body", async () => {
+    mockFetchApi.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+    });
+
+    const { result } = renderHook(() => usePersonalVaultListAdapter());
+    const entry = { id: "e1" } as DisplayEntry;
+
+    const caught = await result.current.restore(entry).catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(Error);
+    expect(isStepUpRequiredError(caught)).toBe(false);
+    expect((caught as Error).message).toBe("restore failed");
   });
 
   it("notifyDataChanged calls notifyVaultDataChanged (personal event)", () => {

--- a/src/lib/vault/personal-vault-list-adapter.test.ts
+++ b/src/lib/vault/personal-vault-list-adapter.test.ts
@@ -394,7 +394,7 @@ describe("usePersonalVaultListAdapter", () => {
   });
 
   it("throws when a mutation returns non-ok response", async () => {
-    mockFetchApi.mockResolvedValue({ ok: false });
+    mockFetchApi.mockResolvedValue({ ok: false, json: () => Promise.resolve(null) });
 
     const { result } = renderHook(() => usePersonalVaultListAdapter());
     const entry = { id: "e1" } as DisplayEntry;

--- a/src/lib/vault/personal-vault-list-adapter.ts
+++ b/src/lib/vault/personal-vault-list-adapter.ts
@@ -6,6 +6,7 @@ import { decryptData, type EncryptedData } from "@/lib/crypto/crypto-client";
 import { buildPersonalEntryAAD, VAULT_TYPE } from "@/lib/crypto/crypto-aad";
 import { buildPersonalGetDetail } from "@/lib/vault/build-personal-get-detail";
 import { fetchApi } from "@/lib/url-helpers";
+import { throwIfStepUp } from "@/lib/http/handle-step-up-error";
 import { API_PATH, apiPath, ENTRY_TYPE } from "@/lib/constants";
 import type { EntryTypeValue } from "@/lib/constants";
 import { filterTravelSafe } from "@/lib/auth/policy/travel-mode";
@@ -213,14 +214,18 @@ export function usePersonalVaultListAdapter(): VaultListAdapter<DisplayEntry> {
     },
 
     async deletePermanently(entry: DisplayEntry): Promise<void> {
+      // @stepup id:passwords-id-delete-permanent
       const res = await fetchApi(`${apiPath.passwordById(entry.id)}?permanent=true`, {
         method: "DELETE",
       });
+      await throwIfStepUp(res);
       if (!res.ok) throw new Error("deletePermanently failed");
     },
 
     async emptyTrash(): Promise<void> {
+      // @stepup id:passwords-empty-trash
       const res = await fetchApi(API_PATH.PASSWORDS_EMPTY_TRASH, { method: "POST" });
+      await throwIfStepUp(res);
       if (!res.ok) throw new Error("emptyTrash failed");
     },
 

--- a/src/lib/vault/team-vault-list-adapter.test.ts
+++ b/src/lib/vault/team-vault-list-adapter.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/lib/team/team-vault-context", () => ({
 
 import { renderHook } from "@testing-library/react";
 import { decryptTeamOverview, useTeamVaultListAdapter } from "./team-vault-list-adapter";
+import { isStepUpRequiredError } from "@/lib/http/handle-step-up-error";
 import type { TeamDisplayEntry } from "@/types/team-display-entry";
 
 const TEAM_ID = "team-1";
@@ -190,5 +191,51 @@ describe("useTeamVaultListAdapter", () => {
         [`/api/teams/${TEAM_ID}/passwords/empty-trash`, "POST"],
       ]),
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Step-up (SESSION_STEP_UP_REQUIRED) handling — deletePermanently/emptyTrash only
+  // ---------------------------------------------------------------------------
+  it("deletePermanently rejects with StepUpRequiredError on a 403 SESSION_STEP_UP_REQUIRED", async () => {
+    mockFetchApi.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+    });
+
+    const { result } = renderHook(() => useTeamVaultListAdapter(TEAM_ID, "OWNER"));
+    const entry = { id: "e1" } as TeamDisplayEntry;
+
+    const caught = await result.current.deletePermanently(entry).catch((e: unknown) => e);
+    expect(isStepUpRequiredError(caught)).toBe(true);
+  });
+
+  it("emptyTrash rejects with StepUpRequiredError on a 403 SESSION_STEP_UP_REQUIRED", async () => {
+    mockFetchApi.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+    });
+
+    const { result } = renderHook(() => useTeamVaultListAdapter(TEAM_ID, "OWNER"));
+
+    const caught = await result.current.emptyTrash().catch((e: unknown) => e);
+    expect(isStepUpRequiredError(caught)).toBe(true);
+  });
+
+  it("an ungated mutation (restore) rejects with a plain Error (not StepUpRequiredError) on the same 403 body", async () => {
+    mockFetchApi.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: "SESSION_STEP_UP_REQUIRED" }),
+    });
+
+    const { result } = renderHook(() => useTeamVaultListAdapter(TEAM_ID, "OWNER"));
+    const entry = { id: "e1" } as TeamDisplayEntry;
+
+    const caught = await result.current.restore(entry).catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(Error);
+    expect(isStepUpRequiredError(caught)).toBe(false);
+    expect((caught as Error).message).toBe("restore failed");
   });
 });

--- a/src/lib/vault/team-vault-list-adapter.ts
+++ b/src/lib/vault/team-vault-list-adapter.ts
@@ -7,6 +7,7 @@ import { decryptData } from "@/lib/crypto/crypto-client";
 import { buildTeamEntryAAD, VAULT_TYPE } from "@/lib/crypto/crypto-aad";
 import { buildTeamGetDetail } from "@/lib/vault/build-team-get-detail";
 import { fetchApi } from "@/lib/url-helpers";
+import { throwIfStepUp } from "@/lib/http/handle-step-up-error";
 import { apiPath, ENTRY_TYPE, TEAM_ROLE } from "@/lib/constants";
 import type { EntryTypeValue } from "@/lib/constants";
 import { notifyTeamDataChanged } from "@/lib/events";
@@ -250,14 +251,18 @@ export function useTeamVaultListAdapter(teamId: string, role: string): VaultList
       },
 
       async deletePermanently(entry: TeamDisplayEntry): Promise<void> {
+        // @stepup id:team-password-id-delete-permanent
         const res = await fetchApi(`${apiPath.teamPasswordById(teamId, entry.id)}?permanent=true`, {
           method: "DELETE",
         });
+        await throwIfStepUp(res);
         if (!res.ok) throw new Error("deletePermanently failed");
       },
 
       async emptyTrash(): Promise<void> {
+        // @stepup id:team-password-empty-trash
         const res = await fetchApi(apiPath.teamPasswordsEmptyTrash(teamId), { method: "POST" });
+        await throwIfStepUp(res);
         if (!res.ok) throw new Error("emptyTrash failed");
       },
 


### PR DESCRIPTION
## Summary

Closes the whole class where a mutating-UI caller of a step-up-gated route (a route
that calls `requireRecentCurrentAuthMethod`, which emits `SESSION_STEP_UP_REQUIRED`
on a stale >15-min window) swallowed the 403 into a generic error — a UX dead-end
with no re-authentication path. The started-from symptom was a single tenant policy
card; the authoritative member-set, derived from the defining primitive, is **45
gated (route, method) call sites** (≈2× the initial estimate).

## Approach — guard-first

A marker-verified, adjacency-scoped CI guard is implemented first and its `S \ C`
output is the authoritative work-list. This structurally prevents the per-component
under-enumeration that a prior pass produced (a component could handle `POST` but not
its `DELETE`).

- `scripts/checks/check-step-up-client-coverage.sh` — matches `// @stepup id:X method:M`
  markers on each gated server call against `// @stepup id:X` markers above each client
  `fetchApi`, and requires a reauth branch within an adjacency window. Wired into
  `scripts/pre-pr.sh` and the CI `static-checks` job (pure text/fs scan, no
  `@prisma/client` — survives the no-`prisma generate` job).
- 10-fixture self-test, including the two-handlers-one-file regression lock and a
  thrower-without-catcher check.

## Shared helper (commonization)

`src/lib/http/handle-step-up-error.ts` centralizes the client branch:
`handleStepUpError` / `isStepUpRequired`, plus a typed-error layer
(`StepUpRequiredError` / `throwIfStepUp` / `isStepUpRequiredError`) for the non-hook
vault-list adapters.

## Fixes applied across the class

- **C2** developer/security cards + 8 tenant policy cards + tenant-members (incl. the
  partial gaps: `mcp-client` PUT/DELETE, `service-account` PUT/DELETE/token-DELETE,
  `scim-token` DELETE, `access-request` deny, `api-key` DELETE).
- **C3** admin pages: team member role/remove, ownership transfer, team delete.
- **C4** vault permanent-delete / empty-trash / bulk-purge (`use-bulk-action` +
  both vault-list adapters + `entry-list-view`).
- **C5** shared `base-webhook-card` (covers tenant AND team webhooks).

## Security-UX bug fixed in review

`entry-list-view` optimistically removed the row **before** the permanent-delete
server call; on a step-up 403 it opened reauth and returned without rollback, leaving
a purged-looking-but-still-alive secret. Now it `reload()`s to roll back before
opening reauth; the reauth-success replay commits the removal for real. Regression
test asserts the row stays visible after a step-up denial.

## Testing

- Denial unit test per (component, gated method); helper unit test; direct
  step-up tests for the bulk-purge hook and both vault-list adapters.
- E2E `step-up-stale-window.spec.ts` authored (companion to `trash.spec.ts`);
  not executed here (full stack not up — E2E is outside the pre-PR gate).
- `npx vitest run` 12099 pass; `npx next build` ok; `bash scripts/pre-pr.sh` 45/45.

## Notes

- This is a separate PR from the auto-lock work (`#642`).
- Guard limitations are documented honestly in its header: coverage is a set
  comparison (a shared route-id like `tenant-policy-patch` is satisfied by one of its
  8 cards — all 8 are wired here), and the thrower/catcher pairing is existence-level,
  not per-call-site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
