### PR TITLE
feat(ios): show a persistent banner when the vault is read-only offline

### DIFF
--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -2859,6 +2859,54 @@
           }
         }
       }
+    },
+    "Locks the vault so you can sign in again" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locks the vault so you can sign in again"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保管庫をロックして再度サインインできるようにします"
+          }
+        }
+      }
+    },
+    "Showing saved items. Sign in again to make changes." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Showing saved items. Sign in again to make changes."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存済みの項目を表示しています。変更するには再度サインインしてください。"
+          }
+        }
+      }
+    },
+    "You're signed out" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You're signed out"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サインアウトしました"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/ios/PasswdSSOApp/Localizable.xcstrings
+++ b/ios/PasswdSSOApp/Localizable.xcstrings
@@ -338,6 +338,54 @@
         }
       }
     },
+    "Showing saved items. Sign in again to make changes." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Showing saved items. Sign in again to make changes."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存済みの項目を表示しています。変更するには再度サインインしてください。"
+          }
+        }
+      }
+    },
+    "Signs out so you can sign in again" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signs out so you can sign in again"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サインアウトして再度サインインできるようにします"
+          }
+        }
+      }
+    },
+    "You're signed out" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You're signed out"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サインアウトしました"
+          }
+        }
+      }
+    },
     "biometrics" : {
       "comment" : "Fallback biometry name when neither Face ID nor Touch ID is detected.",
       "extractionState" : "stale",
@@ -2856,54 +2904,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "セッション情報が古くなっています。パスフレーズを入力して解錠してください。"
-          }
-        }
-      }
-    },
-    "Locks the vault so you can sign in again" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Locks the vault so you can sign in again"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保管庫をロックして再度サインインできるようにします"
-          }
-        }
-      }
-    },
-    "Showing saved items. Sign in again to make changes." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Showing saved items. Sign in again to make changes."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存済みの項目を表示しています。変更するには再度サインインしてください。"
-          }
-        }
-      }
-    },
-    "You're signed out" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You're signed out"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サインアウトしました"
           }
         }
       }

--- a/ios/PasswdSSOApp/Vault/PostSyncDecision.swift
+++ b/ios/PasswdSSOApp/Vault/PostSyncDecision.swift
@@ -108,6 +108,28 @@ public func syncFailedSessionExpired(from error: Error) -> Bool {
   return false
 }
 
+/// How a post-unlock `runSync` outcome should move the persistent "you're signed
+/// out" banner state. Extracted from `VaultListView.sync()` (a SwiftUI method,
+/// not XCTest-reachable) so the three transition arms are unit-testable — same
+/// rationale as `decidePostSync`/`syncFailedSessionExpired` above.
+public enum SessionBannerTransition: Equatable {
+  /// Sync reached the server → the session is alive; hide the banner.
+  case clear
+  /// Sync failed with a dead session (`authenticationRequired`); show the banner.
+  case show
+  /// A transient failure (offline / server blip) — the session state is unknown,
+  /// so LEAVE the banner as-is (a network blip must not clear a real signed-out
+  /// banner, nor raise one).
+  case unchanged
+}
+
+/// Map a `runSync` result to the banner transition. `error == nil` means the
+/// sync succeeded (reached the server).
+public func sessionBannerTransition(syncError error: Error?) -> SessionBannerTransition {
+  guard let error else { return .clear }
+  return syncFailedSessionExpired(from: error) ? .show : .unchanged
+}
+
 /// Map a fail-closed unlock (sync failed with no trustworthy local cache) to the
 /// banner outcome: a dead session routes to "sign in again", a mere offline failure
 /// to "try again with your passphrase".

--- a/ios/PasswdSSOApp/Views/RootView.swift
+++ b/ios/PasswdSSOApp/Views/RootView.swift
@@ -29,7 +29,8 @@ enum AppState {
     cacheData: CacheData,
     autoLockService: AutoLockService,
     apiClient: MobileAPIClient,
-    cacheKey: SymmetricKey?
+    cacheKey: SymmetricKey?,
+    sessionExpired: Bool
   )
   // Locked but still signed in: re-unlock needs only the passphrase, keeping the
   // server config + token (no OAuth re-sign-in). Carries serverConfig/apiClient
@@ -115,7 +116,7 @@ struct RootView: View {
         // Arriving via sign-in / app entry → auto-prompt Face ID on appear.
         vaultLockedScreen(serverConfig: serverConfig, apiClient: apiClient, autoPromptOnAppear: true)
 
-      case .vaultUnlocked(let serverConfig, let vaultKey, let userId, let keyVersion, let cacheData, let autoLockService, let apiClient, let cacheKey):
+      case .vaultUnlocked(let serverConfig, let vaultKey, let userId, let keyVersion, let cacheData, let autoLockService, let apiClient, let cacheKey, let sessionExpired):
         VaultListView(
           cacheData: cacheData,
           vaultKey: vaultKey,
@@ -124,7 +125,8 @@ struct RootView: View {
           autoLockService: autoLockService,
           apiClient: apiClient,
           hostSyncService: hostSyncService ?? makeFallbackSyncService(apiClient: apiClient),
-          cacheKey: cacheKey
+          cacheKey: cacheKey,
+          sessionExpiredAtUnlock: sessionExpired
         )
         .onChange(of: autoLockService.state) { _, newState in
           switch newState {
@@ -504,7 +506,10 @@ struct RootView: View {
       cacheData: cacheData,
       autoLockService: autoLockService,
       apiClient: apiClient,
-      cacheKey: unlockResult.cacheKey
+      cacheKey: unlockResult.cacheKey,
+      // A dead-session unlock that fell back to the local cache (.useLocalCache /
+      // .useEmptyCache) reaches the vault read-only — surface it via the banner.
+      sessionExpired: sessionExpired
     )
     return .reachedVault
   }

--- a/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
@@ -22,7 +22,14 @@ struct VaultListView: View {
   /// The REAL cacheKey from unlock (nil in debug). Needed to decrypt team entries
   /// in-app + persist/read team keys; cannot be re-derived (readDirect is empty).
   let cacheKey: SymmetricKey?
+  /// Whether the unlock-time sync found the server session dead (refresh token
+  /// expired / replay-revoked). Seeds the persistent offline banner; a later
+  /// successful sync clears it, a later authenticationRequired sync re-arms it.
+  let sessionExpiredAtUnlock: Bool
 
+  /// Live session-expired state driving the banner. Seeded from
+  /// `sessionExpiredAtUnlock` on first appear, then updated by sync outcomes.
+  @State private var sessionExpired: Bool = false
   @State private var isScreenRecording: Bool = UIScreen.main.isCaptured
   @State private var isShowingSettings: Bool = false
   @State private var isShowingCreateForm: Bool = false
@@ -36,6 +43,9 @@ struct VaultListView: View {
   var body: some View {
     NavigationStack {
       VStack(spacing: 0) {
+        if sessionExpired {
+          sessionExpiredBanner
+        }
         vaultSwitcher
         Group {
           if isScreenRecording {
@@ -148,6 +158,9 @@ struct VaultListView: View {
       }
     }
     .onAppear {
+      // Seed the banner from the unlock-time verdict (idempotent — re-running on
+      // a benign re-appear just re-applies the same value).
+      sessionExpired = sessionExpiredAtUnlock
       reload(cacheData)
       updateScreenRecordingState()
       // Configure the favicon loader BEFORE resolving showFavicons so the first
@@ -186,6 +199,40 @@ struct VaultListView: View {
         viewModel.searchQuery = ""
       }
     }
+  }
+
+  /// Persistent banner shown while the vault is usable from the local cache but
+  /// the server session is dead — the read-only degraded state that would
+  /// otherwise only reveal itself when the user tries to edit/create. Tapping it
+  /// locks the vault; the re-unlock flow then routes a dead session to sign-in.
+  @ViewBuilder private var sessionExpiredBanner: some View {
+    Button {
+      autoLockService.recordActivity()
+      // Lock → the passphrase unlock re-probes the session; a dead session
+      // surfaces there as "sign in again" (VaultUnlocker → .sessionExpired).
+      autoLockService.lock()
+    } label: {
+      HStack(spacing: 8) {
+        Image(systemName: "wifi.exclamationmark")
+        VStack(alignment: .leading, spacing: 1) {
+          Text("You're signed out")
+            .font(.subheadline.weight(.semibold))
+          Text("Showing saved items. Sign in again to make changes.")
+            .font(.caption)
+        }
+        Spacer(minLength: 0)
+        Image(systemName: "chevron.right")
+          .font(.caption.weight(.semibold))
+          .opacity(0.6)
+      }
+      .foregroundStyle(.primary)
+      .padding(.horizontal)
+      .padding(.vertical, 10)
+      .frame(maxWidth: .infinity)
+      .background(.yellow.opacity(0.18))
+    }
+    .buttonStyle(.plain)
+    .accessibilityHint(Text("Locks the vault so you can sign in again"))
   }
 
   /// Decrypt + bind a fresh cache: use the unlock-time cacheKey (for team entries)
@@ -390,7 +437,13 @@ struct VaultListView: View {
       if let fresh = report.cacheData {
         reload(fresh)
       }
+      // Sync reached the server → the session is alive again; clear the banner.
+      sessionExpired = false
     } catch MobileAPIError.authenticationRequired {
+      // Persistent state, set even on a SILENT foreground sync (surfaceErrors ==
+      // false): the banner is the ambient "you're signed out" signal, distinct
+      // from the transient alert that only a user-initiated sync raises.
+      sessionExpired = true
       if surfaceErrors {
         syncError = L10n.string("Your session expired. Lock and unlock to sign in again.")
       }

--- a/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
+++ b/ios/PasswdSSOApp/Views/Vault/VaultListView.swift
@@ -27,9 +27,14 @@ struct VaultListView: View {
   /// successful sync clears it, a later authenticationRequired sync re-arms it.
   let sessionExpiredAtUnlock: Bool
 
-  /// Live session-expired state driving the banner. Seeded from
-  /// `sessionExpiredAtUnlock` on first appear, then updated by sync outcomes.
+  /// Live session-expired state driving the banner. Seeded ONCE from
+  /// `sessionExpiredAtUnlock` via the `didSeedSession` one-shot below — NOT
+  /// re-applied on every `onAppear`, which re-fires on navigation pop-back and
+  /// would clobber a sync-updated value with the stale unlock-time verdict.
+  /// After seeding it is updated only by sync outcomes.
   @State private var sessionExpired: Bool = false
+  /// One-shot guard so the unlock-time seed runs exactly once per view identity.
+  @State private var didSeedSession: Bool = false
   @State private var isScreenRecording: Bool = UIScreen.main.isCaptured
   @State private var isShowingSettings: Bool = false
   @State private var isShowingCreateForm: Bool = false
@@ -158,9 +163,13 @@ struct VaultListView: View {
       }
     }
     .onAppear {
-      // Seed the banner from the unlock-time verdict (idempotent — re-running on
-      // a benign re-appear just re-applies the same value).
-      sessionExpired = sessionExpiredAtUnlock
+      // Seed the banner from the unlock-time verdict EXACTLY ONCE. A re-fire on
+      // navigation pop-back must not re-apply the stale unlock verdict over a
+      // value a later sync updated.
+      if !didSeedSession {
+        sessionExpired = sessionExpiredAtUnlock
+        didSeedSession = true
+      }
       reload(cacheData)
       updateScreenRecordingState()
       // Configure the favicon loader BEFORE resolving showFavicons so the first
@@ -204,13 +213,16 @@ struct VaultListView: View {
   /// Persistent banner shown while the vault is usable from the local cache but
   /// the server session is dead — the read-only degraded state that would
   /// otherwise only reveal itself when the user tries to edit/create. Tapping it
-  /// locks the vault; the re-unlock flow then routes a dead session to sign-in.
+  /// signs out and routes straight to the sign-in screen.
   @ViewBuilder private var sessionExpiredBanner: some View {
     Button {
       autoLockService.recordActivity()
-      // Lock → the passphrase unlock re-probes the session; a dead session
-      // surfaces there as "sign in again" (VaultUnlocker → .sessionExpired).
-      autoLockService.lock()
+      // The session is already dead (that is why the banner is showing), so a
+      // passphrase re-unlock would only loop back here. Sign out with the
+      // idleTimeout reason: it clears the dead tokens and routes STRAIGHT to
+      // sign-in (skipping the change-server URL screen that `.manual` shows),
+      // matching the banner copy "Sign in again to make changes".
+      autoLockService.signOut(reason: .idleTimeout)
     } label: {
       HStack(spacing: 8) {
         Image(systemName: "wifi.exclamationmark")
@@ -232,7 +244,7 @@ struct VaultListView: View {
       .background(.yellow.opacity(0.18))
     }
     .buttonStyle(.plain)
-    .accessibilityHint(Text("Locks the vault so you can sign in again"))
+    .accessibilityHint(Text("Signs out so you can sign in again"))
   }
 
   /// Decrypt + bind a fresh cache: use the unlock-time cacheKey (for team entries)
@@ -431,27 +443,41 @@ struct VaultListView: View {
     // foreground auto-refresh is NOT user interaction, so it must not extend the
     // auto-lock window just because the app returned to the foreground.
     if surfaceErrors { autoLockService.recordActivity() }
+    var caught: Error?
     do {
       let report = try await hostSyncService.runSync(
         vaultKey: vaultKey, userId: userId, cacheKey: cacheKey)
       if let fresh = report.cacheData {
         reload(fresh)
       }
-      // Sync reached the server → the session is alive again; clear the banner.
-      sessionExpired = false
-    } catch MobileAPIError.authenticationRequired {
-      // Persistent state, set even on a SILENT foreground sync (surfaceErrors ==
-      // false): the banner is the ambient "you're signed out" signal, distinct
-      // from the transient alert that only a user-initiated sync raises.
-      sessionExpired = true
-      if surfaceErrors {
-        syncError = L10n.string("Your session expired. Lock and unlock to sign in again.")
-      }
     } catch {
-      if surfaceErrors {
-        syncError = L10n.string("Couldn't sync. Check your connection and try again.")
-      }
+      caught = error
     }
+
+    // Banner transition is a pure mapping of the sync outcome (tested in
+    // PostSyncDecisionTests): success → clear, dead session → show, a
+    // transient/offline failure → leave the banner untouched. Set even on a
+    // SILENT foreground sync (surfaceErrors == false) — the banner is the
+    // ambient "you're signed out" signal, distinct from the transient alert a
+    // user-initiated sync raises.
+    switch sessionBannerTransition(syncError: caught) {
+    case .clear: applyBannerState(false)
+    case .show: applyBannerState(true)
+    case .unchanged: break
+    }
+
+    if surfaceErrors, let caught {
+      syncError = (syncFailedSessionExpired(from: caught))
+        ? L10n.string("Your session expired. Lock and unlock to sign in again.")
+        : L10n.string("Couldn't sync. Check your connection and try again.")
+    }
+  }
+
+  /// Animate the banner in/out so a sync-driven state flip doesn't produce a
+  /// hard layout jump (the banner enters/leaves the VStack).
+  private func applyBannerState(_ expired: Bool) {
+    guard sessionExpired != expired else { return }
+    withAnimation(.easeInOut(duration: 0.2)) { sessionExpired = expired }
   }
 
   private func resolveShowFavicons() {

--- a/ios/PasswdSSOTests/PostSyncDecisionTests.swift
+++ b/ios/PasswdSSOTests/PostSyncDecisionTests.swift
@@ -146,4 +146,33 @@ final class PostSyncDecisionTests: XCTestCase {
   func testFailClosedResult_offline_routesToPassphraseRetry() {
     XCTAssertEqual(failClosedResult(sessionExpired: false), .failedOffline)
   }
+
+  // MARK: - sessionBannerTransition (offline read-only banner set/clear)
+
+  func testSessionBannerTransition_syncSucceeded_clears() {
+    XCTAssertEqual(sessionBannerTransition(syncError: nil), .clear)
+  }
+
+  func testSessionBannerTransition_deadSession_shows() {
+    XCTAssertEqual(
+      sessionBannerTransition(syncError: MobileAPIError.authenticationRequired), .show)
+  }
+
+  /// The load-bearing invariant: a transient/offline failure must LEAVE the
+  /// banner as-is — it must neither raise a false "signed out" banner nor clear
+  /// a real one (the session state is unknown when merely offline).
+  func testSessionBannerTransition_offlineError_leavesUnchanged() {
+    let offline = MobileAPIError.networkError(URLError(.notConnectedToInternet))
+    XCTAssertEqual(sessionBannerTransition(syncError: offline), .unchanged)
+  }
+
+  func testSessionBannerTransition_otherServerError_leavesUnchanged() {
+    XCTAssertEqual(
+      sessionBannerTransition(syncError: MobileAPIError.serverError(status: 500)), .unchanged)
+  }
+
+  func testSessionBannerTransition_nonMobileError_leavesUnchanged() {
+    struct Other: Error {}
+    XCTAssertEqual(sessionBannerTransition(syncError: Other()), .unchanged)
+  }
 }


### PR DESCRIPTION
## Summary

A dead server session (expired/replay-revoked refresh token) still unlocks the iOS vault from the local encrypted cache — a deliberate offline-tolerant design — but nothing told the user they were signed out, so the read-only state only revealed itself when an edit/create failed. This adds a persistent banner surfacing that state.

## Change

- Threads the unlock-time `sessionExpired` verdict (already computed in `handleVaultUnlocked`, previously dropped on the `.useLocalCache`/`.useEmptyCache` paths) through the `.vaultUnlocked` app-state into `VaultListView`.
- Shows a tappable **"You're signed out — showing saved items"** banner above the list. Tapping calls `signOut(reason: .idleTimeout)` — the session is already dead, so this clears the dead tokens/cache and routes straight to sign-in (matching the "Sign in again to make changes" copy).
- Banner state is seeded once at unlock, then updated by sync outcomes: a successful sync clears it; an `authenticationRequired` sync (even a silent foreground one) re-arms it; a transient/offline error leaves it unchanged.
- The set/clear logic is extracted into a pure `sessionBannerTransition()` in `PostSyncDecision.swift` (matching the existing `decidePostSync` pattern) and unit-tested.

## Security posture (unchanged, fail-closed)

Write operations remain fail-closed: `createEntry`/`saveEntry` call the server first and a dead session throws before any local write — the banner is purely informational. Tapping it fully tears down the session (tokens, cache, wrapped keys). Reviewed via /triangulate over two rounds (functionality/security/testing) — no Critical/Major findings; the `signOut` routing was assessed as a security improvement (no residual cache/tokens after "signed out").

## Follow-up (separate issue)

Suppressing the create/edit UI controls while read-only (belt-and-suspenders over the server-side rejection) + an integration test — tracked separately.

## Testing

- iOS: 785 unit + 3 UI, 0 failures. New `sessionBannerTransition` tests cover all three arms incl. the "transient error must not clear the banner" invariant.
- i18n: en+ja for all new strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)