### PR TITLE
fix(ios): recover mutating API calls from an expired access token

### DIFF
--- a/ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift
+++ b/ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift
@@ -47,10 +47,35 @@ public struct AutofillTokenRefresher: Sendable {
       let nonce = try? hostTokenStore.loadNonce()
       try uploadTokenStore.save(token: response.token, expiresAt: expiresAt, dpopNonce: nonce)
     } catch {
-      // Log only the error TYPE, never its associated values: `mintAutofillToken`
-      // throws an arbitrary Error, so dumping it whole risks leaking a URL /
-      // response / internal state the day it throws a richer type.
-      Self.log.error("autofill-token refresh failed: \(String(describing: type(of: error)), privacy: .public)")
+      // Diagnostic only: emit a FIXED, non-secret label per known failure mode so
+      // the "refresh failed" symptom can be triaged from Console.app —
+      // authenticationRequired (expected: session lapsed while backgrounded) vs.
+      // dpopInvalid (nonce desync) vs. serverError(5xx) (a real server fault).
+      // The label set is hardcoded; associated values are NEVER interpolated
+      // except the plain HTTP status / rate-limit bucket, which carry no secret.
+      Self.log.error("autofill-token refresh failed: \(Self.diagnosticSummary(for: error), privacy: .public)")
+    }
+  }
+
+  /// Maps an error to a stable, secret-free label for logging. For a
+  /// `MobileAPIError` it names the case (plus the HTTP status for `serverError`);
+  /// any other error falls back to its type name only — never its value, which
+  /// could carry a URL / response body / internal state.
+  static func diagnosticSummary(for error: Error) -> String {
+    guard let apiError = error as? MobileAPIError else {
+      return "other(\(type(of: error)))"
+    }
+    switch apiError {
+    case .bridgeCodeInvalid: return "bridgeCodeInvalid"
+    case .pkceMismatch: return "pkceMismatch"
+    case .dpopInvalid: return "dpopInvalid"  // nonce intentionally omitted
+    case .rateLimited: return "rateLimited"
+    case .notFound: return "notFound"
+    case .quotaExceeded: return "quotaExceeded"
+    case .teamKeyNotDistributed: return "teamKeyNotDistributed"
+    case .serverError(let status): return "serverError(\(status))"
+    case .networkError(let urlError): return "networkError(\(urlError.code.rawValue))"
+    case .authenticationRequired: return "authenticationRequired"
     }
   }
 

--- a/ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift
+++ b/ios/PasswdSSOApp/Auth/AutofillTokenRefresher.swift
@@ -52,7 +52,8 @@ public struct AutofillTokenRefresher: Sendable {
       // authenticationRequired (expected: session lapsed while backgrounded) vs.
       // dpopInvalid (nonce desync) vs. serverError(5xx) (a real server fault).
       // The label set is hardcoded; associated values are NEVER interpolated
-      // except the plain HTTP status / rate-limit bucket, which carry no secret.
+      // except the plain HTTP status and URLError code (both integers), which
+      // carry no secret.
       Self.log.error("autofill-token refresh failed: \(Self.diagnosticSummary(for: error), privacy: .public)")
     }
   }

--- a/ios/PasswdSSOApp/Network/MobileAPIClient.swift
+++ b/ios/PasswdSSOApp/Network/MobileAPIClient.swift
@@ -367,7 +367,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
   }
 
   /// POST /api/mobile/cache-rollback-report with DPoP-signed access token.
-  /// On 401 + new DPoP-Nonce, retries once.
+  /// On 401, applies the full retry ladder (DPoP-nonce retry, then token-refresh retry).
   public func postCacheRollbackReport(_ body: CacheRollbackReportBody) async throws {
     let accessToken = try await validAccessToken()
 
@@ -419,7 +419,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
 
   /// Create a new personal entry via POST /api/passwords.
   /// Requires a valid access token (DPoP-signed with ath).
-  /// On 401 + new DPoP-Nonce, retries once with the fresh nonce.
+  /// On 401, applies the full retry ladder (DPoP-nonce retry, then token-refresh retry).
   /// Returns the server-stored entry id (must equal the client-generated id).
   public func createEntry(body: CreateEntryRequest) async throws -> String {
     let accessToken = try await validAccessToken()
@@ -474,7 +474,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
   /// POST /api/mobile/autofill-token (plan C6). `extensionJWK` is the AutoFill
   /// extension's OWN shared-group SE public key — the server binds the minted
   /// token to its thumbprint, so only the extension can spend it.
-  /// On 401 + new DPoP-Nonce, retries once with the fresh nonce.
+  /// On 401, applies the full retry ladder (DPoP-nonce retry, then token-refresh retry).
   public func mintAutofillToken(extensionJWK: [String: String]) async throws -> AutofillTokenResponse {
     let accessToken = try await validAccessToken()
 
@@ -527,7 +527,7 @@ public actor MobileAPIClient: VaultUnlockDataSource {
 
   /// Update an existing personal entry via PUT /api/passwords/{entryId}.
   /// Requires a valid access token (DPoP-signed with ath).
-  /// On 401 + new DPoP-Nonce, retries once with the fresh nonce.
+  /// On 401, applies the full retry ladder (DPoP-nonce retry, then token-refresh retry).
   public func updateEntry(entryId: String, body: UpdateEntryRequest) async throws {
     let accessToken = try await validAccessToken()
 

--- a/ios/PasswdSSOApp/Network/MobileAPIClient.swift
+++ b/ios/PasswdSSOApp/Network/MobileAPIClient.swift
@@ -398,16 +398,20 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
     request.httpBody = bodyData
 
-    try await performVoidHTTP(request) { newNonce in
+    try await performVoidHTTP(request, staleToken: accessToken) { nonce, freshToken in
+      let token = freshToken ?? accessToken
       let retryProof = try await buildDPoPProof(
         htm: HTTPMethod.post,
         htu: htu,
         jwk: localJWK,
-        ath: ath,
-        nonce: newNonce,
+        ath: freshToken != nil ? sha256Base64URL(token) : ath,
+        nonce: nonce ?? (try? self.tokenStore.loadNonce()),
         signer: localSigner
       )
       var retryRequest = request
+      if freshToken != nil {
+        retryRequest.setValue("\(HTTPAuthScheme.bearerPrefix)\(token)", forHTTPHeaderField: HTTPHeader.authorization)
+      }
       retryRequest.setValue(retryProof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       return retryRequest
     }
@@ -447,16 +451,20 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
     request.httpBody = bodyData
 
-    return try await performCreateHTTP(request) { newNonce in
+    return try await performCreateHTTP(request, staleToken: accessToken) { nonce, freshToken in
+      let token = freshToken ?? accessToken
       let retryProof = try await buildDPoPProof(
         htm: HTTPMethod.post,
         htu: htu,
         jwk: localJWK,
-        ath: ath,
-        nonce: newNonce,
+        ath: freshToken != nil ? sha256Base64URL(token) : ath,
+        nonce: nonce ?? (try? self.tokenStore.loadNonce()),
         signer: localSigner
       )
       var retryRequest = request
+      if freshToken != nil {
+        retryRequest.setValue("\(HTTPAuthScheme.bearerPrefix)\(token)", forHTTPHeaderField: HTTPHeader.authorization)
+      }
       retryRequest.setValue(retryProof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       return retryRequest
     }
@@ -497,16 +505,20 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
     request.httpBody = bodyData
 
-    let data = try await performBodyHTTP(request) { newNonce in
+    let data = try await performBodyHTTP(request, staleToken: accessToken) { nonce, freshToken in
+      let token = freshToken ?? accessToken
       let retryProof = try await buildDPoPProof(
         htm: HTTPMethod.post,
         htu: htu,
         jwk: localJWK,
-        ath: ath,
-        nonce: newNonce,
+        ath: freshToken != nil ? sha256Base64URL(token) : ath,
+        nonce: nonce ?? (try? self.tokenStore.loadNonce()),
         signer: localSigner
       )
       var retryRequest = request
+      if freshToken != nil {
+        retryRequest.setValue("\(HTTPAuthScheme.bearerPrefix)\(token)", forHTTPHeaderField: HTTPHeader.authorization)
+      }
       retryRequest.setValue(retryProof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       return retryRequest
     }
@@ -546,16 +558,20 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
     request.httpBody = bodyData
 
-    try await performVoidHTTP(request) { newNonce in
+    try await performVoidHTTP(request, staleToken: accessToken) { nonce, freshToken in
+      let token = freshToken ?? accessToken
       let retryProof = try await buildDPoPProof(
         htm: HTTPMethod.put,
         htu: htu,
         jwk: localJWK,
-        ath: ath,
-        nonce: newNonce,
+        ath: freshToken != nil ? sha256Base64URL(token) : ath,
+        nonce: nonce ?? (try? self.tokenStore.loadNonce()),
         signer: localSigner
       )
       var retryRequest = request
+      if freshToken != nil {
+        retryRequest.setValue("\(HTTPAuthScheme.bearerPrefix)\(token)", forHTTPHeaderField: HTTPHeader.authorization)
+      }
       retryRequest.setValue(retryProof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       return retryRequest
     }
@@ -669,16 +685,20 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     request.setValue(proof.jws, forHTTPHeaderField: HTTPHeader.dpop)
     request.httpBody = bodyData
 
-    let data = try await performBodyHTTP(request) { newNonce in
+    let data = try await performBodyHTTP(request, staleToken: accessToken) { nonce, freshToken in
+      let token = freshToken ?? accessToken
       let retryProof = try await buildDPoPProof(
         htm: HTTPMethod.put,
         htu: htu,
         jwk: localJWK,
-        ath: ath,
-        nonce: newNonce,
+        ath: freshToken != nil ? sha256Base64URL(token) : ath,
+        nonce: nonce ?? (try? self.tokenStore.loadNonce()),
         signer: localSigner
       )
       var retryRequest = request
+      if freshToken != nil {
+        retryRequest.setValue("\(HTTPAuthScheme.bearerPrefix)\(token)", forHTTPHeaderField: HTTPHeader.authorization)
+      }
       retryRequest.setValue(retryProof.jws, forHTTPHeaderField: HTTPHeader.dpop)
       return retryRequest
     }
@@ -902,33 +922,79 @@ public actor MobileAPIClient: VaultUnlockDataSource {
   // the extension-side uploader and this client share one implementation.
   // Unqualified calls in this file resolve to those free functions.
 
-  /// Perform an HTTP request that returns no body; on 401 + new nonce, retry once.
-  /// Throws `MobileAPIError.notFound` for 404, `.serverError(status:)` for other non-2xx.
+  /// Closure that rebuilds a mutating request for a retry. Both arguments are
+  /// nil-unless-relevant so one closure serves both rungs of the ladder:
+  ///   - `nonce != nil`  → a DPoP-Nonce challenge: re-sign the proof with it
+  ///     (same access token / ath).
+  ///   - `freshToken != nil` → the access token was refreshed: rebuild the ath
+  ///     from the new token AND swap the Authorization header to it.
+  /// Exactly one is non-nil per invocation.
+  typealias MutatingRetryBuilder = (_ nonce: String?, _ freshToken: String?) async throws -> URLRequest
+
+  /// Shared retry ladder for mutating (non-GET) requests, mirroring
+  /// `performAuthedGET` so mutating calls recover from an expired access token
+  /// the same way GETs do:
+  ///   1. Initial request.
+  ///   2. On 401 with a fresh DPoP-Nonce (once): nonce-retry, same token.
+  ///   3. On still-401 (once): refresh via the single-flight gate, retry with the
+  ///      new token (rebuilt ath + Authorization).
+  ///   4. Still 401 → return status 401 to the decoder (surfaces .serverError(401),
+  ///      NOT .authenticationRequired — a failed REFRESH already threw that).
+  /// Saves any DPoP-Nonce on every response. `staleToken` is the access token the
+  /// caller signed the initial request with — the refresh rung passes it to the
+  /// single-flight gate so a token already rotated by a concurrent call is reused
+  /// instead of triggering a second refresh.
+  private func performMutatingWithLadder(
+    _ request: URLRequest,
+    staleToken: String,
+    makeRetry: MutatingRetryBuilder?
+  ) async throws -> (Data, Int) {
+    var current = request
+    var didNonceRetry = false
+    var didRefreshRetry = false
+    var token = staleToken
+
+    while true {
+      let (data, response) = try await performHTTP(current)
+      let http = response as! HTTPURLResponse
+      let freshNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce)
+      if let freshNonce {
+        try? tokenStore.saveNonce(freshNonce)
+      }
+
+      if http.statusCode == 401, let makeRetry {
+        // Rung 2: a nonce in THIS response is the challenge signal; a stale
+        // stored nonce must NOT drive a retry (keeps the ladder bounded at ≤3).
+        if !didNonceRetry, freshNonce != nil {
+          didNonceRetry = true
+          current = try await makeRetry(freshNonce, nil)
+          continue
+        }
+        // Rung 3: token rejected — refresh and retry with the new token. A failed
+        // refresh throws .authenticationRequired from ensureRefreshed.
+        if !didRefreshRetry {
+          didRefreshRetry = true
+          token = try await ensureRefreshed(staleToken: token)
+          current = try await makeRetry(nil, token)
+          continue
+        }
+      }
+
+      return (data, http.statusCode)
+    }
+  }
+
+  /// Perform an HTTP request that returns no body; full 401 ladder (nonce +
+  /// token refresh). Throws `MobileAPIError.notFound` for 404,
+  /// `.serverError(status:)` for other non-2xx.
   private func performVoidHTTP(
     _ request: URLRequest,
-    makeRetry: ((String) async throws -> URLRequest)? = nil
+    staleToken: String,
+    makeRetry: MutatingRetryBuilder? = nil
   ) async throws {
-    let (_, response) = try await performHTTP(request)
-    let http = response as! HTTPURLResponse
-
-    if let newNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
-      try? tokenStore.saveNonce(newNonce)
-    }
-
-    if http.statusCode == 401,
-       let makeRetry,
-       let newNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
-      let retryRequest = try await makeRetry(newNonce)
-      let (_, retryResponse) = try await performHTTP(retryRequest)
-      let retryHTTP = retryResponse as! HTTPURLResponse
-      if let retryNonce = retryHTTP.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
-        try? tokenStore.saveNonce(retryNonce)
-      }
-      try decodeVoidResponse(status: retryHTTP.statusCode)
-      return
-    }
-
-    try decodeVoidResponse(status: http.statusCode)
+    let (_, status) = try await performMutatingWithLadder(
+      request, staleToken: staleToken, makeRetry: makeRetry)
+    try decodeVoidResponse(status: status)
   }
 
   private func decodeVoidResponse(status: Int) throws {
@@ -942,33 +1008,17 @@ public actor MobileAPIClient: VaultUnlockDataSource {
     }
   }
 
-  /// Perform a request whose success (200/201) response body is returned raw.
-  /// On 401 + new nonce, retries once. 404 → .notFound; other non-2xx →
+  /// Perform a request whose success (200/201) response body is returned raw;
+  /// full 401 ladder (nonce + token refresh). 404 → .notFound; other non-2xx →
   /// .serverError(status:).
   private func performBodyHTTP(
     _ request: URLRequest,
-    makeRetry: ((String) async throws -> URLRequest)? = nil
+    staleToken: String,
+    makeRetry: MutatingRetryBuilder? = nil
   ) async throws -> Data {
-    let (data, response) = try await performHTTP(request)
-    let http = response as! HTTPURLResponse
-
-    if let newNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
-      try? tokenStore.saveNonce(newNonce)
-    }
-
-    if http.statusCode == 401,
-       let makeRetry,
-       let newNonce = http.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
-      let retryRequest = try await makeRetry(newNonce)
-      let (retryData, retryResponse) = try await performHTTP(retryRequest)
-      let retryHTTP = retryResponse as! HTTPURLResponse
-      if let retryNonce = retryHTTP.value(forHTTPHeaderField: HTTPHeader.dpopNonce) {
-        try? tokenStore.saveNonce(retryNonce)
-      }
-      return try decodeBodyResponse(retryData, status: retryHTTP.statusCode)
-    }
-
-    return try decodeBodyResponse(data, status: http.statusCode)
+    let (data, status) = try await performMutatingWithLadder(
+      request, staleToken: staleToken, makeRetry: makeRetry)
+    return try decodeBodyResponse(data, status: status)
   }
 
   private func decodeBodyResponse(_ data: Data, status: Int) throws -> Data {
@@ -990,12 +1040,13 @@ public actor MobileAPIClient: VaultUnlockDataSource {
   }
 
   /// Perform a create (POST) request that returns a body with an `id` field.
-  /// Accepts 200 or 201 as success. On 401 + new nonce, retries once.
+  /// Accepts 200 or 201 as success; full 401 ladder (nonce + token refresh).
   private func performCreateHTTP(
     _ request: URLRequest,
-    makeRetry: ((String) async throws -> URLRequest)? = nil
+    staleToken: String,
+    makeRetry: MutatingRetryBuilder? = nil
   ) async throws -> String {
-    let data = try await performBodyHTTP(request, makeRetry: makeRetry)
+    let data = try await performBodyHTTP(request, staleToken: staleToken, makeRetry: makeRetry)
     let resp = try JSONDecoder().decode(CreateEntryResponse.self, from: data)
     return resp.id
   }

--- a/ios/PasswdSSOTests/AutofillTokenRefresherTests.swift
+++ b/ios/PasswdSSOTests/AutofillTokenRefresherTests.swift
@@ -145,4 +145,12 @@ final class AutofillTokenRefresherTests: XCTestCase {
       for: URLError(.notConnectedToInternet))
     XCTAssertTrue(summary.hasPrefix("other("))
   }
+
+  /// networkError is the second value-interpolating case: it must emit ONLY the
+  /// numeric URLError code (a stable, non-secret integer), never a message/URL.
+  func testDiagnosticSummaryNetworkErrorEmitsOnlyNumericCode() {
+    let summary = AutofillTokenRefresher.diagnosticSummary(
+      for: MobileAPIError.networkError(URLError(.timedOut)))
+    XCTAssertEqual(summary, "networkError(\(URLError.timedOut.rawValue))")
+  }
 }

--- a/ios/PasswdSSOTests/AutofillTokenRefresherTests.swift
+++ b/ios/PasswdSSOTests/AutofillTokenRefresherTests.swift
@@ -115,4 +115,34 @@ final class AutofillTokenRefresherTests: XCTestCase {
     XCTAssertNotNil(AutofillTokenRefresher.parseISO8601("2026-06-13T01:23:45Z"))
     XCTAssertNil(AutofillTokenRefresher.parseISO8601("not-a-date"))
   }
+
+  // MARK: - diagnosticSummary (secret-free, case-distinguishing log labels)
+
+  func testDiagnosticSummaryNamesTheFailureMode() {
+    XCTAssertEqual(
+      AutofillTokenRefresher.diagnosticSummary(for: MobileAPIError.authenticationRequired),
+      "authenticationRequired")
+    XCTAssertEqual(
+      AutofillTokenRefresher.diagnosticSummary(for: MobileAPIError.serverError(status: 503)),
+      "serverError(503)")
+    XCTAssertEqual(
+      AutofillTokenRefresher.diagnosticSummary(for: MobileAPIError.dpopInvalid(newNonce: "n")),
+      "dpopInvalid")
+  }
+
+  /// The DPoP nonce (though non-secret) and any error value beyond the plain
+  /// status/code must never appear in the label — the whole point of the summary
+  /// is a fixed vocabulary that cannot leak state.
+  func testDiagnosticSummaryOmitsDPoPNonceValue() {
+    let summary = AutofillTokenRefresher.diagnosticSummary(
+      for: MobileAPIError.dpopInvalid(newNonce: "super-secret-nonce"))
+    XCTAssertFalse(summary.contains("super-secret-nonce"))
+  }
+
+  /// A non-MobileAPIError falls back to its TYPE name only, never its value.
+  func testDiagnosticSummaryFallsBackToTypeForOtherErrors() {
+    let summary = AutofillTokenRefresher.diagnosticSummary(
+      for: URLError(.notConnectedToInternet))
+    XCTAssertTrue(summary.hasPrefix("other("))
+  }
 }

--- a/ios/PasswdSSOTests/MobileAPIClientTests.swift
+++ b/ios/PasswdSSOTests/MobileAPIClientTests.swift
@@ -54,6 +54,18 @@ func httpResponse(status: Int, url: URL, headers: [String: String] = [:]) -> HTT
   HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headers)!
 }
 
+/// Shared UpdateEntryRequest fixture used by both MobileAPIClientTests and
+/// TokenRefreshTests (file-scope so neither class owns a private duplicate).
+func makeUpdateEntryRequestFixture() -> UpdateEntryRequest {
+  let enc = EncryptedData(
+    ciphertext: "aabbcc",
+    iv: "112233445566778899aabbcc",
+    authTag: "deadbeefdeadbeefdeadbeefdeadbeef"
+  )
+  return UpdateEntryRequest(
+    encryptedBlob: enc, encryptedOverview: enc, keyVersion: 1, aadVersion: 1)
+}
+
 /// Read all bytes from an InputStream (URLProtocol replaces httpBody with httpBodyStream).
 func readStream(_ stream: InputStream?) -> Data? {
   guard let stream else { return nil }
@@ -323,19 +335,6 @@ final class MobileAPIClientTests: XCTestCase {
 
   // MARK: - updateEntry
 
-  private func makeUpdateRequest() -> UpdateEntryRequest {
-    let enc = EncryptedData(
-      ciphertext: "aabbcc",
-      iv: "112233445566778899aabbcc",
-      authTag: "deadbeefdeadbeefdeadbeefdeadbeef"
-    )
-    return UpdateEntryRequest(
-      encryptedBlob: enc,
-      encryptedOverview: enc,
-      keyVersion: 1,
-      aadVersion: 1
-    )
-  }
 
   private func seedAccessToken() {
     try? tokenStore.saveTokens(
@@ -366,7 +365,7 @@ final class MobileAPIClientTests: XCTestCase {
       urlSession: session
     )
 
-    try await client.updateEntry(entryId: entryId, body: makeUpdateRequest())
+    try await client.updateEntry(entryId: entryId, body: makeUpdateEntryRequestFixture())
 
     let req = try XCTUnwrap(capturedRequest)
     XCTAssertEqual(req.httpMethod, "PUT")
@@ -469,7 +468,7 @@ final class MobileAPIClientTests: XCTestCase {
       urlSession: session
     )
 
-    try await client.updateEntry(entryId: entryId, body: makeUpdateRequest())
+    try await client.updateEntry(entryId: entryId, body: makeUpdateEntryRequestFixture())
 
     let req = try XCTUnwrap(capturedRequest)
     // DPoP proof is a JWS — decode payload to verify ath claim.
@@ -768,7 +767,7 @@ final class MobileAPIClientTests: XCTestCase {
       urlSession: session
     )
 
-    try await client.updateEntry(entryId: entryId, body: makeUpdateRequest())
+    try await client.updateEntry(entryId: entryId, body: makeUpdateEntryRequestFixture())
 
     let nonce = try XCTUnwrap(try tokenStore.loadNonce())
     XCTAssertEqual(nonce, "nonce-upd-1")
@@ -794,7 +793,7 @@ final class MobileAPIClientTests: XCTestCase {
     )
 
     do {
-      try await client.updateEntry(entryId: entryId, body: makeUpdateRequest())
+      try await client.updateEntry(entryId: entryId, body: makeUpdateEntryRequestFixture())
       XCTFail("Expected notFound")
     } catch MobileAPIError.notFound {
       // Expected.
@@ -825,7 +824,7 @@ final class MobileAPIClientTests: XCTestCase {
       urlSession: session
     )
 
-    try await client.updateEntry(entryId: entryId, body: makeUpdateRequest())
+    try await client.updateEntry(entryId: entryId, body: makeUpdateEntryRequestFixture())
     XCTAssertEqual(callCount, 2, "Client should retry exactly once after 401+nonce")
   }
 
@@ -1612,16 +1611,6 @@ final class TokenRefreshTests: XCTestCase {
                    "Resource endpoint must not be reached when refresh fails with network error")
   }
 
-  private func makeLadderUpdateRequest() -> UpdateEntryRequest {
-    let enc = EncryptedData(
-      ciphertext: "aabbcc",
-      iv: "112233445566778899aabbcc",
-      authTag: "deadbeefdeadbeefdeadbeefdeadbeef"
-    )
-    return UpdateEntryRequest(
-      encryptedBlob: enc, encryptedOverview: enc, keyVersion: 1, aadVersion: 1)
-  }
-
   // MARK: - Mutating-call refresh ladder (parity with the GET ladder)
   //
   // Regression: `performBodyHTTP`/`performVoidHTTP` previously only did a
@@ -1655,14 +1644,18 @@ final class TokenRefreshTests: XCTestCase {
       return (Data(), httpResponse(status: 200, url: putURL))
     }
 
-    try await makeClient().updateEntry(entryId: entryId, body: makeLadderUpdateRequest())
+    try await makeClient().updateEntry(entryId: entryId, body: makeUpdateEntryRequestFixture())
 
     XCTAssertEqual(resourceCallCount, 2, "PUT must be retried once after the reactive refresh")
     XCTAssertEqual(refreshCallCount, 1, "refresh must run exactly once")
-    // The retry must carry the NEW access token in its Authorization header.
+    // The retry must carry the NEW token in BOTH the Authorization header AND the
+    // DPoP proof's `ath` claim — the two bindings must move together.
     let retryAuth = capturedRequests.last?.value(forHTTPHeaderField: "Authorization")
     XCTAssertEqual(retryAuth, "Bearer acc_upd_new",
                    "the refresh-retry must swap Authorization to the rotated token")
+    let retryDPoP = try XCTUnwrap(capturedRequests.last?.value(forHTTPHeaderField: "DPoP"))
+    XCTAssertEqual(try decodeDPoPAth(retryDPoP), sha256Base64URL("acc_upd_new"),
+                   "the refresh-retry proof's ath must be rebound to SHA-256(newToken)")
   }
 
   func testUpdateEntry_refreshFails_throwsAuthenticationRequired() async throws {
@@ -1682,7 +1675,7 @@ final class TokenRefreshTests: XCTestCase {
     }
 
     do {
-      try await makeClient().updateEntry(entryId: entryId, body: makeLadderUpdateRequest())
+      try await makeClient().updateEntry(entryId: entryId, body: makeUpdateEntryRequestFixture())
       XCTFail("a dead refresh must throw authenticationRequired")
     } catch MobileAPIError.authenticationRequired {
       // expected
@@ -1707,6 +1700,7 @@ final class TokenRefreshTests: XCTestCase {
                 httpResponse(status: 200, url: request.url!))
       }
       self?.resourceCallCount += 1
+      self?.capturedRequests.append(request)
       if (self?.resourceCallCount ?? 0) == 1 {
         return (Data(), httpResponse(status: 401, url: mintURL))
       }
@@ -1719,6 +1713,90 @@ final class TokenRefreshTests: XCTestCase {
     XCTAssertEqual(response.token, "upload_tok")
     XCTAssertEqual(resourceCallCount, 2, "mint must be retried once after the reactive refresh")
     XCTAssertEqual(refreshCallCount, 1, "refresh must run exactly once")
+
+    // The retry must carry the NEW token in BOTH the Authorization header AND
+    // the DPoP proof's `ath` claim — a stale `ath` would be a token/proof
+    // mismatch the server rejects, so both bindings must move together.
+    XCTAssertEqual(capturedRequests.count, 2, "mint: initial + one retry")
+    XCTAssertEqual(capturedRequests.last?.value(forHTTPHeaderField: "Authorization"),
+                   "Bearer acc_mint_new",
+                   "the refresh-retry must swap Authorization to the rotated token")
+    let retryDPoP = try XCTUnwrap(capturedRequests.last?.value(forHTTPHeaderField: "DPoP"))
+    XCTAssertEqual(try decodeDPoPAth(retryDPoP), sha256Base64URL("acc_mint_new"),
+                   "the refresh-retry proof's ath must be rebound to SHA-256(newToken)")
+  }
+
+  /// Bounded-ladder property: after a SUCCESSFUL refresh the resource still 401s.
+  /// The ladder must NOT loop or throw authenticationRequired — it surfaces
+  /// serverError(401) so callers fall back to cached data (mirrors the GET path).
+  func testUpdateEntry_postRefreshStill401_surfacesServerError401() async throws {
+    try tokenStore.saveTokens(
+      access: "acc_still", refresh: "ref_still", expiresAt: fixedNow.addingTimeInterval(3600))
+
+    let entryId = "entry-still-401"
+    let putURL = serverURL.appending(path: "/api/passwords/\(entryId)", directoryHint: .notDirectory)
+
+    MockURLProtocol.requestHandler = { [weak self] request in
+      if request.url?.path == "/api/mobile/token/refresh" {
+        self?.refreshCallCount += 1
+        return (tokenResponseJSON(accessToken: "acc_still_new", refreshToken: "ref_still_new"),
+                httpResponse(status: 200, url: request.url!))
+      }
+      self?.resourceCallCount += 1
+      // Every PUT 401s, with NO nonce header → nonce rung skipped, refresh rung
+      // taken once, then the ladder is exhausted.
+      return (Data(), httpResponse(status: 401, url: putURL))
+    }
+
+    do {
+      try await makeClient().updateEntry(entryId: entryId, body: makeUpdateEntryRequestFixture())
+      XCTFail("a persistent 401 after a successful refresh must throw serverError(401)")
+    } catch MobileAPIError.serverError(let status) {
+      XCTAssertEqual(status, 401, "post-refresh persistent 401 must surface as serverError(401)")
+    }
+    XCTAssertEqual(resourceCallCount, 2, "ladder must be bounded: initial + one post-refresh retry")
+    XCTAssertEqual(refreshCallCount, 1, "refresh must run exactly once, never loop")
+  }
+
+  /// Full 3-rung ladder on a mutating call: 401+nonce → nonce-retry → still 401
+  /// → refresh → 200. Locks the nonce-then-refresh interaction (a bug where the
+  /// nonce rung consumes the refresh slot would drop to 2 resource calls).
+  func testUpdateEntry_nonceRetryThenRefreshLadder() async throws {
+    try tokenStore.saveTokens(
+      access: "acc_ladder", refresh: "ref_ladder", expiresAt: fixedNow.addingTimeInterval(3600))
+
+    let entryId = "entry-ladder"
+    let putURL = serverURL.appending(path: "/api/passwords/\(entryId)", directoryHint: .notDirectory)
+
+    MockURLProtocol.requestHandler = { [weak self] request in
+      if request.url?.path == "/api/mobile/token/refresh" {
+        self?.refreshCallCount += 1
+        return (tokenResponseJSON(accessToken: "acc_ladder_new", refreshToken: "ref_ladder_new"),
+                httpResponse(status: 200, url: request.url!))
+      }
+      let n = (self?.resourceCallCount ?? 0) + 1
+      self?.resourceCallCount = n
+      self?.capturedRequests.append(request)
+      switch n {
+      case 1:
+        // Rung 1: 401 WITH a fresh nonce → drives the nonce-retry.
+        return (Data(), httpResponse(status: 401, url: putURL, headers: ["DPoP-Nonce": "ladder-nonce"]))
+      case 2:
+        // Rung 2: nonce retry still 401, NO nonce → drives the refresh rung.
+        return (Data(), httpResponse(status: 401, url: putURL))
+      default:
+        // Rung 3: retry with the refreshed token → 200.
+        return (Data(), httpResponse(status: 200, url: putURL))
+      }
+    }
+
+    try await makeClient().updateEntry(entryId: entryId, body: makeUpdateEntryRequestFixture())
+
+    XCTAssertEqual(resourceCallCount, 3, "full ladder: initial + nonce-retry + refresh-retry")
+    XCTAssertEqual(refreshCallCount, 1, "refresh runs exactly once, after the nonce rung is spent")
+    // The final retry must carry the refreshed token.
+    XCTAssertEqual(capturedRequests.last?.value(forHTTPHeaderField: "Authorization"),
+                   "Bearer acc_ladder_new")
   }
 
   // MARK: - Helpers: decode DPoP JWS payload claims

--- a/ios/PasswdSSOTests/MobileAPIClientTests.swift
+++ b/ios/PasswdSSOTests/MobileAPIClientTests.swift
@@ -1612,6 +1612,115 @@ final class TokenRefreshTests: XCTestCase {
                    "Resource endpoint must not be reached when refresh fails with network error")
   }
 
+  private func makeLadderUpdateRequest() -> UpdateEntryRequest {
+    let enc = EncryptedData(
+      ciphertext: "aabbcc",
+      iv: "112233445566778899aabbcc",
+      authTag: "deadbeefdeadbeefdeadbeefdeadbeef"
+    )
+    return UpdateEntryRequest(
+      encryptedBlob: enc, encryptedOverview: enc, keyVersion: 1, aadVersion: 1)
+  }
+
+  // MARK: - Mutating-call refresh ladder (parity with the GET ladder)
+  //
+  // Regression: `performBodyHTTP`/`performVoidHTTP` previously only did a
+  // DPoP-Nonce retry, NOT a token-refresh retry. A same-server 401 on an
+  // access token still within its validity window (server-side invalidation /
+  // rotation) surfaced as .serverError(401) with no recovery, so the AutoFill
+  // upload-token mint failed on every foreground return. These lock the refresh
+  // rung for mutating calls — before the fix they fail (only 1 resource call).
+
+  func testUpdateEntry_401_reactiveRefreshThen200() async throws {
+    // Token is VALID (not expired) so no proactive refresh — the 401 is a
+    // server-side rejection that must drive the reactive refresh rung.
+    try tokenStore.saveTokens(
+      access: "acc_upd", refresh: "ref_upd", expiresAt: fixedNow.addingTimeInterval(3600))
+
+    let entryId = "entry-refresh"
+    let putURL = serverURL.appending(path: "/api/passwords/\(entryId)", directoryHint: .notDirectory)
+
+    MockURLProtocol.requestHandler = { [weak self] request in
+      if request.url?.path == "/api/mobile/token/refresh" {
+        self?.refreshCallCount += 1
+        return (tokenResponseJSON(accessToken: "acc_upd_new", refreshToken: "ref_upd_new"),
+                httpResponse(status: 200, url: request.url!))
+      }
+      self?.resourceCallCount += 1
+      self?.capturedRequests.append(request)
+      // First PUT: 401 with NO nonce header → skip nonce retry, go to refresh.
+      if (self?.resourceCallCount ?? 0) == 1 {
+        return (Data(), httpResponse(status: 401, url: putURL))
+      }
+      return (Data(), httpResponse(status: 200, url: putURL))
+    }
+
+    try await makeClient().updateEntry(entryId: entryId, body: makeLadderUpdateRequest())
+
+    XCTAssertEqual(resourceCallCount, 2, "PUT must be retried once after the reactive refresh")
+    XCTAssertEqual(refreshCallCount, 1, "refresh must run exactly once")
+    // The retry must carry the NEW access token in its Authorization header.
+    let retryAuth = capturedRequests.last?.value(forHTTPHeaderField: "Authorization")
+    XCTAssertEqual(retryAuth, "Bearer acc_upd_new",
+                   "the refresh-retry must swap Authorization to the rotated token")
+  }
+
+  func testUpdateEntry_refreshFails_throwsAuthenticationRequired() async throws {
+    try tokenStore.saveTokens(
+      access: "acc_upd_dead", refresh: "ref_upd_dead", expiresAt: fixedNow.addingTimeInterval(3600))
+
+    let entryId = "entry-dead"
+    let putURL = serverURL.appending(path: "/api/passwords/\(entryId)", directoryHint: .notDirectory)
+
+    MockURLProtocol.requestHandler = { [weak self] request in
+      if request.url?.path == "/api/mobile/token/refresh" {
+        self?.refreshCallCount += 1
+        return (Data(), httpResponse(status: 401, url: request.url!))
+      }
+      self?.resourceCallCount += 1
+      return (Data(), httpResponse(status: 401, url: putURL))
+    }
+
+    do {
+      try await makeClient().updateEntry(entryId: entryId, body: makeLadderUpdateRequest())
+      XCTFail("a dead refresh must throw authenticationRequired")
+    } catch MobileAPIError.authenticationRequired {
+      // expected
+    }
+    XCTAssertEqual(resourceCallCount, 1, "PUT hit once before the failed refresh")
+    XCTAssertEqual(refreshCallCount, 1, "refresh attempted exactly once")
+  }
+
+  func testMintAutofillToken_401_reactiveRefreshThen200() async throws {
+    // The exact reported symptom: mint 401s on a valid token; must refresh+retry
+    // rather than surface serverError(401).
+    try tokenStore.saveTokens(
+      access: "acc_mint", refresh: "ref_mint", expiresAt: fixedNow.addingTimeInterval(3600))
+
+    let mintURL = serverURL.appending(path: "/api/mobile/autofill-token", directoryHint: .notDirectory)
+    let extJWK = ["kty": "EC", "crv": "P-256", "x": "xExt", "y": "yExt"]
+
+    MockURLProtocol.requestHandler = { [weak self] request in
+      if request.url?.path == "/api/mobile/token/refresh" {
+        self?.refreshCallCount += 1
+        return (tokenResponseJSON(accessToken: "acc_mint_new", refreshToken: "ref_mint_new"),
+                httpResponse(status: 200, url: request.url!))
+      }
+      self?.resourceCallCount += 1
+      if (self?.resourceCallCount ?? 0) == 1 {
+        return (Data(), httpResponse(status: 401, url: mintURL))
+      }
+      return (Data(#"{"token":"upload_tok","expiresAt":"2026-06-13T01:23:45.678Z","scope":["passwords:write"],"cnfJkt":"jkt1"}"#.utf8),
+              httpResponse(status: 200, url: mintURL))
+    }
+
+    let response = try await makeClient().mintAutofillToken(extensionJWK: extJWK)
+
+    XCTAssertEqual(response.token, "upload_tok")
+    XCTAssertEqual(resourceCallCount, 2, "mint must be retried once after the reactive refresh")
+    XCTAssertEqual(refreshCallCount, 1, "refresh must run exactly once")
+  }
+
   // MARK: - Helpers: decode DPoP JWS payload claims
 
   private func decodeDPoPPayload(_ jws: String) throws -> [String: AnyDecodable] {


### PR DESCRIPTION
## Summary

Fixes a bug where iOS mutating API calls (POST/PUT — `mintAutofillToken`, `updateEntry`, `createEntry`, …) could not recover from a server-rejected access token. The GET path (`performAuthedGET`) had a full retry ladder; the mutating helpers only did a DPoP-nonce retry, so a same-server 401 on a still-valid-window token surfaced as `serverError(401)` with no recovery. Symptom: the AutoFill upload-token mint failed on every foreground return from the browser, silently dropping the extension's passkey-registration path to iCloud Keychain.

## Root cause & diagnosis

`performBodyHTTP` / `performVoidHTTP` / `performCreateHTTP` lacked the token-refresh rung that `performAuthedGET` has. A diagnostic-logging improvement (first commit) surfaced the exact failure mode (`serverError(401)`, not `authenticationRequired`), pinpointing the missing rung.

## Fix

- Shared `performMutatingWithLadder` mirrors the GET ladder: nonce-retry → refresh-and-retry (rebuilt `ath` + swapped `Authorization`) → `serverError(401)` only after a **successful** refresh still 401s (a failed refresh throws `authenticationRequired`, so a dead session is not misread as a resource-level rejection).
- The retry closure now takes `(nonce, freshToken)` so one closure serves both rungs. All 5 mutating call sites updated.
- Reuses the existing single-flight `TokenRefreshCoordinator` (no new refresh call site → no risk of duplicate concurrent refreshes / token-family revocation).
- `diagnosticSummary(for:)` gives secret-free per-failure-mode log labels (no token/nonce interpolation).

## Testing

- Regression tests lock the refresh rung for `updateEntry` + `mintAutofillToken`, asserting the retry rebinds **both** the `Authorization` header and the DPoP proof's `ath`. Plus bounded-ladder (post-refresh-still-401 → `serverError(401)`) and full nonce-then-refresh ladder tests. Prove-red verified (disabling each rung turns the corresponding test red).
- iOS: 776 unit + 3 UI, 0 failures. **Verified on-device**: after the fix, an expired session correctly routes to `authenticationRequired` (read-only fallback), and re-sign-in clears it.
- Reviewed via /triangulate (functionality/security/testing) — no implementation defects; all findings were test-coverage + doc accuracy, resolved in `review(1)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)