### PR TITLE
fix(extension): replace Edge-colliding default keyboard shortcuts with minimal X/F scheme

### DIFF
--- a/docs/architecture/feature-gap-analysis.md
+++ b/docs/architecture/feature-gap-analysis.md
@@ -244,7 +244,7 @@ Chrome `contextMenus` API with URL-matched entry listing (max 5), debounced upda
 
 #### ~~X-4 Extension keyboard shortcuts~~ — Implemented (2026-02-28)
 
-5 Chrome `commands`: open popup (Cmd+Shift+A, Chrome-native), copy password (Cmd+Shift+P), copy username (Cmd+Shift+U), trigger autofill (Cmd+Shift+F), lock vault. Clipboard auto-clear after 30 seconds.
+5 Chrome `commands`: open popup (Cmd+Shift+X, Chrome-native), trigger autofill (Cmd+Shift+F), copy password / copy username / lock vault (no default key — the Ctrl/Cmd+Shift letter space collides with Edge built-ins). Clipboard auto-clear after 30 seconds.
 
 #### ~~X-5 New-login detection~~ — Implemented (2026-02-28)
 

--- a/docs/archive/review/extension-shortcut-defaults-code-review.md
+++ b/docs/archive/review/extension-shortcut-defaults-code-review.md
@@ -1,0 +1,73 @@
+# Code Review: extension-shortcut-defaults
+
+Date: 2026-07-12
+Review round: 1 (converged — all experts returned No findings)
+
+## Scope
+
+Standalone Phase 3 review (no Phase 1 plan — small user-approved change).
+Diff source: uncommitted working tree (`git diff HEAD`), files:
+
+- `extension/manifest.config.ts` — `_execute_action` suggested_key `Ctrl/Cmd+Shift+A` → `Ctrl/Cmd+Shift+X`; `copy-password` / `copy-username` suggested_key removed (commands remain, unbound by default); `trigger-autofill` (`Ctrl/Cmd+Shift+F`) and `lock-vault` (unbound) unchanged
+- `docs/extension-store-listing.md` — shortcut list updated; Japanese short/detailed description added (added mid-round by user request; orchestrator-verified: ja shortcut list matches new manifest, vault → 保管庫, no internal jargon)
+- `docs/architecture/feature-gap-analysis.md` — X-4 paragraph updated
+
+Rationale: old defaults collided with Edge built-ins — A = tab search (Win/Mac), P = system print dialog (Win), U = Read Aloud (Win/Mac). Verified against Microsoft Edge keyboard shortcuts support page. New scheme follows 1Password precedent (activate = Shift+Cmd+X) and the "minimal defaults" pattern (1Password/KeePassXC ship most commands unbound).
+
+Out of review scope: `.claude/settings.json` (session permission record, left uncommitted).
+
+## Changes from Previous Round
+
+Initial review.
+
+## Functionality Findings
+
+No findings.
+
+Verification: feature-gap-analysis.md "5 Chrome `commands`" matches the 5 manifest entries; store listing matches manifest exactly; no stale old-shortcut references outside docs/archive; suggested_key count = 2 (within Chromium's 4-slot auto-assign cap); `chrome.commands.onCommand` listener (extension/src/background/index.ts:929) dispatches by command-name string independent of suggested_key — no orphaned handler; manually-bound commands still trigger.
+
+## Security Findings
+
+No findings.
+
+Verification: diff touches only `commands.*.suggested_key`; permissions / optional_host_permissions / CSP / web_accessible_resources unchanged (grep-confirmed zero matches in diff). Vault-unlock gate for copy commands (index.ts:960-962) and clipboard auto-clear (index.ts:1020) untouched. R43 boundary-widening check negative — the change is a narrowing/no-op on the security surface. `edge://extensions/shortcuts` reference is docs prose, no injection surface.
+
+## Testing Findings
+
+No findings.
+
+Seed disposition: Ollama seed [Major] "mock-reality misalignment in test suites" REJECTED with evidence — App.test.tsx stubs `chrome.commands.getAll()` with arbitrary display fixture data (options page renders runtime API values, never reads manifest.config.ts); background-commands.test.ts dispatches by CMD_* constants, not shortcut strings; no test imports manifest.config.ts; 899/899 pass with the new manifest.
+
+Informational note (not a finding): no regression net catches a future colliding suggested_key or a 5th suggested_key. Literal-string pinning would be low-value; if ever wanted, prefer a structural invariant test (`count of commands with suggested_key ≤ 4`).
+
+## Adjacent Findings
+
+None.
+
+## Quality Warnings
+
+None.
+
+## Recurring Issue Check
+
+### Functionality expert
+R1-R43: all N/A or OK. Notable OK: R23 (suggested_key 2/4 cap), R34 (CMD_* already const exports, pre-existing), R35/R37 (user-facing wording clean), R36 (no stale shortcut refs outside docs/archive), R39 (no orphaned handler), R42 (fixed enumerable set of 5 commands — no broader class).
+
+### Security expert
+R1-R43 + RS1-RS6: all N/A or OK. Notable OK: R3 (all 3 surfaces consistent), R18 (manifest allowlists unchanged, grep-confirmed), R30 (chrome:///edge:// prose only), R41 (onCommand handles all declared commands; manual rebinding path real), R43 (negative — narrowing), RS4 (no PII in new doc text).
+
+### Testing expert
+R1-R43 + RT1-RT9: all N/A or OK. Notable OK: R7 (no E2E references extension shortcuts), R19/RT1 (App.test.tsx fixture display-only, no mock-reality divergence), RT3 (fixture string arbitrary, not duplicated production constant), RT9 (dist/manifest.json generated from single source, post-build verified).
+
+## Environment Verification Report
+
+N/A — no environment constraints declared (no Phase 1). Verification executed:
+- `verified-local` — `cd extension && npm run build` (pass; dist/manifest.json inspected: commands match intent)
+- `verified-local` — `cd extension && npx vitest run` (899 pass / 0 fail)
+- Root `npx next build` / root vitest intentionally skipped: diff contains no files that enter the Next.js build graph (extension/ + docs/*.md only).
+
+## Resolution Status
+
+No findings to resolve. Round 1 converged; loop terminated per Step 3-8 ("all agents return No findings").
+
+Known limitation (disclosed to user, not a finding): Chromium assigns suggested_key at install time only — existing installs keep the old A/P/U bindings; release notes should mention the change.

--- a/docs/extension-store-listing.md
+++ b/docs/extension-store-listing.md
@@ -34,10 +34,9 @@ Tired of copying and pasting passwords from your passwd-sso vault? This extensio
 🏠 **Your server, your data** — The extension connects only to your self-hosted passwd-sso instance. No third-party cloud, no data collection, no tracking.
 
 **Keyboard Shortcuts:**
-- Ctrl+Shift+A (Cmd+Shift+A on Mac) — Open popup
-- Ctrl+Shift+P (Cmd+Shift+P on Mac) — Copy password
-- Ctrl+Shift+U (Cmd+Shift+U on Mac) — Copy username
+- Ctrl+Shift+X (Cmd+Shift+X on Mac) — Open popup
 - Ctrl+Shift+F (Cmd+Shift+F on Mac) — Trigger autofill
+- Copy password / Copy username / Lock vault — unbound by default; assign your own keys at chrome://extensions/shortcuts (edge://extensions/shortcuts on Edge)
 
 **Getting Started:**
 1. Install the extension
@@ -46,6 +45,43 @@ Tired of copying and pasting passwords from your passwd-sso vault? This extensio
 4. Visit any login page — the extension handles the rest
 
 This extension is fully open source: https://github.com/ngc-shj/passwd-sso
+
+## Short Description — Japanese (132 chars max)
+
+パスワードの手入力はもう不要。セルフホストの保管庫からワンクリックで自動入力 — エンドツーエンド暗号化対応。
+
+## Detailed Description — Japanese
+
+passwd-sso の保管庫からパスワードをコピー&ペーストする作業にうんざりしていませんか?この拡張機能は保管庫をブラウザに直接統合し、ワンクリックでどのサイトにもログインできるようにします。
+
+**この拡張機能をインストールする理由**
+
+🔑 **ワンクリックログイン** — ログインフォームを自動検出して認証情報を入力します。パスワードを調べるためにタブを切り替える必要はもうありません。
+
+📋 **すばやくコピー** — 右クリックメニューまたはショートカットキーで、パスワードやユーザー名をクリップボードにコピー。1 秒もかかりません。
+
+🔍 **保管庫全体を検索** — ポップアップの検索ボックスは、現在のサイトに一致する項目だけでなく保管庫内のすべての項目を横断検索。どこからでも目的の認証情報を見つけてコピーできます。
+
+🔒 **ゼロ知識セキュリティ** — マスターパスフレーズがデバイスの外に出ることはありません。すべてのデータはネットワークに送信される前に AES-256-GCM で暗号化されます。通信を傍受されても、見えるのは暗号文だけです。
+
+⏱️ **自動ロック** — 席を離れても大丈夫。設定した時間が経過すると保管庫は自動的にロックされ、認証情報が無防備なまま放置されることはありません。
+
+🔐 **パスキー自動入力** — WebAuthn リクエストを検知し、保管庫に保存されたパスキーを自動的に提案します。新しいパスキーの作成と保管庫への保存にも対応(重複時は置き換えを確認)。一致するパスキーがない場合は、プラットフォーム認証器へシームレスに引き継ぎます。
+
+🏠 **あなたのサーバー、あなたのデータ** — この拡張機能はセルフホストした passwd-sso インスタンスにのみ接続します。サードパーティのクラウドなし、データ収集なし、トラッキングなし。
+
+**キーボード ショートカット:**
+- Ctrl+Shift+X(Mac は Cmd+Shift+X)— ポップアップを開く
+- Ctrl+Shift+F(Mac は Cmd+Shift+F)— 自動入力を実行
+- パスワードをコピー / ユーザー名をコピー / 保管庫をロック — 初期状態では未割り当て。chrome://extensions/shortcuts(Edge は edge://extensions/shortcuts)で任意のキーを割り当てられます
+
+**はじめかた:**
+1. 拡張機能をインストール
+2. オプションページを開き、passwd-sso サーバーの URL を入力
+3. アカウントでログインし、保管庫のロックを解除
+4. ログインページを開くだけ — あとは拡張機能にお任せください
+
+この拡張機能は完全なオープンソースです: https://github.com/ngc-shj/passwd-sso
 
 ## Permission Justifications
 

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -33,24 +33,20 @@ export default defineManifest({
   },
   commands: {
     _execute_action: {
+      // X/F are unassigned in Edge and Chrome on all platforms; the previous
+      // A/P/U defaults collided with Edge built-ins (tab search, system
+      // print, read aloud). Copy commands ship unset — users can bind them
+      // at chrome://extensions/shortcuts (edge://extensions/shortcuts).
       suggested_key: {
-        default: "Ctrl+Shift+A",
-        mac: "Command+Shift+A",
+        default: "Ctrl+Shift+X",
+        mac: "Command+Shift+X",
       },
       description: "__MSG_cmdOpenPopup__",
     },
     [CMD_COPY_PASSWORD]: {
-      suggested_key: {
-        default: "Ctrl+Shift+P",
-        mac: "Command+Shift+P",
-      },
       description: "__MSG_cmdCopyPassword__",
     },
     [CMD_COPY_USERNAME]: {
-      suggested_key: {
-        default: "Ctrl+Shift+U",
-        mac: "Command+Shift+U",
-      },
       description: "__MSG_cmdCopyUsername__",
     },
     [CMD_LOCK_VAULT]: {


### PR DESCRIPTION
## Summary
- The default extension shortcuts collided with Microsoft Edge built-ins: `Ctrl/Cmd+Shift+A` (tab search), `Ctrl+Shift+P` (system print, Windows), `Ctrl/Cmd+Shift+U` (Read Aloud). This moves the popup to `Ctrl/Cmd+Shift+X` and ships the copy commands unbound by default.
- Adopts a "minimal defaults" scheme (1Password/KeePassXC precedent): only `trigger-autofill` (`Ctrl/Cmd+Shift+F`) keeps a default key; `copy-password`, `copy-username`, and `lock-vault` are unbound — users assign their own at `chrome://extensions/shortcuts` (`edge://extensions/shortcuts`).
- Adds a Japanese store-listing description; updates the shortcut docs.
- Triangulate Round 1 code review converged with zero findings (functionality / security / testing).

## Motivation
The old defaults silently intercepted native Edge actions, degrading UX. `A` = tab search, `P` = print dialog, `U` = Read Aloud — all confirmed against Microsoft Edge's keyboard-shortcut reference. `X` and `F` are unassigned across Edge and Chrome on both Windows and macOS.

## Implementation notes
- `extension/manifest.config.ts`: `_execute_action` moves to `Ctrl/Cmd+Shift+X`; `suggested_key` removed from `copy-password` / `copy-username`. Commands stay declared and dispatch via `chrome.commands.onCommand` (`extension/src/background/index.ts:929`), so manual rebinding still works and no handler is orphaned.
- Security surface is narrowed, not widened: `permissions`, host permissions, CSP, and `web_accessible_resources` are untouched (grep-confirmed). Vault-unlock gate (`extension/src/background/index.ts:960-962`) and clipboard auto-clear (`extension/src/background/index.ts:1020`) are unaffected.
- **Behavioral caveat:** Chromium applies `suggested_key` only at install time. Existing installs keep the old `A`/`P`/`U` bindings until manually changed or reinstalled — release notes should disclose this.

## Review artifacts
- `docs/archive/review/extension-shortcut-defaults-code-review.md`

## Test plan
- [x] `cd extension && npm run build` — passes; `dist/manifest.json` reflects new bindings
- [x] `cd extension && npx vitest run` — 899/899 pass with the updated manifest
- [x] `scripts/pre-pr.sh` — 36/36 checks pass
- [ ] Manual: in Edge, confirm `Cmd/Ctrl+Shift+X` opens the popup and no Edge built-in is intercepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)