### PR TITLE
fix(vault): validate null auto-lock against shared default and reset stale client timer

### DIFF
--- a/docs/archive/review/vault-null-autolock-default-code-review.md
+++ b/docs/archive/review/vault-null-autolock-default-code-review.md
@@ -1,0 +1,114 @@
+# Code Review: vault-null-autolock-default
+
+Date: 2026-07-08
+Review round: 1 (Phase 3)
+
+## Changes from Previous Round
+
+Initial Phase 3 code review of the implemented diff (5 source/test files) on
+branch `fix/vault-null-autolock-default`. Phase 1 plan review already ran 2
+rounds and fixed a Critical (S1: explicit-null bypass) at the plan stage; Phase 2
+verified red-before/green-after empirically. This round verified the ACTUAL
+committed code against the plan contracts.
+
+## Functionality Findings
+
+No findings. All six verification points confirmed against `git diff main...HEAD`:
+- C3 parenthesization correct — `(ternary) ?? VAULT_AUTO_LOCK_DEFAULT` wraps the
+  whole ternary; explicit-null and absent both resolve to 15.
+- `tsc --noEmit` clean, ESLint clean on the three changed source files. The two
+  `typeof mergedVaultAutoLock === "number"` guards are now tautological but fire
+  no lint (harmless).
+- INV-C3c holds: `mergedVaultAutoLock` appears only at its definition and the two
+  comparisons; `updateData.vaultAutoLockMinutes = vaultAutoLockMinutes ?? null`
+  recomputes from the raw request param, so the default never leaks into storage
+  or the response body.
+- Imports correct (both `route.ts` and `auto-lock-context.tsx` import from
+  `@/lib/validations/common`).
+- No regression on explicit-value paths (EC3/EC6 pass).
+- Value 15 matches the pre-change client literal. Extension (`DEFAULTS.autoLockMinutes
+  = 15`) and iOS (`_autoLockMinutes = 15`, `defaultMinutes = 15`) keep their own
+  local constants in separate codebases with no shared-constant mechanism —
+  correctly out of scope, value-consistent, not a silent divergence.
+
+## Security Findings
+
+No findings. S1 confirmed closed in the actual code:
+- Traced `{vaultAutoLockMinutes: null, sessionIdleTimeoutMinutes: 5}` → inner
+  ternary `null` → `null ?? 15` → 15 → `15 > 5` → 400. Confirmed by passing EC1.
+- No residual bypass: `vaultAutoLockMinutes` is validated (integer in [5,1440] or
+  null/undefined) and returns early BEFORE the merge, so no string/NaN/0/negative
+  reaches the merge unvalidated.
+- Authz + step-up unchanged (no diff in that region).
+- Storing null while validating 15 introduces no downstream fail-open — every
+  reader applies the same 15-min default; the diff consolidates the previously
+  duplicated client/server 15 into one named constant (removes drift risk).
+- No new secrets/PII logged; audit metadata shape unchanged.
+- RS1-RS5 all pass.
+
+## Testing Findings
+
+- **T1 (Low) — resolved**: coverage gap — the (explicit-null | absent) × (sessionIdle
+  | extIdle) matrix had 3 of 4 cells covered; "explicit-null vaultAutoLock ×
+  extension-token-idle violation" was untested. Fix: added **EC2c** (explicit
+  `vaultAutoLockMinutes: null` + `extensionTokenIdleTimeoutMinutes: 5` → 400).
+  Non-blocking completeness nit; fixed in-round per the 30-minute rule.
+- Vacuity independently verified: the reviewer reverted the route ternary and
+  re-ran — EC1/EC2/EC2b failed (200≠400), EC3/EC6 stayed green (non-vacuous
+  negative control), then restored. The client value-regression assertion was
+  verified by temporarily setting the constant to 20 (assertion failed as
+  expected), then restored.
+- Fixture completeness confirmed: all EC fixtures set all three idle/vault fields
+  explicitly (number or null, never undefined), matching the Prisma select shape.
+- `mockUpdateReturn` realism confirmed: `FULL_POLICY_RESPONSE` is a complete
+  object; EC3/EC6 overrides produce a full shape, no vacuous pass.
+
+Note on reviewer method: two reviewers (functionality, testing) temporarily
+mutated `VAULT_AUTO_LOCK_DEFAULT` (15→20) in their own sandboxed check to prove
+the assertions catch drift, then restored via `git checkout`. Working tree
+verified clean at committed `15` afterward; no residue (R21 spot-check passed —
+the mutations were on the reviewers' side, not left in the production source).
+
+## Adjacent Findings
+
+None routed cross-scope.
+
+## Quality Warnings
+
+None. Every finding carried file:line evidence; vacuity and value-regression
+claims were empirically reproduced (revert-and-rerun), not asserted.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R2 (shared constant / no magic-number drift): satisfied — 15 consolidated into
+  VAULT_AUTO_LOCK_DEFAULT; `* MS_PER_MINUTE` derives from base constant.
+- R21 (no mutation residue in production source): pass — reviewer mutations
+  restored, tree clean.
+- Const-object / time-constants / suppression rules: N/A or satisfied.
+
+### Security expert
+- RS1 (fail-open on null/undefined): pass — closed, trace + regression tests.
+- RS2 (bypass via coercion): pass — validation precedes merge.
+- RS3 (authz/step-up regression): pass — no diff in that region.
+- RS4 (client/server default drift): pass — actively fixes a prior instance.
+- RS5 (secrets/PII in logs): pass — none introduced.
+
+### Testing expert
+- RT (non-vacuous / red-before-green): pass — verified by revert-and-rerun.
+- feedback_multi_agent_review_gaps (fixture/mock-return realism): pass.
+
+## Environment Verification Report
+
+N/A — no environment constraints declared in Phase 1 (all paths `verifiable-local`;
+route unit tests and client unit test executed locally and pass).
+
+## Resolution Status
+
+### T1 (Low) Coverage gap: explicit-null vaultAutoLock × ext-idle untested
+- Action: added EC2c test case (explicit null + extensionTokenIdle=5 → 400).
+- Modified file: `src/__tests__/api/tenant/tenant-policy.test.ts` (EC2c block).
+- Verification: `npx vitest run src/__tests__/api/tenant/tenant-policy.test.ts`
+  → 36 passed. pre-pr.sh → 44/44 pass.
+
+All Critical/Major/Minor findings resolved. One Low finding fixed in-round.

--- a/docs/archive/review/vault-null-autolock-default-code-review.md
+++ b/docs/archive/review/vault-null-autolock-default-code-review.md
@@ -103,6 +103,46 @@ claims were empirically reproduced (revert-and-rerun), not asserted.
 N/A — no environment constraints declared in Phase 1 (all paths `verifiable-local`;
 route unit tests and client unit test executed locally and pass).
 
+## Round 2 — user-reported Major (client-side null-reset)
+
+**M1 (Major, user-reported) — resolved. Essence shift.**
+The Phase 1-3 review scoped the fix to the SERVER cross-bound validation plus the
+client DEFAULT *constant* extraction, and missed that the client never RESETS its
+active timer to the default when the effective value transitions to null.
+
+- Evidence: `auto-lock-context.tsx:29-33` (old) only wrote `autoLockMsRef.current`
+  for positive numbers — on `60 → null` the ref kept the stale 60-min value.
+  `vault-context.tsx:212-214` (old) only called `setAutoLockMinutes` for positive
+  numbers — a status API `null` never propagated, so the provider never saw the
+  change.
+- Impact: a tenant switching from an explicit longer value (e.g. 60) to null while
+  lowering session idle (e.g. to 20) is accepted server-side (null ⇒ 15 ≤ 20), but
+  a mounted/unlocked client keeps enforcing 60 until remount/reload — decrypted
+  vault material stays readable past the intended session idle boundary. The server
+  invariant `effective(vaultAutoLock=null) = 15` is only true if the client actually
+  applies 15; the client did not on the null-transition path.
+- Root cause of the miss: the invariant "null's effective value is 15" was treated
+  as a server-validation property, but it is a **distributed contract** that every
+  layer applying the effective value must honor — including the client's dynamic
+  update path, not just its initial-mount default. This is the essence shift: the
+  task was framed as "server null-case validation" but the real class is
+  "null ⇒ default consistency across all effective-value appliers."
+- Fix:
+  - `auto-lock-context.tsx` — the prop-change effect now sets `autoLockMsRef.current`
+    to `DEFAULT_INACTIVITY_TIMEOUT_MS` on null/non-positive (was: skip).
+  - `vault-context.tsx` — the status-API handler now propagates `null` into
+    `setAutoLockMinutes` (was: only positive), so the provider resets.
+  - Regression test in `auto-lock-context.test.tsx`: `60 → null` must NOT lock
+    before the 15-min default and MUST lock after it. Verified red-before on a
+    temporary in-place revert (restored via git, no residue), green-after.
+- Member-set of the null-reset class (derived by grepping the effective-value
+  appliers): web client had exactly 2 sites (both fixed). The browser extension
+  re-resolves per alarm via `getEffectiveAutoLockMinutes()`
+  (`extension/src/background/index.ts:177-183, 543, 2042`) so it falls back to the
+  local setting on null — no stale-ref bug. iOS uses a separate storage model.
+  Neither is in the affected member-set.
+- Verification: full suite 12107 pass; pre-pr.sh 44/44 pass (incl. build).
+
 ## Resolution Status
 
 ### T1 (Low) Coverage gap: explicit-null vaultAutoLock × ext-idle untested
@@ -111,4 +151,15 @@ route unit tests and client unit test executed locally and pass).
 - Verification: `npx vitest run src/__tests__/api/tenant/tenant-policy.test.ts`
   → 36 passed. pre-pr.sh → 44/44 pass.
 
-All Critical/Major/Minor findings resolved. One Low finding fixed in-round.
+### M1 (Major) Client keeps stale timer when tenant clears vaultAutoLockMinutes
+- Action: reset `autoLockMsRef` to default on null in the provider; propagate null
+  from the status API into state.
+- Modified files: `src/lib/vault/auto-lock-context.tsx:28-40`,
+  `src/lib/vault/vault-context.tsx:211-221`,
+  `src/lib/vault/auto-lock-context.test.tsx` (60→null regression).
+- Verification: red-before proven (temporary revert), green-after; full suite +
+  pre-pr pass.
+
+All Critical/Major/Minor findings resolved. The Major surfaced from user review
+after the automated triangulate rounds missed the client-side leg of the
+distributed null⇒default invariant — recorded as an essence-shift lesson.

--- a/docs/archive/review/vault-null-autolock-default-plan.md
+++ b/docs/archive/review/vault-null-autolock-default-plan.md
@@ -1,0 +1,306 @@
+# Plan: Share client vault auto-lock default with server cross-bound validation
+
+TODO marker being closed: `TODO(vault-null-autolock-default)`
+Tracked in: PR #642 follow-up ("Follow-up (separate PR)" section).
+
+## Project context
+
+- **Type**: web app (Next.js 16 App Router API route + React client component)
+- **Test infrastructure**: unit + integration (`vitest`) + E2E (Playwright) + CI/CD (`scripts/pre-pr.sh`, GitHub Actions)
+- **Verification environment constraints**: none that block this change. The affected surface is:
+  - Pure integer validation in an API route handler → `verifiable-local` via `vitest` route tests.
+  - A client-side default constant → `verifiable-local` via the existing `auto-lock-context.test.tsx`.
+  - No paid-tier API, no external service, no hardware attestation, no multi-billing-account isolation. All manual-test paths are `verifiable-local`.
+
+## Objective
+
+Close the fail-open gap where the tenant-policy PATCH handler skips the
+`vaultAutoLock <= sessionIdle` (and `<= extensionTokenIdle`) cross-bound check
+whenever `vaultAutoLockMinutes` is `null`, even though the client applies a
+hardcoded 15-minute default in that same null case. An admin can set
+`sessionIdleTimeoutMinutes = 5` while leaving `vaultAutoLockMinutes` null; the
+server accepts it, and the client then runs a 15-minute auto-lock that exceeds
+the 5-minute idle timeout — exactly the "logged out but locally readable"
+state the invariant exists to prevent.
+
+## Requirements
+
+Functional:
+- R-F1: The client's 15-minute auto-lock default MUST be a single named
+  constant shared with the server, not a magic literal duplicated per-side.
+- R-F2: When `vaultAutoLockMinutes` resolves to `null` (neither request nor DB
+  supplies a value), the server cross-bound check MUST validate against the
+  shared default (15), matching the client's effective behavior.
+- R-F3: A partial PATCH that lowers `sessionIdleTimeoutMinutes` (or
+  `extensionTokenIdleTimeoutMinutes`) below the default MUST be rejected when
+  `vaultAutoLockMinutes` is null — the same rejection the user would get if
+  they had explicitly set `vaultAutoLockMinutes = 15`.
+
+Non-functional:
+- R-N1: No behavior change to the explicit-value path (a non-null
+  `vaultAutoLockMinutes` already validated correctly and must keep doing so).
+- R-N2: `needsCurrentState` must already fetch the DB row for the paths R-F3
+  covers (it does — `vaultAutoLockMinutes`, `sessionIdleTimeoutMinutes`,
+  `extensionTokenIdleTimeoutMinutes` each set `needsCurrentState`). No new DB
+  read introduced.
+
+## Technical approach
+
+Single shared constant + null-coalescing merge.
+
+1. Add `VAULT_AUTO_LOCK_DEFAULT = 15` to `src/lib/validations/common.ts`,
+   adjacent to the existing `VAULT_AUTO_LOCK_MIN` / `VAULT_AUTO_LOCK_MAX`.
+   The value is chosen to keep the client's current runtime behavior
+   (`DEFAULT_INACTIVITY_TIMEOUT_MS = 15 * MS_PER_MINUTE`) byte-for-byte
+   unchanged — this is an extraction, not a value change.
+
+2. Client (`src/lib/vault/auto-lock-context.tsx`): replace the literal `15` in
+   `DEFAULT_INACTIVITY_TIMEOUT_MS = 15 * MS_PER_MINUTE` with
+   `VAULT_AUTO_LOCK_DEFAULT * MS_PER_MINUTE`. `common.ts` is
+   client-import-safe (already imported by the client card
+   `tenant-session-policy-card.tsx` for `VAULT_AUTO_LOCK_MIN/MAX`), so no
+   server-only code leaks into the client bundle.
+
+3. Server (`src/app/api/tenant/policy/route.ts`): change the
+   `mergedVaultAutoLock` fallback from `?? null` to `?? VAULT_AUTO_LOCK_DEFAULT`
+   so the merged effective value mirrors the client. The two downstream
+   `typeof mergedVaultAutoLock === "number"` guards then fire in the null case
+   (they were previously short-circuited by the `null` value being non-numeric).
+
+No cross-field logic beyond the two existing comparisons changes. The
+comparison thresholds (`mergedSessionIdle`, `mergedExtIdle`) keep their `?? null`
+fallback — when the idle timeout itself is null we still cannot compare, which
+is correct because the GET default for session idle (`SESSION_IDLE_TIMEOUT_DEFAULT
+= 8h`) is far above 15 and the write path for those fields is non-nullable
+anyway.
+
+### Why `mergedVaultAutoLock`'s default changes but the comparison operands don't
+
+The invariant is `effective(vaultAutoLock) <= effective(sessionIdle)`. The
+client's `effective(vaultAutoLock)` when the stored value is null is 15 (the
+shared default). So the server must compare 15, not skip. For the RHS,
+`effective(sessionIdle)` when null is 8h (`SESSION_IDLE_TIMEOUT_DEFAULT`), which
+is `>= 15` for any legal config, so leaving the RHS `?? null` (skip when null)
+can only ever *under*-reject, never *over*-reject — and since idle-timeout
+fields are non-nullable on write (see route.ts:273-284, they reject explicit
+null), a null RHS only occurs for a legacy row that predates the non-null
+migration, where skipping is the conservative choice. Changing only the LHS
+default is the minimal correct fix.
+
+## Contracts
+
+### C1 — Shared default constant
+
+- **Signature**: `export const VAULT_AUTO_LOCK_DEFAULT = 15;` in
+  `src/lib/validations/common.ts`.
+- **Invariants** (app-enforced):
+  - INV-C1a: `VAULT_AUTO_LOCK_MIN <= VAULT_AUTO_LOCK_DEFAULT <= VAULT_AUTO_LOCK_MAX`
+    (5 <= 15 <= 1440). A default outside the accepted range would let the
+    server derive an effective value the PATCH validator would itself reject.
+  - INV-C1b: The numeric value equals the client's pre-change literal (15), so
+    the extraction is behavior-preserving.
+- **Forbidden patterns** (grep keys for Phase 2-4 conformance):
+  - `pattern: 15 \* MS_PER_MINUTE — reason: the client 15-min literal must be replaced by VAULT_AUTO_LOCK_DEFAULT * MS_PER_MINUTE; a surviving literal means the extraction was not applied`
+  - `pattern: mergedVaultAutoLock[\s\S]{0,80}\?\? null — reason: the server LHS fallback must coalesce to VAULT_AUTO_LOCK_DEFAULT (wrapping the whole ternary), not null; a surviving ?? null on mergedVaultAutoLock means the fix was not applied or was applied only to the DB branch (S1)`
+- **Acceptance criteria**:
+  - `grep VAULT_AUTO_LOCK_DEFAULT src/lib/validations/common.ts` returns the export.
+  - The constant is imported by both `auto-lock-context.tsx` and
+    `route.ts`.
+
+### C2 — Client default uses the shared constant
+
+- **Signature**: `const DEFAULT_INACTIVITY_TIMEOUT_MS = VAULT_AUTO_LOCK_DEFAULT * MS_PER_MINUTE;`
+  in `src/lib/vault/auto-lock-context.tsx`.
+- **Invariants** (app-enforced):
+  - INV-C2a: `DEFAULT_INACTIVITY_TIMEOUT_MS` numeric value is unchanged
+    (still 900000 ms). Verified by the existing null-prop test in
+    `auto-lock-context.test.tsx` (autoLockMinutes={null} → 15-min behavior).
+- **Consumer-flow walkthrough**:
+  - Consumer: `AutoLockProvider` (path: `src/lib/vault/auto-lock-context.tsx`)
+    reads `autoLockMinutes: number | null` prop and, when null/undefined,
+    falls back to `DEFAULT_INACTIVITY_TIMEOUT_MS` for `autoLockMsRef`. It uses
+    that ref in `checkInactivity` (`now - lastActivity > autoLockMsRef.current`).
+    The change only redefines the constant's *source*; the null→default branch
+    logic (lines 29-32) is untouched. No new field required.
+- **Acceptance criteria**:
+  - `auto-lock-context.test.tsx` passes unchanged (behavior preserved).
+  - No literal `15 * MS_PER_MINUTE` remains in the source file.
+  - **Value-regression guard (T4, round 1)**: `auto-lock-context.test.tsx`
+    currently re-derives `DEFAULT_INACTIVITY_TIMEOUT_MS = 15 * MS_PER_MINUTE`
+    locally (line 9), so a wrong value in the C2 extraction could pass
+    vacuously (the local literal and the behavioral `advanceTimersByTime` margin
+    move together). Add a direct assertion that imports the shared constant:
+    `import { VAULT_AUTO_LOCK_DEFAULT } from "@/lib/validations/common";` then
+    `expect(VAULT_AUTO_LOCK_DEFAULT).toBe(15);` (and/or
+    `expect(VAULT_AUTO_LOCK_DEFAULT * MS_PER_MINUTE).toBe(900_000);`). This
+    catches an accidental unit/value change (INV-C2a, INV-C1b) by direct import
+    rather than by re-deriving the same literal in two places.
+
+### C3 — Server cross-bound check validates the null case
+
+- **Signature** (the changed expression, no new function):
+  ```
+  const mergedVaultAutoLock =
+    (vaultAutoLockMinutes !== undefined
+      ? vaultAutoLockMinutes
+      : currentTenant?.vaultAutoLockMinutes) ?? VAULT_AUTO_LOCK_DEFAULT;
+  ```
+  in `src/app/api/tenant/policy/route.ts` (was `... ?? null`).
+
+  **The `?? VAULT_AUTO_LOCK_DEFAULT` MUST wrap the ENTIRE ternary**, not just
+  the DB-fallback branch. If it sits only on the DB branch (as an earlier draft
+  of this plan mistakenly specified — `vaultAutoLockMinutes !== undefined ?
+  vaultAutoLockMinutes : currentTenant?.vaultAutoLockMinutes ?? DEFAULT`), an
+  explicit `null` in the request body takes the first branch (`null !==
+  undefined` is true), yielding `mergedVaultAutoLock = null`, and the downstream
+  `typeof === "number"` guard skips the check — the exact fail-open this fix
+  exists to close would persist for the explicit-null API path (S1, round 1).
+- **Invariants** (app-enforced):
+  - INV-C3a: When the PATCH would leave `vaultAutoLockMinutes` null AND
+    `effective(sessionIdle) < VAULT_AUTO_LOCK_DEFAULT`, the handler returns
+    `VALIDATION_ERROR` (400). This is the fail-open closure.
+  - INV-C3b: When `vaultAutoLockMinutes` is explicitly null in the request
+    (user disabling the per-tenant override), the merge coalesces null →
+    `VAULT_AUTO_LOCK_DEFAULT` because the `??` wraps the whole ternary, so an
+    explicit-null PATCH is validated identically to an unset one — there is no
+    way to bypass the check by sending `null`. (This invariant is FALSE for the
+    DB-branch-only placement; the whole-ternary placement above is what makes it
+    hold.)
+  - INV-C3c: The stored DB value is still `null` (line 828-830 writes
+    `vaultAutoLockMinutes ?? null`); only the *validation* uses the default.
+    The GET response still returns `null` (line 138) so the client can
+    distinguish "unset (apply 15 default)" from "explicitly 15". This preserves
+    the round-trip the client card relies on
+    (`autoLockEnabledVal = !(autoLockVal === null || undefined)`).
+- **Edge cases**:
+  - EC1: `vaultAutoLockMinutes` explicitly null in request, `sessionIdle = 5`
+    → 400 (previously 200 — the bug; the whole-ternary `??` placement is what
+    makes this case reject, per INV-C3b). New behavior.
+  - EC2: `sessionIdleTimeoutMinutes = 5` in request, `vaultAutoLockMinutes`
+    absent from request, DB null → 400 (previously 200 — the bug). New behavior.
+  - EC2b: `extensionTokenIdleTimeoutMinutes = 5` in request, `vaultAutoLockMinutes`
+    absent from request, DB null → 400 (previously 200 — same bug, extension-token
+    variant; both guards share `mergedVaultAutoLock`, so the single LHS-default
+    fix closes both, but this variant is tested independently so a future
+    refactor of one branch cannot silently regress the other — T3, round 1).
+    New behavior.
+  - EC3: `vaultAutoLockMinutes = 10`, `sessionIdle = 20` → 200 (unchanged).
+  - EC4: both absent, DB both null → merged autoLock 15, merged sessionIdle
+    null (RHS skip) → 200 (unchanged; no over-rejection).
+  - EC5: `vaultAutoLockMinutes = 20`, `sessionIdle = 15` → 400 (unchanged).
+  - EC6 (legacy-null-idle skip, SC1 proof): DB `sessionIdleTimeoutMinutes = null`
+    (pre-migration legacy row), request `vaultAutoLockMinutes = 10`, no idle field
+    in request → 200 (RHS null → comparison skipped, conservative). Proves the
+    RHS `?? null` skip path is intentional, not an accident (F1, round 1).
+- **Consumer-flow walkthrough** (server response shape unchanged):
+  - Consumer: `tenant-session-policy-card.tsx` (path:
+    `src/components/settings/security/`) reads `vaultAutoLockMinutes` from both
+    GET and PATCH JSON. It derives `autoLockEnabledVal = !(val === null ||
+    undefined)`. Because C3 does NOT change the stored/returned value (still
+    null when unset — INV-C3c), the card's enable-toggle round-trip is
+    unaffected. The only observable change is that a PATCH which *would* have
+    silently accepted an inconsistent config now returns a 400 the card already
+    surfaces via its existing `errorResponseWithMessage` toast path
+    (the card already renders server validation messages, see line ~263 comment
+    "errors (e.g. vaultAutoLock...)").
+- **Acceptance criteria**:
+  - Route tests live in `src/__tests__/api/tenant/tenant-policy.test.ts` (the
+    file that ALREADY owns the cross-bound invariant tests — the ext-idle case
+    at its `Cross-field invariant` describe block, ~lines 331-370). Add EC1,
+    EC2, EC2b, EC3, EC4, EC5, EC6 as new `it()` blocks in that same describe
+    block, reusing its `mockTenantFindUnique` fixture pattern. Do NOT add them to
+    `src/app/api/tenant/policy/route.test.ts` (a separate sibling file that has
+    no cross-bound tests — splitting them across two files causes drift; T1,
+    round 1).
+  - EC1, EC2, EC2b → 400 with the `must be <= sessionIdleTimeoutMinutes` /
+    `must be <= extensionTokenIdleTimeoutMinutes` message. EC3-EC6 behavior as
+    stated.
+  - **Red-before/green-after gate (T2, round 1)**: EC2 (the reported bug) MUST be
+    added and run BEFORE the C3 code change, and observed to FAIL (returns 200,
+    not 400). Only then apply the whole-ternary `?? VAULT_AUTO_LOCK_DEFAULT` and
+    re-run to confirm 400. The PR must make this checkable — commit the test
+    first, or paste the pre-fix failure in the PR body. A test added after the
+    fix that "happens to pass" is a decorative test and does not satisfy this
+    criterion.
+  - **EC1 is the placement-footgun proof (T6, round 2)**: the red-green gate MUST
+    ALSO cover EC1 (explicit-null request). EC1 and EC2 exercise DIFFERENT
+    branches of the merge ternary — EC2 hits the DB-fallback branch, EC1 hits the
+    request branch. The DB-branch-only `??` misplacement this plan warns against
+    (C3 Signature note) would make EC2 pass while EC1 stays broken. So EC2 alone
+    does NOT prove the whole-ternary placement; EC1 does. Require observing EC1
+    fail pre-fix (200) and pass post-fix (400) as the mechanized proof of
+    INV-C3b, not just a review-time prose check.
+
+## Go/No-Go Gate
+
+| ID | Subject                                             | Status |
+|----|-----------------------------------------------------|--------|
+| C1 | Shared `VAULT_AUTO_LOCK_DEFAULT` constant            | locked |
+| C2 | Client default consumes the shared constant          | locked |
+| C3 | Server cross-bound check validates the null case     | locked |
+
+C3 was re-opened in round 2 for the S1 signature correction (whole-ternary `??`
+placement) and re-locked after the security round-2 re-verification confirmed the
+explicit-null bypass is closed. All three contracts are in final form.
+
+## Testing strategy
+
+- Unit (route): add EC1-EC6 to `src/__tests__/api/tenant/tenant-policy.test.ts`
+  in its existing `Cross-field invariant` describe block (~lines 331-370), NOT
+  to `src/app/api/tenant/policy/route.test.ts` (T1). Assert status code and, for
+  the 400 cases, the error message substring (`sessionIdleTimeoutMinutes` for
+  EC1/EC2, `extensionTokenIdleTimeoutMinutes` for EC2b). Reuse the file's
+  `mockTenantFindUnique` fixture and set a complete `currentTenant` including all
+  three relevant fields (`vaultAutoLockMinutes`, `sessionIdleTimeoutMinutes`,
+  `extensionTokenIdleTimeoutMinutes`) in every case — not just the one being
+  varied — so no field silently resolves `undefined` vs `null` (T5).
+- Unit (client): `auto-lock-context.test.tsx` already covers `autoLockMinutes={null}`
+  → 15-min behavior; it must stay green (proves INV-C2a). Additionally add the
+  direct-import value-regression assertion required by C2 acceptance (T4) so a
+  wrong extraction value cannot pass vacuously.
+- Regression discipline (T2): EC2 is the exact reported bug. Its test MUST be
+  added and observed to FAIL on the pre-fix `?? null` (returns 200) BEFORE the
+  C3 change, then pass (400) after `?? VAULT_AUTO_LOCK_DEFAULT` (per
+  common/testing.md: bug fix ships a regression test red-before / green-after).
+  This is a checkable gate, not prose — see C3 acceptance criteria.
+- Full suite: `npx vitest run` + `npx next build` (mandatory per CLAUDE.md).
+
+## Considerations & constraints
+
+- **Scope contract**:
+  - SC1: The RHS (`mergedSessionIdle` / `mergedExtIdle`) null-fallback is
+    deliberately NOT changed to a default — owned by this plan's "Why the
+    comparison operands don't change" rationale. Legacy null idle rows skip the
+    check conservatively; changing this is out of scope and unnecessary because
+    write-path idle fields are non-nullable.
+  - SC2: No schema migration. `vaultAutoLockMinutes` stays nullable in the DB;
+    the default lives only in application code (client + server validation).
+    A CHECK-constraint / schema-enforced form is out of scope because the
+    invariant is cross-column and cross-effective-default (it depends on the
+    client's runtime default, which the DB cannot know).
+- **Known risk**: an existing tenant with `vaultAutoLockMinutes = null` and a
+  `sessionIdleTimeoutMinutes < 15` already persisted (set before this fix) will
+  now get a 400 on their *next* policy PATCH even if they didn't touch either
+  field — because `needsCurrentState` fetches the row and the merge re-validates.
+  Worst case: an admin editing an unrelated field (e.g. a retention day) is
+  blocked until they either raise sessionIdle to >= 15 or set an explicit
+  vaultAutoLock <= sessionIdle. Likelihood: low (requires a pre-existing
+  sub-15-min idle timeout with null auto-lock, an unusual combination — the
+  idle-timeout min is well below 15 so it is *possible*). Cost to fix if it
+  bites: the error message already tells the admin exactly what to set. This is
+  the correct fail-closed direction (the config was already inconsistent). We
+  accept it as the intended behavior, not a defect. Documented here so Phase 3
+  does not re-raise it as a surprise.
+
+## User operation scenarios
+
+1. Admin opens Security → Session Policy, leaves "vault auto-lock" toggle OFF
+   (null), sets session idle timeout to 5 minutes, saves → now blocked with
+   "vaultAutoLockMinutes (15) must be <= sessionIdleTimeoutMinutes (5)". Before
+   this fix: silently saved, then the vault ran a 15-min auto-lock over a 5-min
+   session. After: admin either raises idle to >= 15 or turns the auto-lock
+   toggle ON and picks a value <= 5.
+2. Admin with a healthy config (idle 480 min, auto-lock OFF) edits an unrelated
+   retention field → still saves fine (merged autoLock 15 <= 480).
+3. Admin explicitly sends `vaultAutoLockMinutes: null` via API with idle 5 →
+   400 (cannot bypass the check by disabling the override).

--- a/docs/archive/review/vault-null-autolock-default-review.md
+++ b/docs/archive/review/vault-null-autolock-default-review.md
@@ -1,0 +1,125 @@
+# Plan Review: vault-null-autolock-default
+
+Date: 2026-07-08
+Review rounds: 2
+
+## Changes from Previous Round
+
+Round 1: initial three-expert review of the plan closing `TODO(vault-null-autolock-default)`
+(PR #642 follow-up). Round 2: verified the round-1 fixes, focused on the Critical S1
+signature correction; one new Low finding (T6) surfaced and was applied.
+
+## Functionality Findings
+
+### Round 1
+- **F1 (Minor) — resolved**: The RHS (`mergedSessionIdle`/`mergedExtIdle`) keeps
+  `?? null` and skips the check for legacy null-idle rows; the plan asserted this
+  in prose (SC1) but had no executable proof. Fix: added **EC6** (legacy DB
+  `sessionIdleTimeoutMinutes = null`, request `vaultAutoLockMinutes = 10` → 200
+  skip) as the SC1 proof.
+- Round-1 Q6 gap (ext-token EC not enumerated) → folded into **EC2b** (see T3).
+
+### Round 2
+- No findings. Traced the corrected merge expression: every non-legacy case
+  yields `number` (explicit-null→15, absent+DB-null→15, absent+DB-value→passthrough,
+  explicit-value→passthrough). EC6 correctly skips (no false 400). EC3/EC5 no
+  regression (the `?? DEFAULT` is a no-op for non-nullish ternary results).
+  Non-blocking observation: `mergedVaultAutoLock` is now always numeric, so the
+  two `typeof === "number"` LHS guards are vestigially always-true — harmless,
+  the effective gate is the RHS operand's numeric check (intended).
+
+## Security Findings
+
+### Round 1
+- **S1 (Critical, escalate:true) — resolved**: The original C3 signature placed
+  `?? VAULT_AUTO_LOCK_DEFAULT` only on the DB-fallback branch of the ternary. An
+  explicit `null` in the request body (`{vaultAutoLockMinutes: null,
+  sessionIdleTimeoutMinutes: 5}`) takes the first branch (`null !== undefined`),
+  yielding `mergedVaultAutoLock = null`; the downstream `typeof === "number"`
+  guard then skips the cross-bound check — the fail-open persists for the
+  explicit-null API path, contradicting the plan's own INV-C3b and EC1 (which
+  expected 400). Fix: the `??` now wraps the **entire** ternary
+  (`(vaultAutoLockMinutes !== undefined ? vaultAutoLockMinutes :
+  currentTenant?.vaultAutoLockMinutes) ?? VAULT_AUTO_LOCK_DEFAULT`), and the
+  Signature note documents the footgun. INV-C3b reworded.
+  - **Escalation decision**: escalate:true was flagged. Orchestrator assessed the
+    finding as unambiguous (ternary-branch trace, no trust-boundary complexity)
+    and self-evidently correct — corroborated independently by the functionality
+    and testing agents reading the same code. Accepted without Opus re-run; the
+    round-2 security re-verification (below) confirms closure.
+
+### Round 2
+- No findings — S1 resolved. Re-traced: explicit-null → `null ?? 15` = 15 → 400.
+  Store-vs-validate split confirmed consistent (stored null via
+  `updateData.vaultAutoLockMinutes = vaultAutoLockMinutes ?? null`, validated
+  against 15; every downstream reader applies the same 15-min default). RS3/RS4
+  pass.
+
+## Testing Findings
+
+### Round 1
+- **T1 (High) — resolved**: "the existing tenant-policy route test file" was
+  ambiguous between two real files. Fix: plan now names
+  `src/__tests__/api/tenant/tenant-policy.test.ts` (owns the existing cross-bound
+  tests) and explicitly forbids adding to `src/app/api/tenant/policy/route.test.ts`.
+- **T2 (High) — resolved**: red-before/green-after was prose, not a checkable
+  gate. Fix: C3 acceptance now mandates adding+running EC2 pre-fix (observe 200),
+  then fix, then 400, with PR-checkable enforcement (test-first commit or pasted
+  pre-fix failure). Empirically reproduced: pre-fix `?? null` returns 200.
+- **T3 (Medium) — resolved**: EC1/EC2 only covered `sessionIdle`; the identical
+  `mergedExtIdle` guard had the same bug untested. Fix: added **EC2b**
+  (extension-token variant → 400).
+- **T4 (Low) — resolved, upgraded to required**: `auto-lock-context.test.tsx`
+  re-derives `15 * MS_PER_MINUTE` locally, so a wrong extraction value could pass
+  vacuously. Fix: C2 acceptance now REQUIRES a direct-import assertion
+  (`import { VAULT_AUTO_LOCK_DEFAULT }; expect(...).toBe(15)`).
+- **T5 (Low) — resolved**: fixture completeness. Fix: Testing strategy requires a
+  complete `currentTenant` (all three relevant fields) in every EC test.
+
+### Round 2
+- **T6 (Low, new in round 2) — resolved**: The red-green gate (T2) anchored only
+  on EC2, but EC2 hits the DB-fallback branch and would pass even under the
+  DB-branch-only `??` misplacement S1 warned about. EC1 (explicit-null, request
+  branch) is the case that specifically catches that footgun. Fix: the gate now
+  ALSO requires observing EC1 red-before/green-after as the mechanized proof of
+  INV-C3b's whole-ternary placement.
+
+## Adjacent Findings
+
+None routed cross-scope; all findings stayed within originating scope.
+
+## Quality Warnings
+
+None. All findings carried file:line evidence; T2's regression claim was
+empirically reproduced (200 pre-fix) rather than asserted.
+
+## Recurring Issue Check
+
+### Functionality expert
+- Constant/enum consumers: pass (all VAULT_AUTO_LOCK consumers enumerated).
+- Shared-utility discovery: pass (no existing default-resolution helper; inline
+  `?? DEFAULT` matches file convention).
+- Type-shape (merge now non-nullable): pass (all branches → number; guards safe).
+- Consumer-flow (client card round-trip): pass (INV-C3c; updateData reads raw field).
+- Do-not-blindly-follow-pattern (vault vs jit/deleg `?? null`): pass (justified by
+  client-side default asymmetry; EC6 provides executable proof).
+- Edge-case completeness: pass (EC1/EC2/EC2b/EC3/EC4/EC5/EC6 enumerated).
+
+### Security expert
+- RS1 (authz bypass): pass (MEMBER_MANAGE + step-up gates untouched).
+- RS2 (injection): n/a (pure integer comparison).
+- RS3 (fail-open direction): pass (closes fail-open on both explicit-null and
+  absent paths; fail-closed is safer direction; no new fail-open).
+- RS4 (business-logic bypass via alternate path, A04): pass (the explicit-null
+  alternate branch that S1 exploited is folded into the same default).
+- RS5 (secrets/PII in logs): pass (vaultAutoLockMinutes logged as plain integer).
+
+### Testing expert
+- R-common-testing (regression red-before/green-after): resolved (T2 + T6 gates).
+- R-common-testing (no decorative tests): resolved (T4 direct-import assertion).
+- RT1 (framework detection): ok (vitest/Playwright).
+- RT2 (mock at module scope, typed): ok.
+- RT3 (React components via rendered DOM): ok.
+- RT7 (fixture realism, no vacuous `{}`): resolved (T5).
+- feedback_triangulate_enumerate_completeness: applied (T3 ext-idle, T6 EC1/EC2
+  branch enumeration derived from re-reading the guard class, not the prompt list).

--- a/src/__tests__/api/tenant/tenant-policy.test.ts
+++ b/src/__tests__/api/tenant/tenant-policy.test.ts
@@ -369,6 +369,120 @@ describe("PATCH /api/tenant/policy", () => {
     expect(String(json.details?.message ?? "")).toMatch(/extensionTokenIdleTimeoutMinutes/);
   });
 
+  // ── Null-effective-default cross-bound (VAULT_AUTO_LOCK_DEFAULT) ──
+  //   When vaultAutoLockMinutes resolves to null (neither request nor DB
+  //   supplies a value), the client still runs a VAULT_AUTO_LOCK_DEFAULT (15)
+  //   auto-lock, so the server must validate the effective 15 against the idle
+  //   timeouts — not skip the check. EC1/EC2/EC2b are the previously-fail-open
+  //   cases; EC6 proves the RHS legacy-null-idle skip is intentional.
+
+  // EC1: explicit null in request + sub-15 sessionIdle → 400 (whole-ternary
+  // placement proof: a DB-branch-only ?? would leave this at 200).
+  it("returns 400 when vaultAutoLockMinutes is explicitly null and sessionIdle < default", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue({ tenantId: "tenant1" });
+    mockTenantFindUnique.mockResolvedValue({
+      allowedCidrs: [],
+      tailscaleEnabled: false,
+      tailscaleTailnet: null,
+      sessionIdleTimeoutMinutes: 5,
+      extensionTokenIdleTimeoutMinutes: EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT,
+      vaultAutoLockMinutes: null,
+    });
+    const req = createRequest("PATCH", "http://localhost/api/tenant/policy", {
+      body: { vaultAutoLockMinutes: null, sessionIdleTimeoutMinutes: 5 },
+    });
+    const res = await PATCH(req);
+    const { status, json } = await parseResponse(res);
+    expect(status).toBe(400);
+    expect(String(json.details?.message ?? "")).toMatch(/sessionIdleTimeoutMinutes/);
+  });
+
+  // EC2: vaultAutoLock absent from request, DB null, request lowers sessionIdle
+  // below the default → 400. This is the exact reported bug (red pre-fix: 200).
+  it("returns 400 when vaultAutoLockMinutes is absent (DB null) and request sets sessionIdle < default", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue({ tenantId: "tenant1" });
+    mockTenantFindUnique.mockResolvedValue({
+      allowedCidrs: [],
+      tailscaleEnabled: false,
+      tailscaleTailnet: null,
+      sessionIdleTimeoutMinutes: 480,
+      extensionTokenIdleTimeoutMinutes: EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT,
+      vaultAutoLockMinutes: null,
+    });
+    const req = createRequest("PATCH", "http://localhost/api/tenant/policy", {
+      body: { sessionIdleTimeoutMinutes: 5 },
+    });
+    const res = await PATCH(req);
+    const { status, json } = await parseResponse(res);
+    expect(status).toBe(400);
+    expect(String(json.details?.message ?? "")).toMatch(/sessionIdleTimeoutMinutes/);
+  });
+
+  // EC2b: same bug, extension-token variant.
+  it("returns 400 when vaultAutoLockMinutes is absent (DB null) and request sets extensionTokenIdle < default", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue({ tenantId: "tenant1" });
+    mockTenantFindUnique.mockResolvedValue({
+      allowedCidrs: [],
+      tailscaleEnabled: false,
+      tailscaleTailnet: null,
+      sessionIdleTimeoutMinutes: 480,
+      extensionTokenIdleTimeoutMinutes: EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT,
+      vaultAutoLockMinutes: null,
+    });
+    const req = createRequest("PATCH", "http://localhost/api/tenant/policy", {
+      body: { extensionTokenIdleTimeoutMinutes: 5 },
+    });
+    const res = await PATCH(req);
+    const { status, json } = await parseResponse(res);
+    expect(status).toBe(400);
+    expect(String(json.details?.message ?? "")).toMatch(/extensionTokenIdleTimeoutMinutes/);
+  });
+
+  // EC3: explicit non-null vaultAutoLock below sessionIdle → 200 (unchanged).
+  it("succeeds when vaultAutoLockMinutes (10) is below sessionIdle (20)", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue({ tenantId: "tenant1" });
+    mockTenantFindUnique.mockResolvedValue({
+      allowedCidrs: [],
+      tailscaleEnabled: false,
+      tailscaleTailnet: null,
+      sessionIdleTimeoutMinutes: 20,
+      extensionTokenIdleTimeoutMinutes: EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT,
+      vaultAutoLockMinutes: null,
+    });
+    mockUpdateReturn({ vaultAutoLockMinutes: 10, sessionIdleTimeoutMinutes: 20 });
+    const req = createRequest("PATCH", "http://localhost/api/tenant/policy", {
+      body: { vaultAutoLockMinutes: 10, sessionIdleTimeoutMinutes: 20 },
+    });
+    const res = await PATCH(req);
+    expect((await parseResponse(res)).status).toBe(200);
+  });
+
+  // EC6: legacy DB row with null sessionIdle, explicit vaultAutoLock in request
+  // → 200. The RHS ?? null intentionally skips the comparison when the idle
+  // operand is null (conservative). Proves the LHS/RHS asymmetry is deliberate.
+  it("succeeds (skips check) when sessionIdle is null in DB (legacy row) and vaultAutoLock is set", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue({ tenantId: "tenant1" });
+    mockTenantFindUnique.mockResolvedValue({
+      allowedCidrs: [],
+      tailscaleEnabled: false,
+      tailscaleTailnet: null,
+      sessionIdleTimeoutMinutes: null,
+      extensionTokenIdleTimeoutMinutes: null,
+      vaultAutoLockMinutes: null,
+    });
+    mockUpdateReturn({ vaultAutoLockMinutes: 10 });
+    const req = createRequest("PATCH", "http://localhost/api/tenant/policy", {
+      body: { vaultAutoLockMinutes: 10 },
+    });
+    const res = await PATCH(req);
+    expect((await parseResponse(res)).status).toBe(200);
+  });
+
   it("successfully updates all policy fields including access restriction", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockRequireTenantPermission.mockResolvedValue({ tenantId: "tenant1" });

--- a/src/__tests__/api/tenant/tenant-policy.test.ts
+++ b/src/__tests__/api/tenant/tenant-policy.test.ts
@@ -441,6 +441,29 @@ describe("PATCH /api/tenant/policy", () => {
     expect(String(json.details?.message ?? "")).toMatch(/extensionTokenIdleTimeoutMinutes/);
   });
 
+  // EC2c: explicit null in request + sub-15 extensionTokenIdle → 400. Completes
+  // the (explicit-null | absent) × (sessionIdle | extIdle) matrix (EC1 covers
+  // explicit-null × sessionIdle; EC2b covers absent × extIdle).
+  it("returns 400 when vaultAutoLockMinutes is explicitly null and extensionTokenIdle < default", async () => {
+    mockAuth.mockResolvedValue(DEFAULT_SESSION);
+    mockRequireTenantPermission.mockResolvedValue({ tenantId: "tenant1" });
+    mockTenantFindUnique.mockResolvedValue({
+      allowedCidrs: [],
+      tailscaleEnabled: false,
+      tailscaleTailnet: null,
+      sessionIdleTimeoutMinutes: 480,
+      extensionTokenIdleTimeoutMinutes: 5,
+      vaultAutoLockMinutes: null,
+    });
+    const req = createRequest("PATCH", "http://localhost/api/tenant/policy", {
+      body: { vaultAutoLockMinutes: null, extensionTokenIdleTimeoutMinutes: 5 },
+    });
+    const res = await PATCH(req);
+    const { status, json } = await parseResponse(res);
+    expect(status).toBe(400);
+    expect(String(json.details?.message ?? "")).toMatch(/extensionTokenIdleTimeoutMinutes/);
+  });
+
   // EC3: explicit non-null vaultAutoLock below sessionIdle → 200 (unchanged).
   it("succeeds when vaultAutoLockMinutes (10) is below sessionIdle (20)", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);

--- a/src/app/api/tenant/policy/route.ts
+++ b/src/app/api/tenant/policy/route.ts
@@ -57,6 +57,7 @@ import {
   EXTENSION_TOKEN_ABSOLUTE_TIMEOUT_MAX,
   VAULT_AUTO_LOCK_MIN,
   VAULT_AUTO_LOCK_MAX,
+  VAULT_AUTO_LOCK_DEFAULT,
   SA_TOKEN_MAX_EXPIRY_MIN,
   SA_TOKEN_MAX_EXPIRY_MAX,
   JIT_TOKEN_TTL_MIN,
@@ -730,9 +731,15 @@ async function handlePATCH(req: NextRequest) {
   // timeout, the vault stays decrypted after the token/session dies —
   // the "logged out but locally readable" state is confusing UX and
   // extends the effective credential-material lifetime unnecessarily.
-  const mergedVaultAutoLock = vaultAutoLockMinutes !== undefined
-    ? vaultAutoLockMinutes
-    : currentTenant?.vaultAutoLockMinutes ?? null;
+  // The ?? VAULT_AUTO_LOCK_DEFAULT wraps the ENTIRE ternary, not just the
+  // DB-fallback branch: an explicit null in the request takes the first branch,
+  // so a DB-branch-only default would leave that path unvalidated (the client
+  // still runs a 15-min lock). Coalescing the whole ternary makes the effective
+  // value mirror the client for both the absent-field and explicit-null paths.
+  const mergedVaultAutoLock =
+    (vaultAutoLockMinutes !== undefined
+      ? vaultAutoLockMinutes
+      : currentTenant?.vaultAutoLockMinutes) ?? VAULT_AUTO_LOCK_DEFAULT;
   const mergedSessionIdle = sessionIdleTimeoutMinutes !== undefined
     ? sessionIdleTimeoutMinutes
     : currentTenant?.sessionIdleTimeoutMinutes ?? null;

--- a/src/lib/validations/common.ts
+++ b/src/lib/validations/common.ts
@@ -206,6 +206,11 @@ export const EXTENSION_TOKEN_ABSOLUTE_TIMEOUT_DEFAULT = 30 * MIN_PER_DAY;
 //   vaultAutoLockMinutes <= min(sessionIdleTimeoutMinutes, extensionTokenIdleTimeoutMinutes)
 export const VAULT_AUTO_LOCK_MIN = 5;
 export const VAULT_AUTO_LOCK_MAX = MIN_PER_DAY;
+// Effective auto-lock when the tenant sets no explicit value (null). The client
+// applies this default (auto-lock-context.tsx), so the server cross-bound check
+// must validate against it — otherwise a null value silently bypasses the
+// vaultAutoLock <= idle invariant while the client still runs a 15-min lock.
+export const VAULT_AUTO_LOCK_DEFAULT = 15;
 
 // ─── Lockout Policy ──────────────────────────────────────────
 export const LOCKOUT_THRESHOLD_MIN = 1;

--- a/src/lib/vault/auto-lock-context.test.tsx
+++ b/src/lib/vault/auto-lock-context.test.tsx
@@ -4,9 +4,12 @@ import { render, act } from "@testing-library/react";
 import { AutoLockProvider } from "./auto-lock-context";
 import { VAULT_STATUS } from "@/lib/constants";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
+import { VAULT_AUTO_LOCK_DEFAULT } from "@/lib/validations/common";
 
 const ACTIVITY_CHECK_INTERVAL_MS = 30_000;
-const DEFAULT_INACTIVITY_TIMEOUT_MS = 15 * MS_PER_MINUTE;
+// Derived from the shared constant (not a re-hardcoded literal) so a wrong
+// value in the source extraction is caught here, not masked by a duplicate.
+const DEFAULT_INACTIVITY_TIMEOUT_MS = VAULT_AUTO_LOCK_DEFAULT * MS_PER_MINUTE;
 
 function setHidden(hidden: boolean) {
   Object.defineProperty(document, "hidden", { configurable: true, get: () => hidden });
@@ -23,6 +26,13 @@ describe("AutoLockProvider", () => {
     // Reset here (not in test bodies) so a failing assertion cannot leak
     // document.hidden=true into the next test — teardown runs even on throw.
     setHidden(false);
+  });
+
+  it("keeps the shared auto-lock default at 15 minutes (900000ms)", () => {
+    // Guards INV-C1b / INV-C2a: the extraction to a shared constant must not
+    // change the value the client applies when the tenant sets no override.
+    expect(VAULT_AUTO_LOCK_DEFAULT).toBe(15);
+    expect(DEFAULT_INACTIVITY_TIMEOUT_MS).toBe(900_000);
   });
 
   it("does not call lock before the inactivity threshold", () => {

--- a/src/lib/vault/auto-lock-context.test.tsx
+++ b/src/lib/vault/auto-lock-context.test.tsx
@@ -381,4 +381,45 @@ describe("AutoLockProvider", () => {
     });
     expect(lock).toHaveBeenCalled();
   });
+
+  it("resets to the 15-min default when autoLockMinutes changes from a longer value to null", () => {
+    // Regression: clearing an explicit longer value (60 → null) must drop the
+    // effective timer back to the default. A stale 60-min timer would leave the
+    // vault decrypted past the tenant's (possibly lowered) session idle boundary.
+    const lock = vi.fn();
+    const { rerender } = render(
+      <AutoLockProvider
+        vaultStatus={VAULT_STATUS.UNLOCKED}
+        lock={lock}
+        autoLockMinutes={60}
+      >
+        <div />
+      </AutoLockProvider>,
+    );
+
+    // Tenant clears the explicit value; effective lock must become the default.
+    rerender(
+      <AutoLockProvider
+        vaultStatus={VAULT_STATUS.UNLOCKED}
+        lock={lock}
+        autoLockMinutes={null}
+      >
+        <div />
+      </AutoLockProvider>,
+    );
+
+    // Just under the 15-min default — must NOT have locked (would already have
+    // fired if the timer were incorrectly reset to something shorter).
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_INACTIVITY_TIMEOUT_MS - ACTIVITY_CHECK_INTERVAL_MS);
+    });
+    expect(lock).not.toHaveBeenCalled();
+
+    // Cross the 15-min default — must lock now (proves it did NOT keep the
+    // stale 60-min timer, which would still be far from firing).
+    act(() => {
+      vi.advanceTimersByTime(2 * ACTIVITY_CHECK_INTERVAL_MS);
+    });
+    expect(lock).toHaveBeenCalled();
+  });
 });

--- a/src/lib/vault/auto-lock-context.tsx
+++ b/src/lib/vault/auto-lock-context.tsx
@@ -25,11 +25,18 @@ export function AutoLockProvider({
   const lastActivityRef = useRef(0);
   const autoLockMsRef = useRef(DEFAULT_INACTIVITY_TIMEOUT_MS);
 
-  // Update timeout value when prop changes
+  // Update timeout value when prop changes. Falling back to the default on
+  // null/non-positive is required, not cosmetic: when a tenant clears an
+  // explicit longer value (e.g. 60 → null) the effective lock must drop back to
+  // DEFAULT_INACTIVITY_TIMEOUT_MS immediately, otherwise a mounted client keeps
+  // enforcing the stale longer timer past the (possibly lowered) session idle
+  // boundary — the exact inconsistency the server's null⇒default validation
+  // assumes cannot happen client-side.
   useEffect(() => {
-    if (autoLockMinutes != null && autoLockMinutes > 0) {
-      autoLockMsRef.current = autoLockMinutes * MS_PER_MINUTE;
-    }
+    autoLockMsRef.current =
+      autoLockMinutes != null && autoLockMinutes > 0
+        ? autoLockMinutes * MS_PER_MINUTE
+        : DEFAULT_INACTIVITY_TIMEOUT_MS;
   }, [autoLockMinutes]);
 
   // Reset activity timestamp when vault becomes unlocked

--- a/src/lib/vault/auto-lock-context.tsx
+++ b/src/lib/vault/auto-lock-context.tsx
@@ -4,8 +4,9 @@ import { useEffect, useRef, type ReactNode } from "react";
 import { VAULT_STATUS } from "@/lib/constants";
 import type { VaultStatus } from "@/lib/constants";
 import { MS_PER_MINUTE, MS_PER_SECOND } from "@/lib/constants/time";
+import { VAULT_AUTO_LOCK_DEFAULT } from "@/lib/validations/common";
 
-const DEFAULT_INACTIVITY_TIMEOUT_MS = 15 * MS_PER_MINUTE;
+const DEFAULT_INACTIVITY_TIMEOUT_MS = VAULT_AUTO_LOCK_DEFAULT * MS_PER_MINUTE;
 const ACTIVITY_CHECK_INTERVAL_MS = 30 * MS_PER_SECOND;
 
 interface AutoLockProviderProps {

--- a/src/lib/vault/vault-context.tsx
+++ b/src/lib/vault/vault-context.tsx
@@ -208,10 +208,16 @@ export function VaultProvider({ children }: { children: ReactNode }) {
         const data = await res.json();
         setHasRecoveryKey(!!data.hasRecoveryKey);
         setRecoveryKeyInvalidated(!!data.recoveryKeyInvalidated);
-        // Apply tenant-configured vault auto-lock timeout
-        if (data.vaultAutoLockMinutes != null && data.vaultAutoLockMinutes > 0) {
-          setAutoLockMinutes(data.vaultAutoLockMinutes);
-        }
+        // Apply tenant-configured vault auto-lock timeout. Propagate null too
+        // (not only positive values) so that clearing an explicit value resets
+        // the provider to its default timer — otherwise a longer stale value
+        // would keep enforcing past the intended boundary after the tenant
+        // switches back to the default.
+        setAutoLockMinutes(
+          data.vaultAutoLockMinutes != null && data.vaultAutoLockMinutes > 0
+            ? data.vaultAutoLockMinutes
+            : null,
+        );
         // Store tenant password policy for enforcement in personal vault forms
         setTenantPolicy({
           minPasswordLength: data.tenantMinPasswordLength ?? 0,


### PR DESCRIPTION
## Summary
- Closes a fail-open security gap where `vaultAutoLockMinutes: null` bypassed server-side cross-bound validation against `sessionIdleTimeoutMinutes` and `extensionTokenIdleTimeoutMinutes`.
- Introduces `VAULT_AUTO_LOCK_DEFAULT` (15) as a shared constant between the Next.js server route and the React client, eliminating magic-number drift and unifying the distributed invariant.
- Resolves a client-side bug where clearing `vaultAutoLockMinutes` left the inactivity timer at a stale explicit value instead of resetting to the 15-minute default.
- Adds regression tests (EC1–EC6 route-side, plus a client `60 → null` reset case) with empirically verified red-before/green-after gates.

## Motivation
The tenant-policy PATCH handler previously skipped the `vaultAutoLock <= sessionIdle` (and `<= extensionTokenIdle`) cross-bound check whenever `vaultAutoLockMinutes` resolved to `null`, even though the client runtime enforced a 15-minute auto-lock in that exact scenario. This allowed admins to set `sessionIdleTimeoutMinutes` below 15 while leaving vault auto-lock disabled (`null`), leaving locally decrypted vault material readable past the intended idle boundary. The core issue is a distributed invariant: the server treated the 15-minute default as a validation-only concept while the client applied it locally. Consolidating the default into one shared constant ensures both sides apply the same effective value and prevents silent divergence.

Additionally, a user-reported issue (`M1` in the code-review log) revealed that the web client failed to reset its active inactivity timer to the default when a tenant cleared `vaultAutoLockMinutes` via the API. A mounted client kept enforcing a stale explicit value (e.g. 60 min) until remount, violating the server's effective-value invariant. This is patched in `ffef5b86`, aligning client state propagation with the server's null⇒default contract.

## Implementation notes
- **Ternary placement (Critical `S1`):** the server merge expression `(vaultAutoLockMinutes !== undefined ? vaultAutoLockMinutes : currentTenant?.vaultAutoLockMinutes) ?? VAULT_AUTO_LOCK_DEFAULT` wraps the entire ternary in `?? VAULT_AUTO_LOCK_DEFAULT`. Placing the coalesce only on the DB-fallback branch would let an explicit `null` request payload bypass validation.
- **Shared constant:** `VAULT_AUTO_LOCK_DEFAULT = 15` was added to `src/lib/validations/common.ts` and imported by both `src/app/api/tenant/policy/route.ts` and `src/lib/vault/auto-lock-context.tsx`, removing the duplicated literal.
- **Client reset:** `auto-lock-context.tsx` now resets `autoLockMsRef.current` to `DEFAULT_INACTIVITY_TIMEOUT_MS` on `null`/non-positive props (was: skip, keeping the stale value); `vault-context.tsx` propagates `null` from the status API into `setAutoLockMinutes` so the provider tracks the change without a remount.
- **RHS null handling (`EC6`):** `mergedSessionIdle` / `mergedExtIdle` intentionally keep `?? null`, skipping the comparison when the idle timeout itself is `null`. This is conservative and correct — idle fields reject explicit `null` on write, so a `null` idle value only occurs on a legacy row, where skipping avoids a false 400 against the 15-minute vault default.
- **Adjacent surfaces unaffected:** the browser extension re-resolves the effective auto-lock per alarm via `getEffectiveAutoLockMinutes()`, so it falls back on `null` with no stale-ref bug; iOS uses a separate storage model. The web client was the only affected null-reset site.

## Review artifacts
- [vault-null-autolock-default-plan.md](./docs/archive/review/vault-null-autolock-default-plan.md)
- [vault-null-autolock-default-review.md](./docs/archive/review/vault-null-autolock-default-review.md)
- [vault-null-autolock-default-code-review.md](./docs/archive/review/vault-null-autolock-default-code-review.md)

## Test plan
- [x] `npx vitest run` — full suite passes (942 files / 12,107 tests).
- [x] `scripts/pre-pr.sh` — all 44 checks pass, including `npx next build`.
- [x] Red-before/green-after verified for EC1 (explicit-null) and EC2/EC2b (absent, DB null) in `src/__tests__/api/tenant/tenant-policy.test.ts` — 400 after fix, 200 before.
- [x] Client null-reset regression (`60 → null`) in `src/lib/vault/auto-lock-context.test.tsx` — locks at the 15-minute default, not the stale 60-minute value; proven red on a temporary revert.
- [x] Explicit non-null values (EC3) and legacy-null-idle skip (EC6) behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
