### PR TITLE
fix(vault): reject overview-only updates; harden destructive-wrapper re-export gate

### DIFF
--- a/docs/archive/review/comprehensive-assessment-report-verification.md
+++ b/docs/archive/review/comprehensive-assessment-report-verification.md
@@ -1,7 +1,7 @@
 # Report Verification: Comprehensive Assessment (A / 9.2) — Triangulated Review
 Date: 2026-07-17
 Review round: 1 (terminal — no Critical/Major findings)
-Target: externally produced comprehensive evaluation report (A / 9.2) vs repo state at main @ 00ed72362
+Target: externally produced comprehensive evaluation report (A / 9.2) vs repo state at main @ `00ed72362`
 Mode adaptation: triangulate Phase 3 applied to report-claims-vs-repo verification (no branch diff; Ollama seed step N/A)
 
 ## Functionality Findings (quantitative claims)

--- a/docs/archive/review/comprehensive-assessment-report-verification.md
+++ b/docs/archive/review/comprehensive-assessment-report-verification.md
@@ -1,0 +1,66 @@
+# Report Verification: Comprehensive Assessment (A / 9.2) — Triangulated Review
+Date: 2026-07-17
+Review round: 1 (terminal — no Critical/Major findings)
+Target: externally produced comprehensive evaluation report (A / 9.2) vs repo state at main @ 00ed72362
+Mode adaptation: triangulate Phase 3 applied to report-claims-vs-repo verification (no branch diff; Ollama seed step N/A)
+
+## Functionality Findings (quantitative claims)
+
+No findings. All scale/structure claims reproduced exactly against `git ls-files` at HEAD:
+
+- Total tracked files 4,275; src TS/TSX 2,020; production (non-test) 996; API routes 212 — all exact.
+- Strict test files 1,177; broad 1,249 — exact (broad = strict + 69 iOS `*Tests*` Swift + 3 e2e infra files).
+- Workflows 7; scripts/checks files 49; runnable .sh/.mjs checks 34; Prisma models 58; migrations 176; npm scripts 51 — all exact.
+- LOC by area: ios 36,022 / extension 35,873 / cli 15,811 / prisma 10,578 / e2e 8,552 exact; src 374,844 vs 374,857 (+13 lines, 0.003%); scripts within 1.5%.
+- route-policy-manifest.json: bijective with the 212 route.ts files; all classification counts (161/41/5/2/1/1/1), all 15 auth-method counts, and HTTP method distribution (119/101/34/20/7) exact. Report omits (but does not miscount) `none-410-stub: 1` (deprecated dcr-cleanup route).
+- destructive 9, operator-gated 10 (truthy) exact; step-up "49" is 48 route entries + 1 `$schema-note` metadata key (off-by-one in counting method, immaterial).
+
+## Security Findings (control claims)
+
+Key-version guard (A1–A6), lock ordering (users FOR SHARE→entry FOR UPDATE; rotation users FOR UPDATE), 409 semantics, metadata-only handling, blob-without-version rejection, restore/bulk-import coverage: **all VERIFIED** with file:line evidence (`src/lib/vault/key-version-guard.ts:45-61`, `src/app/api/passwords/[id]/route.ts:162-269`, `src/lib/vault/rotate-key-server.ts:190-214`).
+
+Rotation CAS: **VERIFIED** — compares all three of `key_version`, `vault_setup_at` (null-aware), `account_salt` under FOR UPDATE (`rotate-key-server.ts:196-214`). Note: the project memory phrasing "CAS must key on accountSalt not keyVersion/vaultSetupAt" describes only why accountSalt is necessary; the code compares the full tuple.
+
+### S1 [Minor] Overview-only PUT bypasses the key-version guard
+- File: `src/app/api/passwords/[id]/route.ts:157-265` (mirrored in `src/app/api/v1/passwords/[id]/route.ts`)
+- `updateE2EPasswordSchema` allows `encryptedOverview` without `encryptedBlob`; both keyVersion guards condition on `encryptedBlob` only, so an overview-only PUT takes the plain-update branch with no transaction and no `assertCurrentKeyVersion`. A stale pre-rotation client can overwrite `encryptedOverview` with old-key ciphertext while `keyVersion` stays at N+1 → undecryptable overview.
+- Mitigations: blob intact → overview re-derivable by re-saving (recoverable, unlike the blob case); narrow window. Severity Minor, but inside the exact threat model the guard addresses.
+- Recommended fix: require `keyVersion` with `encryptedOverview` and run the same guard, or reject overview-without-blob.
+- Status: **reported, not fixed** (report-verification session; awaiting user instruction).
+
+### S2 [Minor] Report claim wording: non-grep-matchable wrapper forms
+- The report says non-stable forms are "禁止 unless deleteSignal または AST 解決で許可". Actually (`check-destructive-wrapper-derivation.mjs:46-48,638-647`): instance methods and any default export are hard-failed as `NON_GREP_MATCHABLE_DESTRUCTIVE_WRAPPER`; AST resolvability does NOT admit them — the only escape is explicit exemption in `destructive-wrapper-exempt.txt` or refactor. Report's conclusion (A−) unaffected.
+
+### S3 [Minor][Adjacent] Re-export chains are a documented-open residual
+- `check-destructive-wrapper-derivation.mjs:68-79`: the route pass resolves imports one hop and does not follow barrel re-export chains; compensated by review + barrel-free convention, zero current occurrences. Relevant only if the report's "namespace経由" was read as covering re-export chains.
+
+## Testing Findings (debt/hygiene claims)
+
+No findings. All 15 claims verified:
+- Gate self-test: 34 checks, 23 with sibling `scripts/__tests__/<base>.test.*`, 11 without — the 11 are exactly the path entries in `gate-selftest-debt.txt` (24 entries total = 11 paths + 13 `pre-pr:Static:` inline gates, all with enforced reasons). 23/34 = 67.65%.
+- fail-closed-test-debt.txt: 42 routes exact; 3/3 spot-checked routes DO set `failClosedOnRedisError: true` (debt is test-only, runtime is fail-closed). Context: 62 routes total set the flag; 20 have dedicated tests.
+- Hygiene (production src): explicit any 25 (per-construct sum), ts-ignore 3/5, TODO 8/19 (all-src figure case-insensitive), eslint-disable 48/124, console.* 11 — all exact.
+- Raw SQL: exactly 25 of 996 production files; all claimed categories present in the actual file list.
+
+## Adjacent Findings
+- S3 (above).
+
+## Quality Warnings
+None — all findings carry file:line evidence.
+
+## Recurring Issue Check
+Adapted scope (report verification, no code diff authored this session). Rules exercised where applicable:
+- R21 (subagent completion vs verification): sub-agent outputs cross-checked against each other (34-check count independently reproduced by two agents) — pass.
+- R29 (citation accuracy): report's numeric claims treated as citations and 100% recomputed — pass with S2 wording note.
+- R42 (class-membership derivation): fail-closed debt member-set re-derived from primitive (62 flag-setters vs 42 debt entries) — consistent.
+- Remaining R/RS/RT rules: N/A (no code authored).
+
+## Environment Verification Report
+N/A — no environment constraints declared; no code changed, no build/test run required this session.
+
+## Resolution Status
+- S1: reported to user; fix not applied (no instruction to modify code in a report-verification session). Cheap fix identified.
+- S2, S3: informational corrections to the report text; no repo action.
+
+## Verdict on the report
+**Accurate.** Every quantitative claim reproduced exactly or within counting-method tolerance (largest deviation 1.5%). All security-control claims verified against implementation with evidence. The A / 9.2 grade is supported by the evidence; the only substantive addition from this verification is S1 (Minor, recoverable) — consistent with the report's own "明確なMedium脆弱性: 確認なし" statement.

--- a/docs/archive/review/overview-pairing-and-reexport-guard-code-review.md
+++ b/docs/archive/review/overview-pairing-and-reexport-guard-code-review.md
@@ -1,6 +1,26 @@
 # Code Review: overview-pairing-and-reexport-guard
 Date: 2026-07-18
-Review round: 3 — external post-push review round (rounds 1-2 log below)
+Review round: 4 — second external review round (rounds 1-3 log below)
+
+## Round 4 — external review findings (two reviewers, post-review(2))
+
+Both reviewers confirmed the round-3 fixes (alias resolver, dotted member propagation) resolved. Four new evasion findings, all fixed in review(3):
+
+### R4-1 [Major→fixed] Whitespace-dependent pre-filter (`content.includes(" from ")`) skips valid syntax
+Newline-before-`from`, compact `export*from"./x"`, and comment-separated forms never reached the AST. **Fixed**: pre-filter reduced to the bare token `from` (a sound necessary condition — every detected shape textually requires the keyword, in the re-export or in the import that created a laundered binding), and the pass restructured to parse each file exactly once up front (`extractReExportFacts`) with the fixpoint iterating over extracted data — removing the per-iteration re-parse the old structure paid.
+
+### R4-2 [Major→fixed] Import-then-export laundering undetected
+`import { executeVaultReset as reset } from "./vault-reset"; export { reset };` — a specifier-less ExportDeclaration was never examined, so the barrel escaped registration AND the route pass could not resolve `reset()`. **Fixed**: exported bindings resolve back to their ImportDeclarations and are matched exactly like direct re-exports (named + second alias, namespace `export { svc }`, and `export default r`), with member propagation intact.
+
+### R4-3 [Major→fixed] `.tsx` barrels outside the scan set
+`getSourceFiles` collected `.ts` only, so a `.tsx` barrel was unscanned and unreachable via `knownRels` despite the resolver's `.tsx` candidates. **Fixed**: the re-export pass scans production `.ts` + `.tsx` (primitive derivation stays `.ts`-only — `.tsx` files are not delete-primitive sites); a flagged `.tsx` barrel fails CI outright, which is the enforcement even where the route pass's own `.ts`-fixed resolution would not follow it.
+
+### R4-4 [covered by R4-1] Comment-separated `from` — same root cause, pinned by its own fixture.
+
+### Round 4 verification
+- 9 new fixtures: newline-`from`, compact `export*from`, comment-separated, import-then-export (plain / second alias / namespace / default), `.tsx` barrel — all red with single-failure-code isolation; innocent import-then-export — green.
+- Checker self-test 64/64; real tree exit 0 (the `.tsx` scan and laundering detection introduce no false positives on existing code); eslint clean.
+- Residual limitation narrowed again and re-documented: only VALUE-LEVEL indirect bindings (`const q = r;`, higher-order pass-through) remain, requiring whole-program resolution by design.
 
 ## Round 3 — external static review findings (user-provided, post-push)
 

--- a/docs/archive/review/overview-pairing-and-reexport-guard-code-review.md
+++ b/docs/archive/review/overview-pairing-and-reexport-guard-code-review.md
@@ -1,0 +1,69 @@
+# Code Review: overview-pairing-and-reexport-guard
+Date: 2026-07-17
+Review round: 2 — CONVERGED (round 1 log below; fix commit: 2326bc597)
+
+## Round 2 — incremental review of fix commit 2326bc597
+All three perspectives: **No findings**. Round-1 findings F1/F2 verified resolved. Empirical verification highlights:
+- Fixpoint re-scan: adversarial scan-order fixture (alphabetically-first evader re-exporting from a not-yet-registered mid-chain file) — both hops flagged; scoping change does not weaken transitive closure.
+- `export { type A, b } from` mixed declarations: declaration-level `isTypeOnly()` is false for mixed, per-specifier skip removes only `type A`; runtime `b` still flagged. No detection gap.
+- R43 (vs round 1's state, not just main): the F2 narrowing removes only false positives; mutation test proved the flat fallback remains load-bearing for exactly the unresolved-specifier fixtures (new pin + pre-existing route.ts fixture both go red when fallback removed).
+- RT7: the three new fixtures each fail for their claimed distinct reason; restore-verified clean (orchestrator residue grep: worktree clean, `isTypeOnly` ×2 present).
+- Suite: checker self-test 47/47; real tree exit 0.
+
+Termination: all experts returned No findings at Round 2 → loop ends (Step 3-8). No R42 ①b accretion signature (the C2 detection-case set expanded once — type-only/collision precision, added with mutation-verified fixtures in the same round; the class remains closed by the mutation-verified CI guard itself, which is wired into pre-pr/CI).
+
+## Changes from Previous Round
+Initial review (incremental atop the Phase 2 self-R-check baseline, which reported No findings with RT7 mutation-proof of both new guards).
+
+## Functionality Findings
+No findings.
+- Seed disposition: the single Ollama seed ([Major] `getAliasNode()?.getText()` returns "as x") **Rejected — does not reproduce**: empirical ts-morph probe shows `getAliasNode()?.getText()` returns just the alias identifier (`"x"`); the seed's premise is wrong about the API and its suggested fix (`getName()`) would break fixture 8 (2-hop named chain) by registering the pre-alias name.
+- Verified: fixpoint termination (monotonic flagged-set, bounded loop); pass ordering (re-export pass feeds `destructiveExportsByModule` before the route pass consumes it — composable); `resolveRelativeSpecifierToRel` fails safe on `..`-past-root; `.refine` composes transparently with `parseBody`/`z.treeifyError` (same as team precedent); Implementation Checklist ⇔ diff cross-check complete (the two unlisted sibling test trees verified unaffected, not skipped).
+- Below-threshold visibility note (not a finding): the resolver tries only `<path>.ts`, never `<path>/index.ts` — a future directory-barrel `export * from "./dir"` hiding a destructive wrapper would evade case (b) resolution (named re-exports stay covered via the flat fallback). Zero occurrences today; recorded for a future hardening pass.
+
+## Security Findings
+### F1 [Minor][Adjacent→fixed] Type-only re-exports false-positive
+`export type { executeVaultReset } from ...` (compile-time-erased, no call surface) tripped `REEXPORTED_DESTRUCTIVE_WRAPPER`. False positives on a security gate train reflexive exemption. **Fixed in 2326bc597**: `decl.isTypeOnly()` / `named.isTypeOnly()` skipped; green fixture added.
+### F2 [Minor][Adjacent→fixed] Flat name-set cross-module collision false-positive
+A same-named but unrelated symbol re-exported from a cleanly-resolved in-scope module was flagged because matching consulted the flat cross-module name union. **Fixed in 2326bc597**: resolved targets match only their own registered export set; the flat fallback now applies solely when resolution fails (fail-closed for `.tsx`/generated targets — pinned by a new red fixture so the fallback cannot silently regress).
+- Adversarial evasion sweep otherwise clean: mixed star→named chains, `export { default as x } from` (moot — default exports already NON_GREP_MATCHABLE-rejected), `./x.ts`/`./a/../b`/case-variant specifiers, out-of-scope `.tsx` targets — all detected or fail-closed.
+- C1 bypass check: `updateE2EPasswordSchema` has exactly 2 consumers; no `.partial()/.omit()/.extend()/.pick()/.merge()` derivative exists — refine not bypassable.
+- R43: both boundaries strictly narrow vs main. RS4: no personal data in diff.
+
+## Testing Findings
+No findings.
+- Load-sensitivity note root-caused as environmental: no spawnSync timeout/maxBuffer to trip, per-test `mkdtempSync` isolation, sequential execution, deterministic sort + fixpoint; 3 consecutive full-suite runs green.
+- Sub-agent test red flags: none across the 5 changed test files (mock binding, awaits, shapes all verified — v1 `keyVersion: 2` matches its guard mock deliberately, not coincidentally).
+- Coverage: all C1/C2 acceptance criteria have tests; metadata-only PUT covered by pre-existing tests; e2e tree has zero `encryptedOverview` references.
+- RT7 re-proven this round: refine removal → exactly the 3 expected tests red, rest green (restored, residue-grepped).
+
+## Adjacent Findings
+Sec F1/F2 were tagged [Adjacent] (outside the locked C2 contract's enumerated cases) — both fixed rather than deferred.
+
+## Quality Warnings
+None.
+
+## Seed Finding Disposition (preserved per expert)
+- Functionality: seed Rejected — does not reproduce (see above; empirical probe + fixture-8 counter-evidence).
+- Security: seed returned No findings — nothing to disposition.
+- Testing: seed returned No findings — nothing to disposition.
+
+## Recurring Issue Check
+### Functionality expert
+R1-R44: pass or n/a per expert report; notable — R3 pass (5-consumer walkthrough), R5 pass (guard tx unchanged), R17 pass (reuses encryptedFieldSchema/team idiom/checker maps), R19 pass (3 trees enumerated, 2 verified-unaffected), R21 pass, R34 pass (history/restore sibling checked — unaffected), R40 pass-with-note, R42 pass (writer set re-derived, matches), R44 pass (unpiped exit codes).
+### Security expert
+R1-R44 + RS1-RS6: pass or n/a; notable — R42 re-applied to C2's own coverage (surfaced F1/F2, both fixed), R43 pass (narrowing only), RS3 satisfied (the fix IS boundary validation), RS4 clean, RT7/RT8 re-verified.
+### Testing expert
+R1-R44 + RT1-RT9: pass or n/a; notable — R7 pass (e2e grep clean), R19 pass, R21 satisfied (independent re-run), R42 pass, RT1 pass, RT5 pass (real handlers), RT7 pass (mutation-proved), RT8 pass, RT9 n/a.
+
+## Environment Verification Report
+N/A — no environment constraints declared in Phase 1 beyond `verifiable-local`; all executed: targeted vitest (1101), full vitest (12,569), next build, real-DB integration (key-version-guard), extension suite (58), pre-pr.sh (51 gates), checker real-tree run. All pass, exit codes observed unpiped (R44).
+
+## Resolution Status
+### F1 [Minor] Type-only re-export false positive — FIXED
+- Action: skip `isTypeOnly()` at declaration and specifier level; green fixture pins non-flagging.
+- Modified: scripts/checks/check-destructive-wrapper-derivation.mjs, scripts/__tests__/check-destructive-wrapper-derivation.test.mjs (commit 2326bc597)
+### F2 [Minor] Flat-name cross-module false positive — FIXED
+- Action: scoped matching for resolved targets; flat fallback restricted to unresolved specifiers; collision green fixture + unresolved-fallback red fixture pin both sides.
+- Modified: same files (commit 2326bc597)
+- Post-fix verification: checker self-test 47/47; real tree exit 0.

--- a/docs/archive/review/overview-pairing-and-reexport-guard-code-review.md
+++ b/docs/archive/review/overview-pairing-and-reexport-guard-code-review.md
@@ -1,6 +1,12 @@
 # Code Review: overview-pairing-and-reexport-guard
 Date: 2026-07-18
-Review round: 4 — second external review round (rounds 1-3 log below)
+Review round: 5 — CONVERGED, both external reviewers merge-approve (rounds 1-4 log below)
+
+## Round 5 — external re-review of review(3)
+
+- Reviewer A: **merge-OK** — whitespace/newline/compact/comment evasions confirmed closed with the requested regression fixtures; bare-token `from` pre-filter accepted as sound for the covered grammar; no new Major/Medium.
+- Reviewer B: **merge-OK** (no security blocker) with one Minor: `export * as svc from` collapsed into `isStarLike` and dropped the namespace name, so hop B registered `executeVaultReset` instead of `svc.executeVaultReset` — a following `export { svc }` hop went undetected (B itself still flags, so CI fails; the gap was vs the "all hops, any depth" claim, not a full evasion).
+- **Fixed in review(4)**: `extractReExportFacts` preserves `getNamespaceExport()?.getName()`; the star branch registers under `svc.` prefix when present (plain `export * from` keeps the empty prefix). New 2-hop fixture asserts BOTH hops flag, with hop A's message proving the `svc.executeVaultReset` registration. Self-test 65/65; real tree exit 0; eslint clean.
 
 ## Round 4 — external review findings (two reviewers, post-review(2))
 

--- a/docs/archive/review/overview-pairing-and-reexport-guard-code-review.md
+++ b/docs/archive/review/overview-pairing-and-reexport-guard-code-review.md
@@ -1,6 +1,25 @@
 # Code Review: overview-pairing-and-reexport-guard
-Date: 2026-07-17
-Review round: 2 — CONVERGED (round 1 log below; fix commit: 2326bc597)
+Date: 2026-07-18
+Review round: 3 — external post-push review round (rounds 1-2 log below)
+
+## Round 3 — external static review findings (user-provided, post-push)
+
+An external static review of the pushed branch surfaced two Major evasion gaps in the C2 re-export gate plus resolver precision items. All verified against the code and fixed in review(2):
+
+### R3-1 [Major→fixed] `@/`-alias star/namespace re-exports undetected
+The resolver handled only `./`/`../`; `export * from "@/lib/vault/vault-reset"` (the repo's dominant import style) evaded cases (b)/(c). **Fixed**: unified `resolveSpecifierToRel` maps `@/*` → `<SCAN_ROOT rel>/*` (tsconfig `"@/*": ["./src/*"]`, computed from SCAN_ROOT so fixtures resolve identically), with candidates `<p>.ts` / `<p>.tsx` / `<p>/index.ts` / `<p>/index.tsx` — directory-index barrels (R3-3) resolve too.
+
+### R3-2 [Major→fixed] Object/class binding named re-exports undetected
+Destructive registrations for object/static-class wrappers are dotted (`vaultService.purgeUserEntries`, `VaultService.purgeAll`) but named-re-export matching compared only the bare binding name — `export { vaultService } from ...` evaded, breaking the anti-evasion guarantee for wrapper forms the checker explicitly supports. **Fixed**: matching is binding-prefix-aware (`n === sourceName || n.startsWith(sourceName + ".")`) and each member path is propagated under the post-alias local name (`vaultService.purge` re-exported `as service` registers `service.purge`), preserving semantics across multi-hop dotted chains.
+
+### R3-3 [Minor→fixed] Resolver did not try `/index.ts` (directory barrels) — folded into R3-1's candidate list.
+### R3-4 [Minor→fixed] Unresolved named re-exports flat-matched even for true package imports (false-positive/exemption-erosion risk). **Fixed**: three-way rule — resolved target → scoped set only; repo-shaped (relative or `@/`) but unresolved → flat fallback fail-closed (pinned fixture retained); true package import → skipped entirely (new green fixture).
+
+### R3-5 [Observation — follow-up, not this PR] Blob-only general updates can leave `encryptedOverview` stale relative to a changed blob (title edits etc.). C1 is precisely an overview-only-mutation ban plus key-version-guard closure, not a full blob↔overview content-consistency guarantee — the server cannot inspect E2E ciphertext to distinguish counter-only from content changes. External review's suggested design (dedicated passkey-counter endpoint or an explicit `operation` discriminator, making the general PUT require both fields; re-examine whether v1 needs the blob-only exception at all) is recorded as a follow-up item; out of scope for this PR per the review's own merge criteria.
+
+### Round 3 verification
+- New fixtures (8): `@/` star, `@/` namespace, directory-index barrel, object-binding named, 2-hop aliased object chain (member propagated under each hop's local name), static-class binding, aliased class binding — all red with single-failure-code isolation; package-import same-name re-export — green (skip rule).
+- Checker self-test 55/55; real tree exit 0 (no new false positives on existing `@/`/barrel usage); eslint clean on both files.
 
 ## Round 2 — incremental review of fix commit 2326bc597
 All three perspectives: **No findings**. Round-1 findings F1/F2 verified resolved. Empirical verification highlights:

--- a/docs/archive/review/overview-pairing-and-reexport-guard-deviation.md
+++ b/docs/archive/review/overview-pairing-and-reexport-guard-deviation.md
@@ -1,0 +1,9 @@
+# Coding Deviation Log: overview-pairing-and-reexport-guard
+
+## Phase 2 (commit 9ad0ea37e)
+
+No deviations. Both implementation batches (A: C1 refine + schema/route/extension tests; B: C2 re-export pass + C3 header + 8 red fixtures + green regression) followed the locked contracts (plan rev. 3) exactly — verified by orchestrator diff review (C1 refine byte-matches the contract signature; C2 pass placement, fixpoint, post-alias name registration, and route.ts-inclusive scan scope all present), R21 residue grep (clean), and forbidden-pattern grep (clean).
+
+Notes (not deviations):
+- R30 fix applied to `comprehensive-assessment-report-verification.md` (bare SHA → backticked) flagged by check-markdown-autolinks — documentation hygiene, outside plan contracts.
+- `.claude/settings.json` working-tree modification pre-dates this task and is excluded from all commits.

--- a/docs/archive/review/overview-pairing-and-reexport-guard-plan.md
+++ b/docs/archive/review/overview-pairing-and-reexport-guard-plan.md
@@ -139,6 +139,23 @@ sends blob-without-overview)
 4. Stale tab / third-party v1 script PUTs overview without blob → 400 with Zod message naming `encryptedOverview`.
 5. Developer adds `export { executeVaultReset } from "./vault-reset"` (any depth of barrel, incl. inside route.ts) → CI fails `REEXPORTED_DESTRUCTIVE_WRAPPER`.
 
+## Implementation Checklist
+
+Batch A (C1 + C4 app tests):
+- [ ] `src/lib/validations/entry.ts` — one-direction refine + scope-difference comment
+- [ ] R19 test trees referencing `updateE2EPasswordSchema` (ALL must be checked/updated): `src/lib/validations/entry.test.ts` (co-located), `src/lib/validations/validations.test.ts`, `src/lib/validations.test.ts`
+- [ ] `src/app/api/passwords/[id]/route.test.ts` — overview-only 400 + no-mutation (RT8); blob-only success pin
+- [ ] `src/app/api/v1/passwords/[id]/route.test.ts` — same two cases
+- [ ] `extension/src/__tests__/background-passkey-provider.test.ts` — PUT body `not.toHaveProperty("encryptedOverview")`
+
+Batch B (C2 + C3 + checker fixtures):
+- [ ] `scripts/checks/check-destructive-wrapper-derivation.mjs` — re-export pass (post-map, fixpoint, post-alias name registration, route.ts included), header edits (C3 + residual narrowing)
+- [ ] `scripts/__tests__/check-destructive-wrapper-derivation.test.mjs` — 8 red fixtures + green regression
+
+Shared utilities to reuse (no reimplementation): `encryptedFieldSchema` (entry.ts), team refine idiom (team.ts:103-113), checker's `destructiveExportsByModule` / `getRouteFiles` / `sourceFiles` / `seedWrapperStubs()` harness.
+
+CI gate parity: pre-pr.sh (54 gates) covers all app CI jobs; known-uncovered CI jobs = Extension CI + integration tests (memory: project_ci_gates_beyond_pre_pr) — both explicitly in Testing strategy steps 3-4. No new parity gap introduced by this diff.
+
 ## Go/No-Go Gate
 
 | ID  | Subject                                                          | Status |

--- a/docs/archive/review/overview-pairing-and-reexport-guard-plan.md
+++ b/docs/archive/review/overview-pairing-and-reexport-guard-plan.md
@@ -1,0 +1,153 @@
+# Plan: overview-pairing-and-reexport-guard
+
+Source: triangulated verification of the comprehensive assessment report (see
+`comprehensive-assessment-report-verification.md`) — findings S1, S2, S3.
+Branch: `fix/overview-pairing-and-reexport-guard`
+Revision: 3 (round 2 reflected: named-chain fixpoint name-registration rule + fixture 8;
+C4 blob-only route-unit tests + extension shape pin. Round 1: C1 redesigned to
+one-direction refine after Critical finding F1-func — extension passkey counter flow
+sends blob-without-overview)
+
+## Project context
+
+- Type: web app (Next.js 16 App Router + Prisma 7 + PostgreSQL)
+- Test infrastructure: unit + integration + E2E + CI/CD (vitest incl. `scripts/__tests__/**/*.test.mjs`, real-DB integration via `npm run test:integration`, Playwright, 34-gate scripts/checks suite, pre-pr.sh aggregate)
+- Verification environment constraints: `npm run test:integration` requires a running local Postgres (docker compose) — classified `verifiable-local`; all other acceptance paths are plain-local. No `blocked-deferred` paths.
+
+## Objective
+
+1. **S1**: Close the key-version-guard bypass where a PUT carrying `encryptedOverview` without `encryptedBlob` writes overview columns outside the guard, allowing a stale pre-rotation client to persist old-key ciphertext.
+2. **S3**: Convert the destructive-wrapper checker's documented re-export-chain residual into a fail-closed mechanical gate.
+3. **S2**: Reinforce the checker header comment so the "AST resolution admits non-grep-matchable forms" misreading cannot recur.
+
+## Requirements
+
+- Functional: no first-party client flow changes. Verified consumers of `PUT /api(/v1)?/passwords/[id]`:
+  - full edit (web `entry-save-core.ts`): blob+overview pair;
+  - metadata-only (web `personal-vault-list-adapter.ts`): neither;
+  - **extension passkey signature-counter persist (`extension/src/background/passkey-provider.ts:278-285`): blob WITHOUT overview** — a legitimate, shipped shape ("overview unchanged, omit from PUT", line 270) that the fix MUST keep working.
+- Non-functional: schema-enforced invariant at the shared validation boundary; checker keeps the no-Program ts-morph precedent; all new gates RT7 red-proven.
+
+## Technical approach
+
+- S1 is fixed at the shared Zod boundary (`updateE2EPasswordSchema`, `src/lib/validations/entry.ts:57-69`) because both routes parse with it (`src/app/api/passwords/[id]/route.ts:121`, `src/app/api/v1/passwords/[id]/route.ts:144`).
+- **One-direction refine**: reject `encryptedOverview` without `encryptedBlob`. The reverse shape (blob-without-overview) is intentionally allowed:
+  - It is the extension passkey counter flow (same-keyVersion blob re-encrypt, overview untouched).
+  - It is NOT a corruption path: the blob branch runs `assertCurrentKeyVersion` (users FOR SHARE) inside the tx, serializing against rotation (users FOR UPDATE); rotation itself rewrites blob+overview+keyVersion atomically, so a stored overview is always at the entry's current keyVersion, and a blob-only write cannot desynchronize it. (Round-1 plan claimed the mirror direction was corruptive — refuted by this lock/rewrite analysis and withdrawn.)
+- Overview-only writes have no legitimate consumer (all clients derive overview from blob content at save time) and are the S1 corruption vector → rejected.
+- Precedent: `updateTeamE2EPasswordSchema` refine (`src/lib/validations/team.ts:103-113`). NOTE the deliberate scope difference: team enforces all-or-none over FOUR fields (blob, overview, aadVersion, teamKeyVersion) and both directions; personal C1 enforces one direction over TWO fields because the personal blob-only shape is a shipped flow. The C1 code comment must state this difference explicitly.
+- No concurrency-primitive change; no plan-stage real-DB probe needed (no new isolation/lock semantics). Existing real-DB proof of the guard (`src/__tests__/db-integration/key-version-guard.integration.test.ts`) uses blob-only bodies (lines 244-248, 422-426, 494-498) — under the one-direction refine these remain VALID and the suite runs unchanged; the Testing strategy still executes it to prove that.
+
+## Contracts
+
+### C1 — updateE2EPasswordSchema overview-requires-blob refine (S1)
+
+- Signature: append to the object schema in `src/lib/validations/entry.ts:57-69`:
+  `.refine((d) => d.encryptedOverview === undefined || d.encryptedBlob !== undefined, { message: "encryptedOverview requires encryptedBlob", path: ["encryptedOverview"] })`
+  Inferred type `UpdateE2EPasswordInput` unchanged. Code comment states the deliberate one-direction / two-field scope difference from the team refine (see Technical approach).
+- Error surface: refine failure → `parseBody` → 400 `VALIDATION_ERROR` envelope (same as team refine). No new API error code.
+- Invariant (schema-enforced at the shared boundary): **an update request that writes overview columns also writes blob columns**, and therefore (composed with the existing blob→keyVersion→guard chain at `route.ts:162-175` / v1 `185-199`) every overview write executes inside `assertCurrentKeyVersion`'s transaction.
+- **R42 member-set derivation** (defining primitive: assignment of overview columns into a Prisma write payload; `grep -rn "overviewIv" src --include='*.ts'` filtered to writers):
+  | Writer | Path | Status |
+  |---|---|---|
+  | personal update PUT | `src/app/api/passwords/[id]/route.ts:159` | **GAP → closed by C1** |
+  | v1 update PUT | `src/app/api/v1/passwords/[id]/route.ts:182` | **GAP → closed by C1** (same schema) |
+  | personal/v1/bulk create | via `createE2EPasswordSchema` | both fields required (entry.ts:42-44) — safe |
+  | team create/update | `toOverviewColumns` in `team-password-service.ts:448` | team refine (team.ts:103-113) — safe |
+  | personal rotation | `rotate-key-server.ts` | CAS + FOR UPDATE — safe |
+  | team rotation | `teams/[teamId]/rotate-key/route.ts:190` | team CAS — safe |
+  | history restore | `history/[historyId]/restore/route.ts` | writes blob+overview from history inside guard tx — safe |
+- **Consumer-flow walkthrough**:
+  - Consumer 1 (web full edit: `src/lib/vault/entry-save-core.ts:36-45` via `personal-entry-save.ts`) sends `{encryptedBlob, encryptedOverview, keyVersion, aadVersion, tagIds, ...}` → passes.
+  - Consumer 2 (web metadata mutations: `personal-vault-list-adapter.ts:188-204`) sends `{isFavorite}` / `{isArchived}` — neither field → passes.
+  - Consumer 3 (extension passkey counter: `extension/src/background/passkey-provider.ts:278-285`) sends `{encryptedBlob, keyVersion, aadVersion}` — blob-only → passes under one-direction refine (would have broken under round-1's two-direction design; this consumer is why the direction is scoped).
+  - Consumer 4 (v1 REST external callers): overview-only PUT now 400. Pre-1.0 tightening; converts a corruption-capable request into an explicit rejection.
+  - Consumer 5 (route handlers post-parseBody): no code change; the overview branch (`route.ts:157-161` / v1 `179-183`) becomes reachable only alongside the blob branch.
+- Acceptance criteria:
+  - PUT `{encryptedOverview}` only → 400 VALIDATION_ERROR, no DB write (both routes).
+  - PUT `{encryptedBlob, keyVersion, aadVersion}` (passkey counter shape) → unchanged behavior (guard runs in tx; 200 on current keyVersion, 409 on stale).
+  - PUT with both + keyVersion → unchanged. PUT metadata-only → unchanged.
+  - `key-version-guard.integration.test.ts` passes unchanged (its blob-only bodies remain valid).
+
+### C2 — checker re-export detection (S3)
+
+- Location: `scripts/checks/check-destructive-wrapper-derivation.mjs`.
+- New failure code: `REEXPORTED_DESTRUCTIVE_WRAPPER: <file> re-exports <name> from <specifier>`.
+- Detection cases (ExportDeclaration with `moduleSpecifier`):
+  - (a) named re-export `export { x } from` / `export { x as y } from` — flag when the *source-side* name is in the destructive set (name match; catches any chain depth for named chains without resolution).
+  - (b) `export * from "<relative specifier>"` — flag when the one-hop-resolved target file is a destructive-exporting module.
+  - (c) `export * as ns from "<relative specifier>"` — same lookup as (b) (namespace re-export binds the whole module).
+  - Non-relative specifiers (package imports) out of scope — destructive wrappers are all in-repo.
+- **Implementation ordering & transitivity (from review F2-func / F1-sec)**:
+  - The re-export scan runs as a **separate pass after** the main derivation loop fully populates `destructiveExportsByModule` (mirrors the route-pass sequencing at `:682+`); it must NOT be interleaved into the per-file derivation loop (a barrel sorting before its target would otherwise false-negative).
+  - The destructive-module lookup must be **transitively closed**: when a file is flagged for re-exporting a destructive symbol (any case a/b/c), register that file into the same lookup, and iterate the scan to a fixpoint (bounded by file count) so an A→B→C `export *` chain of any depth flags every hop. Without this, depth ≥3 chains evade (round-1 design under-delivered its own claim).
+  - **Name registration rule for named chains (round-2 sec finding)**: for case (a), the fixpoint step registers the re-exporting file's **own locally-visible export name (post-alias)** — e.g. for `B: export { executeVaultReset as x } from "./C"`, register `B → x`, NOT `B → executeVaultReset`. A further hop `A: export { x as y } from "./B"` matches by looking up `x` against B's registered exports. Registering the original destructive-set name would silently break named chains after hop 1.
+- **Scan scope extension**: the re-export pass scans production `src/**/*.ts` INCLUDING `route.ts` files (a re-export inside route.ts is invisible to the import/call-walking route pass — review F3-sec); route.ts stays excluded from the primitive-call derivation scan as before.
+- Header update: RESIDUAL LIMITATION paragraph narrows to "only an INDIRECT binding evades" (local-variable assignment / higher-order pass-through — SC1).
+- Invariant (app-enforced, CI gate): no production module (route.ts included) re-exports a destructive wrapper; barrel-free convention machine-checked.
+- Acceptance criteria — red fixtures, each isolated to exactly the new failure code (assert exit 1 + stderr contains `REEXPORTED_DESTRUCTIVE_WRAPPER` and does NOT contain `ROUTE_DESTRUCTIVE_NO_STEPUP` / `UNDECLARED_DESTRUCTIVE_WRAPPER`; `seedWrapperStubs()` isolation pattern per `scripts/__tests__/check-destructive-wrapper-derivation.test.mjs:74-83`):
+  1. named re-export; 2. aliased named re-export; 3. `export * from` (2-hop);
+  4. `export * from` 3-hop chain A→B→C (proves transitive closure);
+  5. ordering-adversarial: barrel file sorts before its target in scan order;
+  6. `export * as ns from`; 7. re-export hosted inside a route.ts file;
+  8. 2-hop NAMED chain with a distinct alias at each hop (`A: export {x as y} from "./B"`; `B: export {executeVaultReset as x} from "./C"`) — proves the post-alias name-registration rule.
+  Green: current repo tree passes unchanged (grep-verified zero re-exports today); existing failure codes and exit semantics unchanged.
+
+### C3 — checker header comment reinforcement (S2)
+
+- Location: header wrapper-forms paragraph (lines 37-48) of the checker.
+- Add one explicit sentence: the ROUTE PASS (AST) compensates only for alias/namespace *imports of grep-matchable forms*; it never admits a non-grep-matchable form — the only escapes are refactor to a grep-matchable form or an explicit `destructive-wrapper-exempt.txt` entry.
+- Acceptance: comment-only; checker behavior for C3 byte-identical (self-test suite green without C3-attributable fixture changes).
+
+### C4 — tests
+
+- Schema unit tests (sibling test of `entry.ts`): overview-only rejected; blob-only accepted (passkey counter shape); both accepted; neither accepted. One behavioral assertion each.
+- Route tests (existing `route.test.ts` harnesses for both routes; RT8 pattern at `route.test.ts:807-810`, `934-936`): overview-only PUT → assert 400 AND Prisma update mock **not** called. **Blob-only PUT unit test added per route** (assert success + guard/tx path executes) — round-2 correction: no existing route-unit test sends blob-only (every blob-carrying body pairs both fields); the only blob-only coverage today is the real-DB integration suite, so the passkey-counter shape gets an explicit route-mock pin. No existing test sends overview-only (verified).
+- Extension shape pin (round-2 testing finding): add one assertion to the existing counter-persist PUT test(s) in `extension/src/__tests__/background-passkey-provider.test.ts` (~396-448) asserting the sent body does NOT contain `encryptedOverview` (e.g. `expect(putBody).not.toHaveProperty("encryptedOverview")`) — pins the client shape that motivated the one-direction refine against future two-direction regressions.
+- Checker self-test (`scripts/__tests__/check-destructive-wrapper-derivation.test.mjs`, vitest harness): the 8 red fixtures + green regression above (RT7 — every new detection path proven able to fail for the claimed reason).
+- Integration (real DB): `key-version-guard.integration.test.ts` must pass unchanged — executed in Testing strategy step 3.
+
+## Forbidden patterns
+
+- pattern: `OVERVIEW_WITHOUT_BLOB` — reason: no new API error code; the fix is the shared-schema refine.
+- pattern: `eslint-disable` (new occurrences in the diff) — reason: R36.
+- pattern: `\.skip\(` (in touched test files) — reason: no disabled tests to force green.
+- pattern: `keyVersion === undefined` (new occurrences in the two update routes beyond existing lines 173/218 and v1 197/239) — reason: C1 must not be reimplemented as duplicated route-level conditionals.
+
+## Testing strategy
+
+1. Targeted: `npx vitest run src/lib/validations src/app/api/passwords src/app/api/v1/passwords scripts/__tests__/check-destructive-wrapper-derivation.test.mjs` (single vitest invocation — the checker self-test is vitest-based per `vitest.config.ts:8-13`; `node --test` does not work).
+2. Full: `npx vitest run`, then `npx next build` (mandatory per CLAUDE.md).
+3. Real-DB: `npm run test:integration -- key-version-guard` (running Postgres required) — proves the blob-only integration bodies still pass through the refine.
+4. Extension: run the touched extension test file (`cd extension && npx vitest run src/__tests__/background-passkey-provider.test.ts`) — extension CI is a separate job pre-pr.sh does not cover.
+5. `scripts/pre-pr.sh` before push.
+
+## Considerations & constraints
+
+- Pre-1.0: the v1 REST tightening (overview-only PUT → 400) needs no deprecation shim.
+- Scope contract:
+  - SC1 — INDIRECT-binding evasion of the route pass (local-variable assignment / higher-order pass-through) stays a documented residual; closing it needs whole-program resolution the repo's AST guards deliberately avoid. Owner: future ts-morph AST-guard upgrade.
+  - SC2 — Team update path: already enforced by team refine; no changes.
+  - SC3 — Overview-only update capability: not added (no client derives overview independently of blob).
+  - SC4 — External-report text corrections: recorded in the verification artifact; not a repo change.
+
+## User operation scenarios
+
+1. Web full edit → blob+overview+keyVersion → unchanged.
+2. Favorite/archive toggle → metadata-only PUT → unchanged.
+3. Extension passkey sign-in → blob-only counter persist PUT → unchanged (409 if a rotation raced it — extension soft-fail path already handles).
+4. Stale tab / third-party v1 script PUTs overview without blob → 400 with Zod message naming `encryptedOverview`.
+5. Developer adds `export { executeVaultReset } from "./vault-reset"` (any depth of barrel, incl. inside route.ts) → CI fails `REEXPORTED_DESTRUCTIVE_WRAPPER`.
+
+## Go/No-Go Gate
+
+| ID  | Subject                                                          | Status |
+|-----|------------------------------------------------------------------|--------|
+| C1  | updateE2EPasswordSchema overview-requires-blob refine (one-way)  | locked |
+| C2  | checker re-export detection (transitive, ordered, route.ts incl.)| locked |
+| C3  | checker header comment reinforcement                             | locked |
+| C4  | schema/route/checker/extension/integration tests (RT7/RT8)       | locked |
+
+Locked at review round 3 (2026-07-17): rounds 1-2 findings all resolved; round 3
+returned one Minor documentation-count drift (fixed inline: C4 "7"→"8 fixtures")
+and No findings from all three perspectives otherwise.

--- a/docs/archive/review/overview-pairing-and-reexport-guard-review.md
+++ b/docs/archive/review/overview-pairing-and-reexport-guard-review.md
@@ -1,0 +1,81 @@
+# Plan Review: overview-pairing-and-reexport-guard
+Date: 2026-07-17
+Review round: 2 (round 1 log preserved below)
+
+## Round 2 — incremental review of plan revision 2
+
+### Changes from Previous Round
+C1 redesigned to one-direction refine; C2 gained pass-ordering, transitive fixpoint, route.ts scope, 7 fixtures; Testing strategy corrected.
+
+### Round-1 finding status
+All five merged round-1 findings verified **resolved** by all three experts. The C1 narrowing (two-direction → one-direction) was independently re-derived by the Security expert per R43: rotation rewrites blob+overview+keyVersion atomically for ALL entries (no archived/trash filter, `ENTRY_COUNT_MISMATCH` all-or-fail, `rotate-key-server.ts:275-294,320-336`), and lock ordering (guard FOR SHARE vs rotation FOR UPDATE on users) serializes writers — blob-only writes cannot desynchronize overview. Narrowing justified, not merely asserted.
+
+### New findings (round 2 — all Minor, reflected in plan revision 3)
+- **Sec-1 [Minor→resolved]** Named re-export chains at depth ≥2 with distinct aliases per hop were unproven; fixpoint name-registration ambiguity (original name vs post-alias local name). → Plan now mandates registering the re-exporting file's own post-alias export name + fixture 8 (2-hop named chain, distinct aliases).
+- **Test-1 [Minor→resolved]** "Blob-only already covered" claim inaccurate at route-unit level (only the integration suite covers it). → Claim corrected; explicit blob-only PUT unit test per route added to C4.
+- **Test-2 [Minor→resolved]** No extension-side shape pin for the passkey counter PUT body. → One assertion (`not.toHaveProperty("encryptedOverview")`) added to C4 + extension test run added to Testing strategy.
+- Functionality expert: No findings (all round-1 items verified resolved against live code, incl. fixpoint feasibility via existing `getRouteFiles`/`sourceFiles` union).
+
+### Recurring Issue Check (round 2)
+- Functionality: R3/R34/R40/R42 resolved-verified; R43 pass (narrowing corrects an incorrect round-1 claim); all others pass/n/a unchanged.
+- Security: R43 applied directly (narrowing justified with independently-verified lock/atomicity argument — pass); R42 re-applied to C2's revised design (Sec-1 is an R42-style coverage-claim gap, now closed); RS1-RS6 pass/n/a unchanged.
+- Testing: RT7 pass (extended by Test-2, now closed); RT8 pass (non-mutation-on-reject specified); RT4 re-verified (integration contention tests unaffected); all others pass/n/a unchanged.
+
+## Round 3 — convergence check of plan revision 3
+All three round-2 reflections verified faithful and complete. Functionality: No findings. Security: No findings (post-alias name-registration rule + fixture 8 verified as asked). Testing: one Minor documentation drift — C4 said "7 red fixtures" vs C2's authoritative list of 8; fixed inline (no behavioral impact). **Converged: contracts C1-C4 locked.**
+
+### Forward-looking observation (informational, out of scope — no action this plan)
+The blob-only safety argument depends on rotation's no-filter, all-or-fail entry enumeration remaining unchanged. A future rotation change adding a filter would silently invalidate it; an integration pin (archived entry required in rotation payload) is worth considering in a future hardening pass.
+
+---
+
+# Round 1 log
+
+## Changes from Previous Round
+Initial review.
+
+## Merged Findings (Ollama merge-findings + mechanical json join)
+
+### F1 [Critical→resolved in rev.2] C1 refine breaks real passkey flow & integration tests
+Perspectives: Functionality (Critical) + Testing (Major) — perspective convergence.
+The round-1 two-direction refine rejects `extension/src/background/passkey-provider.ts:278-285` (passkey signature-counter persist: blob-without-overview, a shipped first-party flow) and breaks `src/__tests__/db-integration/key-version-guard.integration.test.ts` (blob-only bodies at 244-248/422-426/494-498 would 400 before reaching the guard).
+Resolution: C1 redesigned to a ONE-DIRECTION refine (`encryptedOverview` requires `encryptedBlob`; blob-only stays valid). Safety of blob-only re-verified: the blob branch runs the guard (FOR SHARE) serializing against rotation (FOR UPDATE), and rotation rewrites blob+overview atomically, so overview cannot desynchronize. Round-1 plan's "mirror-image corruption" claim withdrawn as incorrect. Integration suite now passes unchanged; `npm run test:integration -- key-version-guard` added to Testing strategy as proof.
+
+### F2 [Major→resolved in rev.2] C2 export-* resolution lacks multi-hop closure & pass ordering
+Perspectives: Security (Major) + Functionality (Minor) — convergence.
+`destructiveExportsByModule` is populated only by primitive-calling files; depth ≥3 `export *` chains evade one-hop resolution, and interleaving the scan into the derivation loop false-negatives on scan order.
+Resolution: C2 now specifies (i) separate pass after full map build, (ii) transitively-closed lookup iterated to fixpoint, (iii) red fixtures for 3-hop chain and ordering-adversarial barrel.
+
+### F3 [Minor→resolved in rev.2] `export * as ns from` not enumerated
+Resolution: C2 detection case (c) + fixture 6.
+
+### F4 [Minor→resolved in rev.2] Test-runner command wrong; fixture isolation discipline
+`node --test` does not run the vitest-based checker self-test. Resolution: Testing strategy step 1 rewritten to a single `npx vitest run` invocation; C2 acceptance now mandates single-failure-code isolation per fixture (seedWrapperStubs pattern) with negative stderr assertions.
+
+### F5 [Minor→resolved in rev.2] Scope clarifications (team.ts precedent, route.ts re-export)
+Team refine is 4-field/two-direction vs C1's 2-field/one-direction → C1 requires an explicit code comment stating the deliberate difference. Re-export hosted inside route.ts was invisible to both scans → C2 re-export pass scope extended to include route.ts (fixture 7).
+
+## Quality Warnings
+None (merge-findings quality gate: no VAGUE / NO-EVIDENCE / UNTESTED-CLAIM flags).
+
+## Local LLM pre-screening disposition
+One pre-screen finding ("refine must pair a separate `encryptedOverviewIv` field") REJECTED: `overviewIv` is a DB column; request shape is nested `encryptedOverview {ciphertext,iv,authTag}`; Zod strips unknown keys. Rejection independently confirmed by the Functionality expert.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R3: finding-ref F1 (unpaired-shape pattern not fully propagated across all consumers)
+- R5, R17, R34: pass. R40: subsumed by F1. R42: finding-ref F1 (consumer member-set incomplete — extension passkey PUT omitted); overview-column-writer member-set independently re-verified complete.
+- All other R1-R44: pass or n/a.
+
+### Security expert
+- R42: applied — F2 is an R42-style class-membership issue on C2's own coverage. R43: pass (plan strictly narrows). RS3: satisfied (boundary validation is the fix itself). RS5: n/a (keyVersion/aadVersion already bounded by existing schema).
+- All other R1-R44 + RS1-RS6: pass or n/a.
+
+### Testing expert
+- R34: related F1 — integration-test cost folded into C4 (not deferred). R42: satisfied for C1 writer set; F1 was the analogous test-body gap.
+- RT2/RT5/RT6/RT8: satisfied by plan (RT8 pattern exists at route.test.ts:807-810, 934-936). RT7: addressed by C4, refined by F4.
+- All other R1-R44 + RT1-RT9: pass or n/a.
+
+## Resolution Status (round 1 → plan revision 2)
+All five merged findings reflected in plan revision 2 (C1 redesign, C2 ordering/transitivity/scope/fixtures, C3 unchanged, C4 expanded, Testing strategy corrected). No Skipped/Accepted/Deferred entries — no Anti-Deferral records required this round.

--- a/extension/src/__tests__/background-passkey-provider.test.ts
+++ b/extension/src/__tests__/background-passkey-provider.test.ts
@@ -399,6 +399,9 @@ describe("passkey-provider", () => {
       const decryptedBlobStr = await decryptData(putBody.encryptedBlob, testKey, aad);
       const decryptedBlob = JSON.parse(decryptedBlobStr) as { passkeySignCount: number };
       expect(decryptedBlob.passkeySignCount).toBe(1);
+      // Shape pin: counter persist sends blob-without-overview (schema's
+      // one-direction refine requires this shape to stay valid — entry.ts).
+      expect(putBody).not.toHaveProperty("encryptedOverview");
       // Verify invalidateCache was called after successful PUT
       expect(deps.invalidateCache).toHaveBeenCalledOnce();
     });

--- a/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
+++ b/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
@@ -946,6 +946,65 @@ describe("check-destructive-wrapper-derivation.mjs", () => {
       expect(exitCode).toBe(0);
       expect(stderr).not.toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
     });
+
+    it("passes (no REEXPORTED_DESTRUCTIVE_WRAPPER) for a TYPE-ONLY re-export of a destructive wrapper name", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/vault/reexport-type-only.ts",
+        'export type { executeVaultReset } from "./vault-reset";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("passes (no REEXPORTED_DESTRUCTIVE_WRAPPER) for a same-named but unrelated symbol re-exported from a RESOLVED in-scope module", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      // Unrelated module whose innocuous export coincidentally shares the
+      // destructive wrapper's name — must NOT flag when the specifier
+      // resolves cleanly to this in-scope file (its own export set decides).
+      writeSource(
+        "src/lib/labels/label-formatter.ts",
+        "export function executeVaultReset(label) {\n  return label.trim();\n}\n",
+      );
+      writeSource(
+        "src/lib/labels/reexport-collision.ts",
+        'export { executeVaultReset } from "./label-formatter";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for a destructive-named re-export whose specifier does NOT resolve in-scope (flat-fallback fail-closed)", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      // Target lives outside the .ts scan scope (e.g. .tsx / generated) so
+      // resolution fails — the flat cross-module name set must fail closed.
+      writeSource(
+        "src/lib/vault/reexport-unresolved.ts",
+        'export { executeVaultReset } from "./generated/not-in-scan";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/vault/reexport-unresolved.ts re-exports executeVaultReset from ./generated/not-in-scan",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
   });
 
   describe("env-pollution guard (sec-F6)", () => {

--- a/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
+++ b/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
@@ -746,6 +746,208 @@ describe("check-destructive-wrapper-derivation.mjs", () => {
     expect(stderr).toContain("ROUTE_DESTRUCTIVE_NO_STEPUP: src/app/api/danger2/route.ts");
   });
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // Re-export pass (C2): the residual limitation this file used to document
+  // ("re-export chains evade") is now mechanically rejected. Each red fixture
+  // is isolated to REEXPORTED_DESTRUCTIVE_WRAPPER only (no
+  // ROUTE_DESTRUCTIVE_NO_STEPUP / UNDECLARED_DESTRUCTIVE_WRAPPER
+  // contamination) — seedWrapperStubs() keeps STALE_DELETE_SIGNAL_NAME quiet,
+  // and the barrel fixtures below stand alone (no route imports them), so the
+  // route pass and the wrapper-derivation loop have nothing to say.
+  // ─────────────────────────────────────────────────────────────────────────
+  describe("re-export pass (C2)", () => {
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for a named re-export of a destructive wrapper", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/vault/reexport-barrel.ts",
+        'export { executeVaultReset } from "./vault-reset";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/vault/reexport-barrel.ts re-exports executeVaultReset from ./vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for an ALIASED named re-export of a destructive wrapper", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/vault/reexport-barrel-alias.ts",
+        'export { executeVaultReset as resetVault } from "./vault-reset";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/vault/reexport-barrel-alias.ts re-exports executeVaultReset from ./vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for `export * from` (2-hop)", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource("src/lib/vault/barrel-star.ts", 'export * from "./vault-reset";\n');
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/vault/barrel-star.ts re-exports executeVaultReset from ./vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for a 3-hop `export * from` chain A->B->C (transitive closure)", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset-c.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource("src/lib/vault/barrel-b.ts", 'export * from "./vault-reset-c";\n');
+      writeSource("src/lib/vault/barrel-a.ts", 'export * from "./barrel-b";\n');
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      // Every hop must be flagged, not just the direct one.
+      expect(stderr).toContain(
+        "src/lib/vault/barrel-b.ts re-exports executeVaultReset from ./vault-reset-c",
+      );
+      expect(stderr).toContain(
+        "src/lib/vault/barrel-a.ts re-exports executeVaultReset from ./barrel-b",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) when the barrel sorts BEFORE its target in scan order (ordering-adversarial)", () => {
+      seedWrapperStubs();
+      // "aaa-barrel.ts" sorts before "vault-reset.ts" alphabetically — the
+      // fixpoint loop, not scan order, must still catch this.
+      writeSource(
+        "src/lib/vault/aaa-barrel.ts",
+        'export { executeVaultReset } from "./vault-reset";\n',
+      );
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/vault/aaa-barrel.ts re-exports executeVaultReset from ./vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for `export * as ns from`", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/vault/barrel-ns.ts",
+        'export * as vaultReset from "./vault-reset";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/vault/barrel-ns.ts re-exports executeVaultReset from ./vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for a re-export hosted inside a route.ts file", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      // A route.ts acting as a re-export SOURCE for some other file — invisible
+      // to the route pass's import-walk (which only resolves @/-aliased
+      // imports into wrapper modules, not a route file as a barrel).
+      writeSource(
+        "src/app/api/internal/route.ts",
+        [
+          'export { executeVaultReset } from "@/lib/vault/vault-reset";',
+          "export async function GET() {",
+          "  return new Response('ok');",
+          "}",
+          "",
+        ].join("\n"),
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/app/api/internal/route.ts re-exports executeVaultReset from @/lib/vault/vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for a 2-hop NAMED chain with a distinct alias at each hop (post-alias name registration)", () => {
+      seedWrapperStubs();
+      // C defines the wrapper; B re-exports it under alias `x`; A re-exports
+      // B's `x` under alias `y`. The fixpoint step must register B -> x (its
+      // OWN locally-visible name), not B -> executeVaultReset, so A's lookup
+      // of the source-side name `x` against B's registered exports succeeds.
+      writeSource(
+        "src/lib/vault/vault-reset-chain-c.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/vault/chain-b.ts",
+        'export { executeVaultReset as x } from "./vault-reset-chain-c";\n',
+      );
+      writeSource("src/lib/vault/chain-a.ts", 'export { x as y } from "./chain-b";\n');
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/vault/chain-b.ts re-exports executeVaultReset from ./vault-reset-chain-c",
+      );
+      expect(stderr).toContain("src/lib/vault/chain-a.ts re-exports x from ./chain-b");
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("passes (no REEXPORTED_DESTRUCTIVE_WRAPPER) for an innocuous non-destructive re-export", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/helpers.ts",
+        "export function formatVaultLabel(name) {\n  return name.trim();\n}\n",
+      );
+      writeSource(
+        "src/lib/vault/reexport-innocuous.ts",
+        'export { formatVaultLabel } from "./helpers";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+    });
+  });
+
   describe("env-pollution guard (sec-F6)", () => {
     it("FAILS when CI=true and an override is set without DESTRUCTIVE_WRAPPER_FIXTURE_MODE=1", () => {
       const { exitCode, stderr } = runGuard({ CI: "true", DESTRUCTIVE_WRAPPER_FIXTURE_MODE: "" });

--- a/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
+++ b/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
@@ -1005,6 +1005,212 @@ describe("check-destructive-wrapper-derivation.mjs", () => {
       expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
       expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
     });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for `export * from` via the @/ path alias", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-alias-star.ts",
+        'export * from "@/lib/vault/vault-reset";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-alias-star.ts re-exports executeVaultReset from @/lib/vault/vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for `export * as ns from` via the @/ path alias", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-alias-ns.ts",
+        'export * as vaultReset from "@/lib/vault/vault-reset";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-alias-ns.ts re-exports executeVaultReset from @/lib/vault/vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for a directory-index barrel (`export * from \"./dir\"` resolving dir/index.ts)", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault-reset-dir/index.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-dir-barrel.ts",
+        'export * from "./vault-reset-dir";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-dir-barrel.ts re-exports executeVaultReset from ./vault-reset-dir",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for a named re-export of an exported OBJECT binding carrying a destructive member", () => {
+      seedWrapperStubs();
+      writeFileSync(
+        patternsFile,
+        JSON.stringify({ deleteSignal: `${FIXTURE_DELETE_SIGNAL}|vaultService\\.purgeUserEntries\\(` }),
+        "utf8",
+      );
+      writeSource(
+        "src/lib/vault-service.ts",
+        [
+          "export const vaultService = {",
+          "  async purgeUserEntries(userId) {",
+          "    await tx.passwordEntry.deleteMany({ where: { userId } });",
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+      );
+      writeSource(
+        "src/lib/reexport-object-binding.ts",
+        'export { vaultService } from "./vault-service";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-object-binding.ts re-exports vaultService.purgeUserEntries from ./vault-service",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for a 2-hop ALIASED object-binding chain, propagating the member under each hop's local name", () => {
+      seedWrapperStubs();
+      writeFileSync(
+        patternsFile,
+        JSON.stringify({ deleteSignal: `${FIXTURE_DELETE_SIGNAL}|vaultService\\.purgeUserEntries\\(` }),
+        "utf8",
+      );
+      writeSource(
+        "src/lib/vault-service.ts",
+        [
+          "export const vaultService = {",
+          "  async purgeUserEntries(userId) {",
+          "    await tx.passwordEntry.deleteMany({ where: { userId } });",
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+      );
+      writeSource(
+        "src/lib/obj-chain-b.ts",
+        'export { vaultService as service } from "./vault-service";\n',
+      );
+      writeSource(
+        "src/lib/obj-chain-a.ts",
+        'export { service as apiService } from "./obj-chain-b";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/obj-chain-b.ts re-exports vaultService.purgeUserEntries from ./vault-service",
+      );
+      expect(stderr).toContain(
+        "src/lib/obj-chain-a.ts re-exports service.purgeUserEntries from ./obj-chain-b",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for a named re-export of a STATIC-class binding carrying a destructive member", () => {
+      seedWrapperStubs();
+      writeFileSync(
+        patternsFile,
+        JSON.stringify({ deleteSignal: `${FIXTURE_DELETE_SIGNAL}|VaultService\\.purgeAll\\(` }),
+        "utf8",
+      );
+      writeSource(
+        "src/lib/vault-service-static.ts",
+        [
+          "export class VaultService {",
+          "  static async purgeAll(userId) {",
+          "    await tx.passwordEntry.deleteMany({ where: { userId } });",
+          "  }",
+          "}",
+          "",
+        ].join("\n"),
+      );
+      writeSource(
+        "src/lib/reexport-class-binding.ts",
+        'export { VaultService } from "./vault-service-static";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-class-binding.ts re-exports VaultService.purgeAll from ./vault-service-static",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for an ALIASED static-class binding re-export", () => {
+      seedWrapperStubs();
+      writeFileSync(
+        patternsFile,
+        JSON.stringify({ deleteSignal: `${FIXTURE_DELETE_SIGNAL}|VaultService\\.purgeAll\\(` }),
+        "utf8",
+      );
+      writeSource(
+        "src/lib/vault-service-static.ts",
+        [
+          "export class VaultService {",
+          "  static async purgeAll(userId) {",
+          "    await tx.passwordEntry.deleteMany({ where: { userId } });",
+          "  }",
+          "}",
+          "",
+        ].join("\n"),
+      );
+      writeSource(
+        "src/lib/reexport-class-alias.ts",
+        'export { VaultService as DestructiveService } from "./vault-service-static";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-class-alias.ts re-exports VaultService.purgeAll from ./vault-service-static",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("passes (no REEXPORTED_DESTRUCTIVE_WRAPPER) for a same-named re-export from a TRUE PACKAGE import (skipped, not flat-matched)", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/reexport-package.ts",
+        'export { executeVaultReset } from "some-npm-package";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+    });
   });
 
   describe("env-pollution guard (sec-F6)", () => {

--- a/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
+++ b/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
@@ -1372,6 +1372,35 @@ describe("check-destructive-wrapper-derivation.mjs", () => {
       expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
     });
 
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) on BOTH hops of a namespace-re-export chain (`export * as svc from` then `export { svc }`)", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/ns-chain-b.ts",
+        'export * as svc from "./vault/vault-reset";\n',
+      );
+      writeSource(
+        "src/lib/ns-chain-a.ts",
+        'export { svc } from "./ns-chain-b";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/ns-chain-b.ts re-exports executeVaultReset from ./vault/vault-reset",
+      );
+      // The second hop only matches if hop B registered `svc.executeVaultReset`
+      // (namespace name preserved), not a bare `executeVaultReset`.
+      expect(stderr).toContain(
+        "src/lib/ns-chain-a.ts re-exports svc.executeVaultReset from ./ns-chain-b",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
     it("passes (no REEXPORTED_DESTRUCTIVE_WRAPPER) for import-then-export of an INNOCENT binding", () => {
       seedWrapperStubs();
       writeSource(

--- a/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
+++ b/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
@@ -1211,6 +1211,181 @@ describe("check-destructive-wrapper-derivation.mjs", () => {
       expect(exitCode).toBe(0);
       expect(stderr).not.toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
     });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) when `from` is on the NEXT LINE (whitespace-format evasion)", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-newline.ts",
+        'export {\n  executeVaultReset,\n}\nfrom "./vault/vault-reset";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-newline.ts re-exports executeVaultReset from ./vault/vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for the compact no-whitespace `export*from` form", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-compact.ts",
+        'export*from"./vault/vault-reset";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-compact.ts re-exports executeVaultReset from ./vault/vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) when a comment separates the clause from `from`", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-comment.ts",
+        'export {\n  executeVaultReset,\n} /* barrel */\nfrom "./vault/vault-reset";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-comment.ts re-exports executeVaultReset from ./vault/vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for IMPORT-THEN-EXPORT laundering of an aliased wrapper binding", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-laundered.ts",
+        'import { executeVaultReset as reset } from "./vault/vault-reset";\nexport { reset };\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-laundered.ts re-exports executeVaultReset from ./vault/vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for import-then-export with a SECOND alias on the export clause", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-laundered-alias.ts",
+        'import { executeVaultReset as reset } from "./vault/vault-reset";\nexport { reset as publicReset };\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-laundered-alias.ts re-exports executeVaultReset from ./vault/vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for NAMESPACE import-then-export (`import * as svc` then `export { svc }`)", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-ns-laundered.ts",
+        'import * as svc from "./vault/vault-reset";\nexport { svc };\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-ns-laundered.ts re-exports executeVaultReset from ./vault/vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for `export default <imported wrapper binding>`", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-default-laundered.ts",
+        'import { executeVaultReset as reset } from "./vault/vault-reset";\nexport default reset;\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-default-laundered.ts re-exports executeVaultReset from ./vault/vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("FAILS (REEXPORTED_DESTRUCTIVE_WRAPPER) for a .tsx barrel re-exporting a .ts wrapper", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/vault-reset.ts",
+        "export async function executeVaultReset(userId) {\n  await tx.passwordEntry.deleteMany({ where: { userId } });\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-barrel.tsx",
+        'export { executeVaultReset as reset } from "./vault/vault-reset";\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+      expect(stderr).toContain(
+        "src/lib/reexport-barrel.tsx re-exports executeVaultReset from ./vault/vault-reset",
+      );
+      expect(stderr).not.toContain("ROUTE_DESTRUCTIVE_NO_STEPUP");
+      expect(stderr).not.toContain("UNDECLARED_DESTRUCTIVE_WRAPPER");
+    });
+
+    it("passes (no REEXPORTED_DESTRUCTIVE_WRAPPER) for import-then-export of an INNOCENT binding", () => {
+      seedWrapperStubs();
+      writeSource(
+        "src/lib/vault/helpers.ts",
+        "export function formatVaultLabel(name) {\n  return name.trim();\n}\n",
+      );
+      writeSource(
+        "src/lib/reexport-innocent-laundered.ts",
+        'import { formatVaultLabel as fmt } from "./vault/helpers";\nexport { fmt };\n',
+      );
+      const { exitCode, stderr } = runGuard();
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("REEXPORTED_DESTRUCTIVE_WRAPPER");
+    });
   });
 
   describe("env-pollution guard (sec-F6)", () => {

--- a/scripts/checks/check-destructive-wrapper-derivation.mjs
+++ b/scripts/checks/check-destructive-wrapper-derivation.mjs
@@ -798,6 +798,10 @@ for (let iteration = 0; iteration <= reExportScanTargets.length; iteration++) {
     let flagged;
 
     for (const decl of getReExportDeclarations(sf)) {
+      // `export type { x } from "..."` is erased at compile time — no runtime
+      // call surface, so flagging it would be a pure false positive that
+      // trains reflexive exemption (review F1).
+      if (decl.isTypeOnly()) continue;
       const specifier = decl.getModuleSpecifierValue();
       const targetRel = resolveRelativeSpecifierToRel(rel, specifier, knownRels);
       const targetSet = targetRel !== undefined ? destructiveExportsByModule.get(targetRel) : undefined;
@@ -817,9 +821,18 @@ for (let iteration = 0; iteration <= reExportScanTargets.length; iteration++) {
 
       // (a) named re-export: `export { x }` / `export { x as y }` from "...".
       for (const named of decl.getNamedExports()) {
+        if (named.isTypeOnly()) continue; // `export { type x } from` — erased, no call surface
         const sourceName = named.getName(); // the SOURCE-side name (before `as`)
+        // When the specifier resolves to an in-scope file, match ONLY against
+        // that file's own registered destructive exports — a same-named but
+        // unrelated symbol in a different module must not flag (review F2).
+        // The flat cross-module fallback applies only when resolution fails
+        // (target outside the .ts scan scope, e.g. .tsx or generated code):
+        // fail closed there, since we cannot inspect the target.
         const isDestructive =
-          destructiveNames.has(sourceName) || (targetSet !== undefined && targetSet.has(sourceName));
+          targetRel !== undefined
+            ? targetSet !== undefined && targetSet.has(sourceName)
+            : destructiveNames.has(sourceName);
         if (!isDestructive) continue;
         // Register the re-exporting file's OWN locally-visible export name
         // (the alias if present, else the source name unchanged) — NOT the

--- a/scripts/checks/check-destructive-wrapper-derivation.mjs
+++ b/scripts/checks/check-destructive-wrapper-derivation.mjs
@@ -57,7 +57,11 @@
  * primitives called directly, and requires that any route reaching a
  * destructive primitive/wrapper calls requireRecentCurrentAuthMethod( or is
  * listed in stepup-delete-exempt.txt — else ROUTE_DESTRUCTIVE_NO_STEPUP. This
- * closes the alias/namespace evasion the grep misses.
+ * closes the alias/namespace evasion the grep misses. The route pass only
+ * compensates for alias/namespace IMPORTS of forms already grep-matchable at
+ * the derivation stage above; it never admits a NON_GREP_MATCHABLE form back
+ * in — the only escapes for those remain refactoring to a grep-matchable form
+ * or an explicit destructive-wrapper-exempt.txt entry.
  *
  * The route pass resolves: bare imports (`import { fn }` → `fn(`), aliases
  * (`import { fn as g }` → `g(`), object/static aliases (`vault.method(`),
@@ -66,17 +70,16 @@
  * (NON_GREP_MATCHABLE) since a default import renames freely.
  *
  * RESIDUAL LIMITATION (documented, not silently ignored — no occurrences in the
- * repo today, verified by grep): the route pass resolves imports one hop. It
- * does NOT follow a RE-EXPORT chain (`export { executeVaultReset } from
- * "./reset"` re-exported by a barrel the route then imports from) nor an
- * INDIRECT binding (assigning the imported function to a local variable, or
- * passing it through a higher-order call). Closing these would require whole-
- * program symbol resolution (a ts-morph Program with type-checking), which this
- * repo's AST guards deliberately avoid for speed/simplicity. The compensating
- * control is code review of route imports plus the barrel-free convention; if a
- * re-export chain of a destructive wrapper is ever introduced, add the barrel
- * module to the scan or register the wrapper at the barrel. The pass narrows the
- * gap to "only a re-export chain or an indirect binding evades".
+ * repo today, verified by grep): RE-EXPORT chains (`export { executeVaultReset }
+ * from "./reset"` re-exported by a barrel, `export * from`, `export * as ns
+ * from`, any depth, including inside route.ts) are now mechanically rejected by
+ * the re-export pass below (REEXPORTED_DESTRUCTIVE_WRAPPER) — closing the gap
+ * this paragraph used to describe. The remaining residual narrows to an
+ * INDIRECT binding only: assigning the imported function to a local variable,
+ * or passing it through a higher-order call, before the route calls it. Closing
+ * that would require whole-program symbol resolution (a ts-morph Program with
+ * type-checking), which this repo's AST guards deliberately avoid for
+ * speed/simplicity. The compensating control is code review of route imports.
  *
  * Inverse: every identifier-like alternative in deleteSignal that is NOT one
  * of the raw Prisma primitives above (i.e. executeVaultReset, deleteTeamPassword
@@ -677,6 +680,182 @@ if (staleExempt.length > 0) {
   for (const e of staleExempt) {
     console.error(`  STALE_WRAPPER_EXEMPT: ${e.key}`);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Re-export pass (C2) — mechanically reject re-exporting a destructive wrapper
+// through a barrel, closing the RESIDUAL LIMITATION this file used to
+// document as merely "compensated by code review". Runs as a separate pass
+// AFTER destructiveExportsByModule is fully populated by the derivation loop
+// above (mirrors the route pass's sequencing) — never interleaved into the
+// per-file derivation loop, since interleaving would let a barrel that sorts
+// BEFORE its target in scan order (getSourceFiles/getRouteFiles both sort by
+// `rel`) false-negative on a target not yet registered.
+//
+// Detection cases (ExportDeclaration with a moduleSpecifier):
+//   (a) named re-export: `export { x } from "..."` / `export { x as y } from "..."`
+//       — flag when the SOURCE-side name `x` matches the destructive set.
+//   (b) `export * from "<relative>"` — flag when the one-hop-resolved target
+//       file is a destructive-exporting module.
+//   (c) `export * as ns from "<relative>"` — same lookup as (b); a namespace
+//       re-export binds the whole module, so any destructive export in the
+//       target counts.
+// Non-relative specifiers (package imports) are skipped — destructive
+// wrappers are all in-repo.
+//
+// Scan scope: production src/**/*.ts INCLUDING route.ts (a re-export hosted
+// inside route.ts is invisible to the route pass's import-walk below, since
+// that pass only resolves `@/`-aliased imports of wrapper modules, not a
+// route.ts acting as a re-export source for some OTHER file). Test files stay
+// excluded (already excluded from `sourceFiles`; route files have no test
+// variant).
+//
+// Transitive closure: when a file is flagged (any case), it is registered
+// into destructiveExportsByModule so a further hop resolves through it too —
+// the scan re-runs to a fixpoint (bounded by file count) so an A->B->C chain
+// of any depth flags every hop, and the re-export pass's own registrations
+// feed later hops within the same fixpoint.
+//
+// Name registration rule (critical for named chains): when file B is flagged
+// under case (a) for `export { executeVaultReset as x } from "./C"`, the
+// fixpoint step registers B's OWN locally-visible export name POST-ALIAS —
+// `B -> x`, NOT `B -> executeVaultReset`. A further hop `A: export { x as y }
+// from "./B"` then matches by looking up the source-side name `x` against B's
+// registered exports. Registering the original destructive-set name at B
+// would silently break named chains after the first hop.
+// ---------------------------------------------------------------------------
+
+/** Flat set of every destructive export name registered anywhere so far (any module). */
+function allDestructiveNames() {
+  const names = new Set();
+  for (const set of destructiveExportsByModule.values()) {
+    for (const n of set) names.add(n);
+  }
+  return names;
+}
+
+/**
+ * Resolve a relative import specifier (`./x`, `../y/z`) from the importing
+ * file's PATH_ROOT-relative path to the target file's PATH_ROOT-relative path.
+ * POSIX string logic only (rel paths are always `/`-separated regardless of
+ * OS) — no reliance on node:path's OS-specific separator handling. Returns
+ * undefined for non-relative specifiers or a target that doesn't resolve to a
+ * known scanned file (`.ts`, optionally already carrying the extension).
+ */
+function resolveRelativeSpecifierToRel(fromRel, spec, knownRels) {
+  if (!spec.startsWith("./") && !spec.startsWith("../")) return undefined;
+  const fromDir = fromRel.split("/").slice(0, -1);
+  const parts = [...fromDir, ...spec.split("/")];
+  const stack = [];
+  for (const part of parts) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") stack.pop();
+    else stack.push(part);
+  }
+  const joined = stack.join("/");
+  const candidate = joined.endsWith(".ts") ? joined : `${joined}.ts`;
+  return knownRels.has(candidate) ? candidate : undefined;
+}
+
+/** Every module ExportDeclaration whose moduleSpecifier is set, for a source file. */
+function getReExportDeclarations(sf) {
+  return sf.getExportDeclarations().filter((d) => d.getModuleSpecifierValue() !== undefined);
+}
+
+// Union of scan targets for the re-export pass: non-route source files plus
+// route.ts files (route.ts is excluded from the primitive-derivation scan
+// above, but not from this pass — see header comment).
+const reExportScanTargets = [...sourceFiles, ...getRouteFiles(API_DIR, PATH_ROOT)];
+const knownRels = new Set(reExportScanTargets.map((f) => f.rel));
+
+const reExportedWrappers = []; // { file, name, specifier }
+const reExportFlaggedFiles = new Set(); // rel paths already flagged (dedup across fixpoint iterations)
+
+// Fixpoint loop: bounded by file count (each iteration can flag at least one
+// previously-unflagged file, or it terminates).
+for (let iteration = 0; iteration <= reExportScanTargets.length; iteration++) {
+  let changed = false;
+
+  for (const { abs, rel } of reExportScanTargets) {
+    if (reExportFlaggedFiles.has(rel)) continue;
+
+    let content;
+    try {
+      content = readFileSync(abs, "utf8");
+    } catch {
+      continue;
+    }
+    if (!content.includes(" from ")) continue; // cheap pre-filter: no re-export possible
+
+    let sf;
+    try {
+      sf = project.createSourceFile(`__reexport__/${rel}`, content, { overwrite: true });
+    } catch {
+      continue;
+    }
+
+    const destructiveNames = allDestructiveNames();
+    let flagged;
+
+    for (const decl of getReExportDeclarations(sf)) {
+      const specifier = decl.getModuleSpecifierValue();
+      const targetRel = resolveRelativeSpecifierToRel(rel, specifier, knownRels);
+      const targetSet = targetRel !== undefined ? destructiveExportsByModule.get(targetRel) : undefined;
+      const isStarLike = decl.getNamedExports().length === 0; // `export * from` or `export * as ns from`
+
+      if (isStarLike) {
+        // (b) `export * from "./x"` / (c) `export * as ns from "./x"` — flag
+        // when the one-hop-resolved target is a destructive-exporting module;
+        // a namespace/star re-export binds the whole module, so register ALL
+        // of the target's destructive export names onto this file for the
+        // next fixpoint hop.
+        if (targetSet === undefined || targetSet.size === 0) continue;
+        for (const n of targetSet) recordDestructiveExport(rel, n);
+        flagged = { name: [...targetSet].sort().join(", "), specifier };
+        break;
+      }
+
+      // (a) named re-export: `export { x }` / `export { x as y }` from "...".
+      for (const named of decl.getNamedExports()) {
+        const sourceName = named.getName(); // the SOURCE-side name (before `as`)
+        const isDestructive =
+          destructiveNames.has(sourceName) || (targetSet !== undefined && targetSet.has(sourceName));
+        if (!isDestructive) continue;
+        // Register the re-exporting file's OWN locally-visible export name
+        // (the alias if present, else the source name unchanged) — NOT the
+        // source-side name — so a further named hop matches correctly.
+        const localName = named.getAliasNode()?.getText() ?? sourceName;
+        recordDestructiveExport(rel, localName);
+        flagged = { name: sourceName, specifier };
+        break;
+      }
+      if (flagged !== undefined) break;
+    }
+
+    if (flagged === undefined) continue;
+
+    reExportFlaggedFiles.add(rel);
+    reExportedWrappers.push({ file: rel, name: flagged.name, specifier: flagged.specifier });
+    changed = true;
+  }
+
+  if (!changed) break;
+}
+
+if (reExportedWrappers.length > 0) {
+  failed = true;
+  console.error(
+    "REEXPORTED_DESTRUCTIVE_WRAPPER: a production module re-exports a destructive wrapper through a barrel — the barrel-free convention requires importing wrappers directly, not through a re-export chain:",
+  );
+  for (const w of reExportedWrappers) {
+    console.error(
+      `  REEXPORTED_DESTRUCTIVE_WRAPPER: ${w.file} re-exports ${w.name} from ${w.specifier}`,
+    );
+  }
+  console.error(
+    "\nResolve by importing the wrapper directly at its call site instead of re-exporting it through" +
+      " a barrel module.",
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/checks/check-destructive-wrapper-derivation.mjs
+++ b/scripts/checks/check-destructive-wrapper-derivation.mjs
@@ -72,14 +72,17 @@
  * RESIDUAL LIMITATION (documented, not silently ignored — no occurrences in the
  * repo today, verified by grep): RE-EXPORT chains (`export { executeVaultReset }
  * from "./reset"` re-exported by a barrel, `export * from`, `export * as ns
- * from`, any depth, including inside route.ts) are now mechanically rejected by
- * the re-export pass below (REEXPORTED_DESTRUCTIVE_WRAPPER) — closing the gap
- * this paragraph used to describe. The remaining residual narrows to an
- * INDIRECT binding only: assigning the imported function to a local variable,
- * or passing it through a higher-order call, before the route calls it. Closing
- * that would require whole-program symbol resolution (a ts-morph Program with
- * type-checking), which this repo's AST guards deliberately avoid for
- * speed/simplicity. The compensating control is code review of route imports.
+ * from`, any depth, relative or `@/`-aliased, `.ts` or `.tsx`, including inside
+ * route.ts) are mechanically rejected by the re-export pass below
+ * (REEXPORTED_DESTRUCTIVE_WRAPPER), as are import-then-export launderings
+ * (`import { X as r } from "./m"; export { r }` — also via `export { r as p }`,
+ * namespace `export { svc }`, and `export default r`). The remaining residual
+ * narrows to a VALUE-LEVEL indirect binding only: assigning the imported
+ * function to a new local variable (`const q = r;`) or passing it through a
+ * higher-order call before export/use. Closing that would require whole-program
+ * symbol resolution (a ts-morph Program with type-checking), which this repo's
+ * AST guards deliberately avoid for speed/simplicity. The compensating control
+ * is code review of route imports.
  *
  * Inverse: every identifier-like alternative in deleteSignal that is NOT one
  * of the raw Prisma primitives above (i.e. executeVaultReset, deleteTeamPassword
@@ -290,7 +293,11 @@ if (exemptParseFailures.length > 0) {
 // ---------------------------------------------------------------------------
 const EXCLUDE_RE = /\.test\.|__tests__/;
 
-function getSourceFiles(root, pathRoot) {
+// exts: primitive-derivation scans .ts only (.tsx routes/components are not
+// delete-primitive sites in this codebase); the re-export pass widens to
+// [".ts", ".tsx"] because a .tsx barrel can still re-export a .ts wrapper
+// (external review, Major).
+function getSourceFiles(root, pathRoot, exts = [".ts"]) {
   const files = [];
   let dirEntries;
   try {
@@ -302,7 +309,7 @@ function getSourceFiles(root, pathRoot) {
   for (const entry of dirEntries) {
     if (!entry.isFile()) continue;
     const ext = extname(entry.name);
-    if (ext !== ".ts") continue; // .tsx routes/components are not delete-primitive sites in this codebase
+    if (!exts.includes(ext)) continue;
     if (entry.name === "route.ts") continue;
     const abs = join(entry.parentPath ?? entry.path, entry.name);
     // rel is PATH_ROOT-relative (repo-relative in production), not
@@ -706,11 +713,15 @@ if (staleExempt.length > 0) {
 //   (c) `export * as ns from "<in-repo specifier>"` — same lookup as (b); a
 //       namespace re-export binds the whole module, so any destructive export
 //       in the target counts.
+//   (d) import-then-export laundering — `import { X as r } from "./m"` followed
+//       by `export { r }` / `export { r as p }` / namespace `export { svc }` /
+//       `export default r`: the exported binding resolves back to its import
+//       and is matched exactly like (a)/(c) (external review, Major).
 // True package imports are skipped — destructive wrappers are all in-repo.
-// Repo-shaped specifiers that fail to resolve (target outside the .ts scan
+// Repo-shaped specifiers that fail to resolve (target outside the scan
 // scope) keep the fail-closed flat-name fallback for named re-exports.
 //
-// Scan scope: production src/**/*.ts INCLUDING route.ts (a re-export hosted
+// Scan scope: production src/**/*.ts AND *.tsx INCLUDING route.ts (a re-export hosted
 // inside route.ts is invisible to the route pass's import-walk below, since
 // that pass only resolves `@/`-aliased imports of wrapper modules, not a
 // route.ts acting as a re-export source for some OTHER file). Test files stay
@@ -789,106 +800,193 @@ function resolveSpecifierToRel(fromRel, spec, knownRels) {
   return { targetRel: candidates.find((c) => knownRels.has(c)), inRepo: true };
 }
 
-/** Every module ExportDeclaration whose moduleSpecifier is set, for a source file. */
-function getReExportDeclarations(sf) {
-  return sf.getExportDeclarations().filter((d) => d.getModuleSpecifierValue() !== undefined);
+/**
+ * Extract every re-export-relevant fact from a source file ONCE, so the
+ * fixpoint below iterates over plain data instead of re-parsing ASTs per
+ * iteration. Shapes covered:
+ *   - specifier-bearing ExportDeclarations (`export { x } from`, `export *
+ *     from`, `export * as ns from`) — type-only declarations/specifiers
+ *     dropped here (erased at compile time, no call surface);
+ *   - import bindings (named, aliased, namespace) — so a specifier-LESS
+ *     `export { binding }` that launders an imported wrapper through a local
+ *     binding is treated as the re-export it is (external review, Major);
+ *   - `export default <identifier>` of an import binding — same laundering
+ *     via the default slot.
+ */
+function extractReExportFacts(sf) {
+  const reexports = [];
+  for (const decl of sf.getExportDeclarations()) {
+    if (decl.isTypeOnly()) continue;
+    const specifier = decl.getModuleSpecifierValue();
+    const named = decl
+      .getNamedExports()
+      .filter((n) => !n.isTypeOnly())
+      .map((n) => ({
+        sourceName: n.getName(), // the SOURCE-side name (before `as`)
+        localName: n.getAliasNode()?.getText() ?? n.getName(),
+      }));
+    if (specifier !== undefined) {
+      reexports.push({ specifier, isStarLike: decl.getNamedExports().length === 0, named });
+    }
+  }
+
+  const importBindings = new Map(); // local binding name → { specifier, sourceName, isNamespace }
+  for (const imp of sf.getImportDeclarations()) {
+    if (imp.isTypeOnly()) continue;
+    const specifier = imp.getModuleSpecifierValue();
+    const ns = imp.getNamespaceImport();
+    if (ns) importBindings.set(ns.getText(), { specifier, sourceName: undefined, isNamespace: true });
+    for (const ni of imp.getNamedImports()) {
+      if (ni.isTypeOnly()) continue;
+      const local = ni.getAliasNode()?.getText() ?? ni.getName();
+      importBindings.set(local, { specifier, sourceName: ni.getName(), isNamespace: false });
+    }
+  }
+
+  const localExports = []; // specifier-less `export { binding [as name] }`
+  for (const decl of sf.getExportDeclarations()) {
+    if (decl.getModuleSpecifierValue() !== undefined || decl.isTypeOnly()) continue;
+    for (const n of decl.getNamedExports()) {
+      if (n.isTypeOnly()) continue;
+      localExports.push({
+        bindingName: n.getName(),
+        exportedName: n.getAliasNode()?.getText() ?? n.getName(),
+      });
+    }
+  }
+
+  const defaultExportIds = sf
+    .getExportAssignments()
+    .filter((a) => !a.isExportEquals())
+    .map((a) => a.getExpression())
+    .filter((e) => Node.isIdentifier(e))
+    .map((e) => e.getText());
+
+  return { reexports, importBindings, localExports, defaultExportIds };
 }
 
-// Union of scan targets for the re-export pass: non-route source files plus
-// route.ts files (route.ts is excluded from the primitive-derivation scan
-// above, but not from this pass — see header comment).
-const reExportScanTargets = [...sourceFiles, ...getRouteFiles(API_DIR, PATH_ROOT)];
+// Union of scan targets for the re-export pass: non-route .ts source files,
+// production .tsx files (a .tsx barrel can re-export a .ts wrapper — external
+// review, Major; .tsx stays excluded from the primitive-derivation scan), and
+// route.ts files (excluded from derivation, included here).
+const reExportScanTargets = [
+  ...sourceFiles,
+  ...getSourceFiles(SCAN_ROOT, PATH_ROOT, [".tsx"]),
+  ...getRouteFiles(API_DIR, PATH_ROOT),
+];
 const knownRels = new Set(reExportScanTargets.map((f) => f.rel));
+
+// Parse once, up front. Pre-filter on the bare token `from` — every shape
+// this pass detects textually requires the `from` keyword (in the re-export
+// itself or in the import that created the laundered binding). Deliberately
+// NOT `" from "`: `export{x}from"./y"` and newline-before-`from` are valid
+// syntax a whitespace-dependent filter would skip (external review, Major).
+const reExportFacts = []; // { rel, facts }
+for (const { abs, rel } of reExportScanTargets) {
+  let content;
+  try {
+    content = readFileSync(abs, "utf8");
+  } catch {
+    continue;
+  }
+  if (!content.includes("from")) continue;
+  let sf;
+  try {
+    sf = project.createSourceFile(`__reexport__/${rel}`, content, { overwrite: true });
+  } catch {
+    continue;
+  }
+  reExportFacts.push({ rel, facts: extractReExportFacts(sf) });
+}
 
 const reExportedWrappers = []; // { file, name, specifier }
 const reExportFlaggedFiles = new Set(); // rel paths already flagged (dedup across fixpoint iterations)
 
 // Fixpoint loop: bounded by file count (each iteration can flag at least one
 // previously-unflagged file, or it terminates).
-for (let iteration = 0; iteration <= reExportScanTargets.length; iteration++) {
+for (let iteration = 0; iteration <= reExportFacts.length; iteration++) {
   let changed = false;
 
-  for (const { abs, rel } of reExportScanTargets) {
+  for (const { rel, facts } of reExportFacts) {
     if (reExportFlaggedFiles.has(rel)) continue;
-
-    let content;
-    try {
-      content = readFileSync(abs, "utf8");
-    } catch {
-      continue;
-    }
-    if (!content.includes(" from ")) continue; // cheap pre-filter: no re-export possible
-
-    let sf;
-    try {
-      sf = project.createSourceFile(`__reexport__/${rel}`, content, { overwrite: true });
-    } catch {
-      continue;
-    }
 
     const destructiveNames = allDestructiveNames();
     let flagged;
 
-    for (const decl of getReExportDeclarations(sf)) {
-      // `export type { x } from "..."` is erased at compile time — no runtime
-      // call surface, so flagging it would be a pure false positive that
-      // trains reflexive exemption (review F1).
-      if (decl.isTypeOnly()) continue;
-      const specifier = decl.getModuleSpecifierValue();
+    // Shared named-binding matcher. Pool selection: resolved target → that
+    // module's own registered exports only — a same-named but unrelated
+    // symbol in a different module must not flag (review F2). Repo-shaped
+    // but unresolved → flat cross-module fallback, fail closed since we
+    // cannot inspect the target. True package import → skip. Matching is
+    // binding-prefix-aware: a destructive export is either the bare binding
+    // (`executeVaultReset`) or a member behind it (`vaultService.purge`) —
+    // re-exporting the binding re-exports every member, and each member path
+    // is re-registered under the locally-visible (post-alias) name so
+    // further hops and the route pass match the name their own specifier
+    // actually uses.
+    const matchNamedBinding = (specifier, sourceName, localName) => {
       const { targetRel, inRepo } = resolveSpecifierToRel(rel, specifier, knownRels);
       const targetSet = targetRel !== undefined ? destructiveExportsByModule.get(targetRel) : undefined;
-      const isStarLike = decl.getNamedExports().length === 0; // `export * from` or `export * as ns from`
-
-      if (isStarLike) {
-        // (b) `export * from "./x"` / (c) `export * as ns from "./x"` — flag
-        // when the one-hop-resolved target is a destructive-exporting module;
-        // a namespace/star re-export binds the whole module, so register ALL
-        // of the target's destructive export names onto this file for the
-        // next fixpoint hop.
-        if (targetSet === undefined || targetSet.size === 0) continue;
-        for (const n of targetSet) recordDestructiveExport(rel, n);
-        flagged = { name: [...targetSet].sort().join(", "), specifier };
-        break;
+      let pool;
+      if (targetRel !== undefined) pool = targetSet ?? new Set();
+      else if (inRepo) pool = destructiveNames;
+      else return undefined;
+      const memberPrefix = `${sourceName}.`;
+      const matching = [...pool].filter((n) => n === sourceName || n.startsWith(memberPrefix));
+      if (matching.length === 0) return undefined;
+      for (const n of matching) {
+        recordDestructiveExport(rel, localName + n.slice(sourceName.length));
       }
+      return { name: matching.sort().join(", "), specifier };
+    };
 
-      // (a) named re-export: `export { x }` / `export { x as y }` from "...".
-      for (const named of decl.getNamedExports()) {
-        if (named.isTypeOnly()) continue; // `export { type x } from` — erased, no call surface
-        const sourceName = named.getName(); // the SOURCE-side name (before `as`)
-        // Match pool: resolved target → that module's own registered exports
-        // only — a same-named but unrelated symbol in a different module must
-        // not flag (review F2). Repo-shaped but unresolved (target outside
-        // the .ts scan scope, e.g. .tsx or generated code) → flat
-        // cross-module fallback, fail closed since we cannot inspect the
-        // target. True package import → skip (not this repo's wrapper).
-        let pool;
-        if (targetRel !== undefined) pool = targetSet ?? new Set();
-        else if (inRepo) pool = destructiveNames;
-        else continue;
-        // A destructive export is either the bare binding itself
-        // (`executeVaultReset`) or a member behind an exported binding
-        // (`vaultService.purge`, `VaultService.purgeAll`). Re-exporting the
-        // binding re-exports every member, so match by binding prefix — bare
-        // name comparison alone lets `export { vaultService } from ...`
-        // evade (external review, Major).
-        const memberPrefix = `${sourceName}.`;
-        const matching = [...pool].filter(
-          (n) => n === sourceName || n.startsWith(memberPrefix),
-        );
-        if (matching.length === 0) continue;
-        // Register under the re-exporting file's OWN locally-visible binding
-        // name (the alias if present) with each member path preserved —
-        // `vaultService.purge` re-exported `as service` propagates as
-        // `service.purge` so a further hop (and the route pass) matches the
-        // name its own specifier actually uses.
-        const localName = named.getAliasNode()?.getText() ?? sourceName;
-        for (const n of matching) {
-          recordDestructiveExport(rel, localName + n.slice(sourceName.length));
+    // Star/namespace re-export of a resolved destructive module — binds the
+    // whole module, so register ALL of the target's destructive export names
+    // for the next fixpoint hop. memberPrefix distinguishes the plain-star
+    // form (names re-exported as-is) from a bound namespace (`ns.name`).
+    const matchStarLike = (specifier, memberPrefix) => {
+      const { targetRel } = resolveSpecifierToRel(rel, specifier, knownRels);
+      const targetSet = targetRel !== undefined ? destructiveExportsByModule.get(targetRel) : undefined;
+      if (targetSet === undefined || targetSet.size === 0) return undefined;
+      for (const n of targetSet) recordDestructiveExport(rel, `${memberPrefix}${n}`);
+      return { name: [...targetSet].sort().join(", "), specifier };
+    };
+
+    for (const re of facts.reexports) {
+      if (re.isStarLike) {
+        flagged = matchStarLike(re.specifier, "");
+      } else {
+        for (const { sourceName, localName } of re.named) {
+          flagged = matchNamedBinding(re.specifier, sourceName, localName);
+          if (flagged !== undefined) break;
         }
-        flagged = { name: matching.sort().join(", "), specifier };
-        break;
       }
       if (flagged !== undefined) break;
+    }
+
+    // Import-then-export laundering: `import { X as r } from "./m"` followed
+    // by a specifier-less `export { r [as pub] }` is semantically the same
+    // re-export — resolve the exported binding back to its import.
+    if (flagged === undefined) {
+      for (const { bindingName, exportedName } of facts.localExports) {
+        const binding = facts.importBindings.get(bindingName);
+        if (binding === undefined) continue;
+        flagged = binding.isNamespace
+          ? matchStarLike(binding.specifier, `${exportedName}.`)
+          : matchNamedBinding(binding.specifier, binding.sourceName, exportedName);
+        if (flagged !== undefined) break;
+      }
+    }
+
+    // `export default r` where r is an imported destructive binding — the
+    // default slot launders the wrapper under an arbitrary import name.
+    if (flagged === undefined) {
+      for (const id of facts.defaultExportIds) {
+        const binding = facts.importBindings.get(id);
+        if (binding === undefined || binding.isNamespace) continue;
+        flagged = matchNamedBinding(binding.specifier, binding.sourceName, "default");
+        if (flagged !== undefined) break;
+      }
     }
 
     if (flagged === undefined) continue;

--- a/scripts/checks/check-destructive-wrapper-derivation.mjs
+++ b/scripts/checks/check-destructive-wrapper-derivation.mjs
@@ -694,14 +694,21 @@ if (staleExempt.length > 0) {
 //
 // Detection cases (ExportDeclaration with a moduleSpecifier):
 //   (a) named re-export: `export { x } from "..."` / `export { x as y } from "..."`
-//       — flag when the SOURCE-side name `x` matches the destructive set.
-//   (b) `export * from "<relative>"` — flag when the one-hop-resolved target
-//       file is a destructive-exporting module.
-//   (c) `export * as ns from "<relative>"` — same lookup as (b); a namespace
-//       re-export binds the whole module, so any destructive export in the
-//       target counts.
-// Non-relative specifiers (package imports) are skipped — destructive
-// wrappers are all in-repo.
+//       — flag when the SOURCE-side name `x` matches the destructive set as a
+//       bare name OR as the binding prefix of a member key
+//       (`vaultService.purge` matches `export { vaultService }` — the binding
+//       carries its members); the member path is propagated under the
+//       post-alias local name.
+//   (b) `export * from "<in-repo specifier>"` — flag when the one-hop-resolved
+//       target file is a destructive-exporting module. Both relative and `@/`
+//       alias specifiers resolve (see resolveSpecifierToRel), including
+//       directory-index barrels.
+//   (c) `export * as ns from "<in-repo specifier>"` — same lookup as (b); a
+//       namespace re-export binds the whole module, so any destructive export
+//       in the target counts.
+// True package imports are skipped — destructive wrappers are all in-repo.
+// Repo-shaped specifiers that fail to resolve (target outside the .ts scan
+// scope) keep the fail-closed flat-name fallback for named re-exports.
 //
 // Scan scope: production src/**/*.ts INCLUDING route.ts (a re-export hosted
 // inside route.ts is invisible to the route pass's import-walk below, since
@@ -734,27 +741,52 @@ function allDestructiveNames() {
   return names;
 }
 
+// `@/*` maps to `<scan root>/*` (tsconfig paths: `"@/*": ["./src/*"]`).
+// Derived from SCAN_ROOT so fixture trees (which relocate the scan root)
+// resolve the alias against their own root exactly like production resolves
+// against src/.
+const SCAN_ROOT_REL = SCAN_ROOT.slice(PATH_ROOT.length).replace(/^\/+/, "");
+
 /**
- * Resolve a relative import specifier (`./x`, `../y/z`) from the importing
- * file's PATH_ROOT-relative path to the target file's PATH_ROOT-relative path.
- * POSIX string logic only (rel paths are always `/`-separated regardless of
- * OS) — no reliance on node:path's OS-specific separator handling. Returns
- * undefined for non-relative specifiers or a target that doesn't resolve to a
- * known scanned file (`.ts`, optionally already carrying the extension).
+ * Resolve a module specifier to a PATH_ROOT-relative file in the scan set.
+ * Handles relative specifiers (`./x`, `../y/z`) AND the repo's `@/` path
+ * alias — the alias is the dominant import style in this codebase, so a
+ * relative-only resolver would let `export * from "@/lib/..."` barrels evade
+ * (external review, Major). Candidate forms tried: the path as written (when
+ * it already carries `.ts`/`.tsx`), `<p>.ts`, `<p>.tsx`, `<p>/index.ts`,
+ * `<p>/index.tsx` — directory-index barrels resolve too.
+ *
+ * Returns { targetRel, inRepo }:
+ *   - targetRel: resolved rel path, or undefined when no candidate is in the
+ *     scan set;
+ *   - inRepo: true for repo-shaped specifiers (relative or `@/`). Callers use
+ *     it to keep the fail-closed flat-name fallback for repo-shaped
+ *     specifiers that do not resolve (e.g. a `.tsx`/generated target), while
+ *     true package imports are skipped entirely — a same-named symbol from an
+ *     npm package is not this repo's destructive wrapper.
+ * POSIX string logic only — rel paths are always `/`-separated.
  */
-function resolveRelativeSpecifierToRel(fromRel, spec, knownRels) {
-  if (!spec.startsWith("./") && !spec.startsWith("../")) return undefined;
-  const fromDir = fromRel.split("/").slice(0, -1);
-  const parts = [...fromDir, ...spec.split("/")];
+function resolveSpecifierToRel(fromRel, spec, knownRels) {
+  let baseParts;
+  if (spec.startsWith("@/")) {
+    baseParts = [...SCAN_ROOT_REL.split("/"), ...spec.slice(2).split("/")];
+  } else if (spec.startsWith("./") || spec.startsWith("../")) {
+    baseParts = [...fromRel.split("/").slice(0, -1), ...spec.split("/")];
+  } else {
+    return { targetRel: undefined, inRepo: false };
+  }
   const stack = [];
-  for (const part of parts) {
+  for (const part of baseParts) {
     if (part === "" || part === ".") continue;
     if (part === "..") stack.pop();
     else stack.push(part);
   }
-  const joined = stack.join("/");
-  const candidate = joined.endsWith(".ts") ? joined : `${joined}.ts`;
-  return knownRels.has(candidate) ? candidate : undefined;
+  const base = stack.join("/");
+  const candidates =
+    base.endsWith(".ts") || base.endsWith(".tsx")
+      ? [base]
+      : [`${base}.ts`, `${base}.tsx`, `${base}/index.ts`, `${base}/index.tsx`];
+  return { targetRel: candidates.find((c) => knownRels.has(c)), inRepo: true };
 }
 
 /** Every module ExportDeclaration whose moduleSpecifier is set, for a source file. */
@@ -803,7 +835,7 @@ for (let iteration = 0; iteration <= reExportScanTargets.length; iteration++) {
       // trains reflexive exemption (review F1).
       if (decl.isTypeOnly()) continue;
       const specifier = decl.getModuleSpecifierValue();
-      const targetRel = resolveRelativeSpecifierToRel(rel, specifier, knownRels);
+      const { targetRel, inRepo } = resolveSpecifierToRel(rel, specifier, knownRels);
       const targetSet = targetRel !== undefined ? destructiveExportsByModule.get(targetRel) : undefined;
       const isStarLike = decl.getNamedExports().length === 0; // `export * from` or `export * as ns from`
 
@@ -823,23 +855,37 @@ for (let iteration = 0; iteration <= reExportScanTargets.length; iteration++) {
       for (const named of decl.getNamedExports()) {
         if (named.isTypeOnly()) continue; // `export { type x } from` — erased, no call surface
         const sourceName = named.getName(); // the SOURCE-side name (before `as`)
-        // When the specifier resolves to an in-scope file, match ONLY against
-        // that file's own registered destructive exports — a same-named but
-        // unrelated symbol in a different module must not flag (review F2).
-        // The flat cross-module fallback applies only when resolution fails
-        // (target outside the .ts scan scope, e.g. .tsx or generated code):
-        // fail closed there, since we cannot inspect the target.
-        const isDestructive =
-          targetRel !== undefined
-            ? targetSet !== undefined && targetSet.has(sourceName)
-            : destructiveNames.has(sourceName);
-        if (!isDestructive) continue;
-        // Register the re-exporting file's OWN locally-visible export name
-        // (the alias if present, else the source name unchanged) — NOT the
-        // source-side name — so a further named hop matches correctly.
+        // Match pool: resolved target → that module's own registered exports
+        // only — a same-named but unrelated symbol in a different module must
+        // not flag (review F2). Repo-shaped but unresolved (target outside
+        // the .ts scan scope, e.g. .tsx or generated code) → flat
+        // cross-module fallback, fail closed since we cannot inspect the
+        // target. True package import → skip (not this repo's wrapper).
+        let pool;
+        if (targetRel !== undefined) pool = targetSet ?? new Set();
+        else if (inRepo) pool = destructiveNames;
+        else continue;
+        // A destructive export is either the bare binding itself
+        // (`executeVaultReset`) or a member behind an exported binding
+        // (`vaultService.purge`, `VaultService.purgeAll`). Re-exporting the
+        // binding re-exports every member, so match by binding prefix — bare
+        // name comparison alone lets `export { vaultService } from ...`
+        // evade (external review, Major).
+        const memberPrefix = `${sourceName}.`;
+        const matching = [...pool].filter(
+          (n) => n === sourceName || n.startsWith(memberPrefix),
+        );
+        if (matching.length === 0) continue;
+        // Register under the re-exporting file's OWN locally-visible binding
+        // name (the alias if present) with each member path preserved —
+        // `vaultService.purge` re-exported `as service` propagates as
+        // `service.purge` so a further hop (and the route pass) matches the
+        // name its own specifier actually uses.
         const localName = named.getAliasNode()?.getText() ?? sourceName;
-        recordDestructiveExport(rel, localName);
-        flagged = { name: sourceName, specifier };
+        for (const n of matching) {
+          recordDestructiveExport(rel, localName + n.slice(sourceName.length));
+        }
+        flagged = { name: matching.sort().join(", "), specifier };
         break;
       }
       if (flagged !== undefined) break;

--- a/scripts/checks/check-destructive-wrapper-derivation.mjs
+++ b/scripts/checks/check-destructive-wrapper-derivation.mjs
@@ -826,7 +826,15 @@ function extractReExportFacts(sf) {
         localName: n.getAliasNode()?.getText() ?? n.getName(),
       }));
     if (specifier !== undefined) {
-      reexports.push({ specifier, isStarLike: decl.getNamedExports().length === 0, named });
+      reexports.push({
+        specifier,
+        isStarLike: decl.getNamedExports().length === 0,
+        // `export * as svc from` binds the target under `svc` — the name must
+        // survive so the next hop's `export { svc }` matches `svc.<member>`
+        // registrations; a plain `export * from` re-exports names as-is.
+        namespaceName: decl.getNamespaceExport()?.getName(),
+        named,
+      });
     }
   }
 
@@ -954,7 +962,10 @@ for (let iteration = 0; iteration <= reExportFacts.length; iteration++) {
 
     for (const re of facts.reexports) {
       if (re.isStarLike) {
-        flagged = matchStarLike(re.specifier, "");
+        flagged = matchStarLike(
+          re.specifier,
+          re.namespaceName !== undefined ? `${re.namespaceName}.` : "",
+        );
       } else {
         for (const { sourceName, localName } of re.named) {
           flagged = matchNamedBinding(re.specifier, sourceName, localName);

--- a/src/app/api/passwords/[id]/route.test.ts
+++ b/src/app/api/passwords/[id]/route.test.ts
@@ -935,6 +935,45 @@ describe("PUT /api/passwords/[id]", () => {
     expect(txMock.passwordEntry.update).not.toHaveBeenCalled();
   });
 
+  // C1/S1: overview-only PUT has no legitimate consumer (all clients derive
+  // overview from blob at save time) and is the corruption vector the refine closes.
+  it("C1: rejects encryptedOverview without encryptedBlob → 400 VALIDATION_ERROR, no write attempted", async () => {
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+
+    const res = await PUT(
+      createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, {
+        body: {
+          encryptedOverview: { ciphertext: "new-over", iv: "c".repeat(24), authTag: "d".repeat(32) },
+        },
+      }),
+      createParams({ id: PW_ID }),
+    );
+    const json = await res.json();
+    expect(res.status).toBe(400);
+    expect(json.error).toBe(API_ERROR.VALIDATION_ERROR);
+    expect(mockPrismaTransaction).not.toHaveBeenCalled();
+    expect(mockPrismaPasswordEntry.update).not.toHaveBeenCalled();
+    expect(txMock.passwordEntry.update).not.toHaveBeenCalled();
+  });
+
+  // C1: the extension passkey signature-counter persist sends blob-without-overview
+  // (passkey-provider.ts) — must remain a valid, successful shape under the refine.
+  it("C1: accepts encryptedBlob without encryptedOverview (passkey counter shape) → 200", async () => {
+    mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
+
+    const res = await PUT(
+      createRequest("PUT", `http://localhost:3000/api/passwords/${PW_ID}`, {
+        body: {
+          encryptedBlob: { ciphertext: "new-blob", iv: "a".repeat(24), authTag: "b".repeat(32) },
+          keyVersion: 1,
+        },
+      }),
+      createParams({ id: PW_ID }),
+    );
+    expect(res.status).toBe(200);
+    expect(txMock.passwordEntry.update).toHaveBeenCalledTimes(1);
+  });
+
   it("C1: metadata-only PUT issues no $queryRaw and no History.create", async () => {
     mockPrismaPasswordEntry.findUnique.mockResolvedValue(ownedEntry);
     mockPrismaPasswordEntry.update.mockResolvedValue({

--- a/src/app/api/v1/passwords/[id]/route.test.ts
+++ b/src/app/api/v1/passwords/[id]/route.test.ts
@@ -613,6 +613,41 @@ describe("PUT /api/v1/passwords/[id]", () => {
     expect(json).toHaveProperty("tagIds");
     expect(json).toHaveProperty("encryptedOverview");
   });
+
+  // C1/S1: overview-only PUT has no legitimate consumer (all clients derive
+  // overview from blob at save time) and is the corruption vector the refine closes.
+  it("C1: rejects encryptedOverview without encryptedBlob → 400 VALIDATION_ERROR, no write attempted", async () => {
+    const res = await PUT(
+      createRequest("PUT", `http://localhost/api/v1/passwords/${PW_ID}`, {
+        body: {
+          encryptedOverview: { ciphertext: "new-over", iv: "c".repeat(24), authTag: "d".repeat(32) },
+        },
+      }),
+      createParams({ id: PW_ID }),
+    );
+    const { status, json } = await parseResponse(res);
+    expect(status).toBe(400);
+    expect(json.error).toBe("VALIDATION_ERROR");
+    expect(mockEntryUpdate).not.toHaveBeenCalled();
+    expect(mockHistoryCreate).not.toHaveBeenCalled();
+  });
+
+  // C1: the extension passkey signature-counter persist sends blob-without-overview
+  // (passkey-provider.ts) — must remain a valid, successful shape under the refine.
+  it("C1: accepts encryptedBlob without encryptedOverview (passkey counter shape) → 200", async () => {
+    const res = await PUT(
+      createRequest("PUT", `http://localhost/api/v1/passwords/${PW_ID}`, {
+        body: {
+          encryptedBlob: { ciphertext: "new-blob", iv: "a".repeat(24), authTag: "b".repeat(32) },
+          keyVersion: 2,
+        },
+      }),
+      createParams({ id: PW_ID }),
+    );
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(mockEntryUpdate).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("DELETE /api/v1/passwords/[id]", () => {

--- a/src/lib/validations/entry.test.ts
+++ b/src/lib/validations/entry.test.ts
@@ -279,6 +279,29 @@ describe("updateE2EPasswordSchema", () => {
     const result = updateE2EPasswordSchema.safeParse({ aadVersion: 2 });
     expect(result.success).toBe(false);
   });
+
+  it("rejects encryptedOverview without encryptedBlob", () => {
+    const result = updateE2EPasswordSchema.safeParse({ encryptedOverview: validEncryptedField() });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts encryptedBlob without encryptedOverview", () => {
+    const result = updateE2EPasswordSchema.safeParse({ encryptedBlob: validEncryptedField() });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts encryptedBlob and encryptedOverview together", () => {
+    const result = updateE2EPasswordSchema.safeParse({
+      encryptedBlob: validEncryptedField(),
+      encryptedOverview: validEncryptedField(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts neither encryptedBlob nor encryptedOverview", () => {
+    const result = updateE2EPasswordSchema.safeParse({ isFavorite: true });
+    expect(result.success).toBe(true);
+  });
 });
 
 // ─── generateRequestSchema ──────────────────────────────────

--- a/src/lib/validations/entry.ts
+++ b/src/lib/validations/entry.ts
@@ -66,7 +66,14 @@ export const updateE2EPasswordSchema = z.object({
   entryType: entryTypeSchema.optional(),
   requireReprompt: z.boolean().optional(),
   expiresAt: z.string().datetime({ offset: true }).optional().nullable(),
-});
+}).refine(
+  // Unlike the team refine (team.ts:103-113, 4-field all-or-none both directions),
+  // this is one-direction over 2 fields: blob-without-overview is a legitimate
+  // shipped shape (extension passkey counter persist, passkey-provider.ts),
+  // while overview-without-blob has no legitimate consumer.
+  (d) => d.encryptedOverview === undefined || d.encryptedBlob !== undefined,
+  { message: "encryptedOverview requires encryptedBlob", path: ["encryptedOverview"] },
+);
 
 // ─── Generate Request Schema (with legacy mode fallback) ────
 


### PR DESCRIPTION
## Summary
- Closes a key-version-guard bypass where `encryptedOverview` updates without `encryptedBlob` could persist stale ciphertext outside the atomic rotation transaction.
- Reinforces the destructive-wrapper CI gate (`check-destructive-wrapper-derivation.mjs`) with a parse-once, transitive-fixpoint re-export pass that resolves `@/` aliases, directory-index barrels, namespace exports, object/class binding members, import-then-export laundering, and whitespace-independent syntax.
- Adds schema validation, route-level unit tests, an extension shape pin, and integration verification so the one-direction refine coexists with the legitimate blob-only consumer flow (extension passkey counter).

## Motivation
- **Security/Integrity (S1):** The password PUT endpoints lacked a shared validation boundary enforcing that overview writes accompany blob writes. A stale pre-rotation client could overwrite overview columns outside `assertCurrentKeyVersion`'s transaction, corrupting the overview irrecoverably-until-resave. Closed at the shared Zod schema layer.
- **CI Gate Precision (S3):** The wrapper checker documented barrel re-exports as a review-compensated residual. Three external review rounds iteratively closed every mechanical evasion: `@/`-alias/star/namespace forms, object/static-class binding member propagation (`vaultService.purge` propagated as `service.purge` across hops), whitespace/comment formatting, import-then-export laundering (incl. `export default`), `.tsx` barrels, and namespace-name preservation in multi-hop chains.
- **Consumer Safety:** The shipped extension passkey counter flow (`passkey-provider.ts`) legitimately sends `encryptedBlob` without `encryptedOverview`; the plan documents why a one-direction refine (not a two-direction ban) is correct — rotation rewrites blob+overview atomically for all entries, so blob-only writes cannot desynchronize.

## Implementation notes
- **One-direction Zod refine** in `src/lib/validations/entry.ts` (shared by `/api/passwords/[id]` and `/api/v1/passwords/[id]`): rejects overview-without-blob (400), permits blob-only; deliberately narrower than the 4-field team refine (comment in code explains why).
- **Checker re-export pass**: parses each target once (`extractReExportFacts`), then iterates extracted facts to a fixpoint; registers post-alias local names with member paths preserved; resolved targets match only their own export set (flat fallback restricted to unresolved repo-shaped specifiers, fail-closed; true package imports skipped); scans production `.ts` + `.tsx` including `route.ts`. Remaining residual (documented in-code): value-level indirect bindings only.
- **Known limitation (recorded as follow-up, R3-5 in the code-review log):** blob-only general updates can still leave overview content stale relative to a changed blob — full blob↔overview pairing would need a dedicated passkey-counter endpoint/operation.

## Review artifacts
- [plan](./docs/archive/review/overview-pairing-and-reexport-guard-plan.md) / [plan review](./docs/archive/review/overview-pairing-and-reexport-guard-review.md) / [deviation log](./docs/archive/review/overview-pairing-and-reexport-guard-deviation.md) / [code review (5 rounds incl. 3 external)](./docs/archive/review/overview-pairing-and-reexport-guard-code-review.md)

## Test plan (all executed locally)
- [x] Full suite: `npx vitest run` (12,569 tests) and `npx next build`
- [x] Overview-only PUT → 400 `VALIDATION_ERROR` + no Prisma mutation (both routes); blob-only PUT → guard transaction executes (both routes)
- [x] Real-DB integration: `npm run test:integration -- key-version-guard` (blob-only bodies pass the refine unchanged)
- [x] Checker self-test: 65 tests — every evasion shape pinned by a red fixture with single-failure-code isolation, plus false-positive green fixtures (type-only, resolved same-name collision, package import, innocent laundering); real-tree run exits 0
- [x] Extension shape pin: `background-passkey-provider.test.ts` asserts the counter PUT body omits `encryptedOverview` (58 tests)
- [x] `scripts/pre-pr.sh` — 51 gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)