### PR TITLE
feat(supply-chain): pin npm provenance, add signature verification + crypto/auth dep governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,10 @@
 
 # Check scripts — all under scripts/checks/ after PR 2.
 /scripts/checks/**                           @ngc-shj
+# Supply-chain crypto/auth-deps parity test: gate the ENFORCING test too, not
+# just the manifest data, so the reconciliation logic + name-pattern heuristic +
+# manual-allowance acceptance cannot be weakened without owner review.
+/src/__tests__/checks/**                      @ngc-shj
 # PR 9 (F25 Round 4): dead flat-file patterns /src/lib/crypto* and
 # /src/lib/auth* REMOVED — no files match them after PR #392 split
 # (all crypto/auth/audit code now under subdirs). /src/lib/{auth,crypto,audit}/**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,40 @@ updates:
           - "*"
     open-pull-requests-limit: 5
 
-  # npm dependencies (root) — keep existing cadence; this file only adds
-  # github-actions ecosystem. Other ecosystems can be added here later.
+  # npm ecosystems (root app + CLI + extension). Grouped weekly bumps requiring
+  # human review — NO auto-merge (a password manager must not treat an untrusted
+  # upstream version bump as trusted; tests do not detect a supply-chain payload).
+  # No swift ecosystem: iOS uses xcodegen with no Package.swift/Podfile for
+  # Dependabot to read.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      npm-root:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/cli"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      npm-cli:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/extension"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      npm-extension:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,15 +23,42 @@ updates:
   # upstream version bump as trusted; tests do not detect a supply-chain payload).
   # No swift ecosystem: iOS uses xcodegen with no Package.swift/Podfile for
   # Dependabot to read.
+  # Crypto/auth-sensitive packages get their own Dependabot group so their bumps
+  # land in a dedicated PR that warrants the deeper supply-chain review the
+  # crypto-auth-deps-manifest exists to demand — separated from routine UI/tooling
+  # bumps. The sensitive-patterns list mirrors the manifest's `packages` members;
+  # keep the two in sync (a manifest addition of a new crypto/auth dep should add
+  # its pattern here). General deps are grouped separately.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
     groups:
-      npm-root:
+      npm-root-security-sensitive:
+        patterns:
+          - "next-auth"
+          - "@auth/*"
+          - "@simplewebauthn/*"
+          - "hash-wasm"
+          - "@prisma/*"
+          - "pg"
+          - "nodemailer"
+          - "resend"
+          - "otpauth"
+      npm-root-general:
         patterns:
           - "*"
+        exclude-patterns:
+          - "next-auth"
+          - "@auth/*"
+          - "@simplewebauthn/*"
+          - "hash-wasm"
+          - "@prisma/*"
+          - "pg"
+          - "nodemailer"
+          - "resend"
+          - "otpauth"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
@@ -40,9 +67,16 @@ updates:
       interval: "weekly"
       day: "monday"
     groups:
-      npm-cli:
+      npm-cli-security-sensitive:
+        patterns:
+          - "bcrypt-pbkdf"
+          - "otpauth"
+      npm-cli-general:
         patterns:
           - "*"
+        exclude-patterns:
+          - "bcrypt-pbkdf"
+          - "otpauth"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
@@ -51,7 +85,12 @@ updates:
       interval: "weekly"
       day: "monday"
     groups:
-      npm-extension:
+      npm-extension-security-sensitive:
+        patterns:
+          - "otpauth"
+      npm-extension-general:
         patterns:
           - "*"
+        exclude-patterns:
+          - "otpauth"
     open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,6 +618,9 @@ jobs:
 
       - run: npm ci
       - run: npm audit --omit=dev --audit-level=high
+      # Verify registry signatures/attestations of installed deps (and our own
+      # published versions). Fails closed on tamper; do not mask its exit.
+      - run: npm audit signatures
 
   # ─── Security Audit: Extension ────────────────────────────
   audit-ext:
@@ -640,6 +643,7 @@ jobs:
 
       - run: npm ci
       - run: npm audit --omit=dev --audit-level=high
+      - run: npm audit signatures
 
   # ─── Security Audit: CLI ──────────────────────────────────
   audit-cli:
@@ -662,6 +666,7 @@ jobs:
 
       - run: npm ci
       - run: npm audit --omit=dev --audit-level=high
+      - run: npm audit signatures
 
   # ─── License Audit ─────────────────────────────────────────
   license-audit:

--- a/.github/workflows/dependency-signatures.yml
+++ b/.github/workflows/dependency-signatures.yml
@@ -1,0 +1,49 @@
+name: "Dependency Signatures"
+
+# npm registry signature/attestation verification (`npm audit signatures`) also
+# runs in the per-workspace PR audit jobs (ci.yml), but those are gated by
+# dorny/paths-filter — they only fire on a PR that touches that workspace. A
+# registry-side signature/attestation tamper of an already-installed, unchanged
+# dependency would otherwise be re-verified only on the next PR touching that
+# workspace (weeks for cli/extension). This weekly wall-clock sweep re-verifies
+# all three trees against the registry independent of code changes.
+#
+# Needs no secret: `npm audit signatures` reads the public registry.
+
+on:
+  schedule:
+    - cron: "0 4 * * 1" # Weekly, Monday 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-signatures:
+    name: "Verify npm signatures (${{ matrix.workspace }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - workspace: "root"
+            dir: "."
+          - workspace: "cli"
+            dir: "cli"
+          - workspace: "extension"
+            dir: "extension"
+    defaults:
+      run:
+        working-directory: ${{ matrix.dir }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+
+      - run: npm ci
+      - run: npm audit signatures

--- a/.github/workflows/dependency-signatures.yml
+++ b/.github/workflows/dependency-signatures.yml
@@ -45,5 +45,8 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      # Pin npm to match the release producer so the verifier tracks the same
+      # attestation format the packages were published with (L2).
+      - run: npm install -g npm@11.12.1
       - run: npm ci
       - run: npm audit signatures

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,32 @@ jobs:
       - name: Publish to npm
         working-directory: cli
         run: npm publish # Auth via OIDC Trusted Publishing (no NODE_AUTH_TOKEN)
+
+      # Fail-closed provenance assertion (INV-C1b): publishConfig.provenance:true
+      # only *emits* provenance in a supported OIDC context. If the context ever
+      # degrades (id-token narrowing, unsupported-context best-effort), the publish
+      # still succeeds but ships no attestation. Assert the just-published version
+      # actually carries an SLSA provenance attestation, distinguishing a registry
+      # lookup error (retry, propagation lag) from a definitive "published but
+      # unattested" (hard-fail). Never mask this step's exit.
+      - name: Assert published provenance
+        working-directory: cli
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Asserting SLSA provenance for passwd-sso-cli@${VERSION}"
+          for attempt in 1 2 3 4 5; do
+            if VIEW=$(npm view "passwd-sso-cli@${VERSION}" --json 2>/dev/null); then
+              PREDICATE=$(echo "$VIEW" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);process.stdout.write(j?.dist?.attestations?.provenance?.predicateType||'')}catch{process.stdout.write('')}})")
+              if [ "$PREDICATE" = "https://slsa.dev/provenance/v1" ]; then
+                echo "✓ SLSA provenance present"
+                exit 0
+              fi
+              echo "attempt ${attempt}: attestation not yet visible (predicate='${PREDICATE}'); retrying for propagation lag"
+            else
+              echo "attempt ${attempt}: npm view failed (registry/network); retrying"
+            fi
+            sleep 15
+          done
+          echo "::error::published passwd-sso-cli@${VERSION} carries no SLSA provenance attestation after retries — OIDC provenance emission may have silently failed"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,15 +35,19 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # npm Trusted Publishing requires BOTH npm >= 11.5.1 AND Node >= 22.14.0.
+      # The repo .nvmrc pins Node 20 (ships npm 10) for the app; the publish job
+      # must NOT inherit it — pin Node 24 here explicitly so OIDC publishing meets
+      # the current requirement. Do not switch this back to node-version-file.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: ".nvmrc"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 20 ships npm 10.
-      # Pin the version (matches Dockerfile NPM_VER) — this job holds id-token:write,
-      # so an unpinned npm@latest is a supply-chain path to the OIDC publish token.
-      - name: Upgrade npm for Trusted Publishing
+      # Pin the npm version (matches Dockerfile NPM_VER) — this job holds
+      # id-token:write, so an unpinned npm@latest is a supply-chain path to the
+      # OIDC publish token.
+      - name: Install pinned npm
         run: npm install -g npm@11.12.1
 
       - name: Install and build CLI
@@ -71,6 +75,10 @@ jobs:
       # actually carries an SLSA provenance attestation, distinguishing a registry
       # lookup error (retry, propagation lag) from a definitive "published but
       # unattested" (hard-fail). Never mask this step's exit.
+      # Known operational limit (L1): reads dist.attestations metadata shape
+      # rather than the documented npm audit signatures verifier. Verified today;
+      # a future output-shape change could false-fail. Acceptable: fails closed
+      # (never false-green) and the weekly signature sweep re-verifies officially.
       - name: Assert published provenance
         working-directory: cli
         run: |

--- a/cli/package.json
+++ b/cli/package.json
@@ -23,6 +23,9 @@
   "bin": {
     "passwd-sso": "./dist/index.js"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.d.ts"

--- a/docs/archive/review/p1-supply-chain-provenance-code-review.md
+++ b/docs/archive/review/p1-supply-chain-provenance-code-review.md
@@ -88,3 +88,19 @@ RT1/RT2/RT5/RT9 met (real manifest + real tree, proven by RED-on-mutation; fs+ts
 - Modified: docs/archive/review/p1-supply-chain-provenance-deviation.md
 
 Verification: 54 guard+manifest tests pass; full suite 950 files / 12359 tests pass (1 skip); lint clean.
+
+---
+
+## Round 2
+Incremental review of the Round-1 fix commit. Round-1 guard-widening itself introduced defects — 1 Critical (self-inflicted ReDoS), 3 Major — all in the workflow guard, all self-verified and fixed.
+
+### R2 findings (all resolved)
+- Critical ReDoS (sec/test): gh api pulls/N/merge overlapping greedy groups + unsatisfiable tail. Fixed: removed (redundant with the bounded pulls/*/merge alternative). Evil input now 0.4ms.
+- Major missed shapes (sec/test): fastify/github-action-merge-dependabot + github.rest.pulls.merge. Fixed: added merge-dependabot and pulls.merge.
+- Major dead match (sec/test): the colon no-op never matched under a trailing word-boundary. Fixed: lookahead boundary + RED self-test.
+- Major verifierRe misses real release.yml (func): provenance uses optional chaining j?.dist?.attestations with npm view/attestations on separate lines. Fixed: optional-chaining match + workflow-level runsVerifier. Self-verified: continue-on-error on the real release.yml provenance step now RED.
+
+Resolution recorded in deviation D8. Guard self-tests 16; full suite 950 files / 12361 tests; lint clean. All R2 fixes are tightenings (R43 clean).
+
+### R2 lesson
+The Round-1 guard regexes were self-tested only against shapes they already caught, and against a synthetic literal instead of the real release.yml optional-chaining string. A guard that protects a specific artifact must be self-tested against that artifact actual content. Round 2 self-tests now mirror the real shapes.

--- a/docs/archive/review/p1-supply-chain-provenance-code-review.md
+++ b/docs/archive/review/p1-supply-chain-provenance-code-review.md
@@ -1,0 +1,90 @@
+# Code Review: p1-supply-chain-provenance
+Date: 2026-07-16
+Review round: 1
+
+## Changes from Previous Round
+Initial code review of the implemented branch (C1-C4). Three experts reviewed `git diff main...HEAD` against the plan + deviation log. All load-bearing claims (C1 fail-closed shell paths, C4 member-set completeness, CODEOWNERS gating, no injection) were independently verified against the code. 8 findings merged (3 Major, 5 Minor); no Critical.
+
+## Merged Findings
+
+### Major
+
+**M1 — `detectedBy` accuracy (INV-C4c / Round-2 T2) unimplemented.** (Testing T2 + Functionality F1 — convergence)
+`computeUnbackedSensitiveDeps` only branches on `manual` and never verifies a `detectedBy` claim against the actual import shape. For a non-crypto-named member (`next-auth`, `@auth/prisma-adapter`, `@prisma/adapter-pg`, `pg`, `@prisma/client`, `resend`), if its import is removed from all CODE roots but it stays in package.json + manifest, no check fires — the stale `static-import` claim is undetected. Plan line 157 / INV-C4c / Round-2 T2 promised this + a three-branch self-test. Real impact low (metadata drift, not a supply-chain hole) but it's an undocumented deviation from a LOCKED invariant + a missing promised self-test.
+Fix: add `computeDetectedByViolations(manifestByPackage, codeSpecifiers)` flagging a `static-import`/`dynamic-import` entry with no CODE occurrence (excluding `manual`), with the T2 self-tests.
+
+**M2 — auto-merge guard misses standard Dependabot auto-merge shapes.** (Security SEC-1)
+`check-workflow-supply-chain.mjs:33` `mergeRe` catches `gh pr merge --auto` but misses `peter-evans/enable-pull-request-automerge` (the documented Action), `enablePullRequestAutoMerge` GraphQL, `gh api pulls/N/merge` REST, and reusable-workflow splits (cross-file, unfixable by a per-file grep). Plan INV-C3a frames the guard as THE enforcement. Mitigated by CODEOWNERS on `/.github/workflows/` → any auto-merge workflow still needs owner approval → Major not Critical.
+Fix: widen `mergeRe` (add `enable-pull-request-automerge`, `enablePullRequestAutoMerge`, `pulls/[^ ]*/merge`); document CODEOWNERS as the PRIMARY control in the guard header.
+
+**M3 — (B) presence check has no isolated pure-function negative test.** (Testing T1)
+The manifest∖DEPS presence check is inlined (`.filter(p => !depSet.has(p))`) and covered only by the committed-tree assertion. Plan line 160 / INV-C4d singled this out as "the one gate previously lacking a unit negative" and required a synthetic-DEPS unit negative. No such unit exists.
+Fix: extract `computeMissingDeps(manifestPackages, depSet)` + RED/GREEN units.
+
+### Minor
+
+**m1 — anti-mask regex misses realistic exit-masks.** (Functionality F3 + Security SEC-2 — convergence) `maskRe` misses `| tee`, `|& tee`, `|| exit 0`, `; exit 0`, `set +e`, YAML `continue-on-error: true`. No present offender. Fix: expand `maskRe` (add `exit\s+0`, `continue-on-error`) or narrow the docstring.
+
+**m2 — guard comment overstates provenance-assertion coverage.** (Security SEC-3) `check-workflow-supply-chain.mjs:14` claims coverage for the post-publish provenance assertion but `findMaskedVerifierViolations` matches only `audit\s+signatures`. No live risk (release.yml assertion is fail-closed + CODEOWNERS-gated). Fix: extend the match to the `npm view` provenance assertion OR correct the comment.
+
+**m3 — `--merge\b` regex over-broad (false positive).** (Functionality F2) matches any `--merge` co-occurring with "dependabot"; `gh pr merge` is already covered. Fix: drop bare `--merge\b` or scope to `pr\s+merge`.
+
+**m4 — `toPackageRoot` has only positive assertions.** (Testing T3) strict RT7 wants a fail-if-regresses case. Fix: add a bare-`name` and deep-subpath assertion.
+
+**m5 — (B) real-tree check reads only `dependencies`; a listed devDependency would false-RED.** (Testing T4, Adjacent) No violation found. Fix: record the runtime-dependencies assumption in the deviation log (every listed package is a runtime dep).
+
+## Adjacent Findings
+- Testing T4 (devDependency assumption) → Functionality data-model (m5).
+
+## Quality Warnings
+None — all findings carry concrete file/line evidence and verified repro.
+
+## Environment Verification Report
+- VC1 (npm OIDC provenance emission, CI-only-at-release): the C1 emission path is `verified-CI`-at-next-release; today's live registry state (GT-1) already demonstrates it; the INV-C1b assertion makes future emission fail-closed. Not exercisable pre-release — matches the Phase-1 VC1 constraint.
+- VC2 (`npm audit signatures` verifies published registry state, not HEAD): the C2 verifier is `verified-local` (ran `npm audit signatures` in cli/ during investigation, reported verified signatures/attestations) and `verified-CI` on the audit jobs + cron. No blocked-deferred path.
+
+## Recurring Issue Check
+### Functionality expert
+R42 applied (member-set re-derived from code across 3 workspaces, matched). R44: guard intent is R44 defense but mask regex has FNs (m1). RT7: all pure fns have negative self-tests EXCEPT the detectedBy-contradiction branch (M1). No R21 residue (prove-it-fails were scratch-only). R1-R41,R43 no hits.
+
+### Security expert
+R44/RS5: C1 assertion genuinely fail-closed (all shell paths simulated); ci.yml audit steps unmasked; no auto-merge introduced but the backstopping guard has gaps (M2). R42: member-set re-derived, name-invisible auth pkgs CODE-covered, complete. RS2/RS6: C4 gates manifest + enforcing test, owners enum + ≥10-char reason enforced+self-tested. RS1: no `${{}}` in any run: block, no shell interpolation of npm output beyond the fail-closed predicate. RS3: no token in assert step, cron secret-free, OIDC publish. RS4 n/a.
+
+### Testing expert
+RT1/RT2/RT5/RT9 met (real manifest + real tree, proven by RED-on-mutation; fs+ts-morph only). RT4/RT8: no vacuity. RT7: partially violated — (B) lacks isolated unit negative (M3), detectedBy-accuracy branch absent (M1), toPackageRoot positive-only (m4). RT3/RT6 n/a.
+
+## Resolution Status
+
+### M1 [Major] detectedBy accuracy (INV-C4c) unimplemented
+- Action: added `computeDetectedByViolations(manifestByPackage, codeSpecifiers)` pure fn + a real-tree `(detectedBy accuracy)` assertion per workspace + 5 RED/GREEN self-tests (static-no-code→finding, dynamic-no-code→finding, static-with-code→none, dynamic-confirmed→none, manual-exempt→none). Real tree green ⇒ every manifest static/dynamic claim has a confirming CODE occurrence.
+- Modified: src/__tests__/checks/crypto-auth-deps-manifest.test.ts
+
+### M2 [Major] auto-merge guard misses standard shapes
+- Action: widened `mergeRe` (peter-evans/enable-pull-request-automerge, enablePullRequestAutoMerge GraphQL, gh api pulls/N/merge REST); documented CODEOWNERS as the PRIMARY control in the guard header (regex = defense-in-depth; cross-file split out of a per-file grep's reach). Added 4 self-tests (3 new shapes fire + git-merge stays quiet).
+- Modified: scripts/checks/check-workflow-supply-chain.mjs, scripts/__tests__/check-workflow-supply-chain.test.mjs
+
+### M3 [Major] (B) presence check no isolated unit negative
+- Action: extracted `computeMissingDeps(manifestPackages, deps)` pure fn (real-tree (B) now calls it) + RED/GREEN self-tests.
+- Modified: src/__tests__/checks/crypto-auth-deps-manifest.test.ts
+
+### m1 [Minor] anti-mask regex misses realistic masks
+- Action: extended `maskRe` to `|| exit 0` / `; exit 0`, added a `continue-on-error: true` detector on verifier-running workflows. Self-tests for both.
+- Modified: scripts/checks/check-workflow-supply-chain.mjs, scripts/__tests__/check-workflow-supply-chain.test.mjs
+
+### m2 [Minor] guard comment overstates provenance coverage
+- Action: extended `findMaskedVerifierViolations` to also match the `npm view … attestations` provenance assertion (comment now accurate); a masked provenance step is now flagged. Self-test added.
+- Modified: scripts/checks/check-workflow-supply-chain.mjs, scripts/__tests__/check-workflow-supply-chain.test.mjs
+
+### m3 [Minor] --merge over-broad false positive
+- Action: dropped the bare `--merge\b` alternative (gh pr merge already covered); added a git-merge-near-dependabot no-false-positive self-test.
+- Modified: scripts/checks/check-workflow-supply-chain.mjs, scripts/__tests__/check-workflow-supply-chain.test.mjs
+
+### m4 [Minor] toPackageRoot positive-only
+- Action: added a 3-case self-test (bare name unchanged, unscoped subpath stripped, scoped deep subpath → scope/name).
+- Modified: src/__tests__/checks/crypto-auth-deps-manifest.test.ts
+
+### m5 [Minor] (B) reads only dependencies (devDependency assumption)
+- Action: recorded the runtime-dependencies assumption in the deviation log (D5) after confirming every listed package is a runtime dependency; no code change needed.
+- Modified: docs/archive/review/p1-supply-chain-provenance-deviation.md
+
+Verification: 54 guard+manifest tests pass; full suite 950 files / 12359 tests pass (1 skip); lint clean.

--- a/docs/archive/review/p1-supply-chain-provenance-code-review.md
+++ b/docs/archive/review/p1-supply-chain-provenance-code-review.md
@@ -104,3 +104,6 @@ Resolution recorded in deviation D8. Guard self-tests 16; full suite 950 files /
 
 ### R2 lesson
 The Round-1 guard regexes were self-tested only against shapes they already caught, and against a synthetic literal instead of the real release.yml optional-chaining string. A guard that protects a specific artifact must be self-tested against that artifact actual content. Round 2 self-tests now mirror the real shapes.
+
+### Round 3 -- converged
+Convergence check of the Round-2 fix commit: mergeRe ReDoS-free (hostile 50k input under 1ms), maskRe colon lookahead correct + no ternary false-positive, verifierRe/runsVerifier verified against the REAL release.yml (0 violations clean; continue-on-error injection to RED; optional-chaining matched; no false verifier-running workflow). 56 guard+manifest tests green, real guard exit 0. R43: no boundary weakened -- every change is a RED-detector broadening (tightening) or ReDoS-removal-with-redundant-coverage. No findings -- converged.

--- a/docs/archive/review/p1-supply-chain-provenance-deviation.md
+++ b/docs/archive/review/p1-supply-chain-provenance-deviation.md
@@ -36,3 +36,11 @@ Created: 2026-07-16
 
 ### D7: workflow guard hardened against evasion shapes
 - Round-1 code review (M2 = Sec SEC-1; m1 = Func F3 + Sec SEC-2; m2 = Sec SEC-3; m3 = Func F2) widened the auto-merge regex to the documented Dependabot shapes (peter-evans action, enablePullRequestAutoMerge GraphQL, gh api pulls/N/merge REST), dropped the over-broad bare --merge, extended the anti-mask detector to || exit 0 / continue-on-error, extended verifier coverage to the npm view attestations provenance assertion, and documented CODEOWNERS as the PRIMARY control (the regex is defense-in-depth; a cross-file reusable-workflow split is out of a per-file grep's reach). New self-tests cover each shape (fire + stay-quiet).
+
+### D8: workflow guard regex hardened again (Round-2 code review)
+- Round-1's guard-widening (D7) itself introduced defects the Round-2 review caught, all self-verified:
+  - Critical (ReDoS): the gh api pulls/N/merge alternative had overlapping greedy groups with an unsatisfiable tail — a hostile workflow line could hang the guard. Removed; pulls/[^\s]*/merge (single bounded class) already covers every REST pulls/N/merge case, zero coverage loss.
+  - Major (missed shapes): added merge-dependabot (fastify action) + pulls.merge (github-script REST client).
+  - Major (|| : dead match): the : no-op never matched under a shared trailing \b; gave it a lookahead boundary + a RED self-test.
+  - Major (verifierRe missed real release.yml): the provenance assertion uses optional chaining j?.dist?.attestations, which dist.attestations did not match, and npm view + attestations are on separate lines. Switched to dist optional-chaining match + a WORKFLOW-level runsVerifier flag. Verified: injecting continue-on-error on the real release.yml provenance step now goes RED (was green before).
+- All tightenings (no boundary widened). Guard self-tests grew to 16; real workflows stay clean.

--- a/docs/archive/review/p1-supply-chain-provenance-deviation.md
+++ b/docs/archive/review/p1-supply-chain-provenance-deviation.md
@@ -44,3 +44,14 @@ Created: 2026-07-16
   - Major (|| : dead match): the : no-op never matched under a shared trailing \b; gave it a lookahead boundary + a RED self-test.
   - Major (verifierRe missed real release.yml): the provenance assertion uses optional chaining j?.dist?.attestations, which dist.attestations did not match, and npm view + attestations are on separate lines. Switched to dist optional-chaining match + a WORKFLOW-level runsVerifier flag. Verified: injecting continue-on-error on the real release.yml provenance step now goes RED (was green before).
 - All tightenings (no boundary widened). Guard self-tests grew to 16; real workflows stay clean.
+
+## Post-review external findings
+
+### D9: [High] classification-completeness gate — every runtime dep must be packages OR excluded
+- An external review found the three-set guard's blind spot was still exploitable: a new auth lib (e.g. better-auth) added OUTSIDE the CODE_ROOTS and whose name misses CRYPTO_NAME_RE passes (A), (C), CODEOWNERS, and lands unclassified. Self-verified.
+- Fix: added (E) computeUnclassifiedDeps — EVERY runtime dependency of each workspace must be classified as a crypto/auth packages member OR an excluded support dep; a dep in neither is a finding. This forces a supply-chain review decision on every new dependency regardless of name or import location, closing the R-3 residual at its root. Enumerated all 17 previously-unclassified root deps into excluded with reasons. RED/GREEN self-tests incl. the better-auth scenario.
+- Also surfaced a latent bug: react/react-dom were excluded for BOTH root and extension under the same JSON key, so the extension entry silently overwrote root's (JSON dup-key). The (E) check caught it; fixed with composite keys (react@extension). (E) is itself the safety net against future dup-key overwrites.
+
+### D10: [Medium] anti-mask guard missed multi-line + expression masks
+- External review found findMaskedVerifierViolations only detected a mask on the SAME line as the verifier, missing `npm audit signatures \` + newline + `|| true`, and missed continue-on-error: ${{ true }} (expression form). Both self-verified as false-negatives.
+- Fix: join shell line-continuations into one logical line (tracking the original line number) before scanning; broaden the continue-on-error match to the expression form. Self-tests for both; real workflows stay clean.

--- a/docs/archive/review/p1-supply-chain-provenance-deviation.md
+++ b/docs/archive/review/p1-supply-chain-provenance-deviation.md
@@ -63,3 +63,6 @@ Created: 2026-07-16
 
 ### D12 [Medium] anti-mask guard now folds YAML folded/block scalars
 - A run: > folded scalar evaded the guard (earlier fix only joined backslash-continuations). The logical-line builder now absorbs a run block deeper-indented body before scanning. Folded-scalar self-test added.
+
+### D13 block-scalar header variants (Low)
+- Header regex required a trailing anchor after the indicator, so a trailing comment and an indentation indicator evaded folding. Fixed: accepts indentation + chomping indicators in any order plus an optional trailing comment. Self-tests for both.

--- a/docs/archive/review/p1-supply-chain-provenance-deviation.md
+++ b/docs/archive/review/p1-supply-chain-provenance-deviation.md
@@ -1,0 +1,27 @@
+# Coding Deviation Log: p1-supply-chain-provenance
+Created: 2026-07-16
+
+## Deviations from Plan
+
+### D1: manifest keyed by name, composite keys for multi-workspace / duplicate packages
+- **Plan**: `packages` keyed by package name.
+- **Actual**: `otpauth` ships in all three workspaces and `zod` in both root and cli; a single name-keyed map cannot hold per-workspace entries. Used composite keys (`otpauth@cli`, `otpauth@extension`, `zod@cli`) carrying the real name in a `package` field; the test resolves `entry.package ?? key`. No behavior change to the reconciliation contract.
+- **Impact**: manifest shape only; the three-set logic and self-tests are unaffected.
+
+### D2: C2 anti-mask + C3 no-auto-merge folded into ONE guard file
+- **Plan**: C2 anti-mask grep and C3 no-auto-merge guard as (possibly) separate `run_step`s.
+- **Actual**: both are pure exported functions in a single `scripts/checks/check-workflow-supply-chain.mjs` (one `run_step`), each with its own RT7 self-test in `scripts/__tests__/check-workflow-supply-chain.test.mjs`. Both are workflow-file lints, so one guard file is cohesive (KISS) and both invariants still fire independently.
+- **Impact**: one `pre-pr.sh` `run_step` instead of two; both forbidden-pattern classes covered.
+
+### D3: root CODE roots widened to the passkey/webauthn API routes
+- **Plan**: root roots listed "WebAuthn/passkey/SAML route trees" generically.
+- **Actual**: concretely `src/app/api/auth/passkey` + `src/app/api/webauthn` (SAML has no npm dep, so no SAML route is a crypto/auth-import source). Root also includes `src/lib/email/**` (SEC-5) and `src/components/passwords/shared/**` (TOTP field).
+- **Impact**: none — matches the GT-6 intent; the concrete paths are what actually import the sensitive packages.
+
+### D4: `walkSourceFiles` single-file guard + descendant const resolution (implementation fixes found during verification)
+- Two bugs surfaced while running against the real tree and were fixed before commit: (a) `walkSourceFiles` must special-case a root that points at a single `.ts` file (`src/lib/prisma.ts`) before `readdirSync`; (b) the dynamic-import `const moduleName` binding is function-scoped, so resolution must walk `getDescendantsOfKind(VariableDeclaration)`, not just top-level `getVariableDeclarations()` — otherwise `hash-wasm` (the load-bearing dynamic member) is missed. The (A) integration prove-it-fails demo confirmed the fix: dropping `hash-wasm` from the manifest turns (A) RED via the resolved dynamic import.
+
+### Prove-it-fails demonstrations (Phase 2, scratch only, not committed)
+- (B) presence: added a synthetic `nonexistent-crypto-pkg` to a scratch copy of the manifest → (B) RED; restored clean.
+- (A) drift: dropped `hash-wasm` from a scratch copy (still imported) → (A) RED (proving the dynamic-import member flows through the drift gate); restored clean, 26/26 green.
+- (C)/(D)/heuristic/dynamic-resolver: proven RED at the pure-function unit level (RT7 self-tests in the test file).

--- a/docs/archive/review/p1-supply-chain-provenance-deviation.md
+++ b/docs/archive/review/p1-supply-chain-provenance-deviation.md
@@ -55,3 +55,11 @@ Created: 2026-07-16
 ### D10: [Medium] anti-mask guard missed multi-line + expression masks
 - External review found findMaskedVerifierViolations only detected a mask on the SAME line as the verifier, missing `npm audit signatures \` + newline + `|| true`, and missed continue-on-error: ${{ true }} (expression form). Both self-verified as false-negatives.
 - Fix: join shell line-continuations into one logical line (tracking the original line number) before scanning; broaden the continue-on-error match to the expression form. Self-tests for both; real workflows stay clean.
+
+## Second external-review round
+
+### D11 [High] classification check moved to a standalone always-run guard
+- (E) in the vitest test rides app-ci (gated app||ci); a cli/ext-only package.json PR skips it. Extracted (E) into standalone scripts/checks/check-crypto-auth-deps-classified.mjs (node:fs+JSON only) wired into pre-pr.sh which static-checks runs unconditionally. RT7 self-test + prisma-displacement-verified.
+
+### D12 [Medium] anti-mask guard now folds YAML folded/block scalars
+- A run: > folded scalar evaded the guard (earlier fix only joined backslash-continuations). The logical-line builder now absorbs a run block deeper-indented body before scanning. Folded-scalar self-test added.

--- a/docs/archive/review/p1-supply-chain-provenance-deviation.md
+++ b/docs/archive/review/p1-supply-chain-provenance-deviation.md
@@ -66,3 +66,13 @@ Created: 2026-07-16
 
 ### D13 block-scalar header variants (Low)
 - Header regex required a trailing anchor after the indicator, so a trailing comment and an indentation indicator evaded folding. Fixed: accepts indentation + chomping indicators in any order plus an optional trailing comment. Self-tests for both.
+
+## Third external-review round
+
+### D14 release Node 24 pin (M1, release-blocker)
+- npm Trusted Publishing needs both npm 11.5.1+ AND Node 22.14+. The release job used node-version-file .nvmrc (Node 20) and only upgraded npm, so the next npm publish would fail OIDC auth. Pinned the release job to node-version 24 explicitly. Added findTrustedPublishNodeViolation guard (an npm-publish workflow must pin node-version >= 22.14) with 5 self-tests, wired into the workflow-supply-chain guard.
+
+### D15 verifier npm pin + Dependabot sensitive group + L1 note
+- L2: pinned npm in the weekly signature-sweep so the verifier tracks the release producer attestation format.
+- L3: split each Dependabot npm ecosystem into a security-sensitive group + a general group, so sensitive bumps land in a dedicated PR.
+- L1: documented that the post-publish assertion reads dist.attestations metadata shape rather than npm audit signatures; acceptable because it fails closed and the weekly sweep re-verifies officially.

--- a/docs/archive/review/p1-supply-chain-provenance-deviation.md
+++ b/docs/archive/review/p1-supply-chain-provenance-deviation.md
@@ -25,3 +25,14 @@ Created: 2026-07-16
 - (B) presence: added a synthetic `nonexistent-crypto-pkg` to a scratch copy of the manifest → (B) RED; restored clean.
 - (A) drift: dropped `hash-wasm` from a scratch copy (still imported) → (A) RED (proving the dynamic-import member flows through the drift gate); restored clean, 26/26 green.
 - (C)/(D)/heuristic/dynamic-resolver: proven RED at the pure-function unit level (RT7 self-tests in the test file).
+
+## Phase 3 code-review fixes
+
+### D5: (B) presence check reads only `dependencies` (runtime-dep assumption)
+- The (B) real-tree check reads each workspace's package.json `dependencies` only, not `devDependencies` (Round-1 code-review T4). Confirmed every manifest-listed package is a runtime `dependencies` entry in its workspace. A crypto/auth primitive would never be a devDependency in production, so the assumption is sound; recorded so a reviewer can contest it.
+
+### D6: detectedBy-accuracy + (B) extracted to pure functions with unit negatives
+- Round-1 code review (M1 = Func F1 + Test T2; M3 = Test T1) found the (B) presence check inlined and the INV-C4c detectedBy-accuracy branch unimplemented. Added `computeMissingDeps` (B) and `computeDetectedByViolations` (detectedBy accuracy) as pure exported functions, each wired into the real-tree reconciliation AND given RED/GREEN unit self-tests. The detectedBy-accuracy check catches the case (C) misses: a non-crypto-named member (e.g. next-auth) whose import is removed but left in package.json+manifest — a stale static-import claim now goes RED.
+
+### D7: workflow guard hardened against evasion shapes
+- Round-1 code review (M2 = Sec SEC-1; m1 = Func F3 + Sec SEC-2; m2 = Sec SEC-3; m3 = Func F2) widened the auto-merge regex to the documented Dependabot shapes (peter-evans action, enablePullRequestAutoMerge GraphQL, gh api pulls/N/merge REST), dropped the over-broad bare --merge, extended the anti-mask detector to || exit 0 / continue-on-error, extended verifier coverage to the npm view attestations provenance assertion, and documented CODEOWNERS as the PRIMARY control (the regex is defense-in-depth; a cross-file reusable-workflow split is out of a per-file grep's reach). New self-tests cover each shape (fire + stay-quiet).

--- a/docs/archive/review/p1-supply-chain-provenance-deviation.md
+++ b/docs/archive/review/p1-supply-chain-provenance-deviation.md
@@ -76,3 +76,6 @@ Created: 2026-07-16
 - L2: pinned npm in the weekly signature-sweep so the verifier tracks the release producer attestation format.
 - L3: split each Dependabot npm ecosystem into a security-sensitive group + a general group, so sensitive bumps land in a dedicated PR.
 - L1: documented that the post-publish assertion reads dist.attestations metadata shape rather than npm audit signatures; acceptable because it fails closed and the weekly sweep re-verifies officially.
+
+### D16 node-version guard: 22.14 floor + per-job evaluation
+- The guard checked only major 22-plus whole-file, passing 22.13.1 and a Node-24 pin in a different job than npm publish. Added isTrustedPublishingNodeVersion (numeric; major 22 needs minor 14-plus) + splitJobs so node-version is evaluated only within the npm-publish job. Self-tests + real/reverted verification.

--- a/docs/archive/review/p1-supply-chain-provenance-plan.md
+++ b/docs/archive/review/p1-supply-chain-provenance-plan.md
@@ -1,0 +1,243 @@
+# Plan: P1 Supply-Chain Hardening (roadmap C-P1, ship-today scope)
+
+## Project context
+
+- Type: `mixed` — Next.js 16 web app + CLI (npm, `passwd-sso-cli`) + browser extension + iOS (xcodegen) + a large `scripts/checks/*` CI static-guard suite.
+- Test infrastructure: `unit + integration + E2E + CI/CD` (vitest, real-DB integration, Playwright, XCTest, `scripts/checks/*` guards + `scripts/pre-pr.sh`).
+- Verification environment constraints:
+  - **VC1**: npm OIDC Trusted Publishing provenance generation happens only on the GitHub Actions release runner (keyless OIDC). It CANNOT be exercised from a local dev machine or a PR CI job → provenance-emission is `verifiable-CI` on the release path only, and in practice already proven by the live registry state (see GT-1). The regression this plan guards is a *future* config drift, observable only at the next release.
+  - **VC2**: `npm audit signatures` verifies signatures/attestations of packages **as published to the npm registry**, using the working-tree lockfile to know *which* versions to check. It verifies our own package's provenance only for **already-published** versions, never the unpublished working-tree HEAD. So the CI verifier asserts "every dependency (and our last-published self) has a valid registry signature/attestation," NOT "this PR's HEAD build carries provenance." → `verifiable-CI` and `verifiable-local` (runs against public registry; no secret needed).
+
+## Ground-truth reconciliation (verified against the repo + live npm registry before planning)
+
+- **GT-1 (overturns roadmap-review C1)**: `passwd-sso-cli@0.4.70` on the npm registry **already carries full SLSA provenance**. Measured:
+  - `dist.attestations.provenance.predicateType = "https://slsa.dev/provenance/v1"` (SLSA build provenance) AND a `https://github.com/npm/attestation/.../publish/v0.1` npm publish attestation, both in a Sigstore bundle with a Rekor transparency-log entry.
+  - `npm audit signatures` (run in `cli/`) reports "verified registry signatures" + "verified attestations".
+  - Cause: `release.yml:63-65` runs a bare `npm publish` under **OIDC Trusted Publishing** with npm 11.12.1 (`release.yml:47`). npm ≥ 11.5.1 auto-generates SLSA provenance server-side when publishing via OIDC — no `--provenance` flag needed. **So roadmap-review finding C1's premise ("ships with no provenance today; cosign is needed") is false.** The producer already exists and works. This plan does NOT add a producer; it (A′) pins the behavior against drift + adds the missing *verifier*, (B) extends dependency monitoring, (C) adds a crypto/auth sensitive-dep manifest.
+- **GT-2 (Actions boundary already hardened — no work)**: every workflow has an explicit top-level `permissions:` (baseline `contents: read`; only `codeql.yml`/`release.yml` grant any write, and `release.yml` narrows `id-token: write` to the `publish-cli` job). Actions are 40-hex SHA-pinned with the `check-actions-sha-pinned.sh` guard (wired via `pre-pr.sh:169` → `ci.yml` static-checks). `.github/CODEOWNERS:39` gates `/.github/workflows/`. No `pull_request_target` / `workflow_run` anywhere. `SHARE_MASTER_KEY` in `ci.yml`/`ci-integration.yml` is a **public dummy literal**, not a repo secret, and those jobs run on `pull_request` (not `pull_request_target`), so fork PRs never see real secrets. → the roadmap C-P1 "Actions boundary" line is already satisfied; adding redundant guards is out of scope (SC3).
+- **GT-3 (Dependabot ecosystem gap)**: `.github/dependabot.yml` covers **only** `github-actions`. `npm` (root, `cli/`, `extension/`) is NOT configured. No auto-merge config exists anywhere (grep of workflows for `dependabot` + `auto.?merge`/`gh pr merge` is empty) — so the M-h "auto-merge fail-open" hazard is currently *absent* and this plan must NOT introduce it.
+- **GT-4 (iOS has no Dependabot-supported manifest)**: `ios/` uses **xcodegen** (`ios/project.yml`) with no `Package.swift` (SPM) and no `Podfile` (CocoaPods). Dependabot's `swift` ecosystem requires a `Package.swift`. → iOS is correctly excluded from Dependabot npm/swift scope; recorded as SC1, not an omission.
+- **GT-5 (no crypto/auth sensitive-dep manifest)**: `scripts/checks/` has no crypto/auth dependency allowlist (`check-crypto-domains.mjs` is domain-separation, not deps; `check-licenses.mjs` + `scripts/license-allowlist.json` is a *license* allowlist, not a package-criticality list). The closest mirror-able patterns are `check-licenses.mjs`/`license-allowlist.json` (`.mjs` guard + JSON data file, node:fs only, no `@prisma/client`) and `src/__tests__/workers/worker-policy-manifest.test.ts` (filesystem-only parity test with mechanical grep + negative self-test).
+- **GT-6 (member-set for the crypto/auth manifest — code-derived, ALL THREE npm workspaces)**: derived by grepping external (non-relative, non-`node:`, non-framework) imports. The scope spans the web app AND the CLI AND the extension — the CLI is the very artifact this roadmap hardens, so omitting its own crypto surface would be a hollow gate (Round-1 M1: Func F1 + Sec SEC-2 convergence). Defining roots per workspace:
+  - **root (web app)**: `src/lib/crypto/**`, `src/lib/auth/**`, `src/lib/prisma.ts`, `src/lib/email/**`, `src/auth.ts`, `src/auth.config.ts`, WebAuthn/passkey/SAML route trees, and the TOTP component tree `src/components/passwords/shared/**` (TOTP is a crypto primitive that lives in a component, not under `src/lib/**` — verified: `src/components/passwords/shared/totp-field.tsx:5` imports `otpauth`; a naive `src/lib`-only root would miss it, the exact R-3 blind-spot class). `src/lib/email/**` is included because the magic-link auth channel's SMTP/Resend transports (`nodemailer`, `resend`) carry the session-granting token and are an auth-flow surface — Round-2 SEC-5.
+  - **cli**: `cli/src/**`.
+  - **extension**: `extension/src/**`.
+
+  Production crypto/auth-sensitive packages (with workspace):
+  - `next-auth` (root) — `src/auth.ts`, `src/auth.config.ts`, `src/lib/auth/session/auth-adapter.ts`
+  - `@auth/prisma-adapter` (root) — `src/lib/auth/session/auth-adapter.ts`
+  - `@simplewebauthn/server` (root) — `src/lib/auth/webauthn/webauthn-server.ts`
+  - `@simplewebauthn/types` (root) — webauthn-server + several WebAuthn/passkey routes
+  - `hash-wasm` (root) — `src/lib/crypto/crypto-client.ts:149-150` **via dynamic `import(moduleName)`** (a static `from "…"` grep MISSES this — the manifest guard MUST detect the dynamic form)
+  - `@prisma/adapter-pg` + `pg` (root, `static-import`) — `src/lib/prisma.ts:2-3`, worker DB clients (the driver-adapter pair the whole auth/session store rides on; `src/lib/prisma.ts` is IN the drift roots so these are statically re-derivable — Round-1 m1 / Round-2 m2: mark `static-import`, NOT `manual`)
+  - `@prisma/client` (root, category `db-identity-store`) — pervasive in `src/lib/auth/**`; the ORM for all identity/session/token tables. Classified as a **data-access boundary**, not a crypto primitive (Round-2 m3) — it is in-scope because it is the identity store, and the `db-identity-store` category keeps the taxonomy honest vs. the KDF/signature/OTP primitives.
+  - `bcrypt-pbkdf` (cli, `dynamic-import`) — an OpenSSH-key KDF that decrypts encrypted SSH private keys, **via dynamic `import("bcrypt-pbkdf")`** at `cli/src/lib/openssh-key-parser.ts:158` (`const { pbkdf } = await import("bcrypt-pbkdf")`) — same dynamic+KDF shape the manifest catches for hash-wasm (Round-1 M1)
+  - `otpauth` (root + cli + extension, `static-import`) — TOTP (2FA shared-secret OTP) generation: `src/components/passwords/shared/totp-field.tsx` (root, `^9.5.0`), `cli/src/lib/totp.ts` (`^9.4.0`), `extension/src/lib/totp.ts` (`^9.5.0`) (Round-1 M1; root occurrence found during member-set re-derivation)
+  - `nodemailer` (root, `static-import`, category `auth-flow`) — SMTP transport for the magic-link auth channel, `src/lib/email/smtp-provider.ts:1`; also the NextAuth Nodemailer provider (`src/auth.config.ts:3`). The channel carries the session-granting token (Round-2 SEC-5).
+  - `resend` (root, `static-import`, category `auth-flow`) — Resend transport for the same magic-link channel, `src/lib/email/resend-provider.ts:1` (Round-2 SEC-5).
+  - **Excluded, with reason (workspace-scoped — Round-2 M1 design principle)**: an exclusion is validated against the specific workspace's code, so "unimported in root" cannot suppress a real import in another workspace. Root exclusions: `ioredis` (session cache transport), `@sentry/nextjs` (error reporting), `bowser` (UA parsing for new-device detection), `zod` (validation), `@noble/hashes` (**test-only** oracle, `*.test.ts`), `@simplewebauthn/browser` (production dep but **not imported anywhere** in `src/` — `webauthn-client.ts:5` is a comment noting the app deliberately uses the raw WebAuthn API instead; **verified absent from `extension/package.json` too** — Round-2 M1 was a false positive on this). cli exclusions: `chalk`, `commander`, `cli-table3` (CLI UX). extension exclusions: `tldts` (public-suffix/domain parsing for autofill origin), `react`/`react-dom` (framework). SAML uses an **out-of-process Jackson** OIDC endpoint — there is no `@boxyhq/saml-jackson` npm dependency. `jose` and native `argon2` are **not used**. The main vault crypto uses native Web Crypto `crypto.subtle` (no npm primitive). The manifest scopes to packages that implement or wrap an auth-flow / KDF / signature / OTP / identity-store primitive; the workspace-scoped exclusions are recorded so a reviewer can contest the boundary per workspace.
+
+## Objective
+
+Land the ship-today slice of roadmap C-P1: make the already-working npm provenance explicit, drift-proof, and fail-closed-at-release; add the missing signature *verifier* (PR jobs + a scheduled sweep); extend dependency monitoring to the npm ecosystems; and add a mechanized crypto/auth sensitive-dependency manifest that reconciles code-imports, package.json, and the manifest across all three npm workspaces (root/cli/extension) — without adding a producer that already exists, without redundant Actions guards, and without an auto-merge fail-open path.
+
+## Requirements
+
+Functional:
+- CLI publish continues to emit SLSA provenance, now via an **explicit** `publishConfig.provenance: true` rather than an implicit npm-version-dependent default.
+- CI runs `npm audit signatures` so a future regression in dependency signing (or our own once published) is caught.
+- Dependabot opens grouped npm update PRs for root, `cli/`, and `extension/`, requiring human review (no auto-merge).
+- A CI-checked JSON manifest enumerates crypto/auth-sensitive npm packages across all three npm workspaces (root/cli/extension); a **three-set reconciliation** guard (CODE-derived imports ∪ package.json DEPS ∪ MANIFEST) fails when (A) a new sensitive import is unregistered, (B) a manifest entry vanished from `package.json`, (C) a sensitive `package.json` dep has no code-derived occurrence AND is not a reasoned `detectedBy:["manual"]` entry, or (D) an entry's `reason`/`owners` is empty. It is a **set**-membership gate, deliberately NOT a per-version pin (pinning would force a manifest edit on every routine bump for no supply-chain gain; the value is catching a *new* sensitive dep or a metadata gap), and it correctly accounts for dynamic imports (`hash-wasm`, `bcrypt-pbkdf`).
+
+Non-functional:
+- No new runtime code paths; all changes are CI/config/test + one `package.json` field.
+- The manifest guard must run in an environment WITHOUT a generated Prisma client (mirror `worker-policy-manifest.test.ts`: filesystem-only, no `@prisma/client` import) — see the `project_static_check_ci_no_prisma_generate` hazard.
+- Language policy: code comments English; all else per repo/global rules.
+
+## Technical approach
+
+- **(A′) provenance pin + verifier.** Add `"publishConfig": { "provenance": true }` to `cli/package.json` (explicit, npm-version-independent) + a post-publish attestation assertion in `publish-cli` (INV-C1b). Add `npm audit signatures` to the three existing npm-audit jobs (reusing their `npm ci` trees) plus a weekly `schedule: cron` sweep workflow (M2) so an unchanged-tree tamper is re-verified independent of PRs.
+- **(B) Dependabot npm.** Add three `package-ecosystem: "npm"` entries (`/`, `/cli`, `/extension`) to `.github/dependabot.yml`, weekly, grouped, no auto-merge (enforced by a wired `pre-pr.sh` guard, M3). Preserve the existing `github-actions` entry verbatim. Swift excluded (GT-4).
+- **(C) crypto/auth sensitive-dep manifest + three-set reconciliation guard.** New data file `scripts/checks/crypto-auth-deps-manifest.json` (object-keyed, member-set from the full GT-6 three-workspace set) + a parity test mirroring `worker-policy-manifest.test.ts` (filesystem-only vitest, ts-morph AST). The guard reconciles CODE-derived imports, package.json DEPS, and MANIFEST per workspace, failing on (A)-(D) above, allowing reasoned `detectedBy:["manual"]` entries for defensive/outside-root deps, with a negative self-test per pure detection function (RT7).
+
+## Contracts
+
+### C1 — `cli/package.json` gains explicit provenance opt-in
+- **Change**: add top-level `"publishConfig": { "provenance": true }` to `cli/package.json`. No other key touched.
+- **Invariants** (app-enforced — this is config, not schema):
+  - INV-C1a: `release.yml` publish step stays a bare `npm publish` under the `publish-cli` job's `id-token: write` (the OIDC path). `publishConfig.provenance` is honored by `npm publish` without a CLI flag. Do NOT add `--provenance` to the command (redundant with the field, and doubles the surface to keep in sync).
+  - INV-C1b (m2 — Sec SEC-4/SEC-7): `provenance: true` only *emits* provenance in a supported OIDC context; it fails open if the context degrades (future `id-token` narrowing, npm treating an unsupported context as best-effort). Add a **post-publish attestation assertion** in the `publish-cli` job that fails the release if the just-published version carries no attestation. It MUST be robustly fail-closed (Round-2 SEC-7): prefer running `npm audit signatures` in `cli/` post-publish (the same verifier as C2, which fails closed by design and has registry-retry semantics) rather than a hand-rolled `npm view … | jq`. If `npm view` is used, it must (a) `set -o pipefail`, (b) check `npm view`'s own exit BEFORE the pipe so a registry/network error fails the release rather than being read as "attestation present", (c) positively assert the predicateType (`.dist.attestations.provenance.predicateType == "https://slsa.dev/provenance/v1"`), not mere key presence, (d) retry only on the *absent* signal for registry-propagation lag, never swallowing the definitively-unattested case into success, and (e) never be `|| true`-masked (in the C2 anti-mask grep scope). This converts the R-1 "post-hoc, next-PR" residual into fail-closed-at-release (a cheap subset of SC5, not the permanently-red transitive gate SC5 defers).
+- **Forbidden patterns**:
+  - `pattern: --provenance` in `.github/workflows/release.yml` — reason: provenance is expressed once, via `publishConfig`; a CLI flag duplicates the contract.
+- **Acceptance**:
+  - `cli/package.json` parses and contains `publishConfig.provenance === true`.
+  - `release.yml` publish command unchanged (still bare `npm publish`), followed by the INV-C1b post-publish attestation assertion.
+  - A **concrete named test** (m3 — Test F4), NOT an "or": an `it(...)` block (in the C4 test file or a small dedicated `cli/package.json` shape test) asserting BOTH (i) `cli/package.json` `publishConfig.provenance === true` AND (ii) the `release.yml` `--provenance` forbidden-pattern grep returns zero matches.
+  - Consumer-flow: the only consumer of this field is the npm CLI during `release.yml`'s `publish-cli` job. It reads `publishConfig.provenance` and, combined with `id-token: write` OIDC, emits the SLSA provenance attestation. No repo code reads this field. Emission is `verifiable-CI` at the next release (VC1); today's live registry state (GT-1) already demonstrates it works; the INV-C1b assertion makes future emission fail-closed.
+
+### C2 — CI verifies registry signatures/attestations (PR jobs + scheduled sweep)
+- **Change**:
+  1. Add a `npm audit signatures` step to **all three** npm-audit jobs in `.github/workflows/ci.yml` — `audit-cli` (`working-directory: cli`), `audit-app` (root), `audit-ext` (`working-directory: extension`) — each after that job's existing `npm ci`. (These jobs are `dorny/paths-filter`-gated, so they fire on PRs touching that workspace.)
+  2. **Scheduled sweep (M2 — Func F3 + Sec SEC-1 convergence)**: add a small dedicated workflow (e.g. `.github/workflows/dependency-signatures.yml`, `permissions: contents: read`) that runs `npm audit signatures` for all three trees on a weekly `schedule: cron` (and `workflow_dispatch`), independent of code changes. This closes the temporal hole where a registry-side tamper of an already-installed, unchanged dependency would otherwise be re-verified only on the next PR touching that workspace.
+- **Invariants**:
+  - INV-C2a: the step verifies **registry** signature/attestation state of installed dependencies (and, for our own package, only already-published versions). It MUST NOT assert the working-tree HEAD carries provenance (VC2) — a permanently-red/vacuous assertion.
+  - INV-C2b: the step FAILS the job on a real signature verification failure (default `npm audit signatures` exit), sited so a network/registry outage surfaces as an infra failure, not a silent skip (R44 — no exit-masking pipe).
+  - INV-C2c (M5 — Test F2): the verifier is only non-vacuous if the trees actually contain signed/attested deps today. Phase 2 MUST record, per tree, that `npm audit signatures` reports ≥1 verified signature/attestation (observed output in the deviation log); if a tree has none, mark that step **known-vacuous** rather than presenting it as an active verifier. Phase 2 MUST also demonstrate the can-fail path once (a corrupted/known-bad signature fixture → non-zero exit) and record the observed red.
+- **Forbidden patterns**:
+  - `pattern: audit signatures.*\|\| *(true|:)`, `pattern: audit signatures.*; *true`, `pattern: audit signatures.*\|\| *echo` in workflows — reason: masking the verifier's exit defeats it (R44).
+- **Acceptance**:
+  - `ci.yml` `audit-cli`, `audit-app`, `audit-ext` jobs each contain an un-masked `npm audit signatures` step; each step's exit is the job step's exit (no trailing `|| true`).
+  - A scheduled workflow runs the three verifications on a weekly cron with `contents: read`.
+  - The anti-mask forbidden-pattern guard (INV-C2b) is wired as a `pre-pr.sh` `run_step` (same M3 wiring discipline as C3) with a negative self-test proving it goes RED on a planted `audit signatures … || true` fixture.
+  - Phase 2 deviation log records the per-tree ≥1-signed-dep observation (INV-C2c) and the one-time can-fail demonstration.
+  - **Local mirror decision (m3 — Test F5)**: the `npm audit signatures` verifier itself is CI/cron-only, NOT mirrored into `pre-pr.sh`, because it requires network access to the npm registry and would make `pre-pr.sh` fail offline — recorded here as the Anti-Deferral justification rather than left implicit. Only the *masking* grep guard (offline-safe) rides `pre-pr.sh`.
+
+### C3 — Dependabot covers npm ecosystems, no auto-merge
+- **Change**: `.github/dependabot.yml` — append three `npm` ecosystem entries (`directory: "/"`, `"/cli"`, `"/extension"`), weekly Monday cadence, grouped, `open-pull-requests-limit` set (e.g. 5). Keep the existing `github-actions` entry.
+- **Invariants**:
+  - INV-C3a: no auto-merge — no `dependabot` + `gh pr merge`/`auto-merge` workflow is added (M-h fail-open avoidance). Human approval remains required.
+  - INV-C3b: no `swift` ecosystem entry (GT-4: no `Package.swift`).
+- **Forbidden patterns**:
+  - `pattern: dependabot` co-occurring with `gh pr merge` or `--auto` in any `.github/workflows/*.yml` — reason: auto-merging upstream bumps into a password-manager is an RS5/M-h fail-open supply-chain path.
+- **Guard wiring (M3 — Sec SEC-3)**: the no-auto-merge check is implemented as a pure function over workflow-file contents in a `scripts/checks/*` guard (or the C4 test file), and is **explicitly added as a `run_step` line in the enumerated `scripts/pre-pr.sh` static block (~line 169)** so it fires in the `static-checks` CI job — an authored-but-unwired guard silently fail-opens. It carries a negative self-test (M5 — Test F3): a synthetic in-memory workflow string containing `dependabot` + `gh pr merge --auto` → violation; a clean string → none.
+- **Acceptance**:
+  - `dependabot.yml` parses (YAML) and has exactly 4 `updates:` entries: 1 github-actions + 3 npm.
+  - Each npm entry has `schedule.interval: weekly`, a `groups:` block, and no auto-merge/rebase-strategy that implies auto-merge.
+  - The no-auto-merge guard appears in the `pre-pr.sh` `run_step` list AND fires in `static-checks` CI, AND its negative self-test proves it goes RED on the planted `dependabot`+`--auto` fixture.
+
+### C4 — crypto/auth sensitive-dep manifest + three-set reconciliation guard (all 3 npm workspaces)
+
+**Design principle (user directive, Round-1)**: import scanning is NOT the sole source of truth. A manifest driven only by code-imports misses: dynamic `import()`, `require()`, CLI-only usage, build-script usage, transitively-important deps, and **defensive deps present in `package.json` but not yet imported**. The guard therefore reconciles **three sets** and fails on their disagreements, allowing reasoned manual entries for the code-not-imported case.
+
+The three sets, per workspace:
+1. **CODE** — the crypto/auth-sensitive external specifiers derived from source via ts-morph AST (static import + string-literal `import()` + const-resolved `import()` + `require()`), rooted at the GT-6 defining roots.
+2. **DEPS** — the `dependencies` (direct) set of that workspace's `package.json`, filtered to crypto/auth-sensitive names by (i) manifest membership and (ii) a **name-pattern heuristic** — an enumerated, self-tested regex set (Round-2 T3): `/crypt|cipher|kdf|pbkdf|bcrypt|scrypt|argon|hash|hmac|sign|jwt|jose|jwk|webauthn|passkey|fido|otp|totp|hotp|nacl|sodium|noble|tweetnacl|oidc|oauth|saml|nodemailer/i`. The heuristic ONLY widens the DEPS side so a crypto-named dep outside the CODE roots still trips (C); it NEVER auto-approves (an entry must still be in `packages` or `excluded`). The pattern list is a `const` in the test with its own negative self-test (crypto-named synthetic → surfaced; plain name → not).
+3. **MANIFEST** — the declared `packages` in `crypto-auth-deps-manifest.json`.
+
+- **Change**:
+  1. New `scripts/checks/crypto-auth-deps-manifest.json` — shape (user-directed object-keyed structure):
+     ```json
+     {
+       "packages": {
+         "@simplewebauthn/server": {
+           "workspace": "root",
+           "reason": "WebAuthn verification boundary",
+           "detectedBy": ["static-import"],
+           "owners": ["security"],
+           "category": "signature"
+         },
+         "hash-wasm": {
+           "workspace": "root",
+           "reason": "Password KDF (Argon2id) implementation",
+           "detectedBy": ["dynamic-import"],
+           "owners": ["security"],
+           "category": "kdf"
+         },
+         "bcrypt-pbkdf": {
+           "workspace": "cli",
+           "reason": "OpenSSH private-key KDF",
+           "detectedBy": ["dynamic-import"],
+           "owners": ["security"],
+           "category": "kdf"
+         }
+       },
+       "excluded": {
+         "zod": { "reason": "input validation, not a crypto/auth primitive" }
+       }
+     }
+     ```
+     - `packages` is keyed by package name. Each value: `{ workspace, reason (**≥10 chars**, mirroring the worker-policy template's `>=10-char` reason floor — Round-2 SEC-6), detectedBy: [ "static-import" | "dynamic-import" | "manual" ], owners: [**≥1, each from a fixed OWNERS enum** validated by the test, e.g. `"security"` — free-text owners rejected, Round-2 SEC-6], category }`. `detectedBy: ["manual"]` is the sanctioned marker for a package present in `package.json` but not imported under the CODE roots (defensive/transitive/build-script) — it satisfies reconciliation (C) without a code occurrence, provided `reason` (≥10 chars) + `owners` (enum) are valid. (`require` dropped from the `detectedBy` enum: verified no `require()` of an external crypto/auth dep exists in any workspace — Round-2 SEC-7; cli/extension have zero bare `require()` and the app is ESM. Re-add only if a CJS crypto import appears.)
+     - `excluded` is keyed by package name → `{ reason }`. Seeds: `ioredis`, `@sentry/nextjs`, `bowser`, `zod`, `@noble/hashes` (test-only), `@simplewebauthn/browser` (unimported), plus per-workspace non-crypto deps the CODE scan surfaces (`chalk`/`commander`/`cli-table3` cli; `tldts`/`react`/`react-dom` ext).
+     - Member-set of `packages` = full GT-6 three-workspace set (incl. `bcrypt-pbkdf`, `otpauth` in root+cli+ext, the prisma pair as `detectedBy:["manual"]` since they live outside the drift roots — see reconciliation (C) below).
+  2. New parity test `src/__tests__/checks/crypto-auth-deps-manifest.test.ts` (filesystem-only, mirrors `worker-policy-manifest.test.ts`), **all detection logic in pure exported functions** (like the template's `classifySweeps`) so each is independently self-testable. It computes the three sets and asserts the four reconciliation failures the user specified:
+     - **(A) new sensitive import unregistered**: a specifier in `CODE \ (MANIFEST ∪ excluded)` → finding. (Pure `computeCandidateDrift(code, manifest, excluded)`.)
+     - **(B) manifest entry vanished from package.json**: a `MANIFEST` package absent from its workspace `DEPS` → finding. (This is the presence check; a package legitimately removed must be removed from the manifest too.)
+     - **(C) sensitive package in package.json but not in CODE-derived set**: a `DEPS`-side crypto/auth-sensitive package (by manifest membership) whose code occurrence is absent → **finding UNLESS the manifest entry carries `detectedBy` including `manual` (or `dynamic-import`/`require` that the scanner then confirms)**. This is the case the user flagged as "not necessarily an error": `@prisma/adapter-pg`/`pg` (imported in `src/lib/prisma.ts`, outside the crypto/auth drift roots) and any defensive dep are represented as `detectedBy:["manual"]` with a reason, satisfying (C) without a drift-root code hit. This resolves Round-1 m1/F2 (the prisma-pair asymmetry) by making the code-not-imported case explicit and reasoned rather than silently list-only.
+     - **(D) empty reason or owners**: any `packages` entry with empty `reason` or empty `owners` → finding (metadata completeness).
+     - **import-evidence for `detectedBy` accuracy**: for `dynamic-import` members (`hash-wasm`, `bcrypt-pbkdf`), the scanner MUST resolve the `import()` specifier — including the **indirected `const moduleName = "<pkg>"; await import(moduleName)` shape** (recovering the name resolves the `const` binding to its string-literal initializer; net-new logic the template helpers lack → self-tested). For `static-import`, the specifier is found statically. A `detectedBy` claim contradicted by the code (e.g. marked `static-import` but only present dynamically) → finding.
+     - **negative self-tests (RT7, INV-C4d)** — for EACH pure function:
+       - (A) drift: planted un-manifested specifier → finding; excluded → none; in-manifest → none; `node:`/`@/`/`next`/`react`/relative → dropped.
+       - (B) presence (Round-2 T1 — the one gate previously lacking a *unit* negative): a manifest entry absent from a synthetic DEPS set → finding; present in DEPS → none. (Not only the committed-tree mutation — an isolated pure-function negative.)
+       - (C) code-not-imported reconciler, ALL THREE branches (Round-2 T2): a `manual`-marked entry with no code hit → NO finding; the same entry WITHOUT `manual` and no code hit → finding; **AND a `dynamic-import`-marked entry that the resolver DOES confirm in code → NO finding, but marked `dynamic-import` with NO confirmable dynamic occurrence → finding** (proving the dynamic-confirmed suppression branch, not just the manual allowance).
+       - (D) metadata: empty/`<10-char` `reason` → finding; `owners` empty or containing a value outside the OWNERS enum → finding (Round-2 SEC-6).
+       - dynamic resolver: `const x="hash-wasm"; await import(x)` → resolves to `hash-wasm`; `await import("bcrypt-pbkdf")` → resolves to `bcrypt-pbkdf`; dropping either from the manifest → an (A) finding (proving the dynamic member flows through the drift gate, not merely presence).
+       - DEPS name-pattern heuristic (Round-2 T3): a synthetic crypto-named dep (matching an enumerated pattern) present in DEPS but absent from CODE and MANIFEST → surfaced by the heuristic → (C) finding; a clearly-non-crypto name → not surfaced. Proves the R-3 backstop can actually fire.
+  3. Wire into the normal vitest run (rides `npx vitest run`; NOT the prisma-generate-free static-checks job). ts-morph (`parseRouteSource`) + `node:fs` only — no `@prisma/client` (INV-C4b).
+  4. **CODEOWNERS gate on BOTH the manifest AND its enforcing test (Round-2 SEC-6)**: the manifest lives at `scripts/checks/crypto-auth-deps-manifest.json` (already `@ngc-shj`-gated by `.github/CODEOWNERS:15` `/scripts/checks/**`). Add a CODEOWNERS rule gating `/src/__tests__/checks/**` to `@ngc-shj` so the parity test — which holds the reconciliation logic, the name-pattern heuristic, and the manual-allowance acceptance — cannot be weakened without owner review. Gating only the data file is insufficient: an ungated test could shrink the DEPS heuristic or loosen (D), a strictly more powerful bypass than editing the gated manifest.
+- **Invariants**:
+  - INV-C4a (three-set reconciliation, code-derived, ALL workspaces): the guard reconciles CODE ∪ DEPS ∪ MANIFEST per workspace and fails on failures (A)-(D); a prompt-supplied list cannot silently diverge from either code or package.json for root, cli, AND extension.
+  - INV-C4b: the guard imports NO `@prisma/client` (filesystem-only).
+  - INV-C4c: dynamic-import members are detected by resolving the `import()` specifier (incl. the indirected `const moduleName` form) to the package name, not by `from "…"`.
+  - INV-C4d (RT7): every pure detection function (drift differ, presence, code-not-imported reconciler incl. the dynamic-confirmed branch, metadata-completeness, dynamic-import resolver, DEPS name-pattern heuristic) has ≥1 self-test proving it returns a violation on planted-bad input AND passes on clean input.
+  - INV-C4e: the code-not-imported case (C) is NOT auto-failed — a `detectedBy:["manual"]` entry with a ≥10-char `reason` + an enum-valid `owners` is permitted (user directive), so defensive/transitive/outside-root deps are declarable without a forced code occurrence. The bypass is bounded by INV-C4f.
+  - INV-C4f (Round-2 SEC-6): both the manifest (`scripts/checks/crypto-auth-deps-manifest.json`) and its enforcing test (`src/__tests__/checks/**`) are CODEOWNERS-gated to `@ngc-shj`, so a `manual` allowance or a heuristic weakening requires owner review — the compensating control that makes the (C) manual-allowance an acceptable residual rather than a silent in-PR self-service bypass.
+- **Forbidden patterns**:
+  - `pattern: from ['"]@prisma/client['"]` in `crypto-auth-deps-manifest.test.ts` — reason: INV-C4b.
+- **Acceptance**:
+  - Manifest JSON parses; every `packages` entry has a ≥10-char `reason`, ≥1 enum-valid `owners`, `workspace`, `detectedBy`, `category`; member-set = GT-6 three-workspace set (incl. `nodemailer`, `resend`, `otpauth`×3, `bcrypt-pbkdf`, prisma pair as `static-import`).
+  - Reconciliation (A)-(D), import-evidence, the DEPS name-pattern heuristic, and ALL negative self-tests (INV-C4d) pass on the current tree.
+  - `.github/CODEOWNERS` gates BOTH `scripts/checks/crypto-auth-deps-manifest.json` (existing) and `src/__tests__/checks/**` (new rule) to `@ngc-shj` (INV-C4f).
+  - Removing a manifest package from its `package.json` → (B) RED; a new crypto import without a manifest entry → (A) RED; a `<10-char` reason or a non-enum owner → (D) RED; a non-`manual` entry whose code occurrence is absent → (C) RED; a `dynamic-import` entry the resolver can't confirm → (C) RED — each demonstrated once in Phase 2 (scratch, not committed), recorded in the deviation log.
+  - Consumer-flow: consumers are (i) the parity test (reads every field; `workspace` for DEPS selection, `detectedBy` for evidence-mode + the (C) allowances, `reason`/`owners` for (D)) and (ii) a human reviewer / Dependabot triage (reads `reason`/`owners`/`category` for review routing on a bump). Both consumers' required fields are present.
+
+## Testing strategy
+
+- C1: a concrete named `it(...)` (m3) asserting `cli/package.json` `publishConfig.provenance === true` AND the `release.yml` `--provenance` forbidden grep = 0. INV-C1b post-publish attestation assertion is `verifiable-CI` at release (VC1). Emission proven live today by GT-1.
+- C2: the `npm audit signatures` step IS its own test in CI (3 PR jobs + 1 weekly cron sweep); the anti-mask grep guard rides `pre-pr.sh` with a negative self-test (RT7). Phase 2 records the per-tree ≥1-signed-dep observation and a one-time can-fail demonstration (INV-C2c). The verifier is `verifiable-local` (network) but deliberately not in `pre-pr.sh` (offline-safety Anti-Deferral).
+- C3: YAML-parse + entry-count + no-auto-merge pure-function guard, wired into `pre-pr.sh` `run_step` + `static-checks` CI, with a negative self-test proving it fires on a planted `dependabot`+`--auto` fixture (RT7).
+- C4: the three-set reconciliation parity test — failures (A) unregistered import, (B) manifest-vanished-from-package.json, (C) sensitive-in-deps-not-in-code (allowing reasoned `detectedBy:["manual"]`), (D) empty reason/owners — each with its own RT7 negative self-test on a pure exported function, plus the dynamic-import (`const moduleName`) resolver self-test. Prove-it-fails demonstrated in Phase 2 (scratch mutations → RED per failure kind), recorded in the deviation log, not committed.
+- **Changes-filter mapping (m3 — Test F7)**: verify `dorny/paths-filter` globs in `ci.yml` route the new files to jobs that actually run — `scripts/checks/crypto-auth-deps-manifest.json` + `src/__tests__/checks/**` map to the filter output that gates the vitest job, and the audit jobs' filters cover the workspaces the C2 steps live in. State the mapping in the deviation log so a supply-chain PR exercises the gates it adds.
+- Regression gate: `npx vitest run` (full) + `scripts/pre-pr.sh` (static guards) must stay green. `npx next build` runs because a `package.json` is touched, though no runtime import graph changes (the touched `cli/package.json` is not in the app bundle).
+
+## Considerations & constraints
+
+### Scope contract
+- **SC1**: iOS Swift dependency monitoring — deferred. iOS uses xcodegen with no `Package.swift`/`Podfile` (GT-4); Dependabot's swift ecosystem has no manifest to read. Owner: a future PR if/when iOS adopts SPM. Anti-Deferral: adding a swift entry with no manifest is a no-op that Dependabot ignores; cost of a placeholder = confusion, benefit = zero → correctly deferred.
+- **SC2**: iOS distribution-artifact provenance (cosign/attestation of the app binary) — deferred. iOS ships via App Store Connect, not a GitHub-Actions-built artifact cosign can sign. Owner: out of the C-P1 npm scope entirely (roadmap SC2).
+- **SC3**: Additional GitHub Actions boundary guards (ban-`pull_request_target` guard, third-party action allowlist, `read-all` default) — deferred as **already-satisfied preventive controls** (GT-2). No `pull_request_target`/`workflow_run` exists, permissions are already scoped, actions already SHA-pinned + CODEOWNERS-gated. Anti-Deferral: adding a guard for a pattern that cannot currently occur is a preventive-only control with no present offender; the existing CODEOWNERS gate on `/.github/workflows/` already forces human review of any future `pull_request_target` introduction. Cost of the guard now > benefit (no offender) → deferred, revisit if a fork-triggered workflow is ever added.
+- **SC4**: Container-image SBOM/signing (cosign + syft) — deferred (roadmap SC1). No container release path exists in `release.yml` (release-please + npm CLI only); the `ci.yml:593` `docker build … -t passwd-sso:scan` image is ephemeral (Trivy scan only, never pushed). No producer to attach an SBOM/signature to. Owner: a future "containerize release" PR.
+- **SC5**: Blanket dependency-provenance *enforcement* (failing CI when any transitive dep lacks provenance) — deferred. Most of the npm ecosystem does not yet emit provenance; a hard gate would be permanently red. C2's `npm audit signatures` verifies signatures that DO exist and fails on tampering, which is the achievable bar today.
+
+### Risks
+- **R-1 (npm-version drift, mitigated by C1)**: relying on npm's default-provenance-under-OIDC is version-dependent; a runner npm downgrade could silently drop provenance. `publishConfig.provenance: true` makes it explicit. Residual: if a future npm removes support for the field, the next release's registry state (checked by C2 once published) surfaces it — but only post-hoc. Acceptable: this is a monitoring, not prevention, boundary; recorded here so a reviewer sees the residual.
+- **R-2 (C4 boundary subjectivity)**: the auth-flow/kdf/signature/otp vs support-dep line (GT-6 exclusions) is a judgment call. Mitigated by the `excluded[]` block with reasons IN the manifest, so reconciliation (A) is exact and a reviewer can contest a specific exclusion; and by the `owners`/`reason` metadata gate (D) forcing every included entry to carry an accountable owner.
+- **R-3 (false-green completeness check — residual)**: the CODE-set is derived per-workspace over defining roots (`src/lib/crypto`, `src/lib/auth`, `src/lib/prisma.ts`, auth entrypoints, WebAuthn/SAML routes, `src/components/passwords/shared/**`; `cli/src/**`; `extension/src/**`). A crypto/auth file added OUTSIDE these roots (e.g. a new `src/components/**` subtree importing a crypto lib) still escapes the CODE side — the same class as any rooted guard. **Residual mitigation via the three-set model**: because reconciliation (C) also flags a crypto/auth-sensitive `package.json` dep with no CODE occurrence (widened by the enumerated, self-tested name-pattern heuristic — Round-2 T3), a genuinely-new dep is caught on the DEPS side even if its file is outside the CODE roots — UNLESS it is name-pattern-invisible to the heuristic. The remaining blind spot is a new crypto dep whose name matches NONE of the heuristic patterns AND whose file is outside the CODE roots; recorded as the known limit. Widening the CODE roots to all of `src/**` was rejected (excessive noise from non-crypto imports); the DEPS-side (C) check with the pattern heuristic is the cheaper backstop, and adding `src/lib/email/**` to the roots (Round-2 SEC-5) shrank the blind spot by moving the magic-link transports onto the CODE side.
+
+## User operation scenarios
+
+- **Release**: maintainer merges the release-please PR → `release.yml` `publish-cli` runs `npm publish` with `publishConfig.provenance: true` under OIDC → registry receives the package + SLSA provenance attestation (as today, now explicit).
+- **Dependency bump**: Dependabot opens a weekly grouped npm PR → CI runs (including `npm audit signatures` + the crypto/auth manifest parity test) → maintainer reviews; if the bump touches a crypto/auth-listed package, the `category`/`reason` fields flag it for deeper review; merge is manual (no auto-merge).
+- **New crypto dep added by a developer**: developer adds a new signature library under `src/lib/auth/` + to `package.json` → C4 reconciliation (A) goes RED (new import in `CODE \ (MANIFEST ∪ excluded)`) → developer must add a `packages` entry (reason/owners/detectedBy/category) or an `excluded` entry, forcing a supply-chain review at add-time.
+- **Defensive/outside-root dep**: developer adds a crypto dep imported only in `src/lib/prisma.ts` (outside CODE roots) or present in `package.json` but not yet imported → reconciliation (C) goes RED UNLESS the entry is marked `detectedBy:["manual"]` with a non-empty reason/owners — the sanctioned path for defensive/transitive/outside-root deps.
+- **Manifest drift**: developer removes `hash-wasm` from `package.json` but leaves the manifest entry → reconciliation (B) goes RED. Removing `hash-wasm` from the manifest while it is still imported → (A) goes RED via the dynamic-import resolver.
+- **Metadata gap**: a developer adds a `packages` entry with an empty `reason` or `owners` → reconciliation (D) goes RED.
+
+## Implementation Checklist
+
+### Files to modify / create
+- **C1**: `cli/package.json` (add `publishConfig.provenance:true`); `.github/workflows/release.yml` (post-publish attestation assertion in `publish-cli`, after `npm publish`).
+- **C2**: `.github/workflows/ci.yml` (add `- run: npm audit signatures` to `audit-app`/`audit-ext`/`audit-cli`, each after `npm ci`); NEW `.github/workflows/dependency-signatures.yml` (weekly cron sweep, `contents: read`).
+- **C3**: `.github/dependabot.yml` (append 3 npm ecosystem entries); NEW `scripts/checks/check-dependabot-no-automerge.mjs` (pure guard, wired into `pre-pr.sh`).
+- **C2 anti-mask guard**: NEW `scripts/checks/check-audit-signatures-unmasked.mjs` (or fold into the dependabot guard as one workflow-lint guard), wired into `pre-pr.sh`.
+- **C4**: NEW `scripts/checks/crypto-auth-deps-manifest.json`; NEW `src/__tests__/checks/crypto-auth-deps-manifest.test.ts`; `.github/CODEOWNERS` (add `/src/__tests__/checks/**  @ngc-shj`).
+
+### Reusable patterns (MUST follow)
+- audit job step shape: `- run: npm ci` then `- run: npm audit signatures` (mirror `ci.yml:619/641/663`).
+- `.mjs` guard shape: `scripts/checks/check-*.mjs` (node:fs, no `@prisma/client`), wired as `run_step "Static: <name>" node scripts/checks/check-*.mjs` in `pre-pr.sh` (mirror `check-team-auth-rls.mjs` at the `run_step` block ~line 185).
+- C4 test: mirror `src/__tests__/workers/worker-policy-manifest.test.ts` — `import { parseRouteSource } from "../proxy/ast-guards"`, `ts-morph` `Node`/`SyntaxKind`, `node:fs` `readFileSync`/`readdirSync`, pure exported detection functions + a self-test `describe` block. NO `@prisma/client`.
+- SHA-pin any new `uses:` in the cron workflow (guard `check-actions-sha-pinned.sh` enforces).
+
+### CI parity
+- `app` paths-filter includes `src/**` + `scripts/**` (`ci.yml:37,48`) → the new manifest JSON + `src/__tests__/checks/**` trigger the App vitest job. Editing `ci.yml` sets `ci==true` → all 3 audit jobs run. `static-checks` runs `pre-pr.sh` unconditionally → the new `.mjs` guards fire. No parity gap.
+- `dorny/paths-filter` `ci:` output must include `.github/dependabot.yml` and `.github/workflows/dependency-signatures.yml`? Not required — those don't gate a test job; they are the artifacts themselves. Confirm no guard greps them expecting a filter entry.
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | `cli/package.json` explicit `publishConfig.provenance: true` + fail-closed post-publish attestation assertion (INV-C1b) | locked |
+| C2 | `npm audit signatures` verifier in 3 audit jobs + weekly cron sweep; un-masked exit; can-fail demonstrated (INV-C2c) | locked |
+| C3 | Dependabot npm ecosystems (root/cli/extension), no auto-merge (wired `pre-pr.sh` guard), no swift | locked |
+| C4 | crypto/auth 3-workspace sensitive-dep manifest + three-set reconciliation guard (A/B/C/D), per-function RT7 self-tests, CODEOWNERS-gated manifest+test, `≥10`-char reason + owners-enum | locked |
+
+Round 2 closed with no Critical and no open Major (both Round-2 Majors — SEC-5 member-set, SEC-6 control-gate — were reflected into the contracts above). All contracts re-locked after the Round-2 revisions.

--- a/docs/archive/review/p1-supply-chain-provenance-review.md
+++ b/docs/archive/review/p1-supply-chain-provenance-review.md
@@ -1,0 +1,50 @@
+# Plan Review: p1-supply-chain-provenance
+Date: 2026-07-16
+
+## Round 1
+Three experts reviewed against the real repo + live npm registry. Local-LLM pre-screen ran first (3 items addressed pre-review). Findings summary: 0 Critical, 5 Major, 3 Minor.
+
+### Round 1 Major
+- **M1** (Func F1 + Sec SEC-2 convergence): crypto/auth manifest covered only `src/**`; CLI (`bcrypt-pbkdf`, `otpauth`) + extension (`otpauth`) crypto deps invisible. → Extended GT-6 to all 3 workspaces.
+- **M2** (Func F3 + Sec SEC-1 convergence): `npm audit signatures` temporal/path-gating hole. → Added weekly cron sweep workflow.
+- **M3** (Sec SEC-3): forbidden-pattern guards inert unless wired into `pre-pr.sh` run_step. → Made wiring an explicit deliverable with negative self-tests.
+- **M4** (Test F1+F6): C4 completeness + hash-wasm dynamic-import resolver no proven-can-fail. → Pure exported functions + per-function RT7 self-tests.
+- **M5** (Test F2+F3): C2 / C3 verifiers lack negative self-tests. → C2 can-fail demonstration in Phase 2 + C3 pure-function guard + synthetic fixture.
+
+### Round 1 Minor
+- **m1** (Func F2): prisma pair listed but outside drift roots. → three-set reconciliation with (C) + `detectedBy:["manual"]`.
+- **m2** (Sec SEC-4): `publishConfig.provenance` fail-open on OIDC-context loss. → INV-C1b post-publish assertion.
+- **m3** (Test F4+F5+F7): C1 shape "or", C2 no pre-pr mirror, changes-filter mapping. → concrete named test, offline-safety Anti-Deferral, mapping recorded.
+
+**Round 1 also incorporated the user's directive** to redesign C4 as a THREE-SET reconciliation (CODE ∪ DEPS ∪ MANIFEST), object-keyed manifest with `detectedBy`/`owners`/`reason`, failing on (A) unregistered import, (B) manifest-vanished, (C) sensitive-in-deps-not-in-code (reasoned manual allowance), (D) empty reason/owners.
+
+## Round 2
+Incremental review of the revised plan. Summary: 0 Critical, 2 Major (both member-set/control gaps in the not-yet-implemented plan, correctable before merge), 5 Minor. One Round-1 fix (F2/prisma) produced a self-contradiction that R2 caught.
+
+### Round 2 Major (adopted)
+- **SEC-5** (Sec + Func F-R2-1 convergence — both experts independently reached `nodemailer`): `nodemailer` (^9.0.1) + `resend` (^6.9.2) are real magic-link auth-channel deps bare-imported at `src/lib/email/smtp-provider.ts:1` / `resend-provider.ts:1`, outside the original CODE roots, listed in neither `packages` nor `excluded`. **Self-verified true.** → Added `src/lib/email/**` to CODE roots; added `nodemailer`+`resend` as `auth-flow`/`static-import` members.
+- **SEC-6** (Sec): the (C) `detectedBy:["manual"]` allowance is an in-PR self-service bypass unless bound to CODEOWNERS + a validated `owners`. **Self-verified**: `.github/CODEOWNERS` gates `/scripts/checks/**` (manifest) but NOT `src/__tests__/checks/**` (the enforcing test). worker-policy template uses a `>=10-char reason` floor. → INV-C4f (CODEOWNERS-gate both files), reason ≥10 chars, `owners` from a fixed enum.
+
+### Round 2 Minor (adopted)
+- **SEC-7** (Sec): INV-C1b `npm view | jq -e` conflates absent-attestation vs network error, no pipefail. → prefer `npm audit signatures` post-publish; if `npm view`, pipefail + exit-check + predicateType assertion + retry-on-absent-only. Also verified: no `require()` of a crypto/auth dep in any workspace → dropped `require` from the `detectedBy` enum.
+- **m2 / F-R2-2** (Func, both rounds converge): prisma pair now in drift roots (`src/lib/prisma.ts` static import) → `detectedBy:["static-import"]`, not `manual` (the `manual` claim would trip the import-evidence contradiction check). → Corrected.
+- **m3** (Func): `@prisma/client` is a data-access boundary, not a crypto primitive. → `category: db-identity-store` with a note.
+- **T1** (Test): (B) presence lacked a *unit* negative self-test (only committed-tree mutation). → Added.
+- **T2** (Test): (C)'s `dynamic-import`-confirmed suppression branch unproven at unit level. → Added a self-test row for that third branch.
+- **T3** (Test): DEPS name-pattern heuristic (R-3 backstop) had no pattern list + no self-test. → Enumerated the regex set + negative self-test.
+
+### Round 2 Rejected (hallucination, self-verified)
+- **M1** (Func Round-2, first pass): "extension uses `@simplewebauthn/browser`, add it + make exclusions workspace-scoped." **REJECTED**: `@simplewebauthn/browser` is ABSENT from `extension/package.json` and NOT imported in `extension/src/**`; `webauthn-client.ts:5` is a comment saying the app deliberately uses the raw WebAuthn API. The **workspace-scoped exclusions** design principle was adopted; the `@simplewebauthn/browser` addition was not. (The Functionality expert self-corrected this in its final pass, converging with the Security expert.)
+
+## Convergence & verification note
+Both the member-set gaps (`nodemailer`/`resend`) were reached independently by the Functionality and Security experts (Round-2 SEC-5 / F-R2-1). Every load-bearing member-set claim was self-verified against the code by the orchestrator, because a prior investigation sub-agent had hallucinated non-existent files earlier this session — `nodemailer`/`resend`/`bcrypt-pbkdf`/`otpauth`×3 confirmed real; `@simplewebauthn/browser` confirmed absent. R42 was applied by re-deriving the three-workspace member-set from code, not from any supplied list.
+
+## Quality Warnings
+None — all findings carried concrete file/line evidence and verified repro.
+
+## Recurring Issue Check (condensed, both rounds)
+- **R42** (member-set code-derived): CENTRAL — drove M1/SEC-2 (3-workspace), SEC-5/F-R2-1 (email transports), and rejected the hallucinated extension webauthn addition. Final member-set re-derived from code across all 3 workspaces.
+- **R44 / RS5** (masked exit / fail-open): C2 anti-mask grep + wired guard + INV-C1b pipefail (SEC-7); no auto-merge (INV-C3a).
+- **R41 / RS2 / RS6** (unenforced capability, ungated surface, weak metadata gate): SEC-6 — CODEOWNERS-gate the enforcing test + reason floor + owners enum.
+- **RT7** (every guard proven-can-fail): all pure detection functions (drift/presence/reconciler-3-branches/metadata/dynamic-resolver/name-heuristic) now carry unit negative self-tests (INV-C4d).
+- **R29** (external spec citation): npm OIDC provenance + SLSA predicateType claims verified against the live GT-1 registry measurement.

--- a/scripts/__tests__/check-crypto-auth-deps-classified.test.mjs
+++ b/scripts/__tests__/check-crypto-auth-deps-classified.test.mjs
@@ -1,0 +1,19 @@
+/**
+ * RT7 self-test for check-crypto-auth-deps-classified.mjs.
+ */
+import { describe, it, expect } from "vitest";
+import { computeUnclassifiedDeps } from "../checks/check-crypto-auth-deps-classified.mjs";
+
+describe("computeUnclassifiedDeps (classification-completeness E)", () => {
+  it("flags a runtime dep that is neither classified nor excluded", () => {
+    const classified = new Set(["next-auth", "clsx"]);
+    expect(computeUnclassifiedDeps(["better-auth", "next-auth", "clsx"], classified)).toEqual([
+      "better-auth",
+    ]);
+  });
+
+  it("returns empty when every dep is classified", () => {
+    const classified = new Set(["next-auth", "clsx"]);
+    expect(computeUnclassifiedDeps(["next-auth", "clsx"], classified)).toEqual([]);
+  });
+});

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -153,6 +153,23 @@ describe("findMaskedVerifierViolations", () => {
     expect(findMaskedVerifierViolations(wf, "release.yml")).toHaveLength(1);
   });
 
+  it("flags a folded scalar with a trailing comment and an indentation indicator", () => {
+    const withComment = [
+      "    steps:",
+      "      - run: > # folded",
+      "          npm audit signatures",
+      "          || true",
+    ].join("\n");
+    expect(findMaskedVerifierViolations(withComment, "ci.yml")).toHaveLength(1);
+    const withIndent = [
+      "    steps:",
+      "      - run: >2",
+      "          npm audit signatures",
+      "          || true",
+    ].join("\n");
+    expect(findMaskedVerifierViolations(withIndent, "ci.yml")).toHaveLength(1);
+  });
+
   it("catches continue-on-error when npm view + attestations span separate lines", () => {
     // The real release.yml has `npm view` and `attestations` on different lines;
     // continue-on-error on such a workflow must still be caught.

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -115,6 +115,27 @@ describe("findMaskedVerifierViolations", () => {
     expect(findMaskedVerifierViolations(wf, "ci.yml")).toHaveLength(1);
   });
 
+  it("flags a mask split across a shell line-continuation", () => {
+    const wf = [
+      "    steps:",
+      "      - run: |",
+      "          npm audit signatures \\",
+      "            || true",
+    ].join("\n");
+    expect(findMaskedVerifierViolations(wf, "ci.yml")).toHaveLength(1);
+  });
+
+  it("flags continue-on-error in the expression form", () => {
+    const wf = [
+      "    steps:",
+      "      - run: npm audit signatures",
+      "        continue-on-error: ${{ true }}",
+    ].join("\n");
+    expect(
+      findMaskedVerifierViolations(wf, "ci.yml").some((m) => /continue-on-error/.test(m)),
+    ).toBe(true);
+  });
+
   it("flags a provenance assertion (optional-chaining shape) masked with || true", () => {
     // Mirrors the REAL release.yml assertion, which uses optional chaining
     // (j?.dist?.attestations) — the detector must tolerate the `?.`.

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -8,6 +8,7 @@ import { describe, it, expect } from "vitest";
 import {
   findAutoMergeViolation,
   findMaskedVerifierViolations,
+  findTrustedPublishNodeViolation,
 } from "../checks/check-workflow-supply-chain.mjs";
 
 describe("findAutoMergeViolation", () => {
@@ -210,5 +211,44 @@ describe("findMaskedVerifierViolations", () => {
         continue-on-error: true
 `;
     expect(findMaskedVerifierViolations(wf, "build.yml")).toEqual([]);
+  });
+});
+
+describe("findTrustedPublishNodeViolation", () => {
+  it("flags an npm-publish workflow that inherits node-version-file (Node 20)", () => {
+    const wf = [
+      "    steps:",
+      "      - uses: actions/setup-node@sha",
+      "        with:",
+      "          node-version-file: \".nvmrc\"",
+      "      - run: npm publish",
+    ].join("\n");
+    expect(findTrustedPublishNodeViolation(wf, "release.yml")).toMatch(/22\.14/);
+  });
+
+  it("passes an npm-publish workflow pinned to node-version 24", () => {
+    const wf = [
+      "    steps:",
+      "      - uses: actions/setup-node@sha",
+      "        with:",
+      "          node-version: \"24\"",
+      "      - run: npm publish",
+    ].join("\n");
+    expect(findTrustedPublishNodeViolation(wf, "release.yml")).toBeNull();
+  });
+
+  it("passes node-version 22.14.x", () => {
+    const wf = `          node-version: "22.14.0"\n      - run: npm publish\n`;
+    expect(findTrustedPublishNodeViolation(wf, "release.yml")).toBeNull();
+  });
+
+  it("flags node-version 20 explicitly for an npm-publish workflow", () => {
+    const wf = `          node-version: "20"\n      - run: npm publish\n`;
+    expect(findTrustedPublishNodeViolation(wf, "release.yml")).not.toBeNull();
+  });
+
+  it("returns null for a workflow that does not run npm publish", () => {
+    const wf = `          node-version-file: ".nvmrc"\n      - run: npm ci\n`;
+    expect(findTrustedPublishNodeViolation(wf, "ci.yml")).toBeNull();
   });
 });

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -1,0 +1,71 @@
+/**
+ * RT7 self-test for check-workflow-supply-chain.mjs — the guard must be
+ * provably able to fail. The current tree has zero auto-merge and no masked
+ * verifier, so the live guard passes trivially; these synthetic-string cases
+ * prove each detector fires on a planted violation and stays quiet on clean input.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  findAutoMergeViolation,
+  findMaskedVerifierViolations,
+} from "../checks/check-workflow-supply-chain.mjs";
+
+describe("findAutoMergeViolation", () => {
+  it("flags a workflow pairing dependabot with gh pr merge --auto", () => {
+    const wf = `
+on: pull_request
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - run: gh pr merge --auto --squash "$PR_URL"
+`;
+    expect(findAutoMergeViolation(wf, "automerge.yml")).toMatch(/dependabot/);
+  });
+
+  it("returns null for a dependabot-mentioning workflow with no merge command", () => {
+    const wf = `
+# dependabot config reference only
+jobs:
+  build:
+    steps:
+      - run: npm ci
+`;
+    expect(findAutoMergeViolation(wf, "build.yml")).toBeNull();
+  });
+
+  it("returns null for a merge command with no dependabot context", () => {
+    const wf = `
+jobs:
+  release:
+    steps:
+      - run: gh pr merge --auto "$PR"
+`;
+    expect(findAutoMergeViolation(wf, "release.yml")).toBeNull();
+  });
+});
+
+describe("findMaskedVerifierViolations", () => {
+  it("flags npm audit signatures masked with || true", () => {
+    const wf = `
+    steps:
+      - run: npm audit signatures || true
+`;
+    const v = findMaskedVerifierViolations(wf, "ci.yml");
+    expect(v).toHaveLength(1);
+    expect(v[0]).toMatch(/masked/);
+  });
+
+  it("flags npm audit signatures masked with ; true", () => {
+    const wf = `      - run: npm audit signatures ; true\n`;
+    expect(findMaskedVerifierViolations(wf, "ci.yml")).toHaveLength(1);
+  });
+
+  it("returns no violations for an unmasked npm audit signatures step", () => {
+    const wf = `
+    steps:
+      - run: npm audit signatures
+`;
+    expect(findMaskedVerifierViolations(wf, "ci.yml")).toEqual([]);
+  });
+});

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -110,9 +110,31 @@ describe("findMaskedVerifierViolations", () => {
     expect(findMaskedVerifierViolations(wf, "ci.yml")).toHaveLength(1);
   });
 
-  it("flags a provenance assertion masked with || true", () => {
-    const wf = `      - run: npm view pkg --json | jq .dist.attestations || true\n`;
+  it("flags npm audit signatures masked with || :", () => {
+    const wf = `      - run: npm audit signatures || :\n`;
+    expect(findMaskedVerifierViolations(wf, "ci.yml")).toHaveLength(1);
+  });
+
+  it("flags a provenance assertion (optional-chaining shape) masked with || true", () => {
+    // Mirrors the REAL release.yml assertion, which uses optional chaining
+    // (j?.dist?.attestations) — the detector must tolerate the `?.`.
+    const wf = `      - run: node -e "j?.dist?.attestations?.provenance" || true\n`;
     expect(findMaskedVerifierViolations(wf, "release.yml")).toHaveLength(1);
+  });
+
+  it("catches continue-on-error when npm view + attestations span separate lines", () => {
+    // The real release.yml has `npm view` and `attestations` on different lines;
+    // continue-on-error on such a workflow must still be caught.
+    const wf = `
+    steps:
+      - run: |
+          VIEW=$(npm view pkg --json)
+          echo "$VIEW" | jq .dist.attestations
+        continue-on-error: true
+`;
+    expect(
+      findMaskedVerifierViolations(wf, "release.yml").some((m) => /continue-on-error/.test(m)),
+    ).toBe(true);
   });
 
   it("flags continue-on-error on a verifier-running workflow", () => {

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -9,6 +9,7 @@ import {
   findAutoMergeViolation,
   findMaskedVerifierViolations,
   findTrustedPublishNodeViolation,
+  isTrustedPublishingNodeVersion,
 } from "../checks/check-workflow-supply-chain.mjs";
 
 describe("findAutoMergeViolation", () => {
@@ -250,5 +251,70 @@ describe("findTrustedPublishNodeViolation", () => {
   it("returns null for a workflow that does not run npm publish", () => {
     const wf = `          node-version-file: ".nvmrc"\n      - run: npm ci\n`;
     expect(findTrustedPublishNodeViolation(wf, "ci.yml")).toBeNull();
+  });
+
+  it("flags node-version 22.13.1 (below the 22.14 floor)", () => {
+    const wf = [
+      "jobs:",
+      "  publish:",
+      "    steps:",
+      "      - uses: actions/setup-node@sha",
+      "        with:",
+      "          node-version: \"22.13.1\"",
+      "      - run: npm publish",
+    ].join("\n");
+    expect(findTrustedPublishNodeViolation(wf, "release.yml")).not.toBeNull();
+  });
+
+  it("does NOT accept a Node-24 pin that lives in a different job than npm publish", () => {
+    const wf = [
+      "jobs:",
+      "  test:",
+      "    steps:",
+      "      - uses: actions/setup-node@sha",
+      "        with:",
+      "          node-version: \"24\"",
+      "  publish:",
+      "    steps:",
+      "      - uses: actions/setup-node@sha",
+      "        with:",
+      "          node-version-file: \".nvmrc\"",
+      "      - run: npm publish",
+    ].join("\n");
+    expect(findTrustedPublishNodeViolation(wf, "release.yml")).not.toBeNull();
+  });
+
+  it("passes when the publish job itself pins node-version 24 (sibling job irrelevant)", () => {
+    const wf = [
+      "jobs:",
+      "  test:",
+      "    steps:",
+      "      - run: npm ci",
+      "  publish:",
+      "    steps:",
+      "      - uses: actions/setup-node@sha",
+      "        with:",
+      "          node-version: \"24\"",
+      "      - run: npm publish",
+    ].join("\n");
+    expect(findTrustedPublishNodeViolation(wf, "release.yml")).toBeNull();
+  });
+});
+
+describe("isTrustedPublishingNodeVersion", () => {
+  it("rejects the 22.0-22.13 range and bare 22 / 22.x", () => {
+    for (const v of ["22", "22.0.0", "22.13.1", "22.x"]) {
+      expect(isTrustedPublishingNodeVersion(v), v).toBe(false);
+    }
+  });
+  it("accepts 22.14+, 23, 24, 24.x", () => {
+    for (const v of ["22.14.0", "22.15", "23", "24", "24.x"]) {
+      expect(isTrustedPublishingNodeVersion(v), v).toBe(true);
+    }
+  });
+  it("rejects below-22 majors", () => {
+    for (const v of ["20", "18.19.0"]) {
+      expect(isTrustedPublishingNodeVersion(v), v).toBe(false);
+    }
   });
 });

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -43,6 +43,50 @@ jobs:
 `;
     expect(findAutoMergeViolation(wf, "release.yml")).toBeNull();
   });
+
+  it("flags the peter-evans enable-pull-request-automerge action for dependabot", () => {
+    const wf = `
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: peter-evans/enable-pull-request-automerge@v3
+`;
+    expect(findAutoMergeViolation(wf, "automerge.yml")).toMatch(/auto-merge/);
+  });
+
+  it("flags an enablePullRequestAutoMerge GraphQL mutation for dependabot", () => {
+    const wf = `
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - run: gh api graphql -f query='mutation { enablePullRequestAutoMerge(input: {}) { clientMutationId } }'
+`;
+    expect(findAutoMergeViolation(wf, "automerge.yml")).not.toBeNull();
+  });
+
+  it("flags a REST pulls/N/merge call for dependabot", () => {
+    const wf = `
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - run: gh api -X PUT repos/o/r/pulls/123/merge
+`;
+    expect(findAutoMergeViolation(wf, "automerge.yml")).not.toBeNull();
+  });
+
+  it("does NOT false-positive on a bare 'git merge' near the word dependabot", () => {
+    const wf = `
+# dependabot bumps land on main
+jobs:
+  sync:
+    steps:
+      - run: git merge --no-ff origin/main
+`;
+    expect(findAutoMergeViolation(wf, "sync.yml")).toBeNull();
+  });
 });
 
 describe("findMaskedVerifierViolations", () => {
@@ -61,11 +105,40 @@ describe("findMaskedVerifierViolations", () => {
     expect(findMaskedVerifierViolations(wf, "ci.yml")).toHaveLength(1);
   });
 
+  it("flags npm audit signatures masked with || exit 0", () => {
+    const wf = `      - run: npm audit signatures || exit 0\n`;
+    expect(findMaskedVerifierViolations(wf, "ci.yml")).toHaveLength(1);
+  });
+
+  it("flags a provenance assertion masked with || true", () => {
+    const wf = `      - run: npm view pkg --json | jq .dist.attestations || true\n`;
+    expect(findMaskedVerifierViolations(wf, "release.yml")).toHaveLength(1);
+  });
+
+  it("flags continue-on-error on a verifier-running workflow", () => {
+    const wf = `
+    steps:
+      - run: npm audit signatures
+        continue-on-error: true
+`;
+    const v = findMaskedVerifierViolations(wf, "ci.yml");
+    expect(v.some((m) => /continue-on-error/.test(m))).toBe(true);
+  });
+
   it("returns no violations for an unmasked npm audit signatures step", () => {
     const wf = `
     steps:
       - run: npm audit signatures
 `;
     expect(findMaskedVerifierViolations(wf, "ci.yml")).toEqual([]);
+  });
+
+  it("does not flag continue-on-error in a workflow that runs no verifier", () => {
+    const wf = `
+    steps:
+      - run: npm ci
+        continue-on-error: true
+`;
+    expect(findMaskedVerifierViolations(wf, "build.yml")).toEqual([]);
   });
 });

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -125,6 +125,16 @@ describe("findMaskedVerifierViolations", () => {
     expect(findMaskedVerifierViolations(wf, "ci.yml")).toHaveLength(1);
   });
 
+  it("flags a mask folded across a YAML folded scalar (>)", () => {
+    const wf = [
+      "    steps:",
+      "      - run: >",
+      "          npm audit signatures",
+      "          || true",
+    ].join("\n");
+    expect(findMaskedVerifierViolations(wf, "ci.yml")).toHaveLength(1);
+  });
+
   it("flags continue-on-error in the expression form", () => {
     const wf = [
       "    steps:",

--- a/scripts/checks/check-crypto-auth-deps-classified.mjs
+++ b/scripts/checks/check-crypto-auth-deps-classified.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * CI guard (E): every runtime dependency of every npm workspace MUST be
+ * classified in scripts/checks/crypto-auth-deps-manifest.json as either a
+ * crypto/auth `packages` member OR an `excluded` support dep. A dependency in
+ * neither is unclassified — the exact hole the ts-morph reconciliation test
+ * leaves open when a dep is added outside the CODE roots with a name that misses
+ * the crypto name-heuristic (e.g. `better-auth`).
+ *
+ * This lives in a standalone .mjs guard (not only the vitest reconciliation
+ * test) BECAUSE the vitest test rides the `app-ci` job, which the ci.yml
+ * paths-filter runs only on `app || ci` — a PR touching ONLY cli/package.json or
+ * extension/package.json would enable just the `cli`/`extension` filter and skip
+ * the classification check. This guard is wired into scripts/pre-pr.sh, which the
+ * `static-checks` job runs UNCONDITIONALLY on every PR, so the completeness gate
+ * fires regardless of which workspace's deps changed.
+ *
+ * Filesystem + JSON only (no @prisma/client, no ts-morph) — safe in the
+ * generate-free static-checks job. The richer AST checks (A/C/detectedBy) stay
+ * in the vitest test.
+ */
+import { readFileSync } from "node:fs";
+
+const MANIFEST_PATH = "scripts/checks/crypto-auth-deps-manifest.json";
+const WORKSPACE_PACKAGE_JSON = {
+  root: "package.json",
+  cli: "cli/package.json",
+  extension: "extension/package.json",
+};
+
+/** Real package name for a manifest key (composite keys carry it in `package`). */
+function entryPackage(key, entry) {
+  return entry.package ?? key;
+}
+
+/** Runtime deps of a workspace not present in the manifest's packages union excluded. */
+export function computeUnclassifiedDeps(deps, classified) {
+  return deps.filter((d) => !classified.has(d)).sort();
+}
+
+function main() {
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  const violations = [];
+  for (const [workspace, pkgPath] of Object.entries(WORKSPACE_PACKAGE_JSON)) {
+    const classified = new Set();
+    for (const [key, entry] of Object.entries(manifest.packages)) {
+      if (entry.workspace === workspace) classified.add(entryPackage(key, entry));
+    }
+    for (const [key, entry] of Object.entries(manifest.excluded)) {
+      if (entry.workspace === workspace) classified.add(entryPackage(key, entry));
+    }
+    const deps = Object.keys(JSON.parse(readFileSync(pkgPath, "utf8")).dependencies ?? {});
+    for (const dep of computeUnclassifiedDeps(deps, classified)) {
+      violations.push(
+        `${workspace} (${pkgPath}): '${dep}' is unclassified — add it to packages (crypto/auth) or excluded (support dep) in ${MANIFEST_PATH}`,
+      );
+    }
+  }
+  if (violations.length > 0) {
+    console.error("crypto/auth deps classification-completeness guard failed:");
+    for (const v of violations) console.error(`  - ${v}`);
+    process.exit(1);
+  }
+  console.log("crypto/auth deps classification-completeness guard passed.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -128,11 +128,53 @@ function listWorkflowFiles() {
     .map((f) => join(WORKFLOWS_DIR, f));
 }
 
+export function isTrustedPublishingNodeVersion(version) {
+  const m = version.match(/^(\d+)(?:\.(\d+|x))?(?:\.(\d+|x))?$/);
+  if (!m) return false;
+  const major = Number(m[1]);
+  if (major > 22) return true;
+  if (major < 22) return false;
+  // major === 22: need an explicit numeric minor >= 14 (bare `22`/`22.x`
+  // resolves to the latest 22.x at runtime — not a reproducible >= 22.14).
+  if (m[2] === undefined || m[2] === "x") return false;
+  return Number(m[2]) >= 14;
+}
+
+function splitJobs(content) {
+  const lines = content.split("\n");
+  const jobsIdx = lines.findIndex((l) => /^jobs:\s*(#.*)?$/.test(l));
+  if (jobsIdx === -1) return [];
+  const jobs = [];
+  let current = null;
+  for (let i = jobsIdx + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^\S/.test(line) && line.trim() !== "") break;
+    const jobHeader = line.match(/^ {2}([A-Za-z0-9_-]+):\s*(#.*)?$/);
+    if (jobHeader) {
+      if (current) jobs.push(current);
+      current = { name: jobHeader[1], text: line + "\n" };
+    } else if (current) {
+      current.text += line + "\n";
+    }
+  }
+  if (current) jobs.push(current);
+  return jobs;
+}
+
 export function findTrustedPublishNodeViolation(content, name) {
   if (!/npm\s+publish/.test(content)) return null;
-  const okNode = /node-version:\s*["']?(2[2-9]|[3-9]\d)(\.\d+)*(\.x)?["']?/i.test(content);
-  if (!okNode) {
-    return `${name}: runs 'npm publish' (Trusted Publishing) but does not pin an explicit node-version >= 22.14 — OIDC publishing requires Node >= 22.14.0 (do not inherit the Node-20 .nvmrc)`;
+  const jobs = splitJobs(content);
+  const publishJobs = jobs.filter((j) => /npm\s+publish/.test(j.text));
+  // Fall back to whole-file evaluation if job-splitting finds no publish job,
+  // so the guard never silently passes on an unusual layout.
+  const targets = publishJobs.length > 0 ? publishJobs : [{ name: "(file)", text: content }];
+  for (const job of targets) {
+    const versions = [...job.text.matchAll(/node-version:\s*["']?([\d.x]+)["']?/gi)].map(
+      (mm) => mm[1],
+    );
+    if (!versions.some((v) => isTrustedPublishingNodeVersion(v))) {
+      return `${name} (job '${job.name}'): runs 'npm publish' (Trusted Publishing) but does not pin an explicit node-version >= 22.14 in that job — OIDC publishing requires Node >= 22.14.0 (do not inherit the Node-20 .nvmrc)`;
+    }
   }
   return null;
 }

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * CI guard: supply-chain workflow invariants.
+ *
+ *  1. No Dependabot auto-merge. Auto-merging an upstream version bump into a
+ *     password manager treats an untrusted upstream as trusted (tests do not
+ *     detect a supply-chain payload — event-stream/ua-parser-js/xz were all
+ *     patch/minor bumps that passed tests). Human review must stay required, so
+ *     no workflow may pair a `dependabot` trigger/context with a merge command.
+ *
+ *  2. `npm audit signatures` must never be exit-masked. A signature verifier
+ *     behind `|| true` / `; true` / `|| echo` is theater — a real tamper would
+ *     be swallowed. The same applies to the post-publish provenance assertion.
+ *
+ * The detection logic is exported as pure functions so it can be unit-tested
+ * with synthetic inputs (RT7 — the guard must be provably able to fail).
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const WORKFLOWS_DIR = ".github/workflows";
+
+/**
+ * Returns a violation string if the workflow content pairs a dependabot
+ * trigger/context with an auto-merge command, else null.
+ * @param {string} content
+ * @param {string} name
+ * @returns {string | null}
+ */
+export function findAutoMergeViolation(content, name) {
+  const mentionsDependabot = /dependabot/i.test(content);
+  if (!mentionsDependabot) return null;
+  const mergeRe = /gh\s+pr\s+merge|--auto\b|--merge\b|pull-request\/merge/i;
+  if (mergeRe.test(content)) {
+    return `${name}: workflow references 'dependabot' and a merge command (gh pr merge / --auto) — Dependabot auto-merge is forbidden (human review required)`;
+  }
+  return null;
+}
+
+/**
+ * Returns violation strings for any `npm audit signatures` or provenance
+ * assertion whose exit status is masked by a trailing || true / ; true / || echo.
+ * @param {string} content
+ * @param {string} name
+ * @returns {string[]}
+ */
+export function findMaskedVerifierViolations(content, name) {
+  const violations = [];
+  const lines = content.split("\n");
+  const maskRe = /(\|\|\s*true|;\s*true|\|\|\s*:\s*$|\|\|\s*echo)\b/;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/audit\s+signatures/.test(line) && maskRe.test(line)) {
+      violations.push(
+        `${name}:${i + 1}: 'npm audit signatures' exit status is masked (|| true / ; true / || echo) — the verifier must fail closed`,
+      );
+    }
+  }
+  return violations;
+}
+
+function listWorkflowFiles() {
+  return readdirSync(WORKFLOWS_DIR)
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+    .map((f) => join(WORKFLOWS_DIR, f));
+}
+
+function main() {
+  const violations = [];
+  for (const file of listWorkflowFiles()) {
+    const content = readFileSync(file, "utf8");
+    const autoMerge = findAutoMergeViolation(content, file);
+    if (autoMerge) violations.push(autoMerge);
+    violations.push(...findMaskedVerifierViolations(content, file));
+  }
+  if (violations.length > 0) {
+    console.error("Supply-chain workflow guard failed:");
+    for (const v of violations) console.error(`  - ${v}`);
+    process.exit(1);
+  }
+  console.log("Supply-chain workflow guard passed.");
+}
+
+// Run only when invoked directly, not when imported by the self-test.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -69,9 +69,23 @@ export function findMaskedVerifierViolations(content, name) {
   // is caught. Track the original 1-based line number of each logical line's start.
   const rawLines = content.split("\n");
   const logical = [];
+  const indentOf = (s) => (s.match(/^\s*/)?.[0].length ?? 0);
   for (let i = 0; i < rawLines.length; i += 1) {
     let joined = rawLines[i];
     const start = i;
+    const blockMatch = joined.match(/(^\s*)(?:-\s+)?run:\s*[>|][+-]?\s*$/);
+    if (blockMatch && i + 1 < rawLines.length) {
+      const baseIndent = blockMatch[1].length;
+      while (
+        i + 1 < rawLines.length &&
+        (rawLines[i + 1].trim() === "" || indentOf(rawLines[i + 1]) > baseIndent)
+      ) {
+        joined += " " + rawLines[i + 1].trim();
+        i += 1;
+      }
+      logical.push({ text: joined, line: start + 1 });
+      continue;
+    }
     while (/\\\s*$/.test(joined) && i + 1 < rawLines.length) {
       joined = joined.replace(/\\\s*$/, " ") + rawLines[i + 1];
       i += 1;

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -73,7 +73,9 @@ export function findMaskedVerifierViolations(content, name) {
   for (let i = 0; i < rawLines.length; i += 1) {
     let joined = rawLines[i];
     const start = i;
-    const blockMatch = joined.match(/(^\s*)(?:-\s+)?run:\s*[>|][+-]?\s*$/);
+    // Block-scalar header: `>`/`|` then indentation- and chomping-indicators in
+    // any order (`>2`, `|-`, `>2-`, `|+2`), then an optional trailing comment.
+    const blockMatch = joined.match(/(^\s*)(?:-\s+)?run:\s*[>|][0-9+-]*\s*(#.*)?$/);
     if (blockMatch && i + 1 < rawLines.length) {
       const baseIndent = blockMatch[1].length;
       while (

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -39,8 +39,13 @@ const WORKFLOWS_DIR = ".github/workflows";
 export function findAutoMergeViolation(content, name) {
   const mentionsDependabot = /dependabot/i.test(content);
   if (!mentionsDependabot) return null;
+  // Each alternative uses a single bounded character class (no overlapping
+  // greedy groups) so the pattern is linear — no ReDoS surface on hostile
+  // workflow content. `pulls\/[^\s]*\/merge` covers every `gh api … pulls/N/merge`
+  // REST shape, so no separate `gh api …` alternative is needed. `merge-dependabot`
+  // and `pulls.merge` cover the fastify action and github-script REST client.
   const mergeRe =
-    /gh\s+pr\s+merge|--auto\b|enable-pull-request-automerge|enablePullRequestAutoMerge|gh\s+api[^\n]*pulls\/[^\n]*\/merge|pulls\/[^\s]*\/merge|pull-request\/merge/i;
+    /gh\s+pr\s+merge|--auto\b|enable-pull-request-automerge|enablePullRequestAutoMerge|merge-dependabot|pulls\.merge|pulls\/[^\s]*\/merge|pull-request\/merge/i;
   if (mergeRe.test(content)) {
     return `${name}: workflow references 'dependabot' and an auto-merge command — Dependabot auto-merge is forbidden (human review required)`;
   }
@@ -60,18 +65,22 @@ export function findAutoMergeViolation(content, name) {
 export function findMaskedVerifierViolations(content, name) {
   const violations = [];
   const lines = content.split("\n");
-  const verifierRe = /audit\s+signatures|npm\s+view[^\n]*attestations|dist\.attestations/;
-  const maskRe = /(\|\|\s*(true|:|exit\s+0|echo)|;\s*(true|exit\s+0))\b/;
-  let runsVerifier = false;
+  // `dist\??\.attestations` tolerates optional chaining (`j?.dist?.attestations`
+  // in the real release.yml assertion). `runsVerifier` is a WORKFLOW-level flag,
+  // not per-line, so a `npm view` and an `attestations` reference on separate
+  // lines still mark the workflow as verifier-running.
+  const verifierLineRe = /audit\s+signatures|dist\??\.attestations/;
+  const runsVerifier =
+    /audit\s+signatures/.test(content) ||
+    (/npm\s+view/.test(content) && /attestations/.test(content));
+  // `:` needs a lookahead boundary (a trailing \b never matches after non-word `:`).
+  const maskRe = /(\|\|\s*(true|exit\s+0|echo)|;\s*(true|exit\s+0)|\|\|\s*:(?=\s|$))/;
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i];
-    if (verifierRe.test(line)) {
-      runsVerifier = true;
-      if (maskRe.test(line)) {
-        violations.push(
-          `${name}:${i + 1}: supply-chain verifier exit status is masked (|| true / ; true / || exit 0 / || echo) — it must fail closed`,
-        );
-      }
+    if (verifierLineRe.test(line) && maskRe.test(line)) {
+      violations.push(
+        `${name}:${i + 1}: supply-chain verifier exit status is masked (|| true / ; true / || exit 0 / || : / || echo) — it must fail closed`,
+      );
     }
   }
   // A workflow-level continue-on-error on a verifier-running workflow silently

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -128,12 +128,23 @@ function listWorkflowFiles() {
     .map((f) => join(WORKFLOWS_DIR, f));
 }
 
+export function findTrustedPublishNodeViolation(content, name) {
+  if (!/npm\s+publish/.test(content)) return null;
+  const okNode = /node-version:\s*["']?(2[2-9]|[3-9]\d)(\.\d+)*(\.x)?["']?/i.test(content);
+  if (!okNode) {
+    return `${name}: runs 'npm publish' (Trusted Publishing) but does not pin an explicit node-version >= 22.14 — OIDC publishing requires Node >= 22.14.0 (do not inherit the Node-20 .nvmrc)`;
+  }
+  return null;
+}
+
 function main() {
   const violations = [];
   for (const file of listWorkflowFiles()) {
     const content = readFileSync(file, "utf8");
     const autoMerge = findAutoMergeViolation(content, file);
     if (autoMerge) violations.push(autoMerge);
+    const nodePin = findTrustedPublishNodeViolation(content, file);
+    if (nodePin) violations.push(nodePin);
     violations.push(...findMaskedVerifierViolations(content, file));
   }
   if (violations.length > 0) {

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -64,7 +64,20 @@ export function findAutoMergeViolation(content, name) {
  */
 export function findMaskedVerifierViolations(content, name) {
   const violations = [];
-  const lines = content.split("\n");
+  // Join shell line-continuations (`… \` + newline) into one logical line BEFORE
+  // scanning, so a mask split across lines (`npm audit signatures \` / `  || true`)
+  // is caught. Track the original 1-based line number of each logical line's start.
+  const rawLines = content.split("\n");
+  const logical = [];
+  for (let i = 0; i < rawLines.length; i += 1) {
+    let joined = rawLines[i];
+    const start = i;
+    while (/\\\s*$/.test(joined) && i + 1 < rawLines.length) {
+      joined = joined.replace(/\\\s*$/, " ") + rawLines[i + 1];
+      i += 1;
+    }
+    logical.push({ text: joined, line: start + 1 });
+  }
   // `dist\??\.attestations` tolerates optional chaining (`j?.dist?.attestations`
   // in the real release.yml assertion). `runsVerifier` is a WORKFLOW-level flag,
   // not per-line, so a `npm view` and an `attestations` reference on separate
@@ -75,17 +88,17 @@ export function findMaskedVerifierViolations(content, name) {
     (/npm\s+view/.test(content) && /attestations/.test(content));
   // `:` needs a lookahead boundary (a trailing \b never matches after non-word `:`).
   const maskRe = /(\|\|\s*(true|exit\s+0|echo)|;\s*(true|exit\s+0)|\|\|\s*:(?=\s|$))/;
-  for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i];
-    if (verifierLineRe.test(line) && maskRe.test(line)) {
+  for (const { text, line } of logical) {
+    if (verifierLineRe.test(text) && maskRe.test(text)) {
       violations.push(
-        `${name}:${i + 1}: supply-chain verifier exit status is masked (|| true / ; true / || exit 0 / || : / || echo) — it must fail closed`,
+        `${name}:${line}: supply-chain verifier exit status is masked (|| true / ; true / || exit 0 / || : / || echo) — it must fail closed`,
       );
     }
   }
   // A workflow-level continue-on-error on a verifier-running workflow silently
-  // downgrades a red verifier to a soft warning.
-  if (runsVerifier && /continue-on-error:\s*true/i.test(content)) {
+  // downgrades a red verifier to a soft warning — including the `${{ true }}`
+  // expression form and a bare `true`.
+  if (runsVerifier && /continue-on-error:\s*(\$\{\{\s*)?true/i.test(content)) {
     violations.push(
       `${name}: a verifier-running workflow sets 'continue-on-error: true' — remove it so the verifier fails closed`,
     );

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -6,11 +6,18 @@
  *     password manager treats an untrusted upstream as trusted (tests do not
  *     detect a supply-chain payload — event-stream/ua-parser-js/xz were all
  *     patch/minor bumps that passed tests). Human review must stay required, so
- *     no workflow may pair a `dependabot` trigger/context with a merge command.
+ *     no workflow may pair a `dependabot` context with an auto-merge command.
  *
- *  2. `npm audit signatures` must never be exit-masked. A signature verifier
- *     behind `|| true` / `; true` / `|| echo` is theater — a real tamper would
- *     be swallowed. The same applies to the post-publish provenance assertion.
+ *  2. A supply-chain verifier (`npm audit signatures`, or the post-publish
+ *     provenance assertion `npm view … dist.attestations`) must never be
+ *     exit-masked. A verifier behind `|| true` / `; true` / `|| exit 0` /
+ *     `continue-on-error` is theater — a real tamper would be swallowed.
+ *
+ * PRIMARY control note: `/.github/workflows/` is CODEOWNERS-gated to @ngc-shj,
+ * so ANY new auto-merge or verifier-masking workflow — in any shape — already
+ * requires owner review to land. These regex checks are DEFENSE-IN-DEPTH: they
+ * catch the common shapes fast in `pre-pr.sh`, but a per-file grep cannot see a
+ * cross-file reusable-workflow auto-merge split, so CODEOWNERS is the backstop.
  *
  * The detection logic is exported as pure functions so it can be unit-tested
  * with synthetic inputs (RT7 — the guard must be provably able to fail).
@@ -21,8 +28,10 @@ import { join } from "node:path";
 const WORKFLOWS_DIR = ".github/workflows";
 
 /**
- * Returns a violation string if the workflow content pairs a dependabot
- * trigger/context with an auto-merge command, else null.
+ * Returns a violation string if the workflow content pairs a dependabot context
+ * with an auto-merge command, else null. Covers the documented Dependabot
+ * auto-merge shapes; a cross-file reusable-workflow split is out of a per-file
+ * grep's reach and is backstopped by CODEOWNERS (see header).
  * @param {string} content
  * @param {string} name
  * @returns {string | null}
@@ -30,16 +39,20 @@ const WORKFLOWS_DIR = ".github/workflows";
 export function findAutoMergeViolation(content, name) {
   const mentionsDependabot = /dependabot/i.test(content);
   if (!mentionsDependabot) return null;
-  const mergeRe = /gh\s+pr\s+merge|--auto\b|--merge\b|pull-request\/merge/i;
+  const mergeRe =
+    /gh\s+pr\s+merge|--auto\b|enable-pull-request-automerge|enablePullRequestAutoMerge|gh\s+api[^\n]*pulls\/[^\n]*\/merge|pulls\/[^\s]*\/merge|pull-request\/merge/i;
   if (mergeRe.test(content)) {
-    return `${name}: workflow references 'dependabot' and a merge command (gh pr merge / --auto) — Dependabot auto-merge is forbidden (human review required)`;
+    return `${name}: workflow references 'dependabot' and an auto-merge command — Dependabot auto-merge is forbidden (human review required)`;
   }
   return null;
 }
 
 /**
- * Returns violation strings for any `npm audit signatures` or provenance
- * assertion whose exit status is masked by a trailing || true / ; true / || echo.
+ * Returns violation strings for any supply-chain verifier — `npm audit
+ * signatures` or the post-publish provenance assertion (`npm view` reading
+ * `dist.attestations`) — whose exit status is masked (|| true / ; true /
+ * || exit 0 / || : / || echo), or a step-level `continue-on-error: true`
+ * anywhere in a workflow that runs such a verifier.
  * @param {string} content
  * @param {string} name
  * @returns {string[]}
@@ -47,14 +60,26 @@ export function findAutoMergeViolation(content, name) {
 export function findMaskedVerifierViolations(content, name) {
   const violations = [];
   const lines = content.split("\n");
-  const maskRe = /(\|\|\s*true|;\s*true|\|\|\s*:\s*$|\|\|\s*echo)\b/;
+  const verifierRe = /audit\s+signatures|npm\s+view[^\n]*attestations|dist\.attestations/;
+  const maskRe = /(\|\|\s*(true|:|exit\s+0|echo)|;\s*(true|exit\s+0))\b/;
+  let runsVerifier = false;
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i];
-    if (/audit\s+signatures/.test(line) && maskRe.test(line)) {
-      violations.push(
-        `${name}:${i + 1}: 'npm audit signatures' exit status is masked (|| true / ; true / || echo) — the verifier must fail closed`,
-      );
+    if (verifierRe.test(line)) {
+      runsVerifier = true;
+      if (maskRe.test(line)) {
+        violations.push(
+          `${name}:${i + 1}: supply-chain verifier exit status is masked (|| true / ; true / || exit 0 / || echo) — it must fail closed`,
+        );
+      }
     }
+  }
+  // A workflow-level continue-on-error on a verifier-running workflow silently
+  // downgrades a red verifier to a soft warning.
+  if (runsVerifier && /continue-on-error:\s*true/i.test(content)) {
+    violations.push(
+      `${name}: a verifier-running workflow sets 'continue-on-error: true' — remove it so the verifier fails closed`,
+    );
   }
   return violations;
 }

--- a/scripts/checks/crypto-auth-deps-manifest.json
+++ b/scripts/checks/crypto-auth-deps-manifest.json
@@ -1,0 +1,127 @@
+{
+  "$note": "Crypto/auth-sensitive npm dependency manifest across all three npm workspaces (root/cli/extension). Reconciled by src/__tests__/checks/crypto-auth-deps-manifest.test.ts against (1) CODE imports derived via ts-morph AST over the crypto/auth roots, (2) each workspace package.json dependencies, (3) this manifest. A bump to any listed package should trigger deeper supply-chain review; a NEW crypto/auth import must be added here (or to excluded[]). Both this file and its enforcing test are CODEOWNERS-gated.",
+  "owners_enum": ["security"],
+  "packages": {
+    "next-auth": {
+      "workspace": "root",
+      "reason": "Core authentication framework (Auth.js v5): session strategy, OAuth/SAML/passkey/magic-link providers.",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "auth-flow"
+    },
+    "@auth/prisma-adapter": {
+      "workspace": "root",
+      "reason": "Auth.js Prisma adapter backing the database session store.",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "auth-flow"
+    },
+    "@simplewebauthn/server": {
+      "workspace": "root",
+      "reason": "WebAuthn/passkey registration + authentication verification boundary.",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "signature"
+    },
+    "@simplewebauthn/types": {
+      "workspace": "root",
+      "reason": "WebAuthn type contracts used at the passkey verification boundary.",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "signature"
+    },
+    "hash-wasm": {
+      "workspace": "root",
+      "reason": "Argon2id password KDF (WASM) for vault wrapping-key derivation.",
+      "detectedBy": ["dynamic-import"],
+      "owners": ["security"],
+      "category": "kdf"
+    },
+    "@prisma/adapter-pg": {
+      "workspace": "root",
+      "reason": "Postgres driver adapter for the identity/session/token store.",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "db-identity-store"
+    },
+    "pg": {
+      "workspace": "root",
+      "reason": "Postgres driver underlying the identity/session/token store.",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "db-identity-store"
+    },
+    "@prisma/client": {
+      "workspace": "root",
+      "reason": "ORM for all identity/session/token tables (data-access boundary, not a crypto primitive).",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "db-identity-store"
+    },
+    "nodemailer": {
+      "workspace": "root",
+      "reason": "SMTP transport for the magic-link auth channel that carries the session-granting token.",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "auth-flow"
+    },
+    "resend": {
+      "workspace": "root",
+      "reason": "Resend transport for the magic-link auth channel that carries the session-granting token.",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "auth-flow"
+    },
+    "otpauth": {
+      "workspace": "root",
+      "reason": "TOTP (2FA shared-secret OTP) generation in the vault entry TOTP field.",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "otp"
+    },
+    "otpauth@cli": {
+      "package": "otpauth",
+      "workspace": "cli",
+      "reason": "TOTP (2FA shared-secret OTP) generation in the CLI.",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "otp"
+    },
+    "otpauth@extension": {
+      "package": "otpauth",
+      "workspace": "extension",
+      "reason": "TOTP (2FA shared-secret OTP) generation in the browser extension.",
+      "detectedBy": ["static-import"],
+      "owners": ["security"],
+      "category": "otp"
+    },
+    "bcrypt-pbkdf": {
+      "workspace": "cli",
+      "reason": "OpenSSH-key KDF that decrypts encrypted SSH private keys in the CLI.",
+      "detectedBy": ["dynamic-import"],
+      "owners": ["security"],
+      "category": "kdf"
+    }
+  },
+  "excluded": {
+    "ioredis": { "workspace": "root", "reason": "Session-cache transport, not a crypto/auth primitive." },
+    "@sentry/nextjs": { "workspace": "root", "reason": "Error reporting, not a crypto/auth primitive." },
+    "bowser": { "workspace": "root", "reason": "User-agent parsing for new-device detection, not a crypto/auth primitive." },
+    "zod": { "workspace": "root", "reason": "Input validation, not a crypto/auth primitive." },
+    "@noble/hashes": { "workspace": "root", "reason": "Test-only oracle (devDependency, *.test.ts) for crypto conformance vectors; not a runtime path." },
+    "@simplewebauthn/browser": { "workspace": "root", "reason": "Production dep but not imported anywhere; the app uses the raw WebAuthn API instead (see webauthn-client.ts)." },
+    "lucide-react": { "workspace": "root", "reason": "Icon components (UI), not a crypto/auth primitive; imported in the shared component tree alongside the TOTP field." },
+    "next-intl": { "workspace": "root", "reason": "i18n framework (UI), not a crypto/auth primitive; imported in the shared component tree." },
+    "react-markdown": { "workspace": "root", "reason": "Markdown rendering (UI), not a crypto/auth primitive; imported in the shared component tree." },
+    "remark-gfm": { "workspace": "root", "reason": "Markdown GFM plugin (UI), not a crypto/auth primitive; imported in the shared component tree." },
+    "chalk": { "workspace": "cli", "reason": "CLI terminal styling, not a crypto/auth primitive." },
+    "commander": { "workspace": "cli", "reason": "CLI argument parsing, not a crypto/auth primitive." },
+    "cli-table3": { "workspace": "cli", "reason": "CLI table rendering, not a crypto/auth primitive." },
+    "clipboardy": { "workspace": "cli", "reason": "Clipboard access, not a crypto/auth primitive." },
+    "inquirer": { "workspace": "cli", "reason": "CLI interactive prompts, not a crypto/auth primitive." },
+    "zod@cli": { "package": "zod", "workspace": "cli", "reason": "Input validation, not a crypto/auth primitive." },
+    "tldts": { "workspace": "extension", "reason": "Public-suffix/domain parsing for autofill origin matching, not a crypto/auth primitive." },
+    "react": { "workspace": "extension", "reason": "UI framework, not a crypto/auth primitive." },
+    "react-dom": { "workspace": "extension", "reason": "UI framework, not a crypto/auth primitive." }
+  }
+}

--- a/scripts/checks/crypto-auth-deps-manifest.json
+++ b/scripts/checks/crypto-auth-deps-manifest.json
@@ -114,6 +114,23 @@
     "next-intl": { "workspace": "root", "reason": "i18n framework (UI), not a crypto/auth primitive; imported in the shared component tree." },
     "react-markdown": { "workspace": "root", "reason": "Markdown rendering (UI), not a crypto/auth primitive; imported in the shared component tree." },
     "remark-gfm": { "workspace": "root", "reason": "Markdown GFM plugin (UI), not a crypto/auth primitive; imported in the shared component tree." },
+    "@hookform/resolvers": { "workspace": "root", "reason": "react-hook-form validation resolver (UI form glue), not a crypto/auth primitive." },
+    "@swc/helpers": { "workspace": "root", "reason": "SWC runtime helpers (build output), not a crypto/auth primitive." },
+    "class-variance-authority": { "workspace": "root", "reason": "Tailwind class variant helper (UI), not a crypto/auth primitive." },
+    "clsx": { "workspace": "root", "reason": "className concatenation (UI), not a crypto/auth primitive." },
+    "dotenv": { "workspace": "root", "reason": "Loads .env into process.env; not a crypto/auth primitive (no cryptographic secret handling)." },
+    "file-type": { "workspace": "root", "reason": "Magic-byte MIME detection for uploads; content-type sniffing, not a crypto/auth primitive." },
+    "jsqr": { "workspace": "root", "reason": "QR image decoding (UI, e.g. TOTP setup scan); not a crypto/auth primitive — the OTP secret is handled by otpauth." },
+    "next": { "workspace": "root", "reason": "Next.js framework, not a crypto/auth primitive." },
+    "next-themes": { "workspace": "root", "reason": "Theme switching (UI), not a crypto/auth primitive." },
+    "pino": { "workspace": "root", "reason": "Structured logging, not a crypto/auth primitive." },
+    "radix-ui": { "workspace": "root", "reason": "Headless UI primitives, not a crypto/auth primitive." },
+    "react": { "workspace": "root", "reason": "UI framework, not a crypto/auth primitive." },
+    "react-dom": { "workspace": "root", "reason": "UI framework, not a crypto/auth primitive." },
+    "react-hook-form": { "workspace": "root", "reason": "Form state (UI), not a crypto/auth primitive." },
+    "sonner": { "workspace": "root", "reason": "Toast notifications (UI), not a crypto/auth primitive." },
+    "tailwind-merge": { "workspace": "root", "reason": "Tailwind class merge helper (UI), not a crypto/auth primitive." },
+    "undici": { "workspace": "root", "reason": "HTTP client for outbound webhook delivery; transport, not a crypto/auth primitive (webhook signing lives in app code)." },
     "chalk": { "workspace": "cli", "reason": "CLI terminal styling, not a crypto/auth primitive." },
     "commander": { "workspace": "cli", "reason": "CLI argument parsing, not a crypto/auth primitive." },
     "cli-table3": { "workspace": "cli", "reason": "CLI table rendering, not a crypto/auth primitive." },
@@ -121,7 +138,7 @@
     "inquirer": { "workspace": "cli", "reason": "CLI interactive prompts, not a crypto/auth primitive." },
     "zod@cli": { "package": "zod", "workspace": "cli", "reason": "Input validation, not a crypto/auth primitive." },
     "tldts": { "workspace": "extension", "reason": "Public-suffix/domain parsing for autofill origin matching, not a crypto/auth primitive." },
-    "react": { "workspace": "extension", "reason": "UI framework, not a crypto/auth primitive." },
-    "react-dom": { "workspace": "extension", "reason": "UI framework, not a crypto/auth primitive." }
+    "react@extension": { "package": "react", "workspace": "extension", "reason": "UI framework, not a crypto/auth primitive." },
+    "react-dom@extension": { "package": "react-dom", "workspace": "extension", "reason": "UI framework, not a crypto/auth primitive." }
   }
 }

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -168,6 +168,7 @@ run_step "Static: passkey-mint-gate" bash scripts/checks/check-passkey-mint-gate
 run_step "Static: raw-body-read" bash scripts/checks/check-raw-body-read.sh
 run_step "Static: actions-sha-pinned" bash scripts/checks/check-actions-sha-pinned.sh
 run_step "Static: workflow-supply-chain" node scripts/checks/check-workflow-supply-chain.mjs
+run_step "Static: crypto-auth-deps-classified" node scripts/checks/check-crypto-auth-deps-classified.mjs
 run_step "Static: dockerfile-prisma-pin" bash scripts/checks/check-dockerfile-prisma-pin.sh
 run_step "Static: ios-no-diagnostic-logging" bash scripts/checks/check-ios-no-diagnostic-logging.sh
 run_step "Static: ios-authenticated-session-pinning" bash scripts/checks/check-ios-authenticated-session-pinning.sh

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -167,6 +167,7 @@ run_step "Static: step-up-client-coverage" bash scripts/checks/check-step-up-cli
 run_step "Static: passkey-mint-gate" bash scripts/checks/check-passkey-mint-gate.sh
 run_step "Static: raw-body-read" bash scripts/checks/check-raw-body-read.sh
 run_step "Static: actions-sha-pinned" bash scripts/checks/check-actions-sha-pinned.sh
+run_step "Static: workflow-supply-chain" node scripts/checks/check-workflow-supply-chain.mjs
 run_step "Static: dockerfile-prisma-pin" bash scripts/checks/check-dockerfile-prisma-pin.sh
 run_step "Static: ios-no-diagnostic-logging" bash scripts/checks/check-ios-no-diagnostic-logging.sh
 run_step "Static: ios-authenticated-session-pinning" bash scripts/checks/check-ios-authenticated-session-pinning.sh

--- a/src/__tests__/checks/crypto-auth-deps-manifest.test.ts
+++ b/src/__tests__/checks/crypto-auth-deps-manifest.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Three-set reconciliation parity test for
+ * scripts/checks/crypto-auth-deps-manifest.json.
+ *
+ * Import scanning is NOT the sole source of truth (it misses dynamic import(),
+ * defensive/transitive deps, and package-json-present-but-unimported deps).
+ * The guard reconciles THREE sets per workspace and fails on their disagreement:
+ *   1. CODE     — crypto/auth-sensitive external specifiers derived from source
+ *                 via ts-morph AST (static import + string-literal import() +
+ *                 const-resolved import()), over the crypto/auth defining roots.
+ *   2. DEPS     — the workspace package.json `dependencies`.
+ *   3. MANIFEST — the declared `packages` in the manifest.
+ *
+ * Failures:
+ *   (A) a CODE specifier absent from MANIFEST ∪ excluded          → new sensitive import unregistered
+ *   (B) a MANIFEST package absent from its workspace DEPS         → manifest entry vanished from package.json
+ *   (C) a crypto/auth-sensitive DEPS package with no CODE hit AND
+ *       not marked detectedBy including "manual" / confirmed dynamic → sensitive-in-deps-not-in-code
+ *   (D) a MANIFEST entry with a <10-char reason or a non-enum owner → metadata completeness
+ *
+ * Filesystem + ts-morph only (no @prisma/client) — safe without a generated
+ * Prisma client. Mirrors src/__tests__/workers/worker-policy-manifest.test.ts.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import { parseRouteSource } from "../proxy/ast-guards";
+import { Node, SyntaxKind } from "ts-morph";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const MANIFEST_PATH = path.join(REPO_ROOT, "scripts/checks/crypto-auth-deps-manifest.json");
+
+// Crypto/auth defining roots per workspace (GT-6). A file/dir here is scanned
+// for external imports; a crypto/auth dep imported OUTSIDE these roots relies on
+// the DEPS-side (C) name-pattern heuristic instead.
+const CODE_ROOTS: Record<string, string[]> = {
+  root: [
+    "src/lib/crypto",
+    "src/lib/auth",
+    "src/lib/prisma.ts",
+    "src/lib/email",
+    "src/auth.ts",
+    "src/auth.config.ts",
+    "src/components/passwords/shared",
+    "src/app/api/auth/passkey",
+    "src/app/api/webauthn",
+  ],
+  cli: ["cli/src"],
+  extension: ["extension/src"],
+};
+
+const WORKSPACE_PACKAGE_JSON: Record<string, string> = {
+  root: "package.json",
+  cli: "cli/package.json",
+  extension: "extension/package.json",
+};
+
+const OWNERS_ENUM = ["security"];
+
+// Names that make an unmatched DEPS package crypto/auth-sensitive (widens the
+// (C) DEPS side; NEVER auto-approves). Enumerated + self-tested (T3).
+const CRYPTO_NAME_RE =
+  /crypt|cipher|kdf|pbkdf|bcrypt|scrypt|argon|hash|hmac|sign|jwt|jose|jwk|webauthn|passkey|fido|otp|totp|hotp|nacl|sodium|noble|tweetnacl|oidc|oauth|saml|nodemailer/i;
+
+interface ManifestEntry {
+  package?: string;
+  workspace: string;
+  reason: string;
+  detectedBy: string[];
+  owners: string[];
+  category: string;
+}
+interface Manifest {
+  packages: Record<string, ManifestEntry>;
+  excluded: Record<string, { package?: string; workspace: string; reason: string }>;
+}
+
+function loadManifest(): Manifest {
+  return JSON.parse(readFileSync(MANIFEST_PATH, "utf8")) as Manifest;
+}
+
+// The real package name for a manifest key (composite keys like "otpauth@cli"
+// carry the actual name in `package`).
+function entryPackage(key: string, entry: { package?: string }): string {
+  return entry.package ?? key;
+}
+
+// ── pure detection functions (each independently self-tested, RT7) ──────────
+
+/**
+ * Strip a subpath import specifier to its package root:
+ * "@scope/name/sub" → "@scope/name"; "name/sub" → "name".
+ */
+export function toPackageRoot(specifier: string): string {
+  if (specifier.startsWith("@")) {
+    return specifier.split("/").slice(0, 2).join("/");
+  }
+  return specifier.split("/")[0];
+}
+
+export function isExternalSpecifier(specifier: string): boolean {
+  if (specifier.startsWith(".") || specifier.startsWith("/")) return false;
+  if (specifier.startsWith("node:")) return false;
+  if (specifier.startsWith("@/")) return false;
+  const root = toPackageRoot(specifier);
+  if (root === "next" || root === "react" || root === "react-dom") return false;
+  if (root.startsWith("next/") || root.startsWith("react/")) return false;
+  return true;
+}
+
+/**
+ * Extract external package-root specifiers from one source file: static imports,
+ * string-literal dynamic import(), AND const-resolved dynamic import() where the
+ * argument is an identifier bound to a same-file string literal
+ * (`const m = "pkg"; await import(m)`). Returns a de-duplicated set.
+ */
+export function extractExternalSpecifiers(source: string, virtualPath: string): Set<string> {
+  const sf = parseRouteSource(source, virtualPath);
+  const out = new Set<string>();
+
+  for (const imp of sf.getImportDeclarations()) {
+    const spec = imp.getModuleSpecifierValue();
+    if (isExternalSpecifier(spec)) out.add(toPackageRoot(spec));
+  }
+
+  // Resolve same-file `const x = "literal"` bindings for indirected import(x).
+  // Use descendants (not just top-level) — the binding is commonly a
+  // function-scoped const (e.g. crypto-client.ts's `const moduleName = "hash-wasm"`).
+  const stringConsts = new Map<string, string>();
+  for (const decl of sf.getDescendantsOfKind(SyntaxKind.VariableDeclaration)) {
+    const init = decl.getInitializer();
+    if (init && Node.isStringLiteral(init)) {
+      stringConsts.set(decl.getName(), init.getLiteralText());
+    }
+  }
+
+  for (const call of sf.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    if (call.getExpression().getKind() !== SyntaxKind.ImportKeyword) continue;
+    const arg = call.getArguments()[0];
+    if (!arg) continue;
+    let spec: string | undefined;
+    if (Node.isStringLiteral(arg)) {
+      spec = arg.getLiteralText();
+    } else if (Node.isIdentifier(arg)) {
+      spec = stringConsts.get(arg.getText());
+    }
+    if (spec && isExternalSpecifier(spec)) out.add(toPackageRoot(spec));
+  }
+
+  return out;
+}
+
+/** (A) CODE specifiers not in MANIFEST and not excluded → findings. */
+export function computeUnregisteredImports(
+  codeSpecifiers: Set<string>,
+  manifestPackages: Set<string>,
+  excluded: Set<string>,
+): string[] {
+  const findings: string[] = [];
+  for (const spec of codeSpecifiers) {
+    if (!manifestPackages.has(spec) && !excluded.has(spec)) {
+      findings.push(spec);
+    }
+  }
+  return findings.sort();
+}
+
+/** (C) crypto-named DEPS packages with no CODE hit that aren't legitimately code-absent. */
+export function computeUnbackedSensitiveDeps(
+  deps: string[],
+  codeSpecifiers: Set<string>,
+  manifestByPackage: Map<string, ManifestEntry>,
+  excluded: Set<string>,
+): string[] {
+  const findings: string[] = [];
+  for (const dep of deps) {
+    if (excluded.has(dep)) continue;
+    if (!CRYPTO_NAME_RE.test(dep)) continue; // heuristic only widens; never approves
+    if (codeSpecifiers.has(dep)) continue; // has a real CODE occurrence
+    const entry = manifestByPackage.get(dep);
+    // Code-absent is allowed only if declared manual, or dynamic-import that the
+    // scanner could NOT resolve here (outside these roots) — represented as manual.
+    if (entry && entry.detectedBy.includes("manual")) continue;
+    findings.push(dep);
+  }
+  return findings.sort();
+}
+
+/** (D) metadata completeness: reason ≥10 chars and every owner in the enum. */
+export function computeMetadataViolations(
+  key: string,
+  entry: ManifestEntry,
+  ownersEnum: string[],
+): string[] {
+  const violations: string[] = [];
+  if (!entry.reason || entry.reason.length < 10) {
+    violations.push(`${key}: reason must be ≥10 chars`);
+  }
+  if (!entry.owners || entry.owners.length === 0) {
+    violations.push(`${key}: owners must be non-empty`);
+  } else {
+    for (const owner of entry.owners) {
+      if (!ownersEnum.includes(owner)) {
+        violations.push(`${key}: owner "${owner}" not in OWNERS enum`);
+      }
+    }
+  }
+  return violations;
+}
+
+// ── helpers for walking the real tree ───────────────────────────────────────
+
+function walkSourceFiles(root: string): string[] {
+  const abs = path.join(REPO_ROOT, root);
+  if (!existsSync(abs)) return [];
+  // If root points at a single file, handle it directly.
+  if (root.endsWith(".ts") || root.endsWith(".tsx")) {
+    return [abs];
+  }
+  const files: string[] = [];
+  for (const entry of readdirSync(abs, { withFileTypes: true })) {
+    const full = path.join(abs, entry.name);
+    const rel = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkSourceFiles(rel));
+    } else if (/\.(ts|tsx)$/.test(entry.name) && !/\.(test|spec)\.(ts|tsx)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function codeSpecifiersForWorkspace(workspace: string): Set<string> {
+  const out = new Set<string>();
+  for (const root of CODE_ROOTS[workspace] ?? []) {
+    for (const file of walkSourceFiles(root)) {
+      const source = readFileSync(file, "utf8");
+      const rel = path.relative(REPO_ROOT, file);
+      for (const spec of extractExternalSpecifiers(source, rel)) out.add(spec);
+    }
+  }
+  return out;
+}
+
+function depsForWorkspace(workspace: string): string[] {
+  const pkgPath = path.join(REPO_ROOT, WORKSPACE_PACKAGE_JSON[workspace]);
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+    dependencies?: Record<string, string>;
+  };
+  return Object.keys(pkg.dependencies ?? {});
+}
+
+// ── reconciliation over the real tree ───────────────────────────────────────
+
+describe("crypto-auth-deps-manifest — three-set reconciliation", () => {
+  const manifest = loadManifest();
+
+  // MANIFEST packages / excluded, grouped by workspace, keyed by real package name.
+  function manifestPackagesFor(workspace: string): Map<string, ManifestEntry> {
+    const m = new Map<string, ManifestEntry>();
+    for (const [key, entry] of Object.entries(manifest.packages)) {
+      if (entry.workspace === workspace) m.set(entryPackage(key, entry), entry);
+    }
+    return m;
+  }
+  function excludedFor(workspace: string): Set<string> {
+    const s = new Set<string>();
+    for (const [key, entry] of Object.entries(manifest.excluded)) {
+      if (entry.workspace === workspace) s.add(entryPackage(key, entry));
+    }
+    return s;
+  }
+
+  it("manifest JSON parses and every packages entry has complete metadata (D)", () => {
+    const violations: string[] = [];
+    for (const [key, entry] of Object.entries(manifest.packages)) {
+      violations.push(...computeMetadataViolations(key, entry, OWNERS_ENUM));
+      expect(entry.workspace, `${key}.workspace`).toBeTruthy();
+      expect(entry.detectedBy?.length, `${key}.detectedBy`).toBeGreaterThan(0);
+      expect(entry.category, `${key}.category`).toBeTruthy();
+    }
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  for (const workspace of ["root", "cli", "extension"]) {
+    describe(`workspace: ${workspace}`, () => {
+      const code = codeSpecifiersForWorkspace(workspace);
+      const deps = depsForWorkspace(workspace);
+      const manifestByPackage = manifestPackagesFor(workspace);
+      const manifestPackages = new Set(manifestByPackage.keys());
+      const excluded = excludedFor(workspace);
+
+      it("(A) every CODE crypto/auth import is registered in the manifest or excluded", () => {
+        const findings = computeUnregisteredImports(code, manifestPackages, excluded);
+        expect(
+          findings,
+          `unregistered imports in ${workspace}: ${findings.join(", ")}`,
+        ).toEqual([]);
+      });
+
+      it("(B) every manifest package is present in the workspace package.json dependencies", () => {
+        const depSet = new Set(deps);
+        const missing = [...manifestPackages].filter((p) => !depSet.has(p));
+        expect(missing, `manifest packages missing from ${workspace} deps: ${missing.join(", ")}`).toEqual(
+          [],
+        );
+      });
+
+      it("(C) every crypto-named dependency has a CODE occurrence or a reasoned manual entry", () => {
+        const findings = computeUnbackedSensitiveDeps(deps, code, manifestByPackage, excluded);
+        expect(
+          findings,
+          `crypto-named deps in ${workspace} lacking CODE evidence and manual marker: ${findings.join(", ")}`,
+        ).toEqual([]);
+      });
+    });
+  }
+});
+
+// ── RT7 negative self-tests: each pure function must be provably able to fail ──
+
+describe("RT7 self-test — extractExternalSpecifiers", () => {
+  it("extracts static, string-literal-dynamic, and const-resolved-dynamic imports", () => {
+    const src = [
+      `import { a } from "next-auth";`,
+      `import x from "./local";`,
+      `import y from "node:crypto";`,
+      `const moduleName = "hash-wasm";`,
+      `async function f() { await import(moduleName); }`,
+      `async function g() { await import("bcrypt-pbkdf"); }`,
+    ].join("\n");
+    const specs = extractExternalSpecifiers(src, "virtual/x.ts");
+    expect(specs.has("next-auth")).toBe(true);
+    expect(specs.has("hash-wasm")).toBe(true);
+    expect(specs.has("bcrypt-pbkdf")).toBe(true);
+    expect(specs.has("./local")).toBe(false);
+    expect(specs.has("node:crypto")).toBe(false);
+  });
+
+  it("strips subpaths to the package root", () => {
+    const src = `import N from "next-auth/providers/nodemailer";\nimport t from "@simplewebauthn/server/helpers";`;
+    const specs = extractExternalSpecifiers(src, "virtual/y.ts");
+    expect(specs.has("next-auth")).toBe(true);
+    expect(specs.has("@simplewebauthn/server")).toBe(true);
+  });
+});
+
+describe("RT7 self-test — isExternalSpecifier", () => {
+  it("drops relative, node:, @/, and framework specifiers", () => {
+    expect(isExternalSpecifier("./x")).toBe(false);
+    expect(isExternalSpecifier("node:fs")).toBe(false);
+    expect(isExternalSpecifier("@/lib/x")).toBe(false);
+    expect(isExternalSpecifier("next/server")).toBe(false);
+    expect(isExternalSpecifier("react")).toBe(false);
+    expect(isExternalSpecifier("hash-wasm")).toBe(true);
+    expect(isExternalSpecifier("@simplewebauthn/server")).toBe(true);
+  });
+});
+
+describe("RT7 self-test — computeUnregisteredImports (A)", () => {
+  it("flags a CODE import absent from manifest and excluded", () => {
+    const code = new Set(["new-crypto-lib", "next-auth"]);
+    const findings = computeUnregisteredImports(code, new Set(["next-auth"]), new Set());
+    expect(findings).toEqual(["new-crypto-lib"]);
+  });
+  it("does not flag an excluded or manifest-listed import", () => {
+    const code = new Set(["zod", "next-auth"]);
+    expect(
+      computeUnregisteredImports(code, new Set(["next-auth"]), new Set(["zod"])),
+    ).toEqual([]);
+  });
+});
+
+describe("RT7 self-test — computeUnbackedSensitiveDeps (C)", () => {
+  const staticEntry = (): ManifestEntry => ({
+    workspace: "root",
+    reason: "x".repeat(10),
+    detectedBy: ["static-import"],
+    owners: ["security"],
+    category: "kdf",
+  });
+  const manualEntry = (): ManifestEntry => ({ ...staticEntry(), detectedBy: ["manual"] });
+
+  it("flags a crypto-named dep with no CODE hit and no manual marker", () => {
+    const findings = computeUnbackedSensitiveDeps(
+      ["hash-wasm"],
+      new Set(),
+      new Map([["hash-wasm", staticEntry()]]),
+      new Set(),
+    );
+    expect(findings).toEqual(["hash-wasm"]);
+  });
+  it("does NOT flag a code-absent dep marked detectedBy manual", () => {
+    const findings = computeUnbackedSensitiveDeps(
+      ["hash-wasm"],
+      new Set(),
+      new Map([["hash-wasm", manualEntry()]]),
+      new Set(),
+    );
+    expect(findings).toEqual([]);
+  });
+  it("does NOT flag a crypto-named dep that has a CODE occurrence", () => {
+    const findings = computeUnbackedSensitiveDeps(
+      ["hash-wasm"],
+      new Set(["hash-wasm"]),
+      new Map([["hash-wasm", staticEntry()]]),
+      new Set(),
+    );
+    expect(findings).toEqual([]);
+  });
+  it("ignores a non-crypto-named dep entirely (heuristic does not widen)", () => {
+    const findings = computeUnbackedSensitiveDeps(["chalk"], new Set(), new Map(), new Set());
+    expect(findings).toEqual([]);
+  });
+  it("ignores an excluded crypto-named dep", () => {
+    const findings = computeUnbackedSensitiveDeps(
+      ["jsrsasign"],
+      new Set(),
+      new Map(),
+      new Set(["jsrsasign"]),
+    );
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("RT7 self-test — computeMetadataViolations (D)", () => {
+  const base = (): ManifestEntry => ({
+    workspace: "root",
+    reason: "a sufficiently long reason",
+    detectedBy: ["static-import"],
+    owners: ["security"],
+    category: "kdf",
+  });
+  it("flags a <10-char reason", () => {
+    const e = { ...base(), reason: "short" };
+    expect(computeMetadataViolations("k", e, OWNERS_ENUM)).toContain("k: reason must be ≥10 chars");
+  });
+  it("flags an owner outside the enum", () => {
+    const e = { ...base(), owners: ["nobody"] };
+    expect(computeMetadataViolations("k", e, OWNERS_ENUM)).toContain(
+      'k: owner "nobody" not in OWNERS enum',
+    );
+  });
+  it("flags empty owners", () => {
+    const e = { ...base(), owners: [] };
+    expect(computeMetadataViolations("k", e, OWNERS_ENUM)).toContain("k: owners must be non-empty");
+  });
+  it("passes a complete entry", () => {
+    expect(computeMetadataViolations("k", base(), OWNERS_ENUM)).toEqual([]);
+  });
+});
+
+describe("RT7 self-test — DEPS name-pattern heuristic (T3)", () => {
+  it("surfaces a crypto-named synthetic dep", () => {
+    expect(CRYPTO_NAME_RE.test("some-argon2-lib")).toBe(true);
+    expect(CRYPTO_NAME_RE.test("jsrsasign")).toBe(true);
+    expect(CRYPTO_NAME_RE.test("nodemailer")).toBe(true);
+  });
+  it("does not surface a clearly non-crypto name", () => {
+    expect(CRYPTO_NAME_RE.test("chalk")).toBe(false);
+    expect(CRYPTO_NAME_RE.test("commander")).toBe(false);
+  });
+});

--- a/src/__tests__/checks/crypto-auth-deps-manifest.test.ts
+++ b/src/__tests__/checks/crypto-auth-deps-manifest.test.ts
@@ -186,6 +186,32 @@ export function computeUnbackedSensitiveDeps(
   return findings.sort();
 }
 
+/** (B) manifest packages absent from the workspace's package.json dependencies. */
+export function computeMissingDeps(manifestPackages: Set<string>, deps: Set<string>): string[] {
+  return [...manifestPackages].filter((p) => !deps.has(p)).sort();
+}
+
+/**
+ * detectedBy accuracy (INV-C4c): a `static-import`/`dynamic-import`-marked entry
+ * whose package has NO CODE occurrence in its workspace is a stale/mis-labeled
+ * claim → finding. `manual` entries are exempt (they are declared code-absent).
+ * This catches the case a crypto-named-only (C) check misses: a non-crypto-named
+ * member (e.g. next-auth) whose import was removed but left in package.json+manifest.
+ */
+export function computeDetectedByViolations(
+  manifestByPackage: Map<string, ManifestEntry>,
+  codeSpecifiers: Set<string>,
+): string[] {
+  const findings: string[] = [];
+  for (const [pkg, entry] of manifestByPackage) {
+    if (entry.detectedBy.includes("manual")) continue;
+    if (!codeSpecifiers.has(pkg)) {
+      findings.push(`${pkg}: detectedBy=[${entry.detectedBy.join(",")}] but no CODE occurrence found`);
+    }
+  }
+  return findings.sort();
+}
+
 /** (D) metadata completeness: reason ≥10 chars and every owner in the enum. */
 export function computeMetadataViolations(
   key: string,
@@ -299,8 +325,7 @@ describe("crypto-auth-deps-manifest — three-set reconciliation", () => {
       });
 
       it("(B) every manifest package is present in the workspace package.json dependencies", () => {
-        const depSet = new Set(deps);
-        const missing = [...manifestPackages].filter((p) => !depSet.has(p));
+        const missing = computeMissingDeps(manifestPackages, new Set(deps));
         expect(missing, `manifest packages missing from ${workspace} deps: ${missing.join(", ")}`).toEqual(
           [],
         );
@@ -312,6 +337,11 @@ describe("crypto-auth-deps-manifest — three-set reconciliation", () => {
           findings,
           `crypto-named deps in ${workspace} lacking CODE evidence and manual marker: ${findings.join(", ")}`,
         ).toEqual([]);
+      });
+
+      it("(detectedBy accuracy) every static/dynamic-import entry has a confirming CODE occurrence", () => {
+        const findings = computeDetectedByViolations(manifestByPackage, code);
+        expect(findings, `stale detectedBy claims in ${workspace}: ${findings.join(", ")}`).toEqual([]);
       });
     });
   }
@@ -355,6 +385,22 @@ describe("RT7 self-test — isExternalSpecifier", () => {
     expect(isExternalSpecifier("hash-wasm")).toBe(true);
     expect(isExternalSpecifier("@simplewebauthn/server")).toBe(true);
   });
+  it("does NOT drop a package whose name merely starts with a framework name", () => {
+    expect(isExternalSpecifier("nextfoo")).toBe(true);
+    expect(isExternalSpecifier("react-markdown")).toBe(true);
+  });
+});
+
+describe("RT7 self-test — toPackageRoot", () => {
+  it("returns a bare package name unchanged", () => {
+    expect(toPackageRoot("otpauth")).toBe("otpauth");
+  });
+  it("strips an unscoped subpath to the first segment", () => {
+    expect(toPackageRoot("next-auth/providers/nodemailer")).toBe("next-auth");
+  });
+  it("keeps exactly scope/name for a scoped deep subpath", () => {
+    expect(toPackageRoot("@simplewebauthn/server/helpers/x")).toBe("@simplewebauthn/server");
+  });
 });
 
 describe("RT7 self-test — computeUnregisteredImports (A)", () => {
@@ -368,6 +414,62 @@ describe("RT7 self-test — computeUnregisteredImports (A)", () => {
     expect(
       computeUnregisteredImports(code, new Set(["next-auth"]), new Set(["zod"])),
     ).toEqual([]);
+  });
+});
+
+describe("RT7 self-test — computeMissingDeps (B)", () => {
+  it("flags a manifest package absent from the DEPS set", () => {
+    const findings = computeMissingDeps(new Set(["hash-wasm", "next-auth"]), new Set(["next-auth"]));
+    expect(findings).toEqual(["hash-wasm"]);
+  });
+  it("returns empty when every manifest package is present in DEPS", () => {
+    expect(computeMissingDeps(new Set(["next-auth"]), new Set(["next-auth", "zod"]))).toEqual([]);
+  });
+});
+
+describe("RT7 self-test — computeDetectedByViolations (detectedBy accuracy, INV-C4c)", () => {
+  const entry = (detectedBy: string[]): ManifestEntry => ({
+    workspace: "root",
+    reason: "x".repeat(10),
+    detectedBy,
+    owners: ["security"],
+    category: "auth-flow",
+  });
+  it("flags a static-import entry with no CODE occurrence", () => {
+    const findings = computeDetectedByViolations(
+      new Map([["next-auth", entry(["static-import"])]]),
+      new Set(),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatch(/next-auth/);
+  });
+  it("flags a dynamic-import entry with no confirmable dynamic occurrence", () => {
+    const findings = computeDetectedByViolations(
+      new Map([["hash-wasm", entry(["dynamic-import"])]]),
+      new Set(),
+    );
+    expect(findings).toHaveLength(1);
+  });
+  it("does NOT flag a static-import entry that has a CODE occurrence", () => {
+    const findings = computeDetectedByViolations(
+      new Map([["next-auth", entry(["static-import"])]]),
+      new Set(["next-auth"]),
+    );
+    expect(findings).toEqual([]);
+  });
+  it("does NOT flag a dynamic-import entry the resolver confirms", () => {
+    const findings = computeDetectedByViolations(
+      new Map([["hash-wasm", entry(["dynamic-import"])]]),
+      new Set(["hash-wasm"]),
+    );
+    expect(findings).toEqual([]);
+  });
+  it("exempts a manual entry with no CODE occurrence", () => {
+    const findings = computeDetectedByViolations(
+      new Map([["defensive-dep", entry(["manual"])]]),
+      new Set(),
+    );
+    expect(findings).toEqual([]);
   });
 });
 

--- a/src/__tests__/checks/crypto-auth-deps-manifest.test.ts
+++ b/src/__tests__/checks/crypto-auth-deps-manifest.test.ts
@@ -192,6 +192,23 @@ export function computeMissingDeps(manifestPackages: Set<string>, deps: Set<stri
 }
 
 /**
+ * (E) completeness of the classification itself: EVERY runtime dependency of the
+ * workspace MUST be classified as either a crypto/auth `packages` member OR an
+ * `excluded` support dep. A dep in neither is unclassified — the exact hole a
+ * name-pattern heuristic + fixed CODE_ROOTS leaves open (a new auth lib like
+ * `better-auth`, added outside the roots and not matching CRYPTO_NAME_RE, would
+ * otherwise pass every other check silently). This forces a supply-chain review
+ * decision on every new dependency, regardless of its name or import location.
+ */
+export function computeUnclassifiedDeps(
+  deps: string[],
+  manifestPackages: Set<string>,
+  excluded: Set<string>,
+): string[] {
+  return deps.filter((d) => !manifestPackages.has(d) && !excluded.has(d)).sort();
+}
+
+/**
  * detectedBy accuracy (INV-C4c): a `static-import`/`dynamic-import`-marked entry
  * whose package has NO CODE occurrence in its workspace is a stale/mis-labeled
  * claim → finding. `manual` entries are exempt (they are declared code-absent).
@@ -343,6 +360,14 @@ describe("crypto-auth-deps-manifest — three-set reconciliation", () => {
         const findings = computeDetectedByViolations(manifestByPackage, code);
         expect(findings, `stale detectedBy claims in ${workspace}: ${findings.join(", ")}`).toEqual([]);
       });
+
+      it("(E) every runtime dependency is classified as a crypto/auth member OR excluded", () => {
+        const unclassified = computeUnclassifiedDeps(deps, manifestPackages, excluded);
+        expect(
+          unclassified,
+          `unclassified ${workspace} deps (add to packages or excluded): ${unclassified.join(", ")}`,
+        ).toEqual([]);
+      });
     });
   }
 });
@@ -424,6 +449,21 @@ describe("RT7 self-test — computeMissingDeps (B)", () => {
   });
   it("returns empty when every manifest package is present in DEPS", () => {
     expect(computeMissingDeps(new Set(["next-auth"]), new Set(["next-auth", "zod"]))).toEqual([]);
+  });
+});
+
+describe("RT7 self-test — computeUnclassifiedDeps (E)", () => {
+  it("flags a runtime dep that is neither a manifest member nor excluded", () => {
+    // The `better-auth` scenario: a new auth lib whose name doesn't match
+    // CRYPTO_NAME_RE and which lives outside CODE_ROOTS — (A)/(C) miss it, (E) catches it.
+    const findings = computeUnclassifiedDeps(["better-auth", "next-auth"], new Set(["next-auth"]), new Set());
+    expect(findings).toEqual(["better-auth"]);
+  });
+  it("does not flag a dep that is a manifest member", () => {
+    expect(computeUnclassifiedDeps(["next-auth"], new Set(["next-auth"]), new Set())).toEqual([]);
+  });
+  it("does not flag a dep that is excluded", () => {
+    expect(computeUnclassifiedDeps(["clsx"], new Set(), new Set(["clsx"]))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Ship-today slice of the roadmap **C-P1** ("supply-chain monitoring"). The CLI
already emits SLSA provenance via npm OIDC Trusted Publishing, but nothing pinned
that behavior, verified dependency signatures, monitored npm dependency bumps, or
enumerated the crypto/auth dependency surface. This PR adds those controls, plus
CI guards that keep them from silently regressing.

## What changed

### C1 — npm provenance, explicit and fail-closed
- `cli/package.json` gains `publishConfig.provenance: true` so provenance is
  expressed explicitly, independent of the npm-version default.
- `release.yml` gains a **fail-closed post-publish assertion**: after `npm
  publish`, it asserts the just-published version carries an
  `slsa.dev/provenance/v1` attestation (retrying for registry propagation lag),
  failing the release if it is absent. It never false-greens.
- The `publish-cli` job is pinned to **Node 24** (not the repo's Node-20
  `.nvmrc`): npm Trusted Publishing requires npm 11.5.1+ **and** Node 22.14.0+.

### C2 — dependency signature verification
- `npm audit signatures` runs in the three per-workspace CI audit jobs and in a
  new weekly `dependency-signatures.yml` cron sweep (`contents: read`, no
  secret), so a registry-side tamper of an unchanged dependency is re-verified
  independent of PR path-filters.

### C3 — Dependabot npm coverage, no auto-merge
- Dependabot now covers the `npm` ecosystem for root, `cli`, and `extension`
  (Swift excluded — iOS has no `Package.swift`). Each ecosystem is split into a
  **security-sensitive group** (crypto/auth packages) and a general group, so
  sensitive bumps land in a dedicated PR. **No auto-merge** — human review stays
  required.

### C4 — crypto/auth sensitive-dep manifest + three-set guard
- `scripts/checks/crypto-auth-deps-manifest.json` classifies every crypto/auth
  dependency across all three workspaces. A ts-morph parity test reconciles three
  sets — code imports, `package.json` dependencies, and the manifest — and fails
  on: a new sensitive import unregistered, a manifest entry vanished from
  `package.json`, a crypto-named dep with no code evidence and no reasoned manual
  marker, or an entry with a `<10`-char reason / non-enum owner.
- A standalone `check-crypto-auth-deps-classified.mjs` guard (wired into
  `pre-pr.sh`, run unconditionally in `static-checks`) enforces that **every**
  runtime dependency is classified as sensitive or excluded — so a new auth
  library added outside the code-scan roots cannot land unclassified, even on a
  cli/extension-only PR.
- Both the manifest and its enforcing test are CODEOWNERS-gated.

### CI guards
- `check-workflow-supply-chain.mjs` (wired into `pre-pr.sh`) fails on Dependabot
  auto-merge shapes, on a masked supply-chain verifier (`|| true` / `;true` /
  `|| exit 0` / `continue-on-error`, including YAML block/folded-scalar and
  line-continuation splits), and on an `npm publish` job that does not pin an
  explicit `node-version >= 22.14`. Every detector has a proven-can-fail
  self-test.

## Deliberately out of scope
- Container-image SBOM/cosign signing — no container release path exists to
  attach to.
- iOS distribution-artifact provenance — iOS ships via App Store Connect, not a
  GitHub-Actions-built artifact.
- Additional GitHub Actions boundary guards — actions are already SHA-pinned +
  CODEOWNERS-gated, permissions already scoped, no `pull_request_target`.

## Verification
- `npx vitest run` — full suite passes (951 files).
- `scripts/pre-pr.sh` (static) — 39/39 passes, including the two new guards.
- `npx next build` — compiles.
- The published `passwd-sso-cli@0.4.70` was confirmed to carry
  `slsa.dev/provenance/v1` provenance on the live registry.

## Review process
Developed via the triangulate workflow (plan → implement → review): 2-round plan
review + 3-round code review (converged), then multiple external-review rounds
that surfaced and closed residual guard-completeness gaps (member-set omissions,
a self-inflicted ReDoS, YAML mask-evasion shapes, the Node-version requirement,
and the version/per-job precision of the release guard). Artifacts under
`docs/archive/review/p1-supply-chain-provenance-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
