### PR TITLE
refactor(security): migrate 13 fail-closed legacy routes to helper mode (SC-T3-1)

### DIFF
--- a/docs/archive/review/fail-closed-tranche3-code-review.md
+++ b/docs/archive/review/fail-closed-tranche3-code-review.md
@@ -1,0 +1,75 @@
+# Code Review: fail-closed-tranche3
+Date: 2026-07-20
+Review round: 1
+
+## Changes from Previous Round
+Initial code review (Phase 3). Phase 2 self-R-check already ran a focused R1-R44
+pass that found + fixed one R20 tsc regression (D4). This round is incremental
+verification by three experts (functionality / security / testing), each performing
+independent live mutation-proofs.
+
+## Functionality Findings
+No findings. All 15 assertRedisFailClosed cases across 13 files verified migrated;
+auth dynamic-import loadRoute() captures 2 distinct limiters correctly; reset-vault
+D4 const-before-return fix confirmed (tsc clean project-wide); ssh custom envelope
+(D1) matches route.ts:87-91 byte-for-byte; emptied FROZEN_STUB_EXEMPTIONS + guard
+sound; no production route.ts touched. C1-C5 all verified against live evidence
+(gate exit 0, full vitest 12769 passed, classifier distinct=2 for the 2 multi-limiter
+routes).
+
+## Security Findings
+No findings. Independent live verification:
+- `git grep vi.mock rate-limit-audit -- src` → empty (zero stubs remain).
+- legacy manifest empty; gate exit 0 with EXPECTED_LEGACY_COUNT=0.
+- RT7 mutation-proofs: flipped `failClosedOnRedisError: true→false` in auth callback,
+  reset-vault admin, dcr-cleanup — each reds the targeted case while the sibling
+  distinct-limiter case stays green (proves distinct attribution discriminates), then
+  reverted clean.
+- Live probe: added `expect(mockLogAudit).toHaveBeenCalled()` after the reset-vault
+  admin case — passed, proving the real emitRateLimitFailClosed→logAuditAsync chain
+  fires on the 503 path (not swallowed by throttle/tenantId-resolution/leftover stub).
+  Reverted; worktree byte-identical afterward.
+- M9: zero logAuditAsync in any assertNoMutation array.
+- `is_stub_exempt()` is dead code (never called; real C6 enforcement is the awk block
+  which builds an empty EX[] from the empty list — no accidental blanket exemption).
+  The added `[ -n ... ]` guard is harmless defense-in-depth.
+
+## Testing Findings
+No findings. All 15 assertNoMutation spies are real post-limiter, load-bearing
+primitives (full table verified against each route.ts); purge-audit-logs correctly
+uses the load-bearing $queryRaw (not dead deleteMany). __resetThrottleForTests()
+present in exactly the 4 stub-removal files where the real emit now runs, correctly
+absent from the 8 single-emission files (vitest isolate:true rules out cross-file
+bleed). The flipped gate self-test is a valid dual-assertion red-proof. No
+it.skip/xit residue; no stale parallel/central test tree for the 13 routes (R19).
+
+## Adjacent Findings
+None.
+
+## Quality Warnings
+None.
+
+## Recurring Issue Check
+### Functionality expert
+R1 OK · R2 OK · R17 OK · R19 OK · R20 OK (D4 fixed) · R42 OK · RT5 OK · RT7 OK (self-test flip verified) · RT8 OK · RT9 OK · all others n-a.
+
+### Security expert
+R42 pass (member-set re-derived: both greps empty, manifest 65 unedited) · RS2 n/a (no new endpoint) · RT5 pass (real primitive reached, live-verified) · RT7 pass (3 live mutation-proofs on the hardest cases) · RT8 pass · RS1/RS3/RS4/RS5/RS6 n/a · no Critical.
+
+### Testing expert
+RT1 clear · RT3 clear (fixtures use env overrides, insulated from 13→0) · RT5 clear · RT7 clear (dual-assertion red-proof + live mutation-proof) · RT8 clear (spy table verified) · RT9 n/a · R19 clear · throttle-isolation clear.
+
+## Environment Verification Report
+Per Phase 1 VC3: every fail-closed contract path is `verifiable-local`.
+- `verified-local`: full vitest (12769 passed), real gate `check-fail-closed-routes-have-test.sh` exit 0, meta-gate exit 0, classifier self-test 53, gate self-test 56, `next build` + Extension build (pre-pr 51/51). RT7 red-proofs executed on throwaway/reverted copies.
+- No `blocked-deferred` paths. Integration-lane (SC-T3-4) explicitly out of scope.
+
+## Resolution Status
+### Post-review inline fix (tightening-only)
+- Stale comment at `scripts/__tests__/check-fail-closed-routes-have-test.test.mjs:49`
+  ("0 debt / 16 legacy" → "0 debt / 0 legacy") — inline minor, no assertion, no
+  security boundary. Applied verbatim (Testing expert awareness note; not a blocking
+  finding). Fits the Step 3-8 tightening-only skip criteria.
+
+All three experts returned "No findings". No Critical/Major/Minor blocking findings.
+Code review converged in 1 round.

--- a/docs/archive/review/fail-closed-tranche3-deviation.md
+++ b/docs/archive/review/fail-closed-tranche3-deviation.md
@@ -37,6 +37,20 @@ recording `vi.fn()` returning two distinct objects, both delegating to the share
 (callback + magic-link) were removed as superseded by the stronger helper contract.
 Classifier confirms `calls=2 mock=0 distinct=2`.
 
+## D4 — reset-vault vi.hoisted self-reference (R20 self-check fix)
+
+**Found by**: Phase-2 self-R-check (Functionality expert, R20). The initial
+reset-vault edit placed `mockAdminLimiterCheck`/`mockTargetLimiterCheck` as sibling
+properties of the `vi.hoisted` return object while `mockCreateRateLimiter`'s
+`mockImplementationOnce` callbacks referenced them — a self-referential object
+literal that TypeScript cannot type (TS7022/TS7024/TS7031). Vitest passed (esbuild
+skips type-check) but `tsc --noEmit` / `next build` failed.
+
+**Fixed**: declared the two check mocks as `const` inside the `vi.hoisted` function
+body BEFORE the return object (mirroring the approve-route sibling test), then
+referenced them via shorthand. Zero tsc errors project-wide after the fix; 30/30
+reset-vault tests still green; classifier still `distinct=2`.
+
 ## D3 — reset-vault distinct-limiter split
 
 **Applied** (C1 M-refactor, as planned): split the shared `mockRateLimiterCheck` into

--- a/docs/archive/review/fail-closed-tranche3-deviation.md
+++ b/docs/archive/review/fail-closed-tranche3-deviation.md
@@ -1,0 +1,51 @@
+# Coding Deviation Log: fail-closed-tranche3
+
+## D1 — ssh/sign-authorize uses a custom 503 envelope, not canonical
+
+**Plan said**: per-route table #13 and the `expectation` bullet classified all 15
+cases as `{ envelope: "canonical" }`.
+
+**Reality (verified route.ts:80-91)**: `vault/ssh/sign-authorize` passes a bespoke
+`envelope` callback to `checkRateLimitOrFail` returning
+`NextResponse.json({ authorized: false, reason: "service_unavailable" }, { status:
+503, headers: { "Retry-After": "30" } })`. It is a custom envelope (matching the
+route's `{ authorized, reason }` response shape), not the canonical
+`{ error: "SERVICE_UNAVAILABLE" }`.
+
+**Applied**: #13's `assertRedisFailClosed` call uses
+`expectation: { envelope: "custom", status: 503, body: { authorized: false, reason:
+"service_unavailable" }, retryAfter: "required" }`. All other 14 cases remain
+canonical. Plan per-route table + expectation bullet corrected to reflect this.
+
+**Why non-Critical**: the fail-closed guarantee is identical (503, no mutation,
+Retry-After present); only the response body shape differs, and the helper's custom
+envelope tier exists precisely for this. No security weakening.
+
+## D2 — auth/[...nextauth] dedicated fail-closed describe block (dynamic-import topology)
+
+**Plan said** (C1 #1 exception): capture + snapshot the two limiters after a
+post-import, in a dedicated block, because the auth test uses dynamic `await
+import()` + `resetModules()`.
+
+**Applied**: added a `describe("fail-closed contract (Redis unavailable → 503)")`
+block that (a) `vi.resetModules()` + `mockCreateRateLimiter.mockClear()`, (b) imports
+the route once (both `createRateLimiter` calls fire in creation order), (c) captures
+`mock.results[0]/[1].value` and snapshots each. The factory was converted to a
+recording `vi.fn()` returning two distinct objects, both delegating to the shared
+`mockRateLimitCheck` so the ~14 existing wrapper tests (which assert only on
+`mockRateLimitCheck`) are unchanged. The two former status-only direct-503 cases
+(callback + magic-link) were removed as superseded by the stronger helper contract.
+Classifier confirms `calls=2 mock=0 distinct=2`.
+
+## D3 — reset-vault distinct-limiter split
+
+**Applied** (C1 M-refactor, as planned): split the shared `mockRateLimiterCheck` into
+`mockAdminLimiterCheck` / `mockTargetLimiterCheck` behind a recording
+`mockCreateRateLimiter` with two `mockImplementationOnce` returning distinct objects
+(creation order adminResetLimiter then targetResetLimiter). Removed the
+`vi.mock("@/lib/security/rate-limit-audit")` partial stub; the real
+`emitRateLimitFailClosed` now runs (tenantId passed directly → no `resolveUserTenantId`
+DB hit; `@/lib/audit/audit` already mocked). Added `__resetThrottleForTests()` to
+`beforeEach`. The two direct-503 cases became `assertRedisFailClosed` calls; the two
+429 cases were rewired to the distinct mocks. Classifier confirms
+`calls=2 mock=0 distinct=2`.

--- a/docs/archive/review/fail-closed-tranche3-plan.md
+++ b/docs/archive/review/fail-closed-tranche3-plan.md
@@ -1,0 +1,462 @@
+# Plan: fail-closed-tranche3 — legacy-manifest burn-down (SC-T3-1) → whole class helper-mode
+
+Parent roadmap: `fail-closed-tranche2-plan.md` Scope contract SC-T3-1 (owner: tranche 3).
+Predecessor: PR #681 (`feature/fail-closed-tranche2`, merged 2026-07-19) — burned the
+debt file to 0 and pinned the class manifest. Deviation history that shapes this tranche:
+tranche-2 deviation D10 (3-tier helper: Response / silent-drop / direct-result),
+D17 (semantic-hybrid classifier). This plan is authored anew for tranche 3; it does
+NOT reopen any tranche-2 contract.
+
+## Project context
+
+- Type: `web app` (Next.js 16 App Router). This tranche touches **test code only**
+  plus two `scripts/checks/` control files (the gate script constants + the legacy
+  manifest). No production route code changes (unlike tranche-2's C8c v1 fix). No
+  classifier logic change is anticipated (the classifier already recognizes all 3
+  helper tiers — D10 — and all 13 targets use `assertRedisFailClosed`, the Response
+  tier).
+- Test infrastructure: `unit + integration + E2E + CI/CD` (vitest unit lane;
+  `scripts/checks/*` gates; meta-gate `check-gate-selftest-coverage.sh`).
+- Verification environment constraints (inherited from parent plan):
+  - VC3: Redis-failure fail-closed behavior is `verifiable-local` via the mocked
+    limiter in unit tests (the `assertRedisFailClosed` contract). No integration-lane
+    work is in scope for this tranche — C10's two-family real-broken-Redis proof
+    (tranche 2) already covers the route-handler integration floor; extending it to
+    these families is SC-T3-4, explicitly deferred. Every contract path below is
+    `verifiable-local`.
+
+## Objective
+
+Migrate all **13 routes** currently registered in
+`scripts/checks/fail-closed-legacy-direct.txt` from **legacy-direct tier** (test
+asserts 503 directly with code-level `redisErrored`, pre-helper form; 4 of them
+partial-stub `@/lib/security/rate-limit-audit`) to **helper mode** (each route's
+sibling test calls `assertRedisFailClosed` — the strongest tier with recorded
+factory attribution, envelope assertion, and non-empty `assertNoMutation`).
+
+On completion:
+1. `fail-closed-legacy-direct.txt` holds **0 route entries** (header + empty).
+2. `EXPECTED_LEGACY_COUNT` drops `13 → 0` in the gate script (visible ratchet diff).
+3. The C6 `FROZEN_STUB_EXEMPTIONS` list (4 tenant/* files) is **emptied** — every
+   `vi.mock("@/lib/security/rate-limit-audit")` under `src` is removed, so the C6
+   structural stub gate finds **zero** stubs and needs zero exemptions.
+4. The whole fail-closed class (all 65 manifest members) is now machine-verified at
+   helper tier or already-migrated tiers — no member sits at the weaker legacy tier.
+
+## Ground truth (verified 2026-07-20 against main @ e3498ca6f)
+
+Legacy manifest = 13 routes. Per-route survey (`grep` over each sibling test +
+route):
+
+| # | Route (src/app/api/...) | Limiters | Sibling test | Stub? | redisErrored | Tier target |
+|---|---|---|---|---|---|---|
+| 1 | auth/[...nextauth] | **2** (callbackRateLimiter, magicLinkIpLimiter) | route.test.ts (426L) | no | 4 | helper ×2 cases |
+| 2 | maintenance/audit-chain-verify | 1 | route.test.ts (230L) | no | 1 | helper |
+| 3 | maintenance/audit-outbox-metrics | 1 | route.test.ts (240L) | no | 1 | helper |
+| 4 | maintenance/audit-outbox-purge-failed | 1 | route.test.ts (304L) | no | 1 | helper |
+| 5 | maintenance/dcr-cleanup | 1 | route.test.ts (200L) | no | 1 | helper |
+| 6 | maintenance/purge-audit-logs | 1 | route.test.ts (428L) | no | 1 | helper |
+| 7 | maintenance/purge-history | 1 | route.test.ts (433L) | no | 1 | helper |
+| 8 | tenant/breakglass | 1 | route.test.ts (517L) | no | 2 | helper |
+| 9 | tenant/members/[userId]/reset-vault | **2** (adminResetLimiter, targetResetLimiter) | route.test.ts (753L) | **yes** | 4 | helper ×2 cases |
+| 10 | tenant/operator-tokens | 1 | route.test.ts (373L) | **yes** | 3 | helper |
+| 11 | tenant/scim-tokens | 1 | route.test.ts (326L) | **yes** | 3 | helper |
+| 12 | tenant/service-accounts | 1 | route.test.ts (271L) | **yes** | 3 | helper |
+| 13 | vault/ssh/sign-authorize | 1 | route.test.ts (365L) | no | 1 | helper |
+
+Total cases: 15 (13 routes; #1 and #9 contribute 2 each — one per distinct limiter,
+mandated by the gate's `HELPER_CALLS_BELOW_LIMITER_COUNT` distinct-arg rule).
+
+Limiter-consumption topology (determines mock arrangement + which spies are legal
+in `assertNoMutation`):
+
+- **11 canonical `checkRateLimitOrFail` routes** (#1–8, #10–13): the route calls
+  `checkRateLimitOrFail({ req, limiter | result, scope, userId, tenantId })` which
+  maps `redisErrored → serviceUnavailable()` (canonical 503 + Retry-After) and
+  fires `emitRateLimitFailClosed` internally on the post-auth path. Envelope =
+  `canonical`.
+- **#1 auth/[...nextauth]** is canonical but pre-auth (`userId: null`): it composes
+  `checkIpRateLimit(... limiter)` → `checkRateLimitOrFail({ req, result, scope,
+  userId: null })`. On redisErrored the emit is **warn-log only** (no
+  `logAuditAsync`) because userId is null (rate-limit-audit.ts:110-118). The two
+  limiters are reached via the exported wrappers `_withCallbackRateLimit` /
+  `_withMagicLinkIpRateLimit`, each gated by a pathname/method match
+  (`isCallbackRoute` / `isMagicLinkSigninRoute`). Precedent for the ip-limiter arrange
+  (real `checkIpRateLimit` skips a null-IP limiter with `{allowed:true}`,
+  ip-rate-limit.ts:52-59): tranche-2 row #9 (extension/bridge-code, U refactor) — a
+  non-null client IP must be arranged so the limiter is actually reached.
+- **#9 reset-vault** is the sole **direct `.check()`** route: it calls
+  `Promise.all([adminResetLimiter.check(...), targetResetLimiter.check(...)])`
+  (route.ts:123-124), then `if (adminResult.redisErrored || targetResult.redisErrored)
+  { void emitRateLimitFailClosed({ ... userId: session.user.id, tenantId }); return
+  serviceUnavailable(); }`. Post-auth → **`logAuditAsync` fires on the 503 path**
+  (via emitRateLimitFailClosed) → `logAuditAsync` is FORBIDDEN in `assertNoMutation`
+  (tranche-2 M9 rule). Envelope = `canonical`. The two `.check()` calls run under a
+  single request, so the two cases arrange one limiter to `redisErrored` while the
+  sibling resolves `{allowed:true}`.
+
+Stub form in the 4 tenant/* siblings (partial `importOriginal`, D4/C6 target):
+```ts
+vi.mock("@/lib/security/rate-limit-audit", async (importOriginal) => ({
+  ...(await importOriginal()) as Record<string, unknown>,
+  emitRateLimitFailClosed: vi.fn(),   // ← stubbed to a no-op
+}));
+```
+This keeps real `checkRateLimitOrFail` (so redisErrored→503 mapping runs) but spies
+`emitRateLimitFailClosed` to dodge its transitive deps. C6 forbids ANY
+rate-limit-audit mock in a non-exempt file; migrating to helper mode requires
+**removing this mock entirely** and letting the real emit run — which then fires
+`logAuditAsync`, so the migrated tests must pin the audit seam at
+`@/lib/audit/audit` (legal — C6 bans only rate-limit-audit) and honor throttle
+hygiene.
+
+### Member-set derivation (R42)
+
+Class SC-T3-1 = current content of `scripts/checks/fail-closed-legacy-direct.txt`.
+
+```
+grep -vE '^\s*#|^\s*$' scripts/checks/fail-closed-legacy-direct.txt | sort   # 13 routes
+```
+
+Cross-check against the C6 exemption primitive (the 4 stub files must be a subset):
+
+```
+git grep -lE 'vi\.mock\("@/lib/security/rate-limit-audit"' -- 'src'
+# → exactly the 4 tenant/* siblings (reset-vault, operator-tokens, scim-tokens,
+#   service-accounts) — matches FROZEN_STUB_EXEMPTIONS in the gate script.
+```
+
+Verified 2026-07-20: 13 legacy entries; 4 of them are the frozen-exemption set; no
+other rate-limit-audit stub remains anywhere under `src` (tranche 2 removed the
+central-tree ones). Post-migration both greps return empty.
+
+Whole-class invariant (unchanged by this tranche, re-asserted as the completeness
+check): manifest = 65 members = (helper 18+3 lib from tranche 2 ∪ these 13 → helper)
+∪ … The manifest `path<TAB>count` set and per-file counts are NOT edited by this
+tranche — no `failClosedOnRedisError: true` literal is added or removed. Only the
+tier of the 13 routes' sibling tests changes.
+
+## Contracts
+
+### C1 — Per-case helper migration (15 cases across 13 sibling tests)
+
+- Every route's sibling `route.test.ts` gains (or has its existing direct-503 test
+  REPLACED by) a test that calls `assertRedisFailClosed` with:
+  - `invoke`: a thunk running the real handler (GET/POST as the route's limiter
+    guards) and returning its `Response`.
+  - `limiter`: the **factory-result object** for the limiter under test (strict
+    identity — the object `createRateLimiter` returned, captured via the recording
+    factory mock). For #1/#9 each case passes a **distinct** limiter object.
+  - `limiterFactory`: the recorded `createRateLimiter` `vi.fn()` (snapshot-replayed
+    per M10 — every one of the 13 files clears mocks in `beforeEach`, so
+    `snapshotFactory` at module scope right after the route import is mandatory).
+    **Exception — #1 auth uses dynamic `await import()`** (see the M-refactor note
+    below): its factory fires only after the first dynamic import, so the
+    module-scope snapshot pattern does not apply; capture + snapshot after the first
+    `await import(...)` instead.
+  - `expectation`: `{ envelope: "canonical" }` for all 15 cases (every route maps
+    redisErrored → `serviceUnavailable()` / canonical 503 + Retry-After). Note this
+    STRENGTHENS the assertion set beyond the current direct-503 tests (which assert
+    status only): the helper additionally asserts the body `{ error:
+    "SERVICE_UNAVAILABLE" }` and a strictly-positive integer `Retry-After`. Every
+    route's 503 path reaches `serviceUnavailable()` (verified), so this passes — but
+    each migrated `invoke` must actually reach `serviceUnavailable()`, not a bare
+    `Response(..., {status:503})`.
+  - `assertNoMutation`: non-empty, real write/side-effect spies for that route's
+    guarded mutation (table below). **`logAuditAsync` is FORBIDDEN in
+    `assertNoMutation` on EVERY post-auth row (#2–#13)** (M9). Derivation rule (not a
+    hand-picked subset): any route that passes a **non-null `userId` with a
+    resolvable `tenantId`** to `checkRateLimitOrFail` (or calls
+    `emitRateLimitFailClosed` directly, as #9 does) fires `logAuditAsync` on the
+    redisErrored 503 path (rate-limit-audit.ts:135-167) — all of #2–#13 do. Spying it
+    as "no mutation" races the un-awaited emission (flake) and, if "fixed" by
+    stubbing, suppresses the audit trail of a fail-closed event on a privileged route.
+    #1 (pre-auth, `userId: null`) also excludes it, but because the emit is warn-log
+    only (no `logAuditAsync`) — a different reason. The write-primitive spies in the
+    table are the correct non-empty set; never add `logAuditAsync` alongside them.
+  - `failure`: inline literal `{ allowed: false, redisErrored: true }` (gate literal
+    must be code, not comment).
+- Test name: `"fails closed (503, no mutation) when Redis is unavailable"`
+  (multi-limiter files suffix ` — <limiter scope>`: e.g. ` — callback`,
+  ` — magic-link`, ` — admin limiter`, ` — target limiter`).
+
+**Per-route `assertNoMutation` spies + arrange notes:**
+
+All post-auth rows (#2–#13) exclude `logAuditAsync` per the derivation rule above —
+the "NOT logAuditAsync" note is stated once here and applies to every one, not just
+the four it was originally written on.
+
+| # | Route | limiter arg(s) | assertNoMutation spies | arrange notes |
+|---|---|---|---|---|
+| 1 | auth/[...nextauth] | callbackRateLimiter / magicLinkIpLimiter (2 cases) | (read-only wrapper — tranche-2 read-only-route semantic extension) handler-proceeded spy: the wrapped `handler` mock `.not.toHaveBeenCalled()` | non-null client IP so real checkIpRateLimit reaches limiter; callback case → callback pathname, magic-link case → POST /api/auth/signin/nodemailer; both `userId:null` (warn-log only, no logAuditAsync) |
+| 2 | audit-chain-verify | rateLimiter | auditLog read/verify svc spy (nearest downstream) | admin bearer; NOT logAuditAsync |
+| 3 | audit-outbox-metrics | rateLimiter | outbox metrics read spy | admin bearer; NOT logAuditAsync |
+| 4 | audit-outbox-purge-failed | rateLimiter | auditOutbox.deleteMany | admin bearer; NOT logAuditAsync |
+| 5 | dcr-cleanup | rateLimiter | `requireMaintenanceOperator` `.not.toHaveBeenCalled()` (410 stub has NO DB write; this is the first effect AFTER the limiter, so its non-invocation proves the 503 short-circuited before any downstream work) | admin bearer; limiter precedes the 410 (verified route.ts:42<71); NOT logAuditAsync (its only other effect is a logAuditAsync, forbidden) |
+| 6 | purge-audit-logs | rateLimiter | auditLog.deleteMany | admin bearer; NOT logAuditAsync |
+| 7 | purge-history | rateLimiter | passwordHistory.deleteMany | admin bearer; NOT logAuditAsync |
+| 8 | breakglass | breakglassRateLimiter | breakGlassGrant.create | admin session + step-up; NOT logAuditAsync |
+| 9 | reset-vault | adminResetLimiter / targetResetLimiter (2 cases) | adminVaultReset.create, createNotification | step-up → null; per case arrange the SIBLING limiter's own check to {allowed:true} (Promise.all runs both concurrently); NOT logAuditAsync |
+| 10 | operator-tokens | scoped create limiter | operatorToken.create (+ advisory-lock $executeRaw if present) | admin session + step-up; NOT logAuditAsync |
+| 11 | scim-tokens | scimTokenCreateLimiter | scimToken.create | admin session + step-up; NOT logAuditAsync |
+| 12 | service-accounts | saCreateLimiter | serviceAccount.create | admin session + step-up; NOT logAuditAsync |
+| 13 | ssh/sign-authorize | signRateLimiter | shareAccessLog/sign-authorize downstream svc spy | authed session; NOT logAuditAsync |
+
+- Refactor sub-tasks per file:
+  - **F (factory→recording)**: the current factory form varies — some files use a
+    **plain arrow** `createRateLimiter: () => ({ check, clear })` (verified:
+    purge-history:36, dcr-cleanup:20, auth:34, sign-authorize:35 — NO `vi.fn`, so
+    `snapshotFactory` reading `mock.mock.calls` would throw), others a non-recording
+    `vi.fn(() => ({...}))` (e.g. operator-tokens:69). Convert EVERY file's factory to
+    a **recording `vi.fn()`** captured in a module-scoped `const` (unconditionally —
+    do not assume `.mock` already exists) so `snapshotFactory` can replay it and
+    strict-identity attribution works. (Precedent: tranche-2 F column.)
+  - **M (multi-limiter split)**: #1 and #9 — the recording factory MUST return a
+    **distinct object per `createRateLimiter` call** (do NOT return one shared
+    object). Both files today share ONE `check` mock across their two limiters,
+    distinguished only by ordered `mockResolvedValueOnce` — that shape is
+    incompatible with the helper (which does `limiter.check.mockResolvedValue(failure)`
+    on the ONE limiter passed, and attributes via
+    `findIndex(r => r.value === limiter)` — a shared object resolves to index 0 for
+    both, so the second case's flag-attribution reads the wrong factory call, and a
+    shared `check` cannot isolate one limiter failing while the sibling is healthy).
+    - **Reference shape (solved in-repo)**: mirror
+      `tenant/members/[userId]/reset-vault/[resetId]/approve/route.test.ts` (tranche-2
+      row #20) — two distinct `check` fns, `mockImplementationOnce`×2 returning
+      distinct `{ check }` objects in `createRateLimiter` creation order, module-scope
+      capture of `results[0].value` / `results[1].value`. Per case: pass the
+      under-test limiter object; arrange the SIBLING limiter's `check` to
+      `mockResolvedValue({ allowed: true })` BEFORE invoking (both `.check()` run
+      concurrently under the route's `Promise.all`, so both must be pre-armed). This
+      gives 2 distinct `limiter:` args → satisfies `HELPER_CALLS_BELOW_LIMITER_COUNT`
+      (declared count 2).
+    - **#1 auth exception (dynamic-import topology)**: the auth test imports the route
+      via `await import(...)` inside each test body with `resetModules()` — there is
+      NO static module-scope route import, so the module-scope `snapshotFactory` /
+      `results[i].value` capture reads an EMPTY `mock.results` → undefined limiters.
+      Do NOT copy the approve-route module-scope pattern here. Instead: import once in
+      a `beforeAll` (or capture after the first `await import(...)` in each case) and
+      snapshot/replay the factory AFTER that import resolves; the two limiters
+      (`callbackRateLimiter`, `magicLinkIpLimiter`) are separate production consts, so
+      the factory's two calls yield distinct results once captured post-import.
+      Wiring precision (the existing structure is two separate describe blocks —
+      `withCallbackRateLimit` and `withMagicLinkIpRateLimit` — each with its own
+      per-test `resetModules`, and ~14 existing wrapper tests reference the shared
+      `mockRateLimitCheck` directly): to preserve those tests, the module-scope
+      `@/lib/security/rate-limit` mock must return **two distinct result objects that
+      both delegate their `check` to the existing `mockRateLimitCheck`** (not one
+      shared object, and not two independent checks that would break the existing
+      assertions). Both limiters are co-constructed only on a single module
+      evaluation (route.ts:77 callback, :127 magic-link), so the redisErrored cases
+      must capture `mock.results[0]/[1].value` from ONE import that constructs both —
+      place them in a dedicated describe block that imports once (no `resetModules`
+      between the two limiter cases), separate from the two wrapper blocks. Do not
+      rewire the existing wrapper assertions. Auth is the HIGHEST-risk case (alongside
+      reset-vault); verify `distinct=2` classification explicitly. Record the chosen
+      shape in the deviation log.
+  - **S (stub removal)**: #9–12 (the 4 tenant/*) — DELETE the
+    `vi.mock("@/lib/security/rate-limit-audit", …)` block entirely. To keep the now-real
+    `emitRateLimitFailClosed → logAuditAsync` from pulling transitive deps or throwing,
+    mock `@/lib/audit/audit` exporting spied `logAuditAsync` + `tenantAuditBase`
+    (legal under C6), and call `__resetThrottleForTests()` in `beforeEach` (throttle
+    hygiene — tranche-2 F-R2-2: `emitRateLimitFailClosed` throttles per
+    `rlfc:<scope>:<userId>` in a module-scoped 5-min Map; without reset an earlier
+    test's emission silently swallows a later assertion). These files assert
+    row-count no-mutation (not emission), so the reset is defensive isolation, not an
+    emission assertion — but it is mandatory because the real emit now runs.
+- Existing non-fail-closed cases in each file are preserved unchanged; only the
+  redisErrored/503 case is restructured to the helper contract, and (for #9–12) the
+  rate-limit-audit stub removal is applied globally in the file.
+- Acceptance: `npx vitest run` green; each migrated test FAILS if the route's 503
+  envelope changes family or loses Retry-After, the guarded mutation executes, the
+  flag is removed from the limiter options (factory attribution), or the file
+  re-introduces a rate-limit-audit stub (C6 gate).
+
+**Consumer-flow walkthrough** (C1 defines no new producer shape — it consumes the
+existing `assertRedisFailClosed` helper contract): the sole consumer of each test is
+the vitest runner + the gate classifier. Classifier reads each migrated file and must
+emit `calls≥1` (helper-mode flip) and `mock=0` (no rate-limit-audit stub). For #1/#9
+the gate additionally reads `distinct` limiter args = 2. Walkthrough:
+`Consumer classify-fail-closed-test.mjs (path: scripts/checks/) reads { calls, mock,
+redis } per file and uses calls>0 ∧ mock=0 to classify the file as helper-mode; the
+gate then reads distinct-limiter count from the helper callsites and compares to the
+manifest limiter count.` No field is missing — the helper API is unchanged, so this
+is a tier flip, not a shape change.
+
+### C2 — Legacy manifest burn-down (atomic, 13 → 0) + ratchet decrement
+
+- Remove all 13 entries from `scripts/checks/fail-closed-legacy-direct.txt` in the
+  SAME PR that migrates the tests (STALE_LEGACY_ENTRY enforces per-route atomicity —
+  a migrated test whose entry lingers fails the gate). File stays in place (header +
+  zero entries) as the future opt-in target.
+- Set `EXPECTED_LEGACY_COUNT` `13 → 0` in `check-fail-closed-routes-have-test.sh`
+  (line 63). The gate asserts EXACT equality (`legacy_count -ne EXPECTED_LEGACY_COUNT`
+  → fail), so the constant edit is mandatory and review-visible — symmetric with the
+  entry removal.
+- Also correct the now-stale comments that describe the legacy count as "16 (13
+  routes + 3 lib members)" — the real constant is already 13 (the 3 lib members are
+  helper-mode, not legacy) and drops to 0 here: gate comment
+  `check-fail-closed-routes-have-test.sh:61` and self-test comment
+  `check-fail-closed-routes-have-test.test.mjs:967`. Update both to the post-tranche
+  end-state so the ratchet diff is self-consistent.
+- Acceptance: `bash scripts/checks/check-fail-closed-routes-have-test.sh` exits 0
+  with an empty legacy file and `EXPECTED_LEGACY_COUNT=0`.
+
+### C3 — C6 frozen-exemption emptying
+
+- Empty the `FROZEN_STUB_EXEMPTIONS` variable in
+  `check-fail-closed-routes-have-test.sh` (currently the 4 tenant/* `route.test.ts`
+  paths, ~line 558). After C1's S-refactor removes all 4 stubs, no file needs an
+  exemption; leaving stale exemptions would be dead config but not a gate failure —
+  however emptying it is the explicit SC-T3-1 end-state and makes the "zero stubs
+  anywhere" invariant visible in the script diff.
+- The gate's stub scan (`STUB_MOCKED_RATE_LIMIT_AUDIT`) then requires **zero**
+  `mock=1` files under `src` across both lanes. Any residual stub fails CI.
+- Acceptance: `git grep -lE 'vi\.mock\("@/lib/security/rate-limit-audit"' -- 'src'`
+  returns empty; the gate's stub scan reports zero findings with an empty exemption
+  list.
+
+### C4 — Anti-pattern forbidden patterns (diff-scoped)
+
+- pattern: `vi\.mock\("@/lib/security/rate-limit-audit"` anywhere in the diff —
+  reason: RT5 mapping stub; C6 now enforces zero across all of `src` (no exemptions).
+  The 4 tenant/* removals are the only legitimate occurrences of this string in the
+  diff (as deletions).
+- pattern: `checkRateLimitOrFail\s*:\s*vi\.fn` in the diff — reason: same
+  anti-pattern via inline factory property (MAPPING_MOCKED_CONTRACT_TEST).
+- pattern: `success:\s*(true|false)` in fail-closed fixtures — reason: field does
+  not exist on `RateLimitResult` (tranche-2 C4).
+- pattern: `logAuditAsync` inside any `assertNoMutation` array in the diff — reason:
+  M9 rule; the 503 path fires it on post-auth routes, so spying it as "no mutation"
+  races the intended emission.
+- pattern: a single shared limiter object returned by the #1/#9 recording factory
+  (i.e. the factory `vi.fn(() => sharedObj)` form) — reason: defeats distinct-arg
+  attribution; each `createRateLimiter` call must yield its own result object.
+
+### C5 — Classifier & self-test integrity (no logic change expected)
+
+- No change to `classify-fail-closed-test.mjs` is anticipated: all 13 targets use
+  `assertRedisFailClosed` (Response tier, already recognized), and stub removal only
+  flips `mock 1→0` (already handled). If migration surfaces a classifier gap
+  (unexpected), any fix follows the tranche-2 order-of-work invariant: red fixture in
+  `scripts/__tests__/classify-fail-closed-test.test.mjs` FIRST, then the change, and
+  the semantic-hybrid architecture (D17) is preserved — no `getSymbol` over the
+  syntactic project, no by-name whole-scan.
+- The gate self-tests (`check-fail-closed-routes-have-test.test.mjs`,
+  `classify-fail-closed-test.test.mjs`) must stay green. The EXPECTED_LEGACY_COUNT
+  ratchet is exercised via the existing `FAIL_CLOSED_EXPECTED_LEGACY_COUNT` override
+  fixtures — verify a fixture asserting count-0 legacy passes and count-1 fails still
+  holds after the constant change (the fixtures use overrides, not the real constant,
+  so they are insulated; confirm no self-test hardcodes 13).
+- Acceptance: `npx vitest run scripts/__tests__/classify-fail-closed-test.test.mjs`
+  and `.../check-fail-closed-routes-have-test.test.mjs` green;
+  `bash scripts/checks/check-gate-selftest-coverage.sh` exits 0.
+
+## Testing strategy
+
+- `npx vitest run` — 15 migrated cases + all existing suites; gate + classifier
+  self-tests via the `scripts/__tests__/*` vitest lane.
+- `bash scripts/checks/check-fail-closed-routes-have-test.sh; echo $?` — the real
+  gate, EXIT 0 (C1 helper-mode flips + C2 empty legacy + C3 empty exemptions).
+- `bash scripts/checks/check-gate-selftest-coverage.sh; echo $?` — meta-gate.
+- `time node scripts/checks/classify-fail-closed-test.mjs $(git ls-files src | grep -E '\.test\.tsx?$' | sed "s|^|$(pwd)/|")`
+  — ONLY IF the classifier is touched (baseline: full gate ~9.4s / classifier ~4s;
+  CI timeouts 10s/60s). If untouched, skip.
+- `PRE_PR_CACHE_TTL=0 bash ~/.claude/hooks/check-pre-pr.sh run` — full (vitest +
+  build + all gates). Build runs even though only test/script files change (the
+  hook decides); no production route code is modified so a build regression is not
+  expected, but pre-pr is authoritative.
+- `npx next build` — mandatory per CLAUDE.md only if pre-pr does not already cover
+  it; test-only + script changes normally skip build, but pre-pr is the gate.
+
+## Considerations & constraints
+
+### Scope contract
+
+- **SC-T3-1** (this tranche): 13 legacy routes → helper mode + 4 stub removals + C6
+  exemption emptying + EXPECTED_LEGACY_COUNT 13→0. **In scope.**
+- SC-T3-2: SCIM 503 Retry-After header (RFC 7644 review) — deferred, future SCIM
+  hardening. Not touched here.
+- SC-T3-3: v1/passwords + v1/passwords/[id] direct-redisErrored tests → helper mode —
+  deferred; those are NOT legacy-manifest members (their limiter member is
+  `rate-limiters.ts`, already helper), so out of SC-T3-1's set. Promote only if
+  touched.
+- SC-T3-4: route-handler integration for families beyond C10's two (incl.
+  verify-access token-limiter, needing a selectively-failing Redis fake) — deferred.
+- SC-T3-5: magicLinkEmailLimiter redisErrored observability upgrade — deferred.
+
+### Risks
+
+- **The two multi-limiter routes (#1 auth, #9 reset-vault) are the two hard cases —
+  do them FIRST, in this order: #9 then #1.** #9 reset-vault consumes
+  `Promise.all([admin.check, target.check])` by `.redisErrored` OR; the recording
+  factory must return two distinct objects (approve-route shape, C1 M-refactor) and
+  each case must pre-arm the sibling limiter. #1 auth is HIGHER-risk still: its test
+  uses dynamic `await import()` + `resetModules()`, so the module-scope snapshot
+  pattern does NOT transfer — it needs the post-import capture described in C1's #1
+  exception, restructuring only the redisErrored cases. Do NOT assume "mirror #9 to
+  #1"; they differ in import topology. Verify `distinct=2` classification on each.
+  Record the chosen shape for both in the deviation log. Only after both pass do the
+  11 single-limiter routes fan out. Fallback for #9 if call-order distinct results
+  prove fragile: two separate `createRateLimiter` module mocks keyed by options.
+- **Un-stubbing the 4 tenant/* rate-limit-audit mocks may surface transitive-dep
+  import errors** (the stub's stated purpose was "avoid pulling transitive deps").
+  Mitigation: mock `@/lib/audit/audit` (`logAuditAsync`, `tenantAuditBase`) — the
+  same seam tranche-2 C8b used for SCIM — which is exactly the transitive dep the
+  stub was dodging. Verify on operator-tokens (#10) first.
+- **Throttle bleed across the migrated tenant/* tests**: real `emitRateLimitFailClosed`
+  now runs; `__resetThrottleForTests()` in `beforeEach` is mandatory in #9–12.
+  Without it, a second redisErrored case in the same file (or a neighboring file in
+  the same worker) silently swallows the emission — but since these tests assert
+  row-count not emission, the failure mode is subtler (a later emission-inspecting
+  test elsewhere flakes). Add the reset defensively per the tranche-2 mandate.
+- **#1 auth wrapper reach**: the two limiters only fire when `isCallbackRoute` /
+  `isMagicLinkSigninRoute` match. Each case must invoke the exported wrapper with a
+  matching pathname/method and a non-null client IP, else real `checkIpRateLimit`
+  short-circuits `{allowed:true}` and the limiter is never reached (helper step 3
+  `expect(limiter.check).toHaveBeenCalled()` would fail loud — good, catches a
+  mis-arranged case).
+- **15-file mechanical fan-out drift** — mitigation: batch (reset-vault + auth first
+  as the two hard cases, then the 4 tenant/* stub-removals, then the 7 clean
+  single-limiter routes), `vitest related` per batch, C4 grep, full suite last.
+- Pre-1.0, no production behavior change (test-tier + gate-constant only) — no
+  changelog user-visible entry; conventional commit `test(security):` /
+  `refactor(security):` for the gate control-file edits (release-please: `test` does
+  not bump; the gate-script edit is `refactor` to register a patch bump if a bump is
+  desired — decide at commit time, low stakes).
+
+### Accepted residual
+
+- After this tranche the legacy tier is empty but the **mechanism** (legacy manifest
+  + EXPECTED_LEGACY_COUNT + STALE/DANGLING tokens) remains in the gate as the
+  registration path for any future pre-helper onboarding. This is intentional — the
+  tier is retired of members, not deleted as machinery (deleting it would remove the
+  ratchet that blocks a future silent legacy re-entry).
+
+## User operation scenarios
+
+- Operator during a Redis outage: every one of the 13 endpoints (admin key-rotation
+  maintenance ops, breakglass grant, tenant token/SA creation, admin vault reset, SSH
+  sign authorize, auth callback / magic-link signin) returns canonical 503 +
+  Retry-After; no maintenance mutation runs, no token/SA/grant created, no vault
+  reset performed, no signature authorized, no auth callback processed — now proven
+  by the strongest-tier contract with recorded factory attribution, not a
+  direct-503 assertion that could pass on a mis-wired limiter.
+- Developer touching any of these 13 routes' rate-limit wiring later: the sibling
+  test is now helper-mode, so a broken 503 envelope, a dropped Retry-After, a
+  removed `failClosedOnRedisError` flag, or a re-introduced rate-limit-audit stub all
+  fail CI at the strongest tier.
+- Developer adding a NEW fail-closed limiter anywhere under src: unchanged from
+  tranche 2 — manifest entry + helper contract (or debt entry with visible
+  EXPECTED_DEBT_COUNT bump) demanded; a new rate-limit-audit stub fails CI with an
+  empty exemption list (previously 4 slots were "available cover" — now zero).
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | Per-case helper migration (15 cases / 13 files; F/M/S refactors) | locked |
+| C2 | Legacy manifest burn-down 13→0 + EXPECTED_LEGACY_COUNT 13→0 | locked |
+| C3 | C6 FROZEN_STUB_EXEMPTIONS emptied; zero rate-limit-audit stubs under src | locked |
+| C4 | Anti-pattern forbidden patterns (rate-limit-audit stub, mapping stub, logAuditAsync-in-noMutation, shared-limiter-object) | locked |
+| C5 | Classifier/self-test integrity (no logic change expected; ratchet fixtures insulated) | locked |

--- a/docs/archive/review/fail-closed-tranche3-plan.md
+++ b/docs/archive/review/fail-closed-tranche3-plan.md
@@ -154,8 +154,13 @@ tier of the 13 routes' sibling tests changes.
     below): its factory fires only after the first dynamic import, so the
     module-scope snapshot pattern does not apply; capture + snapshot after the first
     `await import(...)` instead.
-  - `expectation`: `{ envelope: "canonical" }` for all 15 cases (every route maps
-    redisErrored → `serviceUnavailable()` / canonical 503 + Retry-After). Note this
+  - `expectation`: `{ envelope: "canonical" }` for 14 of 15 cases (every route maps
+    redisErrored → `serviceUnavailable()` / canonical 503 + Retry-After). The sole
+    exception is **#13 ssh/sign-authorize**, which supplies a bespoke
+    `checkRateLimitOrFail` `envelope` returning `{ authorized: false, reason:
+    "service_unavailable" }` (status 503, Retry-After 30) — its case uses
+    `{ envelope: "custom", status: 503, body: { authorized: false, reason:
+    "service_unavailable" }, retryAfter: "required" }` (deviation D1). Note this
     STRENGTHENS the assertion set beyond the current direct-503 tests (which assert
     status only): the helper additionally asserts the body `{ error:
     "SERVICE_UNAVAILABLE" }` and a strictly-positive integer `Retry-After`. Every
@@ -200,7 +205,7 @@ the four it was originally written on.
 | 10 | operator-tokens | scoped create limiter | operatorToken.create (+ advisory-lock $executeRaw if present) | admin session + step-up; NOT logAuditAsync |
 | 11 | scim-tokens | scimTokenCreateLimiter | scimToken.create | admin session + step-up; NOT logAuditAsync |
 | 12 | service-accounts | saCreateLimiter | serviceAccount.create | admin session + step-up; NOT logAuditAsync |
-| 13 | ssh/sign-authorize | signRateLimiter | shareAccessLog/sign-authorize downstream svc spy | authed session; NOT logAuditAsync |
+| 13 | ssh/sign-authorize | signRateLimiter | prisma.sSHAgentKey.findFirst (or the downstream key-lookup/authorize svc spy) | authed session; NOT logAuditAsync; **CUSTOM envelope** — `{ envelope: "custom", status: 503, body: { authorized: false, reason: "service_unavailable" }, retryAfter: "required" }` (verified route.ts:87-91; NOT canonical — deviation D1) |
 
 - Refactor sub-tasks per file:
   - **F (factory→recording)**: the current factory form varies — some files use a

--- a/docs/archive/review/fail-closed-tranche3-review.md
+++ b/docs/archive/review/fail-closed-tranche3-review.md
@@ -1,0 +1,104 @@
+# Plan Review: fail-closed-tranche3
+Date: 2026-07-20
+Review round: 1
+
+## Changes from Previous Round
+Round 1: initial review, 9 findings (1 High, 2 Major, 1 Med×2-perspective, 5
+Minor/Low) — all applied to the plan.
+
+## Round 2 (verification)
+All 9 Round-1 fixes verified correct and complete against source. The approve-route
+reference shape (`.../reset-vault/[resetId]/approve/route.test.ts`) confirmed real
+(mockImplementationOnce×2 + module-scope results[0]/[1].value capture). Auth
+post-import capture confirmed feasible. One NEW Low finding (F-new-1): auth test has
+two separate describe blocks with per-test `resetModules` and ~14 existing wrapper
+tests referencing the shared `mockRateLimitCheck` — "leave existing cases untouched"
+needed a precise wiring note (two distinct result objects both delegating to
+`mockRateLimitCheck`; capture in a dedicated import-once describe block). Applied. No
+Critical/High/Major findings in Round 2. Plan review converged.
+
+## Merged Findings
+
+1. **High** [Security] — M9 logAuditAsync-exclusion under-enumerated. The per-route
+   table annotates "NOT logAuditAsync" only on #9–12, but ALL 12 post-auth routes
+   (#2–13) pass non-null userId + resolvable tenantId to `checkRateLimitOrFail`, so
+   `emitRateLimitFailClosed` fires `logAuditAsync` on the 503 path for every one.
+   Following the table literally invites adding `logAuditAsync` to `assertNoMutation`
+   for #2–8,#13 → races the un-awaited emission (flake) or invites an
+   audit-suppressing stub on a fail-closed control. R42 member-set gap: M9 applied to
+   a hand-picked subset, not code-derived from the primitive (non-null userId +
+   resolvable tenantId → logAuditAsync fires). Not Critical: C4 grep is a diff-scoped
+   backstop and the plan prose states the correct universal rule; the table
+   contradicts it. Fix: annotate every post-auth row #2–13 + state the derivation
+   rule once.
+
+2. **Major** [Functionality, Testing] — auth/[...nextauth] test uses dynamic
+   `await import()` inside test bodies (with `resetModules()`), so module-scope
+   `snapshotFactory` + `mock.results[i].value` capture reads empty `mock.results` →
+   undefined limiters. The cited precedent (approve route, static import) does NOT
+   transfer. Fix: add an auth-specific sub-task — capture+snapshot after the first
+   dynamic import (or a `beforeAll` import once); budget auth as a hard case
+   alongside reset-vault.
+
+3. **Major** [Functionality, Testing] — #9 reset-vault (and #1 auth) share ONE
+   `check` mock across both limiters, distinguished only by `mockResolvedValueOnce`
+   ordering. `findIndex(r => r.value === limiter)` returns 0 for both (same object) →
+   wrong attribution; and `Promise.all` runs both `.check()` concurrently so both
+   mocks must be pre-armed. Fix: adopt the approve route's exact shape — two distinct
+   `check` fns, `mockImplementationOnce`×2 returning distinct `{check}` objects in
+   creation order, module-scope capture of `results[0]/[1].value`, sibling
+   `check.mockResolvedValue({allowed:true})` per case. Reference in-repo, not as
+   "fallback".
+
+4. **Medium** [Security, Testing] — #5 dcr-cleanup is a 410 stub with no DB write;
+   only downstream effects are `requireMaintenanceOperator` (guard) + `logAuditAsync`
+   (forbidden by M9). The helper throws on empty `assertNoMutation`. Fix: specify
+   `requireMaintenanceOperator.not.toHaveBeenCalled()` as the fail-closed witness
+   (first effect after the limiter). Do NOT use `logAuditAsync`.
+
+5. **Minor** [Functionality] — the helper strengthens 503 assertions (body
+   `{error:SERVICE_UNAVAILABLE}` + `Retry-After` integer>0) beyond the current
+   status-only direct-503 cases; the plan calls output "unchanged". Documentation gap
+   only (production reaches `serviceUnavailable()`).
+
+6. **Minor** [Functionality] — #9 table lists "adminVaultReset.updateMany (or
+   .create)" but the POST route only calls `.create` + `createNotification`.
+   `updateMany` is a copy-forward from tranche-2 row #20 (approve). Fix to
+   `adminVaultReset.create`, `createNotification`.
+
+7. **Minor** [Functionality] — #1 `assertNoMutation` uses a handler-proceed spy
+   (wrapped handler `.not.toHaveBeenCalled`), valid via the tranche-2 read-only-route
+   semantic extension but not restated. Fix: cite the extension for #1.
+
+8. **Low** [Testing] — plan says "non-recording `vi.fn(()=>...)`" but purge-history:36,
+   dcr-cleanup:20, auth:34, sign-authorize:35 use a PLAIN ARROW (no `vi.fn`).
+   `snapshotFactory` reads `mock.mock.calls` → throws on a plain arrow. Fix: correct
+   the F-refactor to "plain arrow OR non-recording vi.fn → convert to recording
+   vi.fn unconditionally".
+
+9. **Low** [Testing] — gate comment :61 and self-test comments :49,:966-967 say
+   "16 (13 routes + 3 lib members)" but the real constant is 13, no lib members in
+   legacy; doubly stale after 13→0. Fix: C2 also corrects these comments to the
+   post-tranche end-state.
+
+## Quality Warnings
+None. All findings carry specific file/route references, concrete failure modes, and
+actionable remediation.
+
+## Recurring Issue Check
+### Functionality expert
+R1 pass · R2 pass · R17 FLAG (F2/F3 multi-limiter helper adoption) · R42 pass (both
+greps recomputed, zero delta: 13 routes, 4 stubs) · all others n-a.
+
+### Security expert
+R42 flag (F1 — M9 applied to subset not code-derived member-set) · RS2 flag (F1
+audit-suppression risk on fail-closed control) · RS1/RS3-RS6 ok · ratchet
+bypass-proof; C6 exemption-emptying safe (broadened anti-evasion sweep found no
+additional stub forms — the 4 are the whole class); no Critical, no fail-open member
+missed.
+
+### Testing expert
+RT7 WARN (#1/#9 distinct-limiter wiring) · RT8 WARN (#5 empty assertNoMutation, #9
+shared-check vacuity) · RT1/RT3/RT5/RT9 ok · classifier-no-change confirmed for 12/13
+(M-refactor probe yields distinct=2); self-test ratchet insulated (no hardcoded 13 in
+the constant path).

--- a/scripts/__tests__/check-fail-closed-routes-have-test.test.mjs
+++ b/scripts/__tests__/check-fail-closed-routes-have-test.test.mjs
@@ -46,7 +46,7 @@ function runGuard(extraEnv = {}) {
       // Fixture-mode default so the env-pollution guard does not fire under
       // CI=true; the pollution-guard test overrides it back to "".
       FAIL_CLOSED_TEST_FIXTURE_MODE: "1",
-      // Real-repo defaults (0 debt / 16 legacy) are meaningless against an
+      // Real-repo defaults (0 debt / 0 legacy) are meaningless against an
       // empty fixture tree — default fixture expectations to 0/0 so plain
       // fixtures (no debt, no legacy entries) pass without every test
       // needing to pass these explicitly. Individual ratchet tests override.

--- a/scripts/__tests__/check-fail-closed-routes-have-test.test.mjs
+++ b/scripts/__tests__/check-fail-closed-routes-have-test.test.mjs
@@ -846,7 +846,10 @@ it("x", () => {});
       expect(stdout).not.toContain("STUB_MOCKED_RATE_LIMITERS_MODULE:");
     });
 
-    it("passes for a stub in an EXEMPT frozen-list file (tenant/service-accounts sibling shape)", () => {
+    it("flags a rate-limit-audit stub in the formerly-exempt tenant/service-accounts file (exemption list emptied by SC-T3-1)", () => {
+      // The frozen exemption list is empty as of tranche 3 — the 4 tenant/*
+      // stubs were migrated to helper mode. A stub re-introduced into the
+      // formerly-exempt sibling now fails the C6 scan (no cover remains).
       const rel = writeRoute("tenant/service-accounts", FAIL_CLOSED_LINE);
       writeAdjacentTest(
         "tenant/service-accounts",
@@ -857,8 +860,8 @@ it("legacy direct", () => { expect(rl.redisErrored).toBe(true); });
       );
       writeFileSync(legacyFile, `${rel}\n`, "utf8");
       const { exitCode, stdout } = runGuard({ FAIL_CLOSED_EXPECTED_LEGACY_COUNT: "1" });
-      expect(exitCode, stdout).toBe(0);
-      expect(stdout).not.toContain("STUB_MOCKED_RATE_LIMIT_AUDIT:");
+      expect(exitCode, stdout).not.toBe(0);
+      expect(stdout).toContain("STUB_MOCKED_RATE_LIMIT_AUDIT:");
     });
   });
 
@@ -962,14 +965,14 @@ it("2", async () => { await assertRedisFailClosed({ limiter: onlyLimiter, failur
   });
 
   describe("real repo (no overrides)", () => {
-    // End-state assertion (fail-closed-tranche2, all batches landed): the real
-    // repo now passes the gate cleanly — debt burned to 0, legacy pinned at 16
-    // (13 routes + 3 lib members), the manifest set-equality + per-file counts
-    // match the tree, and every rate-limit-audit stub is either migrated
-    // (C7/C8b) or one of the 4 frozen tenant/* legacy exemptions. This test
-    // pins the clean state so ANY regression — a re-added debt entry, a
+    // End-state assertion (fail-closed-tranche3, SC-T3-1 landed): the real repo
+    // passes the gate cleanly — debt burned to 0, legacy burned to 0 too (the
+    // former 13 route members migrated to helper mode), the manifest
+    // set-equality + per-file counts match the tree, and ZERO rate-limit-audit
+    // stubs remain anywhere under src (the frozen exemption list is empty). This
+    // test pins the clean state so ANY regression — a re-added debt entry, a
     // dropped opt-in flag, a new stub, manifest drift — fails loudly.
-    it("passes cleanly with the tranche-2 burndown applied", () => {
+    it("passes cleanly with the tranche-3 legacy burndown applied", () => {
       // The real-repo run classifies the whole src/app/api sibling-test set
       // PLUS every *.test.ts(x) under src for the C6 stub scan (~2 batched
       // ts-morph invocations over hundreds of files) — slower than the

--- a/scripts/checks/check-fail-closed-routes-have-test.sh
+++ b/scripts/checks/check-fail-closed-routes-have-test.sh
@@ -56,11 +56,14 @@ MANIFEST_FILE="${FAIL_CLOSED_TEST_MANIFEST_FILE:-$FIXTURE_ROOT/scripts/checks/fa
 CLASSIFIER="$REPO_ROOT/scripts/checks/classify-fail-closed-test.mjs"
 
 # Ratchet constants (C3/C5) — fixture-overridable so red fixtures (a 1-entry
-# debt/17-entry legacy list vs the real-repo expectation) are executable
+# debt/1-entry legacy list vs the real-repo expectation) are executable
 # without mutating the real manifests. Real-repo defaults: debt burns down to
-# 0 (C3); legacy holds exactly 16 (13 routes + 3 lib members, C8d).
+# 0 (C3); legacy burns down to 0 too (SC-T3-1, tranche 3) — the former 13 route
+# members migrated to helper mode. The legacy tier now holds ZERO members; the
+# mechanism (manifest + this constant + STALE/DANGLING tokens) remains as the
+# registration path for any future pre-helper onboarding.
 EXPECTED_DEBT_COUNT="${FAIL_CLOSED_EXPECTED_DEBT_COUNT:-0}"
-EXPECTED_LEGACY_COUNT="${FAIL_CLOSED_EXPECTED_LEGACY_COUNT:-13}"
+EXPECTED_LEGACY_COUNT="${FAIL_CLOSED_EXPECTED_LEGACY_COUNT:-0}"
 
 # CI-auditable: print effective scan paths on one line.
 echo "check-fail-closed-routes-have-test: FIXTURE_ROOT=$FIXTURE_ROOT DEBT_FILE=$DEBT_FILE LEGACY_FILE=$LEGACY_FILE MANIFEST_FILE=$MANIFEST_FILE EXPECTED_DEBT_COUNT=$EXPECTED_DEBT_COUNT EXPECTED_LEGACY_COUNT=$EXPECTED_LEGACY_COUNT"
@@ -555,12 +558,15 @@ EOF
 # src (both lanes) PLUS setupFiles derived from the vitest configs, batch-
 # classify, and reject any non-exempt production-mapping stub.
 # ---------------------------------------------------------------------------
-FROZEN_STUB_EXEMPTIONS='src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
-src/app/api/tenant/operator-tokens/route.test.ts
-src/app/api/tenant/scim-tokens/route.test.ts
-src/app/api/tenant/service-accounts/route.test.ts'
+# EMPTIED by SC-T3-1 (tranche 3): the 4 tenant/* siblings that partial-stubbed
+# rate-limit-audit have been migrated to helper mode and their stubs removed, so
+# no file needs an exemption. The variable is retained (empty) as the
+# registration surface for any future pre-helper onboarding — adding an entry is
+# a visible script diff. With an empty list the C6 stub scan requires ZERO
+# rate-limit-audit mocks anywhere under src across both lanes.
+FROZEN_STUB_EXEMPTIONS=''
 
-is_stub_exempt() { grep -qxF "$1" <<<"$FROZEN_STUB_EXEMPTIONS"; }
+is_stub_exempt() { [ -n "$FROZEN_STUB_EXEMPTIONS" ] && grep -qxF "$1" <<<"$FROZEN_STUB_EXEMPTIONS"; }
 
 STUB_TEST_FILES=""
 if [ -n "${FAIL_CLOSED_TEST_ROOT:-}" ]; then

--- a/scripts/checks/fail-closed-legacy-direct.txt
+++ b/scripts/checks/fail-closed-legacy-direct.txt
@@ -17,18 +17,10 @@
 #   - An entry whose route no longer opts into fail-closed is rejected
 #     (DANGLING_ENTRY) so flag removal is always a visible manifest diff.
 #
+# EMPTIED by SC-T3-1 (tranche 3): all 13 former legacy routes were migrated to
+# helper mode (assertRedisFailClosed) in the same PR, and EXPECTED_LEGACY_COUNT
+# was dropped 13 -> 0. The whole fail-closed class is now machine-verified at
+# the strongest tier. This file remains (header + zero entries) as the
+# registration target for any future pre-helper onboarding.
+#
 # Format: one route path per line, relative to repo root, sorted.
-
-src/app/api/auth/[...nextauth]/route.ts
-src/app/api/maintenance/audit-chain-verify/route.ts
-src/app/api/maintenance/audit-outbox-metrics/route.ts
-src/app/api/maintenance/audit-outbox-purge-failed/route.ts
-src/app/api/maintenance/dcr-cleanup/route.ts
-src/app/api/maintenance/purge-audit-logs/route.ts
-src/app/api/maintenance/purge-history/route.ts
-src/app/api/tenant/breakglass/route.ts
-src/app/api/tenant/members/[userId]/reset-vault/route.ts
-src/app/api/tenant/operator-tokens/route.ts
-src/app/api/tenant/scim-tokens/route.ts
-src/app/api/tenant/service-accounts/route.ts
-src/app/api/vault/ssh/sign-authorize/route.ts

--- a/src/app/api/auth/[...nextauth]/route.test.ts
+++ b/src/app/api/auth/[...nextauth]/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
 
 // Mirrors the `RouteHandler` signature in route.ts (not exported). The
 // wrappers are generic `<H extends RouteHandler>(h: H): H`, so the inner
@@ -29,9 +30,16 @@ vi.mock("@/lib/auth/session/session-meta", () => ({
 }));
 
 // Controllable rate-limit mock used by the callback rate-limit tests.
+// Recording factory returns a DISTINCT object per createRateLimiter call
+// (route.ts:77 callbackRateLimiter THEN :127 magicLinkIpLimiter), both
+// delegating to the shared mockRateLimitCheck so the existing wrapper tests
+// (which only assert on mockRateLimitCheck) are unaffected. The distinct
+// objects let assertRedisFailClosed attribute each limiter to its
+// createRateLimiter call — see the "fail-closed contract" describe block.
 const mockRateLimitCheck = vi.fn();
+const mockCreateRateLimiter = vi.fn(() => ({ check: mockRateLimitCheck }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: () => ({ check: mockRateLimitCheck }),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 
 const mockExtractClientIp = vi.fn();
@@ -278,19 +286,10 @@ describe("withCallbackRateLimit", () => {
     expect(inner).toHaveBeenCalledTimes(2);
   });
 
-  it("fails closed with 503 when the limiter reports redisErrored (does NOT invoke handler)", async () => {
-    mockRateLimitCheck.mockResolvedValue({ allowed: false, redisErrored: true });
-    const { _withCallbackRateLimit } = await import(
-      "@/app/api/auth/[...nextauth]/route"
-    );
-    const inner = vi.fn<RouteHandler>(async () => new Response("ok"));
-    const wrapped = _withCallbackRateLimit(inner);
-
-    const res = await wrapped(makeReq("/api/auth/callback/google", "GET"));
-
-    expect(res.status).toBe(503);
-    expect(inner).not.toHaveBeenCalled();
-  });
+  // Redis-unavailable fail-closed (503) for this limiter is covered by the
+  // stronger helper contract in the "fail-closed contract" describe block
+  // (envelope + Retry-After + factory attribution) — the former status-only
+  // direct case is superseded and removed to avoid duplication.
 
   it("skips the limiter and warn-logs when client IP cannot be determined", async () => {
     mockExtractClientIp.mockReturnValue(null);
@@ -395,19 +394,10 @@ describe("withMagicLinkIpRateLimit", () => {
     expect(inner).not.toHaveBeenCalled();
   });
 
-  it("fails closed with 503 when the limiter reports redisErrored (does NOT invoke handler)", async () => {
-    mockRateLimitCheck.mockResolvedValue({ allowed: false, redisErrored: true });
-    const { _withMagicLinkIpRateLimit } = await import(
-      "@/app/api/auth/[...nextauth]/route"
-    );
-    const inner = vi.fn<RouteHandler>(async () => new Response("ok"));
-    const wrapped = _withMagicLinkIpRateLimit(inner);
-
-    const res = await wrapped(makeReq("/api/auth/signin/nodemailer"));
-
-    expect(res.status).toBe(503);
-    expect(inner).not.toHaveBeenCalled();
-  });
+  // Redis-unavailable fail-closed (503) for this limiter is covered by the
+  // stronger helper contract in the "fail-closed contract" describe block
+  // (envelope + Retry-After + factory attribution) — the former status-only
+  // direct case is superseded and removed to avoid duplication.
 
   it("fail-OPEN: forwards when client IP cannot be determined (no 503)", async () => {
     mockExtractClientIp.mockReturnValue(null);
@@ -422,5 +412,89 @@ describe("withMagicLinkIpRateLimit", () => {
     expect(res.status).toBe(200);
     expect(inner).toHaveBeenCalledTimes(1);
     expect(mockRateLimitCheck).not.toHaveBeenCalled();
+  });
+});
+
+// Fail-closed contract (helper tier). The route's two limiters
+// (callbackRateLimiter, magicLinkIpLimiter) are both pre-auth `userId: null`
+// → checkRateLimitOrFail warn-logs (no logAuditAsync) and returns canonical
+// 503 on redisErrored. Because the route module is imported dynamically with
+// per-test resetModules elsewhere in this file, this block imports ONCE, then
+// captures the two distinct createRateLimiter results by creation order and
+// snapshots the factory for strict-identity attribution. assertNoMutation uses
+// the wrapped handler-proceed spy (tranche-2 read-only-route semantic
+// extension): the auth handler is the guarded side-effect, and its
+// non-invocation proves the 503 short-circuited before the handler ran.
+describe("fail-closed contract (Redis unavailable → 503)", () => {
+  beforeEach(() => {
+    mockRateLimitCheck.mockReset();
+    mockExtractClientIp.mockReturnValue("203.0.113.5");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  async function loadRoute() {
+    // Reset so this block owns the factory's call/result ledger, then import
+    // once — both createRateLimiter calls fire at module-load in creation order.
+    vi.resetModules();
+    mockCreateRateLimiter.mockClear();
+    const mod = await import("@/app/api/auth/[...nextauth]/route");
+    const callbackFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+    const callbackLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+      check: typeof mockRateLimitCheck;
+    };
+    const magicLinkFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+    const magicLinkLimiter = mockCreateRateLimiter.mock.results[1]!.value as {
+      check: typeof mockRateLimitCheck;
+    };
+    return {
+      mod,
+      callbackLimiter,
+      callbackFactorySnapshot,
+      magicLinkLimiter,
+      magicLinkFactorySnapshot,
+    };
+  }
+
+  it("fails closed (503, no mutation) when Redis is unavailable — callback", async () => {
+    const { mod, callbackLimiter, callbackFactorySnapshot } = await loadRoute();
+    const inner = vi.fn<RouteHandler>(async () => new Response("ok"));
+    const wrapped = mod._withCallbackRateLimit(inner);
+    await assertRedisFailClosed({
+      invoke: () =>
+        wrapped(
+          new NextRequest(
+            "http://localhost/api/auth/callback/google/",
+            { method: "POST" },
+          ),
+        ),
+      limiter: callbackLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [inner],
+      limiterFactory: callbackFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
+  });
+
+  it("fails closed (503, no mutation) when Redis is unavailable — magic-link", async () => {
+    const { mod, magicLinkLimiter, magicLinkFactorySnapshot } = await loadRoute();
+    const inner = vi.fn<RouteHandler>(async () => new Response("ok"));
+    const wrapped = mod._withMagicLinkIpRateLimit(inner);
+    await assertRedisFailClosed({
+      invoke: () =>
+        wrapped(
+          new NextRequest(
+            "http://localhost/api/auth/signin/nodemailer",
+            { method: "POST" },
+          ),
+        ),
+      limiter: magicLinkLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [inner],
+      limiterFactory: magicLinkFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 });

--- a/src/app/api/maintenance/audit-chain-verify/route.test.ts
+++ b/src/app/api/maintenance/audit-chain-verify/route.test.ts
@@ -1,23 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
 
 const {
   mockVerifyAdminToken,
   mockQueryRawUnsafe,
   mockRequireMaintenanceOperator,
   mockCheck,
+  mockCreateRateLimiter,
   mockLogAudit,
   mockWithBypassRls,
-} = vi.hoisted(() => ({
-  mockVerifyAdminToken: vi.fn(),
-  mockQueryRawUnsafe: vi.fn(),
-  mockRequireMaintenanceOperator: vi.fn(),
-  mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
-  mockLogAudit: vi.fn(),
-  mockWithBypassRls: vi.fn(
-    async (prisma: unknown, fn: (tx: unknown) => unknown, _purpose?: unknown) => fn(prisma),
-  ),
-}));
+} = vi.hoisted(() => {
+  const mockCheck = vi.fn().mockResolvedValue({ allowed: true });
+  return {
+    mockVerifyAdminToken: vi.fn(),
+    mockQueryRawUnsafe: vi.fn(),
+    mockRequireMaintenanceOperator: vi.fn(),
+    mockCheck,
+    mockCreateRateLimiter: vi.fn(() => ({ check: mockCheck, clear: vi.fn() })),
+    mockLogAudit: vi.fn(),
+    mockWithBypassRls: vi.fn(
+      async (prisma: unknown, fn: (tx: unknown) => unknown, _purpose?: unknown) => fn(prisma),
+    ),
+  };
+});
 
 vi.mock("@/lib/auth/tokens/admin-token", () => ({
   verifyAdminToken: mockVerifyAdminToken,
@@ -28,7 +34,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
@@ -51,6 +57,13 @@ vi.mock("@/lib/auth/access/maintenance-auth", () => ({
 
 import { GET } from "./route";
 import { OPERATOR_TOKEN_PREFIX } from "@/lib/constants/auth/operator-token";
+
+// Module-scope snapshot: route.ts's `rateLimiter = createRateLimiter(...)` runs
+// at import time above, before any beforeEach's vi.clearAllMocks() can wipe it.
+const chainVerifyLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const chainVerifyLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockCheck;
+};
 
 const SUBJECT_USER_ID = "660e8400-e29b-41d4-a716-446655440001";
 const TOKEN_ID = "op-token-id-1";
@@ -131,12 +144,16 @@ describe("GET /api/maintenance/audit-chain-verify", () => {
     expect(mockCheck).toHaveBeenCalledWith(`rl:maintenance:chain-verify:${TENANT_ID}`);
   });
 
-  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+  it("fails closed (503, no mutation) when Redis is unavailable", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockCheck.mockResolvedValue({ redisErrored: true });
-    const req = createRequest({ tenantId: TENANT_ID }, VALID_OP_TOKEN);
-    const res = await GET(req);
-    expect(res.status).toBe(503);
+    await assertRedisFailClosed({
+      invoke: () => GET(createRequest({ tenantId: TENANT_ID }, VALID_OP_TOKEN)),
+      limiter: chainVerifyLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockQueryRawUnsafe],
+      limiterFactory: chainVerifyLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   // ─── Query Validation ────────────────────────────────────

--- a/src/app/api/maintenance/audit-outbox-metrics/route.test.ts
+++ b/src/app/api/maintenance/audit-outbox-metrics/route.test.ts
@@ -1,23 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
 
 const {
   mockVerifyAdminToken,
   mockQueryRaw,
   mockRequireMaintenanceOperator,
   mockCheck,
+  mockCreateRateLimiter,
   mockLogAudit,
   mockWithBypassRls,
-} = vi.hoisted(() => ({
-  mockVerifyAdminToken: vi.fn(),
-  mockQueryRaw: vi.fn(),
-  mockRequireMaintenanceOperator: vi.fn(),
-  mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
-  mockLogAudit: vi.fn(),
-  mockWithBypassRls: vi.fn(
-    async (prisma: unknown, fn: (tx: unknown) => unknown, _purpose?: unknown) => fn(prisma),
-  ),
-}));
+} = vi.hoisted(() => {
+  const mockCheck = vi.fn().mockResolvedValue({ allowed: true });
+  return {
+    mockVerifyAdminToken: vi.fn(),
+    mockQueryRaw: vi.fn(),
+    mockRequireMaintenanceOperator: vi.fn(),
+    mockCheck,
+    mockCreateRateLimiter: vi.fn(() => ({ check: mockCheck, clear: vi.fn() })),
+    mockLogAudit: vi.fn(),
+    mockWithBypassRls: vi.fn(
+      async (prisma: unknown, fn: (tx: unknown) => unknown, _purpose?: unknown) => fn(prisma),
+    ),
+  };
+});
 
 vi.mock("@/lib/auth/tokens/admin-token", () => ({
   verifyAdminToken: mockVerifyAdminToken,
@@ -28,7 +34,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
@@ -51,6 +57,13 @@ vi.mock("@/lib/auth/access/maintenance-auth", () => ({
 
 import { GET } from "./route";
 import { OPERATOR_TOKEN_PREFIX } from "@/lib/constants/auth/operator-token";
+
+// Module-scope snapshot: route.ts's `rateLimiter = createRateLimiter(...)` runs
+// at import time above, before any beforeEach's vi.clearAllMocks() can wipe it.
+const outboxMetricsLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const outboxMetricsLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockCheck;
+};
 
 const SUBJECT_USER_ID = "660e8400-e29b-41d4-a716-446655440001";
 const TOKEN_ID = "op-token-id-1";
@@ -133,12 +146,16 @@ describe("GET /api/maintenance/audit-outbox-metrics", () => {
     expect(mockCheck).toHaveBeenCalledWith(`rl:maintenance:outbox-metrics:${TENANT_ID}`);
   });
 
-  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+  it("fails closed (503, no mutation) when Redis is unavailable", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockCheck.mockResolvedValue({ redisErrored: true });
-    const req = createRequest(VALID_OP_TOKEN);
-    const res = await GET(req);
-    expect(res.status).toBe(503);
+    await assertRedisFailClosed({
+      invoke: () => GET(createRequest(VALID_OP_TOKEN)),
+      limiter: outboxMetricsLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockQueryRaw],
+      limiterFactory: outboxMetricsLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   // ─── Operator Membership Check ────────────────────────────

--- a/src/app/api/maintenance/audit-outbox-purge-failed/route.test.ts
+++ b/src/app/api/maintenance/audit-outbox-purge-failed/route.test.ts
@@ -1,23 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
 
 const {
   mockVerifyAdminToken,
   mockQueryRaw,
   mockRequireMaintenanceOperator,
   mockCheck,
+  mockCreateRateLimiter,
   mockLogAudit,
   mockWithBypassRls,
-} = vi.hoisted(() => ({
-  mockVerifyAdminToken: vi.fn(),
-  mockQueryRaw: vi.fn(),
-  mockRequireMaintenanceOperator: vi.fn(),
-  mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
-  mockLogAudit: vi.fn(),
-  mockWithBypassRls: vi.fn(
-    async (prisma: unknown, fn: (tx: unknown) => unknown, _purpose?: unknown) => fn(prisma),
-  ),
-}));
+} = vi.hoisted(() => {
+  const mockCheck = vi.fn().mockResolvedValue({ allowed: true });
+  return {
+    mockVerifyAdminToken: vi.fn(),
+    mockQueryRaw: vi.fn(),
+    mockRequireMaintenanceOperator: vi.fn(),
+    mockCheck,
+    mockCreateRateLimiter: vi.fn(() => ({ check: mockCheck, clear: vi.fn() })),
+    mockLogAudit: vi.fn(),
+    mockWithBypassRls: vi.fn(
+      async (prisma: unknown, fn: (tx: unknown) => unknown, _purpose?: unknown) => fn(prisma),
+    ),
+  };
+});
 
 vi.mock("@/lib/auth/tokens/admin-token", () => ({
   verifyAdminToken: mockVerifyAdminToken,
@@ -28,7 +34,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
@@ -51,6 +57,13 @@ vi.mock("@/lib/auth/access/maintenance-auth", () => ({
 
 import { POST } from "./route";
 import { OPERATOR_TOKEN_PREFIX } from "@/lib/constants/auth/operator-token";
+
+// Module-scope snapshot: route.ts's `rateLimiter = createRateLimiter(...)` runs
+// at import time above, before any beforeEach's vi.clearAllMocks() can wipe it.
+const outboxPurgeLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const outboxPurgeLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockCheck;
+};
 
 const SUBJECT_USER_ID = "660e8400-e29b-41d4-a716-446655440001";
 const TOKEN_ID = "op-token-id-1";
@@ -127,12 +140,16 @@ describe("POST /api/maintenance/audit-outbox-purge-failed", () => {
     expect(mockCheck).toHaveBeenCalledWith(`rl:maintenance:outbox-purge:${TENANT_ID}`);
   });
 
-  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+  it("fails closed (503, no mutation) when Redis is unavailable", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockCheck.mockResolvedValue({ redisErrored: true });
-    const req = createRequest({}, VALID_OP_TOKEN);
-    const res = await POST(req);
-    expect(res.status).toBe(503);
+    await assertRedisFailClosed({
+      invoke: () => POST(createRequest({}, VALID_OP_TOKEN)),
+      limiter: outboxPurgeLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockQueryRaw],
+      limiterFactory: outboxPurgeLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   // ─── Operator Membership Check ────────────────────────────

--- a/src/app/api/maintenance/dcr-cleanup/route.test.ts
+++ b/src/app/api/maintenance/dcr-cleanup/route.test.ts
@@ -1,23 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
 
 const {
   mockVerifyAdminToken,
   mockRequireMaintenanceOperator,
   mockCheck,
+  mockCreateRateLimiter,
   mockLogAudit,
-} = vi.hoisted(() => ({
-  mockVerifyAdminToken: vi.fn(),
-  mockRequireMaintenanceOperator: vi.fn(),
-  mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
-  mockLogAudit: vi.fn(),
-}));
+} = vi.hoisted(() => {
+  const mockCheck = vi.fn().mockResolvedValue({ allowed: true });
+  return {
+    mockVerifyAdminToken: vi.fn(),
+    mockRequireMaintenanceOperator: vi.fn(),
+    mockCheck,
+    mockCreateRateLimiter: vi.fn(() => ({ check: mockCheck, clear: vi.fn() })),
+    mockLogAudit: vi.fn(),
+  };
+});
 
 vi.mock("@/lib/auth/tokens/admin-token", () => ({
   verifyAdminToken: mockVerifyAdminToken,
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
@@ -37,6 +43,13 @@ vi.mock("@/lib/auth/access/maintenance-auth", () => ({
 import { POST } from "./route";
 import { AUDIT_ACTION } from "@/lib/constants/audit/audit";
 import { OPERATOR_TOKEN_PREFIX } from "@/lib/constants/auth/operator-token";
+
+// Module-scope snapshot: route.ts's `rateLimiter = createRateLimiter(...)` runs
+// at import time above, before any beforeEach's vi.clearAllMocks() can wipe it.
+const dcrCleanupLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const dcrCleanupLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockCheck;
+};
 
 const SUBJECT_USER_ID = "660e8400-e29b-41d4-a716-446655440001";
 const TOKEN_ID = "op-token-id-1";
@@ -111,12 +124,19 @@ describe("POST /api/maintenance/dcr-cleanup (410 deprecation stub)", () => {
     expect(mockCheck).toHaveBeenCalledWith(`rl:maintenance:dcr-cleanup:${TENANT_ID}`);
   });
 
-  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+  it("fails closed (503, no mutation) when Redis is unavailable", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockCheck.mockResolvedValue({ redisErrored: true });
-    const req = createRequest(VALID_OP_TOKEN);
-    const res = await POST(req);
-    expect(res.status).toBe(503);
+    await assertRedisFailClosed({
+      invoke: () => POST(createRequest(VALID_OP_TOKEN)),
+      limiter: dcrCleanupLimiter,
+      expectation: { envelope: "canonical" },
+      // No DB write exists on this 410 stub route; requireMaintenanceOperator
+      // is the first effect AFTER the limiter, so its non-invocation proves
+      // the 503 short-circuited before any downstream work (including audit).
+      assertNoMutation: [mockRequireMaintenanceOperator],
+      limiterFactory: dcrCleanupLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   it("checks rate limit after auth (401 before 429 for unauthenticated requests)", async () => {

--- a/src/app/api/maintenance/purge-audit-logs/route.test.ts
+++ b/src/app/api/maintenance/purge-audit-logs/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
 
 const {
   mockVerifyAdminToken,
@@ -9,23 +10,28 @@ const {
   mockRequireMaintenanceOperator,
   mockTenantFindUnique,
   mockCheck,
+  mockCreateRateLimiter,
   mockLogAudit,
   mockWithBypassRls,
-} = vi.hoisted(() => ({
-  mockVerifyAdminToken: vi.fn(),
-  mockDeleteMany: vi.fn(),
-  mockCount: vi.fn(),
-  // C13: purge route now calls audit_log_purge() SECURITY DEFINER via
-  // $queryRaw. Stub returns the same shape the function emits.
-  mockQueryRaw: vi.fn(),
-  mockRequireMaintenanceOperator: vi.fn(),
-  mockTenantFindUnique: vi.fn(),
-  mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
-  mockLogAudit: vi.fn(),
-  mockWithBypassRls: vi.fn(
-    async (prisma: unknown, fn: (tx: unknown) => unknown, _purpose?: unknown) => fn(prisma),
-  ),
-}));
+} = vi.hoisted(() => {
+  const mockCheck = vi.fn().mockResolvedValue({ allowed: true });
+  return {
+    mockVerifyAdminToken: vi.fn(),
+    mockDeleteMany: vi.fn(),
+    mockCount: vi.fn(),
+    // C13: purge route now calls audit_log_purge() SECURITY DEFINER via
+    // $queryRaw. Stub returns the same shape the function emits.
+    mockQueryRaw: vi.fn(),
+    mockRequireMaintenanceOperator: vi.fn(),
+    mockTenantFindUnique: vi.fn(),
+    mockCheck,
+    mockCreateRateLimiter: vi.fn(() => ({ check: mockCheck, clear: vi.fn() })),
+    mockLogAudit: vi.fn(),
+    mockWithBypassRls: vi.fn(
+      async (prisma: unknown, fn: (tx: unknown) => unknown, _purpose?: unknown) => fn(prisma),
+    ),
+  };
+});
 
 vi.mock("@/lib/auth/tokens/admin-token", () => ({
   verifyAdminToken: mockVerifyAdminToken,
@@ -38,7 +44,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
@@ -74,6 +80,13 @@ const VALID_AUTH = {
   tenantId: TENANT_ID,
   tokenId: TOKEN_ID,
   scopes: ["maintenance"] as const,
+};
+
+// Module-scope snapshot: route.ts's `rateLimiter = createRateLimiter(...)` runs
+// at import time above, before any beforeEach's vi.clearAllMocks() can wipe it.
+const purgeAuditLogsLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const purgeAuditLogsLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockCheck;
 };
 
 function createRequest(body: unknown, token?: string): NextRequest {
@@ -143,12 +156,18 @@ describe("POST /api/maintenance/purge-audit-logs", () => {
     expect(mockCheck).toHaveBeenCalledWith(`rl:maintenance:purge-audit-logs:${TENANT_ID}`);
   });
 
-  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+  it("fails closed (503, no mutation) when Redis is unavailable", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockCheck.mockResolvedValue({ redisErrored: true });
-    const req = createRequest({}, VALID_OP_TOKEN);
-    const res = await POST(req);
-    expect(res.status).toBe(503);
+    await assertRedisFailClosed({
+      invoke: () => POST(createRequest({}, VALID_OP_TOKEN)),
+      limiter: purgeAuditLogsLimiter,
+      expectation: { envelope: "canonical" },
+      // C13: the real purge executes via $queryRaw(audit_log_purge); deleteMany
+      // is legacy/unused on this path — assert on the primitive that actually runs.
+      assertNoMutation: [mockQueryRaw],
+      limiterFactory: purgeAuditLogsLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   it("checks rate limit after auth (401 before 429 for unauthenticated requests)", async () => {

--- a/src/app/api/maintenance/purge-history/route.test.ts
+++ b/src/app/api/maintenance/purge-history/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
 
 const {
   mockVerifyAdminToken,
@@ -8,20 +9,25 @@ const {
   mockTenantFindUnique,
   mockRequireMaintenanceOperator,
   mockCheck,
+  mockCreateRateLimiter,
   mockLogAudit,
   mockWithBypassRls,
-} = vi.hoisted(() => ({
-  mockVerifyAdminToken: vi.fn(),
-  mockDeleteMany: vi.fn(),
-  mockCount: vi.fn(),
-  mockTenantFindUnique: vi.fn(),
-  mockRequireMaintenanceOperator: vi.fn(),
-  mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
-  mockLogAudit: vi.fn(),
-  mockWithBypassRls: vi.fn(
-    async (prisma: unknown, fn: (tx: unknown) => unknown, _purpose?: unknown) => fn(prisma),
-  ),
-}));
+} = vi.hoisted(() => {
+  const mockCheck = vi.fn().mockResolvedValue({ allowed: true });
+  return {
+    mockVerifyAdminToken: vi.fn(),
+    mockDeleteMany: vi.fn(),
+    mockCount: vi.fn(),
+    mockTenantFindUnique: vi.fn(),
+    mockRequireMaintenanceOperator: vi.fn(),
+    mockCheck,
+    mockCreateRateLimiter: vi.fn(() => ({ check: mockCheck, clear: vi.fn() })),
+    mockLogAudit: vi.fn(),
+    mockWithBypassRls: vi.fn(
+      async (prisma: unknown, fn: (tx: unknown) => unknown, _purpose?: unknown) => fn(prisma),
+    ),
+  };
+});
 
 vi.mock("@/lib/auth/tokens/admin-token", () => ({
   verifyAdminToken: mockVerifyAdminToken,
@@ -33,7 +39,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: () => ({ check: mockCheck, clear: vi.fn() }),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
@@ -69,6 +75,13 @@ const VALID_AUTH = {
   tenantId: TENANT_ID,
   tokenId: TOKEN_ID,
   scopes: ["maintenance"] as const,
+};
+
+// Module-scope snapshot: route.ts's `rateLimiter = createRateLimiter(...)` runs
+// at import time above, before any beforeEach's vi.clearAllMocks() can wipe it.
+const purgeHistoryLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const purgeHistoryLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockCheck;
 };
 
 function createRequest(body: unknown, token?: string): NextRequest {
@@ -126,13 +139,16 @@ describe("POST /api/maintenance/purge-history", () => {
     expect(res.status).toBe(429);
   });
 
-  it("returns 503 when the rate limiter fails closed on a Redis error", async () => {
+  it("fails closed (503, no mutation) when Redis is unavailable", async () => {
     mockVerifyAdminToken.mockResolvedValue({ ok: true, auth: VALID_AUTH });
-    mockCheck.mockResolvedValue({ redisErrored: true });
-    const req = createRequest({}, VALID_OP_TOKEN);
-    const res = await POST(req);
-    expect(res.status).toBe(503);
-    expect(mockDeleteMany).not.toHaveBeenCalled();
+    await assertRedisFailClosed({
+      invoke: () => POST(createRequest({}, VALID_OP_TOKEN)),
+      limiter: purgeHistoryLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockDeleteMany],
+      limiterFactory: purgeHistoryLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   it("keys the rate limiter on the operator-token's tenantId (tenant-scoped, exact key)", async () => {

--- a/src/app/api/tenant/breakglass/route.test.ts
+++ b/src/app/api/tenant/breakglass/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest, parseResponse } from "@/__tests__/helpers/request-builder";
 import { DEFAULT_SESSION } from "@/__tests__/helpers/mock-auth";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
 
 const {
   mockAuth,
@@ -8,6 +9,7 @@ const {
   mockWithTenantRls,
   mockLogAudit,
   mockRateLimiterCheck,
+  mockCreateRateLimiter,
   mockGrantFindMany,
   mockGrantFindFirst,
   mockGrantCreate,
@@ -25,12 +27,14 @@ const {
       this.status = status;
     }
   }
+  const mockRateLimiterCheck = vi.fn();
   return {
     mockAuth: vi.fn(),
     mockRequireTenantPermission: vi.fn(),
     mockWithTenantRls: vi.fn(async (p: unknown, _t: unknown, fn: (tx: unknown) => unknown) => fn(p)),
     mockLogAudit: vi.fn(),
-    mockRateLimiterCheck: vi.fn(),
+    mockRateLimiterCheck,
+    mockCreateRateLimiter: vi.fn(() => ({ check: mockRateLimiterCheck, clear: vi.fn() })),
     mockGrantFindMany: vi.fn(),
     mockGrantFindFirst: vi.fn(),
     mockGrantCreate: vi.fn(),
@@ -77,7 +81,7 @@ vi.mock("@/lib/http/with-request-log", () => ({
   withRequestLog: (handler: (...args: unknown[]) => unknown) => handler,
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: vi.fn(() => ({ check: mockRateLimiterCheck })),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/notification", () => ({
   createNotification: mockCreateNotification,
@@ -91,6 +95,13 @@ vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
 
 import { GET, POST } from "./route";
 import { MS_PER_DAY } from "@/lib/constants/time";
+
+// Module-scope snapshot: route.ts's `rateLimiter = createRateLimiter(...)` runs
+// at import time above, before any beforeEach's vi.clearAllMocks() can wipe it.
+const breakglassLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const breakglassLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockRateLimiterCheck;
+};
 
 const TENANT_ID = "tenant-1";
 const ACTOR_USER_ID = "test-user-id";
@@ -394,18 +405,21 @@ describe("POST /api/tenant/breakglass", () => {
     expect(json.error).toBe("RATE_LIMIT_EXCEEDED");
   });
 
-  it("fails closed with 503 when the limiter reports redisErrored (no grant created)", async () => {
-    mockRateLimiterCheck.mockResolvedValue({ allowed: false, redisErrored: true });
-    const res = await POST(
-      createRequest("POST", "http://localhost/api/tenant/breakglass", {
-        body: validBody,
-        headers: { origin: "http://localhost" },
-      }),
-    );
-    const { status, json } = await parseResponse(res);
-    expect(status).toBe(503);
-    expect(json.error).toBe("SERVICE_UNAVAILABLE");
-    expect(mockGrantCreate).not.toHaveBeenCalled();
+  it("fails closed (503, no mutation) when Redis is unavailable", async () => {
+    await assertRedisFailClosed({
+      invoke: () =>
+        POST(
+          createRequest("POST", "http://localhost/api/tenant/breakglass", {
+            body: validBody,
+            headers: { origin: "http://localhost" },
+          }),
+        ),
+      limiter: breakglassLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockGrantCreate],
+      limiterFactory: breakglassLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   it("returns 403 when target user is not a tenant member", async () => {

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
@@ -36,6 +36,11 @@ const {
       this.status = status;
     }
   }
+  // Declared before the return object so mockCreateRateLimiter's callbacks can
+  // reference them without a self-referential-object TS7022 (mirrors the
+  // approve-route sibling test).
+  const mockAdminLimiterCheck = vi.fn();
+  const mockTargetLimiterCheck = vi.fn();
   return {
     mockAuth: vi.fn(),
     mockPrismaTenantMemberFindFirst: vi.fn(),
@@ -49,8 +54,8 @@ const {
     // in creation order so assertRedisFailClosed's strict-identity attribution
     // resolves each. Testing one limiter twice would not satisfy the gate's
     // HELPER_CALLS_BELOW_LIMITER_COUNT distinct-arg rule (declared count 2).
-    mockAdminLimiterCheck: vi.fn(),
-    mockTargetLimiterCheck: vi.fn(),
+    mockAdminLimiterCheck,
+    mockTargetLimiterCheck,
     mockCreateRateLimiter: vi
       .fn()
       .mockImplementationOnce((_opts: unknown) => ({ check: mockAdminLimiterCheck, clear: vi.fn() }))

--- a/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
+++ b/src/app/api/tenant/members/[userId]/reset-vault/route.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest, createParams } from "@/__tests__/helpers/request-builder";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
+import { __resetThrottleForTests } from "@/lib/security/rate-limit-audit";
 
 const {
   mockAuth,
@@ -8,7 +10,9 @@ const {
   mockPrismaAdminVaultResetCount,
   mockPrismaAdminVaultResetCreate,
   mockPrismaAdminVaultResetFindMany,
-  mockRateLimiterCheck,
+  mockAdminLimiterCheck,
+  mockTargetLimiterCheck,
+  mockCreateRateLimiter,
   mockLogAudit,
   mockCreateNotification,
   mockSendEmail,
@@ -39,7 +43,18 @@ const {
     mockPrismaAdminVaultResetCount: vi.fn(),
     mockPrismaAdminVaultResetCreate: vi.fn(),
     mockPrismaAdminVaultResetFindMany: vi.fn(),
-    mockRateLimiterCheck: vi.fn(),
+    // Two distinct limiters checked in one request via Promise.all
+    // (route.ts:123-124: adminResetLimiter THEN targetResetLimiter). The
+    // recording factory returns a distinct object per createRateLimiter call
+    // in creation order so assertRedisFailClosed's strict-identity attribution
+    // resolves each. Testing one limiter twice would not satisfy the gate's
+    // HELPER_CALLS_BELOW_LIMITER_COUNT distinct-arg rule (declared count 2).
+    mockAdminLimiterCheck: vi.fn(),
+    mockTargetLimiterCheck: vi.fn(),
+    mockCreateRateLimiter: vi
+      .fn()
+      .mockImplementationOnce((_opts: unknown) => ({ check: mockAdminLimiterCheck, clear: vi.fn() }))
+      .mockImplementationOnce((_opts: unknown) => ({ check: mockTargetLimiterCheck, clear: vi.fn() })),
     mockLogAudit: vi.fn(),
     mockCreateNotification: vi.fn(),
     mockSendEmail: vi.fn(),
@@ -85,13 +100,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: vi.fn(() => ({ check: mockRateLimiterCheck })),
-}));
-// The route emits the fail-closed audit directly; stub it to a no-op so the
-// 503 path does not pull the emit helper's transitive deps.
-vi.mock("@/lib/security/rate-limit-audit", async (importOriginal) => ({
-  ...(await importOriginal()) as Record<string, unknown>,
-  emitRateLimitFailClosed: vi.fn(),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
@@ -135,6 +144,18 @@ vi.mock("@/lib/logger", () => ({
 import { POST, GET } from "./route";
 import { MS_PER_DAY } from "@/lib/constants/time";
 
+// Module-scope snapshot: route.ts:40 `adminResetLimiter = createRateLimiter(...)`
+// then :46 `targetResetLimiter = createRateLimiter(...)` run at import time above,
+// in that order — matching mockCreateRateLimiter's two queued implementations.
+const adminLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const adminResetLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockAdminLimiterCheck;
+};
+const targetLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const targetResetLimiter = mockCreateRateLimiter.mock.results[1]!.value as {
+  check: typeof mockTargetLimiterCheck;
+};
+
 const TENANT_ID = "tenant-1";
 const TARGET_USER_ID = "user-target";
 const ACTOR_USER_ID = "test-user-id";
@@ -172,6 +193,10 @@ function expectAdvisoryLockAcquired(mock: ReturnType<typeof vi.fn>) {
 describe("POST /api/tenant/members/[userId]/reset-vault", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Real emitRateLimitFailClosed now runs on the 503 path (rate-limit-audit
+    // stub removed); reset its module-scoped throttle so a prior test's
+    // emission does not swallow this test's (5-min window, per-scope key).
+    __resetThrottleForTests();
     mockAuth.mockResolvedValue({ user: { id: ACTOR_USER_ID, name: "Admin User", email: "admin@example.com" } });
     mockRequireTenantPermission.mockResolvedValue(ACTOR);
     mockIsTenantRoleAbove.mockReturnValue(true);
@@ -195,7 +220,8 @@ describe("POST /api/tenant/members/[userId]/reset-vault", () => {
     mockPrismaAdminVaultResetCreate.mockImplementation(({ data }) =>
       Promise.resolve({ id: data.id ?? "reset-1" }),
     );
-    mockRateLimiterCheck.mockResolvedValue({ allowed: true });
+    mockAdminLimiterCheck.mockResolvedValue({ allowed: true });
+    mockTargetLimiterCheck.mockResolvedValue({ allowed: true });
     mockResolveUserLocale.mockReturnValue("en");
     mockEncryptResetToken.mockReturnValue("psoenc1:0:cipher");
     mockAdminVaultResetPendingEmail.mockReturnValue({
@@ -279,10 +305,8 @@ describe("POST /api/tenant/members/[userId]/reset-vault", () => {
   });
 
   it("returns 429 when admin rate limit is exceeded", async () => {
-    // First call (admin limiter) returns false, second (target limiter) returns true
-    mockRateLimiterCheck
-      .mockResolvedValueOnce({ allowed: false })
-      .mockResolvedValueOnce({ allowed: true });
+    mockAdminLimiterCheck.mockResolvedValue({ allowed: false });
+    mockTargetLimiterCheck.mockResolvedValue({ allowed: true });
     const res = await POST(
       createRequest("POST", `http://localhost/api/tenant/members/${TARGET_USER_ID}/reset-vault`),
       createParams({ userId: TARGET_USER_ID }),
@@ -293,35 +317,43 @@ describe("POST /api/tenant/members/[userId]/reset-vault", () => {
     expect(mockPrismaAdminVaultResetCreate).not.toHaveBeenCalled();
   });
 
-  it("returns 503 (fail-closed) when the admin limiter signals redisErrored", async () => {
-    mockRateLimiterCheck
-      .mockResolvedValueOnce({ allowed: false, redisErrored: true })
-      .mockResolvedValueOnce({ allowed: true });
-    const res = await POST(
-      createRequest("POST", `http://localhost/api/tenant/members/${TARGET_USER_ID}/reset-vault`),
-      createParams({ userId: TARGET_USER_ID }),
-    );
-    expect(res.status).toBe(503);
-    expect(mockPrismaAdminVaultResetCreate).not.toHaveBeenCalled();
+  it("fails closed (503, no mutation) when Redis is unavailable — admin limiter", async () => {
+    await assertRedisFailClosed({
+      invoke: () =>
+        POST(
+          createRequest("POST", `http://localhost/api/tenant/members/${TARGET_USER_ID}/reset-vault`),
+          createParams({ userId: TARGET_USER_ID }),
+        ),
+      limiter: adminResetLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockPrismaAdminVaultResetCreate, mockCreateNotification],
+      limiterFactory: adminLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
-  it("returns 503 (fail-closed) when the target limiter signals redisErrored", async () => {
-    mockRateLimiterCheck
-      .mockResolvedValueOnce({ allowed: true })
-      .mockResolvedValueOnce({ allowed: false, redisErrored: true });
-    const res = await POST(
-      createRequest("POST", `http://localhost/api/tenant/members/${TARGET_USER_ID}/reset-vault`),
-      createParams({ userId: TARGET_USER_ID }),
-    );
-    expect(res.status).toBe(503);
-    expect(mockPrismaAdminVaultResetCreate).not.toHaveBeenCalled();
+  it("fails closed (503, no mutation) when Redis is unavailable — target limiter", async () => {
+    // Helper arranges only the target limiter; keep the sibling (admin) healthy
+    // so this case isolates the target-limiter redisErrored branch (both
+    // .check() run concurrently via Promise.all).
+    mockAdminLimiterCheck.mockResolvedValue({ allowed: true });
+    await assertRedisFailClosed({
+      invoke: () =>
+        POST(
+          createRequest("POST", `http://localhost/api/tenant/members/${TARGET_USER_ID}/reset-vault`),
+          createParams({ userId: TARGET_USER_ID }),
+        ),
+      limiter: targetResetLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockPrismaAdminVaultResetCreate, mockCreateNotification],
+      limiterFactory: targetLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   it("returns 429 when target rate limit is exceeded", async () => {
-    // First call (admin limiter) returns true, second (target limiter) returns false
-    mockRateLimiterCheck
-      .mockResolvedValueOnce({ allowed: true })
-      .mockResolvedValueOnce({ allowed: false });
+    mockAdminLimiterCheck.mockResolvedValue({ allowed: true });
+    mockTargetLimiterCheck.mockResolvedValue({ allowed: false });
     const res = await POST(
       createRequest("POST", `http://localhost/api/tenant/members/${TARGET_USER_ID}/reset-vault`),
       createParams({ userId: TARGET_USER_ID }),

--- a/src/app/api/tenant/operator-tokens/route.test.ts
+++ b/src/app/api/tenant/operator-tokens/route.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRequest } from "@/__tests__/helpers/request-builder";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
+import { __resetThrottleForTests } from "@/lib/security/rate-limit-audit";
 
 const {
   mockAuth,
@@ -10,6 +12,7 @@ const {
   mockLogAudit,
   mockHashToken,
   mockRateLimitCheck,
+  mockCreateRateLimiter,
   mockRequireRecentCurrentAuthMethod,
   TenantAuthError,
 } = vi.hoisted(() => {
@@ -34,6 +37,10 @@ const {
     mockLogAudit: vi.fn(),
     mockHashToken: vi.fn((t: string) => `hashed:${t}`),
     mockRateLimitCheck: vi.fn().mockResolvedValue({ allowed: true }),
+    mockCreateRateLimiter: vi.fn(() => ({
+      check: mockRateLimitCheck,
+      clear: vi.fn(),
+    })),
     mockRequireRecentCurrentAuthMethod: vi.fn(),
     TenantAuthError: _TenantAuthError,
   };
@@ -66,22 +73,21 @@ vi.mock("@/lib/crypto/crypto-server", () => ({
   hashToken: mockHashToken,
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: vi.fn(() => ({
-    check: mockRateLimitCheck,
-    clear: vi.fn(),
-  })),
-}));
-// Keep the real checkRateLimitOrFail (so it maps redisErrored → 503) but
-// stub the audit emit to a no-op to avoid pulling its transitive deps.
-vi.mock("@/lib/security/rate-limit-audit", async (importOriginal) => ({
-  ...(await importOriginal()) as Record<string, unknown>,
-  emitRateLimitFailClosed: vi.fn(),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
   requireRecentCurrentAuthMethod: mockRequireRecentCurrentAuthMethod,
 }));
 
 import { GET, POST } from "./route";
+
+// Module-scope snapshot: route.ts's module-level `createRateLimiter(...)`
+// call runs at import time above. Must be captured before any
+// vi.clearAllMocks() in beforeEach wipes mock.calls/mock.results.
+const createLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const createLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockRateLimitCheck;
+};
 
 // Asserts the per-tenant advisory lock ($executeRaw with pg_advisory_xact_lock)
 // was acquired. Mutation-kill: deleting the lock line from the production
@@ -164,6 +170,10 @@ describe("GET /api/tenant/operator-tokens", () => {
 describe("POST /api/tenant/operator-tokens", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Real emitRateLimitFailClosed now runs on the 503 path (rate-limit-audit
+    // stub removed); reset its module-scoped throttle so a prior test's
+    // emission does not swallow this test's (5-min window, per-scope key).
+    __resetThrottleForTests();
     mockAuth.mockResolvedValue({ user: { id: USER_ID } });
     mockRequireTenantPermission.mockResolvedValue(ACTOR);
     mockRateLimitCheck.mockResolvedValue({ allowed: true });
@@ -279,16 +289,20 @@ describe("POST /api/tenant/operator-tokens", () => {
     expect(mockPrismaOperatorToken.create).not.toHaveBeenCalled();
   });
 
-  it("returns 503 (fail-closed) when the create limiter signals redisErrored", async () => {
-    mockRateLimitCheck.mockResolvedValueOnce({ allowed: false, redisErrored: true });
-
-    const res = await POST(
-      createRequest("POST", "http://localhost/api/tenant/operator-tokens", {
-        body: { name: "Test token" },
-      }),
-    );
-    expect(res.status).toBe(503);
-    expect(mockPrismaOperatorToken.create).not.toHaveBeenCalled();
+  it("fails closed (503, no mutation) when Redis is unavailable", async () => {
+    await assertRedisFailClosed({
+      invoke: () =>
+        POST(
+          createRequest("POST", "http://localhost/api/tenant/operator-tokens", {
+            body: { name: "Test token" },
+          }),
+        ),
+      limiter: createLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockPrismaOperatorToken.create],
+      limiterFactory: createLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   it("creates token and returns plaintext with 201 and Cache-Control: no-store", async () => {

--- a/src/app/api/tenant/scim-tokens/route.test.ts
+++ b/src/app/api/tenant/scim-tokens/route.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 import { createRequest } from "@/__tests__/helpers/request-builder";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
+import { __resetThrottleForTests } from "@/lib/security/rate-limit-audit";
 
 const {
   mockAuth,
@@ -12,6 +14,7 @@ const {
   mockHashToken,
   mockGenerateScimToken,
   mockRateLimitCheck,
+  mockCreateRateLimiter,
   mockRequireRecentSession,
   TenantAuthError,
 } = vi.hoisted(() => {
@@ -37,6 +40,10 @@ const {
     mockHashToken: vi.fn((t: string) => `hashed:${t}`),
     mockGenerateScimToken: vi.fn(() => "scim_test_plaintext_token"),
     mockRateLimitCheck: vi.fn().mockResolvedValue({ allowed: true }),
+    mockCreateRateLimiter: vi.fn(() => ({
+      check: mockRateLimitCheck,
+      clear: vi.fn(),
+    })),
     mockRequireRecentSession: vi.fn().mockResolvedValue(null),
     TenantAuthError: _TenantAuthError,
   };
@@ -71,22 +78,21 @@ vi.mock("@/lib/scim/token-utils", () => ({
   generateScimToken: mockGenerateScimToken,
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: vi.fn(() => ({
-    check: mockRateLimitCheck,
-    clear: vi.fn(),
-  })),
-}));
-// Keep the real checkRateLimitOrFail (so it maps redisErrored → 503) but
-// stub the audit emit to a no-op to avoid pulling its transitive deps.
-vi.mock("@/lib/security/rate-limit-audit", async (importOriginal) => ({
-  ...(await importOriginal()) as Record<string, unknown>,
-  emitRateLimitFailClosed: vi.fn(),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/auth/session/recent-current-auth-method", () => ({
   requireRecentCurrentAuthMethod: mockRequireRecentSession,
 }));
 
 import { GET, POST } from "./route";
+
+// Module-scope snapshot: route.ts's module-level `createRateLimiter(...)`
+// call runs at import time above. Must be captured before any
+// vi.clearAllMocks() in beforeEach wipes mock.calls/mock.results.
+const createLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const createLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockRateLimitCheck;
+};
 
 const TENANT_ID = "tenant-1";
 const ACTOR = { id: "membership-1", tenantId: TENANT_ID, userId: "user-1", role: "OWNER" };
@@ -148,6 +154,10 @@ describe("GET /api/tenant/scim-tokens", () => {
 describe("POST /api/tenant/scim-tokens", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Real emitRateLimitFailClosed now runs on the 503 path (rate-limit-audit
+    // stub removed); reset its module-scoped throttle so a prior test's
+    // emission does not swallow this test's (5-min window, per-scope key).
+    __resetThrottleForTests();
     mockAuth.mockResolvedValue({ user: { id: "user-1" } });
     mockRequireTenantPermission.mockResolvedValue(ACTOR);
     mockPrismaScimToken.count.mockResolvedValue(0);
@@ -301,15 +311,20 @@ describe("POST /api/tenant/scim-tokens", () => {
     expect(mockPrismaScimToken.create).not.toHaveBeenCalled();
   });
 
-  it("returns 503 (fail-closed) when the rate limiter signals redisErrored", async () => {
-    mockRateLimitCheck.mockResolvedValueOnce({ allowed: false, redisErrored: true });
-    const res = await POST(
-      createRequest("POST", "http://localhost/api/tenant/scim-tokens", {
-        body: { description: "test" },
-      }),
-    );
-    expect(res.status).toBe(503);
-    expect(mockPrismaScimToken.create).not.toHaveBeenCalled();
+  it("fails closed (503, no mutation) when Redis is unavailable", async () => {
+    await assertRedisFailClosed({
+      invoke: () =>
+        POST(
+          createRequest("POST", "http://localhost/api/tenant/scim-tokens", {
+            body: { description: "test" },
+          }),
+        ),
+      limiter: createLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockPrismaScimToken.create],
+      limiterFactory: createLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   it("rethrows unexpected errors from POST", async () => {

--- a/src/app/api/tenant/service-accounts/route.test.ts
+++ b/src/app/api/tenant/service-accounts/route.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DEFAULT_SESSION } from "../../../../__tests__/helpers/mock-auth";
 import { createRequest, parseResponse } from "../../../../__tests__/helpers/request-builder";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
+import { __resetThrottleForTests } from "@/lib/security/rate-limit-audit";
 
 const {
   mockAuth,
@@ -8,23 +10,28 @@ const {
   mockWithTenantRls,
   mockLogAudit,
   mockRateLimiterCheck,
+  mockCreateRateLimiter,
   mockServiceAccountFindMany,
   mockServiceAccountCount,
   mockServiceAccountCreate,
   mockExecuteRaw,
   mockDispatchTenantWebhook,
-} = vi.hoisted(() => ({
-  mockAuth: vi.fn(),
-  mockRequireTenantPermission: vi.fn(),
-  mockWithTenantRls: vi.fn(async (prisma: unknown, _tenantId: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
-  mockLogAudit: vi.fn(),
-  mockRateLimiterCheck: vi.fn().mockResolvedValue({ allowed: true }),
-  mockServiceAccountFindMany: vi.fn(),
-  mockServiceAccountCount: vi.fn(),
-  mockServiceAccountCreate: vi.fn(),
-  mockExecuteRaw: vi.fn().mockResolvedValue(1),
-  mockDispatchTenantWebhook: vi.fn(),
-}));
+} = vi.hoisted(() => {
+  const mockRateLimiterCheck = vi.fn().mockResolvedValue({ allowed: true });
+  return {
+    mockAuth: vi.fn(),
+    mockRequireTenantPermission: vi.fn(),
+    mockWithTenantRls: vi.fn(async (prisma: unknown, _tenantId: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
+    mockLogAudit: vi.fn(),
+    mockRateLimiterCheck,
+    mockCreateRateLimiter: vi.fn(() => ({ check: mockRateLimiterCheck, clear: vi.fn() })),
+    mockServiceAccountFindMany: vi.fn(),
+    mockServiceAccountCount: vi.fn(),
+    mockServiceAccountCreate: vi.fn(),
+    mockExecuteRaw: vi.fn().mockResolvedValue(1),
+    mockDispatchTenantWebhook: vi.fn(),
+  };
+});
 
 vi.mock("@/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/auth/access/tenant-auth", () => {
@@ -63,13 +70,7 @@ vi.mock("@/lib/audit/audit", () => ({
   tenantAuditBase: vi.fn((_, userId, tenantId) => ({ scope: "TENANT", userId, tenantId })),
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: () => ({ check: mockRateLimiterCheck }),
-}));
-// Keep the real checkRateLimitOrFail (so it maps redisErrored → 503) but
-// stub the audit emit to a no-op to avoid pulling its transitive deps.
-vi.mock("@/lib/security/rate-limit-audit", async (importOriginal) => ({
-  ...(await importOriginal()) as Record<string, unknown>,
-  emitRateLimitFailClosed: vi.fn(),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/http/with-request-log", () => ({
   withRequestLog: (handler: (...args: unknown[]) => unknown) => handler,
@@ -81,6 +82,14 @@ vi.mock("@/lib/webhook-dispatcher", () => ({
 import { GET, POST } from "@/app/api/tenant/service-accounts/route";
 import { TenantAuthError } from "@/lib/auth/access/tenant-auth";
 import { MAX_SERVICE_ACCOUNTS_PER_TENANT } from "@/lib/constants/auth/service-account";
+
+// Module-scope snapshot: route.ts's module-level `createRateLimiter(...)`
+// call runs at import time above. Must be captured before any
+// vi.clearAllMocks() in beforeEach wipes mock.calls/mock.results.
+const createLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const createLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockRateLimiterCheck;
+};
 
 const ACTOR = { tenantId: "tenant-1", role: "ADMIN" };
 
@@ -149,7 +158,13 @@ describe("GET /api/tenant/service-accounts", () => {
 });
 
 describe("POST /api/tenant/service-accounts", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Real emitRateLimitFailClosed now runs on the 503 path (rate-limit-audit
+    // stub removed); reset its module-scoped throttle so a prior test's
+    // emission does not swallow this test's (5-min window, per-scope key).
+    __resetThrottleForTests();
+  });
 
   it("creates a service account successfully", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
@@ -254,18 +269,21 @@ describe("POST /api/tenant/service-accounts", () => {
     expect(mockServiceAccountCreate).not.toHaveBeenCalled();
   });
 
-  it("returns 503 (fail-closed) when the create limiter signals redisErrored", async () => {
+  it("fails closed (503, no mutation) when Redis is unavailable", async () => {
     mockAuth.mockResolvedValue(DEFAULT_SESSION);
     mockRequireTenantPermission.mockResolvedValue(ACTOR);
-    mockRateLimiterCheck.mockResolvedValueOnce({ allowed: false, redisErrored: true });
-
-    const req = createRequest("POST", "http://localhost/api/tenant/service-accounts", {
-      body: { name: "ci-bot" },
+    await assertRedisFailClosed({
+      invoke: () =>
+        POST(
+          createRequest("POST", "http://localhost/api/tenant/service-accounts", {
+            body: { name: "ci-bot" },
+          }),
+        ),
+      limiter: createLimiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockServiceAccountCreate],
+      limiterFactory: createLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
     });
-    const res = await POST(req);
-    const { status } = await parseResponse(res);
-
-    expect(status).toBe(503);
-    expect(mockServiceAccountCreate).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/vault/ssh/sign-authorize/route.test.ts
+++ b/src/app/api/vault/ssh/sign-authorize/route.test.ts
@@ -1,22 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
 
 const {
   mockAuthOrToken,
   mockPrismaPasswordEntry,
   mockWithBypassRls,
   mockRateLimiterCheck,
+  mockCreateRateLimiter,
   mockLogAudit,
   mockEnforceAccessRestriction,
-} = vi.hoisted(() => ({
-  mockAuthOrToken: vi.fn(),
-  mockPrismaPasswordEntry: {
-    findFirst: vi.fn(),
-  },
-  mockWithBypassRls: vi.fn(async (prisma: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
-  mockRateLimiterCheck: vi.fn(),
-  mockLogAudit: vi.fn(),
-  mockEnforceAccessRestriction: vi.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue(null),
-}));
+} = vi.hoisted(() => {
+  const mockRateLimiterCheck = vi.fn();
+  return {
+    mockAuthOrToken: vi.fn(),
+    mockPrismaPasswordEntry: {
+      findFirst: vi.fn(),
+    },
+    mockWithBypassRls: vi.fn(async (prisma: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
+    mockRateLimiterCheck,
+    mockCreateRateLimiter: vi.fn(() => ({ check: mockRateLimiterCheck, clear: vi.fn() })),
+    mockLogAudit: vi.fn(),
+    mockEnforceAccessRestriction: vi.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue(null),
+  };
+});
 
 vi.mock("@/lib/auth/session/auth-or-token", () => ({
   authOrToken: mockAuthOrToken,
@@ -32,7 +38,7 @@ vi.mock("@/lib/tenant-rls", async (importOriginal) => ({ ...(await importOrigina
   withBypassRls: mockWithBypassRls,
 }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: () => ({ check: mockRateLimiterCheck }),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/audit/audit", () => ({
   logAuditAsync: mockLogAudit,
@@ -57,6 +63,14 @@ vi.mock("@/lib/logger", () => ({
 
 import { POST } from "./route";
 import { NextRequest } from "next/server";
+
+// Module-scope snapshot: route.ts's `signRateLimiter = createRateLimiter(...)`
+// runs at import time above, before any beforeEach's vi.clearAllMocks() can
+// wipe it.
+const signRateLimiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const signRateLimiter = mockCreateRateLimiter.mock.results[0]!.value as {
+  check: typeof mockRateLimiterCheck;
+};
 
 const VALID_KEY_ID = "entry-abc-123";
 const VALID_FINGERPRINT = "SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEF";
@@ -138,13 +152,20 @@ describe("POST /api/vault/ssh/sign-authorize", () => {
     expect(res.headers.get("Retry-After")).toBe("30");
   });
 
-  it("returns 503 when Redis is unavailable (fail-closed)", async () => {
-    mockRateLimiterCheck.mockResolvedValue({ redisErrored: true });
-    const res = await POST(makeRequest({ keyId: VALID_KEY_ID, fingerprint: VALID_FINGERPRINT }));
-    expect(res.status).toBe(503);
-    const json = await res.json();
-    expect(json.authorized).toBe(false);
-    expect(json.reason).toBe("service_unavailable");
+  it("fails closed (503, no mutation) when Redis is unavailable", async () => {
+    await assertRedisFailClosed({
+      invoke: () => POST(makeRequest({ keyId: VALID_KEY_ID, fingerprint: VALID_FINGERPRINT })),
+      limiter: signRateLimiter,
+      expectation: {
+        envelope: "custom",
+        status: 503,
+        body: { authorized: false, reason: "service_unavailable" },
+        retryAfter: "required",
+      },
+      assertNoMutation: [mockPrismaPasswordEntry.findFirst],
+      limiterFactory: signRateLimiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   // ── Body validation ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Burns the fail-closed **legacy-direct manifest down to zero**: all 13 routes now carry an `assertRedisFailClosed` contract test (strongest tier — recorded factory attribution, envelope + Retry-After, non-empty `assertNoMutation`). The C6 `FROZEN_STUB_EXEMPTIONS` list is emptied (zero `rate-limit-audit` stubs under `src` now required) and `EXPECTED_LEGACY_COUNT` drops 13→0. **The whole fail-closed class is now machine-verified at the helper tier.** Test-code + gate-control-file only — no production `route.ts` changes.

## Motivation
Continues the fail-closed hardening initiative (tranche 1, tranche 2), satisfying scope contract `SC-T3-1`. Legacy-tier tests asserted the 503 behavior directly and 4 of them partial-stubbed the production `checkRateLimitOrFail` mapping — a weaker guarantee that could pass on a mis-wired limiter. Routing every route through the shared helper guarantees deterministic Redis-failure handling and audit emission across privileged/destructive endpoints (admin maintenance ops, breakglass, tenant token/SA creation, admin vault reset, SSH sign-authorize, auth callback/magic-link).

## Implementation notes
- **Multi-limiter routes** (`auth/[...nextauth]`, `reset-vault`) split their shared `check` mock into distinct recorded limiters (classifier `distinct=2`), mirroring the in-repo `approve/route.test.ts` shape.
- **auth dynamic-import** (D2): its `await import()` + `resetModules()` topology defeats module-scope `snapshotFactory`; a dedicated describe block imports once and captures `mock.results[0]/[1]`.
- **`vi.hoisted` self-reference fix** (D4): declaring the dual-limiter check mocks as `const` before the return object avoids a `tsc`-only TS7022 regression (vitest passes, `next build` would fail).
- **ssh/sign-authorize** (D1): uses the custom envelope tier (`{authorized:false, reason:"service_unavailable"}`, not canonical).
- **M9**: `logAuditAsync` excluded from every post-auth `assertNoMutation` — the 503 path fires it via the now-real `emitRateLimitFailClosed`.

## Verification (all run locally, green)
- Full `vitest run`: 12,769 tests pass; `tsc --noEmit`: 0 errors; **pre-pr 51/51** (incl. `next build` + Extension build)
- Real gate exit 0 (`EXPECTED_LEGACY_COUNT=0`); classifier self-test 53; gate self-test 56; meta-gate 0
- `git grep vi.mock rate-limit-audit -- src` empty; all 13 routes `mock=0, calls>=1`; 2 multi-limiter `distinct=2`
- 3-expert triangulate review (Phase 3): **No findings**, with live RT7 mutation-proofs confirming distinct-limiter attribution discriminates and `logAuditAsync` fires on the 503 path

## Review artifacts
- [plan](docs/archive/review/fail-closed-tranche3-plan.md) / [review](docs/archive/review/fail-closed-tranche3-review.md) / [deviation](docs/archive/review/fail-closed-tranche3-deviation.md) / [code-review](docs/archive/review/fail-closed-tranche3-code-review.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)