### PR TITLE
feat(ci): add TLS-fixture expiry guard and harden iOS pinning guard

### DIFF
--- a/.github/workflows/tls-fixture-expiry.yml
+++ b/.github/workflows/tls-fixture-expiry.yml
@@ -1,0 +1,36 @@
+name: "TLS Fixture Expiry"
+
+# The iOS real-TLS test-fixture leaves (tlsLeaf*.p12) are 397-day certificates
+# (Apple caps TLS leaf validity at ~398 days), so they lapse roughly once a
+# year. A lapse breaks ServerTrustRealTLSTests on the macOS runner with an
+# opaque handshake error. This monthly job warns ~45 days BEFORE lapse — a
+# wall-clock trigger that fires even in a month where no PR touches the fixtures
+# (the PR-CI static-checks guard only runs on pushes/PRs). It does not
+# regenerate anything; it fails with an actionable message pointing at
+# ios/scripts/generate-tls-test-fixtures.sh.
+#
+# Runs on ubuntu (OpenSSL 3.x) so `openssl pkcs12 -legacy` works — macOS ships
+# LibreSSL, which rejects -legacy.
+
+on:
+  schedule:
+    - cron: "0 3 1 * *" # Monthly, 1st of the month 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-expiry:
+    name: "Check iOS TLS fixture expiry"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Check fixture expiry (45-day look-ahead)
+        env:
+          TLS_FIXTURE_CHECKEND_DAYS: "45"
+        run: bash scripts/checks/check-tls-fixture-expiry.sh

--- a/docs/archive/review/ci-guard-fixture-hardening-plan.md
+++ b/docs/archive/review/ci-guard-fixture-hardening-plan.md
@@ -1,0 +1,267 @@
+# Plan: CI-Guard & TLS-Fixture Hardening (C-P3 + C-P4)
+
+Branch: `feature/ci-guard-fixture-hardening`
+
+Bundles the two low-risk, time-sensitive roadmap items (P3 cert-fixture expiry,
+P4 iOS-guard self-test) into one PR. Contract-locked, with every Critical/Major
+finding from `security-hardening-roadmap-review.md` folded in.
+
+## Project context
+
+- Type: `mixed` (this PR touches only `scripts/checks/`, `scripts/__tests__/`,
+  `.github/workflows/`, `ios/README.md` — no product runtime code).
+- Test infrastructure: `unit + integration + E2E + CI/CD`. New self-tests are
+  `*.test.mjs` under `scripts/__tests__/**`, auto-discovered by vitest
+  (`vitest.config` include line 11) — same job as every other guard self-test.
+- Verification environment constraints:
+  - VC1: XCTest real-TLS *consumption* (ServerTrustRealTLSTests) is macOS-CI-only.
+    But the two NEW self-tests here are **bash + openssl + grep**, Linux-runnable
+    in the `static-checks` (ubuntu-latest) job and locally → `verifiable-local`.
+    Only the XCTest that *uses* the fixtures stays `blocked-deferred`-to-macOS-CI;
+    it is out of scope for this PR (SC1).
+  - VC2 (n/a here — no signing).
+
+## Objective
+
+1. **C-P3**: catch iOS TLS test-fixture leaves *before* they lapse (leaves are
+   397-day, Apple's ~398-day cap), via a Linux-runnable expiry-check guard, a
+   monthly cron, and README documentation of the existing generator.
+2. **C-P4**: give the iOS pinning guard a real self-test proving it can FAIL for
+   each of its three fail branches, using stable machine-readable identifiers and
+   env-root isolation — without touching the working tree.
+
+## Technical approach
+
+- The expiry check lives in `static-checks` (ubuntu-latest, OpenSSL 3.x) — NOT the
+  macOS iOS job — because the committed `.p12` is `-legacy`-encrypted and
+  macos-latest ships LibreSSL, which rejects `-legacy` (review M-a / R16). Verified
+  locally: `openssl version` = OpenSSL 3.6.3; `-clcerts -legacy` reads the leaf.
+- Leaf selection uses `openssl pkcs12 -clcerts` so ONLY the leaf cert (CN=localhost)
+  reaches `openssl x509`, never the 2126-expiry CA (review X3). Verified:
+  `-nokeys -clcerts` emits exactly the `CN=localhost` leaf.
+- Passphrase passed via `-passin env:` never `pass:<literal>` on argv (review m-3 /
+  RS6) — models the correct idiom even though this passphrase is intentionally public.
+- The iOS guard gains a single `IOS_PINNING_CHECK_ROOT` override at the `IOS_DIR`
+  assignment (line 34). Because grep roots (78), `rel`-strip (66), and allowlist
+  resolution (86) all derive from `$IOS_DIR`, one override threads through all three
+  (review X1). CI/pre-pr invoke it with no override → real `ios/`.
+
+## Contracts
+
+### C1 — `scripts/checks/check-tls-fixture-expiry.sh` (new)
+
+- **Signature**: bash script, no args. Reads `$TLS_FIXTURE_CHECK_ROOT` (default
+  `<repo>/ios/PasswdSSOTests/fixtures/TLS`) and `$TLS_FIXTURE_CHECKEND_DAYS`
+  (default `30`). Exit 0 = all leaves valid past the window; exit 1 = at least one
+  leaf expired/expiring, or an extraction failure.
+- **Behavior**: for each `tlsLeaf*.p12` in the root:
+  `openssl pkcs12 -in "$p12" -nokeys -clcerts -passin env:TLS_FIXTURE_PASS -legacy`
+  piped to `openssl x509 -checkend $((DAYS*86400)) -noout`. `TLS_FIXTURE_PASS`
+  defaults to the public `passwd-sso-test` inside the script.
+- **Three distinct outcomes, not collapsed** (review M-b): the script must classify
+  and print a stable identifier per outcome:
+  - leaf valid past window → print `TLS_FIXTURE_OK: <name> valid until <enddate>`, continue.
+  - leaf expired/within window → print `TLS_FIXTURE_EXPIRING: <name> ...`, set fail.
+  - extraction failed (pkcs12 stage non-zero: wrong pass, missing `-legacy`, DER/PEM
+    mixup, empty stream) → print `TLS_FIXTURE_UNREADABLE: <name> ...`, set fail.
+    Extraction failure MUST be detected explicitly (capture the leaf PEM to a
+    variable/temp and check it is non-empty) — NOT swallowed by pipefail.
+- **Invariants** (app-enforced):
+  - INV-C1a: script runs under `set -euo pipefail`; the two-stage extraction cannot
+    false-pass on a stage-1 failure (review M-a / R44).
+  - INV-C1b: `-clcerts` present on every `openssl pkcs12` invocation → the CA is
+    never the checked cert (review X3). **Forbidden pattern**: an `openssl pkcs12`
+    line reaching an `openssl x509 -checkend` without `-clcerts`.
+  - INV-C1c: passphrase via `-passin env:`; **forbidden pattern**:
+    `-passin pass:` literal anywhere (review m-3).
+- **Forbidden patterns**:
+  - `pattern: -passin pass: — reason: passphrase on argv leaks to process list (RS6)`
+  - `pattern: pkcs12 [^|]*\| *openssl x509 (no -clcerts between) — reason: unpinned leaf selection (X3)` (enforced by review + C4 self-test, not grep — regex is approximate)
+- **Acceptance criteria**:
+  - Against the real committed fixtures with default 30-day window → exit 0 today
+    (leaf expires 2027-08-15, far outside 30 days). Verified pre-plan: `-checkend 0` = valid.
+  - Against a deterministically-expired fixture → exit 1 with `TLS_FIXTURE_EXPIRING`.
+  - Against an unreadable/wrong-pass fixture → exit 1 with `TLS_FIXTURE_UNREADABLE`.
+
+### C2 — `.github/workflows/tls-fixture-expiry.yml` (new)
+
+- **Signature**: workflow, `on: schedule: cron "0 3 1 * *"` (monthly) +
+  `workflow_dispatch`. `runs-on: ubuntu-latest`. `permissions: contents: read`.
+- **Behavior**: runs C1 with a **look-ahead** window (`TLS_FIXTURE_CHECKEND_DAYS=45`)
+  so it warns ~1.5 months before lapse (review m-2: cron uses a longer horizon than
+  the PR-CI check). On failure it does NOT auto-regenerate — it fails the job (an
+  actionable red) and the run log names the fixture + `generate-tls-test-fixtures.sh`.
+- **Invariants**:
+  - INV-C2a: `permissions:` defaults to `contents: read` (no write) — review m-5 posture.
+- **Acceptance criteria**: manually triggerable via `workflow_dispatch`; green today;
+  would go red 45 days before the committed leaf's 2027-08-15 expiry.
+
+### C3 — C1 wired into `static-checks` (PR-CI) + `pre-pr.sh`
+
+- **Signature**: one `run_step "Static: tls-fixture-expiry" bash
+  scripts/checks/check-tls-fixture-expiry.sh` line in `pre-pr.sh` (after the other
+  iOS static guards, ~line 172), inheriting the ubuntu-latest static-checks job
+  (review M-a: OpenSSL 3.x runner).
+- **Behavior**: PR-CI uses a **short** window (default 30 days) — blocks a PR that
+  would ship already-lapsed-or-imminent fixtures (review m-2: CI short, cron long).
+- **Invariants**: INV-C3a: the guard runs in a job whose openssl is OpenSSL 3.x
+  (ubuntu), never LibreSSL (macos). Documented in a comment on the run_step line.
+- **Acceptance criteria**: `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` includes the
+  step and it passes today.
+
+### C4 — `scripts/__tests__/check-tls-fixture-expiry.test.mjs` (new self-test)
+
+- **Signature**: vitest `*.test.mjs`, auto-discovered. Runs the real C1 script via
+  `execFileSync` against isolated fixture roots (`TLS_FIXTURE_CHECK_ROOT=<tmpdir>`),
+  never the repo fixtures — mirrors the `CTC_CHECK_ROOT`/`mkdtempSync` idiom of
+  `check-count-then-create-lock.test.mjs`.
+- **Cases (each maps to a distinct C1 branch — RT7)**:
+  - `valid leaf → exit 0, stdout has TLS_FIXTURE_OK`: generate a fresh leaf (`-days 400`)
+    into the tmp root, assert pass. (RT7 positive.)
+  - `expired leaf → exit 1, stderr/stdout has TLS_FIXTURE_EXPIRING`: generate `-days -1`
+    (already-expired at creation — deterministic, no clock-freezing per review M-b),
+    assert the **expiring identifier** fired. (**RT7 red case — proves the guard CAN fail.**)
+  - `unreadable/wrong-pass p12 → exit 1, TLS_FIXTURE_UNREADABLE`: pass wrong
+    `TLS_FIXTURE_PASS`, assert the **unreadable identifier** fired (NOT a generic exit 1)
+    — proves extraction failure is distinguished from expiry (review M-b, RT8).
+- **Invariants**: INV-C4a: at least one case asserts `code === 1` AND a specific
+  identifier string (not exit-code-only) — the red-case gate (review M-k).
+- **Testability note (RT2)**: test-side leaf generation uses the same openssl in the
+  vitest environment; no macOS/Xcode dependency (VC1 does not apply — Linux-runnable).
+
+### C5 — iOS pinning guard: env-root override + error identifiers
+
+- **Signature change to `scripts/checks/check-ios-authenticated-session-pinning.sh`**:
+  - Line 34: `IOS_DIR="${IOS_PINNING_CHECK_ROOT:-$REPO_ROOT/ios}"`. Single override;
+    threads through grep roots (78), `rel`-strip (66), allowlist resolution (86)
+    because all derive from `$IOS_DIR` (review X1 — verified line structure).
+  - **Fail-closed on override (review m2/Security)**: if `IOS_PINNING_CHECK_ROOT` is
+    set, resolve it to an absolute path and require it to be an existing directory;
+    exit non-zero with `PINNING_CHECK_ROOT_INVALID` if it does not exist. (Prevents a
+    PR pointing the guard at a nonexistent/empty dir to pass trivially.)
+  - **Stable identifiers** at the three `fail=1` sites (review M-l / RT8), printed
+    alongside the existing prose:
+    - line 73 (non-allowlisted construction) → `UNPINNED_URLSESSION_CONSTRUCTION`
+    - line 88 (allowlist names missing file) → `ALLOWLIST_MISSING_FILE`
+    - line 92 (allowlist entry no longer constructs) → `ALLOWLIST_STALE_ENTRY`
+- **Invariants**:
+  - INV-C5a: with no override, behavior against the real `ios/` is byte-identical to
+    today (still exit 0 on the current clean tree) — pure additive change. Acceptance:
+    `bash scripts/checks/check-ios-authenticated-session-pinning.sh` still passes.
+  - INV-C5b: identifiers are a **test contract** — changing one is a breaking change to
+    C6. Documented in a comment. Prose remains advisory (C6 asserts the identifier,
+    not the full prose — avoids the brittle full-string match).
+- **Forbidden patterns**: none new.
+- **Acceptance criteria**: real-tree run unchanged; override run against a tmp tree
+  works; invalid override fails closed.
+
+### C6 — `scripts/__tests__/check-ios-authenticated-session-pinning.test.mjs` (new self-test)
+
+- **Signature**: vitest `*.test.mjs`. Runs the real C5 guard via `execFileSync` with
+  `IOS_PINNING_CHECK_ROOT=<tmpdir>`. Every fixture tree seeds
+  `Shared/Network/ServerTrustService.swift` **containing** a `URLSession(` construction,
+  so the allowlist clause stays green and does not spuriously fire (review X1 —
+  the coupled second invariant).
+- **Cases — derived from the guard's ACTUAL branches, NOT the 4-kind template**
+  (review X2):
+  - `clean tree → exit 0`: seeded `ServerTrustService.swift` (allowlisted) + a
+    non-constructing production file. **Positive-passes case, asserted first** so the
+    harness proves it isn't spuriously red before the negatives (review X1).
+  - `non-allowlisted construction → exit 1 + UNPINNED_URLSESSION_CONSTRUCTION`: add
+    `PasswdSSOApp/Foo.swift` with `URLSession.shared`. (**RT7 red case.**)
+  - `allowlisted file missing → exit 1 + ALLOWLIST_MISSING_FILE`: omit
+    `ServerTrustService.swift` from the tree. (Exercises the stale-clause branch A.)
+  - `allowlisted file no longer constructs → exit 1 + ALLOWLIST_STALE_ENTRY`: seed
+    `ServerTrustService.swift` WITHOUT any `URLSession(`. (Stale-clause branch B.)
+  - `construction only in a comment/string in a production file → exit ???`
+    **(known-limitation fixture)**: seed `PasswdSSOApp/Bar.swift` with `// URLSession(`
+    in a comment. The current guard is pure grep with no comment-blanking, so it
+    **fails this (false positive)**. This PR does NOT fix the guard; the fixture PINS
+    the current behavior with a comment `// KNOWN FALSE-POSITIVE: guard has no
+    comment-blanking; see roadmap review X2` so a future comment-aware upgrade has a
+    regression anchor. (review X2 — the genuinely valuable case the template would hide.)
+  - `invalid override root → exit 1 + PINNING_CHECK_ROOT_INVALID`: set the env to a
+    nonexistent path (review m2 fail-closed).
+- **Invariants**: INV-C6a: ≥1 case asserts `code === 1` with a specific identifier
+  (red-case gate, review M-k). INV-C6b: assertions match the **identifier**, not the
+  full prose (review M-l / INV-C5b).
+
+### C7 — README documentation of the TLS fixture procedure (review GT-P3-c)
+
+- **Signature**: a section in `ios/README.md` (currently absent — grep found none).
+- **Content**: how to regenerate (`ios/scripts/generate-tls-test-fixtures.sh`), that
+  leaves are 397-day / re-run ~yearly, that the CA is long-lived, that the expiry
+  check (C1) + monthly cron (C2) warn before lapse, that the passphrase is
+  intentionally public and the keys are test-only (SAN=localhost, CA:FALSE) and MUST
+  NOT be used in production.
+- **Acceptance**: `check-doc-paths.mjs` (if it validates README links) stays green.
+
+## Scope contract
+
+- **SC1**: The XCTest real-TLS *consumption* (`ServerTrustRealTLSTests`) is untouched;
+  it remains macOS-CI-only (VC1). This PR only adds the expiry guard + guard self-tests.
+- **SC2** (design decided during implementation — fail-closed raw-source match):
+  The iOS guard matches RAW source and never strips comments/strings. An earlier
+  attempt normalized comments/whitespace away before scanning; that was reverted
+  because a partial lexer (no string-literal, raw-string, escape, or nested-comment
+  handling) is fail-OPEN — it deletes real code it misreads as a comment, letting an
+  actual construction slip through. Two concrete bypasses were demonstrated against the
+  normalizer: `"https://x"; URLSession.shared` (the `//` inside the string was treated
+  as a line comment, deleting the construction) and `URLSession/* /* */ */.shared`
+  (non-greedy `/* */` ended at the first `*/`). The final guard instead matches raw
+  source with a pattern that TOLERATES whitespace/`/* */` block-comment filler between
+  the `URLSession` token and the `.`/`(` (nothing is deleted), catching the
+  comment-split and whitespace-split spellings while leaving the two normalizer bypasses
+  closed. Its only cost is an accepted false POSITIVE: a `URLSession` mention that lives
+  purely inside a comment/string is flagged — the safe direction for a security guard.
+  C6 asserts all of: comment-split, whitespace-split, string-`//`, nested-comment,
+  multi-line-comment, and backtick-escaped identifier (`` `URLSession`.shared `` /
+  `` URLSession.`shared` ``) — all red — plus the accepted comment-only false positive.
+  The pattern uses a `(?<![A-Za-z0-9_])` boundary so URLSession used purely as a TYPE
+  (`URLSessionConfiguration`, `URLSessionTask`, a `: URLSession` annotation) is NOT
+  flagged — the pinned design injects the session by constructor, so ~30 real type
+  references across 4 production files are legitimate and must pass; C6 pins that.
+  **Accepted fail-open gap (documented, not fixed):** construction through a
+  `typealias Alias = URLSession; Alias.shared` is not caught — alias resolution needs
+  semantic analysis a textual guard cannot do. It requires writing an obvious alias
+  (trivially caught in code review) and is pinned by an expect-PASS regression test as
+  the target for a future SwiftSyntax-based upgrade. That SwiftSyntax rewrite (which
+  would also close the comment-only false positive and the typealias gap in one move)
+  needs a macOS-CI Swift-toolchain build step and is out of scope for this PR.
+- **SC3**: A repo-wide "every guard has a self-test" presence gate (review M-k(b)) is
+  deferred to the P4 continuation; this PR delivers the pattern on the two guards in scope.
+- **SC4**: A count/coverage manifest is intentionally NOT built (review M-k warns it
+  rewards decorative fixtures); the red-case gate (INV-C4a/INV-C6a) is the signal instead.
+
+## Testing strategy
+
+- Both new self-tests (C4, C6) run in the standard vitest job (Linux) and locally —
+  no macOS dependency (VC1 does not reach them).
+- Every guard's self-test contains ≥1 asserted-RED case with a specific identifier
+  (RT7) — the guard is proven able to fail, not merely to pass.
+- Mandatory checks before "complete": `npx vitest run` (C4+C6 pass) and, since only
+  scripts/tests/workflows/docs change with no product runtime touched, `npx next build`
+  is skipped per the project's test-only-change rule — BUT `PRE_PR_STATIC_ONLY=1 bash
+  scripts/pre-pr.sh` is run to exercise C3 in the real static-checks path.
+
+## Considerations & constraints
+
+- **openssl `-legacy` portability**: pinned to ubuntu OpenSSL 3.x (C3/C2); never runs
+  on macos LibreSSL (review M-a). If a future runner drops `-legacy`, C4's
+  `TLS_FIXTURE_UNREADABLE` case catches it as a distinct failure, not a silent pass.
+- **Time-dependence**: C4's expired case uses `-days -1` (expired at creation) so it is
+  deterministic without clock manipulation (review M-b).
+- **No product runtime change** → no security-boundary regression surface; the guards
+  are additive.
+
+## Go/No-Go Gate
+
+| ID | Subject                                                    | Status |
+|----|------------------------------------------------------------|--------|
+| C1 | check-tls-fixture-expiry.sh (leaf via -clcerts, 3 outcomes)| locked |
+| C2 | monthly tls-fixture-expiry.yml (look-ahead 45d, read-only) | locked |
+| C3 | C1 wired into static-checks + pre-pr (ubuntu OpenSSL 3.x)   | locked |
+| C4 | expiry-check self-test (RT7 red case, identifier-asserted)  | locked |
+| C5 | iOS guard env-root override + 3 identifiers + fail-closed   | locked |
+| C6 | iOS guard self-test (branch-derived cases, X2 known-limit)  | locked |
+| C7 | ios/README.md TLS fixture procedure doc                     | locked |

--- a/docs/archive/review/security-hardening-roadmap-plan.md
+++ b/docs/archive/review/security-hardening-roadmap-plan.md
@@ -1,0 +1,160 @@
+# Plan: Security Hardening Roadmap (P1–P4)
+
+## Project context
+
+- Type: `mixed` — Next.js 16 web app + CLI (npm) + browser extension + iOS (Swift) + CI/CD guard suite
+- Test infrastructure: `unit + integration + E2E + CI/CD` (vitest, real-DB integration, Playwright, XCTest, a large `scripts/checks/*` static-guard suite)
+- Verification environment constraints:
+  - VC1: iOS XCTest real-TLS fixtures require macOS + Xcode; the developer's primary environment is Linux. iOS guard/fixture behavior is `verifiable-CI` (macOS runner) but NOT verifiable-local.
+  - VC2: Sigstore/cosign keyless signing requires GitHub Actions OIDC; cannot be exercised from a local dev machine → `verifiable-CI` only.
+  - VC3: Container-image SBOM (syft on an image) requires a built image; `verifiable-CI`.
+
+## Objective
+
+Deepen four existing security postures, in the priority order the roadmap proposes
+(recommended *sequencing* P3 → P4 → P2 → P1; risk *ranking* P1 > P2 > P4 > P3):
+
+- P1 — Supply-chain monitoring (SBOM, provenance/signing, dependency policy, Actions boundary hardening)
+- P2 — Worker runtime invariants (shared wrapper, idempotency key, poison/dead-letter, destructive batch caps, manifest↔code CI parity)
+- P3 — Certificate fixture expiry management (iOS real-TLS test fixtures)
+- P4 — CI-guard self-test maintenance (4-fixture sets, error identifiers, coverage manifest)
+
+## Ground-truth reconciliation (verified against the repo before review)
+
+The roadmap prose was written from memory and contains several factual errors that
+change the shape of the work. Reviewers MUST review against these verified facts,
+not the roadmap's original wording.
+
+### P3 corrections (material)
+
+- **GT-P3-a**: The committed iOS TLS fixtures are `ios/PasswdSSOTests/fixtures/TLS/tlsLeafA.p12`,
+  `tlsLeafB.p12` (PKCS#12, password `passwd-sso-test`, public) and `testLocalCA.der`
+  (DER). There are **no** `leaf-a.pem` / `leaf-b.pem` / `ca.pem` files. The roadmap's
+  `openssl x509 -checkend leaf-a.pem` command targets nonexistent files and would
+  silently need path fixes.
+- **GT-P3-b**: The CA (`testLocalCA.der`) expires **2126-06-20**, not 2027. Only the
+  **leaves** are short-lived: `LEAF_DAYS=397` in the generator (Apple's ~398-day TLS
+  leaf cap, SecTrust -67901). The "leaf失効日 2027-08-15" figure is a stale guess; the
+  real expiry is `generation date + 397 days` and must be read from the fixture, not
+  hardcoded.
+- **GT-P3-c**: A deterministic generator **already exists**:
+  `ios/scripts/generate-tls-test-fixtures.sh`. It already does EC P-256, SAN
+  `localhost,127.0.0.1`, `basicConstraints=CA:FALSE`, `extendedKeyUsage=serverAuth`,
+  same test CA signing both leaves, `LEAF_DAYS=397` (≤398), fixed output filenames,
+  and prints each leaf's expiry. So P3.2 ("make regeneration deterministic") is
+  ~90% done; the true gaps are (i) an **expiry-check script** that can read a `.p12`,
+  (ii) a **scheduled workflow**, (iii) **README documentation** of the procedure
+  (currently absent — `grep` finds no TLS-fixture section in `ios/README.md`).
+- **GT-P3-d**: An expiry check CANNOT run `openssl x509 -checkend` on a `.p12`
+  directly. It must extract the leaf cert first:
+  `openssl pkcs12 -in tlsLeafA.p12 -nokeys -passin pass:passwd-sso-test -legacy | openssl x509 -checkend N -noout`.
+  The CA is DER: `openssl x509 -inform der -in testLocalCA.der -checkend N -noout`
+  (and the CA effectively never expires, so a CA check is near-useless — the check
+  should target the leaves).
+
+### P4 corrections (premise is aspirational, not current-state)
+
+- **GT-P4-a**: `scripts/checks/tests/` does **not** exist. The roadmap's claim that
+  guards "currently hold 4 fixture kinds" is a target, not a description. Today only
+  **one** guard has a regression test: `scripts/__tests__/check-count-then-create-lock.test.mjs`,
+  which uses an **env-var-root** pattern (`CTC_CHECK_ROOT=<tmpdir>`) and writes fixture
+  source into a fresh `mkdtempSync` tree — NOT a committed `positive/negative/stale/false-positive`
+  directory layout. This is the established, working isolation idiom in this repo.
+- **GT-P4-b**: The iOS pinning guard (`check-ios-authenticated-session-pinning.sh`)
+  has **no** self-test and emits no machine-readable identifiers — it prints prose and
+  `exit 1`. It DOES already have a second "stale allowlist entry" guard clause inside it.
+  It reads its scan root from `$IOS_DIR` derived from `BASH_SOURCE`, i.e. it is **not**
+  currently parameterized for an isolated fixture root the way the count-then-create
+  guard is (`CTC_CHECK_ROOT`). Adding a self-test requires first making the guard's
+  scan root overridable — a prerequisite the roadmap does not mention.
+
+### P2 corrections (deepening, not greenfield)
+
+- **GT-P2-a**: `scripts/checks/worker-policy-manifest.json` + its parity test
+  (`src/__tests__/workers/worker-policy-manifest.test.ts`) already exist and already
+  mechanically verify `rawSql` / `destructive` / `emitsAudit` / `usesSecurityDefiner`
+  per worker by grepping declared modules. The manifest already records `idempotent`,
+  `retryPolicy`, `poisonMessageHandling` as **prose (presence-only)** doc fields. So
+  P2.5 ("manifest↔code parity") partly exists; the delta is upgrading the prose doc
+  fields to mechanically-verified (`destructive:true ⇒ DELETE present`,
+  `maxAttempts:N ⇒ code constant = N`, `batchSize:N ⇒ LIMIT ≤ N`).
+- **GT-P2-b**: Workers today already implement retry/backoff, dead-letter (FAILED
+  status + `AUDIT_OUTBOX_DEAD_LETTER`), and `ON CONFLICT DO NOTHING` idempotency
+  **per-worker, ad hoc**. P2's shared `runWorkerJob` wrapper + `WorkerExecution`
+  idempotency table is a **consolidation/refactor** of working behavior, carrying
+  regression risk to a security-audit-critical path (audit outbox). It is NOT adding
+  a missing capability.
+
+### P1 corrections
+
+- **GT-P1-a**: GitHub Actions are already SHA-pinned, with a guard
+  (`check-actions-sha-pinned.sh`) and Dependabot for the `github-actions` ecosystem.
+- **GT-P1-b**: Dependabot currently covers **only** `github-actions`. The npm/Swift/
+  container ecosystems are NOT yet configured (the file comment says "can be added
+  later"). So P1.3's "dependency policy" is partly new config, not just tightening.
+- **GT-P1-c**: `release.yml` publishes the CLI to npm via **OIDC Trusted Publishing**
+  (no long-lived token) and already scopes `id-token: write` to the publish job only.
+  No SBOM / cosign / provenance-attestation exists yet.
+- **GT-P1-d**: There is no container image build/publish in the current release
+  workflow (release-please + CLI npm publish only). Container-image SBOM/signing (P1.1
+  image row, P1.2 image signing) has **no producer to attach to yet** — the roadmap
+  assumes a container release path that isn't in `release.yml`.
+
+## Contracts (per initiative — high-level roadmap granularity; contract-first locking deferred to per-PR plans)
+
+This is a **roadmap review**, not a single-PR implementation plan. Each Pn below is a
+future PR (or PR series) that will get its own contract-locked plan. The purpose of
+THIS review is to validate scope, sequencing, feasibility, and correctness of the
+approach — and to catch the ground-truth errors above before any PR starts.
+
+- **C-P3** (next small PR): TLS-fixture expiry check + monthly workflow + README doc.
+  Signatures: `scripts/checks/check-tls-fixture-expiry.sh` (reads leaves via `openssl
+  pkcs12 | openssl x509 -checkend`); a `.github/workflows/*.yml` monthly cron; a
+  README section documenting `generate-tls-test-fixtures.sh`.
+- **C-P4** (next small PR, bundled with C-P3): iOS pinning-guard self-test with
+  positive/negative/stale/false-positive cases; guard error identifiers; a guard
+  coverage manifest checked in CI. Prerequisite: parameterize the guard's scan root.
+- **C-P2** (medium PR series): shared `runWorkerJob` wrapper, `WorkerExecution`
+  idempotency table + claim, retry-cap/dead-letter states, destructive batch caps,
+  manifest↔code mechanical parity — starting with `audit-outbox-worker` only.
+- **C-P1** (ongoing release-ops): SBOM per release, provenance/signing (cosign +
+  `attest-build-provenance`), dependency policy (Dependabot npm/Swift/container +
+  advisory gating), Actions boundary (CODEOWNERS on workflows, ban `pull_request_target`,
+  default `read-all` permissions, third-party action allowlist).
+
+## Testing strategy
+
+- P3/P4: the expiry check and guard self-tests are themselves testable in CI; the
+  iOS guard self-test must be proven able to FAIL (RT7) — a negative fixture that a
+  broken guard would pass.
+- P2: per-worker integration tests for idempotency (double-run → one side effect),
+  dead-letter transition, destructive batch cap; AST/grep manifest parity in CI.
+- P1: signature *verification* must run in CI and at deploy; deploy by digest not tag.
+
+## Considerations & constraints
+
+- **Scope contract**:
+  - SC1: Container-image SBOM/signing (P1.1/P1.2 image rows) is **deferred** until a
+    container release path exists in `release.yml` (GT-P1-d) — no producer today.
+    Owner: a future "containerize release" PR.
+  - SC2: iOS distribution-artifact provenance (P1.2 iOS row) is deferred — iOS ships
+    via App Store Connect, not a GitHub-Actions-built artifact cosign can sign.
+  - SC3: P2 shared-wrapper rollout to workers beyond `audit-outbox-worker` is deferred
+    to later PRs in the series; the first PR proves the pattern on one worker.
+  - SC4: Worker doc-field prose *accuracy* (tenantScoped reason, etc.) remains a human-
+    review concern per the existing manifest's SC3 note; mechanization covers only the
+    grep-derivable fields.
+- **Risk vs. sequencing divergence is intentional**: P3/P4 are low-risk, low-cost,
+  and time-sensitive (P3 fixtures lapse ~yearly), so they go first despite P1/P2 being
+  higher-risk. Reviewers should validate this trade-off, not just the risk ranking.
+
+## Go/No-Go Gate
+
+This is a roadmap-level review. Per-contract locking happens in each Pn's own plan.
+
+| ID   | Subject                                             | Status  |
+|------|-----------------------------------------------------|---------|
+| C-P3 | TLS fixture expiry check + workflow + README doc    | pending |
+| C-P4 | iOS pinning guard self-test + identifiers + manifest| pending |
+| C-P2 | Worker runtime invariants (audit-outbox first)      | pending |
+| C-P1 | Supply-chain: SBOM/provenance/dep-policy/Actions    | pending |

--- a/docs/archive/review/security-hardening-roadmap-review.md
+++ b/docs/archive/review/security-hardening-roadmap-review.md
@@ -1,0 +1,126 @@
+# Plan Review: Security Hardening Roadmap (P1–P4)
+Date: 2026-07-15
+Review round: 1
+
+## Changes from Previous Round
+Initial review. Plan reviewed as a roadmap (four future PR series), with a
+pre-verified Ground-truth reconciliation section. Three experts reviewed against
+the real repo state, not the roadmap's original (partly-wrong) prose.
+
+## Summary of severities
+- Critical: 4 (C1 npm-provenance/theater, X1 iOS-guard-self-test isolation, X2 P4 fixture taxonomy vacuity, X3 P3 expiry-check wrong-cert silent-pass)
+- Major: 9
+- Minor: 6
+
+---
+
+## Merged Findings (deduplicated across experts)
+
+### CRITICAL
+
+**C1 — P1: npm already emits provenance for free; cosign is the wrong primitive; no verifier = signing theater.** (Security C1, escalated; corroborated by Testing #8)
+- The CLI publishes via npm OIDC Trusted Publishing but does **not** pass `--provenance` / `publishConfig.provenance` — so today it ships with *no* provenance despite being one flag from npm-native SLSA provenance. The plan bundles "cosign + attest-build-provenance" without saying which artifact each covers; cosign is an OCI-image primitive and (per SC1/GT-P1-d) **no image exists**. The testing-strategy line "verification must run in CI and at deploy" names **no verifier** for the npm package (`npm audit signatures` is never run).
+- Action: split C-P1 provenance into (1) npm CLI → enable `--provenance` + a `npm audit signatures` verifier in CI (the ship-today win); (2) container/blob → `attest-build-provenance`/cosign behind SC1. Every signature gets a named verifier or it is theater. Sequence producer-before-consumer (Testing #8): the verification test must consume a genuinely-signed artifact (VC2: CI-only).
+
+**X1 — P4: iOS guard self-test isolation needs a DUAL root override (scan root + allowlist-resolution root), plus a seeded `ServerTrustService.swift`.** (Functionality F6 + Security m2 + Testing #1 — 3-way convergence)
+- `check-ios-authenticated-session-pinning.sh` has two coupled filesystem dependencies: it greps three hardcoded named subdirs (`PasswdSSOApp`/`Shared`/`PasswdSSOAutofillExtension`) AND validates the allowlist against real files (`$IOS_DIR/$entry`, lines 85–96). A single `CTC_CHECK_ROOT`-style override is necessary but not sufficient — unless the fixture tree also reproduces the 3-subdir layout and seeds `Shared/Network/ServerTrustService.swift`, the "stale allowlist" clause fires and every case fails for the wrong reason (false-red masking whether the URLSession scan works).
+- Security add-on (m2): the override must fail **closed** — CI pins the root to the real `ios/`; a root pointing outside the repo must be rejected, or a malicious PR points the guard at an empty dir and passes trivially.
+- Action: C-P4 must thread the override through grep-root + `rel`-strip base + allowlist-existence base together; seed a stub `ServerTrustService.swift`; add a positive-passes case proving the harness isn't spuriously red before asserting negatives.
+
+**X2 — P4: the fixed 4-fixture taxonomy (positive/negative/stale/false-positive) is vacuous for this trivial-regex guard (RT7).** (Functionality F7 + Testing #2; Functionality escalation from Major)
+- The count-then-create guard warrants 9 cases because it has 6+ distinct code-shape branches. The iOS guard is a blanket substring ban (`URLSession\(|URLSession\.init\(|URLSession\.shared`) with one allowlist entry. "stale" has no meaning for a blanket ban (no per-target rule to go stale) — forcing it produces a fixture that can't distinguish a working guard from a broken one. Meanwhile the *genuinely valuable* case — a `// URLSession(` comment/string in a production file, which the current guard gets **wrong** (no comment-blanking) — risks being omitted because the taxonomy slot is "filled."
+- Action: derive fixtures from the guard's **actual branches**, not a template: {allowlisted-constructs→pass, non-allowlisted-constructs→fail, construction-in-comment/string→(fix guard or pin known-FP), test-target-path→pass, allowlist-stale→fail}. Case count follows branches.
+
+**X3 — P3: `openssl pkcs12 -nokeys | openssl x509 -checkend` reads only the FIRST cert; order is not pinned → silent CA-check no-op.** (Functionality F1)
+- `-nokeys` emits leaf **then** CA; `openssl x509` consumes only the first. Today the leaf is first *by emission order* (an implementation detail). If a future openssl / regenerated fixture reverses it, the check silently validates the CA (`notAfter 2126`) and can **never fail** — the exact silent-pass P3 exists to prevent.
+- Action: select the leaf explicitly — add `-clcerts` to `openssl pkcs12` (client/leaf only, excludes the CA chain), or extract to a temp file and pick by subject. Do not rely on pipe order.
+
+### MAJOR
+
+**M-a — P3: `-legacy` is unavailable on macOS runners (LibreSSL), and the pipe needs `set -o pipefail`.** (Functionality F2 — R16 + R44; Testing #3 corroborates)
+- The committed `.p12` is `-legacy`-encrypted. ubuntu-latest (OpenSSL 3.x) accepts `-legacy`; **macos-latest ships LibreSSL** which rejects it. If the check is sited on the iOS/macOS job (natural, next to the fixtures) it breaks. The two-stage pipe's exit is the last command's — a stage-1 failure (wrong pass, missing `-legacy`, empty stream) can false-pass without `pipefail`.
+- Action: pin the expiry check to an ubuntu (OpenSSL 3.x) job; mandate `set -euo pipefail`; distinguish valid / expired / unreadable-or-extraction-failed as **separate** exit paths (don't collapse extraction failure into pipefail).
+
+**M-b — P3: no negative self-test; the check is vacuous as described (RT7).** (Testing #3)
+- A check that passes when the cert is fine and errors ambiguously when input is unreadable cannot distinguish "fixture healthy" from "extraction command broken." The monthly workflow could go green for a year checking nothing.
+- Action: require a deterministically-expired fixture (`openssl ... -days -1`, already-expired at creation — no clock-freezing) that the check MUST reject via the *asserted expired-branch*, plus a healthy-passes assertion. Assert the reason, not just exit code.
+
+**M-c — P2: regression gate not bound to the existing audit-outbox integration suite; and the idempotency test must actually RACE (RT4).** (Functionality F4 + Testing #4 — convergence)
+- GT-P2-b flags refactor risk to a security-audit-critical path but names no gate. The existing dedup test is **serialized** (`claim→deliver→reset→claim→deliver`) — it proves `ON CONFLICT DO NOTHING` de-dupes sequentially, NOT that two concurrent workers can't both insert. The repo already has the right pattern (`audit-outbox-skip-locked.integration.test.ts`, barrier-synchronized `Promise.all`).
+- Action: C-P2 must (1) model the new `WorkerExecution` idempotency-claim test on the barrier `Promise.all` concurrent pattern (assert exactly one row under *simultaneous* claims); (2) name `src/__tests__/db-integration/audit-outbox-*.integration.test.ts` + `retention-gc-*` as the explicit unchanged-green regression gate (`test:integration`, real Postgres — the R32 boot/behavior smoke).
+
+**M-d — P2: the manifest-mechanization + destructive-cap work spans 4 workers, and the destructive-cap gap is REAL (contradicting GT-P2-b framing).** (Functionality F3 — R42)
+- The manifest already governs 4 workers (audit-outbox, retention-gc, audit-anchor-publisher, audit-chain-verify). More importantly: in `audit-outbox-worker.ts` the **claim** paths are `LIMIT`-bounded but the **destructive** paths are NOT — `purgeRetention` (`DELETE FROM audit_outbox`, `DELETE FROM audit_deliveries`) and `reapStuckRows`/`reapStuckDeliveries` have no LIMIT. So "destructive batch cap" *is* a genuinely missing capability, not "already ad hoc." GT-P2-b undersells this.
+- Action: state the 4-worker member-set for the mechanization sub-task; correct GT-P2-b — the uncapped destructive surface is purge/reap, and that cap is net-new work.
+
+**M-e — P2: `WorkerExecution` idempotency table duplicates the existing `ON CONFLICT (outbox_id) DO NOTHING` + `SKIP LOCKED`; composition unspecified.** (Functionality F5; Security A2 adds the tenant-safety constraint)
+- Audit-outbox already enforces claim-once (`FOR UPDATE SKIP LOCKED`) and deliver-once (`ON CONFLICT (outbox_id) DO NOTHING`). A generic `WorkerExecution` table adds a third layer — redundant if in front, a behavior change if it replaces.
+- Action: C-P2 must state, per worker, whether `WorkerExecution` is sole idempotency key or a wrapper; for audit-outbox the existing `ON CONFLICT` stays authoritative and `WorkerExecution` guards only non-idempotent side-effects (fan-out/webhook). **Schema constraint (Security A2): the key must be tenant-partitioned or opaque (random UUID/hash), never a global monotonic counter; the table must be RLS-scoped or worker-role-only** — else it's a cross-tenant enumeration/timing surface.
+
+**M-f — P2: the audit-chain integrity invariant the refactor can silently break is not named.** (Security M3)
+- Dead-letter/reaper events are written via `writeDirectAuditLog`, deliberately bypassing the outbox AND the hash chain (no `chain_seq`); the verifier filters `WHERE chain_seq IS NOT NULL` so they're legitimately unchained. A naive `runWorkerJob` consolidation that routes dead-letter emission back through the normal enqueue path would either recurse infinitely or start chaining dead-letter events, breaking `firstTamperedSeq` semantics.
+- Action: C-P2 contract clause — "dead-letter/reaper/retention-purge audit events MUST stay unchained (`chain_seq IS NULL`) and bypass the outbox; `runWorkerJob` idempotency MUST NOT wrap `writeDirectAuditLog`." Regression test: assert `AUDIT_OUTBOX_DEAD_LETTER` rows have `chain_seq IS NULL`.
+
+**M-g — P2: poison-message replay is a new cross-tenant audit-write privilege with no authz model.** (Security M4)
+- Re-injecting a dead-lettered audit event is a write to the tamper-evident audit_logs of an arbitrary tenant. "operator-gated + audited" is stated but the gate is undefined (which credential class, per-tenant vs system-wide, re-chain vs unchained).
+- Action: C-P2 — replay is a distinct operator scope (not a reused broad admin token), emits its own SYSTEM-actor audit event (who replayed which outbox_id), is idempotent against the `WorkerExecution` key, and follows the M-f unchained rule.
+
+**M-h — P1: dependency auto-merge of "security patch/minor with passing tests" is an RS5 fail-open supply-chain path.** (Security M1)
+- Tests do not detect a supply-chain payload (event-stream/ua-parser-js/xz pattern — all patch/minor that pass tests). Auto-merge into `main` of a password-manager treats an untrusted upstream version bump as trusted.
+- Action: do not auto-merge into `main`; require human approval, or gate behind (a) a cooldown/quarantine window (defeats publish-and-yank), (b) provenance check where available, (c) hard block for any crypto/auth allowlist package (M-i). Classify auto-merge as fail-open in the per-PR threat model.
+
+**M-i — P1: the crypto/auth "stricter review" package list is guessed, not derived (R42).** (Security M2)
+- Action: derive by grepping imports in `src/lib/crypto/**`, `src/lib/auth/**`, `auth.ts`, WebAuthn/SAML routes (`@simplewebauthn/*`, `@auth/*`/`next-auth`, `@boxyhq/saml-jackson` deps, `@prisma/adapter-pg`+`pg`, argon2/KDF, `jose`); pin in a CI-checked manifest, regenerate on `package.json` change.
+
+**M-j — P1: signature-verification is untestable until a producer lands; require producer-first sequencing.** (Testing #8, [Adjacent])
+- Action: C-P1 states producer-before-consumer explicitly; the verification test consumes a genuinely-signed artifact (VC2: keyless OIDC signing is CI-only → this test is `verifiable-CI`, never local).
+
+**M-k — P4: the fixture-count manifest rewards decorative fixtures; use red-case + presence gates instead.** (Testing #5 — R42)
+- Counting is a proxy metric satisfied by N decorative fixtures. Better: (a) every guard self-test must contain ≥1 asserted-RED case (`expect(code).toBe(1)` with the specific error identifier) — grep-mechanizable; (b) presence gate: every `scripts/checks/*.{sh,mjs}` maps to a `scripts/__tests__/*` file or a documented exemption (worker-manifest completeness pattern).
+
+**M-l — P4: exit-code-only assertion conflates the iOS guard's 3 fail branches; introduce stable error identifiers (RT8).** (Testing #6; Functionality corroborates via X1)
+- `exit 1` conflates URLSession-violation / allowlist-missing-file / allowlist-stale. A self-test asserting only exit-code can pass because the wrong clause fired (ties to X1).
+- Action: emit stable identifiers (`UNPINNED_URLSESSION_CONSTRUCTION`, `ALLOWLIST_MISSING_FILE`, `ALLOWLIST_STALE_ENTRY`) alongside prose; self-tests assert the identifier (the test contract), treat prose as advisory. Document identifiers as a breaking-change surface.
+
+### MINOR
+
+**m-1 — P3: the "2027-08-15 stale guess" is numerically correct for the committed fixture (expires exactly `Aug 15 2027`).** (Functionality F8) Reword GT-P3-b to "correct today, must not be hardcoded — it moves every regeneration."
+
+**m-2 — P3: cron + PR-CI split is non-redundant but should use different `-checkend` windows.** (Functionality F9) CI = already-expired/short horizon (block a PR shipping dead fixtures); cron = look-ahead 30–45 days (warn before lapse). They cover disjoint triggers.
+
+**m-3 — P3: `-passin pass:<literal>` leaks the passphrase to the process list — a pattern hazard.** (Security M5, RS6) The passphrase is intentionally public (test-only, SAN=localhost, CA:FALSE — verified), so no live secret leak, but this becomes the repo's canonical "how we read a p12." Use `-passin env:P12_PASS` and comment that `pass:` on argv is banned for non-public passphrases.
+
+**m-4 — P1: "deploy by digest not tag" has no applicable target.** (Functionality F10, R41) The only publish is npm (already content-addressed); no deploy step exists; container path is deferred by SC1. Drop it or move under SC1.
+
+**m-5 — P1: Actions boundary omits `workflow_run`, fork-PR secret exposure, self-hosted runners; and several controls are preventive not fixes.** (Security m1) No `pull_request_target` exists today (so the ban is a *preventive guard*); per-workflow `permissions` are already scoped. Fold `workflow_run` into the same guard as `pull_request_target`; confirm `ci-integration.yml` (needs `SHARE_MASTER_KEY`) doesn't run on fork PRs with secrets.
+
+**m-6 — P3/P4: the shell/openssl/grep self-tests are Linux-runnable, not macOS-only (VC1).** (Testing #9) Only the XCTest real-TLS consumption is macOS-CI-only. Split: expiry-check self-test + iOS pinning-**guard** self-test run on the Linux static-checks/pre-PR job (developers can run them locally); only real-TLS XCTest is VC1.
+
+**m-7 — P4: "guard changed but no test changed → warn" (git-diff coupling) is flaky.** (Testing #7) False-positives on comment/format/rename, false-negatives on shared-helper changes. Prefer the M-k structural gate; if kept, scope to non-comment/non-rename hunks and keep advisory.
+
+**m-8 — Sequencing P3→P4→P2→P1 is sound.** (Functionality F11) No hard dependency forces reorder. Soft reinforcement: P4's self-test harness (env-root override, red-case idiom) is the reusable template for P1's future Actions-boundary guards — doing P4 first means P1's new guards inherit a proven self-test idiom.
+
+---
+
+## Adjacent Findings (routing)
+- Functionality F4 → Testing (merged into M-c).
+- Functionality F7 → Testing (merged into X2).
+- Security A1 (P4 negative fixture must prove guard can FAIL, RT7) → Testing (merged into X2/M-l).
+- Security A2 (WorkerExecution key tenant-partitioned/opaque/RLS) → Functionality data-model (merged into M-e).
+- Testing #8 (P1 verification producer-first) → Functionality/Security (merged into C1/M-j).
+
+## Quality Warnings
+None — all findings carry concrete file/line evidence and verified repro. No VAGUE / NO-EVIDENCE / UNTESTED-CLAIM flags.
+
+---
+
+## Recurring Issue Check
+
+### Functionality expert
+R1 pass · R2 pass · R3 FINDING (F3/F6) · R4–R15 n/a · R16 FINDING (F2, LibreSSL -legacy) · R17–R28 n/a · R29 pass (398-day cap / SecTrust -67901 verified in generator) · R30 n/a · R31 n/a · R32 FINDING (F4, integration suite not bound) · R33–R40 n/a · R41 FINDING (F10, deploy-by-digest dangles; containers correctly deferred) · R42 FINDING (F3 workers=4, F7 guard fixture-set) · R43 n/a · R44 FINDING (F1 wrong-cert, F2 pipefail)
+
+### Security expert
+R1–R28 ok · R29 flag (C1, npm-native vs cosign conflated, no spec cited) · R30–R41 ok · R42 flag (M2 crypto/auth list guessed; worker-set correctly derived) · R43 ok · R44 ok · RS1 ok · RS2 ok · RS3 flag (M4 replay + WorkerExecution key lack authz/validation spec) · RS4 ok (p12 passphrase intentionally public, non-production, verified) · RS5 flag (M1 dependency auto-merge fail-open) · RS6 flag (M5 `pass:` argv leak)
+
+### Testing expert
+R1–R41 ok · R42 flag (F5 count-manifest ≠ branch-coverage) · R43 ok · R44 ok · RT1 ok · RT2 ok · RT3 ok · RT4 flag (F4 serialized dedup ≠ race) · RT5 flag (F8 P1 verification would assert against mock) · RT6 ok · RT7 flag (F2 vacuous stale fixture; F3 expiry-check can't be shown to fail) · RT8 flag (F6 exit-code-only conflates 3 branches) · RT9 ok (no parallel-impl twin introduced)

--- a/ios/README.md
+++ b/ios/README.md
@@ -130,6 +130,43 @@ xcodebuild \
 
 For the iOS 17.0 minimum-deployment-target validation (AutoFill TOTP `prepareOneTimeCodeCredentialList(for:)` regression check), substitute `iOS17.2` for the runtime parameter when creating the simulator.
 
+### Real-TLS test fixtures
+
+`ServerTrustRealTLSTests` drives a genuine TLS handshake against a local server
+using committed fixtures in `PasswdSSOTests/fixtures/TLS/`:
+
+| File | What |
+|------|------|
+| `tlsLeafA.p12` | Pinned "good" server leaf identity |
+| `tlsLeafB.p12` | Rotated / attacker leaf (drives the pin-mismatch case) |
+| `testLocalCA.der` | Long-lived local test CA that signs both leaves |
+
+The leaves are **short-lived by necessity**: Apple's TLS trust policy rejects any
+server leaf whose validity span exceeds ~398 days (SecTrust `-67901`), so the
+generator caps them at 397 days. They therefore **expire roughly once a year**
+and must be regenerated. The CA has no such cap and stays valid for decades.
+
+Regenerate all three with:
+
+```bash
+ios/scripts/generate-tls-test-fixtures.sh
+```
+
+Then commit the updated `tlsLeaf*.p12` (the CA rarely changes).
+
+Two guards warn before a lapse breaks CI:
+
+- **`scripts/checks/check-tls-fixture-expiry.sh`** runs in the `static-checks`
+  CI job and in `pre-pr.sh` (30-day window), blocking a PR that would ship an
+  expired/imminent fixture. It runs on ubuntu (OpenSSL 3.x) because the `.p12`
+  is `-legacy`-encrypted and macOS LibreSSL cannot read it.
+- **`.github/workflows/tls-fixture-expiry.yml`** runs monthly (45-day
+  look-ahead) so a lapse is caught even in a month where no PR touches iOS.
+
+These keys are **test-only**: scoped to `localhost` / `127.0.0.1`, `CA:FALSE` on
+the leaves, and the PKCS#12 passphrase (`passwd-sso-test`) is intentionally
+public. They MUST NOT be used in production.
+
 ### Targets
 
 | Target | Type | Bundle ID |

--- a/scripts/__tests__/check-ios-authenticated-session-pinning.test.mjs
+++ b/scripts/__tests__/check-ios-authenticated-session-pinning.test.mjs
@@ -1,0 +1,268 @@
+/**
+ * Regression tests for check-ios-authenticated-session-pinning.sh.
+ *
+ * The guard bans raw URLSession construction in production iOS code, with a
+ * single allowlisted primitive (ServerTrustService.swift). These tests pin each
+ * of its distinct branches so the guard is provably able to FAIL, and assert on
+ * the stable error IDENTIFIER (not just the exit code) — exit 1 alone conflates
+ * three different fail branches.
+ *
+ * Cases are derived from the guard's ACTUAL branches, not a fixed
+ * positive/negative/stale/false-positive template (a template would force a
+ * vacuous case onto a blanket substring ban and hide the genuinely interesting
+ * comment-false-positive limitation).
+ *
+ * Isolation: each case builds a throwaway iOS-shaped tree under a fresh mkdtemp
+ * root and points the guard there via IOS_PINNING_CHECK_ROOT — never the repo.
+ * Every tree seeds the allowlisted Shared/Network/ServerTrustService.swift WITH
+ * a URLSession construction, so the allowlist-staleness clause stays green and
+ * only the branch under test can fire.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CHECKER = fileURLToPath(
+  new URL("../checks/check-ios-authenticated-session-pinning.sh", import.meta.url),
+);
+
+const ALLOWLISTED = "Shared/Network/ServerTrustService.swift";
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ios-pinning-check-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function write(relPath, source) {
+  const abs = join(dir, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, source, "utf8");
+}
+
+// Seed a well-formed tree: the allowlisted primitive constructs a session, plus
+// a benign production file that constructs nothing.
+function seedCleanTree() {
+  write(ALLOWLISTED, "let session = URLSession(configuration: cfg, delegate: d, delegateQueue: nil)\n");
+  write("PasswdSSOApp/Benign.swift", "func f() { doNothingWithNetworking() }\n");
+}
+
+function run(extraEnv = {}) {
+  try {
+    const stdout = execFileSync("bash", [CHECKER], {
+      env: { ...process.env, IOS_PINNING_CHECK_ROOT: dir, ...extraEnv },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, stdout, stderr: "" };
+  } catch (e) {
+    return {
+      code: e.status,
+      stdout: e.stdout?.toString() ?? "",
+      stderr: e.stderr?.toString() ?? "",
+    };
+  }
+}
+
+describe("check-ios-authenticated-session-pinning", () => {
+  // Asserted first: proves the harness itself isn't spuriously red before the
+  // negative cases mean anything.
+  it("passes on a clean tree (allowlisted construction only)", () => {
+    seedCleanTree();
+
+    const { code } = run();
+
+    expect(code).toBe(0);
+  });
+
+  it("fails with UNPINNED_URLSESSION_CONSTRUCTION for a non-allowlisted construction", () => {
+    seedCleanTree();
+    write("PasswdSSOApp/Foo.swift", "let s = URLSession.shared\n");
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("UNPINNED_URLSESSION_CONSTRUCTION");
+  });
+
+  it("fails with ALLOWLIST_MISSING_FILE when the allowlisted file is absent", () => {
+    // Seed a benign file so the tree exists, but omit ServerTrustService.swift.
+    write("PasswdSSOApp/Benign.swift", "func f() {}\n");
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("ALLOWLIST_MISSING_FILE");
+  });
+
+  it("fails with ALLOWLIST_STALE_ENTRY when the allowlisted file no longer constructs a session", () => {
+    write(ALLOWLISTED, "func noLongerBuildsASession() {}\n");
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("ALLOWLIST_STALE_ENTRY");
+  });
+
+  it("fails closed with PINNING_CHECK_ROOT_INVALID for a nonexistent override root", () => {
+    const { code, stderr } = run({
+      IOS_PINNING_CHECK_ROOT: join(dir, "does-not-exist"),
+    });
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("PINNING_CHECK_ROOT_INVALID");
+  });
+
+  // Swift treats a block comment as whitespace, so `URLSession/* x */.shared` is
+  // a valid construction. The guard tolerates whitespace/block-comment filler
+  // between the tokens (matched on RAW source, nothing stripped), so this is
+  // caught.
+  it("fails on a comment-split construction (URLSession/* */.shared)", () => {
+    seedCleanTree();
+    write("PasswdSSOApp/Split.swift", "let s = URLSession/* bypass */.shared\n");
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("UNPINNED_URLSESSION_CONSTRUCTION");
+  });
+
+  // Whitespace between the type and the member is also valid Swift and must not
+  // slip past the guard.
+  it("fails on a whitespace-split construction (URLSession .shared)", () => {
+    seedCleanTree();
+    write("PasswdSSOApp/Spaced.swift", "let s = URLSession .shared\n");
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("UNPINNED_URLSESSION_CONSTRUCTION");
+  });
+
+  // Fail-CLOSED design (roadmap review): the guard matches raw source and does
+  // NOT strip comments/strings, because a partial lexer that removed them would
+  // delete real code it misread and let a construction slip through (fail-open).
+  // The two cases below are exactly the bypasses a comment-stripping normalizer
+  // opened up; matching raw source closes them.
+
+  // A `//` inside a string literal is NOT a comment in Swift, so a construction
+  // later on the same line is real. A normalizer that treated `//` as a line
+  // comment would delete it — the guard must not.
+  it("fails on a construction after a string containing // on the same line", () => {
+    seedCleanTree();
+    write(
+      "PasswdSSOApp/UrlString.swift",
+      'let endpoint = "https://example.test"; let s = URLSession.shared\n',
+    );
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("UNPINNED_URLSESSION_CONSTRUCTION");
+  });
+
+  // Swift allows nested block comments; a non-greedy `/\*.*?\*/` strip would end
+  // at the first `*/` and leave `.shared` exposed as (mis-parsed) code, but a
+  // stripper is exactly what we avoid — raw-source matching catches this too.
+  it("fails on a construction with a nested block comment between tokens", () => {
+    seedCleanTree();
+    write(
+      "PasswdSSOApp/Nested.swift",
+      "let s = URLSession/* outer /* nested */ outer */.shared\n",
+    );
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("UNPINNED_URLSESSION_CONSTRUCTION");
+  });
+
+  // A block comment split across lines between the tokens is still a single
+  // valid construction in Swift; the /s (dotall) match must cross the newline.
+  it("fails on a construction with a multi-line block comment between tokens", () => {
+    seedCleanTree();
+    write(
+      "PasswdSSOApp/Multiline.swift",
+      "let s = URLSession/* first line\n second line */.shared\n",
+    );
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("UNPINNED_URLSESSION_CONSTRUCTION");
+  });
+
+  // Swift lets an identifier be backtick-escaped: `` `URLSession` `` and
+  // `` .`shared` `` are the SAME identifiers, so these are real constructions.
+  it("fails on a backtick-escaped type (`URLSession`.shared)", () => {
+    seedCleanTree();
+    write("PasswdSSOApp/BacktickType.swift", "let s = `URLSession`.shared\n");
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("UNPINNED_URLSESSION_CONSTRUCTION");
+  });
+
+  it("fails on a backtick-escaped member (URLSession.`shared`)", () => {
+    seedCleanTree();
+    write("PasswdSSOApp/BacktickMember.swift", "let s = URLSession.`shared`\n");
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("UNPINNED_URLSESSION_CONSTRUCTION");
+  });
+
+  // The guard must NOT flag URLSession used purely as a TYPE (annotation,
+  // parameter, return type) — the pinned design injects the session by
+  // constructor, so type references to URLSession are legitimate and pervasive.
+  // Flagging them would force the 30+ real type references into the allowlist
+  // and make the guard meaningless.
+  it("passes on a URLSession type annotation (no construction)", () => {
+    seedCleanTree();
+    write("PasswdSSOApp/TypeRef.swift", "final class C {\n  private let session: URLSession\n  init(session: URLSession) { self.session = session }\n}\n");
+
+    const { code } = run();
+
+    expect(code).toBe(0);
+  });
+
+  it("passes on sibling types like URLSessionConfiguration / URLSessionTask", () => {
+    seedCleanTree();
+    write("PasswdSSOApp/Sibling.swift", "let cfg = URLSessionConfiguration.default\nfunc f(t: URLSessionTask) {}\n");
+
+    const { code } = run();
+
+    expect(code).toBe(0);
+  });
+
+  // ACCEPTED GAP (fail-open, documented): construction through a typealias is
+  // NOT caught — resolving the alias needs semantic analysis a textual guard
+  // cannot do. This test PINS the current (miss) behavior so a future
+  // SwiftSyntax upgrade has a regression target; it is not a bug to "fix" here.
+  it("does NOT catch construction via a typealias (accepted gap, pins current behavior)", () => {
+    seedCleanTree();
+    write("PasswdSSOApp/Aliased.swift", "typealias UnsafeSession = URLSession\nlet s = UnsafeSession.shared\n");
+
+    const { code } = run();
+
+    expect(code).toBe(0);
+  });
+
+  // Accepted false POSITIVE (the safe direction): a URLSession mention that
+  // lives ONLY inside a comment is flagged, because the guard does not parse
+  // comments. This is the deliberate cost of fail-closed raw-source matching.
+  it("flags a URLSession mention that appears only inside a comment (accepted false positive)", () => {
+    seedCleanTree();
+    write("PasswdSSOApp/Commented.swift", "// historically used URLSession.shared here\nfunc f() {}\n");
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("UNPINNED_URLSESSION_CONSTRUCTION");
+  });
+});

--- a/scripts/__tests__/check-tls-fixture-expiry.test.mjs
+++ b/scripts/__tests__/check-tls-fixture-expiry.test.mjs
@@ -1,0 +1,155 @@
+/**
+ * Regression tests for check-tls-fixture-expiry.sh.
+ *
+ * The guard reads iOS TLS test-fixture leaves (tlsLeaf*.p12), extracts ONLY the
+ * leaf cert (via `openssl pkcs12 -clcerts`), and fails when a leaf is expiring
+ * within the window — OR when a fixture cannot be read (which must NOT be
+ * mistaken for "healthy"). These tests pin all three outcomes so the guard is
+ * provably able to FAIL, not merely to pass.
+ *
+ * Isolation: each case builds a throwaway leaf .p12 into a fresh mkdtemp root
+ * and points the guard there via TLS_FIXTURE_CHECK_ROOT — never the repo
+ * fixtures (mirrors the CTC_CHECK_ROOT idiom of check-count-then-create-lock).
+ *
+ * The expired case pins explicit past `-not_before`/`-not_after` dates (both in
+ * the past, correctly ordered), so the red case is deterministic without
+ * freezing the clock. (`-days -1` can't be used: it puts notAfter before
+ * notBefore, which openssl rejects outright.)
+ *
+ * Filesystem + openssl only; Linux-runnable, no macOS/Xcode dependency.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CHECKER = fileURLToPath(
+  new URL("../checks/check-tls-fixture-expiry.sh", import.meta.url),
+);
+const PASS = "passwd-sso-test";
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "tls-expiry-check-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function sh(cmd) {
+  execFileSync("bash", ["-c", cmd], { stdio: ["ignore", "ignore", "ignore"] });
+}
+
+// Build a CA + one leaf p12 (`tlsLeaf<label>.p12`) into `dir`.
+//   validity: "valid"   → leaf valid for 400 days (past the guard's 30d window)
+//             "expired" → leaf with past, correctly-ordered not_before/not_after
+function makeLeafFixture(label, validity) {
+  const p12 = join(dir, `tlsLeaf${label}.p12`);
+  const signSpec =
+    validity === "expired"
+      ? `-not_before 20200101000000Z -not_after 20200201000000Z`
+      : `-days 400`;
+  sh(
+    [
+      `cd "${dir}"`,
+      `openssl ecparam -name prime256v1 -genkey -noout -out ca.key`,
+      `openssl req -x509 -new -key ca.key -sha256 -days 3650 -subj "/CN=Test CA" -out ca.crt`,
+      `openssl ecparam -name prime256v1 -genkey -noout -out leaf.key`,
+      `openssl req -new -key leaf.key -subj "/CN=localhost" -out leaf.csr`,
+      `openssl x509 -req -in leaf.csr -CA ca.crt -CAkey ca.key -CAcreateserial ` +
+        `${signSpec} -sha256 -out leaf.crt`,
+      `openssl pkcs12 -export -inkey leaf.key -in leaf.crt -certfile ca.crt ` +
+        `-name "leaf${label}" -passout pass:${PASS} -legacy -out "${p12}"`,
+      `rm -f "${dir}/ca.key" "${dir}/ca.crt" "${dir}/leaf.key" "${dir}/leaf.csr" ` +
+        `"${dir}/leaf.crt" "${dir}"/*.srl`,
+    ].join(" && "),
+  );
+}
+
+function run(extraEnv = {}) {
+  try {
+    const stdout = execFileSync("bash", [CHECKER], {
+      env: { ...process.env, TLS_FIXTURE_CHECK_ROOT: dir, ...extraEnv },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, stdout, stderr: "" };
+  } catch (e) {
+    return {
+      code: e.status,
+      stdout: e.stdout?.toString() ?? "",
+      stderr: e.stderr?.toString() ?? "",
+    };
+  }
+}
+
+describe("check-tls-fixture-expiry", () => {
+  it("passes when the leaf is valid past the window", () => {
+    makeLeafFixture("A", "valid");
+
+    const { code, stdout } = run();
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("TLS_FIXTURE_OK");
+  });
+
+  it("fails with TLS_FIXTURE_EXPIRING when the leaf is expired", () => {
+    makeLeafFixture("A", "expired");
+
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("TLS_FIXTURE_EXPIRING");
+  });
+
+  it("fails with TLS_FIXTURE_UNREADABLE on a wrong passphrase", () => {
+    makeLeafFixture("A", "valid");
+
+    const { code, stderr } = run({ TLS_FIXTURE_PASS: "wrong-passphrase" });
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("TLS_FIXTURE_UNREADABLE");
+  });
+
+  it("fails when no leaf fixtures are present", () => {
+    const { code, stderr } = run();
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("TLS_FIXTURE_NONE");
+  });
+
+  // A partial extraction (openssl pkcs12 emits some PEM bytes but exits
+  // non-zero) must be treated as UNREADABLE, not OK — checking only for empty
+  // output would let this pass as healthy. A stub openssl reproduces it.
+  it("fails with TLS_FIXTURE_UNREADABLE when pkcs12 emits PEM but exits non-zero", () => {
+    makeLeafFixture("A", "valid");
+    // Extract the real leaf PEM the stub will echo back.
+    const leafPem = execFileSync(
+      "bash",
+      [
+        "-c",
+        `openssl pkcs12 -in "${join(dir, "tlsLeafA.p12")}" -nokeys -clcerts ` +
+          `-passin pass:${PASS} -legacy 2>/dev/null`,
+      ],
+      { encoding: "utf8" },
+    );
+    const stubDir = join(dir, "stub");
+    mkdirSync(stubDir, { recursive: true });
+    const pemFile = join(dir, "leaf.pem");
+    writeFileSync(pemFile, leafPem, "utf8");
+    // Stub `openssl`: for pkcs12, print valid PEM then exit 1; else defer to real.
+    writeFileSync(
+      join(stubDir, "openssl"),
+      `#!/usr/bin/env bash
+if [ "$1" = "pkcs12" ]; then cat "${pemFile}"; exit 1; fi
+exec /usr/bin/openssl "$@"
+`,
+      { mode: 0o755 },
+    );
+
+    const { code, stderr } = run({ PATH: `${stubDir}:${process.env.PATH}` });
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("TLS_FIXTURE_UNREADABLE");
+  });
+});

--- a/scripts/__tests__/check-tls-fixture-expiry.test.mjs
+++ b/scripts/__tests__/check-tls-fixture-expiry.test.mjs
@@ -42,28 +42,54 @@ function sh(cmd) {
 
 // Build a CA + one leaf p12 (`tlsLeaf<label>.p12`) into `dir`.
 //   validity: "valid"   → leaf valid for 400 days (past the guard's 30d window)
-//             "expired" → leaf with past, correctly-ordered not_before/not_after
+//             "expired" → leaf with a past validity window (both dates in the past)
+//
+// The expired leaf is signed with `openssl ca -startdate/-enddate` rather than
+// `openssl x509 -req -not_before/-not_after`: the latter flags only exist on
+// OpenSSL 3.2+, but ubuntu-latest CI ships 3.0.x, so `x509 -req` there errors
+// out. `openssl ca` with explicit start/end dates has been supported for far
+// longer and works on both — a real dev/CI env-parity difference (R16).
 function makeLeafFixture(label, validity) {
   const p12 = join(dir, `tlsLeaf${label}.p12`);
-  const signSpec =
-    validity === "expired"
-      ? `-not_before 20200101000000Z -not_after 20200201000000Z`
-      : `-days 400`;
-  sh(
-    [
-      `cd "${dir}"`,
-      `openssl ecparam -name prime256v1 -genkey -noout -out ca.key`,
-      `openssl req -x509 -new -key ca.key -sha256 -days 3650 -subj "/CN=Test CA" -out ca.crt`,
-      `openssl ecparam -name prime256v1 -genkey -noout -out leaf.key`,
-      `openssl req -new -key leaf.key -subj "/CN=localhost" -out leaf.csr`,
+
+  const common = [
+    `cd "${dir}"`,
+    `openssl ecparam -name prime256v1 -genkey -noout -out ca.key`,
+    `openssl req -x509 -new -key ca.key -sha256 -days 3650 -subj "/CN=Test CA" -out ca.crt`,
+    `openssl ecparam -name prime256v1 -genkey -noout -out leaf.key`,
+    `openssl req -new -key leaf.key -subj "/CN=localhost" -out leaf.csr`,
+  ];
+
+  let sign;
+  if (validity === "expired") {
+    // Minimal `openssl ca` state so -startdate/-enddate can sign a leaf whose
+    // whole validity window is in the past (deterministic — no clock freezing).
+    sign = [
+      `printf '%s\\n' ` +
+        `'[ca]' 'default_ca=CA_default' ` +
+        `'[CA_default]' 'new_certs_dir=.' 'database=index.txt' 'serial=serial' 'default_md=sha256' 'policy=pol' ` +
+        `'[pol]' 'commonName=supplied' > ca.cnf`,
+      `: > index.txt`,
+      `echo 01 > serial`,
+      `openssl ca -batch -config ca.cnf -cert ca.crt -keyfile ca.key ` +
+        `-startdate 20200101000000Z -enddate 20200201000000Z ` +
+        `-in leaf.csr -out leaf.crt -notext`,
+    ];
+  } else {
+    sign = [
       `openssl x509 -req -in leaf.csr -CA ca.crt -CAkey ca.key -CAcreateserial ` +
-        `${signSpec} -sha256 -out leaf.crt`,
-      `openssl pkcs12 -export -inkey leaf.key -in leaf.crt -certfile ca.crt ` +
-        `-name "leaf${label}" -passout pass:${PASS} -legacy -out "${p12}"`,
-      `rm -f "${dir}/ca.key" "${dir}/ca.crt" "${dir}/leaf.key" "${dir}/leaf.csr" ` +
-        `"${dir}/leaf.crt" "${dir}"/*.srl`,
-    ].join(" && "),
-  );
+        `-days 400 -sha256 -out leaf.crt`,
+    ];
+  }
+
+  const pack = [
+    `openssl pkcs12 -export -inkey leaf.key -in leaf.crt -certfile ca.crt ` +
+      `-name "leaf${label}" -passout pass:${PASS} -legacy -out "${p12}"`,
+    `rm -f "${dir}/ca.key" "${dir}/ca.crt" "${dir}/leaf.key" "${dir}/leaf.csr" ` +
+      `"${dir}/leaf.crt" "${dir}/ca.cnf" "${dir}/index.txt"* "${dir}/serial"* "${dir}"/*.srl "${dir}"/*.pem`,
+  ];
+
+  sh([...common, ...sign, ...pack].join(" && "));
 }
 
 function run(extraEnv = {}) {

--- a/scripts/__tests__/check-tls-fixture-expiry.test.mjs
+++ b/scripts/__tests__/check-tls-fixture-expiry.test.mjs
@@ -45,10 +45,10 @@ function sh(cmd) {
 //             "expired" → leaf with a past validity window (both dates in the past)
 //
 // The expired leaf is signed with `openssl ca -startdate/-enddate` rather than
-// `openssl x509 -req -not_before/-not_after`: the latter flags only exist on
-// OpenSSL 3.2+, but ubuntu-latest CI ships 3.0.x, so `x509 -req` there errors
-// out. `openssl ca` with explicit start/end dates has been supported for far
-// longer and works on both — a real dev/CI env-parity difference (R16).
+// `openssl x509 -req -not_before/-not_after`: the latter flags were only added
+// in OpenSSL 3.4.0, but ubuntu-latest CI ships 3.0.x, so `x509 -req` there
+// errors out. `openssl ca` with explicit start/end dates has been supported for
+// far longer and works on both — a real dev/CI env-parity difference (R16).
 function makeLeafFixture(label, validity) {
   const p12 = join(dir, `tlsLeaf${label}.p12`);
 

--- a/scripts/checks/check-ios-authenticated-session-pinning.sh
+++ b/scripts/checks/check-ios-authenticated-session-pinning.sh
@@ -10,18 +10,22 @@
 # access/refresh token — exactly the regression `EntryUploader`'s comment warns
 # about ("a `.shared` default previously let the AutoFill caller silently … ").
 #
-# Rule: a BLANKET ban on `URLSession(` / `URLSession.shared` in production Swift,
-# with ONE narrowly-justified allowlist entry (the pinning primitive itself).
+# Rule: ban every DIRECT `URLSession(` / `URLSession.shared` / `URLSession.init`
+# construction in production Swift, with ONE narrowly-justified allowlist entry
+# (the pinning primitive itself). The match tolerates the whitespace/comment/
+# backtick spellings Swift treats as equivalent; it does NOT resolve a
+# `typealias Alias = URLSession` (see the ACCEPTED GAP note at the pattern below).
 #
-# Why blanket, not "files that set an auth header": an auth client can take its
-# session by constructor injection, so the credential-bearing FILE need not
-# contain any `URLSession(` at all. A rule keyed off auth headers would miss the
-# real injection SOURCE — a helper that builds `URLSession.shared` and hands it
-# to the auth client. Banning every construction site outside the allowlist
-# closes that gap: an unpinned session cannot be created anywhere to inject.
-# This is only tractable because the sole production construction site today is
-# ServerTrustService; a genuinely-unpinned future caller must be added to
-# UNPINNED_ALLOWLIST WITH a justification (and then it is on the reviewer).
+# Why ban the construction site, not "files that set an auth header": an auth
+# client can take its session by constructor injection, so the credential-bearing
+# FILE need not contain any `URLSession(` at all. A rule keyed off auth headers
+# would miss the real injection SOURCE — a helper that builds `URLSession.shared`
+# and hands it to the auth client. Banning every DIRECT construction site outside
+# the allowlist closes that gap: an unpinned session cannot be directly
+# constructed anywhere to inject. This is only tractable because the sole
+# production construction site today is ServerTrustService; a genuinely-unpinned
+# future caller must be added to UNPINNED_ALLOWLIST WITH a justification (and then
+# it is on the reviewer).
 #
 # Scope: production targets only (PasswdSSOApp / Shared / PasswdSSOAutofillExtension).
 # Test targets legitimately build MockURLProtocol / real-TLS sessions and are
@@ -31,7 +35,24 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-IOS_DIR="$REPO_ROOT/ios"
+
+# IOS_DIR is the single scan root. The grep roots, the `rel` path stripping, and
+# the allowlist file-existence checks all derive from it, so overriding it here
+# redirects the entire guard onto an isolated fixture tree — which is how the
+# self-test (scripts/__tests__/check-ios-authenticated-session-pinning.test.mjs)
+# exercises the guard without touching the working tree.
+#
+# Fail closed on a bad override: an env var pointing at a nonexistent/empty dir
+# must not let a PR pass trivially. When overridden, the path MUST exist.
+if [ -n "${IOS_PINNING_CHECK_ROOT:-}" ]; then
+  if [ ! -d "$IOS_PINNING_CHECK_ROOT" ]; then
+    echo "PINNING_CHECK_ROOT_INVALID: IOS_PINNING_CHECK_ROOT is not a directory: $IOS_PINNING_CHECK_ROOT" >&2
+    exit 1
+  fi
+  IOS_DIR="$(cd "$IOS_PINNING_CHECK_ROOT" && pwd)"
+else
+  IOS_DIR="$REPO_ROOT/ios"
+fi
 
 # Files permitted to construct a URLSession. Justify every entry — an
 # unjustified addition defeats the guard.
@@ -45,9 +66,43 @@ UNPINNED_ALLOWLIST=(
 )
 
 # Session construction primitives that bypass the pinned derivation path.
-# Covers the sugared `URLSession(...)`, the explicit `URLSession.init(...)`
-# spelling (valid Swift, so a blanket ban must catch it), and `URLSession.shared`.
-SESSION_CTOR_PATTERN='URLSession\(|URLSession\.init\(|URLSession\.shared'
+# Matched against RAW source — the guard NEVER rewrites or strips the file. A
+# transform that removes comments/strings to "clean up" the input is a
+# fail-OPEN trap: a partial lexer (no string-literal, raw-string, escape, or
+# nested-comment handling) deletes real code it misreads as a comment, letting
+# an actual construction slip through. Matching raw source instead fails CLOSED
+# — its only cost is flagging a URLSession mention that lives purely inside a
+# comment/string (a false POSITIVE), which is the safe direction for a guard.
+#
+# The match still tolerates the two token-splitting spellings Swift allows,
+# WITHOUT deleting anything: between `URLSession` and the `.`/`(` we allow a run
+# of whitespace and/or `/* ... */` block comments (Swift treats a comment as
+# whitespace). We do NOT try to span `//` line comments here — a `//` genuinely
+# ends the line in Swift, so a construction after it on the SAME line does not
+# exist, and one on the NEXT line is matched independently on that line.
+#
+# `perl -0777` slurps the whole file and the match uses /s (dotall), so a block
+# comment spanning newlines between the tokens is crossed by the `.*?` filler.
+# FILLER = (whitespace | /* ...(non-greedy, may span lines)... */)*.
+# The pattern uses the m{...} delimiter so the literal `/*` `*/` need no escaping,
+# and is kept in a single-quoted shell var (NO shell interpolation into the regex
+# body). It is handed to perl as an argument, not spliced into -e, so shell
+# metacharacters in it can never reshape the program.
+#
+# `` ` `` before `URLSession` and around `init`/`shared`: Swift lets an identifier
+# be backtick-escaped (`` `URLSession` `` and `` .`shared` `` are the SAME
+# identifiers), so an optional backtick is allowed at each identifier boundary to
+# close that bypass. A leading `(?<![A-Za-z0-9_]) ` boundary keeps this from
+# matching `URLSessionConfiguration`/`URLSessionTask` etc. (type REFERENCES, which
+# the DI-based design legitimately uses and must NOT flag).
+#
+# KNOWN, ACCEPTED GAP (fail-open — documented, not fixed): construction through a
+# `typealias Alias = URLSession; Alias.shared` is NOT caught. Resolving an alias
+# needs real semantic analysis (SwiftSyntax + a symbol table), out of reach for a
+# textual guard. This is a deliberately-narrow escape hatch that requires writing
+# an obvious alias (trivially caught in code review) and is pinned by an
+# expect-PASS regression test so a future SwiftSyntax upgrade has a target.
+SESSION_CTOR_PERL='(?<![A-Za-z0-9_]) `?URLSession`? (?:\s|/\*.*?\*/)* (?: \( | \. (?:\s|/\*.*?\*/)* `? (?: init | shared ) `? )'
 
 is_allowlisted() {
   local rel="$1" entry
@@ -57,12 +112,27 @@ is_allowlisted() {
   return 1
 }
 
+# True if the RAW file text contains a URLSession construction (tolerating
+# whitespace/block-comment splitting between tokens). No content is modified.
+# The pattern arrives via @ARGV[0]; the file text is slurped from @ARGV[1].
+constructs_session() {
+  perl -0777 -e '
+    my ($pat, $file) = @ARGV;
+    open my $fh, "<", $file or exit 2;
+    local $/; my $src = <$fh>;
+    # /s (dotall) so the `.*?` inside a `/* ... */` filler spans newlines — a
+    # block comment split across lines between the tokens must still be crossed.
+    # Only the two comment-body `.*?` use a bare `.`; every other dot is escaped
+    # (`\.`), so dotall does not loosen the token match itself.
+    exit($src =~ m{$pat}xs ? 0 : 1);
+  ' "$SESSION_CTOR_PERL" "$1"
+}
+
 fail=0
 
-# Enumerate every production Swift file (excluding the test targets) that
-# constructs a URLSession, and flag any that is not allowlisted.
 while IFS= read -r abs; do
   [ -n "$abs" ] || continue
+  constructs_session "$abs" || continue
   rel="${abs#"$IOS_DIR"/}"
 
   if is_allowlisted "$rel"; then
@@ -70,12 +140,16 @@ while IFS= read -r abs; do
     continue
   fi
 
-  echo "FAIL: production file constructs a raw URLSession (must be pinned): $rel" >&2
-  grep -nE -- "$SESSION_CTOR_PATTERN" "$abs" 2>/dev/null | sed 's/^/    /' >&2
+  # UNPINNED_URLSESSION_CONSTRUCTION / ALLOWLIST_MISSING_FILE / ALLOWLIST_STALE_ENTRY
+  # are stable identifiers the self-test asserts on to prove WHICH branch fired
+  # (exit code alone conflates all three). They are a test contract — renaming one
+  # is a breaking change to the self-test. The prose beside them stays advisory.
+  echo "FAIL [UNPINNED_URLSESSION_CONSTRUCTION]: production file constructs a raw URLSession (must be pinned): $rel" >&2
+  grep -nE -- 'URLSession' "$abs" 2>/dev/null | sed 's/^/    /' >&2
   fail=1
 done < <(
-  grep -rlE --include='*.swift' -- "$SESSION_CTOR_PATTERN" \
-    "$IOS_DIR/PasswdSSOApp" "$IOS_DIR/Shared" "$IOS_DIR/PasswdSSOAutofillExtension" 2>/dev/null \
+  find "$IOS_DIR/PasswdSSOApp" "$IOS_DIR/Shared" "$IOS_DIR/PasswdSSOAutofillExtension" \
+    -name '*.swift' -type f 2>/dev/null \
     | grep -vE '/(PasswdSSOTests|PasswdSSOUITests)/' \
     | sort
 )
@@ -85,11 +159,11 @@ done < <(
 for entry in "${UNPINNED_ALLOWLIST[@]}"; do
   abs="$IOS_DIR/$entry"
   if [ ! -f "$abs" ]; then
-    echo "FAIL: UNPINNED_ALLOWLIST names a missing file: $entry" >&2
+    echo "FAIL [ALLOWLIST_MISSING_FILE]: UNPINNED_ALLOWLIST names a missing file: $entry" >&2
     echo "    Update this guard's allowlist to match the moved/renamed primitive." >&2
     fail=1
-  elif ! grep -qE -- "$SESSION_CTOR_PATTERN" "$abs" 2>/dev/null; then
-    echo "FAIL: UNPINNED_ALLOWLIST names a file that no longer constructs a URLSession: $entry" >&2
+  elif ! constructs_session "$abs"; then
+    echo "FAIL [ALLOWLIST_STALE_ENTRY]: UNPINNED_ALLOWLIST names a file that no longer constructs a URLSession: $entry" >&2
     echo "    Remove the stale entry so the allowlist keeps meaning something." >&2
     fail=1
   fi

--- a/scripts/checks/check-tls-fixture-expiry.sh
+++ b/scripts/checks/check-tls-fixture-expiry.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# CI/pre-PR guard: the iOS real-TLS test fixtures (tlsLeaf*.p12) carry
+# short-lived leaves — Apple's TLS trust policy rejects any server leaf whose
+# validity span exceeds ~398 days (SecTrust -67901), so the generator caps them
+# at 397 days and they EXPIRE roughly once a year. When they lapse,
+# ServerTrustRealTLSTests breaks on the macOS runner with an opaque handshake
+# error. This guard catches the lapse EARLY, on Linux, before it reaches CI.
+#
+# WHY THIS RUNS ON UBUNTU, NOT MACOS: the committed .p12 is `-legacy`-encrypted
+# (RC2/3DES PKCS#12). ubuntu-latest ships OpenSSL 3.x which accepts `-legacy`;
+# macos-latest ships LibreSSL which does NOT. This guard must run in the
+# ubuntu static-checks job — never next to the fixtures on the macOS iOS job.
+#
+# WHY -clcerts: `openssl pkcs12 -nokeys` emits the leaf AND the CA chain cert.
+# `openssl x509` reads only the first cert on stdin, so relying on emission
+# order would let a reordering silently check the ~century-lived CA instead of
+# the leaf — a check that can never fail. `-clcerts` restricts the output to the
+# client (leaf) cert, so the leaf is unambiguously the checked cert.
+#
+# The PKCS#12 passphrase is TEST-ONLY and intentionally public (the keys are
+# scoped to localhost/127.0.0.1, CA:FALSE — never a production secret). We still
+# pass it via `-passin env:` rather than `pass:<literal>` so this script models
+# the correct idiom: a literal on argv is visible in the process list.
+#
+# Exit 0 = every leaf valid past the window. Exit 1 = a leaf expired/expiring,
+# or a fixture could not be read (which must NOT be mistaken for "healthy").
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Overridable for the self-test (scripts/__tests__/check-tls-fixture-expiry.test.mjs),
+# which points these at an isolated tmp fixture tree — never the repo fixtures.
+FIXTURE_ROOT="${TLS_FIXTURE_CHECK_ROOT:-$REPO_ROOT/ios/PasswdSSOTests/fixtures/TLS}"
+CHECKEND_DAYS="${TLS_FIXTURE_CHECKEND_DAYS:-30}"
+# Public test passphrase; matches LocalTLSServer.fixturePassphrase and
+# generate-tls-test-fixtures.sh. Overridable so the self-test can drive the
+# wrong-passphrase (unreadable) branch.
+export TLS_FIXTURE_PASS="${TLS_FIXTURE_PASS:-passwd-sso-test}"
+
+checkend_secs=$(( CHECKEND_DAYS * 86400 ))
+fail=0
+found=0
+
+shopt -s nullglob
+for p12 in "$FIXTURE_ROOT"/tlsLeaf*.p12; do
+  found=1
+  name="$(basename "$p12")"
+
+  # Extract ONLY the leaf cert. The pkcs12 exit code AND an empty result are
+  # BOTH treated as "unreadable" — checking only for empty output would let a
+  # partial-then-failed extraction (non-zero exit but some bytes emitted) pass
+  # as healthy. `|| true` here would re-hide exactly that, so the exit status is
+  # captured explicitly instead.
+  extract_ok=1
+  leaf_pem="$(openssl pkcs12 -in "$p12" -nokeys -clcerts \
+    -passin env:TLS_FIXTURE_PASS -legacy 2>/dev/null)" || extract_ok=0
+
+  if [ "$extract_ok" -eq 0 ] || [ -z "$leaf_pem" ]; then
+    echo "TLS_FIXTURE_UNREADABLE: $name — could not extract a leaf certificate" >&2
+    echo "    (wrong passphrase, missing openssl -legacy support, or corrupt p12)" >&2
+    fail=1
+    continue
+  fi
+
+  if printf '%s\n' "$leaf_pem" | openssl x509 -checkend "$checkend_secs" -noout >/dev/null 2>&1; then
+    enddate="$(printf '%s\n' "$leaf_pem" | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)"
+    echo "TLS_FIXTURE_OK: $name valid past ${CHECKEND_DAYS}d (until ${enddate})"
+  else
+    enddate="$(printf '%s\n' "$leaf_pem" | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)"
+    echo "TLS_FIXTURE_EXPIRING: $name expires within ${CHECKEND_DAYS}d (at ${enddate:-unknown})" >&2
+    echo "    Regenerate with: ios/scripts/generate-tls-test-fixtures.sh" >&2
+    fail=1
+  fi
+done
+
+if [ "$found" -eq 0 ]; then
+  echo "TLS_FIXTURE_NONE: no tlsLeaf*.p12 found under $FIXTURE_ROOT" >&2
+  exit 1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "" >&2
+  echo "TLS fixture expiry guard failed." >&2
+  echo "Re-run ios/scripts/generate-tls-test-fixtures.sh to refresh the leaves," >&2
+  echo "then commit the updated tlsLeaf*.p12 (see ios/README.md)." >&2
+  exit 1
+fi
+
+echo "TLS fixture expiry guard passed (window: ${CHECKEND_DAYS}d)."

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -170,6 +170,9 @@ run_step "Static: actions-sha-pinned" bash scripts/checks/check-actions-sha-pinn
 run_step "Static: dockerfile-prisma-pin" bash scripts/checks/check-dockerfile-prisma-pin.sh
 run_step "Static: ios-no-diagnostic-logging" bash scripts/checks/check-ios-no-diagnostic-logging.sh
 run_step "Static: ios-authenticated-session-pinning" bash scripts/checks/check-ios-authenticated-session-pinning.sh
+# Runs here (ubuntu OpenSSL 3.x), never the macOS iOS job — the .p12 fixtures are
+# -legacy-encrypted and macOS LibreSSL rejects `openssl pkcs12 -legacy`.
+run_step "Static: tls-fixture-expiry" bash scripts/checks/check-tls-fixture-expiry.sh
 
 if [ "$RUN_WEB" != "1" ]; then
   printf "${BOLD}▸ Web steps skipped${RESET}  (no app-filter paths changed — iOS-only diff; set PRE_PR_FORCE_FULL=1 to override)\n\n"


### PR DESCRIPTION
## Summary

Two CI/pre-PR guards for the security-hardening roadmap (items P3 and P4):

1. **TLS-fixture expiry guard** — the iOS real-TLS test-fixture leaves (`tlsLeaf*.p12`) are 397-day certificates (Apple caps TLS leaf validity at ~398 days, `SecTrust -67901`), so they lapse roughly yearly and break the macOS test job with an opaque handshake error. Nothing warned before a lapse. This adds a Linux-runnable expiry check plus a monthly look-ahead workflow.

2. **iOS pinning-guard hardening + self-test** — the existing `check-ios-authenticated-session-pinning.sh` had no self-test and could be bypassed by valid-but-non-obvious Swift spellings. It now matches raw source (fail-closed) and ships an isolated self-test.

## What changed

### TLS fixture expiry (new)

- `scripts/checks/check-tls-fixture-expiry.sh` — extracts only the leaf via `openssl pkcs12 -clcerts` (never the ~century-lived CA), then `openssl x509 -checkend`. Classifies three distinct outcomes — valid / expiring / **unreadable** — so a partial extraction failure is never mistaken for a healthy fixture. Runs under `set -euo pipefail`; the passphrase (intentionally public, test-only) is passed via `-passin env:`, never on argv.
- `.github/workflows/tls-fixture-expiry.yml` — monthly cron with a 45-day look-ahead so a lapse is caught even in a month where no PR touches iOS. `permissions: contents: read`.
- Wired into `scripts/pre-pr.sh` (static-checks, 30-day window). Runs on ubuntu (OpenSSL 3.x) — never the macOS job, because the `.p12` is `-legacy`-encrypted and macOS LibreSSL rejects `-legacy`.
- `scripts/__tests__/check-tls-fixture-expiry.test.mjs` — isolated self-test (own tmp fixture root); proves the guard fails on an expired leaf and on a partial-extraction (PEM-then-nonzero-exit) input, not just that it passes.

### iOS pinning guard (hardened)

- The guard matches raw source and never strips comments/strings — a partial lexer that removed them would be fail-open (it would delete real code it misread). It tolerates the whitespace / block-comment / backtick spellings Swift treats as equivalent, so these are all detected: `URLSession .shared`, `URLSession/* */.shared` (single-line, nested, and multi-line), `` `URLSession`.shared ``, `` URLSession.`shared` ``, and a construction after a URL string containing `//` on the same line.
- A `(?<![A-Za-z0-9_])` boundary keeps type *references* passing — `URLSessionConfiguration`, `URLSessionTask`, and `: URLSession` annotations are legitimate under the dependency-injection design (~30 real occurrences across 4 production files) and must not be flagged.
- Three stable error identifiers (`UNPINNED_URLSESSION_CONSTRUCTION`, `ALLOWLIST_MISSING_FILE`, `ALLOWLIST_STALE_ENTRY`) so the self-test asserts which branch fired, not just the exit code.
- An `IOS_PINNING_CHECK_ROOT` override (fail-closed on a bad path) lets the self-test drive an isolated fixture tree without touching the working tree.
- `scripts/__tests__/check-ios-authenticated-session-pinning.test.mjs` — pins every bypass above as a red case, the type-reference cases as green, and the accepted gap as green.

### Accepted gap (documented)

Construction through a `typealias Alias = URLSession; Alias.shared` is not caught — alias resolution needs semantic analysis a textual guard cannot do. It requires writing an obvious alias (trivially caught in code review), is pinned by an expect-pass regression test, and is the target for a future SwiftSyntax-based rewrite (which needs a macOS-CI Swift toolchain and is out of scope here).

## Review artifacts

- `docs/archive/review/ci-guard-fixture-hardening-plan.md` — the contract-locked plan for this PR.
- `docs/archive/review/security-hardening-roadmap-plan.md` / `-review.md` — the broader P1–P4 roadmap and its three-perspective review, from which P3/P4 were sliced. P1 (supply-chain: SBOM/provenance/dependency-policy) and P2 (worker runtime invariants) remain follow-up work.

## Verification

- Self-tests: 21 passing (iOS pinning 15, TLS expiry 6).
- Real guards green; `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` passes all static checks.
- `bash -n` on both scripts; `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
