### PR TITLE
fix(cli): render command errors cleanly and fail fast before passphrase prompts when not logged in

### DIFF
--- a/cli/src/__tests__/integration/agent-decrypt-ipc.test.ts
+++ b/cli/src/__tests__/integration/agent-decrypt-ipc.test.ts
@@ -87,6 +87,7 @@ vi.mock("../../lib/vault-state.js", () => ({
 }));
 vi.mock("../../lib/api-client.js", () => ({
   apiRequest: vi.fn().mockResolvedValue({ ok: false, status: 500, data: {} }),
+  assertLoggedIn: vi.fn(),
   startBackgroundRefresh: vi.fn(),
 }));
 vi.mock("../../lib/output.js", () => ({

--- a/cli/src/__tests__/integration/agent-decrypt-ipc.test.ts
+++ b/cli/src/__tests__/integration/agent-decrypt-ipc.test.ts
@@ -264,4 +264,21 @@ describe("handleConnection socket protocol", () => {
     expect(responses[0].ok).toBe(false);
     expect(responses[0].error).toMatch(/[Pp]arse error/);
   });
+
+  // Keep this the LAST test in this describe: an unconsumed mockRejectedValueOnce
+  // survives clearAllMocks, so last position guarantees no later test can inherit it.
+  it("labels apiRequest rejections as request failures, not parse errors", async () => {
+    vi.mocked(apiRequest).mockRejectedValueOnce(new Error("fetch failed"));
+    const req = JSON.stringify({
+      entryId: "entry_abc123",
+      clientId: "mcpc_test",
+      field: "password",
+    });
+
+    const res = await sendAndReceive(req + "\n");
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/Request failed: fetch failed/);
+    expect(res.error).not.toMatch(/[Pp]arse error/);
+  });
 });

--- a/cli/src/__tests__/integration/cli-error-output.test.ts
+++ b/cli/src/__tests__/integration/cli-error-output.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { MS_PER_SECOND } from "../../lib/time.js";
 
 // cli/src/__tests__/integration/ → cli/dist/
 const distEntry = resolve(import.meta.dirname, "../../../dist/index.js");
@@ -17,7 +18,7 @@ const STACK_FRAME_MARKERS = ["    at ", "node:internal"];
 function runCli(args: string[]): { status: number | null; stdout: string; stderr: string } {
   const { status, stdout, stderr } = spawnSync("node", [distEntry, ...args], {
     encoding: "utf8",
-    timeout: 10000,
+    timeout: 10 * MS_PER_SECOND,
     // Closed stdin: if the not-logged-in fail-fast ever regresses, readPassphrase
     // resolves immediately on EOF instead of hanging the suite at the prompt.
     input: "",

--- a/cli/src/__tests__/integration/cli-error-output.test.ts
+++ b/cli/src/__tests__/integration/cli-error-output.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// cli/src/__tests__/integration/ → cli/dist/
+const distEntry = resolve(import.meta.dirname, "../../../dist/index.js");
+const distExists = existsSync(distEntry);
+
+// Isolated HOME/XDG dirs: no config.json, no credentials, and no legacy
+// ~/.passwd-sso migration source (os.homedir() follows $HOME on POSIX).
+let isolatedHome: string;
+
+const STACK_FRAME_MARKERS = ["    at ", "node:internal"];
+
+function runCli(args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const { status, stdout, stderr } = spawnSync("node", [distEntry, ...args], {
+    encoding: "utf8",
+    timeout: 10000,
+    // Closed stdin: if the not-logged-in fail-fast ever regresses, readPassphrase
+    // resolves immediately on EOF instead of hanging the suite at the prompt.
+    input: "",
+    env: {
+      ...process.env,
+      HOME: isolatedHome,
+      XDG_CONFIG_HOME: join(isolatedHome, ".config"),
+      XDG_DATA_HOME: join(isolatedHome, ".local", "share"),
+    },
+  });
+  return { status, stdout, stderr };
+}
+
+describe("CLI error output without login", () => {
+  beforeAll(() => {
+    isolatedHome = mkdtempSync(join(tmpdir(), "passwd-sso-cli-test-"));
+  });
+
+  afterAll(() => {
+    rmSync(isolatedHome, { recursive: true, force: true });
+  });
+
+  it.skipIf(!distExists)(
+    "unlock fails fast with a clean error and no passphrase prompt",
+    () => {
+      const { status, stdout, stderr } = runCli(["unlock"]);
+
+      expect(status).toBe(1);
+      expect(stderr).toContain("Not logged in. Run `passwd-sso login` first.");
+      expect(stdout).not.toContain("Master passphrase:");
+      for (const marker of STACK_FRAME_MARKERS) {
+        expect(stdout + stderr).not.toContain(marker);
+      }
+    },
+  );
+
+  it.skipIf(!distExists)(
+    "api-key list fails with a clean error and no stack trace",
+    () => {
+      const { status, stdout, stderr } = runCli(["api-key", "list"]);
+
+      expect(status).toBe(1);
+      expect(stderr).toContain("Not logged in. Run `passwd-sso login` first.");
+      for (const marker of STACK_FRAME_MARKERS) {
+        expect(stdout + stderr).not.toContain(marker);
+      }
+    },
+  );
+});

--- a/cli/src/__tests__/unit/agent-decrypt.test.ts
+++ b/cli/src/__tests__/unit/agent-decrypt.test.ts
@@ -122,7 +122,7 @@ describe("decryptAgentCommand", () => {
       value: false,
       configurable: true,
     });
-    process.env.XDG_RUNTIME_DIR = "/run/user/1000";
+    vi.stubEnv("XDG_RUNTIME_DIR", "/run/user/1000");
 
     await expect(decryptAgentCommand({})).rejects.toThrow("process.exit(1)");
     expect(stderrOutput).toContain("No TTY available");
@@ -138,7 +138,7 @@ describe("decryptAgentCommand", () => {
       value: true,
       configurable: true,
     });
-    process.env.XDG_RUNTIME_DIR = "/run/user/1000";
+    vi.stubEnv("XDG_RUNTIME_DIR", "/run/user/1000");
 
     vi.mocked(readPassphrase).mockResolvedValue("");
 
@@ -156,7 +156,7 @@ describe("decryptAgentCommand", () => {
       value: true,
       configurable: true,
     });
-    process.env.XDG_RUNTIME_DIR = "/run/user/1000";
+    vi.stubEnv("XDG_RUNTIME_DIR", "/run/user/1000");
 
     vi.mocked(readPassphrase).mockResolvedValue("wrong-pass");
     vi.mocked(unlockWithPassphrase).mockResolvedValue(false);
@@ -176,7 +176,7 @@ describe("decryptAgentCommand", () => {
       value: true,
       configurable: true,
     });
-    process.env.XDG_RUNTIME_DIR = "/run/user/1000";
+    vi.stubEnv("XDG_RUNTIME_DIR", "/run/user/1000");
 
     vi.mocked(assertLoggedIn).mockImplementationOnce(() => {
       throw new Error("Not logged in. Run `passwd-sso login` first.");

--- a/cli/src/__tests__/unit/agent-decrypt.test.ts
+++ b/cli/src/__tests__/unit/agent-decrypt.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../lib/vault-state.js", () => ({
 
 vi.mock("../../lib/api-client.js", () => ({
   apiRequest: vi.fn(),
+  assertLoggedIn: vi.fn(),
   startBackgroundRefresh: vi.fn(),
 }));
 
@@ -59,6 +60,7 @@ vi.mock("node:child_process", () => ({
 const { readPassphrase, unlockWithPassphrase } = await import(
   "../../commands/unlock.js"
 );
+const { assertLoggedIn } = await import("../../lib/api-client.js");
 const { decryptAgentCommand } = await import("../../commands/agent-decrypt.js");
 
 describe("decryptAgentCommand", () => {
@@ -161,5 +163,27 @@ describe("decryptAgentCommand", () => {
 
     await expect(decryptAgentCommand({})).rejects.toThrow("process.exit(1)");
     expect(exitCode).toBe(1);
+  });
+
+  // Keep this the LAST test in this describe: an unconsumed mockImplementationOnce
+  // survives clearAllMocks, so last position guarantees no later test can inherit it.
+  it("rejects with 'Not logged in' before prompting when not logged in", async () => {
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      configurable: true,
+    });
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+    process.env.XDG_RUNTIME_DIR = "/run/user/1000";
+
+    vi.mocked(assertLoggedIn).mockImplementationOnce(() => {
+      throw new Error("Not logged in. Run `passwd-sso login` first.");
+    });
+
+    await expect(decryptAgentCommand({})).rejects.toThrow("Not logged in");
+
+    expect(readPassphrase).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/__tests__/unit/agent.test.ts
+++ b/cli/src/__tests__/unit/agent.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../lib/vault-state.js", () => ({
 
 vi.mock("../../lib/api-client.js", () => ({
   apiRequest: vi.fn(),
+  assertLoggedIn: vi.fn(),
 }));
 
 vi.mock("../../lib/crypto.js", () => ({
@@ -71,9 +72,9 @@ vi.mock("../../lib/output.js", () => ({
 
 const { spawn } = await import("node:child_process");
 const { decryptAgentCommand } = await import("../../commands/agent-decrypt.js");
-const { autoUnlockIfNeeded } = await import("../../commands/unlock.js");
+const { autoUnlockIfNeeded, readPassphrase } = await import("../../commands/unlock.js");
 const { getEncryptionKey, getUserId, getSecretKeyBytes } = await import("../../lib/vault-state.js");
-const { apiRequest } = await import("../../lib/api-client.js");
+const { apiRequest, assertLoggedIn } = await import("../../lib/api-client.js");
 const { decryptData } = await import("../../lib/crypto.js");
 const { loadKey } = await import("../../lib/ssh-key-agent.js");
 const output = await import("../../lib/output.js");
@@ -290,6 +291,27 @@ describe("agentCommand", () => {
       expect(autoUnlockIfNeeded).not.toHaveBeenCalled();
     } finally {
       onSpy.mockRestore();
+    }
+  });
+
+  // Keep this the LAST test in this describe: an unconsumed mockImplementationOnce
+  // survives clearAllMocks, so last position guarantees no later test can inherit it.
+  it("rejects with 'Not logged in' before prompting in --eval mode when not logged in", async () => {
+    vi.mocked(autoUnlockIfNeeded).mockResolvedValue(false);
+    const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    vi.mocked(assertLoggedIn).mockImplementationOnce(() => {
+      throw new Error("Not logged in. Run `passwd-sso login` first.");
+    });
+
+    try {
+      await expect(agentCommand({ eval: true })).rejects.toThrow("Not logged in");
+
+      expect(readPassphrase).not.toHaveBeenCalled();
+    } finally {
+      if (originalIsTTY) {
+        Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+      }
     }
   });
 });

--- a/cli/src/__tests__/unit/api-client.test.ts
+++ b/cli/src/__tests__/unit/api-client.test.ts
@@ -11,8 +11,27 @@ vi.mock("../../lib/config.js", () => ({
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-const { apiRequest, setTokenCache, clearTokenCache } = await import("../../lib/api-client.js");
+const { apiRequest, setTokenCache, clearTokenCache, assertLoggedIn } = await import("../../lib/api-client.js");
 const { loadCredentials, saveCredentials } = await import("../../lib/config.js");
+
+describe("assertLoggedIn", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearTokenCache();
+  });
+
+  it("throws 'Not logged in' when no token exists", () => {
+    (loadCredentials as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+    expect(() => assertLoggedIn()).toThrow("Not logged in. Run `passwd-sso login` first.");
+  });
+
+  it("does not throw when a token is cached", () => {
+    setTokenCache("test-token-123");
+
+    expect(() => assertLoggedIn()).not.toThrow();
+  });
+});
 
 describe("apiRequest", () => {
   beforeEach(() => {

--- a/cli/src/__tests__/unit/unlock.test.ts
+++ b/cli/src/__tests__/unit/unlock.test.ts
@@ -218,7 +218,7 @@ describe("autoUnlockIfNeeded", () => {
 
   it("does not warn when vault is already unlocked even if PSSO_PASSPHRASE is set", async () => {
     vi.mocked(isUnlocked).mockReturnValue(true);
-    process.env.PSSO_PASSPHRASE = "env-passphrase";
+    vi.stubEnv("PSSO_PASSPHRASE", "env-passphrase");
 
     const result = await autoUnlockIfNeeded();
 
@@ -239,7 +239,7 @@ describe("autoUnlockIfNeeded", () => {
 
   it("calls unlockWithPassphrase when PSSO_PASSPHRASE is set and vault is locked", async () => {
     vi.mocked(isUnlocked).mockReturnValue(false);
-    process.env.PSSO_PASSPHRASE = "env-passphrase";
+    vi.stubEnv("PSSO_PASSPHRASE", "env-passphrase");
 
     vi.mocked(apiRequest).mockResolvedValue({
       ok: true,
@@ -271,7 +271,7 @@ describe("autoUnlockIfNeeded", () => {
 
   it("returns false when PSSO_PASSPHRASE is set but unlock fails", async () => {
     vi.mocked(isUnlocked).mockReturnValue(false);
-    process.env.PSSO_PASSPHRASE = "wrong-passphrase";
+    vi.stubEnv("PSSO_PASSPHRASE", "wrong-passphrase");
 
     vi.mocked(apiRequest).mockResolvedValue({ ok: false, status: 401, data: {} });
 

--- a/cli/src/__tests__/unit/unlock.test.ts
+++ b/cli/src/__tests__/unit/unlock.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // --- Mocks (must be hoisted before imports) ---
 vi.mock("../../lib/api-client.js", () => ({
   apiRequest: vi.fn(),
+  assertLoggedIn: vi.fn(),
 }));
 
 vi.mock("../../lib/crypto.js", () => ({
@@ -26,7 +27,7 @@ vi.mock("../../lib/output.js", () => ({
   warn: vi.fn(),
 }));
 
-const { apiRequest } = await import("../../lib/api-client.js");
+const { apiRequest, assertLoggedIn } = await import("../../lib/api-client.js");
 const { deriveWrappingKey, unwrapSecretKey, deriveEncryptionKey, verifyKey } =
   await import("../../lib/crypto.js");
 const { setEncryptionKey, setSecretKeyBytes, isUnlocked } =
@@ -386,5 +387,23 @@ describe("unlockCommand", () => {
     expect(output.success).toHaveBeenCalledWith(
       expect.stringContaining("unlocked"),
     );
+  });
+
+  // Keep this the LAST test in this describe: an unconsumed mockImplementationOnce
+  // survives clearAllMocks, so last position guarantees no later test can inherit it.
+  it("rejects with 'Not logged in' before prompting when not logged in", async () => {
+    vi.mocked(isUnlocked).mockReturnValue(false);
+    vi.mocked(assertLoggedIn).mockImplementationOnce(() => {
+      throw new Error("Not logged in. Run `passwd-sso login` first.");
+    });
+
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(unlockCommand()).rejects.toThrow("Not logged in");
+
+    expect(stdoutWrite).not.toHaveBeenCalledWith(
+      expect.stringContaining("Master passphrase:"),
+    );
+    expect(apiRequest).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/commands/agent-decrypt.ts
+++ b/cli/src/commands/agent-decrypt.ts
@@ -12,7 +12,7 @@ import { spawn } from "node:child_process";
 import { mkdirSync, lstatSync, chmodSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
-import { apiRequest, startBackgroundRefresh } from "../lib/api-client.js";
+import { apiRequest, assertLoggedIn, startBackgroundRefresh } from "../lib/api-client.js";
 import { decryptData, hexEncode } from "../lib/crypto.js";
 import { buildPersonalEntryAAD, VAULT_TYPE } from "../lib/crypto-aad.js";
 import { getEncryptionKey, getUserId, getSecretKeyBytes, setEncryptionKey } from "../lib/vault-state.js";
@@ -278,6 +278,9 @@ export async function decryptAgentCommand(opts: DecryptAgentOptions): Promise<vo
     );
     process.exit(1);
   }
+
+  // Fail fast before prompting — the passphrase is useless without a login
+  assertLoggedIn();
 
   // In --eval mode, stdout is captured by the shell — write prompt to stderr
   const passphrase = await readPassphrase("Master passphrase: ", { useStderr: opts.eval });

--- a/cli/src/commands/agent-decrypt.ts
+++ b/cli/src/commands/agent-decrypt.ts
@@ -231,7 +231,15 @@ export function handleConnection(socket: Socket): void {
               error: `Invalid request: ${parsed.error.issues.map((i: { message: string }) => i.message).join(", ")}`,
             };
           } else {
-            response = await handleDecryptRequest(parsed.data);
+            try {
+              response = await handleDecryptRequest(parsed.data);
+            } catch (err) {
+              // Request-layer failures (server down, revoked login) — not parse errors
+              response = {
+                ok: false,
+                error: `Request failed: ${err instanceof Error ? err.message : "unknown error"}`,
+              };
+            }
           }
         } catch (err) {
           response = {

--- a/cli/src/commands/agent.ts
+++ b/cli/src/commands/agent.ts
@@ -13,7 +13,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { apiRequest } from "../lib/api-client.js";
+import { apiRequest, assertLoggedIn } from "../lib/api-client.js";
 import { decryptData, hexEncode } from "../lib/crypto.js";
 import { buildPersonalEntryAAD, VAULT_TYPE } from "../lib/crypto-aad.js";
 import {
@@ -158,6 +158,8 @@ export async function agentCommand(opts: AgentOptions): Promise<void> {
   // Unlock the vault in this (parent / foreground) process.
   if (!(await autoUnlockIfNeeded())) {
     if (opts.eval && process.stdin.isTTY) {
+      // Fail fast before prompting — the passphrase is useless without a login
+      assertLoggedIn();
       // Prompt on stderr so stdout stays clean for `eval $(...)` capture.
       const passphrase = await readPassphrase("Master passphrase: ", { useStderr: true });
       if (!passphrase || !(await unlockWithPassphrase(passphrase))) {

--- a/cli/src/commands/unlock.ts
+++ b/cli/src/commands/unlock.ts
@@ -4,7 +4,7 @@
  * Derives the encryption key and stores it in process memory.
  */
 
-import { apiRequest } from "../lib/api-client.js";
+import { apiRequest, assertLoggedIn } from "../lib/api-client.js";
 import {
   hexDecode,
   deriveWrappingKey,
@@ -132,6 +132,9 @@ export async function unlockCommand(): Promise<void> {
     output.info("Vault is already unlocked.");
     return;
   }
+
+  // Fail fast before prompting — the passphrase is useless without a login
+  assertLoggedIn();
 
   const passphrase = await readPassphrase("Master passphrase: ");
   if (!passphrase) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -194,7 +194,13 @@ program
     }
   });
 
-program.parse();
+try {
+  await program.parseAsync();
+} catch (err) {
+  // Render action-handler errors as a clean one-liner — never a stack trace
+  output.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
 
 // ─── Interactive REPL Mode ──────────────────────────────────────
 

--- a/cli/src/lib/api-client.ts
+++ b/cli/src/lib/api-client.ts
@@ -59,6 +59,12 @@ export function clearTokenCache(): void {
   cachedClientId = null;
 }
 
+export function assertLoggedIn(): void {
+  if (!getToken()) {
+    throw new Error("Not logged in. Run `passwd-sso login` first.");
+  }
+}
+
 function getBaseUrl(): string {
   const config = loadConfig();
   if (!config.serverUrl) {
@@ -112,10 +118,8 @@ export async function apiRequest<T = unknown>(
     headers?: Record<string, string>;
   } = {},
 ): Promise<ApiResponse<T>> {
+  assertLoggedIn();
   let token = getToken();
-  if (!token) {
-    throw new Error("Not logged in. Run `passwd-sso login` first.");
-  }
 
   if (isTokenExpiringSoon()) {
     const refreshed = await refreshToken();

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -5,5 +5,8 @@ export default defineConfig({
     globals: false,
     environment: "node",
     include: ["src/__tests__/**/*.test.ts"],
+    // vi.stubEnv stubs are auto-restored after each test (test-hygiene gate
+    // forbids direct process.env mutation; the root app wires this via setup.ts)
+    unstubEnvs: true,
   },
 });

--- a/docs/archive/review/cli-unhandled-rejection-code-review.md
+++ b/docs/archive/review/cli-unhandled-rejection-code-review.md
@@ -1,8 +1,17 @@
 # Code Review: cli-unhandled-rejection
 Date: 2026-07-09
-Review round: 1
+Review rounds: 3 (converged — all experts "No findings")
 
-## Changes from Previous Round
+## Round Summary
+
+| Round | Functionality | Security | Testing | Fix commit |
+|-------|--------------|----------|---------|-----------|
+| 1 | F8 Minor (daemon "Parse error:" mislabel, pre-existing in touched file) | No findings | No findings (3 seed hints rejected with evidence) | `59d087ac` |
+| 2 | No findings (F8 fix verified: nesting, single-respond, shape; independent 312/312 re-run) | No findings (socket disclosure zero-delta; JSON.stringify framing safe; authz semantics unchanged, fail-closed) | No findings (once-impl consumption deterministic; no ordering hazard with T7 chains; red-proof adequate) | — |
+| 2b gate | — | — | pre-pr.sh check-test-hygiene fired (whole-file scan of touched test files): direct env mutations → vi.stubEnv + `unstubEnvs: true` in cli/vitest.config.ts | `46ce45fa` |
+| 3 (testing only) | — | — | No findings (6/6 stub/replace/delete interplay scenarios empirically verified incl. ambient worst case; no test relied on env leakage) | — |
+
+## Round 1 Detail
 Initial code review (on top of the Phase 2 self-R-check baseline, which had already
 surfaced and fixed the R42 class expansion — agent.ts / agent-decrypt.ts
 prompt-before-login — in commit `8e2eaa17`).
@@ -87,6 +96,10 @@ None (all findings carry file/line evidence and concrete fixes).
 - Action: scoped `handleDecryptRequest` in its own catch emitting `Request failed: <message>`; `Parse error:` now covers only the JSON.parse/schema block. Added last-in-describe test with `mockRejectedValueOnce` asserting `Request failed: fetch failed` and NOT `Parse error`.
 - Modified file: cli/src/commands/agent-decrypt.ts (handleConnection IIFE); cli/src/__tests__/integration/agent-decrypt-ipc.test.ts (new case).
 - Red-proof: inner catch reverted → only the new test failed; restored byte-identical; 312/312 green.
+
+### Round 2b test-hygiene gate — Fixed
+- Action: converted direct `process.env.X =` mutations in the two touched test files to `vi.stubEnv` (unlock.test.ts PSSO_PASSPHRASE ×3; agent-decrypt.test.ts XDG_RUNTIME_DIR ×5) and added `unstubEnvs: true` to cli/vitest.config.ts (cli tree previously had no auto-unstub wiring). 312/312 tests + pre-pr 36/36. Round 3 testing review empirically verified hook-interplay safety (6/6 scenarios) and confirmed no test relied on env leakage.
+- Modified files: cli/src/__tests__/unit/unlock.test.ts, cli/src/__tests__/unit/agent-decrypt.test.ts, cli/vitest.config.ts.
 
 ### Testing informational note (isTTY guarded restore) — Accepted
 - **Anti-Deferral check**: acceptable risk.

--- a/docs/archive/review/cli-unhandled-rejection-code-review.md
+++ b/docs/archive/review/cli-unhandled-rejection-code-review.md
@@ -1,0 +1,97 @@
+# Code Review: cli-unhandled-rejection
+Date: 2026-07-09
+Review round: 1
+
+## Changes from Previous Round
+Initial code review (on top of the Phase 2 self-R-check baseline, which had already
+surfaced and fixed the R42 class expansion — agent.ts / agent-decrypt.ts
+prompt-before-login — in commit `8e2eaa17`).
+
+## Functionality Findings
+
+[F8] Minor (new in phase 3 round 1): apiRequest rejections inside the decrypt daemon surfaced with a misleading "Parse error:" label
+- File: cli/src/commands/agent-decrypt.ts (handleConnection IIFE catch; handleDecryptRequest apiRequest calls)
+- Evidence: single try wrapped both JSON parsing AND `await handleDecryptRequest(...)`; catch emitted `Parse error: ${err.message}` — so `fetch failed` / `Not logged in...` mid-daemon-life read as parse failures.
+- Impact: no functional break (client receives ok:false; daemon does not crash), but misleading diagnostics relayed verbatim by `decrypt`.
+- Pre-existing, in-scope per Anti-Deferral (file in diff); fix under 30-minute rule.
+
+Verification backing (no other findings): C1 byte-for-byte vs locked contract; forbidden patterns absent; R42 member-set re-derived (3 members all guarded; indirect-prompt sweep over setRawMode / rl.question / createInterface found no 4th member — login.ts prompts pre-login by design, ssh-confirm and REPL are post-unlock); guard-placement edge cases correct (TTY-check-before-guard deliberate); agent-decrypt C1 routing is a safe behavior change (old output was an unhandled-rejection stack, exit code unchanged at 1, socket clients consume the socket protocol not startup stderr); I3/I3b hold; R19 four factories aligned; build + 311/311 verified including integration cases actually executed (not skipped).
+
+## Security Findings
+
+No findings.
+
+- 8e2eaa17 verified correct and complete by independent member-set re-derivation (3/3 guarded, zero delta; ssh-confirm.ts is not a member).
+- Exhaustive branch walk: no remaining path prompts without login (daemon children receive keys via IPC; autoUnlock env path throws via apiRequest→assertLoggedIn to C1 without prompting; non-eval/non-TTY branches exit before the prompt).
+- agent-decrypt throw→C1 is a strict stderr reduction; C1 renders via console.error (stderr) so `eval $(...)` stdout capture can never receive the error line.
+- err.message surface of newly C1-routed flows: all content previously printed as line 1 of the uncaught dump; no new disclosure.
+- Zeroization paths untouched; guards throw before setRawMode and before any secret exists.
+- Informational (not a finding, pre-existing): assertLoggedIn checks presence, not freshness — expired-token user still prompted, then clean 401 error; passphrase used only locally.
+
+## Testing Findings
+
+No findings.
+
+- All 3 ordering tests: mockImplementationOnce, last-in-describe (verified single-describe files), plan-mandated assertions.
+- Integration test implements every plan mandate (closed stdin, computed timeout, skipIf, per-marker negative assertions on combined output, HOME/XDG isolation).
+- RT7 red-proof records verified in deviation log for all 5 new tests with the plan-predicted red shapes.
+- Cross-file isTTY leak empirically disproven (two-file probe, both parallelism modes).
+
+## Adjacent Findings
+
+None this round. (Phase 1's S-A1 / SC1 exit-0 class remains tracked via TODO(cli-exit-codes); untouched by this diff.)
+
+## Quality Warnings
+
+None (all findings carry file/line evidence and concrete fixes).
+
+## Seed Finding Disposition (per expert)
+
+- Functionality: Seed returned No findings — verified independently, no dispositions to record.
+- Security: Seed returned No findings — verified independently, no dispositions to record.
+- Testing (seed truncated — treated as unavailable; 3 hint items dispositioned):
+  1. agent-decrypt.test.ts XDG_RUNTIME_DIR restoration — Rejected (existing describe-level afterEach deletes it; identical trio contract as pre-existing tests).
+  2. api-client.test.ts sticky loadCredentials.mockReturnValue(null) — Rejected (behaviorally inert: null ≡ undefined for every consumer; token cache seeded in beforeEach; pattern predates diff).
+  3. agent.test.ts isTTY guarded restore — Rejected as finding (stub does persist post-test, but last-in-only-describe has no in-file victim and cross-file leak empirically disproven; informational hygiene note recorded).
+
+## Recurring Issue Check (Phase 3 Round 1 — deltas vs Phase 2 self-check baseline)
+
+### Functionality expert
+- R34: delta — fired as the basis for F8 (pre-existing flaw in diff-touched file, flagged not deferred)
+- R42: delta — re-derived 3-member set + indirect-prompt sweep; no further members
+- R19, R21: delta — verified in-code (factories aligned; full build+test re-run personally)
+- R1-R18, R20, R22-R33, R35-R41: unchanged
+
+### Security expert
+- R42: Checked — no issue (was Finding in Phase 2; fixed in 8e2eaa17; clause ①b does not fire post-fix)
+- R19, R34, R39: Checked — no issue
+- RS1-RS6: unchanged (RS1 N/A presence-check suppression; RS4/RS5 checked)
+- R1-R18, R20-R33, R35-R38, R40, R41: unchanged
+
+### Testing expert
+- R7: verified — no OR-combined assertions (I5 honored)
+- R19/RT1: verified — 4 factories extended; 5 untouched factories verified per-file safe
+- R42: verified by independent re-derivation (self-check error from Phase 2 corrected)
+- RT7: verified via deviation-log records
+- R1-R6, R8-R18, R20-R41, RT2-RT6, RT8: unchanged
+
+## Environment Verification Report
+
+- VE1 (integration requires built dist): `verified-local` — `cd cli && npm run build` then `npx vitest run` (312/312; integration cases confirmed executed, not skipped). Also gated in CI job `cli-ci` (build→test order verified).
+- VE2 (Homebrew-global repro not byte-reproducible locally): `verified-local` via behaviorally-identical `node cli/dist/index.js` spawns with isolated HOME/XDG (same entry point and credential resolution).
+- No `blocked-deferred` paths.
+
+## Resolution Status
+
+### [F8] Minor — apiRequest rejections mislabeled "Parse error:" — Fixed
+- Action: scoped `handleDecryptRequest` in its own catch emitting `Request failed: <message>`; `Parse error:` now covers only the JSON.parse/schema block. Added last-in-describe test with `mockRejectedValueOnce` asserting `Request failed: fetch failed` and NOT `Parse error`.
+- Modified file: cli/src/commands/agent-decrypt.ts (handleConnection IIFE); cli/src/__tests__/integration/agent-decrypt-ipc.test.ts (new case).
+- Red-proof: inner catch reverted → only the new test failed; restored byte-identical; 312/312 green.
+
+### Testing informational note (isTTY guarded restore) — Accepted
+- **Anti-Deferral check**: acceptable risk.
+- **Justification**:
+  - Worst case: a stubbed `process.stdin.isTTY=true` own-property persists after the last test of agent.test.ts within its worker; no test observes it (last in only describe; cross-file leak empirically disproven under both parallelism modes).
+  - Likelihood: zero observable impact today (empirical); could only matter if a future test is appended after the last-position test AND depends on isTTY.
+  - Cost to fix: ~2 lines (`else { delete ... }`) but would touch the pre-existing pattern in agent-decrypt.test.ts too and trigger another review round for zero behavior change; the last-position comment already guards the same victim scope.
+- **Orchestrator sign-off**: acceptable-risk exception satisfied.

--- a/docs/archive/review/cli-unhandled-rejection-deviation.md
+++ b/docs/archive/review/cli-unhandled-rejection-deviation.md
@@ -1,0 +1,15 @@
+# Coding Deviation Log: cli-unhandled-rejection
+
+## RT7 red-proof record (AC3-3, plan I6)
+
+- C1 revert proof: restored `program.parse()` in `cli/src/index.ts`, rebuilt dist, ran
+  `cli-error-output.test.ts` → BOTH integration cases failed on the negative
+  no-stack-frame assertion (`expected '...' not to contain '    at '`), exactly the
+  expected red shape. Re-applied C1, rebuilt → 2/2 green.
+- C2 revert proof: removed the `assertLoggedIn()` call from `unlockCommand` (backup
+  copy under session scratchpad, restored byte-identical afterwards — diff-verified),
+  ran `unlock.test.ts` → new ordering test failed with `Test timed out in 5000ms`
+  (the plan-predicted timeout-shaped failure at readPassphrase's never-resolving
+  promise). Restored → full cli suite 309/309 green.
+- Mutation-residue grep over `git diff`: clean (no commented-out guards, no skip
+  markers; the single `xit\(` regex hit was a false positive on `process.exit(`).

--- a/docs/archive/review/cli-unhandled-rejection-deviation.md
+++ b/docs/archive/review/cli-unhandled-rejection-deviation.md
@@ -47,3 +47,17 @@
 - Red-proof: reverted the inner catch (scratchpad backup) → only the new test
   failed ("Parse error: fetch failed" instead of "Request failed:"); restored
   byte-identical (diff-verified); suite 14/14 → full 312/312 green.
+
+## Phase 3 Round 2 gate fix (test-hygiene)
+
+- scripts/pre-pr.sh (36 checks) surfaced check-test-hygiene: changed test files are
+  scanned WHOLE-FILE for direct `process.env.X =` mutations. Converted all sites in
+  the two touched files to `vi.stubEnv` (unlock.test.ts: PSSO_PASSPHRASE ×3;
+  agent-decrypt.test.ts: XDG_RUNTIME_DIR ×5 incl. the new ordering test) and added
+  `unstubEnvs: true` to cli/vitest.config.ts (the cli tree had no setup.ts wiring —
+  agent.test.ts's comment referenced the root app's setup; the config flag makes
+  auto-unstub actually true for cli). Full suite 312/312 + pre-pr 36/36 green.
+- Process note: Phase 2 completion ran individual lint/test/build but deferred the
+  aggregate pre-pr.sh to Phase 3-6; the gate fired there. No code regression — the
+  violations were pre-existing lines in files this PR touched plus two new lines
+  that copied the pre-existing pattern.

--- a/docs/archive/review/cli-unhandled-rejection-deviation.md
+++ b/docs/archive/review/cli-unhandled-rejection-deviation.md
@@ -13,3 +13,26 @@
   promise). Restored → full cli suite 309/309 green.
 - Mutation-residue grep over `git diff`: clean (no commented-out guards, no skip
   markers; the single `xit\(` regex hit was a false positive on `process.exit(`).
+
+## R42 member-set expansion (Phase 2 self-R-check, security expert)
+
+- Deviation from locked plan: C2 was planned as an unlock-only fix. The Phase 2
+  self-R-check derived the actual class member-set from the defining primitive
+  (production `readPassphrase(` call sites) → 3 members: unlock.ts (seed),
+  agent.ts:162 (`agent --eval`, TTY, vault locked: autoUnlockIfNeeded does no API
+  call → prompt before any login check), agent-decrypt.ts:283 (`agent --decrypt`
+  parent path: prompts directly). The testing self-R-check initially disputed this
+  (claimed apiRequest runs first); orchestrator adjudicated by reading both files —
+  the disputed apiRequest sites are in loadSshKeys()/socket handlers that run AFTER
+  the prompt. Security expert's finding confirmed.
+- Fix applied in-phase per R42 Critical/Major disposition + R34 auth-flow carve-out
+  + 30-minute rule: `assertLoggedIn()` added before both prompts; mock factories for
+  api-client.js extended in agent.test.ts / agent-decrypt.test.ts /
+  agent-decrypt-ipc.test.ts (R19); ordering tests added last-in-describe with
+  mockImplementationOnce (same T6/T7 discipline as unlock).
+- RT7 red-proof: removed both `assertLoggedIn()` calls (scratchpad backup) →
+  both new tests failed fast on assertion (readPassphrase mocked — no hang shape);
+  restored byte-identical (diff-verified). Full suite 311/311 green after restore.
+- Behavior note: agent-decrypt's not-logged-in error now renders via C1
+  (`✗ message`, exit 1) instead of that file's local `process.stderr.write` style —
+  consistent with the PR's error contract.

--- a/docs/archive/review/cli-unhandled-rejection-deviation.md
+++ b/docs/archive/review/cli-unhandled-rejection-deviation.md
@@ -36,3 +36,14 @@
 - Behavior note: agent-decrypt's not-logged-in error now renders via C1
   (`✗ message`, exit 1) instead of that file's local `process.stderr.write` style —
   consistent with the PR's error contract.
+
+## Phase 3 Round 1 fix (F8) red-proof record
+
+- F8 (Minor, pre-existing in diff-touched file): daemon socket handler labeled
+  apiRequest failures as "Parse error:". Fixed by scoping handleDecryptRequest in
+  its own catch emitting "Request failed: <message>"; JSON.parse/schema keep the
+  "Parse error:" label. New test (last-in-describe, mockRejectedValueOnce) in
+  agent-decrypt-ipc.test.ts.
+- Red-proof: reverted the inner catch (scratchpad backup) → only the new test
+  failed ("Parse error: fetch failed" instead of "Request failed:"); restored
+  byte-identical (diff-verified); suite 14/14 → full 312/312 green.

--- a/docs/archive/review/cli-unhandled-rejection-plan.md
+++ b/docs/archive/review/cli-unhandled-rejection-plan.md
@@ -1,0 +1,287 @@
+# Plan: cli-unhandled-rejection
+
+## Project context
+
+- Type: `CLI tool` (the `cli/` workspace of the passwd-sso monorepo; Node.js ≥18 ESM, commander 13, TypeScript `NodeNext`/`ES2022` — top-level await available)
+- Test infrastructure: `unit + integration + CI/CD` (vitest under `cli/src/__tests__/unit/` and `cli/src/__tests__/integration/`; integration tests spawn `node dist/index.js` guarded by `it.skipIf(!distExists)` — see `cli/src/__tests__/integration/version.test.ts`)
+- Verification environment constraints:
+  - **VE1**: integration tests require a built `cli/dist/` (`cd cli && npm run build`). Classification: `verifiable-local` (build is part of the repo's pre-PR checks).
+  - **VE2**: the reported repro (`passwd-sso unlock` against a global Homebrew install) cannot be reproduced byte-for-byte locally, but `node cli/dist/index.js unlock` with isolated `HOME`/`XDG_*` env vars is behaviorally identical (same entry point, same credential resolution). Classification: `verifiable-local`.
+  - No paid services, external APIs, or hardware are involved. No contract is `blocked-deferred`.
+
+## Objective
+
+`passwd-sso unlock` executed without a prior `login` currently crashes with a raw Node.js
+stack trace (unhandled promise rejection) instead of a clean one-line error. Fix the
+reported symptom AND the underlying class: **no top-level CLI command may surface an
+internal stack trace to the user**. Errors must render as the CLI's standard
+`✗ <message>` line on stderr with a non-zero exit code.
+
+Reported repro:
+
+```
+❯ passwd-sso unlock
+Master passphrase:
+file:///.../dist/lib/api-client.js:88
+        throw new Error("Not logged in. Run `passwd-sso login` first.");
+        ...stack trace...
+Node.js v26.4.0
+```
+
+Two defects compound here:
+
+1. `cli/src/index.ts:197` calls `program.parse()` (synchronous). Commander does not await
+   async `.action()` handlers under `parse()`, so any rejection becomes an **unhandled
+   promise rejection** — Node prints the stack trace and aborts.
+2. `unlockCommand()` (`cli/src/commands/unlock.ts:130`) prompts for the master passphrase
+   **before** any login check; the "Not logged in" error from
+   `apiRequest()` (`cli/src/lib/api-client.ts:117`) is only thrown after the user has
+   already typed their passphrase.
+
+## Requirements
+
+Functional:
+- FR1: Any error thrown from a top-level command action is printed as `✗ <message>` on stderr, with exit code 1 and **no stack trace**. The `✗ ` prefix is applied by `output.error` itself (`cli/src/lib/output.ts:12-14`: `console.error(chalk.red(\`✗ ${message}\`))`) — the handler passes the bare message. Scope note: FR1 covers action-handler errors only; commander's own usage/flag errors (handled internally by commander before/without reaching an action) keep commander's standard format and are out of scope (see SC2).
+- FR2: `unlock` without stored credentials fails fast with the "Not logged in" message **before** prompting for the master passphrase (user-approved scope addition).
+- FR3: `audit-verify`'s documented exit codes 10–18 are preserved unchanged.
+- FR4: Successful flows (login → unlock → REPL) are behaviorally unchanged; REPL-internal error handling (`cli/src/index.ts:369-371`) is unchanged.
+
+Non-functional:
+- NF1: Exit code on error remains non-zero (scripts relying on failure detection keep working; the pre-fix unhandled rejection also exited 1).
+- NF2: No new dependencies.
+
+## Technical approach
+
+Class-level structural fix, not per-command patching: replace the synchronous
+`program.parse()` with an awaited `program.parseAsync()` wrapped in a single top-level
+try/catch (ESM top-level await; `module: NodeNext`, `target: ES2022` permit it). This
+creates one choke point through which every top-level action rejection flows, so future
+commands are covered automatically.
+
+Commander behavior notes (verified against commander 13 semantics):
+- `--help`/`--version`/usage errors call `process.exit` inside commander itself (no
+  `exitOverride()` in use), so the new catch only ever sees action-handler rejections.
+- `audit-verify` catches its own errors and calls `process.exit(10..18|1)` inside its
+  action (`cli/src/index.ts:181-194`); it exits before the outer catch, preserving FR3.
+- The interactive REPL runs inside the `unlock` action and therefore inside
+  `parseAsync()`'s promise; its errors are already caught per-command inside the loop
+  (`cli/src/index.ts:369-371`) — unchanged.
+
+For the fail-fast (FR2): extract the existing "Not logged in" throw into a shared
+`assertLoggedIn()` helper in `api-client.ts` (single source of the message, DRY with
+`apiRequest`), and call it at the top of `unlockCommand()` before `readPassphrase()`.
+The thrown error is rendered by the new top-level handler — same message, clean output.
+
+No DB, no concurrency primitives, no schema changes → the plan-stage real-DB probe
+requirement does not apply.
+
+## Contracts
+
+### C1 — Top-level CLI error handler (parseAsync + single catch)
+
+- **Signature** (`cli/src/index.ts`, replacing line 197 `program.parse();`):
+
+  ```ts
+  try {
+    await program.parseAsync();
+  } catch (err) {
+    output.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+  ```
+
+  No new exported symbols. `output.error` is already imported in `index.ts`.
+  `parseAsync()` with zero args defaults to `process.argv` exactly like the current
+  `parse()` call — do not pass args or `{ from: ... }` (F1). Replace line 197 **in
+  place**; the `interactiveMode` function declaration below it hoists and needs no
+  move (F4). Commander 13.1.0 verified: both async-rejection and synchronous-throw
+  paths inside `_parseCommand` propagate to an awaited `parseAsync()`
+  (commander/lib/command.js:1101, runtime-repro confirmed by review).
+
+- **Invariants**:
+  - I1 (app-enforced, structural choke point): every rejection escaping a top-level
+    `.action()` handler is rendered as `✗ <message>` on stderr and terminates the
+    process with exit code 1. A schema-enforced equivalent does not exist for a CLI
+    process boundary; the single-choke-point placement (the only `parse` call in the
+    binary) is the strongest available form — there is no second entry point to forget.
+  - I2 (app-enforced): `audit-verify` exit codes 10–18 are unchanged (its inner catch
+    exits before the outer handler can run).
+  - **Member-set derivation (R42)** — class: "every top-level commander action whose
+    rejection must not escape as a stack trace". Defining primitive: `.action(` in the
+    CLI entry point. Derivation command and result:
+
+    ```
+    $ grep -n '\.action(' cli/src/index.ts
+    64:   login
+    70:   status
+    75:   unlock          (async lambda: unlockCommand + interactiveMode)
+    91:   generate
+    105:  env
+    112:  run
+    122:  api-key list
+    131:  api-key create
+    143:  api-key revoke
+    150:  agent
+    158:  decrypt
+    170:  audit-verify    (self-handles errors; exits with 10–18|1 before outer catch)
+    ```
+
+    All 12 members are covered by the single choke point — the control is applied at
+    the shared `parseAsync()` call, not per-member, so the set cannot silently grow a
+    gap when a new command is added. Indirect members: the REPL dispatch loop
+    (`interactiveMode`) is reached only through the `unlock` action and has its own
+    per-command catch (`cli/src/index.ts:369-371`); it is a covered indirect member.
+    There is no other `parse`/`parseAsync` call site in `cli/src/` (verified:
+    `grep -rn 'program.parse' cli/src/` → only `index.ts:197`).
+
+    Known uncaught throw paths that today reproduce the bug (evidence the class is
+    real beyond the reported seed): `unlock` → `apiRequest` throw
+    (`api-client.ts:117`), `api-key list/create/revoke` → same `apiRequest` throw,
+    `login` → `saveConfig`/`saveCredentials` symlink-refusal throw
+    (`config.ts:86`), network-level `fetch` rejections in any `apiRequest` caller
+    that lacks a local try/catch.
+
+    Clarity note (T5): `env` and `run` are covered members but were never
+    stack-trace-prone — they already fail fast with their own
+    `output.error` + `process.exit(1)` before any rejection can escape
+    (`env.ts:47-51`, `run.ts:50-54`) — which is why they are absent from the
+    "known uncaught throw paths" list above. No per-member regression test is
+    needed for them.
+
+- **Forbidden patterns**:
+  - pattern: `^program\.parse\(\);?$` in `cli/src/index.ts` — reason: sync parse leaves async action rejections unhandled (the root cause).
+  - pattern: `console\.error\(err\)` or passing an `Error` object (not `.message`) to `output.error` in the new handler — reason: would re-print the stack trace the fix exists to remove.
+
+- **Acceptance criteria**:
+  - AC1-1: `node cli/dist/index.js api-key list` with no stored credentials → exit 1; stderr contains `Not logged in. Run \`passwd-sso login\` first.`; neither stdout nor stderr contains stack-frame text (`    at `) or `node:internal`.
+  - AC1-2: `node cli/dist/index.js --version` and `--help` behave exactly as before (exit 0, same output).
+  - AC1-3: `audit-verify` failure paths keep exit codes 10–18 (existing tests `cli/src/__tests__/integration/audit-verify.test.ts` stay green).
+
+- **Consumer-flow walkthrough** (the "shape" this contract defines is the CLI's
+  error-output/exit-code contract consumed outside the producer):
+  - Consumer A (shell scripts / CI pipelines invoking `passwd-sso ...`): reads { exit code, stderr }. Uses exit code ≠ 0 to detect failure — satisfied by `process.exit(1)`; pre-fix behavior was also exit 1 (unhandled rejection), so no consumer-visible regression. Uses stderr for the human-readable reason — satisfied by `output.error` writing to stderr (`console.error`, `cli/src/lib/output.ts:12-14`).
+  - Consumer B (scripted `audit-verify` consumers, e.g. `scripts/` and compliance tooling): reads { exit codes 10–18 } to branch on failure class — satisfied by I2 (inner catch exits first; outer handler unreachable for these paths).
+  - Consumer C (interactive REPL user): reads REPL error lines — unaffected; REPL catches internally and never rejects out of the action (indirect member note above).
+
+### C2 — Fail-fast login check in `unlock` (+ shared `assertLoggedIn`)
+
+- **Signatures**:
+
+  ```ts
+  // cli/src/lib/api-client.ts (new export)
+  export function assertLoggedIn(): void;
+  // throws Error("Not logged in. Run `passwd-sso login` first.") when getToken() returns null
+
+  // cli/src/lib/api-client.ts (existing, modified internally)
+  // apiRequest<T>(...) — replaces its inline `if (!token) throw ...` with assertLoggedIn()
+  // + getToken() (behavior identical; message identical)
+
+  // cli/src/commands/unlock.ts (existing, modified)
+  // unlockCommand(): Promise<void> — calls assertLoggedIn() BEFORE readPassphrase()
+  ```
+
+- **Invariants**:
+  - I3 (app-enforced): the exact message `Not logged in. Run \`passwd-sso login\` first.` (without the ", or set apiKey" suffix) exists in exactly one place (`assertLoggedIn` in `api-client.ts`). Grep check (verified against current code): `grep -rn 'Not logged in' cli/src --include='*.ts'` excluding tests → today 3 hits: `api-client.ts:117` (this contract's target), plus `env.ts:49` and `run.ts:52`, which use a deliberately different message including the apiKey alternative and are NOT members — they guard a different auth mode (config `apiKey`) and already fail fast with `process.exit(1)`. After the change the exact-message grep yields exactly 1 production hit (the helper).
+  - I4 (app-enforced): `unlockCommand` performs no interactive read before the login check. Ordering: `isUnlocked()` guard → `assertLoggedIn()` → `readPassphrase()`.
+  - I3b (app-enforced, F3): `env.ts` and `run.ts` KEEP their existing `getToken()` null-check + own message + `process.exit(1)` idiom. They must NOT be migrated to `assertLoggedIn()` in this PR: their message deliberately differs (", or set apiKey in config"), and they must not throw (they format their own error and exit). Migrating them would be a user-visible message regression.
+- **Forbidden patterns**:
+  - pattern: `Not logged in` string literal appearing in `cli/src/commands/unlock.ts` — reason: message must come from the shared helper, not be duplicated.
+  - pattern: `assertLoggedIn` appearing in `cli/src/commands/env.ts` or `cli/src/commands/run.ts` — reason: I3b; those commands keep their apiKey-aware message and exit idiom.
+- **Acceptance criteria**:
+  - AC2-1: with no stored credentials, `node cli/dist/index.js unlock` → exit 1, stderr contains `Not logged in`, stdout does NOT contain `Master passphrase:`, no stack-frame text.
+  - AC2-2: with valid credentials, `unlock` prompts for the passphrase exactly as before (regression: existing `cli/src/__tests__/unit/unlock.test.ts` suite stays green).
+  - AC2-3: `apiRequest` with no token still throws the identical message (existing `cli/src/__tests__/unit/api-client.test.ts` expectations unchanged or updated in-kind).
+- **Consumer-flow walkthrough**:
+  - Consumer A (`unlock` action in `index.ts:75-80`): reads { thrown Error } via C1's handler; also reads `isUnlocked()` afterwards to decide on `interactiveMode()` — when `assertLoggedIn` throws, `parseAsync` rejects, C1 prints and exits; `interactiveMode` is never reached. Satisfiable from the locked shape.
+  - Consumer B (`apiRequest` internal call path): reads nothing new — behavior and message identical to today's inline throw.
+  - Consumer C (unit tests mocking `api-client.js`): `unlock.test.ts` mocks the `api-client` module; the new `assertLoggedIn` export must be added to that mock factory (R19) — enumerated in C3.
+
+### C3 — Regression tests (unit + integration)
+
+- **Signatures** (test files, no production symbols):
+  - `cli/src/__tests__/unit/unlock.test.ts` (extend). **Required concrete edits (T1/T3/T4)**:
+    1. Mock-factory fix (T1, RT1): the existing factory at lines 4-6 exports only
+       `apiRequest`; add `assertLoggedIn: vi.fn()` (a plain `vi.fn()` is a no-op —
+       returns undefined) or the pre-existing `unlockCommand` tests at lines 310/343
+       fail with `TypeError: assertLoggedIn is not a function` the moment C2 lands.
+    2. New case `unlockCommand rejects with "Not logged in" before prompting when
+       not logged in` (T4, T6): override the mock with the self-consuming
+       `vi.mocked(assertLoggedIn).mockImplementationOnce(() => { throw new Error("Not logged in. Run \`passwd-sso login\` first."); })`
+       — a plain no-op default would make this test a vacuous pass. Do NOT use
+       sticky `mockImplementation(...)`: empirically verified (vitest 4.1.8) that it
+       leaks past this file's `beforeEach: vi.clearAllMocks()` /
+       `afterEach: vi.restoreAllMocks()` hooks (`clearAllMocks` clears call history
+       only; `restoreAllMocks` restores only `vi.spyOn` spies, not `vi.fn()` factory
+       mocks), silently poisoning any test declared after this one. Declare this
+       case as the **last** test in the `unlockCommand` describe block (T7): an
+       unconsumed once-impl also survives `clearAllMocks` (flushed only by
+       `mockReset`), so if the test ever breaks before reaching `assertLoggedIn`,
+       last-position guarantees the residual queued throw has no victim — an
+       already-red-run noise concern only, never a false green.
+    3. Prompt-absence assertion mechanism (T3, RT2): `readPassphrase` is
+       same-module-called (ESM local binding — namespace spies cannot intercept it).
+       Observe absence indirectly, matching the file's existing approach
+       (unlock.test.ts:315-341): `vi.spyOn(process.stdout, "write")` before calling
+       `unlockCommand()`, assert it is never called with a string containing
+       `Master passphrase:`, and assert the rejection message.
+  - `cli/src/__tests__/unit/api-client.test.ts` (extend if needed): `assertLoggedIn` throws when `getToken()` is null; returns undefined when a token exists.
+  - `cli/src/__tests__/integration/cli-error-output.test.ts` (new): spawns `node dist/index.js` with `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME` pointed at a fresh empty temp dir (isolates `config.json`, `credentials`, AND the legacy `~/.passwd-sso` migration path, since `os.homedir()` follows `$HOME` on POSIX):
+    - `unlock` → exit 1, stderr matches `Not logged in`, no `Master passphrase:` on stdout, no `    at ` / `node:internal` anywhere (AC2-1, AC1-1's no-stack-trace property on the reported seed command).
+    - `api-key list` → exit 1, stderr matches `Not logged in`, no stack-frame text (proves C1 generically, on a member WITHOUT a command-local fail-fast — verified: `api-key.ts:25-30` goes straight to `apiRequest` with no local guard; this test goes red if C1 is reverted even with C2 in place).
+    - **Closed-stdin spawn config (T2, mandatory)**: spawn with stdin closed/ended —
+      `execFileSync(..., { input: "" })` or `stdio: ["ignore", "pipe", "pipe"]` —
+      plus a `timeout` option. Review reproduced that an open-pipe stdin HANGS at the
+      passphrase prompt indefinitely if C2 regresses (`readPassphrase` resolves only
+      on data/end); with closed stdin a C2 revert fails fast on the wrong output
+      (`Passphrase is required.` — verified via /dev/null stdin) instead of hanging
+      CI. Default stdio inheritance is environment-dependent — always set it
+      explicitly.
+    - Output-assertion robustness: chalk 5 disables color on non-TTY piped output
+      (review-verified by direct execution), so plain substring assertions are safe.
+    - Uses `it.skipIf(!distExists)` following `version.test.ts`.
+- **Invariants**:
+  - I5 (app-enforced): the integration test's "no stack trace" assertion is a negative assertion on combined stdout+stderr, not an OR-fallback (R7 assertion-side trap).
+  - I6 (RT7, proven-red): each new test must be demonstrated to fail against the pre-fix code — `api-key list` case fails when `program.parse()` is restored; `unlock` unit case fails when the `assertLoggedIn()` call is removed. Recorded in the Phase 2 deviation log.
+- **Forbidden patterns**:
+  - pattern: `\.toContain\(.*\)\s*\|\|` (OR-combined assertions) in the new tests — reason: OR-fallback assertions pass vacuously (R7).
+- **Acceptance criteria**:
+  - AC3-1: `cd cli && npx vitest run` green.
+  - AC3-2: `cd cli && npm run build` green (ESM `.js` import-extension check — tsc catches what vitest does not).
+  - AC3-3: RT7 red-proof performed for both new test families (documented in deviation log, not committed as failing code).
+
+## Go/No-Go Gate
+
+| ID  | Subject                                                        | Status |
+|-----|----------------------------------------------------------------|--------|
+| C1  | Top-level parseAsync + single error choke point                | locked |
+| C2  | unlock fail-fast login check + shared assertLoggedIn           | locked |
+| C3  | Regression tests (unit + integration, proven-red)              | locked |
+
+## Testing strategy
+
+- Unit (vitest, `cli/`): C2 fail-fast ordering and `assertLoggedIn` behavior; existing `unlock.test.ts` / `api-client.test.ts` suites as regression harness. Mock alignment (R19): enumerated via `grep -rln "lib/api-client" cli/src/__tests__/` → 9 files (`unit/unlock.test.ts`, `unit/api-client.test.ts`, `unit/login.test.ts`, `unit/env.test.ts`, `unit/run.test.ts`, `unit/agent.test.ts`, `unit/agent-decrypt.test.ts`, `unit/ssh-sign-authorizer.test.ts`, `integration/agent-decrypt-ipc.test.ts`). Phase 2 must check each file's mock factory for the module and add `assertLoggedIn` where the factory is exhaustive (partial factories that don't reach `unlockCommand`/`apiRequest` need no change — verify per file, don't blanket-edit).
+- Integration (vitest, spawn built CLI): the end-to-end shape of the reported bug — exit code, stderr message, absence of stack trace — for both the seed command (`unlock`) and a generic member (`api-key list`). Env-isolated per test (`HOME`/`XDG_*` → temp dir).
+- Build: `cd cli && npm run build` (mandatory — NodeNext import-extension errors surface only in tsc).
+- Repo-level: `npx vitest run` at root (unchanged tests must stay green); `npx next build` is not affected by `cli/`-only changes but CI runs it regardless. `scripts/pre-pr.sh` covers cli build/test before push.
+- RT7 discipline: temporarily revert C1 (restore `program.parse()`) and C2 (drop the `assertLoggedIn` call) locally to confirm each new test goes red; record in deviation log. Expected red shapes (review-verified): the `api-key list` integration case goes red under a C1 revert solely via the negative no-stack-frame assertion (exit code and stderr message still match on the unhandled-rejection dump); the new unit ordering test under a C2 revert stalls at `readPassphrase`'s never-resolving promise and goes red via vitest's default 5s test timeout — a timeout-shaped failure, not a message mismatch.
+
+## Considerations & constraints
+
+- Commander's own `process.exit` behavior (help/version/usage errors) is intentionally left untouched; no `exitOverride()` is introduced (YAGNI — nothing consumes CommanderError today).
+- `process.exit(1)` in the C1 handler may truncate un-flushed async stdout writes; `output.error` uses `console.error` (synchronous for TTY/pipe on POSIX), matching the existing `process.exit(1)` usage in `env.ts`/`run.ts`.
+- The fix is CLI-only; no server, extension, or iOS surface is touched. The AAD/crypto contracts are untouched.
+
+### Scope contract
+
+- **SC1**: Exit-code semantics of non-exception error paths that print `✗ ...` and `return` (e.g. `unlockCommand`'s empty-passphrase path, `apiKeyListCommand`'s HTTP-error path exit 0 today). Deliberately unchanged — a behavioral contract change beyond the reported bug, owned by a future `TODO(cli-exit-codes)` follow-up if the user requests it.
+- **SC2**: Error-message wording/i18n of individual commands — unchanged; only the delivery mechanism (no stack trace) is in scope. This includes commander-internal exits (F5): unknown commands, missing required options, and other usage errors are handled inside commander itself (stderr message + `process.exit(1)`, or exit 0 for explicit `--help`/`--version`) and never reach the C1 catch; their format is commander's standard output and stays as-is.
+- **SC3**: REPL-internal error handling (`index.ts:369-371`) — already correct; explicitly not modified.
+
+## User operation scenarios
+
+1. **Reported seed**: fresh machine, no login → `passwd-sso unlock` → single line `✗ Not logged in. Run \`passwd-sso login\` first.`, exit 1, no passphrase prompt, no stack trace.
+2. **Generic member**: no login → `passwd-sso api-key list` → same clean error, exit 1 (previously: raw stack trace).
+3. **Server unreachable**: logged in, server down → `passwd-sso unlock` → passphrase prompt, then a clean `✗ fetch failed`-class message (via C1), exit 1 — no stack trace.
+4. **Login file-permission edge**: `~/.local/share/passwd-sso` is a symlink → `passwd-sso login --token` (manual-paste path; the OAuth path's `saveCredentials` is caught locally inside `oauthLogin` and renders via `output.error` without reaching C1) → clean `✗ Data directory is a symlink — refusing to write credentials.`, exit 1.
+5. **Happy path**: `login` → `unlock` → REPL commands → `lock` — unchanged, including REPL error lines for bad subcommands.
+6. **Scripted audit verification**: `passwd-sso audit-verify -m bad.jws` → exit codes 10–18 exactly as documented — unchanged.

--- a/docs/archive/review/cli-unhandled-rejection-plan.md
+++ b/docs/archive/review/cli-unhandled-rejection-plan.md
@@ -191,6 +191,20 @@ requirement does not apply.
   - AC2-1: with no stored credentials, `node cli/dist/index.js unlock` → exit 1, stderr contains `Not logged in`, stdout does NOT contain `Master passphrase:`, no stack-frame text.
   - AC2-2: with valid credentials, `unlock` prompts for the passphrase exactly as before (regression: existing `cli/src/__tests__/unit/unlock.test.ts` suite stays green).
   - AC2-3: `apiRequest` with no token still throws the identical message (existing `cli/src/__tests__/unit/api-client.test.ts` expectations unchanged or updated in-kind).
+- **Member-set correction (R42 clause ①b — added during Phase 2 self-R-check)**: C2's
+  fail-fast belongs to a class ("no passphrase prompt before a login check") whose
+  defining primitive is a production `readPassphrase(` call site. Derivation:
+  `grep -rn 'readPassphrase(' cli/src --include='*.ts'` (excl. tests and the
+  definition) → 3 members: `unlock.ts` (the seed), `agent.ts:162`
+  (`agentCommand` `--eval` TTY path — `autoUnlockIfNeeded()` performs no API call,
+  so nothing checks login before the prompt), and `agent-decrypt.ts:283`
+  (`decryptAgentCommand` parent path — prompts directly). Phase 1 treated C2 as a
+  single-site fix; the Phase 2 security self-R-check surfaced the two sibling
+  members, and per R42/R34 (auth-flow carve-out + 30-minute rule) both received the
+  same `assertLoggedIn()` call before their prompt, with ordering tests mirroring
+  the unlock one (readPassphrase is cross-module in these files, so the mocked
+  `readPassphrase` not-called assertion is direct). `decrypt.ts` has no
+  `readPassphrase` call site (verified) — not a member.
 - **Consumer-flow walkthrough**:
   - Consumer A (`unlock` action in `index.ts:75-80`): reads { thrown Error } via C1's handler; also reads `isUnlocked()` afterwards to decide on `interactiveMode()` — when `assertLoggedIn` throws, `parseAsync` rejects, C1 prints and exits; `interactiveMode` is never reached. Satisfiable from the locked shape.
   - Consumer B (`apiRequest` internal call path): reads nothing new — behavior and message identical to today's inline throw.

--- a/docs/archive/review/cli-unhandled-rejection-review.md
+++ b/docs/archive/review/cli-unhandled-rejection-review.md
@@ -1,0 +1,221 @@
+# Plan Review: cli-unhandled-rejection
+Date: 2026-07-09
+Review rounds: 4 (converged — all experts "No findings")
+
+## Round Summary
+
+| Round | Functionality | Security | Testing | Plan edits |
+|-------|--------------|----------|---------|-----------|
+| 1 (full) | F1,F2,F4,F5 Minor; F3 Major; F6-A,F7-A adjacent | No findings; S-A1 adjacent | T1,T2 Major; T3,T4,T5 Minor | F1/F3/F4/F5, T1-T5, Scenario 4 applied; F2 accepted |
+| 2 (incremental) | No findings (all fixes verified, incl. live commander probe) | No findings (I3b verified security-positive) | T6 Major (new): sticky mockImplementation leaks past clearAllMocks (vitest 4.1.8, empirically reproduced) | T6 → mockImplementationOnce mandated; RT7 expected-red-shapes recorded |
+| 3 (testing only) | — | — | T6 resolved; T7 Minor (new): unconsumed once-impl survives clearAllMocks (noise-only, no false green) | T7 → ordering case declared last in describe |
+| 4 (testing only) | — | — | No findings (T7 fix verified; last-in-describe = last-in-file; per-file module isolation) | — |
+
+Cumulative: Critical 0 / Major 3 (F3, T1, T2→all resolved; +T6 resolved) / Minor 8 (7 resolved in plan, F2 accepted with quantification).
+
+## Round 1 Detail
+Initial review.
+
+## Functionality Findings
+
+[F1] [Minor]: Plan's C1 snippet uses `process.argv` explicitly where existing code relies on the default
+- File: plan C1 signature block vs cli/src/index.ts:197
+- Evidence: `program.parse();` (no args) today; commander's `parseAsync()` with zero args behaves identically.
+- Fix: use `await program.parseAsync();` for minimal diff; don't add `{ from: ... }`.
+
+[F2] [Minor]: `String(err)` on a thrown non-Error object may print `[object Object]`
+- Evidence: all first-party throw sites use `new Error(...)` (verified by grep); degenerate output only via third-party plain-object throws.
+- Fix: acceptable as planned (no stack trace, exit 1 still hold).
+
+[F3] [Major]: I3 "exactly one place" invariant vs env.ts/run.ts null-check idiom — plan must forbid migrating them
+- File: cli/src/commands/env.ts:47-53, cli/src/commands/run.ts:50-56 vs plan C2
+- Evidence: env/run use `getToken()` null-check + own message (", or set apiKey in config") + process.exit(1).
+- Fix: add C2 invariant: env/run keep their idiom (must not throw; different message); migrating them to assertLoggedIn() is forbidden in this PR.
+
+[F4] [Minor]: State that the try/catch replaces line 197 in place; `interactiveMode` declaration below hoists and needs no move.
+
+[F5] [Minor]: FR1 scope note points at SC2, which is about message wording; commander-internal usage-error exits (exit 1 inside commander) should be named explicitly in SC2.
+
+Second verification pass (same expert, final message) — additional verified evidence:
+- commander 13.1.0 parseAsync source (command.js:1101): async-rejection AND sync-throw paths propagate to awaited parseAsync (runtime repro confirmed).
+- Baseline: `npx vitest run --root cli` → 304/304 pass pre-fix (clean RT7 baseline).
+- Scenario 4 wording imprecision: OAuth-path saveCredentials is inside oauthLogin's local try/catch (never reaches C1); only the `--token` manual-paste path's saveCredentials propagates to C1.
+- Ctrl+C in readPassphrase exits 130 directly, bypassing C1 — pre-existing, correctly out of contract surface.
+
+## Security Findings
+
+No findings.
+
+Rationale highlights: C1 output is a strict reduction vs today's uncaught-exception dump (message already printed as line 1 + stack); passphrase never present in any thrown Error.message on traced paths (unlock.ts catches decrypt/derive failures internally with a fixed string); C2 reorder removes an interactive read (no new echo/capture window); no local auth-oracle (single-user local process); process.exit(1) introduces no partially-written secret file or clipboard leftover; config.ts:86 symlink message safe to print.
+
+## Testing Findings
+
+[T1] [Major]: Existing unlockCommand test suite breaks once assertLoggedIn is wired in — unlock.test.ts:4-6 mock factory exports only apiRequest
+- Evidence: pre-existing tests (lines 310, 343) will throw `TypeError: assertLoggedIn is not a function`.
+- Fix: add `assertLoggedIn: vi.fn()` to the factory with a no-op default for pre-existing cases; list as a concrete required edit in C3.
+
+[T2] [Major]: Spawned unlock integration test can hang if C2 regresses — stdin-closing strategy unspecified
+- Evidence: reproduced — open-pipe stdin hangs at prompt (HANG CONFIRMED, 3000ms); /dev/null stdin → immediate "Passphrase is required.".
+- Fix: specify `execFileSync(..., { input: "" })` or `stdio: ["ignore","pipe","pipe"]` so a C2 revert fails fast on wrong-assertion instead of hanging.
+
+[T3] [Minor]: "No prompt written" assertion mechanism unspecified; readPassphrase is same-module-called (ESM binding bypasses namespace spies)
+- Fix: specify `vi.spyOn(process.stdout, "write")` and assert never called with "Master passphrase:" (matches the file's existing spy approach at unlock.test.ts:315-341).
+
+[T4] [Minor]: New ordering test must override assertLoggedIn mock to THROW; the blanket no-op from T1's fix would make it a vacuous pass.
+
+[T5] [Minor]: Member-set framing — env/run are covered members but were never stack-trace-prone (own process.exit(1) fail-fast); add a one-line clarity note next to the derivation.
+
+Additional verified: chalk 5 disables color on non-TTY piped output (substring assertions safe); api-key list correctly proves C1 independently of C2 (api-key.ts:25-30, no local guard; red-on-revert reproduced).
+
+## Adjacent Findings
+
+- [F6-A] Major → Testing: readPassphrase Ctrl+C path exits 130 in raw-mode handler; C3 spawns unlock only WITHOUT credentials (stdin listener never reached with C2 in place). Resolved by T2's closed-stdin spec (hang-avoidance covered).
+- [F7-A] Minor → Security: oauth.ts:215/280 messages embed server response bodies; Security expert confirmed strict-reduction reasoning (no finding).
+- [S-A1] → Functionality: SC1 exit-0-despite-error-output paths (apiKeyListCommand HTTP-error, unlockCommand empty-passphrase). Pre-existing, explicitly scoped out as SC1 with TODO(cli-exit-codes).
+
+## Quality Warnings
+
+None flagged by merge-findings quality gate (all findings carry file/line evidence and concrete fixes).
+
+## Resolution Status (Round 1)
+
+- F1 → Fixed in plan (C1 snippet now `await program.parseAsync();`).
+- F3 → Fixed in plan (C2 invariant I3b + forbidden pattern: env/run migration prohibited).
+- F4 → Fixed in plan (C1 in-place replacement + hoisting note).
+- F5 → Fixed in plan (SC2 extended to name commander-internal exits).
+- Scenario-4 wording → Fixed in plan (now exercises the `--token` manual-paste path).
+- T1 → Fixed in plan (C3 lists the unlock.test.ts factory edit as a required concrete edit).
+- T2 → Fixed in plan (C3 specifies closed-stdin spawn config).
+- T3 → Fixed in plan (C3 names the stdout-write spy mechanism).
+- T4 → Fixed in plan (C3 requires per-test throwing mockImplementation).
+- T5 → Fixed in plan (member-set note added).
+
+### [F2] [Minor] `String(err)` fallback may print `[object Object]` — Accepted
+- **Anti-Deferral check**: acceptable risk.
+- **Justification**:
+  - Worst case: a third-party dependency throws a plain object → user sees `✗ [object Object]` with exit 1 and no stack trace; core contract (no stack trace, non-zero exit) still holds.
+  - Likelihood: low — all first-party throw sites use `new Error(...)` (expert-verified grep); commander/chalk/cli-table3 do not throw plain objects in normal operation.
+  - Cost to fix: ~3 LOC (JSON.stringify fallback), but adds an untestable branch and diverges from the REPL's existing fallback idiom; YAGNI.
+- **Orchestrator sign-off**: acceptable-risk exception satisfied with the three values above.
+
+### [S-A1] Pre-existing exit-0 error paths — Out of scope
+- **Anti-Deferral check**: out of scope (different feature).
+- **Justification**: tracked by the plan's Scope contract SC1 with grep-able marker `TODO(cli-exit-codes)`; behavior-contract change beyond the reported bug, needs its own user decision.
+- **Orchestrator sign-off**: SC1 citation satisfies the out-of-scope exception.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1: checked — output.error reused; assertLoggedIn centralizes existing inline throw; no existing exit/error helper beyond output.ts
+- R2: checked — message single-sourced in assertLoggedIn (I3); env/run variants distinct by design (F3)
+- R3: checked — single parse site verified (index.ts:197 only)
+- R4: not applicable — no events/mutations
+- R5: not applicable — no DB
+- R6: not applicable
+- R7: not applicable — no UI selectors; C3 negative assertions per I5
+- R8: not applicable
+- R9: not applicable — no DB transactions; bg refresh timer unref'd
+- R10: checked — no new import edge cycle (unlock.ts already imports api-client.js)
+- R11: not applicable
+- R12: not applicable
+- R13: not applicable
+- R14: not applicable
+- R15: not applicable
+- R16: checked — AC3-2 tsc in CI; TLA compiles under NodeNext; skipIf(!dist) both envs
+- R17: checked — primitive call sites: apiRequest (adopts), unlockCommand (adopts), env.ts:47/run.ts:50 (skip with concrete reason; see F3)
+- R18: not applicable
+- R19: checked — plan enumerates all 9 files mocking lib/api-client; matches independent grep
+- R20: not applicable at plan stage
+- R21: not applicable at plan stage — Phase 2 full vitest run + build required
+- R22: checked — inverted check: no other "not logged in" fail-fast beyond env/run (3 production hits, all accounted)
+- R23: not applicable
+- R24: not applicable
+- R25: not applicable
+- R26: not applicable
+- R27: not applicable
+- R28: not applicable
+- R29: checked — no external specs cited; commander 13 parseAsync verified against installed typings and source (command.js:1101)
+- R30: checked — plan file has no bare #N/@name/SHA
+- R31: not applicable
+- R32: not applicable — CLI short-lived
+- R33: checked — no CI config changes; cli build/test wired via pre-pr.sh
+- R34: checked — class fixed class-wide by C1 choke point; env/run different class (handled)
+- R35: not applicable — CLI package, not deployed service
+- R36: not applicable
+- R37: checked — message contains no internal jargon
+- R38: checked — catch is terminal failure path; no transient state; no fail-open supersession surface
+- R39: not applicable — fail-fast happens BEFORE passphrase read (improvement)
+- R40: not applicable — exit-code contract covered by C1 consumer walkthrough
+- R41: not applicable
+- R42: checked — independently recomputed 12 members at lines 64,70,75,91,105,112,122,131,143,150,158,170; single parse site; REPL indirect member accounted; no delta
+
+### Security expert
+- R1: checked — assertLoggedIn is genuine dedup, not reimplementation
+- R2: N/A
+- R3: checked — single choke-point pattern, no propagation needed
+- R4: N/A
+- R5: N/A
+- R6: N/A
+- R7: N/A (testing scope; plan I5 covers non-OR assertion)
+- R8: N/A
+- R9: N/A
+- R10: checked — no new import edge
+- R11: N/A
+- R12: N/A
+- R13: N/A
+- R14: N/A
+- R15: N/A
+- R16: N/A
+- R17: checked — apiRequest + unlockCommand covered; env.ts:49/run.ts:52 excluded with reason (I3)
+- R18: N/A
+- R19: N/A for security scope (plan enumerates 9 mock files)
+- R20: N/A
+- R21: N/A (plan phase)
+- R22: checked — no divergent expectation between producer/consumers of assertLoggedIn
+- R23: N/A
+- R24: N/A
+- R25: N/A
+- R26: N/A
+- R27: N/A
+- R28: N/A
+- R29: N/A — no spec citations in plan or this review
+- R30: N/A — no bare autolinks in plan doc
+- R31: N/A — RT7 red-proof is local, reversible, test-only
+- R32: N/A
+- R33: N/A
+- R34: checked — SC1 exit-0 paths flagged as [Adjacent] to Functionality
+- R35: N/A
+- R36: N/A
+- R37: checked — no internal jargon in rendered messages
+- R38: checked — single try/catch, deterministic exit; no fire-and-forget left unresolved
+- R39: checked — no secret-holder lifecycle transition touched; clearTokenCache/lockVault unchanged
+- R40: N/A
+- R41: N/A
+- R42: checked — independently re-ran greps; 12 .action sites, single program.parse site; no delta vs plan
+- RS1: N/A — no credential comparison touched
+- RS2: N/A — no new API route
+- RS3: N/A — assertLoggedIn takes no input
+- RS4: checked — plan file has no personal-identifying data
+- RS5: checked — server-response text in error messages is display-only, never fed to crypto/authz primitive
+- RS6: N/A — no chained .replace() sanitizer
+
+### Testing expert
+- R1: N/A — assertLoggedIn is DRY dedup, no duplication
+- R2: N/A — message consolidated into one helper (I3)
+- R3: N/A — no external standards cited
+- R4: N/A — no constant/enum changes
+- R5: Pass — I3 grep verified accurate (3 pre-fix hits, env/run legitimately different)
+- R6: N/A — no vague test recommendations; T3 flags underspecified mechanism
+- R7: Verified — I5 forbids OR-fallback; zero existing `toContain.*||` hits
+- R8-R18: N/A (except R16 covered via pre-pr wiring, see RT8)
+- R19: Verified with finding T1 — 8 other factories safely partial; unlock.test.ts's OWN factory must add assertLoggedIn
+- R20-R41: N/A
+- R42: Verified — recomputed 12-member set identical; api-key list correctly chosen (no local guard) to prove C1 independent of C2
+- RT1: Finding T1 — mock factory divergence once assertLoggedIn is added
+- RT2: Applied — verified same-module call binding; recommendation testable via stdout spy (T3)
+- RT3: N/A — vitest.config.ts covers new test files
+- RT4: N/A
+- RT5: N/A
+- RT6: N/A
+- RT7: Verified with findings — api-key list red-proof genuine; unlock red-proof risks hang (T2)
+- RT8: N/A — pre-pr.sh:530-538 already wires cli build→test in correct order


### PR DESCRIPTION
## Summary
- Replaced synchronous `program.parse()` with an awaited `parseAsync()` wrapped in a top-level `try/catch` to eliminate unhandled promise rejections and raw Node.js stack trace leaks across all CLI commands.
- Introduced a shared `assertLoggedIn()` guard in `api-client.ts` and applied it to `unlock`, `agent`, and `agent-decrypt` commands before passphrase prompts to fail fast without login.
- Fixed daemon IPC error labeling in `agent-decrypt.ts` to correctly distinguish `apiRequest` failures from JSON parse errors.
- Updated test infrastructure to use `vi.stubEnv` (with `unstubEnvs: true`) and closed-stdin spawning to prevent test hangs and environment leakage.

## Motivation
The CLI crashes with a raw Node.js stack trace (unhandled promise rejection) when executed without a stored login (e.g., `passwd-sso unlock`), violating the expected `✗ <message>` error contract — `program.parse()` does not await async action handlers (`efc6720a`). Additionally, `unlock` prompted for the master passphrase *before* verifying login state (`4e8ee013`). These defects compound across commands due to the lack of a centralized error choke point.

## Implementation notes
- **Single choke point:** `cli/src/index.ts` replaces `program.parse();` with `await program.parseAsync();` inside a top-level `try/catch`. Commander 13 semantics ensure all `.action()` rejections flow here, while `--help`/`--version` and `audit-verify`'s internal exit codes (10–18) bypass it safely.
- **Shared guard:** `cli/src/lib/api-client.ts` now exports `assertLoggedIn()`, centralizing the "Not logged in" message. It is deliberately *not* migrated into `env.ts`/`run.ts`, which keep their distinct `apiKey`-aware messaging and exit idiom (plan invariant I3b).
- **Member-set expansion (R42):** the security review pass identified `agent --eval` and `agent --decrypt` as also prompting for the passphrase before any login check; both were patched with identical guard placement and ordering tests (`8e2eaa17`).
- **Daemon labeling fix:** `59d087ac` scopes `handleDecryptRequest` in its own catch block so `fetch failed`-class errors render as `Request failed:` instead of being mislabeled `Parse error:`.
- **Test hygiene:** direct `process.env` mutations in tests were replaced with `vi.stubEnv`, and `cli/vitest.config.ts` enables `unstubEnvs: true` to prevent cross-test leakage (`46ce45fa`). Integration spawns close stdin (`input: ""`) so a fail-fast regression fails fast instead of hanging CI.

## Review artifacts
- [cli-unhandled-rejection-plan.md](./docs/archive/review/cli-unhandled-rejection-plan.md)
- [cli-unhandled-rejection-review.md](./docs/archive/review/cli-unhandled-rejection-review.md)
- [cli-unhandled-rejection-deviation.md](./docs/archive/review/cli-unhandled-rejection-deviation.md)
- [cli-unhandled-rejection-code-review.md](./docs/archive/review/cli-unhandled-rejection-code-review.md)

## Test plan
- [x] Build CLI (`cd cli && npm run build`) — ESM import-extension compliance
- [x] `cd cli && npx vitest run` — 312/312 green (unit + integration; `it.skipIf(!distExists)` gate exercised, integration cases confirmed executed)
- [x] `node cli/dist/index.js unlock` (no login) exits 1, prints `✗ Not logged in...`, no stack frames, no passphrase prompt
- [x] `node cli/dist/index.js api-key list` (no login) exits 1 with clean error output, proving the top-level catch covers non-unlock commands
- [x] `--help`, `--version`, and `audit-verify` exit codes unchanged
- [x] Daemon IPC `fetch` failures render as `Request failed:` rather than `Parse error:`
- [x] Every new test red-proven by temporarily reverting its fix (recorded in the deviation log)
- [x] `scripts/pre-pr.sh` — 36/36 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)