### PR TITLE
fix(auth): make MCP/iOS OAuth step-up recoverable and fix basePath-doubled signin redirect

### DIFF
--- a/docs/archive/review/fix-mcp-oauth-stepup-recovery-plan.md
+++ b/docs/archive/review/fix-mcp-oauth-stepup-recovery-plan.md
@@ -1,0 +1,156 @@
+# Plan: Fix MCP/iOS OAuth step-up recovery (3-layer defect)
+
+## Project context
+
+- **Type**: web app (Next.js 16 App Router, TypeScript, Auth.js v5 database sessions, `basePath` via `NEXT_PUBLIC_BASE_PATH`)
+- **Test infrastructure**: unit + integration (vitest) + E2E (Playwright) + CI/CD
+- **Verification environment constraints**:
+  - `VC1` — The URL-doubling failure (L1) requires `NEXT_PUBLIC_BASE_PATH` set AND a stale-but-valid session. Local dev usually runs empty basePath → doubling invisible. Regression tests MUST stub a non-empty `BASE_PATH`: `verifiable-CI`.
+  - `VC2` — The step-up loop (L2/L3) requires a session older than `STEP_UP_WINDOW_MS` (15 min). Reproduced manually via live redirect-chain capture with a real session cookie. Full browser E2E of the recovery (reauth → consent) is not wired in CI: `blocked-deferred` — see `SC-E2E`.
+  - `VC3` — Non-WebAuthn recovery exercises the Auth.js provider sign-in flow. Google/SAML round-trips need an external IdP: `blocked-deferred`. Magic-link (Mailpit) and passkey (virtual authenticator) paths: `verifiable-local`.
+
+## Objective
+
+Make MCP OAuth (Claude Code, passwd-sso CLI) and iOS OAuth login succeed for a stale-but-valid session, on any basePath, for every session provider type. Three verified defects currently combine to break it:
+
+- **L1 — URL doubling** (basePath deployments): signin page passes a basePath-qualified path to Next's `redirect()`, which re-prepends basePath → `/passwd-sso/passwd-sso/api/mcp/authorize` → intl adds locale → 404.
+- **L2 — non-canonical step-up primitive**: the three browser-redirect OAuth gates call `requireRecentSession` (createdAt) directly instead of the canonical chooser `requireRecentCurrentAuthMethod`, so even WebAuthn users cannot recover via the passkey `passkeyVerifiedAt` path there.
+- **L3 — signin bounce cannot re-authenticate**: every stale-session recovery path (mcp authorize GET 403, consent POST stale→authorize→…, mobile authorize GET 403) funnels into "redirect to signin with callbackUrl", but the signin page short-circuits any authenticated user straight back to the callback WITHOUT re-authenticating. `Session.createdAt` never refreshes → gate fails again → **infinite redirect loop** (masked as a 404 by L1 on basePath deployments; a live loop elsewhere).
+
+## Root cause (all verified)
+
+### L1 — live redirect-chain capture
+`src/app/[locale]/auth/signin/page.tsx:59`: `nextRedirect(resolved)` where `resolved` is basePath-qualified. Next server-component `redirect()` re-prepends basePath. Sibling non-API branch already strips via `callbackUrlToHref`. Introduced PR #529 (v0.4.57). Never caught: `signin/page.test.ts:28` mocks `BASE_PATH: ""`.
+
+### L2 — code read + member-set derivation (R42)
+Defining primitive grep (`requireRecentSession\(` outside the chooser): exactly 3 members —
+- `src/app/api/mcp/authorize/route.ts:81` (GET)
+- `src/app/api/mcp/authorize/consent/route.ts:48` (POST)
+- `src/app/api/mobile/authorize/route.ts:131` (GET)
+
+The canonical chooser `requireRecentCurrentAuthMethod` (`src/lib/auth/session/recent-current-auth-method.ts:26`) routes `provider === "webauthn"` → `requireRecentPasskeyVerification` (`passkeyVerifiedAt`, recoverable via ceremony) and everything else → `requireRecentSession`. All ~45 in-app gated routes use the chooser; only these 3 browser-redirect routes bypass it.
+
+### L3 — code read + git history
+`requireRecentSession` gates on `Session.createdAt` (`step-up.ts:47`); only `createSession` (fresh sign-in) sets it (`auth-adapter.ts:326`). The in-app recovery for non-WebAuthn sessions already exists: `RecentSessionRequiredDialog` (`src/components/auth/recent-session-required-dialog.tsx:38-46`) does `signOut({ callbackUrl: signin?callbackUrl=<current> })` — sign out (old session destroyed), land on signin unauthenticated, real sign-in mints a fresh session. The browser-redirect flows lack this: PR #646 added the 403→signin bounce assuming "the second pass has a recent-enough session", which is false because of the signin short-circuit (`page.tsx:44`).
+
+## Technical approach
+
+All recovery paths already funnel into the signin page — fix them there, reusing the existing in-app recovery components ("方式は合わせる"). No schema change (unified-field idea evaluated and rejected: for non-WebAuthn sessions a "last verified" field would be write-identical to `createdAt`; the only recoverable-without-resignin ceremony is WebAuthn's, which already has `passkeyVerifiedAt`).
+
+1. **L1**: strip basePath before `nextRedirect` (Next re-adds it).
+2. **L2**: switch the 3 browser-redirect gates to `requireRecentCurrentAuthMethod`.
+3. **L3**: in the signin page's authenticated + `isApiCallbackUrl` branch, evaluate step-up freshness server-side with the SAME chooser semantics. Fresh → redirect to callback (current behavior + L1 fix). Stale → render a **reauth panel** (new client component) instead of redirecting:
+   - WebAuthn session: passkey reauth ceremony (existing `reauthenticateWithPasskey()` + `PasskeyReauthDialog` pattern) → refreshes `passkeyVerifiedAt` (session kept) → navigate to callback.
+   - Non-WebAuthn session: "sign in again" action (existing `RecentSessionRequiredDialog` pattern) → `signOut({ callbackUrl: signin?callbackUrl=<callback> })` → real re-sign-in → fresh session → signin short-circuit (now fresh) → callback.
+   - Requires a user gesture (button) — no auto-signOut on GET (logout-CSRF hygiene).
+
+**IdP silent re-federation caveat (explicit posture decision)**: on "sign in again", Google/SAML may re-federate without re-challenging the user (no `prompt=login` / `forceAuthn` configured — `auth.config.ts:52` uses `prompt: "consent"`). This matches the EXISTING in-app `RecentSessionRequiredDialog` posture; aligning is the consistency choice. Forcing IdP re-challenge is deferred (`SC4`).
+
+**Shared-core refactor (no drift)**: the signin page (server component, no `NextRequest`) and the API gates must evaluate freshness identically. Extract the chooser's core into a token-parameterized function (e.g. `evaluateStepUpFreshness(sessionToken, options): Promise<"fresh" | "stale" | "invalid">`); `requireRecentCurrentAuthMethod(req)` wraps it (unchanged external contract), the signin page calls it with the token from `cookies()`. Single implementation, two entry points.
+
+## Contracts
+
+### C1 — signin API-callback redirect strips basePath before `nextRedirect` (L1)
+
+- **Location**: `src/app/[locale]/auth/signin/page.tsx` line 59 + stale comment at 55-58.
+- **Change**: `nextRedirect(resolved)` → `nextRedirect(callbackUrlToHref(resolved))`; update comment (basePath stripped because Next re-prepends it).
+- **Invariants** (app-enforced): I1 — `Location` for an API callbackUrl contains basePath exactly once, no locale segment. I2 — non-API branch unchanged.
+- **Forbidden patterns**: `pattern: nextRedirect(resolved) — reason: basePath-qualified path re-prefixed by Next redirect (the L1 bug).`
+- **Acceptance**: `BASE_PATH="/passwd-sso"` + callbackUrl resolving to `/passwd-sso/api/mcp/authorize?x=1` → `nextRedirect("/api/mcp/authorize?x=1")`. `BASE_PATH=""` → same call (unchanged). Query string preserved byte-for-byte.
+- **Consumer-flow walkthrough**: consumer *browser/OAuth client* (Claude Code, passwd-sso CLI `runOAuthFlow`, iOS ASWebAuthenticationSession) reads `Location`, navigates with OAuth params (`client_id`, `code_challenge`, `scope`, `state`, `redirect_uri`) intact; `callbackUrlToHref` preserves `pathname + search`. ✅
+
+### C2 — browser-redirect OAuth gates use the canonical chooser (L2)
+
+- **Location**: `src/app/api/mcp/authorize/route.ts:81`, `src/app/api/mcp/authorize/consent/route.ts:48`, `src/app/api/mobile/authorize/route.ts:131`.
+- **Change**: `requireRecentSession(req)` → `requireRecentCurrentAuthMethod(req)` at all 3 sites (default options — no custom `maxAgeMs`).
+- **Invariants**: I3 — WebAuthn sessions gate on `passkeyVerifiedAt` at these routes. I4 — non-WebAuthn gate on `createdAt` (recovered via C3). I5 — the step-up coverage guard (`scripts/checks/check-step-up-client-coverage.sh`, primitives regex line ~112 already includes all three primitive names) still passes; the `@stepup` markers and `@browser-redirect` exempt entries (`mcp-authorize-get`, `mcp-authorize-consent-post`, `mobile-authorize-get`) remain valid.
+- **Forbidden patterns**: `pattern: requireRecentSession\( in src/app/api/(mcp|mobile)/ — reason: bypasses provider-aware chooser (L2).` `pattern: maxAgeMs: in the 3 gate call-sites — reason: custom window would diverge from the signin page's freshness evaluation (C3 parity invariant I6).`
+- **Member-set derivation (R42)**: `grep -rn "requireRecentSession(" src/app/api/` → exactly the 3 sites above (verified in blast-radius audit); all converted, none missed. Indirect members: none (no aliased wrapper of `requireRecentSession` exists).
+- **Acceptance**: WebAuthn session with fresh `passkeyVerifiedAt` but old `createdAt` passes all 3 gates (today it fails — proves the switch is live).
+
+### C3 — signin page reauth panel for stale step-up API callbacks (L3)
+
+- **Location**: `src/app/[locale]/auth/signin/page.tsx` (authenticated branch), new client component (e.g. `src/components/auth/signin-reauth-panel.tsx`), shared-core extraction in `src/lib/auth/session/recent-current-auth-method.ts`, i18n keys in `messages/ja.json` + `messages/en.json`.
+- **Signatures**:
+  - `evaluateStepUpFreshness(sessionToken: string, options?: RequireRecentSessionOptions): Promise<"fresh" | "stale" | "invalid">` — extracted core; ONE `session.findUnique` selecting `{ provider, createdAt, passkeyVerifiedAt }` (F8: collapse the chooser's two round-trips; do not add a third). Branch semantics: `provider === "webauthn"` → `passkeyVerifiedAt` (a NULL `passkeyVerifiedAt` on a live row is `"stale"`, NOT `"invalid"` — matches today's 403 at `recent-passkey-verification.ts:51-52`); other providers → `createdAt`. Default windows stay the per-branch constants (`PASSKEY_VERIFICATION_WINDOW_MS` / `STEP_UP_WINDOW_MS` — both 15 min today; I6 parity silently assumes they remain equal, so the core must import both, not hardcode one).
+  - `requireRecentCurrentAuthMethod(req, options)` becomes a thin wrapper: no token → `unauthorized()`; `"invalid"` → `unauthorized()`; `"stale"` → `errorResponse(options.errorCode ?? SESSION_STEP_UP_REQUIRED, 403)` (**F4: MUST preserve caller-supplied `errorCode`** — `operator-tokens/route.ts:140` passes `OPERATOR_TOKEN_STALE_SESSION` and its client branches on that exact code); `"fresh"` → null. External contract unchanged for all ~45 existing callers.
+  - Page-side token extraction (**F5/S2**): MUST reuse the same cookie-name SSoT as `getSessionToken` (`getSessionCookieName` + `isSecureCookieFromAuthUrl` + basePath — three name shapes `authjs.session-token` / `__Secure-` / `__Host-`, see `src/lib/auth/session/cookie-name.ts:26-33`). Add a `cookies()`-store variant next to `getSessionToken` in `src/app/api/sessions/helpers.ts`; never hand-roll the name in the page.
+  - `SignInReauthPanel({ callbackHref, canUsePasskey })` — client component: passkey path runs `reauthenticateWithPasskey()` then `window.location.assign(callbackHref)` (basePath-QUALIFIED — client navigation gets no framework re-prepend; inverse of C1's stripped form); non-passkey path button runs `signOut({ callbackUrl: <signin with callbackUrl> })` (mirrors `RecentSessionRequiredDialog:38-46`). **F6**: the "sign in again" action is ALWAYS rendered (secondary action on the passkey branch) — a webauthn-provider user who deleted every credential after sign-in must not dead-end (the bootstrap invariant holds at session creation only; `DELETE /api/webauthn/credentials/[id]` has no last-credential guard). `canUsePasskey` is derived server-side: `provider === "webauthn"` AND user has ≥1 registered credential.
+  - **S1 hardening invariant**: `callbackHref` must always be the server-computed `resolved` (never re-derived client-side) and must match `^\/(?!\/)` — assert it in the panel (refuse navigation otherwise) and pin it in the panel test. Guards against future drift turning `window.location.assign` into a protocol-relative open redirect at a post-reauth high-trust moment.
+- **Behavior**: authenticated + `isApiCallbackUrl(resolved)` → evaluate freshness via shared core with **default options** → `"fresh"`: `nextRedirect(callbackUrlToHref(resolved))` (C1); `"stale"`: render `SignInReauthPanel`; `"invalid"`: fall through to the normal sign-in form (session row gone — cookie is a ghost).
+- **Invariants**:
+  - I6 (recovery-liveness, load-bearing): for every provider type, a stale-step-up API callback reaches a terminal recovery (passkey ceremony or re-sign-in) and the second pass satisfies the gate — no infinite loop. Gate parity is guaranteed by the shared core + default-options-only (see C2 forbidden pattern).
+  - I7 (no-self-logout): non-WebAuthn recovery uses `signOut({ callbackUrl })` — the standard Auth.js sequence; the new session exists only after the user actually signs in again. No manual session-row surgery.
+  - I8 (normal-signin-unaffected): non-API callbacks and unauthenticated visits render/redirect exactly as today.
+  - I9 (no-auto-signout): signOut fires only on explicit user gesture (button), never on page load.
+  - I10 (gesture-gated ceremony): passkey ceremony also starts from a button (WebAuthn user-activation requirements).
+- **Forbidden patterns**: `pattern: signOut\( in a useEffect/page-load path of the new panel — reason: logout CSRF / surprise logout (I9).` `pattern: session.update(...createdAt — reason: never fake recency by mutating createdAt.`
+- **Consumer-flow walkthrough**:
+  - Consumer *`/api/mcp/authorize` GET second pass* reads (via chooser) `passkeyVerifiedAt` (webauthn) / `createdAt` (other): the field the panel's action refreshed for that provider type is the field the gate reads. ✅
+  - Consumer *`/api/mcp/authorize/consent` POST* (native form POST from ConsentForm): stale path 303-redirects to authorize GET carrying validated OAuth params (`consent/route.ts:86-103`) → funnels into the same recovered flow. ✅
+  - Consumer *`/api/mobile/authorize` GET second pass*: same chooser semantics inside ASWebAuthenticationSession; panel renders in that browser context. ✅
+  - Consumer *`/dashboard/settings/sessions`*: after non-WebAuthn recovery, old session row is gone (signOut) and the new one is listed. ✅
+- **Acceptance**:
+  - WebAuthn stale: panel offers passkey (primary) + "sign in again" (secondary); ceremony updates `passkeyVerifiedAt`; navigate to callback; consent reached; session token unchanged.
+  - WebAuthn stale, zero credentials left: `canUsePasskey: false` → "sign in again" only; no dead-end (F6/I6).
+  - Non-WebAuthn stale: panel offers "sign in again"; signOut destroys old session; fresh sign-in; callback reached; consent reached; old session absent from sessions list.
+  - Ghost cookie (`"invalid"`): sign-in form renders (no crash, no loop).
+  - operator-tokens step-up still returns `OPERATOR_TOKEN_STALE_SESSION` in the 403 body (F4 regression case).
+  - i18n: panel strings exist in both `ja` and `en` (ja uses 保管庫-style domain language; no internal jargon like "step-up" in user-facing copy). Note (F7): the panel inherits the signin page's locale; `mobile/authorize` hardcodes `DEFAULT_LOCALE` in its bounce URL (`route.ts:105`) — pre-existing signin-page behavior, not a panel defect.
+
+### C4 — regression tests
+
+- **Location**: new `src/app/[locale]/auth/signin/page.basepath.test.ts` (separate file — the existing file's module-scope `BASE_PATH: ""` mock cannot be overridden per-test); route tests for the 3 gates; unit tests for `evaluateStepUpFreshness`; panel component test.
+- **Test-mechanism prerequisites (testing-expert-verified)**:
+  - (a) `vi.mock("next/navigation", () => ({ redirect: mockNextRedirect }))` with a **non-throwing spy** — without it both pre/post-fix throw `NEXT_REDIRECT` and the L1 test is green-on-both.
+  - (b) separate file with module-scope `vi.mock("@/lib/url-helpers", () => ({ BASE_PATH: "/passwd-sso", getAppOrigin: () => "https://example.com", ... }))` — mirrors the proven `callback-url-basepath.test.ts` pattern.
+  - (c) do NOT mock `@/lib/auth/session/callback-url` (exercise the real strip).
+- **Existing-test rewiring (T5/T6/T7 — budgeted, not incidental)**:
+  - T5: the 3 route test files (`mcp/authorize/route.test.ts:62-64,199-215`, `consent/route.test.ts:110-112,250-264`, `mobile/authorize/route.test.ts:69-71,222`) mock `@/lib/auth/session/step-up` and drive stale paths through `mockRequireRecentSession`. After the C2 swap the old mock is dead and the REAL chooser runs (unmocked prisma → loud failures). Each file: mock `@/lib/auth/session/recent-current-auth-method` (default resolve `null`), rewire stale tests to the chooser mock, assert `toHaveBeenCalledWith(req)` with NO options argument (enforces the C2 no-`maxAgeMs` forbidden pattern). Keep the consent 303-funnel test (`consent/route.test.ts:250-264`) as the funnel regression — don't duplicate (T12).
+  - T6: `recent-current-auth-method.test.ts:56-106` (5 delegation-assertion tests) breaks under the extraction — rewrite against the new architecture: wrapper maps core verdicts; core tested directly. Matrix: provider (`webauthn`/`google`/`null`) × (fresh/stale/no-row) PLUS `webauthn + passkeyVerifiedAt: null` → `"stale"`, options passthrough (`errorCode: OPERATOR_TOKEN_STALE_SESSION` appears in 403 body; `maxAgeMs` shifts the boundary on BOTH branches). Keep the security-load-bearing case "fresh `passkeyVerifiedAt` + old `createdAt` → fresh" non-mocked at the core level (security-review adjacent).
+  - T7: `page.test.ts` gains three new module mocks or its existing authenticated-branch tests break at import/run: `next/headers` (cookie store with session token), the freshness core (per-test `"fresh" | "stale" | "invalid"`), and `SignInReauthPanel` as a hoisted spy component (mirrors `mockSignInButton` at `page.test.ts:48-53`; the existing direct-invocation + `hasElement` tree-walker harness at `:74-87` fits the panel-render assertions).
+- **Cases**:
+  - L1: authenticated + fresh + API callbackUrl `https://example.com/passwd-sso/api/mcp/authorize?x=1` → `mockNextRedirect` called with `/api/mcp/authorize?x=1` (RED pre-fix: receives `/passwd-sso/api/mcp/authorize?x=1`). Non-API basePath case: `redirect({ href: "/dashboard?x=1", locale })` (I2 under non-empty basePath).
+  - **T8 (inverse-L1)**: stale + API callback under `BASE_PATH="/passwd-sso"` → panel prop `callbackHref === "/passwd-sso/api/mcp/authorize?x=1"` (basePath-QUALIFIED); empty-basePath file → `/api/mcp/authorize?x=1`. Without this, a stripped href in the panel 404s on basePath deployments with all tests green.
+  - L2: each of the 3 routes — chooser mock called; the "direct `requireRecentSession` import gone" check is the C2 forbidden-pattern grep, NOT a vitest assertion (T12).
+  - L3: freshness matrix per T6; signin page renders panel on stale / redirects on fresh / form on invalid; `canUsePasskey` prop cases (T11): webauthn-stale → `true` (with ≥1 credential), google-stale → `false`, webauthn-stale + zero credentials → `false`.
+  - Panel (`src/components/auth/signin-reauth-panel.test.tsx`, `// @vitest-environment jsdom` pragma — vitest env is `node` by default; template: `signout-button.test.tsx` with its `next-auth/react` signOut mock): no `signOut` on mount (I9); click → `signOut` with correct nested callbackUrl; passkey action → `reauthenticateWithPasskey` (mocked) then `window.location.assign(callbackHref)`; S1 `^\/(?!\/)` refusal case.
+- **Invariants**: I11 — L1 test RED on pre-fix code. I12 — every assertion fails if removed.
+- **Guard upkeep (T10)**: add `evaluateStepUpFreshness` to `STEPUP_PRIMITIVE_RE` in `scripts/checks/check-step-up-client-coverage.sh` (a future route calling the core directly and hand-rolling the 403 must not be invisible to the guard); sync the requireRecentSession-era comment text on the 3 exempt entries in `stepup-client-exempt.txt`.
+
+## Testing strategy
+
+- Unit: C4 (vitest). Full suite `npx vitest run` + `npx next build` (mandatory).
+- Guard: `scripts/checks/check-step-up-client-coverage.sh` must pass (C2/I5).
+- Manual verify (this deployment): re-run `passwd-sso login` and Claude Code MCP connect against the Tailscale deployment with a >15-min session; confirm consent page reached and token issued (both a passkey user and a non-passkey path if available).
+- Deferred: external-IdP E2E (`SC-E2E`).
+
+## Considerations & constraints
+
+- **Scope contract**:
+  - `SC1` — 15-min `STEP_UP_WINDOW_MS` sizing is policy, not in scope (this PR makes it recoverable, not longer/shorter).
+  - `SC2` — MCP discovery hardening (RFC 9728 root `oauth-protected-resource`, `WWW-Authenticate` on `/api/mcp` 401s, RFC 8414 path-aware well-known) — separate latent issue found during investigation; NOT the cause here (CLI does no discovery and hit the same defect). Future PR.
+  - `SC3` — Pre-existing `/passwd-sso//evil.com` → `//evil.com` normalization quirk in the signin NON-API branch (security-review adjacent; not exploitable through the API branch). Future hardening PR.
+  - `SC4` — IdP re-challenge enforcement (`prompt=login` for Google, `forceAuthn` for SAML) on the "sign in again" path. Today's in-app `RecentSessionRequiredDialog` shares the silent-re-federation posture; changing it is a product/security decision spanning both flows. Future PR. **Accepted residual (S3, security-review verbatim)**: an attacker with control of the victim's *browser* while an IdP SSO session is alive (unlocked machine, borrowed session) can satisfy step-up indefinitely and mint MCP/mobile tokens without any credential challenge. Crucially, a **stolen session cookie alone cannot** pass this recovery (attacker lacks the IdP session), so the step-up gate's primary threat model (cookie theft) is intact.
+  - `SC-E2E` — full basePath + provider Playwright harness (VC2/VC3).
+- **Out of scope**: schema changes (unified auth-verified field rejected — see Technical approach), `resolveCallbackUrl`/`callbackUrlToHref` internals, intl routing, proxy modules.
+- **Risk**: L1 trivial; L2 low (3-site call swap, guard-covered); L3 medium — touches signin UX; mitigated by I8 (only the authenticated+API-callback+stale intersection changes behavior, which today is a guaranteed 404/loop, i.e. strictly broken).
+
+## User operation scenarios
+
+1. **WebAuthn user, MCP connect, stale session**: authorize → signin → panel → passkey tap → back to authorize → consent → Allow → CLI/Claude Code token. Session kept.
+2. **Google/SAML user, MCP connect, stale session**: authorize → signin → panel → "sign in again" → signOut → real sign-in → authorize → consent → Allow. Old session revoked.
+3. **Consent-form stale mid-flight** (user sat on consent page >15 min): Allow POST → 303 to authorize → funnels into 1/2.
+4. **iOS OAuth**: same as 1/2 inside ASWebAuthenticationSession.
+5. **Fresh session** (≤15 min): authorize → consent directly; signin never involved. Unchanged.
+6. **Ordinary sign-in / non-API callback**: unchanged (I8).
+7. **Empty-basePath deployment**: L1 no-op; L2/L3 fix the live loop.
+
+## Go/No-Go Gate
+
+| ID  | Subject                                                             | Status |
+|-----|---------------------------------------------------------------------|--------|
+| C1  | signin API-callback strips basePath before nextRedirect (L1)        | locked |
+| C2  | 3 browser-redirect OAuth gates use requireRecentCurrentAuthMethod   | locked |
+| C3  | signin reauth panel + shared freshness core (L3)                    | locked |
+| C4  | regression tests (basePath, chooser, freshness, panel)              | locked |

--- a/docs/archive/review/fix-mcp-oauth-stepup-recovery-review.md
+++ b/docs/archive/review/fix-mcp-oauth-stepup-recovery-review.md
@@ -1,0 +1,105 @@
+# Plan Review: fix-mcp-oauth-stepup-recovery
+Date: 2026-07-09
+Review rounds: 2
+
+## Changes from Previous Round
+
+Round 1 reviewed a narrow one-line plan (URL doubling only). During round-1 assessment the
+functionality expert's loop finding (F1) was **confirmed live** (redirect-chain capture with a
+real session), triggering an essence shift: the plan was rewritten from a 1-line URL fix to a
+3-layer fix (L1 URL doubling / L2 non-canonical step-up primitive / L3 unrecoverable signin
+bounce). Round 2 reviewed the rewritten plan. All round-2 findings were incorporated into the
+plan text; no contract architecture changed.
+
+## Functionality Findings
+
+- **F1 Major (round 1) — RESOLVED**: fixing the URL alone exposes an infinite step-up redirect
+  loop (signin short-circuits authenticated users without re-auth; `createdAt` never refreshes).
+  Confirmed by live capture. → became L3 / C3 (reauth panel + recovery-liveness invariant I6).
+- **F2 Minor (round 1) — RESOLVED**: stale comment at signin page.tsx:55-58 → folded into C1.
+- **F3 Info (round 1)**: double `callbackUrlToHref` computation — negligible, noted.
+- **F4 Major (round 2) — RESOLVED**: wrapper mapping must preserve caller-supplied `errorCode`
+  (`operator-tokens` passes `OPERATOR_TOKEN_STALE_SESSION`; client branches on it) → C3
+  signature now `options.errorCode ?? SESSION_STEP_UP_REQUIRED` + acceptance case.
+- **F5 Minor (round 2) — RESOLVED**: page-side session-token extraction must reuse the
+  cookie-name SSoT (3 name shapes) → C3 mandates a `cookies()`-variant next to `getSessionToken`.
+- **F6 Minor (round 2) — RESOLVED**: webauthn-provider session with all credentials deleted
+  dead-ends a passkey-only panel → "sign in again" is always rendered; `canUsePasskey` derived
+  server-side (provider + credential count).
+- **F7 Info (round 2) — RECORDED**: panel inherits signin-page locale; mobile bounce hardcodes
+  DEFAULT_LOCALE — pre-existing, noted in C3 acceptance.
+- **F8 Info (round 2) — RESOLVED**: core collapses chooser's 2 DB queries into 1; per-branch
+  window constants imported (not hardcoded) — I6 parity assumes they stay equal.
+
+## Security Findings
+
+Round 1 (narrow plan): approve, no findings. Adversarial open-redirect traces of
+`resolveCallbackUrl` → `callbackUrlToHref` all safe; OAuth params preserved; auth gate unchanged.
+Adjacent: `/passwd-sso//evil.com` → `//evil.com` normalization residue in the NON-API branch —
+pre-existing, not exploitable via the API branch → tracked as SC3.
+
+Round 2 (3-layer plan): **no Critical; escalate false; verdict Go — net security improvement.**
+- Q1: C2 chooser switch is NOT a downgrade — `passkeyVerifiedAt` requires a live WebAuthn
+  assertion (stronger than `createdAt`, which silent IdP re-federation can refresh); absolute
+  session cap (`auth-adapter.ts:588,603`, measured from `createdAt`, non-rolling) bounds
+  webauthn session lifetime; operator/SA-token minting already uses the chooser.
+- Q2: panel is not a usable oracle (SOP, SameSite=Lax, XFO/CSP); signOut is button-gated AND
+  Auth.js-CSRF-protected; adversarial callbackUrls cannot reach the panel (`/api/` prefix
+  predicate excludes all `//`-residue outputs).
+- Q5: signOut nested callbackUrl safe end-to-end (Auth.js default redirect callback same-origin
+  + `resolveCallbackUrl` re-validation on return — two independent gates).
+- Q6: the 3-route call swap removes no check; ordering unchanged; consent's
+  validate-before-stale-bounce open-redirect ordering untouched.
+- **S1 Low — RESOLVED**: `callbackHref` structural invariant `^\/(?!\/)` + server-computed-only,
+  asserted in panel + test (drift hardening).
+- **S2 Low — RESOLVED**: page-side token extraction SSoT (same fix as F5).
+- **S3 Info — RESOLVED**: SC4 accepted-residual worst case recorded verbatim in the plan.
+
+## Testing Findings
+
+- **T1 Critical (round 1) — RESOLVED**: `next/navigation` `redirect` must be mocked as a
+  non-throwing spy or the L1 test is green-on-both → C4 prerequisite (a).
+- **T2 Major (round 1) — RESOLVED**: separate test file required (module-scope `BASE_PATH: ""`
+  mock is static) → C4 prerequisite (b), mirrors proven `callback-url-basepath.test.ts`.
+- **T3 Minor (round 1) — RESOLVED**: non-API branch assertion under non-empty basePath → C4.
+- **T4 Info (round 1)**: mock propagation empirically verified; don't mock callback-url;
+  framework basePath re-prepend correctly not unit-tested.
+- **T5 Major (round 2) — RESOLVED**: 3 route test files mock the OLD step-up module; C2 swap
+  breaks them loudly → rewiring enumerated in C4 (chooser mock, no-options assertion).
+- **T6 Major (round 2) — RESOLVED**: extraction breaks 5 chooser delegation tests; matrix must
+  add options passthrough + `webauthn + passkeyVerifiedAt: null` → `"stale"` → C4.
+- **T7 Major (round 2) — RESOLVED**: page tests need `next/headers` + freshness-core +
+  panel-spy mocks → C4.
+- **T8 Major (round 2) — RESOLVED**: inverse-L1 case — panel `callbackHref` asserted
+  basePath-QUALIFIED → C4.
+- **T9 Minor (round 2) — RESOLVED**: panel test jsdom pragma + `signout-button.test.tsx`
+  template → C4.
+- **T10 Minor (round 2) — RESOLVED**: guard verified safe for the swap; add
+  `evaluateStepUpFreshness` to `STEPUP_PRIMITIVE_RE`; sync exempt comments → C4 guard upkeep.
+- **T11 Minor (round 2) — RESOLVED**: `canUsePasskey` prop derivation cases → C4.
+- **T12 Info (round 2) — RECORDED**: reuse existing consent 303-funnel test; "import gone" is
+  the forbidden-pattern grep, not a vitest assertion.
+
+## Adjacent Findings
+
+- Security→Testing: keep the "fresh `passkeyVerifiedAt` + old `createdAt` → fresh" acceptance
+  non-mocked at the core level → folded into T6 resolution.
+- Testing→guard-design: `evaluateStepUpFreshness` not in the primitive regex → T10, resolved.
+- Security round 1: SC3 (`//` residue hardening) routed to a future PR — tracked in plan scope
+  contract.
+
+## Resolution Status
+
+All Critical/Major findings incorporated into the plan. No skipped/deferred findings except
+scope-contract items (SC1-SC4, SC-E2E) each carrying owner + tracking in the plan. Go/No-Go:
+C1-C4 locked.
+
+## Recurring Issue Check
+
+Round-2 experts ran targeted verification rather than the full R1-R42 sweep (focused bug-fix
+plan; the blast-radius audit substituted for the codebase-awareness obligation). Notable:
+- R42 member-set derivation: performed for C2 (3 gate sites derived from the defining primitive
+  grep; verified exactly 3, no aliases) and for the step-up guard primitive set (T10).
+- R12-class (i18n key coverage): C3 acceptance requires ja/en keys; ja domain-language rule
+  applied (no internal jargon).
+- R29 (spec citations): none introduced.

--- a/docs/archive/review/fix-mcp-oauth-stepup-recovery-review.md
+++ b/docs/archive/review/fix-mcp-oauth-stepup-recovery-review.md
@@ -1,6 +1,29 @@
 # Plan Review: fix-mcp-oauth-stepup-recovery
 Date: 2026-07-09
-Review rounds: 2
+Review rounds: 2 (plan) + 1 (code, Phase 3)
+
+## Phase 3 Code Review (implemented diff, 3 experts)
+
+**Verdict: no Critical. 1 Major + 2 Low + 2 Minor, all fixed in-branch; 4 Info recorded.**
+Verified clean: C1-C4 contract conformance, forbidden patterns absent, gate ordering
+unchanged at all 3 routes, fail-closed mappings byte-match the pre-refactor contract,
+no token logging, cookie-name SSoT preserved (no legacy-name fallback), `tsc --noEmit`
+exit 0, step-up guard exit 0, full suite + build green.
+
+| ID | Sev | Finding | Resolution |
+|----|-----|---------|------------|
+| F-P3-1 | Major | Panel handlers lacked try/finally — a network-level rejection stranded both recovery buttons disabled (violates I6 liveness) | FIXED: try/catch/finally in both handlers + regression test (ceremony rejects → buttons re-enabled) |
+| S-P3-1 | Low | Panel S1 regex allowed `/\host` (browsers normalize `\`→`/` → protocol-relative); unreachable through the only caller today, but S1's own drift rationale demands it | FIXED: `/^\/(?![/\\])/` + refusal test |
+| S-P3-3 | Info→hardening | `canRecoverSessionWithPasskey` didn't bind sessionToken↔userId | FIXED: row.userId comparison + mismatch test |
+| T-P3-1 | Minor | Page tests didn't assert argument plumbing across the mocked token seam | FIXED: `toHaveBeenCalledWith("sess-1")` / `("sess-1","u1")` in fresh+stale cases (both files) |
+| T-P3-2 | Minor | F4 errorCode contract pinned only wrapper-side | FIXED: operator-tokens route test now asserts the gate is CALLED WITH `{ errorCode: OPERATOR_TOKEN_STALE_SESSION }` |
+| S-P3-2 | Low (pre-existing) | `resolveCallbackUrl` can emit `//host` for `/.//host` inputs — verified NOT exploitable through any sink in this diff | Deferred: already tracked as plan `SC3`; fix recommendation recorded (reject `pathname.startsWith("//")` on output) |
+| F-P3-2 | Info | `requireRecentSession` / `requireRecentPasskeyVerification` are now production-dead exports (constants/types still live; guard still watches the names) | Accepted: kept deliberately — the guard regex references them and removal is churn without behavior value. TODO(fix-mcp-oauth-stepup-recovery): delete or repoint `src/__tests__/db-integration/require-recent-session.integration.test.ts` to the live chooser path in a cleanup PR |
+| T-P3-3 | Info | Panel test replaces window.location without restore (per-file jsdom isolation makes it safe) | Accepted as-is |
+| T-P3-4 | Info | provider-null fresh case omitted (same branch as google); route tests pin arity not identity (arity is the load-bearing part) | Accepted as-is |
+
+Post-fix verification: targeted 70 tests green, full suite 12,159 passed / 1 skipped,
+`npx next build` exit 0 (0 type errors), step-up coverage guard exit 0.
 
 ## Changes from Previous Round
 

--- a/messages/en/Auth.json
+++ b/messages/en/Auth.json
@@ -34,5 +34,7 @@
   "reauthCancelled": "Passkey verification was cancelled.",
   "recentSessionTitle": "Sign in again to continue",
   "recentSessionDescription": "This action requires a more recent browser sign-in. Sign in again, then retry.",
-  "recentSessionAction": "Sign in again"
+  "recentSessionAction": "Sign in again",
+  "reauthPanelTitle": "Verify your identity to continue",
+  "reauthPanelDescription": "Approving this app connection requires a recent identity check. Verify to continue right where you left off."
 }

--- a/messages/ja/Auth.json
+++ b/messages/ja/Auth.json
@@ -34,5 +34,7 @@
   "reauthCancelled": "Passkey による本人確認をキャンセルしました。",
   "recentSessionTitle": "続行するには再サインインが必要です",
   "recentSessionDescription": "この操作には、より新しいブラウザサインインが必要です。再サインインしてから、もう一度お試しください。",
-  "recentSessionAction": "再サインイン"
+  "recentSessionAction": "再サインイン",
+  "reauthPanelTitle": "続行するには本人確認が必要です",
+  "reauthPanelDescription": "アプリ連携の許可には、直近の本人確認が必要です。本人確認のうえ、そのまま続行できます。"
 }

--- a/scripts/__tests__/check-step-up-client-coverage.test.mjs
+++ b/scripts/__tests__/check-step-up-client-coverage.test.mjs
@@ -48,6 +48,10 @@ const STEPUP_CALL =
 // class is "returns the 403 code", not "calls one named function").
 const STEPUP_CALL_SESSION =
   "  const stepUp = await requireRecentSession(req); if (stepUp) return stepUp;";
+// A third primitive: the freshness core itself, called directly rather than
+// through one of the wrapper gates above.
+const STEPUP_CALL_FRESHNESS =
+  "  const freshness = await evaluateStepUpFreshness(token); if (freshness !== \"fresh\") return stepUpResponse();";
 
 let root;
 let apiDir;
@@ -315,6 +319,17 @@ describe("check-step-up-client-coverage.sh", () => {
     // returns SESSION_STEP_UP_REQUIRED — must be seen by the guard. Without a
     // marker it fails server completeness, proving the primitive is in the set.
     writeRoute("mcp/authorize", `${STEPUP_CALL_SESSION}\n`); // no marker line
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("SERVER_MARKER_MISSING");
+  });
+
+  it("(ix-freshness) discovers evaluateStepUpFreshness as a gate primitive (SERVER_MARKER_MISSING without a marker)", () => {
+    // A route gated by evaluateStepUpFreshness — the freshness core, called
+    // directly rather than through a wrapper gate — must be seen by the guard.
+    // Without a marker it fails server completeness, proving the primitive is
+    // in the set.
+    writeRoute("mcp/authorize", `${STEPUP_CALL_FRESHNESS}\n`); // no marker line
     const { exitCode, stdout } = runGuard();
     expect(exitCode).toBe(1);
     expect(stdout).toContain("SERVER_MARKER_MISSING");

--- a/scripts/checks/check-step-up-client-coverage.sh
+++ b/scripts/checks/check-step-up-client-coverage.sh
@@ -107,9 +107,12 @@ BRANCH_TOKEN_RE='SESSION_STEP_UP_REQUIRED|handleStepUpError[(]|throwIfStepUp[(]|
 #   requireRecentCurrentAuthMethod( — reauth with the session's current method
 #   requireRecentSession(           — recent-session gate (default errorCode = 403 code)
 #   requireRecentPasskeyVerification( — recent passkey gate (same default)
+#   evaluateStepUpFreshness(        — token-parameterized freshness core; a route
+#                                     calling it directly and hand-rolling the 403
+#                                     must not be invisible to this guard
 # ERE with a leading boundary group; used both to LIST gated files and to find
 # each gated CALL line. Keep in sync with the primitives above.
-STEPUP_PRIMITIVE_RE='(^|[^A-Za-z0-9_])(requireRecentCurrentAuthMethod|requireRecentSession|requireRecentPasskeyVerification)\('
+STEPUP_PRIMITIVE_RE='(^|[^A-Za-z0-9_])(requireRecentCurrentAuthMethod|requireRecentSession|requireRecentPasskeyVerification|evaluateStepUpFreshness)\('
 
 fail=0
 

--- a/scripts/checks/stepup-client-exempt.txt
+++ b/scripts/checks/stepup-client-exempt.txt
@@ -11,7 +11,7 @@
 # SENTINEL `@browser-redirect`: a route reached ONLY by browser navigation
 # (OAuth/mobile authorize GET, consent form POST) has no fetch-based UI caller to
 # carry a client marker. Its stale-session recovery is a SERVER-SIDE redirect: the
-# handler converts requireRecentSession's 403 into a redirect back through sign-in
+# handler converts requireRecentCurrentAuthMethod's 403 into a redirect back through sign-in
 # (GET routes → 307/302 to /api/auth/signin or /{locale}/auth/signin; consent POST
 # → 303 to the authorize GET, which then redirects to sign-in), so the browser
 # re-authenticates and returns on the second pass instead of stranding on a JSON
@@ -23,8 +23,8 @@
 # recover via handleStepUpError, not this escape hatch.
 
 ext-bridge-code-post   EXTENSION_CONNECT_ERROR_CODE.SESSION_STEP_UP_REQUIRED  # auto-extension-connect.tsx surfaces step-up via the extension-connect error channel, not the standard API error body
-mcp-authorize-get              @browser-redirect  # OAuth authorize GET (browser nav); stale-session 403 redirects (307) to /api/auth/signin with callbackUrl back here, no fetch UI caller
-mcp-authorize-consent-post     @browser-redirect  # OAuth consent native form POST; stale-session 403 redirects (303) to the authorize GET which re-auths, no fetch UI caller
-mobile-authorize-get           @browser-redirect  # mobile OAuth authorize GET (ASWebAuthenticationSession browser nav); stale-session 403 redirects (302) to sign-in, no fetch UI caller
+mcp-authorize-get              @browser-redirect  # OAuth authorize GET (browser nav); stale-session 403 redirects (307) to sign-in, whose reauth panel recovers (passkey ceremony or re-sign-in), no fetch UI caller
+mcp-authorize-consent-post     @browser-redirect  # OAuth consent native form POST; stale-session 403 redirects (303) to the authorize GET, which funnels into the sign-in reauth panel, no fetch UI caller
+mobile-authorize-get           @browser-redirect  # mobile OAuth authorize GET (ASWebAuthenticationSession browser nav); stale-session 403 redirects (302) to sign-in, whose reauth panel recovers, no fetch UI caller
 team-confirm-key-post  KEY_DISTRIBUTE_INTERVAL_MS  # team-vault-core.tsx background setInterval poller; no awaiting user gesture, retries on next poll (SC3)
 operator-tokens-post   OPERATOR_TOKEN_STALE_SESSION  # operator-token-card.tsx has a bespoke multi-state reauth flow (limit-exceeded vs stale vs generic retry) and does not use the shared inline-reauth hook (SC4)

--- a/src/__tests__/api/mcp/authorize.test.ts
+++ b/src/__tests__/api/mcp/authorize.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextResponse } from "next/server";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 
-const { mockAuth, mockMcpClientFindFirst, mockUserFindUnique, mockWithBypassRls, mockServerAppUrl, mockDetectLocale, mockRateLimiterCheck, mockRequireRecentSession, mockEmitFailClosed, mockCheckRateLimitOrFail, mockDerivePasskeyState } =
+const { mockAuth, mockMcpClientFindFirst, mockUserFindUnique, mockWithBypassRls, mockServerAppUrl, mockDetectLocale, mockRateLimiterCheck, mockRequireRecentCurrentAuthMethod, mockEmitFailClosed, mockCheckRateLimitOrFail, mockDerivePasskeyState } =
   vi.hoisted(() => ({
     mockAuth: vi.fn(),
     mockMcpClientFindFirst: vi.fn(),
@@ -11,7 +11,7 @@ const { mockAuth, mockMcpClientFindFirst, mockUserFindUnique, mockWithBypassRls,
     mockServerAppUrl: vi.fn((path: string) => `http://localhost:3000${path}`),
     mockDetectLocale: vi.fn(() => "en"),
     mockRateLimiterCheck: vi.fn().mockResolvedValue({ allowed: true }),
-    mockRequireRecentSession: vi.fn().mockResolvedValue(null),
+    mockRequireRecentCurrentAuthMethod: vi.fn().mockResolvedValue(null),
     mockEmitFailClosed: vi.fn(),
     // Default: helper returns null → route proceeds. Per-test overrides set
     // it to return a response when the test exercises the rate-limited path.
@@ -20,8 +20,8 @@ const { mockAuth, mockMcpClientFindFirst, mockUserFindUnique, mockWithBypassRls,
   }));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
-vi.mock("@/lib/auth/session/step-up", () => ({
-  requireRecentSession: mockRequireRecentSession,
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: mockRequireRecentCurrentAuthMethod,
 }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {

--- a/src/app/[locale]/auth/signin/page.basepath.test.ts
+++ b/src/app/[locale]/auth/signin/page.basepath.test.ts
@@ -168,6 +168,12 @@ describe("SignInPage under BASE_PATH=/passwd-sso", () => {
       ),
     ).toBe(true);
     expect(mockNextRedirect).not.toHaveBeenCalled();
+    // Token plumbing: token + authenticated user id, in that order.
+    expect(mockEvaluateStepUpFreshness).toHaveBeenCalledWith("sess-1");
+    expect(mockCanRecoverSessionWithPasskey).toHaveBeenCalledWith(
+      "sess-1",
+      "u1",
+    );
   });
 
   it("still strips basePath+locale for the non-API intl redirect (I2)", async () => {

--- a/src/app/[locale]/auth/signin/page.basepath.test.ts
+++ b/src/app/[locale]/auth/signin/page.basepath.test.ts
@@ -1,0 +1,187 @@
+/**
+ * SignInPage — basePath regression tests (separate file).
+ *
+ * The main page.test.ts mocks `@/lib/url-helpers` with `BASE_PATH: ""` at
+ * module scope, which is exactly why the /passwd-sso/passwd-sso/api/...
+ * doubling shipped unnoticed: the doubling cannot manifest under an empty
+ * basePath. vi.mock is hoisted/static — one factory per module per file —
+ * so the non-empty-basePath matrix lives here (mirrors the proven
+ * callback-url-basepath.test.ts pattern).
+ *
+ * Covers:
+ *  - L1: API callback redirect passes the basePath-STRIPPED path to Next's
+ *    redirect() (Next re-prepends basePath; qualified input doubles it).
+ *  - inverse-L1 (T8): the reauth panel receives the basePath-QUALIFIED path
+ *    (window.location.assign gets no framework re-prepend).
+ *  - I2: the non-API branch still strips basePath+locale for the intl
+ *    redirect.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockAuth, mockRedirect, mockGetTranslations, mockSetRequestLocale } =
+  vi.hoisted(() => ({
+    mockAuth: vi.fn(),
+    mockRedirect: vi.fn(),
+    mockGetTranslations: vi.fn(),
+    mockSetRequestLocale: vi.fn(),
+  }));
+const {
+  mockNextRedirect,
+  mockEvaluateStepUpFreshness,
+  mockCanRecoverSessionWithPasskey,
+  mockGetSessionTokenFromCookieStore,
+  mockSignInReauthPanel,
+} = vi.hoisted(() => ({
+  // Non-throwing spy — the real redirect throws NEXT_REDIRECT, which would
+  // make the doubled and fixed argument indistinguishable (green-on-both).
+  mockNextRedirect: vi.fn(),
+  mockEvaluateStepUpFreshness: vi.fn(),
+  mockCanRecoverSessionWithPasskey: vi.fn(),
+  mockGetSessionTokenFromCookieStore: vi.fn(),
+  mockSignInReauthPanel: vi.fn(() => null),
+}));
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/i18n/navigation", () => ({ redirect: mockRedirect }));
+vi.mock("next/navigation", () => ({ redirect: mockNextRedirect }));
+vi.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ get: () => undefined }),
+}));
+vi.mock("next-intl/server", () => ({
+  getTranslations: mockGetTranslations,
+  setRequestLocale: mockSetRequestLocale,
+}));
+// The load-bearing difference from page.test.ts: a NON-EMPTY basePath.
+// callback-url.ts binds BASE_PATH from this module at import time.
+vi.mock("@/lib/url-helpers", () => ({
+  BASE_PATH: "/passwd-sso",
+  getAppOrigin: () => "https://example.com",
+}));
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  evaluateStepUpFreshness: mockEvaluateStepUpFreshness,
+  canRecoverSessionWithPasskey: mockCanRecoverSessionWithPasskey,
+}));
+vi.mock("@/app/api/sessions/helpers", () => ({
+  getSessionTokenFromCookieStore: mockGetSessionTokenFromCookieStore,
+}));
+vi.mock("@/components/auth/signin-reauth-panel", () => ({
+  SignInReauthPanel: mockSignInReauthPanel,
+}));
+const { mockParseAllowedGoogleDomains } = vi.hoisted(() => ({
+  mockParseAllowedGoogleDomains: vi.fn<() => string[]>(() => []),
+}));
+vi.mock("@/lib/url/google-domain", () => ({
+  parseAllowedGoogleDomains: mockParseAllowedGoogleDomains,
+}));
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children }: { children: unknown }) => children,
+  CardContent: ({ children }: { children: unknown }) => children,
+  CardHeader: ({ children }: { children: unknown }) => children,
+  CardTitle: ({ children }: { children: unknown }) => children,
+}));
+vi.mock("@/components/ui/separator", () => ({
+  Separator: () => null,
+}));
+vi.mock("@/components/auth/signin-button", () => ({
+  SignInButton: () => null,
+}));
+vi.mock("lucide-react", () => ({
+  Shield: () => null,
+  ChevronDown: () => null,
+}));
+vi.mock("@/components/auth/security-key-signin-form", () => ({
+  SecurityKeySignInForm: () => null,
+}));
+vi.mock("@/components/ui/app-icon", () => ({
+  AppIcon: () => null,
+}));
+
+import SignInPage from "./page";
+
+const makeParams = (locale = "ja") => Promise.resolve({ locale });
+const makeSearchParams = (callbackUrl?: string) =>
+  Promise.resolve(callbackUrl !== undefined ? { callbackUrl } : {});
+
+function hasElement(
+  node: unknown,
+  predicate: (el: { type: unknown; props: Record<string, unknown> }) => boolean,
+): boolean {
+  if (node == null || typeof node !== "object") return false;
+  const el = node as { type?: unknown; props?: Record<string, unknown> };
+  if (el.type && el.props && predicate(el as { type: unknown; props: Record<string, unknown> }))
+    return true;
+  const children = el.props?.children;
+  if (children == null) return false;
+  const arr = Array.isArray(children) ? children : [children];
+  return arr.some((child: unknown) => hasElement(child, predicate));
+}
+
+describe("SignInPage under BASE_PATH=/passwd-sso", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTranslations.mockResolvedValue((key: string) => key);
+    mockSetRequestLocale.mockReturnValue(undefined);
+    mockRedirect.mockReturnValue(undefined);
+    mockAuth.mockResolvedValue({ user: { id: "u1" } });
+    mockGetSessionTokenFromCookieStore.mockReturnValue("sess-1");
+    mockEvaluateStepUpFreshness.mockResolvedValue("fresh");
+    mockCanRecoverSessionWithPasskey.mockResolvedValue(false);
+    mockSignInReauthPanel.mockReturnValue(null);
+  });
+
+  it("passes the basePath-STRIPPED path to Next redirect for a fresh API callback (L1)", async () => {
+    await SignInPage({
+      params: makeParams("ja"),
+      searchParams: makeSearchParams(
+        "https://example.com/passwd-sso/api/mcp/authorize?x=1",
+      ),
+    });
+
+    // Pre-fix code passed the basePath-qualified path straight through
+    // (/passwd-sso/api/mcp/authorize?x=1) and Next re-prepended basePath →
+    // /passwd-sso/passwd-sso/api/... → 404. The stripped form is the fix.
+    expect(mockNextRedirect).toHaveBeenCalledWith("/api/mcp/authorize?x=1");
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("passes the basePath-QUALIFIED path to the reauth panel for a stale API callback (inverse-L1)", async () => {
+    mockEvaluateStepUpFreshness.mockResolvedValue("stale");
+    mockCanRecoverSessionWithPasskey.mockResolvedValue(true);
+
+    const result = await SignInPage({
+      params: makeParams("ja"),
+      searchParams: makeSearchParams(
+        "https://example.com/passwd-sso/api/mcp/authorize?x=1",
+      ),
+    });
+
+    // window.location.assign gets NO framework basePath re-prepend — the
+    // panel must receive the qualified path (sign-flip of the L1 case).
+    expect(
+      hasElement(
+        result,
+        (el) =>
+          el.type === mockSignInReauthPanel &&
+          el.props.callbackHref === "/passwd-sso/api/mcp/authorize?x=1" &&
+          el.props.canUsePasskey === true,
+      ),
+    ).toBe(true);
+    expect(mockNextRedirect).not.toHaveBeenCalled();
+  });
+
+  it("still strips basePath+locale for the non-API intl redirect (I2)", async () => {
+    await SignInPage({
+      params: makeParams("ja"),
+      searchParams: makeSearchParams(
+        "https://example.com/passwd-sso/ja/dashboard?x=1",
+      ),
+    });
+
+    expect(mockRedirect).toHaveBeenCalledWith({
+      href: "/dashboard?x=1",
+      locale: "ja",
+    });
+    expect(mockNextRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/[locale]/auth/signin/page.basepath.test.ts
+++ b/src/app/[locale]/auth/signin/page.basepath.test.ts
@@ -61,6 +61,7 @@ vi.mock("@/lib/url-helpers", () => ({
 vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
   evaluateStepUpFreshness: mockEvaluateStepUpFreshness,
   canRecoverSessionWithPasskey: mockCanRecoverSessionWithPasskey,
+  STEP_UP_FRESHNESS: { FRESH: "fresh", STALE: "stale", INVALID: "invalid" },
 }));
 vi.mock("@/app/api/sessions/helpers", () => ({
   getSessionTokenFromCookieStore: mockGetSessionTokenFromCookieStore,

--- a/src/app/[locale]/auth/signin/page.test.ts
+++ b/src/app/[locale]/auth/signin/page.test.ts
@@ -318,47 +318,18 @@ describe("SignInPage", () => {
   });
 
   describe("provider button visibility", () => {
-    // Keys checked by the page: ID + SECRET for Google, URL + ID + SECRET for SAML
-    const envKeys = [
-      "AUTH_GOOGLE_ID",
-      "AUTH_GOOGLE_SECRET",
-      "JACKSON_URL",
-      "AUTH_JACKSON_ID",
-      "AUTH_JACKSON_SECRET",
-    ] as const;
-    const saved: Record<string, string | undefined> = {};
-
-    beforeEach(() => {
-      for (const k of envKeys) saved[k] = process.env[k];
-    });
-
-    afterEach(() => {
-      for (const k of envKeys) {
-        if (saved[k] !== undefined) process.env[k] = saved[k];
-        else delete process.env[k];
-      }
-    });
-
+    // Keys checked by the page: ID + SECRET for Google, URL + ID + SECRET for
+    // SAML. vi.stubEnv with "" reads as falsy for the page's !!(...) checks;
+    // afterEach unstubs are wired globally in setup.ts.
     function setGoogle(enabled: boolean) {
-      if (enabled) {
-        process.env.AUTH_GOOGLE_ID = "test-id";
-        process.env.AUTH_GOOGLE_SECRET = "test-secret";
-      } else {
-        delete process.env.AUTH_GOOGLE_ID;
-        delete process.env.AUTH_GOOGLE_SECRET;
-      }
+      vi.stubEnv("AUTH_GOOGLE_ID", enabled ? "test-id" : "");
+      vi.stubEnv("AUTH_GOOGLE_SECRET", enabled ? "test-secret" : "");
     }
 
     function setSaml(enabled: boolean) {
-      if (enabled) {
-        process.env.JACKSON_URL = "http://localhost:5225";
-        process.env.AUTH_JACKSON_ID = "test-jackson-id";
-        process.env.AUTH_JACKSON_SECRET = "test-jackson-secret";
-      } else {
-        delete process.env.JACKSON_URL;
-        delete process.env.AUTH_JACKSON_ID;
-        delete process.env.AUTH_JACKSON_SECRET;
-      }
+      vi.stubEnv("JACKSON_URL", enabled ? "http://localhost:5225" : "");
+      vi.stubEnv("AUTH_JACKSON_ID", enabled ? "test-jackson-id" : "");
+      vi.stubEnv("AUTH_JACKSON_SECRET", enabled ? "test-jackson-secret" : "");
     }
 
     function hasProvider(tree: unknown, provider: string) {
@@ -413,8 +384,8 @@ describe("SignInPage", () => {
     });
 
     it("hides Google button when AUTH_GOOGLE_SECRET is missing", async () => {
-      process.env.AUTH_GOOGLE_ID = "test-id";
-      delete process.env.AUTH_GOOGLE_SECRET;
+      vi.stubEnv("AUTH_GOOGLE_ID", "test-id");
+      vi.stubEnv("AUTH_GOOGLE_SECRET", "");
       setSaml(false);
       mockAuth.mockResolvedValue(null);
 
@@ -425,9 +396,9 @@ describe("SignInPage", () => {
 
     it("hides SSO button when AUTH_JACKSON_SECRET is missing", async () => {
       setGoogle(false);
-      process.env.JACKSON_URL = "http://localhost:5225";
-      process.env.AUTH_JACKSON_ID = "test-jackson-id";
-      delete process.env.AUTH_JACKSON_SECRET;
+      vi.stubEnv("JACKSON_URL", "http://localhost:5225");
+      vi.stubEnv("AUTH_JACKSON_ID", "test-jackson-id");
+      vi.stubEnv("AUTH_JACKSON_SECRET", "");
       mockAuth.mockResolvedValue(null);
 
       const result = await SignInPage({ params: makeParams(), searchParams: makeSearchParams() });
@@ -437,24 +408,13 @@ describe("SignInPage", () => {
   });
 
   describe("Google multi-domain hint", () => {
-    const googleEnvKeys = ["AUTH_GOOGLE_ID", "AUTH_GOOGLE_SECRET"] as const;
-    const savedGoogle: Record<string, string | undefined> = {};
-
-    beforeEach(() => {
-      for (const k of googleEnvKeys) savedGoogle[k] = process.env[k];
-    });
-
     afterEach(() => {
-      for (const k of googleEnvKeys) {
-        if (savedGoogle[k] !== undefined) process.env[k] = savedGoogle[k];
-        else delete process.env[k];
-      }
       mockParseAllowedGoogleDomains.mockReturnValue([]);
     });
 
     it("shows hint when multiple Google Workspace domains are configured", async () => {
-      process.env.AUTH_GOOGLE_ID = "test-id";
-      process.env.AUTH_GOOGLE_SECRET = "test-secret";
+      vi.stubEnv("AUTH_GOOGLE_ID", "test-id");
+      vi.stubEnv("AUTH_GOOGLE_SECRET", "test-secret");
       mockParseAllowedGoogleDomains.mockReturnValue(["example.com", "corp.example.com"]);
       mockAuth.mockResolvedValue(null);
 
@@ -466,8 +426,8 @@ describe("SignInPage", () => {
     });
 
     it("does not show hint when single domain is configured", async () => {
-      process.env.AUTH_GOOGLE_ID = "test-id";
-      process.env.AUTH_GOOGLE_SECRET = "test-secret";
+      vi.stubEnv("AUTH_GOOGLE_ID", "test-id");
+      vi.stubEnv("AUTH_GOOGLE_SECRET", "test-secret");
       mockParseAllowedGoogleDomains.mockReturnValue(["example.com"]);
       mockAuth.mockResolvedValue(null);
 
@@ -479,8 +439,8 @@ describe("SignInPage", () => {
     });
 
     it("does not show hint when no domains are configured", async () => {
-      process.env.AUTH_GOOGLE_ID = "test-id";
-      process.env.AUTH_GOOGLE_SECRET = "test-secret";
+      vi.stubEnv("AUTH_GOOGLE_ID", "test-id");
+      vi.stubEnv("AUTH_GOOGLE_SECRET", "test-secret");
       mockParseAllowedGoogleDomains.mockReturnValue([]);
       mockAuth.mockResolvedValue(null);
 

--- a/src/app/[locale]/auth/signin/page.test.ts
+++ b/src/app/[locale]/auth/signin/page.test.ts
@@ -225,6 +225,8 @@ describe("SignInPage", () => {
         "/api/mcp/authorize?client_id=c&x=1",
       );
       expect(mockRedirect).not.toHaveBeenCalled();
+      // Token plumbing: the freshness core receives the cookie-store token.
+      expect(mockEvaluateStepUpFreshness).toHaveBeenCalledWith("sess-1");
     });
 
     it("renders the reauth panel (no redirect) when the session is stale", async () => {
@@ -247,6 +249,12 @@ describe("SignInPage", () => {
             el.props.canUsePasskey === true,
         ),
       ).toBe(true);
+      // Token plumbing: token + authenticated user id, in that order.
+      expect(mockEvaluateStepUpFreshness).toHaveBeenCalledWith("sess-1");
+      expect(mockCanRecoverSessionWithPasskey).toHaveBeenCalledWith(
+        "sess-1",
+        "u1",
+      );
     });
 
     it("passes canUsePasskey=false to the panel when the session cannot recover via passkey", async () => {

--- a/src/app/[locale]/auth/signin/page.test.ts
+++ b/src/app/[locale]/auth/signin/page.test.ts
@@ -17,9 +17,28 @@ const { mockAuth, mockRedirect, mockGetTranslations, mockSetRequestLocale } =
     mockGetTranslations: vi.fn(),
     mockSetRequestLocale: vi.fn(),
   }));
+const {
+  mockNextRedirect,
+  mockEvaluateStepUpFreshness,
+  mockCanRecoverSessionWithPasskey,
+  mockGetSessionTokenFromCookieStore,
+  mockSignInReauthPanel,
+} = vi.hoisted(() => ({
+  // Non-throwing spy: the real next/navigation redirect throws NEXT_REDIRECT,
+  // which would make pre/post-fix behavior indistinguishable in assertions.
+  mockNextRedirect: vi.fn(),
+  mockEvaluateStepUpFreshness: vi.fn(),
+  mockCanRecoverSessionWithPasskey: vi.fn(),
+  mockGetSessionTokenFromCookieStore: vi.fn(),
+  mockSignInReauthPanel: vi.fn(() => null),
+}));
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
 vi.mock("@/i18n/navigation", () => ({ redirect: mockRedirect }));
+vi.mock("next/navigation", () => ({ redirect: mockNextRedirect }));
+vi.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ get: () => undefined }),
+}));
 vi.mock("next-intl/server", () => ({
   getTranslations: mockGetTranslations,
   setRequestLocale: mockSetRequestLocale,
@@ -27,6 +46,16 @@ vi.mock("next-intl/server", () => ({
 vi.mock("@/lib/url-helpers", () => ({
   BASE_PATH: "",
   getAppOrigin: () => "https://example.com",
+}));
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  evaluateStepUpFreshness: mockEvaluateStepUpFreshness,
+  canRecoverSessionWithPasskey: mockCanRecoverSessionWithPasskey,
+}));
+vi.mock("@/app/api/sessions/helpers", () => ({
+  getSessionTokenFromCookieStore: mockGetSessionTokenFromCookieStore,
+}));
+vi.mock("@/components/auth/signin-reauth-panel", () => ({
+  SignInReauthPanel: mockSignInReauthPanel,
 }));
 const { mockParseAllowedGoogleDomains } = vi.hoisted(() => ({
   mockParseAllowedGoogleDomains: vi.fn<() => string[]>(() => []),
@@ -88,9 +117,14 @@ function hasElement(
 
 describe("SignInPage", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mockGetTranslations.mockResolvedValue(fakeT);
     mockSetRequestLocale.mockReturnValue(undefined);
     mockRedirect.mockReturnValue(undefined);
+    mockGetSessionTokenFromCookieStore.mockReturnValue("sess-1");
+    mockEvaluateStepUpFreshness.mockResolvedValue("fresh");
+    mockCanRecoverSessionWithPasskey.mockResolvedValue(false);
+    mockSignInReauthPanel.mockReturnValue(null);
   });
 
   it("redirects to /dashboard when user is authenticated", async () => {
@@ -168,6 +202,99 @@ describe("SignInPage", () => {
     expect(mockRedirect).toHaveBeenCalledWith({
       href: "/dashboard",
       locale: "en",
+    });
+  });
+
+  describe("step-up-gated API callback (MCP / mobile OAuth)", () => {
+    const API_CALLBACK = "https://example.com/api/mcp/authorize?client_id=c&x=1";
+
+    beforeEach(() => {
+      mockAuth.mockResolvedValue({ user: { id: "u1" } });
+    });
+
+    it("redirects with the basePath/locale-stripped path when the session is fresh", async () => {
+      mockEvaluateStepUpFreshness.mockResolvedValue("fresh");
+
+      await SignInPage({
+        params: makeParams("ja"),
+        searchParams: makeSearchParams(API_CALLBACK),
+      });
+
+      // Plain Next redirect (no locale injection); Next re-prepends basePath.
+      expect(mockNextRedirect).toHaveBeenCalledWith(
+        "/api/mcp/authorize?client_id=c&x=1",
+      );
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it("renders the reauth panel (no redirect) when the session is stale", async () => {
+      mockEvaluateStepUpFreshness.mockResolvedValue("stale");
+      mockCanRecoverSessionWithPasskey.mockResolvedValue(true);
+
+      const result = await SignInPage({
+        params: makeParams("ja"),
+        searchParams: makeSearchParams(API_CALLBACK),
+      });
+
+      expect(mockNextRedirect).not.toHaveBeenCalled();
+      expect(mockRedirect).not.toHaveBeenCalled();
+      expect(
+        hasElement(
+          result,
+          (el) =>
+            el.type === mockSignInReauthPanel &&
+            el.props.callbackHref === "/api/mcp/authorize?client_id=c&x=1" &&
+            el.props.canUsePasskey === true,
+        ),
+      ).toBe(true);
+    });
+
+    it("passes canUsePasskey=false to the panel when the session cannot recover via passkey", async () => {
+      mockEvaluateStepUpFreshness.mockResolvedValue("stale");
+      mockCanRecoverSessionWithPasskey.mockResolvedValue(false);
+
+      const result = await SignInPage({
+        params: makeParams("en"),
+        searchParams: makeSearchParams(API_CALLBACK),
+      });
+
+      expect(
+        hasElement(
+          result,
+          (el) =>
+            el.type === mockSignInReauthPanel &&
+            el.props.canUsePasskey === false,
+        ),
+      ).toBe(true);
+    });
+
+    it("falls through to the sign-in form when the session row is gone (invalid)", async () => {
+      mockEvaluateStepUpFreshness.mockResolvedValue("invalid");
+
+      const result = await SignInPage({
+        params: makeParams("en"),
+        searchParams: makeSearchParams(API_CALLBACK),
+      });
+
+      expect(mockNextRedirect).not.toHaveBeenCalled();
+      expect(mockRedirect).not.toHaveBeenCalled();
+      expect(
+        hasElement(result, (el) => el.type === mockSignInReauthPanel),
+      ).toBe(false);
+      expect(result).toBeDefined();
+    });
+
+    it("treats a missing session cookie as invalid (form, no freshness query)", async () => {
+      mockGetSessionTokenFromCookieStore.mockReturnValue(null);
+
+      const result = await SignInPage({
+        params: makeParams("en"),
+        searchParams: makeSearchParams(API_CALLBACK),
+      });
+
+      expect(mockEvaluateStepUpFreshness).not.toHaveBeenCalled();
+      expect(mockNextRedirect).not.toHaveBeenCalled();
+      expect(result).toBeDefined();
     });
   });
 

--- a/src/app/[locale]/auth/signin/page.test.ts
+++ b/src/app/[locale]/auth/signin/page.test.ts
@@ -50,6 +50,7 @@ vi.mock("@/lib/url-helpers", () => ({
 vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
   evaluateStepUpFreshness: mockEvaluateStepUpFreshness,
   canRecoverSessionWithPasskey: mockCanRecoverSessionWithPasskey,
+  STEP_UP_FRESHNESS: { FRESH: "fresh", STALE: "stale", INVALID: "invalid" },
 }));
 vi.mock("@/app/api/sessions/helpers", () => ({
   getSessionTokenFromCookieStore: mockGetSessionTokenFromCookieStore,
@@ -227,6 +228,8 @@ describe("SignInPage", () => {
       expect(mockRedirect).not.toHaveBeenCalled();
       // Token plumbing: the freshness core receives the cookie-store token.
       expect(mockEvaluateStepUpFreshness).toHaveBeenCalledWith("sess-1");
+      // Fresh path must not do the passkey-recovery credential query.
+      expect(mockCanRecoverSessionWithPasskey).not.toHaveBeenCalled();
     });
 
     it("renders the reauth panel (no redirect) when the session is stale", async () => {

--- a/src/app/[locale]/auth/signin/page.tsx
+++ b/src/app/[locale]/auth/signin/page.tsx
@@ -1,6 +1,13 @@
 import { redirect } from "@/i18n/navigation";
 import { redirect as nextRedirect } from "next/navigation";
+import { cookies } from "next/headers";
 import { auth } from "@/auth";
+import {
+  evaluateStepUpFreshness,
+  canRecoverSessionWithPasskey,
+} from "@/lib/auth/session/recent-current-auth-method";
+import { getSessionTokenFromCookieStore } from "@/app/api/sessions/helpers";
+import { SignInReauthPanel } from "@/components/auth/signin-reauth-panel";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { APP_NAME } from "@/lib/constants";
 import {
@@ -52,15 +59,48 @@ export default async function SignInPage({
     }
     const resolved = resolveCallbackUrl(rawCallbackUrl ?? null, origin);
     if (isApiCallbackUrl(resolved)) {
-      // API routes (e.g. the iOS /api/mobile/authorize OAuth handler) live
-      // outside the [locale] segment. next-intl's redirect() would inject the
-      // active locale (→ /<locale>/api/... → 404), so use the plain redirect
-      // with the basePath-qualified path as-is (no locale prefix).
-      nextRedirect(resolved);
+      // API callbacks (/api/mcp/authorize, /api/mobile/authorize OAuth
+      // handlers) live outside the [locale] segment and are step-up gated.
+      // Evaluate the same freshness core the gate applies: bouncing a stale
+      // session straight back would 403 again and loop forever.
+      const sessionToken = getSessionTokenFromCookieStore(await cookies());
+      const verdict = sessionToken
+        ? await evaluateStepUpFreshness(sessionToken)
+        : "invalid";
+      if (verdict === "fresh") {
+        // Strip basePath + locale: Next's redirect() re-prepends basePath,
+        // so passing the basePath-qualified path as-is would double it
+        // (/base/base/api/...). next-intl's redirect() is still wrong here —
+        // it would inject the locale (→ /<locale>/api/... → 404).
+        nextRedirect(callbackUrlToHref(resolved));
+      }
+      if (verdict === "stale" && sessionToken) {
+        const canUsePasskey = await canRecoverSessionWithPasskey(
+          sessionToken,
+          session.user.id,
+        );
+        return (
+          <SignInReauthPanel
+            callbackHref={resolved}
+            canUsePasskey={canUsePasskey}
+            labels={{
+              title: t("reauthPanelTitle"),
+              description: t("reauthPanelDescription"),
+              passkeyAction: t("reauthAction"),
+              passkeyFailed: t("reauthFailed"),
+              passkeyCancelled: t("reauthCancelled"),
+              signInAgainAction: t("recentSessionAction"),
+            }}
+          />
+        );
+      }
+      // "invalid" (session row vanished mid-flight): fall through to the
+      // sign-in form below.
+    } else {
+      // Strip basePath + locale: next-intl redirect() re-adds both
+      const href = callbackUrlToHref(resolved);
+      redirect({ href, locale });
     }
-    // Strip basePath + locale: next-intl redirect() re-adds both
-    const href = callbackUrlToHref(resolved);
-    redirect({ href, locale });
   }
 
   const hasGoogle = !!(

--- a/src/app/[locale]/auth/signin/page.tsx
+++ b/src/app/[locale]/auth/signin/page.tsx
@@ -5,6 +5,7 @@ import { auth } from "@/auth";
 import {
   evaluateStepUpFreshness,
   canRecoverSessionWithPasskey,
+  STEP_UP_FRESHNESS,
 } from "@/lib/auth/session/recent-current-auth-method";
 import { getSessionTokenFromCookieStore } from "@/app/api/sessions/helpers";
 import { SignInReauthPanel } from "@/components/auth/signin-reauth-panel";
@@ -66,15 +67,15 @@ export default async function SignInPage({
       const sessionToken = getSessionTokenFromCookieStore(await cookies());
       const verdict = sessionToken
         ? await evaluateStepUpFreshness(sessionToken)
-        : "invalid";
-      if (verdict === "fresh") {
+        : STEP_UP_FRESHNESS.INVALID;
+      if (verdict === STEP_UP_FRESHNESS.FRESH) {
         // Strip basePath + locale: Next's redirect() re-prepends basePath,
         // so passing the basePath-qualified path as-is would double it
         // (/base/base/api/...). next-intl's redirect() is still wrong here —
         // it would inject the locale (→ /<locale>/api/... → 404).
         nextRedirect(callbackUrlToHref(resolved));
       }
-      if (verdict === "stale" && sessionToken) {
+      if (verdict === STEP_UP_FRESHNESS.STALE && sessionToken) {
         const canUsePasskey = await canRecoverSessionWithPasskey(
           sessionToken,
           session.user.id,

--- a/src/app/api/mcp/authorize/consent/route.test.ts
+++ b/src/app/api/mcp/authorize/consent/route.test.ts
@@ -13,7 +13,7 @@ const {
   mockTxFindFirst,
   mockTxDelete,
   mockExecuteRaw,
-  mockRequireRecentSession,
+  mockRequireRecentCurrentAuthMethod,
   mockDerivePasskeyState,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
@@ -28,7 +28,7 @@ const {
   mockTxFindFirst: vi.fn().mockResolvedValue(null),
   mockTxDelete: vi.fn().mockResolvedValue({}),
   mockExecuteRaw: vi.fn().mockResolvedValue(0),
-  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
+  mockRequireRecentCurrentAuthMethod: vi.fn().mockResolvedValue(null),
   mockDerivePasskeyState: vi.fn(),
 }));
 
@@ -107,8 +107,8 @@ vi.mock("@/lib/audit/audit", () => ({
   tenantAuditBase: (_req: unknown, userId: string, tenantId: string) => ({ scope: "TENANT", userId, tenantId, ip: "127.0.0.1", userAgent: "test-agent", acceptLanguage: null }),
 }));
 
-vi.mock("@/lib/auth/session/step-up", () => ({
-  requireRecentSession: mockRequireRecentSession,
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: mockRequireRecentCurrentAuthMethod,
 }));
 
 vi.mock("@/lib/url-helpers", () => ({
@@ -190,7 +190,7 @@ describe("POST /api/mcp/authorize/consent", () => {
     mockTxDelete.mockResolvedValue({});
     mockMcpClientCount.mockResolvedValue(0);
     mockMcpClientUpdateMany.mockResolvedValue({ count: 1 });
-    mockRequireRecentSession.mockResolvedValue(null);
+    mockRequireRecentCurrentAuthMethod.mockResolvedValue(null);
     mockCreateAuthorizationCode.mockResolvedValue({
       code: "auth-code-abc123",
       expiresAt: new Date(Date.now() + 60000),
@@ -248,7 +248,7 @@ describe("POST /api/mcp/authorize/consent", () => {
   });
 
   it("redirects to the authorize entry when session step-up is required (stale session, not a JSON 403 dead-end)", async () => {
-    mockRequireRecentSession.mockResolvedValue(Response.json(
+    mockRequireRecentCurrentAuthMethod.mockResolvedValue(Response.json(
       { error: "SESSION_STEP_UP_REQUIRED" },
       { status: 403 },
     ));
@@ -273,6 +273,10 @@ describe("POST /api/mcp/authorize/consent", () => {
     expect(url.searchParams.get("state")).toBe(VALID_FORM_FIELDS.state);
     // No credential-issuance work runs on a stale session.
     expect(mockCreateAuthorizationCode).not.toHaveBeenCalled();
+    // Gate called with the request ONLY — a custom maxAgeMs here would diverge
+    // from the sign-in page's freshness evaluation and re-open the loop.
+    expect(mockRequireRecentCurrentAuthMethod).toHaveBeenCalledTimes(1);
+    expect(mockRequireRecentCurrentAuthMethod.mock.calls[0]).toHaveLength(1);
   });
 
   it("returns 400 when client_id is missing", async () => {

--- a/src/app/api/mcp/authorize/consent/route.ts
+++ b/src/app/api/mcp/authorize/consent/route.ts
@@ -11,7 +11,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { errorResponse, unauthorized } from "@/lib/http/api-response";
 import { readFormWithCap } from "@/lib/http/parse-body";
 import { MAX_JSON_BODY_BYTES } from "@/lib/validations/common.server";
-import { requireRecentSession } from "@/lib/auth/session/step-up";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 import { serverAppUrl, getAppOrigin } from "@/lib/url-helpers";
 import { API_PATH } from "@/lib/constants/auth/api-path";
 import {
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest) {
   // (an unvalidated redirect_uri in the callback would be an open-redirect vector).
   // The unauthorized() paths (no/absent session) still fail closed immediately.
   // @stepup id:mcp-authorize-consent-post method:POST
-  const stepUpError = await requireRecentSession(req);
+  const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError && stepUpError.status !== 403) return stepUpError;
   const stepUpStale = stepUpError?.status === 403;
 

--- a/src/app/api/mcp/authorize/route.test.ts
+++ b/src/app/api/mcp/authorize/route.test.ts
@@ -7,7 +7,7 @@ const {
   mockWithBypassRls,
   mockExtractClientIp,
   mockCheckRateLimit,
-  mockRequireRecentSession,
+  mockRequireRecentCurrentAuthMethod,
   mockLogAuditAsync,
   mockDerivePasskeyState,
 } = vi.hoisted(() => ({
@@ -17,7 +17,7 @@ const {
   mockWithBypassRls: vi.fn(async (p: unknown, fn: (tx: unknown) => unknown) => fn(p)),
   mockExtractClientIp: vi.fn(() => "203.0.113.10"),
   mockCheckRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
-  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
+  mockRequireRecentCurrentAuthMethod: vi.fn().mockResolvedValue(null),
   mockLogAuditAsync: vi.fn().mockResolvedValue(undefined),
   mockDerivePasskeyState: vi.fn(),
 }));
@@ -59,8 +59,8 @@ vi.mock("@/i18n/locale-utils", () => ({
   detectBestLocaleFromAcceptLanguage: () => "en",
 }));
 
-vi.mock("@/lib/auth/session/step-up", () => ({
-  requireRecentSession: mockRequireRecentSession,
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: mockRequireRecentCurrentAuthMethod,
 }));
 
 vi.mock("@/lib/audit/audit", () => ({
@@ -112,7 +112,7 @@ describe("GET /api/mcp/authorize", () => {
     mockUserFindUnique.mockResolvedValue({ tenantId: "tenant-1" });
     mockWithBypassRls.mockImplementation(async (p: unknown, fn: (tx: unknown) => unknown) => fn(p));
     mockCheckRateLimit.mockResolvedValue({ allowed: true });
-    mockRequireRecentSession.mockResolvedValue(null);
+    mockRequireRecentCurrentAuthMethod.mockResolvedValue(null);
     mockLogAuditAsync.mockResolvedValue(undefined);
     // Default: passkey enforcement off (does not block).
     mockDerivePasskeyState.mockResolvedValue({
@@ -197,7 +197,7 @@ describe("GET /api/mcp/authorize", () => {
   });
 
   it("redirects to sign-in when session step-up is required (stale session, not a JSON 403 dead-end)", async () => {
-    mockRequireRecentSession.mockResolvedValue(Response.json(
+    mockRequireRecentCurrentAuthMethod.mockResolvedValue(Response.json(
       { error: "SESSION_STEP_UP_REQUIRED" },
       { status: 403 },
     ));
@@ -216,6 +216,10 @@ describe("GET /api/mcp/authorize", () => {
     expect(location).toContain("callbackUrl=");
     // The credential-issuance work below the gate never runs on a stale session.
     expect(mockFindFirst).not.toHaveBeenCalled();
+    // Gate called with the request ONLY — a custom maxAgeMs here would diverge
+    // from the sign-in page's freshness evaluation and re-open the loop.
+    expect(mockRequireRecentCurrentAuthMethod).toHaveBeenCalledTimes(1);
+    expect(mockRequireRecentCurrentAuthMethod.mock.calls[0]).toHaveLength(1);
   });
 
   // ── C6 (GET): Passkey enforcement gate ───────────────────────────────────

--- a/src/app/api/mcp/authorize/route.ts
+++ b/src/app/api/mcp/authorize/route.ts
@@ -6,7 +6,7 @@ import { prisma } from "@/lib/prisma";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { extractClientIp, rateLimitKeyFromIp } from "@/lib/auth/policy/ip-access";
-import { requireRecentSession } from "@/lib/auth/session/step-up";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 import { logAuditAsync, tenantAuditBase } from "@/lib/audit/audit";
@@ -75,10 +75,11 @@ export async function GET(req: NextRequest) {
 
   // A stale session needs re-authentication, not a JSON 403 the browser would
   // strand on. Bounce through sign-in like the no-session path above; the
-  // callbackUrl returns here and the second pass has a recent-enough session.
-  // requireRecentSession still fails closed on its unauthorized() paths.
+  // sign-in page's reauth panel refreshes the provider-appropriate freshness
+  // (passkey ceremony or re-sign-in) and returns here via callbackUrl.
+  // The chooser still fails closed on its unauthorized() paths.
   // @stepup id:mcp-authorize-get method:GET
-  const stepUpError = await requireRecentSession(req);
+  const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) {
     if (stepUpError.status !== 403) return stepUpError;
     const loginUrl = serverAppUrl("/api/auth/signin");

--- a/src/app/api/mobile/authorize/route.test.ts
+++ b/src/app/api/mobile/authorize/route.test.ts
@@ -9,7 +9,7 @@ const {
   mockWithBypassRls,
   mockWithUserTenantRls,
   mockGetAppOrigin,
-  mockRequireRecentSession,
+  mockRequireRecentCurrentAuthMethod,
   mockEnforceAccessRestriction,
   mockCheckRateLimitOrFail,
   mockLogAuditAsync,
@@ -23,7 +23,7 @@ const {
       fn("22222222-2222-2222-2222-222222222222"),
   ),
   mockGetAppOrigin: vi.fn(() => "https://example.test"),
-  mockRequireRecentSession: vi.fn().mockResolvedValue(null),
+  mockRequireRecentCurrentAuthMethod: vi.fn().mockResolvedValue(null),
   mockEnforceAccessRestriction: vi.fn().mockResolvedValue(null),
   mockCheckRateLimitOrFail: vi.fn().mockResolvedValue(null),
   mockLogAuditAsync: vi.fn().mockResolvedValue(undefined),
@@ -66,8 +66,8 @@ vi.mock("@/lib/redis", () => ({
   validateRedisConfig: () => {},
 }));
 
-vi.mock("@/lib/auth/session/step-up", () => ({
-  requireRecentSession: mockRequireRecentSession,
+vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
+  requireRecentCurrentAuthMethod: mockRequireRecentCurrentAuthMethod,
 }));
 
 vi.mock("@/lib/security/rate-limit-audit", () => ({
@@ -126,7 +126,7 @@ describe("GET /api/mobile/authorize", () => {
       async (_u: string, fn: (tenantId: string) => unknown) =>
         fn("22222222-2222-2222-2222-222222222222"),
     );
-    mockRequireRecentSession.mockResolvedValue(null);
+    mockRequireRecentCurrentAuthMethod.mockResolvedValue(null);
     mockEnforceAccessRestriction.mockResolvedValue(null);
     mockCheckRateLimitOrFail.mockResolvedValue(null);
     mockLogAuditAsync.mockResolvedValue(undefined);
@@ -220,7 +220,7 @@ describe("GET /api/mobile/authorize", () => {
   });
 
   it("redirects to sign-in when session step-up is required (stale session, not a JSON 403 dead-end)", async () => {
-    mockRequireRecentSession.mockResolvedValue(Response.json(
+    mockRequireRecentCurrentAuthMethod.mockResolvedValue(Response.json(
       { error: "SESSION_STEP_UP_REQUIRED" },
       { status: 403 },
     ));
@@ -234,6 +234,10 @@ describe("GET /api/mobile/authorize", () => {
     expect(u.pathname).toBe("/ja/auth/signin");
     expect(u.searchParams.get("callbackUrl")).toContain("/api/mobile/authorize");
     expect(mockMobileBridgeCodeCreate).not.toHaveBeenCalled();
+    // Gate called with the request ONLY — a custom maxAgeMs here would diverge
+    // from the sign-in page's freshness evaluation and re-open the loop.
+    expect(mockRequireRecentCurrentAuthMethod).toHaveBeenCalledTimes(1);
+    expect(mockRequireRecentCurrentAuthMethod.mock.calls[0]).toHaveLength(1);
   });
 
   it("returns 400 when client_kind is missing", async () => {

--- a/src/app/api/mobile/authorize/route.ts
+++ b/src/app/api/mobile/authorize/route.ts
@@ -42,7 +42,7 @@ import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { enforceAccessRestriction } from "@/lib/auth/policy/access-restriction";
 import { BRIDGE_CODE_TTL_MS, MS_PER_MINUTE } from "@/lib/constants";
 import { generateShareToken } from "@/lib/crypto/crypto-server";
-import { requireRecentSession } from "@/lib/auth/session/step-up";
+import { requireRecentCurrentAuthMethod } from "@/lib/auth/session/recent-current-auth-method";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { checkRateLimitOrFail } from "@/lib/security/rate-limit-audit";
 import {
@@ -124,11 +124,12 @@ async function handleGET(req: NextRequest): Promise<Response> {
 
   // A stale session needs re-authentication, not a JSON 403 the ephemeral
   // ASWebAuthenticationSession browser would strand on. Bounce through sign-in
-  // exactly like the no-session path above; the callbackUrl returns here and the
-  // second pass has a fresh (recent-enough) session. requireRecentSession still
-  // fails closed on the unauthorized() paths (no/absent session row).
+  // exactly like the no-session path above; the sign-in page's reauth panel
+  // refreshes the provider-appropriate freshness (passkey ceremony or
+  // re-sign-in) and returns here via callbackUrl. The chooser still fails
+  // closed on the unauthorized() paths (no/absent session row).
   // @stepup id:mobile-authorize-get method:GET
-  const stepUpError = await requireRecentSession(req);
+  const stepUpError = await requireRecentCurrentAuthMethod(req);
   if (stepUpError) {
     return stepUpError.status === 403 ? redirectToSignIn(req) : stepUpError;
   }

--- a/src/app/api/sessions/helpers.test.ts
+++ b/src/app/api/sessions/helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
-import { getSessionToken } from "./helpers";
+import { getSessionToken, getSessionTokenFromCookieStore } from "./helpers";
 
 describe("getSessionToken", () => {
   beforeEach(() => {
@@ -61,5 +61,55 @@ describe("getSessionToken", () => {
       headers: { Cookie: "__Host-authjs.session-token=next123" },
     });
     expect(getSessionToken(req)).toBe("next123");
+  });
+});
+
+describe("getSessionTokenFromCookieStore (server-component cookies() variant)", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function storeWith(entries: Record<string, string>) {
+    return {
+      get: (name: string) =>
+        name in entries ? { value: entries[name] } : undefined,
+    };
+  }
+
+  it("resolves the __Secure- name on https + basePath (production shape)", () => {
+    vi.stubEnv("AUTH_URL", "https://app.example.com");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/passwd-sso");
+
+    const token = getSessionTokenFromCookieStore(
+      storeWith({ "__Secure-authjs.session-token": "sec-1" }),
+    );
+
+    expect(token).toBe("sec-1");
+  });
+
+  it("resolves the plain name on http (dev shape)", () => {
+    vi.stubEnv("AUTH_URL", "http://localhost:3000");
+
+    const token = getSessionTokenFromCookieStore(
+      storeWith({ "authjs.session-token": "dev-1" }),
+    );
+
+    expect(token).toBe("dev-1");
+  });
+
+  it("returns null when the deployment-shaped cookie is absent", () => {
+    vi.stubEnv("AUTH_URL", "https://app.example.com");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/passwd-sso");
+
+    // A dev-shaped cookie must NOT satisfy a production-shaped deployment.
+    const token = getSessionTokenFromCookieStore(
+      storeWith({ "authjs.session-token": "wrong-shape" }),
+    );
+
+    expect(token).toBeNull();
   });
 });

--- a/src/app/api/sessions/helpers.test.ts
+++ b/src/app/api/sessions/helpers.test.ts
@@ -101,6 +101,16 @@ describe("getSessionTokenFromCookieStore (server-component cookies() variant)", 
     expect(token).toBe("dev-1");
   });
 
+  it("resolves the __Host- name on https + empty basePath", () => {
+    vi.stubEnv("AUTH_URL", "https://app.example.com");
+
+    const token = getSessionTokenFromCookieStore(
+      storeWith({ "__Host-authjs.session-token": "host-1" }),
+    );
+
+    expect(token).toBe("host-1");
+  });
+
   it("returns null when the deployment-shaped cookie is absent", () => {
     vi.stubEnv("AUTH_URL", "https://app.example.com");
     vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/passwd-sso");

--- a/src/app/api/sessions/helpers.ts
+++ b/src/app/api/sessions/helpers.ts
@@ -4,10 +4,26 @@ import {
   isSecureCookieFromAuthUrl,
 } from "@/lib/auth/session/cookie-name";
 
-export function getSessionToken(req: NextRequest): string | null {
+/**
+ * Minimal structural view of a cookie store — satisfied by both
+ * `NextRequest.cookies` (route handlers) and the `cookies()` store from
+ * `next/headers` (server components). Keeps the session-cookie NAME
+ * resolution on the single SSoT (`getSessionCookieName`) for every reader.
+ */
+type CookieReader = {
+  get(name: string): { value: string } | undefined;
+};
+
+export function getSessionTokenFromCookieStore(
+  store: CookieReader,
+): string | null {
   const name = getSessionCookieName({
     useSecureCookies: isSecureCookieFromAuthUrl(),
     basePath: process.env.NEXT_PUBLIC_BASE_PATH,
   });
-  return req.cookies.get(name)?.value ?? null;
+  return store.get(name)?.value ?? null;
+}
+
+export function getSessionToken(req: NextRequest): string | null {
+  return getSessionTokenFromCookieStore(req.cookies);
 }

--- a/src/app/api/tenant/operator-tokens/route.test.ts
+++ b/src/app/api/tenant/operator-tokens/route.test.ts
@@ -219,6 +219,12 @@ describe("POST /api/tenant/operator-tokens", () => {
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error).toBe("OPERATOR_TOKEN_STALE_SESSION");
+    // End-to-end half of the errorCode contract: the route must actually PASS
+    // the custom code to the gate — the client branches on this exact code.
+    expect(mockRequireRecentCurrentAuthMethod).toHaveBeenCalledWith(
+      expect.anything(),
+      { errorCode: "OPERATOR_TOKEN_STALE_SESSION" },
+    );
   });
 
   it("returns 400 when body contains subjectUserId (strict schema rejection)", async () => {

--- a/src/components/auth/signin-reauth-panel.test.tsx
+++ b/src/components/auth/signin-reauth-panel.test.tsx
@@ -155,12 +155,70 @@ describe("SignInReauthPanel", () => {
     expect(mockAssign).not.toHaveBeenCalled();
   });
 
+  it("re-enables both actions when signOut rejects on the sign-in-again click", async () => {
+    mockSignOut.mockRejectedValue(new Error("network"));
+    renderPanel();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "recentSessionAction" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "reauthAction" }),
+      ).toBeEnabled();
+    });
+    expect(
+      screen.getByRole("button", { name: "recentSessionAction" }),
+    ).toBeEnabled();
+    expect(mockAssign).not.toHaveBeenCalled();
+  });
+
   it("refuses a backslash protocol-relative callbackHref (browsers normalize \\ to /)", () => {
     renderPanel({ callbackHref: "/\\evil.example/phish" });
 
     expect(
       screen.queryByRole("button", { name: "reauthAction" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("disables both actions while the passkey ceremony is in flight", async () => {
+    let resolveFn: (value: {
+      ok: boolean;
+      error?: string;
+    }) => void = () => {};
+    mockReauthenticateWithPasskey.mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolveFn = r;
+        }),
+    );
+    renderPanel();
+
+    const passkeyButton = screen.getByRole("button", { name: "reauthAction" });
+    const signInAgainButton = screen.getByRole("button", {
+      name: "recentSessionAction",
+    });
+    fireEvent.click(passkeyButton);
+
+    // While busy, the passkey button's accessible name is replaced by the
+    // (unlabelled) spinner icon, so re-query by role name would fail —
+    // assert on the captured element references instead.
+    await waitFor(() => {
+      expect(passkeyButton).toBeDisabled();
+    });
+    expect(signInAgainButton).toBeDisabled();
+
+    resolveFn({ ok: false, error: "PASSKEY_REAUTH_FAILED" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "reauthAction" }),
+      ).toBeEnabled();
+    });
+    expect(
+      screen.getByRole("button", { name: "recentSessionAction" }),
+    ).toBeEnabled();
   });
 
   it("shows the cancelled label when the user aborts the ceremony", async () => {

--- a/src/components/auth/signin-reauth-panel.test.tsx
+++ b/src/components/auth/signin-reauth-panel.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const { mockSignOut, mockReauthenticateWithPasskey, mockAssign } = vi.hoisted(
+  () => ({
+    mockSignOut: vi.fn(),
+    mockReauthenticateWithPasskey: vi.fn(),
+    mockAssign: vi.fn(),
+  }),
+);
+
+vi.mock("next-auth/react", () => ({
+  signOut: mockSignOut,
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "ja",
+}));
+
+vi.mock("@/lib/url-helpers", () => ({
+  withBasePath: (p: string) => `/passwd-sso${p}`,
+}));
+
+vi.mock("@/lib/auth/webauthn/passkey-reauth-client", () => ({
+  reauthenticateWithPasskey: mockReauthenticateWithPasskey,
+}));
+
+import { SignInReauthPanel } from "./signin-reauth-panel";
+
+const LABELS = {
+  title: "reauthPanelTitle",
+  description: "reauthPanelDescription",
+  passkeyAction: "reauthAction",
+  passkeyFailed: "reauthFailed",
+  passkeyCancelled: "reauthCancelled",
+  signInAgainAction: "recentSessionAction",
+};
+
+const CALLBACK = "/passwd-sso/api/mcp/authorize?x=1";
+
+function renderPanel(
+  overrides: Partial<{ callbackHref: string; canUsePasskey: boolean }> = {},
+) {
+  return render(
+    <SignInReauthPanel
+      callbackHref={overrides.callbackHref ?? CALLBACK}
+      canUsePasskey={overrides.canUsePasskey ?? true}
+      labels={LABELS}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // window.location.assign is not writable in jsdom; replace the whole object.
+  Object.defineProperty(window, "location", {
+    value: { assign: mockAssign },
+    writable: true,
+  });
+});
+
+describe("SignInReauthPanel", () => {
+  it("never fires signOut or navigation on mount (I9)", () => {
+    renderPanel();
+
+    expect(mockSignOut).not.toHaveBeenCalled();
+    expect(mockAssign).not.toHaveBeenCalled();
+    expect(mockReauthenticateWithPasskey).not.toHaveBeenCalled();
+  });
+
+  it("always renders the sign-in-again action, even on the passkey branch (I6 no-dead-end)", () => {
+    renderPanel({ canUsePasskey: true });
+
+    expect(
+      screen.getByRole("button", { name: "recentSessionAction" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "reauthAction" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the passkey action when canUsePasskey is false", () => {
+    renderPanel({ canUsePasskey: false });
+
+    expect(
+      screen.queryByRole("button", { name: "reauthAction" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "recentSessionAction" }),
+    ).toBeInTheDocument();
+  });
+
+  it("signs out with the nested signin callbackUrl on the sign-in-again click", async () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "recentSessionAction" }));
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledWith({
+        callbackUrl: `/passwd-sso/ja/auth/signin?callbackUrl=${encodeURIComponent(CALLBACK)}`,
+      });
+    });
+  });
+
+  it("navigates to the callback after a successful passkey ceremony", async () => {
+    mockReauthenticateWithPasskey.mockResolvedValue({
+      ok: true,
+      verifiedAt: "2026-07-09T00:00:00Z",
+    });
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "reauthAction" }));
+
+    await waitFor(() => {
+      expect(mockAssign).toHaveBeenCalledWith(CALLBACK);
+    });
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it("shows the failure label and keeps sign-in-again available on ceremony failure", async () => {
+    mockReauthenticateWithPasskey.mockResolvedValue({
+      ok: false,
+      error: "PASSKEY_REAUTH_FAILED",
+    });
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "reauthAction" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("reauthFailed")).toBeInTheDocument();
+    });
+    expect(mockAssign).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "recentSessionAction" }),
+    ).toBeEnabled();
+  });
+
+  it("shows the cancelled label when the user aborts the ceremony", async () => {
+    mockReauthenticateWithPasskey.mockResolvedValue({
+      ok: false,
+      error: "AUTHENTICATION_CANCELLED",
+    });
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "reauthAction" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("reauthCancelled")).toBeInTheDocument();
+    });
+  });
+
+  it("refuses a protocol-relative callbackHref: no passkey action, no navigation (S1)", async () => {
+    renderPanel({ callbackHref: "//evil.example/phish" });
+
+    // The passkey action is withheld entirely (no safe navigation target)...
+    expect(
+      screen.queryByRole("button", { name: "reauthAction" }),
+    ).not.toBeInTheDocument();
+
+    // ...and sign-in-again omits the nested callbackUrl rather than smuggling it.
+    fireEvent.click(screen.getByRole("button", { name: "recentSessionAction" }));
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledWith({
+        callbackUrl: "/passwd-sso/ja/auth/signin",
+      });
+    });
+    expect(mockAssign).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/auth/signin-reauth-panel.test.tsx
+++ b/src/components/auth/signin-reauth-panel.test.tsx
@@ -137,6 +137,32 @@ describe("SignInReauthPanel", () => {
     ).toBeEnabled();
   });
 
+  it("re-enables recovery when the ceremony rejects at the network level (no stranded panel)", async () => {
+    mockReauthenticateWithPasskey.mockRejectedValue(new Error("network down"));
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "reauthAction" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("reauthFailed")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: "reauthAction" }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "recentSessionAction" }),
+    ).toBeEnabled();
+    expect(mockAssign).not.toHaveBeenCalled();
+  });
+
+  it("refuses a backslash protocol-relative callbackHref (browsers normalize \\ to /)", () => {
+    renderPanel({ callbackHref: "/\\evil.example/phish" });
+
+    expect(
+      screen.queryByRole("button", { name: "reauthAction" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows the cancelled label when the user aborts the ceremony", async () => {
     mockReauthenticateWithPasskey.mockResolvedValue({
       ok: false,

--- a/src/components/auth/signin-reauth-panel.tsx
+++ b/src/components/auth/signin-reauth-panel.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { signOut } from "next-auth/react";
+import { useLocale } from "next-intl";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { AppIcon } from "@/components/ui/app-icon";
+import { reauthenticateWithPasskey } from "@/lib/auth/webauthn/passkey-reauth-client";
+import { withBasePath } from "@/lib/url-helpers";
+
+/**
+ * Server-computed callback paths must be same-origin root-relative: exactly
+ * one leading slash. A protocol-relative value (`//host`) would turn the
+ * post-reauth navigation into an open redirect — refuse it outright rather
+ * than trusting upstream validation alone.
+ */
+const SAFE_CALLBACK_HREF_RE = /^\/(?!\/)/;
+
+type SignInReauthPanelLabels = {
+  title: string;
+  description: string;
+  passkeyAction: string;
+  passkeyFailed: string;
+  passkeyCancelled: string;
+  signInAgainAction: string;
+};
+
+type SignInReauthPanelProps = {
+  /** basePath-qualified same-origin path (window.location gets no framework re-prepend). */
+  callbackHref: string;
+  canUsePasskey: boolean;
+  labels: SignInReauthPanelLabels;
+};
+
+/**
+ * Rendered by the sign-in page when an authenticated user arrives with a
+ * step-up-gated API callback (MCP / iOS OAuth authorize) and a stale session.
+ * Recovery mirrors the in-app step-up pattern: passkey ceremony for
+ * webauthn-established sessions (refreshes `passkeyVerifiedAt`, keeps the
+ * session), sign-out + fresh sign-in for everything else (mints a session
+ * with a fresh `createdAt`). The sign-in-again action is always offered so a
+ * user whose passkeys were deleted after sign-in is never stranded.
+ */
+export function SignInReauthPanel({
+  callbackHref,
+  canUsePasskey,
+  labels,
+}: SignInReauthPanelProps) {
+  const locale = useLocale();
+  const [busy, setBusy] = useState<"passkey" | "signout" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const safeHref = SAFE_CALLBACK_HREF_RE.test(callbackHref)
+    ? callbackHref
+    : null;
+
+  const handlePasskey = async () => {
+    if (!safeHref) return;
+    setBusy("passkey");
+    setError(null);
+    const result = await reauthenticateWithPasskey();
+    if (result.ok) {
+      window.location.assign(safeHref);
+      return;
+    }
+    setError(
+      result.error === "AUTHENTICATION_CANCELLED"
+        ? labels.passkeyCancelled
+        : labels.passkeyFailed,
+    );
+    setBusy(null);
+  };
+
+  const handleSignInAgain = async () => {
+    setBusy("signout");
+    const signInPath = `${withBasePath(`/${locale}/auth/signin`)}${
+      safeHref ? `?callbackUrl=${encodeURIComponent(safeHref)}` : ""
+    }`;
+    await signOut({ callbackUrl: signInPath });
+  };
+
+  const showPasskey = canUsePasskey && safeHref !== null;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center space-y-4">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+            <AppIcon className="h-7 w-7" />
+          </div>
+          <div>
+            <CardTitle className="text-2xl">{labels.title}</CardTitle>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {labels.description}
+            </p>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && (
+            <p className="text-sm text-destructive text-center">{error}</p>
+          )}
+          {showPasskey && (
+            <Button
+              className="w-full"
+              onClick={handlePasskey}
+              disabled={busy !== null}
+            >
+              {busy === "passkey" ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                labels.passkeyAction
+              )}
+            </Button>
+          )}
+          <Button
+            variant={showPasskey ? "outline" : "default"}
+            className="w-full"
+            onClick={handleSignInAgain}
+            disabled={busy !== null}
+          >
+            {busy === "signout" ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              labels.signInAgainAction
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/auth/signin-reauth-panel.tsx
+++ b/src/components/auth/signin-reauth-panel.tsx
@@ -12,11 +12,12 @@ import { withBasePath } from "@/lib/url-helpers";
 
 /**
  * Server-computed callback paths must be same-origin root-relative: exactly
- * one leading slash. A protocol-relative value (`//host`) would turn the
- * post-reauth navigation into an open redirect — refuse it outright rather
- * than trusting upstream validation alone.
+ * one leading slash. A protocol-relative value (`//host` — or `/\host`,
+ * which browsers normalize to `//host`) would turn the post-reauth
+ * navigation into an open redirect — refuse it outright rather than
+ * trusting upstream validation alone.
  */
-const SAFE_CALLBACK_HREF_RE = /^\/(?!\/)/;
+const SAFE_CALLBACK_HREF_RE = /^\/(?![/\\])/;
 
 type SignInReauthPanelLabels = {
   title: string;
@@ -60,17 +61,25 @@ export function SignInReauthPanel({
     if (!safeHref) return;
     setBusy("passkey");
     setError(null);
-    const result = await reauthenticateWithPasskey();
-    if (result.ok) {
-      window.location.assign(safeHref);
-      return;
+    // try/finally: a network-level rejection (fetchApi throw, malformed body)
+    // must not strand the panel with both buttons permanently disabled —
+    // recovery-liveness is the whole point of this component.
+    try {
+      const result = await reauthenticateWithPasskey();
+      if (result.ok) {
+        window.location.assign(safeHref);
+        return;
+      }
+      setError(
+        result.error === "AUTHENTICATION_CANCELLED"
+          ? labels.passkeyCancelled
+          : labels.passkeyFailed,
+      );
+    } catch {
+      setError(labels.passkeyFailed);
+    } finally {
+      setBusy(null);
     }
-    setError(
-      result.error === "AUTHENTICATION_CANCELLED"
-        ? labels.passkeyCancelled
-        : labels.passkeyFailed,
-    );
-    setBusy(null);
   };
 
   const handleSignInAgain = async () => {
@@ -78,7 +87,12 @@ export function SignInReauthPanel({
     const signInPath = `${withBasePath(`/${locale}/auth/signin`)}${
       safeHref ? `?callbackUrl=${encodeURIComponent(safeHref)}` : ""
     }`;
-    await signOut({ callbackUrl: signInPath });
+    try {
+      await signOut({ callbackUrl: signInPath });
+    } catch {
+      // Success navigates away; only a failure needs the buttons back.
+      setBusy(null);
+    }
   };
 
   const showPasskey = canUsePasskey && safeHref !== null;

--- a/src/components/extension/auto-extension-connect.tsx
+++ b/src/components/extension/auto-extension-connect.tsx
@@ -125,7 +125,6 @@ export function AutoExtensionConnect({ onActiveChange }: AutoExtensionConnectPro
     // without that activation. URL param removal is deferred to the click
     // handler so reload reproduces the prompt.
     setStatus(CONNECT_STATUS.AWAITING_CLICK);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Report active/idle to the parent gate so it can defer the vault lock screen

--- a/src/hooks/vault/use-password-entry-detail.test.tsx
+++ b/src/hooks/vault/use-password-entry-detail.test.tsx
@@ -82,7 +82,7 @@ describe("usePasswordEntryDetail", () => {
     const deferredA = makeDeferred<InlineDetailData>();
     const deferredB = makeDeferred<InlineDetailData>();
     let callCount = 0;
-    const getDetail = vi.fn((id: string) => {
+    const getDetail = vi.fn(() => {
       callCount++;
       return callCount === 1 ? deferredA.promise : deferredB.promise;
     });
@@ -150,7 +150,7 @@ describe("usePasswordEntryDetail", () => {
     const deferredA = makeDeferred<InlineDetailData>();
     const deferredB = makeDeferred<InlineDetailData>();
     let callCount = 0;
-    const getDetail = vi.fn((id: string) => {
+    const getDetail = vi.fn(() => {
       callCount++;
       return callCount === 1 ? deferredA.promise : deferredB.promise;
     });

--- a/src/lib/auth/access/delegation.ts
+++ b/src/lib/auth/access/delegation.ts
@@ -128,7 +128,7 @@ export function toAgentFacing(
  * Returns true if the string is safe. Returns false to trigger a 400 at
  * the POST /api/vault/delegation boundary.
  */
-// eslint-disable-next-line no-control-regex -- intentional rejection of control chars
+// Intentional rejection of control characters and invisible/bidi formatting.
 const UNSAFE_METADATA_CHARS_RE =
   /[\x00-\x1F\x7F\u202A-\u202E\u2066-\u2069\u2028\u2029\u200B-\u200D\u2060\uFEFF\u180E]/;
 

--- a/src/lib/auth/session/recent-current-auth-method.test.ts
+++ b/src/lib/auth/session/recent-current-auth-method.test.ts
@@ -1,41 +1,36 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { API_ERROR } from "@/lib/http/api-error-codes";
+import { MS_PER_MINUTE } from "@/lib/constants/time";
 
-const {
-  mockSessionFindUnique,
-  mockWithBypassRls,
-  mockRequireRecentPasskeyVerification,
-  mockRequireRecentSession,
-} = vi.hoisted(() => ({
-  mockSessionFindUnique: vi.fn(),
-  mockWithBypassRls: vi.fn(),
-  mockRequireRecentPasskeyVerification: vi.fn(),
-  mockRequireRecentSession: vi.fn(),
-}));
+const { mockSessionFindUnique, mockCredentialCount, mockWithBypassRls } =
+  vi.hoisted(() => ({
+    mockSessionFindUnique: vi.fn(),
+    mockCredentialCount: vi.fn(),
+    mockWithBypassRls: vi.fn(),
+  }));
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     session: {
       findUnique: mockSessionFindUnique,
     },
+    webAuthnCredential: {
+      count: mockCredentialCount,
+    },
   },
 }));
 
 vi.mock("@/lib/tenant-rls", async (importOriginal) => ({
-  ...(await importOriginal()) as Record<string, unknown>,
+  ...((await importOriginal()) as Record<string, unknown>),
   withBypassRls: mockWithBypassRls,
 }));
 
-vi.mock("@/lib/auth/webauthn/recent-passkey-verification", () => ({
-  requireRecentPasskeyVerification: mockRequireRecentPasskeyVerification,
-}));
-
-vi.mock("./step-up", async (importOriginal) => ({
-  ...(await importOriginal()) as Record<string, unknown>,
-  requireRecentSession: mockRequireRecentSession,
-}));
-
-import { requireRecentCurrentAuthMethod } from "./recent-current-auth-method";
+import {
+  evaluateStepUpFreshness,
+  requireRecentCurrentAuthMethod,
+  canRecoverSessionWithPasskey,
+} from "./recent-current-auth-method";
 
 function makeRequest(cookie = "authjs.session-token=sess-1") {
   return new NextRequest("http://localhost:3000/api/test", {
@@ -43,43 +38,118 @@ function makeRequest(cookie = "authjs.session-token=sess-1") {
   });
 }
 
+function minutesAgo(minutes: number): Date {
+  return new Date(Date.now() - minutes * MS_PER_MINUTE);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithBypassRls.mockImplementation(
+    (prisma: unknown, fn: (tx: unknown) => unknown, _purpose: string) =>
+      fn(prisma),
+  );
+});
+
+describe("evaluateStepUpFreshness", () => {
+  it("returns invalid when the session row is missing", async () => {
+    mockSessionFindUnique.mockResolvedValue(null);
+
+    await expect(evaluateStepUpFreshness("sess-1")).resolves.toBe("invalid");
+  });
+
+  it("judges webauthn sessions on passkeyVerifiedAt: fresh within the window", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "webauthn",
+      createdAt: minutesAgo(120),
+      passkeyVerifiedAt: minutesAgo(5),
+    });
+
+    // Load-bearing security case: fresh passkeyVerifiedAt + OLD createdAt is
+    // fresh — the ceremony (not session age) carries the freshness evidence.
+    await expect(evaluateStepUpFreshness("sess-1")).resolves.toBe("fresh");
+  });
+
+  it("judges webauthn sessions on passkeyVerifiedAt: stale past the window", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "webauthn",
+      createdAt: minutesAgo(5),
+      passkeyVerifiedAt: minutesAgo(20),
+    });
+
+    await expect(evaluateStepUpFreshness("sess-1")).resolves.toBe("stale");
+  });
+
+  it("maps webauthn with NULL passkeyVerifiedAt to stale, not invalid", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "webauthn",
+      createdAt: minutesAgo(5),
+      passkeyVerifiedAt: null,
+    });
+
+    await expect(evaluateStepUpFreshness("sess-1")).resolves.toBe("stale");
+  });
+
+  it("judges non-webauthn sessions on createdAt: fresh within the window", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "google",
+      createdAt: minutesAgo(5),
+      passkeyVerifiedAt: null,
+    });
+
+    await expect(evaluateStepUpFreshness("sess-1")).resolves.toBe("fresh");
+  });
+
+  it("judges non-webauthn sessions on createdAt: stale past the window", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "google",
+      createdAt: minutesAgo(20),
+      passkeyVerifiedAt: null,
+    });
+
+    await expect(evaluateStepUpFreshness("sess-1")).resolves.toBe("stale");
+  });
+
+  it("treats provider null (pre-provenance session) like the createdAt branch", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: null,
+      createdAt: minutesAgo(20),
+      passkeyVerifiedAt: null,
+    });
+
+    await expect(evaluateStepUpFreshness("sess-1")).resolves.toBe("stale");
+  });
+
+  it("honors a custom maxAgeMs on the createdAt branch", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "google",
+      createdAt: minutesAgo(20),
+      passkeyVerifiedAt: null,
+    });
+
+    await expect(
+      evaluateStepUpFreshness("sess-1", { maxAgeMs: 30 * MS_PER_MINUTE }),
+    ).resolves.toBe("fresh");
+  });
+
+  it("honors a custom maxAgeMs on the passkeyVerifiedAt branch", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "webauthn",
+      createdAt: minutesAgo(120),
+      passkeyVerifiedAt: minutesAgo(20),
+    });
+
+    await expect(
+      evaluateStepUpFreshness("sess-1", { maxAgeMs: 30 * MS_PER_MINUTE }),
+    ).resolves.toBe("fresh");
+  });
+});
+
 describe("requireRecentCurrentAuthMethod", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockWithBypassRls.mockImplementation(
-      (prisma: unknown, fn: (tx: unknown) => unknown, _purpose: string) => fn(prisma),
-    );
-    mockRequireRecentPasskeyVerification.mockResolvedValue(null);
-    mockRequireRecentSession.mockResolvedValue(null);
-  });
-
-  it("delegates to recent passkey verification for webauthn sessions", async () => {
-    mockSessionFindUnique.mockResolvedValue({ provider: "webauthn" });
-
-    const result = await requireRecentCurrentAuthMethod(makeRequest());
-
-    expect(result).toBeNull();
-    expect(mockRequireRecentPasskeyVerification).toHaveBeenCalledWith(
-      expect.any(NextRequest),
-      {},
-    );
-  });
-
-  it("falls back to recent session for non-webauthn sessions", async () => {
-    mockSessionFindUnique.mockResolvedValue({ provider: "google" });
-
-    const result = await requireRecentCurrentAuthMethod(makeRequest());
-
-    expect(result).toBeNull();
-    expect(mockRequireRecentSession).toHaveBeenCalledWith(
-      expect.any(NextRequest),
-      {},
-    );
-  });
-
   it("returns 401 when the request has no session cookie", async () => {
     const result = await requireRecentCurrentAuthMethod(makeRequest(""));
+
     expect(result?.status).toBe(401);
+    expect(mockSessionFindUnique).not.toHaveBeenCalled();
   });
 
   it("returns 401 when the cookie is valid but the session row is missing (DB miss)", async () => {
@@ -88,20 +158,84 @@ describe("requireRecentCurrentAuthMethod", () => {
     const result = await requireRecentCurrentAuthMethod(makeRequest());
 
     expect(result?.status).toBe(401);
-    expect(mockRequireRecentPasskeyVerification).not.toHaveBeenCalled();
-    expect(mockRequireRecentSession).not.toHaveBeenCalled();
   });
 
-  it("falls back to recent session when provider is null (pre-provenance-migration session)", async () => {
-    mockSessionFindUnique.mockResolvedValue({ provider: null });
+  it("returns null for a fresh session", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "google",
+      createdAt: minutesAgo(5),
+      passkeyVerifiedAt: null,
+    });
+
+    await expect(
+      requireRecentCurrentAuthMethod(makeRequest()),
+    ).resolves.toBeNull();
+  });
+
+  it("returns 403 SESSION_STEP_UP_REQUIRED for a stale session by default", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "google",
+      createdAt: minutesAgo(20),
+      passkeyVerifiedAt: null,
+    });
 
     const result = await requireRecentCurrentAuthMethod(makeRequest());
 
-    expect(result).toBeNull();
-    expect(mockRequireRecentSession).toHaveBeenCalledWith(
-      expect.any(NextRequest),
-      {},
-    );
-    expect(mockRequireRecentPasskeyVerification).not.toHaveBeenCalled();
+    expect(result?.status).toBe(403);
+    const body = (await result?.json()) as { error: string };
+    expect(body.error).toBe(API_ERROR.SESSION_STEP_UP_REQUIRED);
+  });
+
+  it("preserves a caller-supplied errorCode on the stale 403 (operator-tokens contract)", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "webauthn",
+      createdAt: minutesAgo(5),
+      passkeyVerifiedAt: minutesAgo(20),
+    });
+
+    const result = await requireRecentCurrentAuthMethod(makeRequest(), {
+      errorCode: API_ERROR.OPERATOR_TOKEN_STALE_SESSION,
+    });
+
+    expect(result?.status).toBe(403);
+    const body = (await result?.json()) as { error: string };
+    expect(body.error).toBe(API_ERROR.OPERATOR_TOKEN_STALE_SESSION);
+  });
+});
+
+describe("canRecoverSessionWithPasskey", () => {
+  it("returns true for a webauthn session with at least one credential", async () => {
+    mockSessionFindUnique.mockResolvedValue({ provider: "webauthn" });
+    mockCredentialCount.mockResolvedValue(2);
+
+    await expect(
+      canRecoverSessionWithPasskey("sess-1", "user-1"),
+    ).resolves.toBe(true);
+  });
+
+  it("returns false for a webauthn session whose credentials were all deleted", async () => {
+    mockSessionFindUnique.mockResolvedValue({ provider: "webauthn" });
+    mockCredentialCount.mockResolvedValue(0);
+
+    await expect(
+      canRecoverSessionWithPasskey("sess-1", "user-1"),
+    ).resolves.toBe(false);
+  });
+
+  it("returns false for a non-webauthn session without counting credentials", async () => {
+    mockSessionFindUnique.mockResolvedValue({ provider: "google" });
+
+    await expect(
+      canRecoverSessionWithPasskey("sess-1", "user-1"),
+    ).resolves.toBe(false);
+    expect(mockCredentialCount).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the session row is missing", async () => {
+    mockSessionFindUnique.mockResolvedValue(null);
+
+    await expect(
+      canRecoverSessionWithPasskey("sess-1", "user-1"),
+    ).resolves.toBe(false);
   });
 });

--- a/src/lib/auth/session/recent-current-auth-method.test.ts
+++ b/src/lib/auth/session/recent-current-auth-method.test.ts
@@ -205,7 +205,10 @@ describe("requireRecentCurrentAuthMethod", () => {
 
 describe("canRecoverSessionWithPasskey", () => {
   it("returns true for a webauthn session with at least one credential", async () => {
-    mockSessionFindUnique.mockResolvedValue({ provider: "webauthn" });
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "webauthn",
+      userId: "user-1",
+    });
     mockCredentialCount.mockResolvedValue(2);
 
     await expect(
@@ -214,7 +217,10 @@ describe("canRecoverSessionWithPasskey", () => {
   });
 
   it("returns false for a webauthn session whose credentials were all deleted", async () => {
-    mockSessionFindUnique.mockResolvedValue({ provider: "webauthn" });
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "webauthn",
+      userId: "user-1",
+    });
     mockCredentialCount.mockResolvedValue(0);
 
     await expect(
@@ -222,8 +228,24 @@ describe("canRecoverSessionWithPasskey", () => {
     ).resolves.toBe(false);
   });
 
+  it("returns false when the session row belongs to a different user (parameter binding)", async () => {
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "webauthn",
+      userId: "someone-else",
+    });
+    mockCredentialCount.mockResolvedValue(2);
+
+    await expect(
+      canRecoverSessionWithPasskey("sess-1", "user-1"),
+    ).resolves.toBe(false);
+    expect(mockCredentialCount).not.toHaveBeenCalled();
+  });
+
   it("returns false for a non-webauthn session without counting credentials", async () => {
-    mockSessionFindUnique.mockResolvedValue({ provider: "google" });
+    mockSessionFindUnique.mockResolvedValue({
+      provider: "google",
+      userId: "user-1",
+    });
 
     await expect(
       canRecoverSessionWithPasskey("sess-1", "user-1"),

--- a/src/lib/auth/session/recent-current-auth-method.ts
+++ b/src/lib/auth/session/recent-current-auth-method.ts
@@ -1,27 +1,101 @@
 import type { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSessionToken } from "@/app/api/sessions/helpers";
-import { unauthorized } from "@/lib/http/api-response";
+import { API_ERROR } from "@/lib/http/api-error-codes";
+import { errorResponse, unauthorized } from "@/lib/http/api-response";
 import { withBypassRls, BYPASS_PURPOSE } from "@/lib/tenant-rls";
 import {
-  requireRecentSession,
+  STEP_UP_WINDOW_MS,
   type RequireRecentSessionOptions,
 } from "@/lib/auth/session/step-up";
-import { requireRecentPasskeyVerification } from "@/lib/auth/webauthn/recent-passkey-verification";
+import { PASSKEY_VERIFICATION_WINDOW_MS } from "@/lib/auth/webauthn/recent-passkey-verification";
+
+export type StepUpFreshness = "fresh" | "stale" | "invalid";
 
 /**
- * Route-level step-up chooser.
+ * Provider-aware step-up freshness core, shared by the route-level gate
+ * (`requireRecentCurrentAuthMethod`) and the sign-in page's reauth-panel
+ * branch. Both entry points MUST evaluate through this single function —
+ * any divergence between what the page deems "fresh" and what the gate
+ * accepts re-opens the stale-session redirect loop this exists to close.
  *
- * WebAuthn-established sessions use recent passkey verification; other
- * session types stay on the generic recent-session gate.
+ * WebAuthn-established sessions are judged on `passkeyVerifiedAt` (refreshed
+ * by the passkey reauth ceremony without replacing the session); every other
+ * provider is judged on `createdAt` (refreshed only by a fresh sign-in).
  *
  * Bootstrap-tenant invariant: a `provider === "webauthn"` session can only
  * exist for bootstrap-tenant users because `src/app/api/auth/passkey/verify/route.ts`
- * rejects non-bootstrap users before creating the session row. This means
- * routing the webauthn branch to passkey reauth is always recoverable in-app
- * (the user has at least one credential by construction).
+ * rejects non-bootstrap users before creating the session row. The user had
+ * at least one credential at session creation; credentials may have been
+ * deleted since, which is why reauth UIs must always offer a sign-in-again
+ * fallback alongside the ceremony.
  * `provider === null` (legacy sessions predating the provenance migration)
  * falls through to the generic recent-session gate.
+ */
+export async function evaluateStepUpFreshness(
+  sessionToken: string,
+  options: RequireRecentSessionOptions = {},
+): Promise<StepUpFreshness> {
+  const sessionRow = await withBypassRls(
+    prisma,
+    async (tx) =>
+      tx.session.findUnique({
+        where: { sessionToken },
+        select: { provider: true, createdAt: true, passkeyVerifiedAt: true },
+      }),
+    BYPASS_PURPOSE.AUTH_FLOW,
+  );
+
+  if (!sessionRow) return "invalid";
+
+  if (sessionRow.provider === "webauthn") {
+    // A live webauthn session with no verification timestamp is stale (needs
+    // a ceremony), NOT invalid — matches the pre-refactor 403 semantics.
+    if (!sessionRow.passkeyVerifiedAt) return "stale";
+    const maxAgeMs = options.maxAgeMs ?? PASSKEY_VERIFICATION_WINDOW_MS;
+    return Date.now() - sessionRow.passkeyVerifiedAt.getTime() > maxAgeMs
+      ? "stale"
+      : "fresh";
+  }
+
+  const maxAgeMs = options.maxAgeMs ?? STEP_UP_WINDOW_MS;
+  return Date.now() - sessionRow.createdAt.getTime() > maxAgeMs
+    ? "stale"
+    : "fresh";
+}
+
+/**
+ * Whether a stale session can be recovered with an in-place passkey ceremony
+ * (webauthn-established session AND the user still has at least one
+ * registered credential — credentials may have been deleted after sign-in).
+ * Non-recoverable sessions fall back to sign-out + fresh sign-in.
+ */
+export async function canRecoverSessionWithPasskey(
+  sessionToken: string,
+  userId: string,
+): Promise<boolean> {
+  return withBypassRls(
+    prisma,
+    async (tx) => {
+      const row = await tx.session.findUnique({
+        where: { sessionToken },
+        select: { provider: true },
+      });
+      if (row?.provider !== "webauthn") return false;
+      const credentialCount = await tx.webAuthnCredential.count({
+        where: { userId },
+      });
+      return credentialCount > 0;
+    },
+    BYPASS_PURPOSE.AUTH_FLOW,
+  );
+}
+
+/**
+ * Route-level step-up gate. Thin wrapper over `evaluateStepUpFreshness`
+ * preserving the pre-refactor external contract: missing token / missing
+ * session row → 401; stale → 403 with the caller-supplied `errorCode`
+ * (default `SESSION_STEP_UP_REQUIRED`); fresh → null.
  */
 export async function requireRecentCurrentAuthMethod(
   req: NextRequest,
@@ -32,23 +106,15 @@ export async function requireRecentCurrentAuthMethod(
     return unauthorized();
   }
 
-  const sessionRow = await withBypassRls(
-    prisma,
-    async (tx) =>
-      tx.session.findUnique({
-        where: { sessionToken },
-        select: { provider: true },
-      }),
-    BYPASS_PURPOSE.AUTH_FLOW,
-  );
-
-  if (!sessionRow) {
+  const verdict = await evaluateStepUpFreshness(sessionToken, options);
+  if (verdict === "invalid") {
     return unauthorized();
   }
-
-  if (sessionRow.provider === "webauthn") {
-    return requireRecentPasskeyVerification(req, options);
+  if (verdict === "stale") {
+    return errorResponse(
+      options.errorCode ?? API_ERROR.SESSION_STEP_UP_REQUIRED,
+      403,
+    );
   }
-
-  return requireRecentSession(req, options);
+  return null;
 }

--- a/src/lib/auth/session/recent-current-auth-method.ts
+++ b/src/lib/auth/session/recent-current-auth-method.ts
@@ -10,7 +10,14 @@ import {
 } from "@/lib/auth/session/step-up";
 import { PASSKEY_VERIFICATION_WINDOW_MS } from "@/lib/auth/webauthn/recent-passkey-verification";
 
-export type StepUpFreshness = "fresh" | "stale" | "invalid";
+export const STEP_UP_FRESHNESS = {
+  FRESH: "fresh",
+  STALE: "stale",
+  INVALID: "invalid",
+} as const;
+
+export type StepUpFreshness =
+  (typeof STEP_UP_FRESHNESS)[keyof typeof STEP_UP_FRESHNESS];
 
 /**
  * Provider-aware step-up freshness core, shared by the route-level gate
@@ -46,22 +53,22 @@ export async function evaluateStepUpFreshness(
     BYPASS_PURPOSE.AUTH_FLOW,
   );
 
-  if (!sessionRow) return "invalid";
+  if (!sessionRow) return STEP_UP_FRESHNESS.INVALID;
 
   if (sessionRow.provider === "webauthn") {
     // A live webauthn session with no verification timestamp is stale (needs
     // a ceremony), NOT invalid — matches the pre-refactor 403 semantics.
-    if (!sessionRow.passkeyVerifiedAt) return "stale";
+    if (!sessionRow.passkeyVerifiedAt) return STEP_UP_FRESHNESS.STALE;
     const maxAgeMs = options.maxAgeMs ?? PASSKEY_VERIFICATION_WINDOW_MS;
     return Date.now() - sessionRow.passkeyVerifiedAt.getTime() > maxAgeMs
-      ? "stale"
-      : "fresh";
+      ? STEP_UP_FRESHNESS.STALE
+      : STEP_UP_FRESHNESS.FRESH;
   }
 
   const maxAgeMs = options.maxAgeMs ?? STEP_UP_WINDOW_MS;
   return Date.now() - sessionRow.createdAt.getTime() > maxAgeMs
-    ? "stale"
-    : "fresh";
+    ? STEP_UP_FRESHNESS.STALE
+    : STEP_UP_FRESHNESS.FRESH;
 }
 
 /**
@@ -109,10 +116,10 @@ export async function requireRecentCurrentAuthMethod(
   }
 
   const verdict = await evaluateStepUpFreshness(sessionToken, options);
-  if (verdict === "invalid") {
+  if (verdict === STEP_UP_FRESHNESS.INVALID) {
     return unauthorized();
   }
-  if (verdict === "stale") {
+  if (verdict === STEP_UP_FRESHNESS.STALE) {
     return errorResponse(
       options.errorCode ?? API_ERROR.SESSION_STEP_UP_REQUIRED,
       403,

--- a/src/lib/auth/session/recent-current-auth-method.ts
+++ b/src/lib/auth/session/recent-current-auth-method.ts
@@ -79,9 +79,11 @@ export async function canRecoverSessionWithPasskey(
     async (tx) => {
       const row = await tx.session.findUnique({
         where: { sessionToken },
-        select: { provider: true },
+        select: { provider: true, userId: true },
       });
-      if (row?.provider !== "webauthn") return false;
+      // Bind the two parameters: a caller passing a userId that does not own
+      // this session must not learn whether that user has credentials.
+      if (row?.provider !== "webauthn" || row.userId !== userId) return false;
       const credentialCount = await tx.webAuthnCredential.count({
         where: { userId },
       });


### PR DESCRIPTION
## Summary

Fixes a three-layer defect that broke MCP OAuth (Claude Code / passwd-sso CLI) and iOS OAuth login for stale-but-valid sessions:

- **L1 — basePath URL doubling** (basePath deployments only): the sign-in page passed a basePath-qualified API-callback path to Next's `redirect()`, which re-prepends basePath → `/passwd-sso/passwd-sso/api/mcp/authorize` → locale injection → **404**. Introduced in `ab8e2b2c` (v0.4.57); never caught because the only test mocked `BASE_PATH: ""`.
- **L2 — non-canonical step-up primitive**: the three browser-redirect OAuth gates (`/api/mcp/authorize` GET, `/api/mcp/authorize/consent` POST, `/api/mobile/authorize` GET) called `requireRecentSession` (createdAt gate) directly, bypassing the provider-aware chooser every in-app gate uses — so even WebAuthn users could not recover via the passkey `passkeyVerifiedAt` path.
- **L3 — unrecoverable sign-in bounce**: on a stale session the routes bounce to sign-in, but the sign-in page short-circuited authenticated users straight back to the callback without re-authenticating. `Session.createdAt` never refreshes → **infinite redirect loop** (masked as the L1 404 on basePath deployments; a live loop elsewhere). The `ee331b03` recovery comment's premise ("the second pass has a recent-enough session") did not hold.

All three layers were verified by live redirect-chain capture against a real deployment before implementation.

## Changes

- **Sign-in page** (`src/app/[locale]/auth/signin/page.tsx`): strip basePath via `callbackUrlToHref` before `nextRedirect` (L1); evaluate step-up freshness for API callbacks through the shared core — fresh → redirect, stale → render the new reauth panel, invalid → sign-in form (L3).
- **Shared freshness core** (`evaluateStepUpFreshness` in `src/lib/auth/session/recent-current-auth-method.ts`): single provider-aware query used by BOTH the API gates and the sign-in page, so the two can never diverge (the divergence is what looped). Preserves caller-supplied `errorCode` (operator-tokens contract); webauthn rows with NULL `passkeyVerifiedAt` map to stale (matches pre-refactor 403); `STEP_UP_FRESHNESS` const object.
- **Reauth panel** (`src/components/auth/signin-reauth-panel.tsx`): passkey ceremony for webauthn sessions (refreshes `passkeyVerifiedAt`, session kept); "sign in again" (`signOut` → fresh sign-in → new session, old revoked) for Google/SAML/magic-link — always rendered so a user whose passkeys were deleted is never stranded. Gesture-gated (no signOut on mount); `callbackHref` structurally validated (`^\/(?![/\\])`, server-computed only); try/finally so a network rejection cannot strand the panel.
- **Gates** (3 routes): `requireRecentSession` → `requireRecentCurrentAuthMethod`, no options (parity with the page is CI-guarded).
- **Cookie-store token helper** (`getSessionTokenFromCookieStore`): server-component variant on the same cookie-name SSoT (`__Host-`/`__Secure-`/plain), no legacy-name fallback.
- **Guard**: `evaluateStepUpFreshness` added to `STEPUP_PRIMITIVE_RE`; exempt-list comments synced; guard self-test extended.
- **i18n**: new `Auth.reauthPanelTitle` / `Auth.reauthPanelDescription` in both locales — en: "Verify your identity to continue" / "Approving this app connection requires a recent identity check. Verify to continue right where you left off." Japanese equivalents added in `messages/ja/Auth.json` (domain language, no internal jargon).

## Security posture (reviewed)

- Not a gate weakening: `passkeyVerifiedAt` requires a live WebAuthn assertion (stronger evidence than `createdAt`, which silent IdP re-federation can refresh); the absolute session cap still bounds webauthn session lifetime; operator/SA-token minting already uses the chooser.
- The step-up gate's primary threat model (stolen session cookie) is intact: a cookie alone cannot pass the recovery (no IdP session / no passkey).
- Accepted residual (documented as `SC4`): a browser-resident attacker with a live IdP session can satisfy step-up without a credential challenge — same posture as the existing in-app `RecentSessionRequiredDialog`; IdP re-challenge (`prompt=login` / `forceAuthn`) is a follow-up.
- Deferred follow-ups tracked in the plan: `SC2` (MCP discovery standardization: RFC 9728 root metadata + `WWW-Authenticate`), `SC3` (`//` normalization hardening in `resolveCallbackUrl`), `SC-E2E` (provider-driven basePath E2E harness).

## Review process

Triangulate (3 expert agents × plan 2 rounds + code 1 round) — no Critical findings; 1 Major (panel liveness) + 4 Minor/Low fixed in-branch. Artifacts:
- `docs/archive/review/fix-mcp-oauth-stepup-recovery-plan.md` (contracts C1–C4, invariants, scope contract)
- `docs/archive/review/fix-mcp-oauth-stepup-recovery-review.md` (all rounds, findings, resolutions)

## Test plan

- [x] Full suite: 12,163 passed / 1 skipped (`npx vitest run`)
- [x] `npx next build` exit 0; `npm run lint` 0 problems; `npm run typecheck` pass
- [x] `scripts/pre-pr.sh` green (incl. step-up coverage guard, test-hygiene)
- [x] RED-on-pre-fix proven: reverting the L1 line fails the new basePath regression test
- [x] New coverage: basePath doubling (L1 + inverse-L1 panel href), freshness matrix (provider × fresh/stale/null/missing, `errorCode`/`maxAgeMs` passthrough), panel (mount-safety, in-flight, rejection liveness, S1 refusals), cookie-store shapes, guard anti-drift
- [ ] Manual (post-deploy): connect Claude Code / `passwd-sso login` with a >15-min session on a basePath deployment; confirm reauth panel → consent → token for both a passkey user and an SSO user

🤖 Generated with [Claude Code](https://claude.com/claude-code)
