### PR TITLE
fix(security): close SC-T3 fail-closed backlog — SCIM Retry-After, magic-link log split, v1/verify-access test proofs

### DIFF
--- a/docs/archive/review/fail-closed-sc-t3-remaining-code-review.md
+++ b/docs/archive/review/fail-closed-sc-t3-remaining-code-review.md
@@ -1,0 +1,118 @@
+# Code Review: fail-closed-sc-t3-remaining
+Date: 2026-07-20
+Review round: 1 (converged — tightening-only skip applied)
+
+## Changes from Previous Round
+Initial review, incremental on top of the Phase 2 self-R-check baseline
+(3/3 No findings). Ollama pre-screen produced one Major claim
+(route.test.ts "returns 429" case asserts 401) — VERIFIED FALSE by the
+orchestrator before expert launch (both 429 cases assert 429); recorded as a
+pre-screen hallucination and excluded from expert scope.
+
+## Functionality Findings
+No findings. Independent verification by the expert: 211/211 targeted unit
+tests; 6/6 C4 integration cases against real Postgres+Redis; `next build`
+pass; fail-closed gate exit 0 with zero manifest diffs; INV-C2 member-set
+independently re-derived (bridge-code / reset-vault / nextauth redisErrored
+sites all route through the canonical `serviceUnavailable()` path — no 6th
+producer); C4 key predicates verified non-colliding; `pipeline.incr` always
+first (wrapper's `routeKey ?? ""` fallback unreachable); e2e grep zero hits
+for changed log channels / headers; all 7 SCIM handlers pass-through; both
+forbidden patterns absent; reserved IPs and no-vitest-retry confirmed.
+
+## Security Findings
+No findings. Verified in final code state: C2 header-merge order (Content-Type
+unoverridable; only production caller builds the headers object locally from
+non-request data; 503 body byte-identical); C3 branch order + early return +
+literal-only log (email-send path structurally unreachable from the change);
+C4 substitutes only `getRedis` (production chain unmocked, grep-proven), no
+fabricated command results, no secret material in fixtures; C1 attribution is
+identity-based in the shared helper's step 6 — a route wired without
+`failClosedOnRedisError: true` cannot pass.
+
+## Testing Findings
+One Minor:
+
+- **F1/F1b (Minor)** — `route.test.ts:86` / `[id]/route.test.ts:116`:
+  `mock.results[v1LimiterCallIndex]!.value` after `findIndex` — on future
+  drift of `v1ApiKeyLimiter` options the index is -1 and `.value` throws an
+  opaque TypeError at module-eval time. Fails loudly either way (no silent
+  pass; RT1/RT8 unaffected), but a guard with a descriptive Error
+  (mirroring `assertRedisFailClosed`'s own guard pattern) makes the failure
+  self-explanatory. → FIXED this round.
+
+## Seed Finding Disposition
+- Functionality seed: No findings — no dispositions.
+- Security seed: No findings — no dispositions.
+- Testing seeds (3, all **Rejected** with evidence):
+  1. `routeKey ??=` single-key assumption — production `checkRedis()` opens
+     exactly one pipeline per `check()` with a single key; sequential limiter
+     calls each resolve their own pipeline. Premise holds.
+  2. Move async arrange to `beforeEach` — per-test `vi.doMock` + dynamic
+     import must run in-test (paired with `resetModules`); second case
+     mutates `limiter.check` between arrange and act; matches sibling suites.
+  3. `clearEnv` redundant vs `unstubAllEnvs` — `unstubAllEnvs` restores only
+     AFTER a test; `clearEnv` blanks real ambient env at test START. Not
+     redundant.
+
+## Adjacent Findings
+- Security: `tenant/members/[userId]/reset-vault` 503 path inspected solely
+  to validate INV-C2 completeness — compliant via `serviceUnavailable()`,
+  no action.
+
+## Quality Warnings
+None (manual merge — one substantive finding across three experts; Ollama
+merge-findings skipped as unnecessary for this volume).
+
+## Recurring Issue Check
+### Functionality expert
+- R1-R17: pass/n/a per diff scope; R18: pass; R19: pass (independent
+  test-tree + e2e greps); R20-R28: n/a; R29: pass; R30-R41: n/a; R42: pass
+  (independent re-derivation); R43-R46: n/a
+### Security expert
+- R1/R2: pass (single-owner default; no new "30" literal); R19: pass;
+  R21: n/a (no delegation); R29: pass; R42: pass (fresh-grep re-derivation);
+  other R: n/a
+- RS1-RS6: pass/n/a — RT5 chain unmocked (grep-proven); RT7 negatives
+  present; RT8 side-effect spies asserted
+### Testing expert
+- R1: pass; R2: pass; R3: pass; R4-R9: n/a; R10: pass; R11-R15: n/a;
+  R16: pass; R17: pass; R18: n/a; R19: pass; R20-R28: n/a; R29: pass;
+  R30-R37: n/a; R38: pass; R39: n/a; R40: pass; R41: n/a; R42: pass;
+  R43: pass; R44-R45: n/a; R46: pass
+- RT1: pass (mock identity verified); RT2: pass; RT3: pass; RT4: pass;
+  RT5: pass; RT6: pass; RT7: pass; RT8: pass; RT9: pass
+
+## Environment Verification Report
+- VE1 (Postgres): `verified-local` — `npm run test:integration` against the
+  docker dev stack (89 files pass; rerun clean after one non-reproducing
+  unrelated flake); `verified-CI` path exists via `ci-integration.yml`
+  postgres service.
+- VE2 (Redis): `verified-local` — same run; C4's
+  `describe.skipIf(!redisAvailable)` gates ran ACTIVE (6/6 in the C10 file,
+  stable across 3 consecutive runs); `verified-CI` via `ci-integration.yml`
+  redis service + `REDIS_URL`.
+- VE3 (real-IdP SCIM acceptance): `blocked-deferred` — links to plan
+  "Verification environment constraints" VE3 entry and Scope contract SC4
+  (staging operator acceptance); unit-level response-object assertions are
+  the verification per the recorded cost-justification.
+
+## Resolution Status
+### F1/F1b [Minor] findIndex non-null assertion lacks not-found guard
+- Action: replaced `mock.results[idx]!.value` with a guarded lookup that
+  throws a descriptive Error naming the drift cause
+  (windowMs/max/failClosedOnRedisError match criteria).
+- Modified files: src/app/api/v1/passwords/route.test.ts:86,
+  src/app/api/v1/passwords/[id]/route.test.ts:116
+- Verified: 67/67 tests in the two files; `tsc --noEmit` clean.
+
+## Tightening-only skip — Round 1
+Findings applied directly (no Round 2 review):
+- [F1/F1b] [Minor] findIndex guard + descriptive error — route.test.ts:86 /
+  [id]/route.test.ts:116 — applied verbatim per the finding's recommendation.
+Justification: both findings are scoped within the Phase 2 (C1) fix range;
+inline minor (test-scaffolding diagnostics only — no observable behavior
+change: the suite fails loudly in both worlds, only the error message
+differs); no security boundary touched (production rate-limit path and every
+assertion are byte-identical; the guard runs at test-module eval, before any
+rate-limit logic executes).

--- a/docs/archive/review/fail-closed-sc-t3-remaining-code-review.md
+++ b/docs/archive/review/fail-closed-sc-t3-remaining-code-review.md
@@ -116,3 +116,48 @@ change: the suite fails loudly in both worlds, only the error message
 differs); no security boundary touched (production rate-limit path and every
 assertion are byte-identical; the guard runs at test-module eval, before any
 rate-limit logic executes).
+
+---
+
+# Round 2 (external security review, 2026-07-20)
+
+## Changes from Previous Round
+User-provided security review of `origin/main...HEAD` reported 2 P2 findings
+(production-side C2/C3 changes explicitly cleared by the reviewer).
+
+## Findings and Resolution
+
+### P2-1 [Major-equivalent] v1 tests could not prove limiter-to-route wiring
+All `createRateLimiter` factory returns shared one `check` mock, so a route
+miswired to the fail-open `migrateLimiter` would still appear to call
+`v1Limiter.check` and pass the 503 + attribution assertions.
+- Action: factory now returns a DISTINCT `check: vi.fn()` (default
+  `allowed: true`) per call; `mockCheck` is re-bound to the args-matched v1
+  instance's own check, so only the limiter under test is armed with the
+  failure. A miswired route now fails both the "limiter reached" assertion
+  (v1 check never called) and `assertNoMutation` (sibling returns
+  allowed:true → mutation executes).
+- Modified files: src/app/api/v1/passwords/route.test.ts,
+  src/app/api/v1/passwords/[id]/route.test.ts
+
+### P2-2 [Major-equivalent] integration cleanup pattern-deleted shared-Redis keys
+`KEYS rl:share_verify_*` + bulk `DEL` in `afterEach` would delete counters
+the test never created (resetting real protection state on a shared/staging
+Redis) and `KEYS` blocks large instances.
+- Action: replaced with an exact-key ledger — each case registers
+  `rl:share_verify_ip:<ip>:<sha256(token)>` and
+  `rl:share_verify_token:<sha256(token)>` computed from its reserved IP and
+  per-run random token (key shapes verified against checkIpRateLimit /
+  route.ts); `afterEach` deletes only those keys. No KEYS scan remains.
+- Modified file: src/__tests__/db-integration/rate-limit-fail-closed-routes.integration.test.ts
+
+### ESLint warning (reviewer-noted): unused `Mock` type import
+- Action: removed the unused `import type { Mock }` from
+  src/lib/scim/with-scim-auth.test.ts (pre-existing in a touched file; root
+  fix, no suppression).
+
+## Verification after fixes
+- Unit: 13 files / 186 tests pass (v1/passwords + scim trees).
+- Integration: rate-limit-fail-closed-routes file 6/6 against real
+  Postgres+Redis with the exact-key cleanup in effect.
+- `tsc --noEmit` clean; ESLint clean on all touched files (warning gone).

--- a/docs/archive/review/fail-closed-sc-t3-remaining-deviation.md
+++ b/docs/archive/review/fail-closed-sc-t3-remaining-deviation.md
@@ -1,0 +1,27 @@
+# Coding Deviation Log: fail-closed-sc-t3-remaining
+
+## Phase 2 entries (2026-07-20)
+
+- **Process deviation — Step 2-2 delegation skipped**: contracts C1-C4 were
+  implemented directly by the orchestrator instead of Sonnet sub-agent
+  batches. Reason: contracts were file:line-precise and small (4 batches,
+  9 files, all traps already enumerated in the plan); delegation overhead
+  plus R21 re-verification cost exceeded the benefit. Phase 3 triangulated
+  review still applies unchanged. Ollama deviation scan of the src diff:
+  "No new deviations" (code matches plan contracts).
+- **check-hardcoded-reuse Major ×2 — adjudicated false positive (R2
+  meaning-equality clause)**: the flagged literal
+  `"@/__tests__/helpers/fail-closed"` in the two v1 test files is an ES
+  import specifier; the matching constant `HELPER_MODULE` lives in
+  `scripts/checks/classify-fail-closed-test.mjs` (a Node gate script test
+  files cannot import). All 18 previously migrated helper-mode test files
+  use the same literal specifier. No action.
+- **check-markdown-autolinks residual 2 hits on plan line 411 — hook false
+  positive**: the line contains two inline code spans (`` `709b6d9a8` ``,
+  `` `#682` ``) after the fix; the hook's code-span stripper mishandles
+  multiple spans on one line. Content verified backticked.
+- **C2 test literal "45" instead of "30"**: response.test.ts's
+  extra-headers passthrough case uses `Retry-After: "45"` so the test does
+  not collide with the plan's forbidden pattern (`"Retry-After": "30"` in
+  src/lib/scim/) and does not accidentally couple to the production
+  default. Contract-consistent micro-decision.

--- a/docs/archive/review/fail-closed-sc-t3-remaining-plan.md
+++ b/docs/archive/review/fail-closed-sc-t3-remaining-plan.md
@@ -405,3 +405,34 @@ spy on both branches, not just log lines), M9 (`logAuditAsync` never in
 | C2  | SCIM fail-closed 503 carries Retry-After (last INV-C2 member)  | locked |
 | C3  | magic-link outage log channel split, silent-drop preserved     | locked |
 | C4  | verify-access tokenLimiter selective-failure integration proof | locked |
+
+## Implementation Checklist (Phase 2 Step 2-1)
+
+Baseline (rebased onto main @ 709b6d9a8, post-#682): fail-closed gate exit 0,
+`EXPECTED_DEBT_COUNT=0`, `EXPECTED_LEGACY_COUNT=0`.
+
+Files to modify:
+- C1: `src/app/api/v1/passwords/route.test.ts`, `src/app/api/v1/passwords/[id]/route.test.ts`
+- C2: `src/lib/http/api-response.ts` (visibility-only export), `src/lib/scim/response.ts`, `src/lib/scim/with-scim-auth.ts`, `src/lib/scim/response.test.ts`, `src/lib/scim/with-scim-auth.test.ts`
+- C3: `src/auth.config.ts`, `src/auth.config.test.ts`
+- C4: `src/__tests__/db-integration/rate-limit-fail-closed-routes.integration.test.ts`
+
+Shared assets to reuse (no reimplementation): `assertRedisFailClosed`,
+`snapshotFactory`, `assertRedisFailClosedSilentDrop`
+(`src/__tests__/helpers/fail-closed.ts`), `retryAfterSecondsOrDefault`
+(`src/lib/http/api-response.ts`), switchable `getRedis` harness + `requestWithIp`
+(`rate-limit-fail-closed-routes.integration.test.ts`), `createRequest`/`parseResponse`
+(`src/__tests__/helpers/request-builder`).
+
+R19 test-tree enumeration (all changed symbols): `scimError` →
+`src/lib/scim/response.test.ts` (+ `with-scim-auth.test.ts` behavioral);
+`serviceUnavailable`/`retryAfterSecondsOrDefault` → `src/lib/http/api-response.test.ts`
+(indirect, unchanged behavior); magic-link warn channel `"magic-link.rate-limited"` →
+`src/auth.config.test.ts` only (repo-wide grep: no other reference);
+no centralized/e2e tree references any changed selector/header/log channel.
+
+CI gate parity: pre-pr.sh covers lint/unit/build; integration tests run in
+`ci-integration.yml` (Postgres+Redis services) — mirrored locally via
+`npm run test:integration` per the plan's Testing strategy. This diff adds no
+new file class that CI-only gates (Extension jobs, static-checks-no-generate)
+scan; C4's file already belongs to the integration glob.

--- a/docs/archive/review/fail-closed-sc-t3-remaining-plan.md
+++ b/docs/archive/review/fail-closed-sc-t3-remaining-plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-20
 Branch: `feature/fail-closed-sc-t3-remaining` (from `main`)
-Predecessor: fail-closed tranche 3 (PR #682, `feature/fail-closed-tranche3`, OPEN at plan time)
+Predecessor: fail-closed tranche 3 (PR `#682`, `feature/fail-closed-tranche3`, OPEN at plan time)
 
 ## Project context
 
@@ -33,7 +33,7 @@ SC-T3-4:
    wrapper (IP key succeeds, token key fails).
 
 User decisions already taken (2026-07-20): independent branch from `main`
-(zero file overlap with PR #682, verified by `git diff main...feature/fail-closed-tranche3 --name-only`);
+(zero file overlap with PR `#682`, verified by `git diff main...feature/fail-closed-tranche3 --name-only`);
 ONE PR for all four items with per-item commits; SC-T3-4 is implemented, not
 deferred.
 
@@ -62,7 +62,7 @@ depends on isolation levels or locks).
 All four items ride existing primitives:
 - C1 reuses `assertRedisFailClosed` + `snapshotFactory`
   (`src/__tests__/helpers/fail-closed.ts`) exactly as the 13 routes migrated in
-  PR #682.
+  PR `#682`.
 - C2 extends `scimError` (additive optional param) and reuses the existing
   `retryAfterSecondsOrDefault` logic from `src/lib/http/api-response.ts`
   (currently module-private; exported by this change) so the 30 s default has a
@@ -358,7 +358,7 @@ spy on both branches, not just log lines), M9 (`logAuditAsync` never in
   `refactor` — use `fix` since release-please skips chore/docs and the log-split
   is operator-facing, C4 `test(security)`; release-please prefixes per repo
   rules). ONE PR at the end (user decision 2026-07-20).
-- PR #682 interplay: zero file overlap (verified); merge order free; no rebase
+- PR `#682` interplay: zero file overlap (verified); merge order free; no rebase
   dependency in either direction.
 
 ### Scope contract
@@ -408,7 +408,7 @@ spy on both branches, not just log lines), M9 (`logAuditAsync` never in
 
 ## Implementation Checklist (Phase 2 Step 2-1)
 
-Baseline (rebased onto main @ 709b6d9a8, post-#682): fail-closed gate exit 0,
+Baseline (rebased onto main @ `709b6d9a8`, post-`#682`): fail-closed gate exit 0,
 `EXPECTED_DEBT_COUNT=0`, `EXPECTED_LEGACY_COUNT=0`.
 
 Files to modify:

--- a/docs/archive/review/fail-closed-sc-t3-remaining-plan.md
+++ b/docs/archive/review/fail-closed-sc-t3-remaining-plan.md
@@ -1,0 +1,407 @@
+# Plan: fail-closed-sc-t3-remaining
+
+Date: 2026-07-20
+Branch: `feature/fail-closed-sc-t3-remaining` (from `main`)
+Predecessor: fail-closed tranche 3 (PR #682, `feature/fail-closed-tranche3`, OPEN at plan time)
+
+## Project context
+
+- Type: web app (Next.js 16 App Router + TypeScript 5.9 + Prisma 7 + PostgreSQL 16 + Redis 7)
+- Test infrastructure: unit (vitest) + integration (real DB/Redis, `npm run test:integration`) + E2E + CI/CD
+- Verification environment constraints:
+  - **VE1**: `db-integration` tests require a running Postgres (`DATABASE_URL`/`MIGRATION_DATABASE_URL`). Available locally (docker compose dev stack) and in CI (`ci-integration.yml` postgres service). → `verifiable-local` / `verifiable-CI`.
+  - **VE2**: Redis-dependent integration cases (`redisAvailable = !!process.env.REDIS_URL`) require a reachable Redis. Available locally (docker compose `redis`) and in CI (`ci-integration.yml` redis service, `REDIS_URL=redis://localhost:6379`, ci-integration.yml:66-78). → `verifiable-local` / `verifiable-CI`.
+  - **VE3**: SCIM Retry-After behavior against a real IdP (Okta/Entra provisioning client) is not exercisable locally. Manual-test path is `blocked-deferred`; cost-justification: the change is a purely additive response header whose consumer contract is defined by RFC 9110 generic HTTP semantics, fully verifiable by unit assertion on the response object. Real-IdP validation deferred to operator acceptance in a staging tenant (same posture as tranche 2's SCIM 503 introduction, which shipped without IdP-in-the-loop testing).
+  - No path in this plan is blocked by paid tiers, hardware, or multi-account setups.
+
+## Objective
+
+Close the four remaining SC-T3 backlog items from the fail-closed initiative
+(tranche 3 scope contract), in approved order SC-T3-3 → SC-T3-2 → SC-T3-5 →
+SC-T3-4:
+
+1. **SC-T3-3** (test-only): migrate the 3 remaining hand-rolled v1/passwords
+   fail-closed test cases to the shared `assertRedisFailClosed` helper tier.
+2. **SC-T3-2** (production): add `Retry-After` to the SCIM fail-closed 503,
+   closing the last member of the "every fail-closed 503 carries Retry-After"
+   invariant.
+3. **SC-T3-5** (production, observability-only): split the magic-link limiter's
+   Redis-outage log channel from its over-limit channel, preserving the
+   silent-drop contract.
+4. **SC-T3-4** (test-only, new infra): prove the verify-access `tokenLimiter`
+   fail-closed path at the route-integration tier via a selective-failure Redis
+   wrapper (IP key succeeds, token key fails).
+
+User decisions already taken (2026-07-20): independent branch from `main`
+(zero file overlap with PR #682, verified by `git diff main...feature/fail-closed-tranche3 --name-only`);
+ONE PR for all four items with per-item commits; SC-T3-4 is implemented, not
+deferred.
+
+## Requirements
+
+Functional:
+- SCIM 503 (Redis outage) response carries `Retry-After: <delay-seconds>` with
+  the shared 30 s default. Body shape unchanged.
+- Magic-link `sendVerificationRequest` distinguishes Redis outage from
+  over-limit in logs only; externally observable behavior (silent drop, no
+  email, no throw) unchanged.
+
+Non-functional:
+- No behavior change for any other route or envelope.
+- Test-tier upgrades must keep `scripts/checks/check-fail-closed-routes-have-test.sh` green with **no manifest edits** (v1 routes are not gate members; the `v1ApiKeyLimiter` class member is `src/lib/security/rate-limiters.ts`, already helper-mode via `assertRedisFailClosedResult`).
+- Mandatory checks before completion: `npx vitest run`, `npx next build`
+  (production code changes in C2/C3), `npm run test:integration` (C4),
+  `scripts/pre-pr.sh` before push.
+
+## Technical approach
+
+No new dependencies, no schema changes, no migrations, no concurrency-control
+primitives (plan-stage real-DB concurrency probe: N/A — nothing in this plan
+depends on isolation levels or locks).
+
+All four items ride existing primitives:
+- C1 reuses `assertRedisFailClosed` + `snapshotFactory`
+  (`src/__tests__/helpers/fail-closed.ts`) exactly as the 13 routes migrated in
+  PR #682.
+- C2 extends `scimError` (additive optional param) and reuses the existing
+  `retryAfterSecondsOrDefault` logic from `src/lib/http/api-response.ts`
+  (currently module-private; exported by this change) so the 30 s default has a
+  single owner (R1/R2).
+- C3 is a two-line branch in `src/auth.config.ts` plus test updates.
+- C4 extends the existing switchable-`getRedis` integration harness
+  (`src/__tests__/db-integration/rate-limit-fail-closed-routes.integration.test.ts:71-79`)
+  with a key-predicate routing wrapper.
+
+### External spec citations (R29 — verified verbatim 2026-07-20 against rfc-editor.org)
+
+- RFC 7644 §3.12 "HTTP Status and Error Response Handling" defines the SCIM
+  error envelope (`urn:ietf:params:scim:api:messages:2.0:Error`; `status`
+  REQUIRED as JSON string, `scimType` OPTIONAL, `detail` OPTIONAL). It contains
+  **zero** mentions of `Retry-After` or status 503 (verified:
+  `grep -c "Retry-After" rfc7644.txt` → 0; `grep -c "503" rfc7644.txt` → 0).
+  **Therefore this plan does NOT claim SCIM requires Retry-After.**
+- RFC 9110 §15.6.4 "503 Service Unavailable": "The server MAY send a
+  Retry-After header field (Section 10.2.3) to suggest an appropriate amount of
+  time for the client to wait before retrying the request." (verbatim).
+- RFC 9110 §10.2.3 "Retry-After": "When sent with a 503 (Service Unavailable)
+  response, Retry-After indicates how long the service is expected to be
+  unavailable to the client." (verbatim). `delay-seconds = 1*DIGIT`,
+  a non-negative decimal integer.
+- The change's real justification is **internal invariant consistency**: this
+  repo's own contract "503 envelopes ALWAYS set Retry-After (operator playbook
+  requires a back-off hint on service-unavailable)"
+  (src/lib/http/api-response.ts:154-156). SCIM is the last fail-closed 503
+  producer without it (member-set below). RFC 9110's MAY permits it; nothing
+  forbids it; the SCIM error body is untouched so RFC 7644 §3.12 conformance is
+  unaffected.
+
+## Contracts
+
+### C1 — SC-T3-3: v1/passwords fail-closed tests → helper mode (test-only)
+
+Files:
+- `src/app/api/v1/passwords/route.test.ts` — 2 cases (GET at :138, POST at :368)
+- `src/app/api/v1/passwords/[id]/route.test.ts` — 1 case (GET at :167)
+
+Signatures (test-file internal):
+- Replace plain-arrow factory mock
+  `vi.mock("@/lib/security/rate-limit", () => ({ createRateLimiter: () => ({ check: mockCheck }) }))`
+  with a recording factory: `mockCreateRateLimiter: Mock` created inside the
+  existing `vi.hoisted` block and wired as
+  `vi.mock("@/lib/security/rate-limit", () => ({ createRateLimiter: mockCreateRateLimiter }))`.
+- Module scope, immediately after the route import:
+  `const limiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);`
+  and resolve the limiter under test **by factory-args match, not bare index**:
+  find the `mock.calls` entry whose options equal `v1ApiKeyLimiter`'s
+  (`windowMs: RATE_WINDOW_MS, max: 100, failClosedOnRedisError: true`,
+  src/lib/security/rate-limiters.ts:16-20) and take the corresponding
+  `mock.results[i].value`. Rationale: the route's import graph constructs
+  multiple limiters through the same mocked factory (`migrateLimiter` et al.);
+  a positional index is fragile against import-graph drift.
+- Each of the 3 cases becomes an `assertRedisFailClosed` call:
+  - `expectation: { envelope: "canonical" }` (route consumes the limiter via
+    production `checkRateLimitOrFail` → `serviceUnavailable()`; the helper adds
+    the Retry-After delay-seconds assertion the manual cases lacked).
+  - `assertNoMutation`: GET list → `[mockEntryFindMany]`; POST create →
+    `[mockEntryCreate]`; [id] GET → the entry-read spy used by the current
+    manual case (`mockEntryFindUnique` — [id]/route.test.ts:8,44, backing
+    `prisma.passwordEntry.findUnique`; the existing case at :167-177 already
+    asserts it).
+    `mockLogAudit` is NOT included (M9: the 503 path itself calls
+    `logAuditAsync` via `emitRateLimitFailClosed`).
+  - `failure: { allowed: false, redisErrored: true }` inline literal.
+  - `limiterFactory: limiterFactorySnapshot.replay()`.
+
+Invariants:
+- App-enforced: no manual 503-envelope assertion remains in the 3 cases; the
+  shared helper is the single contract surface. (Schema-enforced equivalent:
+  none — this is a test-code pattern; the gate script is the closest
+  machine-enforcement and stays green unchanged.)
+- `vi.hoisted` TDZ trap (tranche-3 lesson): inside the hoisted callback, bind
+  `const check = vi.fn()` first, then return
+  `{ mockCheck: check, mockCreateRateLimiter: vi.fn(() => ({ check })) }` —
+  the returned object must not reference its own properties.
+
+Forbidden patterns:
+- pattern: `createRateLimiter: \(\) => \(` in the two files — reason: plain-arrow factory defeats `assertRedisFailClosed` attribution.
+- pattern: `toEqual\(\{ error: "SERVICE_UNAVAILABLE" \}\)` inside the 3 migrated cases — reason: manual envelope assertion must be replaced by the helper, not duplicated beside it.
+
+Acceptance criteria:
+- 3 cases invoke `assertRedisFailClosed`; all previously asserted behavior
+  (503, envelope, no-DB-access) still asserted, plus Retry-After and
+  factory-attributed `failClosedOnRedisError: true`.
+- `npx vitest run src/app/api/v1/passwords` green; full suite green;
+  `bash scripts/checks/check-fail-closed-routes-have-test.sh` green with zero
+  manifest diffs.
+
+Consumer-flow walkthrough: N/A — no producer shape changes; test-only.
+
+### C2 — SC-T3-2: SCIM fail-closed 503 carries Retry-After (production)
+
+Signatures:
+- `src/lib/http/api-response.ts`: `export function retryAfterSecondsOrDefault(retryAfterMs?: number): string` — existing implementation, visibility change only (module-private → exported).
+- `src/lib/scim/response.ts`:
+  `export function scimError(status: number, detail: string, scimType?: string, headers?: Record<string, string>): NextResponse`
+  — additive optional 4th param merged into the response headers after the
+  Content-Type default (caller headers must not be able to override
+  `Content-Type: application/scim+json`; spread order: `{ "Content-Type": SCIM_CONTENT_TYPE, ...headers }` is FORBIDDEN — use `{ ...headers, "Content-Type": SCIM_CONTENT_TYPE }`).
+- `src/lib/scim/with-scim-auth.ts:34`:
+  `scimError(503, "Service temporarily unavailable", undefined, { "Retry-After": retryAfterSecondsOrDefault() })`.
+
+Invariants (universally quantified → R42 member-set, code-derived 2026-07-20):
+- **INV-C2: every fail-closed (redisErrored → 503) response producer sets `Retry-After`.**
+  Defining primitive: the 503 branch of `checkRateLimitOrFail`
+  (`rl.redisErrored` → envelope, src/lib/security/rate-limit-audit.ts:239-250)
+  plus direct `scimError(503, ...)` on the `rl.redisErrored` branch in
+  `authorizeScim`. Derivation commands:
+  `grep -rn 'envelope:' src --include='*.ts' | grep -v test` (custom/oauth
+  envelope callers) + `grep -n 'serviceUnavailable\|oauthTemporarilyUnavailable' src/lib/http/api-response.ts`
+  + `grep -n 'scimError(503' src/lib/scim/with-scim-auth.ts`.
+  Member-set (5, verified in source):
+  1. `serviceUnavailable()` canonical — Retry-After ✔ (api-response.ts:171-174)
+  2. `oauthTemporarilyUnavailable()` — Retry-After ✔ (api-response.ts:185-190)
+  3. `vault/delegation/check` custom envelope — `Retry-After: "30"` ✔ (route.ts:75-79)
+  4. `vault/ssh/sign-authorize` custom envelope — `Retry-After: "30"` ✔ (route.ts:87-91)
+  5. `scimError(503, ...)` in `authorizeScim` — ✘ → **closed by this contract**.
+  Indirect members check: no raw `NextResponse.json(..., { status: 503 })` on a
+  `redisErrored` branch outside these five (`grep -rn 'redisErrored' src --include='*.ts' | grep -v test` reviewed; all 503 emissions route through the five producers).
+  App-enforced; additionally test-enforced by `FailClosedExpectation.retryAfter`
+  being a required explicit field for custom envelopes (helper design), so a
+  future custom-envelope consumer must decide rather than silently skip.
+- The SCIM 503 **body** is byte-identical before/after (RFC 7644 §3.12 envelope
+  untouched); only a header is added.
+- `Content-Type: application/scim+json` unoverridable by the new headers param.
+
+Forbidden patterns:
+- pattern: `"Retry-After": "30"` in `src/lib/scim/` — reason: the default must come from `retryAfterSecondsOrDefault()` (single owner), not a new magic literal.
+- pattern: `retryAfter: "forbidden"` in `src/lib/scim/with-scim-auth.test.ts` — reason: the expectation must flip to `"required"`; leaving `"forbidden"` means the test contradicts the contract.
+
+Acceptance criteria:
+- `authorizeScim` Redis-outage response: status 503, SCIM error body unchanged,
+  `Retry-After` matches `/^\d+$/` and > 0 (default 30).
+- `with-scim-auth.test.ts` fail-closed case passes with
+  `retryAfter: "required"`.
+- `response.test.ts` gains coverage for the `headers` param: (a) headers are
+  emitted, (b) `Content-Type` cannot be overridden (RT6/RT7 — prove the new
+  parameter can fail: a deliberately wrong-order implementation fails (b)).
+- All existing `scimError` call sites compile and behave unchanged, verified
+  by `npx next build` plus a call-site grep audit (`grep -rn 'scimError(' src`)
+  — no hardcoded count; independent review greps produced 41-43 depending on
+  methodology, so the number is deliberately not part of the criterion.
+
+Consumer-flow walkthrough (response shape consumed outside the producer):
+- Consumer 1 — the 7 SCIM route handlers (`src/app/api/scim/v2/**`): read
+  `auth.ok`; when false, return `auth.response` verbatim. They read no fields
+  of the response object itself → header addition is pass-through safe.
+- Consumer 2 — IdP SCIM clients (Okta/Entra provisioning engines): read HTTP
+  `status` (503 → retry later) and, per RFC 9110 generic semantics, MAY read
+  `Retry-After` for back-off pacing. Body fields (`schemas`, `status`,
+  `detail`) unchanged; no field the consumer needs is removed.
+- Consumer 3 — `with-scim-auth.test.ts` + `response.test.ts`: assert the
+  envelope; updated in this change as listed above.
+
+### C3 — SC-T3-5: magic-link Redis-outage log channel split (production, observability-only)
+
+Signatures:
+- `src/auth.config.ts` `sendVerificationRequest` (currently :113-121): insert a
+  `redisErrored` branch BEFORE the `!rl.allowed` branch:
+  - outage: `getLogger().error("magic-link.rate-limit.fail_closed"); return;`
+  - over-limit (unchanged): `getLogger().warn("magic-link.rate-limited"); return;`
+- No new exports; no signature changes.
+
+Invariants:
+- **Silent-drop contract preserved on BOTH branches**: no throw, no email
+  (`sendEmail` not called), function resolves `undefined` — anti-enumeration
+  behavior is externally indistinguishable between outage, over-limit, and
+  (from the requester's view) success.
+- **No PII in the new log call**: message string only, no structured fields —
+  the email address must not appear (logging rule: never log emails; precedent:
+  `rate-limit.fail_closed.pre_auth_skip` logs only scope + ipBucket).
+- Channel naming: `magic-link.rate-limit.fail_closed` — `error` level because a
+  Redis outage is operator-actionable, unlike the expected-noise `warn` on
+  over-limit. (`emitRateLimitFailClosed` is NOT used here: it requires a
+  `NextRequest`, which `sendVerificationRequest` does not receive.)
+
+Forbidden patterns:
+- pattern: `identifier` or `email` as an argument to the new `getLogger().error(` call in auth.config.ts — reason: PII in logs.
+- pattern: `throw` inside the `redisErrored` branch — reason: silent-drop contract.
+
+Acceptance criteria:
+- Updated C8a test (`src/auth.config.test.ts:316`): redisErrored →
+  `assertRedisFailClosedSilentDrop` still passes AND
+  `mockError` called with `"magic-link.rate-limit.fail_closed"` AND `mockWarn`
+  NOT called with `"magic-link.rate-limited"`.
+- New sibling over-limit case: `{ allowed: false }` (no `redisErrored`) →
+  `mockWarn` called with `"magic-link.rate-limited"`, `mockError` not called
+  with the outage channel, `sendEmail` not called (RT8: assert the mutation
+  spy, not just the log).
+- `npx next build` green.
+
+Consumer-flow walkthrough: N/A — no shape consumed by code; log lines are
+consumed by operators (channel names documented in the commit message).
+
+### C4 — SC-T3-4: verify-access tokenLimiter route-integration proof (test-only, new infra)
+
+File: `src/__tests__/db-integration/rate-limit-fail-closed-routes.integration.test.ts`
+
+Signatures (test-file internal):
+- `function createSelectiveRedis(broken: IORedis, real: IORedis, failKeyPredicate: (key: string) => boolean): IORedis`
+  — returns an object (cast `as unknown as IORedis`) implementing exactly the
+  surface `createRateLimiter` uses (rate-limit.ts:54-99):
+  - `pipeline()`: returns a shim recording `incr(key)/pexpire(...)/pttl(key)`
+    chained calls; on `exec()`, chooses the target client by
+    `failKeyPredicate(key of the first incr)` and replays the recorded commands
+    onto a real `target.pipeline()`, returning its `exec()` result.
+  - `del(key)`: routes by the same predicate (limiter `clear`). Note
+    (review round 1): the two new cases exercise only 503/404 paths, which
+    never call `limiter.clear()` — the `del` branch is defensive scaffolding
+    so the wrapper is a complete stand-in for the surface `createRateLimiter`
+    uses (rate-limit.ts:60-106), plus it serves the `afterEach` key cleanup.
+- Predicate for the new case: `(key) => key.startsWith("rl:share_verify_token:")`
+  — token-limiter key shape from verify-access route.ts:61; IP-limiter keys
+  (`checkIpRateLimit`, scope `share_verify_ip`) do NOT match and hit the real
+  Redis.
+- Wiring: reuse the existing switchable `activeRedis` (test file :71-79);
+  assign the selective wrapper for the new cases, restore after.
+
+Test cases (new `describe`, `skipIf(!dbAvailable || !redisAvailable)` — VE1+VE2):
+- **Green (fail-closed) case**: schema-valid body, fresh IP → response is 503
+  canonical envelope `{ error: "SERVICE_UNAVAILABLE" }` + `Retry-After`
+  matching `/^\d+$/` > 0; `shareAccessLog` row count unchanged (existing
+  no-mutation pattern of the file).
+- **Discrimination proof (RT4/RT7 red-proof)**: identical fixture with
+  `activeRedis = realRedis` (whole path real) reaches the non-503 domain
+  response (404 — token does not exist). Since the IP-limiter leg is real and
+  identical in both runs, the 503 in the green case is attributable ONLY to the
+  token-limiter leg — proving (a) the ipLimiter passed, (b) the route reached
+  `tokenLimiter`, (c) `tokenLimiter`'s production `checkRateLimitOrFail`
+  mapping produced the 503. This kills the vacuous-pass risk of a wrapper that
+  fails every key. The fixture token is generated fresh (random) per case so
+  the 404 is guaranteed by construction, not by absence-by-convention (a
+  seeded/reused `tokenHash` could otherwise surface a different non-503
+  status and weaken the framing).
+- Hygiene / flake control (review round 1, RT4):
+  - **Reserved IPs**: the new cases use `203.0.113.30` (green) and
+    `203.0.113.31` (red-proof) — verified unused across the whole
+    `src/__tests__/db-integration/` tree (in-use set at plan time: .9, .10,
+    .11, .20, .21, .50, .55, .60, .65). One request per case against a
+    5-req/min IP limit leaves ample headroom.
+  - **Retry interaction**: neither `vitest.config.ts` nor
+    `vitest.integration.config.ts` configures `retry` (verified by grep), so
+    same-IP re-execution within the 1-minute window cannot occur via
+    framework retries. If a `retry` option is ever introduced, this file's
+    IP-per-case allocation must be revisited.
+  - **Cleanup**: `afterEach` deletes the `rl:share_verify_ip:*` keys for the
+    reserved test IPs on the real Redis. Token-key cleanup is deliberately
+    N/A: in the green case the token key's `incr` is routed to the broken
+    client and never lands on real Redis; in the red-proof case it does land
+    — delete it in the same `afterEach` for symmetry.
+
+Invariants:
+- No mocks of `@/lib/security/rate-limit` or `@/lib/security/rate-limit-audit`
+  (RT5: production chain in path) — the ONLY substitution remains `getRedis`,
+  same trust boundary the file already established (tranche-2 C10 adjudication).
+- The selective wrapper must not fabricate results: it delegates every command
+  to a real ioredis client (broken or real); it contains no canned values.
+
+Forbidden patterns:
+- pattern: `vi.mock("@/lib/security/rate-limit"` in this file — reason: RT5, the production limiter chain must stay real.
+- pattern: `mockResolvedValue` on any limiter surface in this file — reason: same.
+
+Acceptance criteria:
+- New cases pass locally with docker Postgres+Redis (`npm run test:integration`)
+  and in CI (`ci-integration.yml`).
+- Existing C10 cases in the file remain green and untouched except for shared
+  harness additions.
+
+Consumer-flow walkthrough: N/A — test-only.
+
+## Testing strategy
+
+Per-item targeted runs during implementation, then the mandatory gates:
+1. `npx vitest run` — full unit suite.
+2. `npx next build` — required (C2/C3 touch production code).
+3. `npm run test:integration` — C4 (requires local Postgres+Redis; also runs in CI).
+4. `bash scripts/checks/check-fail-closed-routes-have-test.sh` — C1 gate
+   regression check (expect: zero manifest diffs, still green).
+5. `scripts/pre-pr.sh` before push (project rule).
+
+Test-design rules honored: RT5 (C4 keeps production chain), RT7 (C2's
+Content-Type-override negative; C4's red-proof), RT8 (C3 asserts `sendEmail`
+spy on both branches, not just log lines), M9 (`logAuditAsync` never in
+`assertNoMutation`), tranche-3 traps (vi.hoisted TDZ; `tsc` via `next build`).
+
+## Considerations & constraints
+
+- Commit granularity: 4 commits, one per contract, in approved order
+  (C1 `refactor(security)`, C2 `fix(security)`, C3 `fix(security)` or
+  `refactor` — use `fix` since release-please skips chore/docs and the log-split
+  is operator-facing, C4 `test(security)`; release-please prefixes per repo
+  rules). ONE PR at the end (user decision 2026-07-20).
+- PR #682 interplay: zero file overlap (verified); merge order free; no rebase
+  dependency in either direction.
+
+### Scope contract
+
+- **SC1 — SCIM 429 Retry-After**: out of scope. RFC 7644 is silent on it, and
+  adding it to SCIM 429 is an unrequested spec change. (Factual note, review
+  round 1: the over-limit branch DOES have `rl.retryAfterMs` available at the
+  call site — with-scim-auth.ts:36-38 simply never plumbs it into `scimError`;
+  the blocker is unwired plumbing, not an unknown value. A future SC1
+  implementer can pass it via the new `headers` param.) Owner: future issue if
+  an IdP integration requests back-off hints on 429.
+- **SC2 — hardcoded `"Retry-After": "30"` literals** in
+  `vault/delegation/check` and `vault/ssh/sign-authorize` custom envelopes:
+  pre-existing; normalizing them onto `retryAfterSecondsOrDefault()` is a
+  behavior-neutral cleanup outside this backlog. Owner: follow-up candidate
+  noted for the next fail-closed housekeeping pass.
+- **SC3 — other legacy patterns in v1/passwords tests** (non-fail-closed
+  cases): untouched. C9.2 "touch it → migrate it" applies only to the 3
+  fail-closed cases; a whole-file modernization is not in scope.
+- **SC4 — real-IdP SCIM acceptance** (VE3): deferred to staging operator
+  acceptance; see Verification environment constraints.
+
+## User operation scenarios
+
+1. **IdP admin during Redis outage**: Entra/Okta provisioning sync hits
+   `/api/scim/v2/Users` → 503 + `Retry-After: 30` + SCIM error body → the IdP
+   marks the cycle retryable and backs off instead of hammering; operator sees
+   the `RATE_LIMIT_FAIL_CLOSED` audit row (existing) and can correlate.
+2. **End user requests a magic link during Redis outage**: no email arrives
+   (silent drop, unchanged); the operator's log search now distinguishes
+   `magic-link.rate-limit.fail_closed` (outage — page the on-call) from
+   `magic-link.rate-limited` (abuse/noise — ignore).
+3. **CLI/API-key consumer during outage**: `GET /api/v1/passwords` → 503 +
+   Retry-After (behavior unchanged; now pinned by the shared helper contract).
+4. **Share-link recipient during a partial Redis failure** (token shard
+   erroring, IP shard healthy): verify-access returns 503, no password oracle
+   exposure — now proven at the route-integration tier, not only unit tier.
+
+## Go/No-Go Gate
+
+| ID  | Subject                                                        | Status |
+|-----|----------------------------------------------------------------|--------|
+| C1  | v1/passwords fail-closed tests → assertRedisFailClosed tier    | locked |
+| C2  | SCIM fail-closed 503 carries Retry-After (last INV-C2 member)  | locked |
+| C3  | magic-link outage log channel split, silent-drop preserved     | locked |
+| C4  | verify-access tokenLimiter selective-failure integration proof | locked |

--- a/docs/archive/review/fail-closed-sc-t3-remaining-review.md
+++ b/docs/archive/review/fail-closed-sc-t3-remaining-review.md
@@ -1,0 +1,187 @@
+# Plan Review: fail-closed-sc-t3-remaining
+Date: 2026-07-20
+Review round: 1 (findings applied; round 2 verification below)
+
+## Changes from Previous Round
+Initial review. Local LLM pre-screen: "No issues found." Three expert
+sub-agents (Functionality / Security / Testing) reviewed in parallel.
+
+## Merged Findings (deduplicated)
+
+| ID | Source | Severity | Finding | Resolution (applied to plan) |
+|----|--------|----------|---------|------------------------------|
+| M-F1 | Func F1 | Minor | SC1 justification cited `rateLimited()` which the SCIM 429 path never calls; `rl.retryAfterMs` IS available, just unwired | SC1 rewritten: RFC-silence + unrequested-spec-change is the sole rationale; factual note on unwired plumbing added |
+| M-F2 | Func F2 + Sec [Adjacent] (2-expert convergence) | Minor | Hardcoded "42 scimError call sites" count wrong (independent greps: 41-43) | Count removed; criterion now "all call sites, via next build + grep audit" |
+| M-F3 | Test F1 | Minor | C1 cited non-existent `mockEntryFindFirst`; actual mock is `mockEntryFindUnique` ([id]/route.test.ts:8,44) | Plan corrected to `mockEntryFindUnique` with line refs |
+| M-F4 | Test F2 | Major (JSON index; prose said Minor/Moderate — adjudicated up) | C4 real-Redis IP-limiter (5/min) cross-case pollution mitigation not pinned (IPs unenumerated, CI-retry unconfirmed, token-key cleanup implicit) | Reserved IPs 203.0.113.30/.31 (verified unused; in-use set enumerated); verified no `retry` in either vitest config; token-key cleanup rationale made explicit (green: never lands on real Redis; red: delete in afterEach) |
+| M-F5 | Sec [Adjacent] | Minor | C4 red-proof 404 should be guaranteed by construction | Fresh/random token per case added to the contract |
+| M-F6 | Func F3 + Test F3 [Adjacent] | Minor | Selective wrapper `del` branch unreachable in the two cases; routing robustness question | Security expert independently confirmed routing sound (disjoint namespaces, falsifiable red-proof); plan now documents `del` as defensive scaffolding + afterEach cleanup use |
+
+## Functionality Findings
+F1 (Minor, applied), F2 (Minor, applied), F3 (Adjacent → M-F6). Notable
+verifications: factory-args-match uniqueness vs migrateLimiter confirmed;
+consumer-flow walkthrough (C2) adequate; R42 member-set independently
+re-derived (exactly 5 members).
+
+## Security Findings
+No findings. Verified: INV-C2 member-set complete (5/5, independent
+recomputation; non-member 503 sites classified); C2 header-injection defense
+(spread order) sound; C3 anti-enumeration preserved on both branches, PII
+forbidden-pattern sufficient; C4 wrapper cannot false-green (red-proof
+falsifiability); C1 identity-based factory attribution cannot mask silent
+fail-open regression. R29: citations accurate, permission-only framing
+correct. Two [Adjacent] Minors → M-F2, M-F5.
+
+## Testing Findings
+F1 (Minor, applied), F2 (Major, applied), F3 (Adjacent → M-F6). Notable
+verifications: both v1 test files use vi.clearAllMocks() (snapshotFactory
+trap real); wrapper surface = complete production Redis surface
+(rate-limit.ts:60-106); retryAfterSecondsOrDefault indirectly covered
+(api-response.test.ts:82-124); C8a logger doMock shape supports the new
+mockError assertions without new mock surface.
+
+## Adjacent Findings
+All three [Adjacent] items merged above (M-F2, M-F5, M-F6); none unrouted.
+
+## Quality Warnings
+None — merge quality gate reported no VAGUE / NO-EVIDENCE / UNTESTED-CLAIM
+findings.
+
+## Severity-index discrepancy note
+Testing expert's F2 prose header said "Minor" (impact "Moderate") while its
+JSON index said "Major". Orchestrator adjudicated to Major (stricter) and
+applied the full recommended action rather than round-tripping — the fix was
+cheap and complete either way.
+
+## Recurring Issue Check
+## Recurring Issue Check
+### Functionality expert
+- R1: pass — all four contracts reuse existing helpers; no reimplementation
+- R2: pass — 30s default centralized via retryAfterSecondsOrDefault export; forbidden pattern blocks new "30" literal in scim/
+- R3: pass — C1 migrates all 3 legacy cases, not a subset
+- R4: n/a; R5: n/a (no DB writes); R6: n/a; R7: n/a; R8: n/a; R9: n/a
+- R10: pass — no new import cycle (verified)
+- R11-R15: n/a
+- R16: pass — C4 gated by VE1+VE2, available locally and in CI
+- R17: pass — factory-args-match unique against migrateLimiter
+- R18: n/a
+- R19: pass — verified against actual current mock shapes
+- R20: n/a; R21: n/a (plan-stage)
+- R22: pass; R23: n/a; R24: n/a (no migration); R25: n/a; R26-R28: n/a
+- R29: finding F1 — not RFC-text accuracy, but plan's application of the rationale to code
+- R30: n/a; R31: n/a; R32: n/a; R33: n/a
+- R34: pass — SC2 deferred with explicit owner/follow-up note
+- R35: pass — VE3 documents SCIM real-IdP gap with cost-justification
+- R36: n/a; R37: n/a (log channels are operator-facing)
+- R38: pass — redisErrored implies allowed:false; new branch correctly ordered first
+- R39: n/a
+- R40: pass — C2 consumer-flow walkthrough covers all 3 consumers adequately
+- R41: n/a
+- R42: pass — independently re-derived; exactly 5 members; other raw 503 sites are unrelated failure classes
+- R43: n/a; R44: n/a; R45: n/a
+- R46: pass — factory calls structurally distinguishable on max/failClosedOnRedisError
+
+```json
+[
+  {"id":"F1","severity":"Minor","title":"SC1's stated justification (rateLimited() only sets Retry-After when known) doesn't match the actual SCIM 429 code path, which never uses rateLimited()","file":"docs/archive/review/fail-closed-sc-t3-remaining-plan.md","line":343,"adjacent":false,"escalate":null},
+  {"id":"F2","severity":"Minor","title":"Acceptance criteria count of '42 existing scimError call sites' is off by one from actual grep count (41)","file":"docs/archive/review/fail-closed-sc-t3-remaining-plan.md","line":205,"adjacent":false,"escalate":null},
+  {"id":"F3","severity":"Minor","title":"C4 selective-Redis-wrapper command-routing robustness against false negatives is adjacent to security/test-design review","file":"src/__tests__/db-integration/rate-limit-fail-closed-routes.integration.test.ts","line":null,"adjacent":true,"escalate":null}
+]
+```
+
+## Recurring Issue Check
+### Security expert
+- R1: pass — C2 reuses retryAfterSecondsOrDefault as single owner; forbidden-pattern gate enforces
+- R2: pass — 30s default single-sourced
+- R3: pass — C1 completes propagation to last 3 legacy cases; C2 completes 5-member invariant
+- R4-R8: n/a
+- R9: n/a
+- R10: n/a — import direction unchanged
+- R11-R28: n/a
+- R29: pass — citations verified accurate; permission-only framing
+- R30: n/a
+- R31: n/a
+- R32-R37: n/a
+- R38: pass — no fail-open supersession; all contracts narrow/observe fail-closed behavior
+- R39: n/a
+- R40: n/a
+- R41: n/a
+- R42: pass — INV-C2 member-set independently recomputed, 5/5 complete
+- R43: pass — headers param additive-optional, Content-Type non-overridable; no boundary widening
+- R44: n/a
+- R45: n/a
+- R46: pass — selective wrapper scoped to exact disjoint key namespace
+- RS1: n/a — no credential/token comparison touched
+- RS2: n/a — no new routes
+- RS3: n/a — no new request-derived input (headers param internal-caller-only)
+- RS4: pass — forbidden-pattern bars identifier/email in new log call
+- RS5: pass — retryAfterSecondsOrDefault clamps to fixed default; no untrusted input reaches it
+- RS6: pass — header spread-order forbidden pattern is the correct ordering
+
+```json
+[]
+```
+
+## Recurring Issue Check
+### Testing expert
+- R1: pass; R2: pass; R3: n/a; R4-R15: n/a
+- R16: pass — VE1/VE2 verified locally + CI (REDIS_URL at ci-integration.yml:78)
+- R17: n/a; R18: n/a
+- R19: pass — pipeline().incr/pexpire/pttl/exec + del confirmed as the complete production Redis surface used by createRateLimiter (rate-limit.ts:60-106)
+- R20: n/a; R21: n/a (review independently re-read all cited files); R22-R28: n/a
+- R29: pass — internally consistent
+- R30-R41: n/a (R34/R35 covered by other experts)
+- R42: pass — 5-member set spot-checked; cited line numbers all matched real source
+- R43-R46: n/a
+- RT1: pass — both v1 test files DO use vi.clearAllMocks() in beforeEach (snapshotFactory trap is real); v1ApiKeyLimiter/migrateLimiter both constructed in rate-limiters.ts (premise holds)
+- RT2: pass
+- RT3: pass
+- RT4: finding F2 — IP pollution mitigation not pinned
+- RT5: pass — forbidden patterns bar limiter mocking; with-scim-auth.test.ts deliberately does not mock rate-limit-audit
+- RT6: pass — retryAfterSecondsOrDefault covered indirectly via api-response.test.ts:82-124; response.test.ts new headers-param coverage exercises it at the scimError boundary
+- RT7: pass — Content-Type-unoverridable negative falsifiable; C4 red-proof mirrors existing passing pattern (:231-257)
+- RT8: pass — sendEmail/mutation spy asserted on both C3 branches; existing logger doMock shape supports mockError without new mock surface
+- RT9: pass — no twin implementation applicable
+
+```json
+[
+  {"id": "F1", "severity": "Minor", "title": "C1's assertNoMutation description cites non-existent mockEntryFindFirst instead of actual mockEntryFindUnique", "file": "docs/archive/review/fail-closed-sc-t3-remaining-plan.md", "line": 127, "adjacent": false, "escalate": null},
+  {"id": "F2", "severity": "Major", "title": "C4 real-Redis IP-limiter (5 req/min) cross-case pollution risk not fully pinned by the plan's stated mitigation", "file": "src/__tests__/db-integration/rate-limit-fail-closed-routes.integration.test.ts", "line": null, "adjacent": false, "escalate": null},
+  {"id": "F3", "severity": "Minor", "title": "C4 selective wrapper's del/clear routing may be unreachable in the two new test cases as scoped", "file": "src/app/api/share-links/verify-access/route.ts", "line": null, "adjacent": true, "escalate": null}
+]
+```
+
+---
+
+# Round 2 (verification of applied fixes)
+Date: 2026-07-20
+
+## Changes from Previous Round
+All 6 merged Round-1 findings (M-F1..M-F6) applied to the plan: SC1 rewrite,
+call-site count removal, mockEntryFindUnique correction, C4 fresh-random
+token, C4 reserved IPs 203.0.113.30/.31 + no-vitest-retry verification +
+token-key cleanup rationale, C4 del-branch documentation.
+
+## Functionality Findings
+No findings. All six fixes verified against plan text and source; references
+accurate (mockEntryFindUnique at [id]/route.test.ts:8,44; existing assertion
+:167-177); no regressions in INV-C2 member-set, consumer walkthrough, C3
+branch ordering, Go/No-Go gate. json index: [].
+
+## Security Findings
+No findings. SC1's retryAfterMs note verified safe (server-computed, bounded
+by windowMs, inherits retryAfterSecondsOrDefault clamp if ever wired — no
+RS5 concern). IPs .30/.31 independently confirmed unused; no vitest retry;
+token-key cleanup asymmetry correct (no orphaned real-Redis key from green
+case). Both Round-1 Adjacent Minors resolved. json index: [].
+
+## Testing Findings
+No findings. F1/F2/F3 verified resolved against live source and config
+(in-use IP set matches grep; no retry in configs, CLI, or CI wrapper;
+random 64-hex token satisfies hexHash schema at
+src/lib/validations/share.ts:125). RT4 fully closed; RT7 strengthened by the
+randomized-token fixture. json index: [].
+
+## Convergence
+All three experts returned "No findings" in Round 2. Plan review complete
+after 2 rounds. All contracts C1-C4 remain `locked`.

--- a/src/__tests__/db-integration/rate-limit-fail-closed-routes.integration.test.ts
+++ b/src/__tests__/db-integration/rate-limit-fail-closed-routes.integration.test.ts
@@ -43,6 +43,7 @@ import {
   beforeEach,
   afterEach,
 } from "vitest";
+import { randomBytes } from "node:crypto";
 import IORedis from "ioredis";
 import type { NextRequest } from "next/server";
 import { createRequest } from "@/__tests__/helpers/request-builder";
@@ -72,6 +73,60 @@ realRedis?.on("error", () => {});
 // client without re-importing — sound because createRateLimiter calls
 // getRedis() per check (rate-limit.ts:54; Round 1 adjudication of Func-A1).
 let activeRedis: IORedis = brokenRedis;
+
+/**
+ * Selective-failure Redis (plan fail-closed-sc-t3-remaining, C4): routes each
+ * command to the broken or the real client by key predicate, so one limiter
+ * leg of a multi-limiter route can fail while its sibling succeeds. Covers
+ * exactly the surface createRateLimiter uses (rate-limit.ts:60-106):
+ * pipeline().incr/pexpire/pttl -> exec, plus del (limiter clear). The del
+ * branch is defensive surface-completeness — the 503/404 paths under test
+ * never call limiter.clear(). No command result is fabricated: everything
+ * delegates to a real ioredis client.
+ */
+function createSelectiveRedis(
+  broken: IORedis,
+  real: IORedis,
+  failKeyPredicate: (key: string) => boolean,
+): IORedis {
+  const pick = (key: string) => (failKeyPredicate(key) ? broken : real);
+  type PipelineCmd = { cmd: "incr" | "pexpire" | "pttl"; args: unknown[] };
+  const selective = {
+    pipeline() {
+      const commands: PipelineCmd[] = [];
+      let routeKey: string | null = null;
+      const shim = {
+        incr(key: string) {
+          routeKey ??= key;
+          commands.push({ cmd: "incr", args: [key] });
+          return shim;
+        },
+        pexpire(key: string, ms: number, mode?: string) {
+          routeKey ??= key;
+          commands.push({ cmd: "pexpire", args: mode !== undefined ? [key, ms, mode] : [key, ms] });
+          return shim;
+        },
+        pttl(key: string) {
+          routeKey ??= key;
+          commands.push({ cmd: "pttl", args: [key] });
+          return shim;
+        },
+        exec() {
+          const pipeline = pick(routeKey ?? "").pipeline();
+          for (const { cmd, args } of commands) {
+            (pipeline[cmd] as (...a: unknown[]) => unknown)(...args);
+          }
+          return pipeline.exec();
+        },
+      };
+      return shim;
+    },
+    del(key: string) {
+      return pick(key).del(key);
+    },
+  };
+  return selective as unknown as IORedis;
+}
 
 vi.mock("@/lib/redis", () => ({
   getRedis: () => activeRedis,
@@ -256,5 +311,87 @@ describe.skipIf(!dbAvailable)(
         },
       );
     });
+
+    // C4 (fail-closed-sc-t3-remaining): the whole-outage cases above cannot
+    // reach verify-access's tokenLimiter — the ipLimiter leg fails closed
+    // first. Selective failure (IP keys real, token keys broken) drives the
+    // request PAST a passing ipLimiter into the token leg, proving the
+    // route wires tokenLimiter's production checkRateLimitOrFail mapping.
+    // Requires a reachable real Redis for the IP leg -> redisAvailable guard.
+    describe.skipIf(!redisAvailable)(
+      "POST /api/share-links/verify-access — tokenLimiter leg (selective Redis failure)",
+      () => {
+        // Reserved IPs (plan C4 hygiene): unused elsewhere in db-integration;
+        // one request per case against the 5-req/min IP cap.
+        const GREEN_IP = "203.0.113.30";
+        const RED_IP = "203.0.113.31";
+
+        // Fresh random token per run: the red-proof's 404 is guaranteed by
+        // construction, not by fixture-absence convention. 64-hex satisfies
+        // verifyShareAccessSchema's token shape.
+        const randomHexToken = () => randomBytes(32).toString("hex");
+
+        afterEach(async () => {
+          // Drop the rl counters this describe wrote to the REAL Redis (IP
+          // legs of both cases + the red-proof's token leg; the green case's
+          // token incr went to the broken client and never landed here).
+          const real = realRedis as IORedis;
+          const keys = await real.keys("rl:share_verify_*");
+          if (keys.length > 0) await real.del(...keys);
+        });
+
+        it("token leg broken, IP leg real -> 503 SERVICE_UNAVAILABLE with Retry-After, no shareAccessLog row", async () => {
+          activeRedis = createSelectiveRedis(brokenRedis, realRedis as IORedis, (key) =>
+            key.startsWith("rl:share_verify_token:"),
+          );
+
+          const countBefore = await ctx.su.prisma.shareAccessLog.count();
+
+          const req = requestWithIp(
+            "POST",
+            "http://localhost:3000/api/share-links/verify-access",
+            GREEN_IP,
+            { token: randomHexToken(), password: "test-password" },
+          );
+
+          const res = await verifyAccessPOST(req);
+
+          expect(res.status).toBe(503);
+          const body = await res.json();
+          expect(body).toEqual({ error: "SERVICE_UNAVAILABLE" });
+          const retryAfter = res.headers.get("Retry-After");
+          expect(retryAfter).toMatch(/^\d+$/);
+          expect(Number(retryAfter)).toBeGreaterThan(0);
+
+          const countAfter = await ctx.su.prisma.shareAccessLog.count();
+          expect(countAfter).toBe(countBefore);
+        });
+
+        it("red-proof: identical fixture with the token leg ALSO real -> non-503 domain response (404)", async () => {
+          // Whole path real. The IP leg is identical to the case above, so
+          // the 503 there is attributable ONLY to the token leg — a wrapper
+          // that failed every key (or was wired backwards) would 503 here
+          // too and fail this assertion.
+          activeRedis = realRedis as IORedis;
+
+          const countBefore = await ctx.su.prisma.shareAccessLog.count();
+
+          const req = requestWithIp(
+            "POST",
+            "http://localhost:3000/api/share-links/verify-access",
+            RED_IP,
+            { token: randomHexToken(), password: "test-password" },
+          );
+
+          const res = await verifyAccessPOST(req);
+
+          expect(res.status).not.toBe(503);
+          expect(res.status).toBe(404);
+
+          const countAfter = await ctx.su.prisma.shareAccessLog.count();
+          expect(countAfter).toBe(countBefore);
+        });
+      },
+    );
   },
 );

--- a/src/__tests__/db-integration/rate-limit-fail-closed-routes.integration.test.ts
+++ b/src/__tests__/db-integration/rate-limit-fail-closed-routes.integration.test.ts
@@ -45,6 +45,7 @@ import {
 } from "vitest";
 import { randomBytes } from "node:crypto";
 import IORedis from "ioredis";
+import { hashToken } from "@/lib/crypto/crypto-server";
 import type { NextRequest } from "next/server";
 import { createRequest } from "@/__tests__/helpers/request-builder";
 import { createTestContext, type TestContext } from "./helpers";
@@ -331,13 +332,31 @@ describe.skipIf(!dbAvailable)(
         // verifyShareAccessSchema's token shape.
         const randomHexToken = () => randomBytes(32).toString("hex");
 
+        // Exact-key cleanup ledger. A pattern KEYS + bulk DEL would delete
+        // counters this test never created (and KEYS blocks a large shared
+        // Redis) — if a developer points REDIS_URL at a shared/staging
+        // instance, that resets real protection state (external security
+        // review 2026-07-20, P2-2). Key shapes derived from the route:
+        // ip leg  rl:share_verify_ip:<ip>:<sha256(token)> (IPv4 passthrough
+        // in rateLimitKeyFromIp; checkIpRateLimit keySuffix = tokenHash),
+        // token leg rl:share_verify_token:<sha256(token)>.
+        const createdKeys: string[] = [];
+        const trackKeys = (ip: string, token: string) => {
+          const tokenHash = hashToken(token);
+          createdKeys.push(
+            `rl:share_verify_ip:${ip}:${tokenHash}`,
+            `rl:share_verify_token:${tokenHash}`,
+          );
+        };
+
         afterEach(async () => {
-          // Drop the rl counters this describe wrote to the REAL Redis (IP
-          // legs of both cases + the red-proof's token leg; the green case's
-          // token incr went to the broken client and never landed here).
-          const real = realRedis as IORedis;
-          const keys = await real.keys("rl:share_verify_*");
-          if (keys.length > 0) await real.del(...keys);
+          // Drop exactly the counters this describe's cases created on the
+          // REAL Redis (the green case's token incr went to the broken
+          // client and never landed here — deleting its computed key is a
+          // no-op, kept for symmetry).
+          if (createdKeys.length > 0) {
+            await (realRedis as IORedis).del(...createdKeys.splice(0));
+          }
         });
 
         it("token leg broken, IP leg real -> 503 SERVICE_UNAVAILABLE with Retry-After, no shareAccessLog row", async () => {
@@ -347,11 +366,13 @@ describe.skipIf(!dbAvailable)(
 
           const countBefore = await ctx.su.prisma.shareAccessLog.count();
 
+          const token = randomHexToken();
+          trackKeys(GREEN_IP, token);
           const req = requestWithIp(
             "POST",
             "http://localhost:3000/api/share-links/verify-access",
             GREEN_IP,
-            { token: randomHexToken(), password: "test-password" },
+            { token, password: "test-password" },
           );
 
           const res = await verifyAccessPOST(req);
@@ -376,11 +397,13 @@ describe.skipIf(!dbAvailable)(
 
           const countBefore = await ctx.su.prisma.shareAccessLog.count();
 
+          const token = randomHexToken();
+          trackKeys(RED_IP, token);
           const req = requestWithIp(
             "POST",
             "http://localhost:3000/api/share-links/verify-access",
             RED_IP,
-            { token: randomHexToken(), password: "test-password" },
+            { token, password: "test-password" },
           );
 
           const res = await verifyAccessPOST(req);

--- a/src/app/api/v1/passwords/[id]/route.test.ts
+++ b/src/app/api/v1/passwords/[id]/route.test.ts
@@ -115,9 +115,13 @@ const v1LimiterCallIndex = mockCreateRateLimiter.mock.calls.findIndex(
   ([opts]) =>
     opts.windowMs === RATE_WINDOW_MS && opts.max === 100 && opts.failClosedOnRedisError === true,
 );
-const v1Limiter = mockCreateRateLimiter.mock.results[v1LimiterCallIndex]!.value as {
-  check: typeof mockCheck;
-};
+const v1LimiterResult = mockCreateRateLimiter.mock.results[v1LimiterCallIndex];
+if (!v1LimiterResult) {
+  throw new Error(
+    "v1ApiKeyLimiter factory call not found — rate-limiters.ts options drifted from this test's match criteria (windowMs/max/failClosedOnRedisError)",
+  );
+}
+const v1Limiter = v1LimiterResult.value as { check: typeof mockCheck };
 
 const PW_ID = "pw-123";
 const USER_ID = "user-1";

--- a/src/app/api/v1/passwords/[id]/route.test.ts
+++ b/src/app/api/v1/passwords/[id]/route.test.ts
@@ -5,6 +5,7 @@ const {
   mockValidateApiKeyOnly,
   mockEnforceAccessRestriction,
   mockCheck,
+  mockCreateRateLimiter,
   mockEntryFindUnique,
   mockEntryUpdate,
   mockEntryDelete,
@@ -37,10 +38,19 @@ const {
     return Promise.resolve([curRow]);
   });
 
+  // Bind `check` first — the factory closure must not reference the returned
+  // object's own properties (vi.hoisted TDZ self-reference, tranche-3 lesson).
+  const check = vi.fn().mockResolvedValue({ allowed: true });
+
   return {
     mockValidateApiKeyOnly: vi.fn(),
     mockEnforceAccessRestriction: vi.fn().mockResolvedValue(null),
-    mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
+    mockCheck: check,
+    // Recording factory: assertRedisFailClosed's factory-attribution step
+    // reads mock.calls/mock.results (a plain arrow would record nothing).
+    mockCreateRateLimiter: vi.fn(
+      (_opts: { windowMs: number; max: number; failClosedOnRedisError?: boolean }) => ({ check }),
+    ),
     mockEntryFindUnique: vi.fn(),
     mockEntryUpdate: vi.fn(),
     mockEntryDelete: vi.fn(),
@@ -67,7 +77,7 @@ const V1_CUR_ROW = {
 vi.mock("@/lib/auth/tokens/api-key", () => ({ validateApiKeyOnly: mockValidateApiKeyOnly }));
 vi.mock("@/lib/auth/policy/access-restriction", () => ({ enforceAccessRestriction: mockEnforceAccessRestriction }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: () => ({ check: mockCheck }),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {
@@ -92,6 +102,22 @@ vi.mock("@/lib/audit/audit", () => ({
 }));
 
 import { GET, PUT, DELETE } from "./route";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
+import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
+
+// Module-scope snapshot: rate-limiters.ts's module-level createRateLimiter
+// calls ran at import time above; capture before beforeEach's
+// vi.clearAllMocks() wipes mock.calls/mock.results (see snapshotFactory doc).
+// Resolve the limiter under test by factory ARGS, not positional index —
+// the same mocked factory also constructs migrateLimiter et al. at load.
+const limiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const v1LimiterCallIndex = mockCreateRateLimiter.mock.calls.findIndex(
+  ([opts]) =>
+    opts.windowMs === RATE_WINDOW_MS && opts.max === 100 && opts.failClosedOnRedisError === true,
+);
+const v1Limiter = mockCreateRateLimiter.mock.results[v1LimiterCallIndex]!.value as {
+  check: typeof mockCheck;
+};
 
 const PW_ID = "pw-123";
 const USER_ID = "user-1";
@@ -165,15 +191,18 @@ describe("GET /api/v1/passwords/[id]", () => {
   });
 
   it("fails closed with 503 when the limiter reports redisErrored (no DB access)", async () => {
-    mockCheck.mockResolvedValue({ allowed: false, redisErrored: true });
-    const res = await GET(
-      createRequest("GET", `http://localhost/api/v1/passwords/${PW_ID}`),
-      createParams({ id: PW_ID }),
-    );
-    const { status, json } = await parseResponse(res);
-    expect(status).toBe(503);
-    expect(json).toEqual({ error: "SERVICE_UNAVAILABLE" });
-    expect(mockEntryFindUnique).not.toHaveBeenCalled();
+    await assertRedisFailClosed({
+      invoke: () =>
+        GET(
+          createRequest("GET", `http://localhost/api/v1/passwords/${PW_ID}`),
+          createParams({ id: PW_ID }),
+        ),
+      limiter: v1Limiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockEntryFindUnique],
+      limiterFactory: limiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   it("returns 404 when entry not found", async () => {

--- a/src/app/api/v1/passwords/[id]/route.test.ts
+++ b/src/app/api/v1/passwords/[id]/route.test.ts
@@ -1,10 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { createRequest, createParams, parseResponse } from "@/__tests__/helpers/request-builder";
 
 const {
   mockValidateApiKeyOnly,
   mockEnforceAccessRestriction,
-  mockCheck,
   mockCreateRateLimiter,
   mockEntryFindUnique,
   mockEntryUpdate,
@@ -38,18 +37,19 @@ const {
     return Promise.resolve([curRow]);
   });
 
-  // Bind `check` first — the factory closure must not reference the returned
-  // object's own properties (vi.hoisted TDZ self-reference, tranche-3 lesson).
-  const check = vi.fn().mockResolvedValue({ allowed: true });
-
   return {
     mockValidateApiKeyOnly: vi.fn(),
     mockEnforceAccessRestriction: vi.fn().mockResolvedValue(null),
-    mockCheck: check,
     // Recording factory: assertRedisFailClosed's factory-attribution step
     // reads mock.calls/mock.results (a plain arrow would record nothing).
+    // Each call returns a DISTINCT check mock (default allowed:true) so a
+    // route wired to the wrong limiter cannot borrow the arranged failure —
+    // the fail-closed cases arm only the v1 instance's check (external
+    // security review 2026-07-20, P2-1).
     mockCreateRateLimiter: vi.fn(
-      (_opts: { windowMs: number; max: number; failClosedOnRedisError?: boolean }) => ({ check }),
+      (_opts: { windowMs: number; max: number; failClosedOnRedisError?: boolean }) => ({
+        check: vi.fn().mockResolvedValue({ allowed: true }),
+      }),
     ),
     mockEntryFindUnique: vi.fn(),
     mockEntryUpdate: vi.fn(),
@@ -121,7 +121,12 @@ if (!v1LimiterResult) {
     "v1ApiKeyLimiter factory call not found — rate-limiters.ts options drifted from this test's match criteria (windowMs/max/failClosedOnRedisError)",
   );
 }
-const v1Limiter = v1LimiterResult.value as { check: typeof mockCheck };
+const v1Limiter = v1LimiterResult.value as { check: Mock };
+// The v1 instance's own check — arranging THIS mock (and only this one)
+// proves the route is wired to v1ApiKeyLimiter; sibling factory products
+// keep their allowed:true default, so a miswired route fails the
+// "limiter reached" assertion instead of borrowing the arranged result.
+const mockCheck = v1Limiter.check;
 
 const PW_ID = "pw-123";
 const USER_ID = "user-1";

--- a/src/app/api/v1/passwords/route.test.ts
+++ b/src/app/api/v1/passwords/route.test.ts
@@ -5,6 +5,7 @@ const {
   mockValidateApiKeyOnly,
   mockEnforceAccessRestriction,
   mockCheck,
+  mockCreateRateLimiter,
   mockEntryFindMany,
   mockEntryCreate,
   mockFolderFindFirst,
@@ -12,25 +13,35 @@ const {
   mockLogAudit,
   mockWithTenantRls,
   mockQueryRaw,
-} = vi.hoisted(() => ({
-  mockValidateApiKeyOnly: vi.fn(),
-  mockEnforceAccessRestriction: vi.fn().mockResolvedValue(null),
-  mockCheck: vi.fn().mockResolvedValue({ allowed: true }),
-  mockEntryFindMany: vi.fn(),
-  mockEntryCreate: vi.fn(),
-  mockFolderFindFirst: vi.fn(),
-  mockTagCount: vi.fn(),
-  mockLogAudit: vi.fn(),
-  mockWithTenantRls: vi.fn(async (prisma: unknown, _tenantId: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
-  // assertCurrentKeyVersion's `SELECT key_version FROM users ... FOR SHARE` —
-  // default matches validBody.keyVersion (1) so the guard passes.
-  mockQueryRaw: vi.fn().mockResolvedValue([{ key_version: 1 }]),
-}));
+} = vi.hoisted(() => {
+  // Bind `check` first — the factory closure must not reference the returned
+  // object's own properties (vi.hoisted TDZ self-reference, tranche-3 lesson).
+  const check = vi.fn().mockResolvedValue({ allowed: true });
+  return {
+    mockValidateApiKeyOnly: vi.fn(),
+    mockEnforceAccessRestriction: vi.fn().mockResolvedValue(null),
+    mockCheck: check,
+    // Recording factory: assertRedisFailClosed's factory-attribution step
+    // reads mock.calls/mock.results (a plain arrow would record nothing).
+    mockCreateRateLimiter: vi.fn(
+      (_opts: { windowMs: number; max: number; failClosedOnRedisError?: boolean }) => ({ check }),
+    ),
+    mockEntryFindMany: vi.fn(),
+    mockEntryCreate: vi.fn(),
+    mockFolderFindFirst: vi.fn(),
+    mockTagCount: vi.fn(),
+    mockLogAudit: vi.fn(),
+    mockWithTenantRls: vi.fn(async (prisma: unknown, _tenantId: unknown, fn: (tx: unknown) => unknown) => fn(prisma)),
+    // assertCurrentKeyVersion's `SELECT key_version FROM users ... FOR SHARE` —
+    // default matches validBody.keyVersion (1) so the guard passes.
+    mockQueryRaw: vi.fn().mockResolvedValue([{ key_version: 1 }]),
+  };
+});
 
 vi.mock("@/lib/auth/tokens/api-key", () => ({ validateApiKeyOnly: mockValidateApiKeyOnly }));
 vi.mock("@/lib/auth/policy/access-restriction", () => ({ enforceAccessRestriction: mockEnforceAccessRestriction }));
 vi.mock("@/lib/security/rate-limit", () => ({
-  createRateLimiter: () => ({ check: mockCheck }),
+  createRateLimiter: mockCreateRateLimiter,
 }));
 vi.mock("@/lib/prisma", () => ({
   prisma: {
@@ -59,6 +70,22 @@ vi.mock("@/lib/logger", () => {
 });
 
 import { GET, POST } from "./route";
+import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
+import { RATE_WINDOW_MS } from "@/lib/validations/common.server";
+
+// Module-scope snapshot: rate-limiters.ts's module-level createRateLimiter
+// calls ran at import time above; capture before beforeEach's
+// vi.clearAllMocks() wipes mock.calls/mock.results (see snapshotFactory doc).
+// Resolve the limiter under test by factory ARGS, not positional index —
+// the same mocked factory also constructs migrateLimiter et al. at load.
+const limiterFactorySnapshot = snapshotFactory(mockCreateRateLimiter);
+const v1LimiterCallIndex = mockCreateRateLimiter.mock.calls.findIndex(
+  ([opts]) =>
+    opts.windowMs === RATE_WINDOW_MS && opts.max === 100 && opts.failClosedOnRedisError === true,
+);
+const v1Limiter = mockCreateRateLimiter.mock.results[v1LimiterCallIndex]!.value as {
+  check: typeof mockCheck;
+};
 
 const USER_ID = "user-1";
 const TENANT_ID = "tenant-1";
@@ -136,12 +163,14 @@ describe("GET /api/v1/passwords", () => {
   });
 
   it("fails closed with 503 when the limiter reports redisErrored (no DB access)", async () => {
-    mockCheck.mockResolvedValue({ allowed: false, redisErrored: true });
-    const res = await GET(createRequest("GET", "http://localhost/api/v1/passwords"));
-    const { status, json } = await parseResponse(res);
-    expect(status).toBe(503);
-    expect(json).toEqual({ error: "SERVICE_UNAVAILABLE" });
-    expect(mockEntryFindMany).not.toHaveBeenCalled();
+    await assertRedisFailClosed({
+      invoke: () => GET(createRequest("GET", "http://localhost/api/v1/passwords")),
+      limiter: v1Limiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockEntryFindMany],
+      limiterFactory: limiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   it("returns access restriction response when denied", async () => {
@@ -366,14 +395,15 @@ describe("POST /api/v1/passwords", () => {
   });
 
   it("fails closed with 503 when the limiter reports redisErrored (no create)", async () => {
-    mockCheck.mockResolvedValue({ allowed: false, redisErrored: true });
-    const res = await POST(
-      createRequest("POST", "http://localhost/api/v1/passwords", { body: validBody }),
-    );
-    const { status, json } = await parseResponse(res);
-    expect(status).toBe(503);
-    expect(json).toEqual({ error: "SERVICE_UNAVAILABLE" });
-    expect(mockEntryCreate).not.toHaveBeenCalled();
+    await assertRedisFailClosed({
+      invoke: () =>
+        POST(createRequest("POST", "http://localhost/api/v1/passwords", { body: validBody })),
+      limiter: v1Limiter,
+      expectation: { envelope: "canonical" },
+      assertNoMutation: [mockEntryCreate],
+      limiterFactory: limiterFactorySnapshot.replay(),
+      failure: { allowed: false, redisErrored: true },
+    });
   });
 
   it("returns 400 on invalid body (missing required fields)", async () => {

--- a/src/app/api/v1/passwords/route.test.ts
+++ b/src/app/api/v1/passwords/route.test.ts
@@ -83,9 +83,13 @@ const v1LimiterCallIndex = mockCreateRateLimiter.mock.calls.findIndex(
   ([opts]) =>
     opts.windowMs === RATE_WINDOW_MS && opts.max === 100 && opts.failClosedOnRedisError === true,
 );
-const v1Limiter = mockCreateRateLimiter.mock.results[v1LimiterCallIndex]!.value as {
-  check: typeof mockCheck;
-};
+const v1LimiterResult = mockCreateRateLimiter.mock.results[v1LimiterCallIndex];
+if (!v1LimiterResult) {
+  throw new Error(
+    "v1ApiKeyLimiter factory call not found — rate-limiters.ts options drifted from this test's match criteria (windowMs/max/failClosedOnRedisError)",
+  );
+}
+const v1Limiter = v1LimiterResult.value as { check: typeof mockCheck };
 
 const USER_ID = "user-1";
 const TENANT_ID = "tenant-1";

--- a/src/app/api/v1/passwords/route.test.ts
+++ b/src/app/api/v1/passwords/route.test.ts
@@ -1,10 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { createRequest, parseResponse } from "@/__tests__/helpers/request-builder";
 
 const {
   mockValidateApiKeyOnly,
   mockEnforceAccessRestriction,
-  mockCheck,
   mockCreateRateLimiter,
   mockEntryFindMany,
   mockEntryCreate,
@@ -14,17 +13,19 @@ const {
   mockWithTenantRls,
   mockQueryRaw,
 } = vi.hoisted(() => {
-  // Bind `check` first — the factory closure must not reference the returned
-  // object's own properties (vi.hoisted TDZ self-reference, tranche-3 lesson).
-  const check = vi.fn().mockResolvedValue({ allowed: true });
   return {
     mockValidateApiKeyOnly: vi.fn(),
     mockEnforceAccessRestriction: vi.fn().mockResolvedValue(null),
-    mockCheck: check,
     // Recording factory: assertRedisFailClosed's factory-attribution step
     // reads mock.calls/mock.results (a plain arrow would record nothing).
+    // Each call returns a DISTINCT check mock (default allowed:true) so a
+    // route wired to the wrong limiter cannot borrow the arranged failure —
+    // the fail-closed cases arm only the v1 instance's check (external
+    // security review 2026-07-20, P2-1).
     mockCreateRateLimiter: vi.fn(
-      (_opts: { windowMs: number; max: number; failClosedOnRedisError?: boolean }) => ({ check }),
+      (_opts: { windowMs: number; max: number; failClosedOnRedisError?: boolean }) => ({
+        check: vi.fn().mockResolvedValue({ allowed: true }),
+      }),
     ),
     mockEntryFindMany: vi.fn(),
     mockEntryCreate: vi.fn(),
@@ -89,7 +90,12 @@ if (!v1LimiterResult) {
     "v1ApiKeyLimiter factory call not found — rate-limiters.ts options drifted from this test's match criteria (windowMs/max/failClosedOnRedisError)",
   );
 }
-const v1Limiter = v1LimiterResult.value as { check: typeof mockCheck };
+const v1Limiter = v1LimiterResult.value as { check: Mock };
+// The v1 instance's own check — arranging THIS mock (and only this one)
+// proves the route is wired to v1ApiKeyLimiter; sibling factory products
+// keep their allowed:true default, so a miswired route fails the
+// "limiter reached" assertion instead of borrowing the arranged result.
+const mockCheck = v1Limiter.check;
 
 const USER_ID = "user-1";
 const TENANT_ID = "tenant-1";

--- a/src/auth.config.test.ts
+++ b/src/auth.config.test.ts
@@ -309,10 +309,12 @@ describe("auth.config magic-link provider settings", () => {
 });
 
 // C8a — magic-link silent-drop fail-closed contract (plan
-// fail-closed-tranche2, contract C8a). `sendVerificationRequest` treats
-// redisErrored identically to over-limit: warn-log + no email sent
-// (anti-enumeration). Production code is unchanged; this pins the
-// existing behavior with the non-Response helper variant.
+// fail-closed-tranche2, contract C8a; log-channel split per
+// fail-closed-sc-t3-remaining C3). `sendVerificationRequest` silently drops
+// on BOTH redisErrored and over-limit (anti-enumeration: no throw, no email),
+// but logs each on a distinct channel — error "magic-link.rate-limit.fail_closed"
+// for the operator-actionable outage vs warn "magic-link.rate-limited" for
+// expected over-limit noise.
 describe("auth.config magic-link: redisErrored silent-drop (C8a)", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -324,15 +326,16 @@ describe("auth.config magic-link: redisErrored silent-drop (C8a)", () => {
     vi.unstubAllEnvs();
   });
 
-  it("fails closed (silent drop, no email) when Redis is unavailable", async () => {
+  async function arrangeMagicLinkProvider() {
     vi.stubEnv("EMAIL_PROVIDER", "nodemailer");
 
     const mockSendEmail = vi.fn();
     vi.doMock("@/lib/email", () => ({ sendEmail: mockSendEmail }));
 
     const mockWarn = vi.fn();
+    const mockError = vi.fn();
     vi.doMock("@/lib/logger", () => ({
-      getLogger: () => ({ warn: mockWarn, error: vi.fn(), info: vi.fn() }),
+      getLogger: () => ({ warn: mockWarn, error: mockError, info: vi.fn() }),
     }));
 
     const mockCheck = vi.fn();
@@ -351,18 +354,41 @@ describe("auth.config magic-link: redisErrored silent-drop (C8a)", () => {
     ) as { sendVerificationRequest: (args: { identifier: string; url: string }) => Promise<void> };
     expect(nodemailerProvider).toBeDefined();
 
+    return { mockSendEmail, mockWarn, mockError, limiter, factorySnapshot, nodemailerProvider };
+  }
+
+  const sendArgs = {
+    identifier: "user@example.com",
+    url: "https://example.com/api/auth/callback/nodemailer?callbackUrl=/ja/dashboard&token=abc",
+  };
+
+  it("fails closed (silent drop, no email) when Redis is unavailable, on the outage log channel", async () => {
+    const { mockSendEmail, mockWarn, mockError, limiter, factorySnapshot, nodemailerProvider } =
+      await arrangeMagicLinkProvider();
+
     await assertRedisFailClosedSilentDrop({
-      invoke: () =>
-        nodemailerProvider.sendVerificationRequest({
-          identifier: "user@example.com",
-          url: "https://example.com/api/auth/callback/nodemailer?callbackUrl=/ja/dashboard&token=abc",
-        }),
+      invoke: () => nodemailerProvider.sendVerificationRequest(sendArgs),
       limiter,
       assertNoEffect: [mockSendEmail],
       limiterFactory: factorySnapshot.replay(),
       failure: { allowed: false, redisErrored: true },
     });
 
+    expect(mockError).toHaveBeenCalledWith("magic-link.rate-limit.fail_closed");
+    expect(mockWarn).not.toHaveBeenCalledWith("magic-link.rate-limited");
+  });
+
+  it("silently drops over-limit sends on the warn channel (no email, no outage log)", async () => {
+    const { mockSendEmail, mockWarn, mockError, limiter, nodemailerProvider } =
+      await arrangeMagicLinkProvider();
+
+    limiter.check.mockResolvedValue({ allowed: false });
+
+    await nodemailerProvider.sendVerificationRequest(sendArgs);
+
+    expect(limiter.check).toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
     expect(mockWarn).toHaveBeenCalledWith("magic-link.rate-limited");
+    expect(mockError).not.toHaveBeenCalledWith("magic-link.rate-limit.fail_closed");
   });
 });

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -115,6 +115,14 @@ export default {
               const rl = await magicLinkEmailLimiter.check(
                 `rl:magic_link:${email.toLowerCase()}`,
               );
+              if (rl.redisErrored) {
+                // Redis outage (fail-closed) — operator-actionable, so log on
+                // a channel distinct from expected over-limit noise. Same
+                // silent drop as over-limit: no throw, no email, and no PII
+                // in the log line (anti-enumeration is externally unchanged).
+                getLogger().error("magic-link.rate-limit.fail_closed");
+                return;
+              }
               if (!rl.allowed) {
                 getLogger().warn("magic-link.rate-limited");
                 return; // silently drop — no user enumeration

--- a/src/lib/http/api-response.ts
+++ b/src/lib/http/api-response.ts
@@ -154,7 +154,9 @@ const DEFAULT_SERVICE_UNAVAILABLE_RETRY_AFTER_SEC = 30;
 // 503 envelopes ALWAYS set Retry-After (operator playbook requires a back-off
 // hint on service-unavailable; 429 may omit when the limiter cannot compute).
 // retryAfterMs of 0 / null / undefined → use the 30 s default, not "no header".
-function retryAfterSecondsOrDefault(retryAfterMs?: number): string {
+// Exported so bespoke 503 producers (e.g. the SCIM error envelope) reuse the
+// same delay-seconds conversion and 30 s default instead of a second literal.
+export function retryAfterSecondsOrDefault(retryAfterMs?: number): string {
   const sec =
     retryAfterMs != null && retryAfterMs > 0
       ? Math.ceil(retryAfterMs / MS_PER_SECOND)

--- a/src/lib/scim/response.test.ts
+++ b/src/lib/scim/response.test.ts
@@ -46,6 +46,20 @@ describe("scimError", () => {
     const res = scimError(400, "Bad request");
     expect(res.headers.get("content-type")).toBe("application/scim+json");
   });
+
+  it("emits caller-supplied extra headers", () => {
+    const res = scimError(503, "Service temporarily unavailable", undefined, {
+      "Retry-After": "45",
+    });
+    expect(res.headers.get("retry-after")).toBe("45");
+  });
+
+  it("caller-supplied headers cannot override Content-Type", () => {
+    const res = scimError(503, "Service temporarily unavailable", undefined, {
+      "Content-Type": "text/html",
+    });
+    expect(res.headers.get("content-type")).toBe("application/scim+json");
+  });
 });
 
 describe("scimListResponse", () => {

--- a/src/lib/scim/response.test.ts
+++ b/src/lib/scim/response.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { scimResponse, scimError, scimListResponse, getScimBaseUrl } from "./response";
 
 describe("scimResponse", () => {
@@ -81,33 +81,29 @@ describe("scimListResponse", () => {
 });
 
 describe("getScimBaseUrl", () => {
-  const originalAppUrl = process.env.APP_URL;
-  const originalAuthUrl = process.env.AUTH_URL;
-  const originalBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
-
+  // vi.stubEnv with undefined unsets the variable (precedent: redis.test.ts);
+  // setup.ts wires the global unstub, the local afterEach keeps this block
+  // hermetic regardless of suite composition.
   function clearEnv() {
-    delete process.env.APP_URL;
-    delete process.env.AUTH_URL;
-    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    vi.stubEnv("APP_URL", undefined);
+    vi.stubEnv("AUTH_URL", undefined);
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", undefined);
   }
 
   afterEach(() => {
-    clearEnv();
-    if (originalAppUrl !== undefined) process.env.APP_URL = originalAppUrl;
-    if (originalAuthUrl !== undefined) process.env.AUTH_URL = originalAuthUrl;
-    if (originalBasePath !== undefined) process.env.NEXT_PUBLIC_BASE_PATH = originalBasePath;
+    vi.unstubAllEnvs();
   });
 
   it("prefers APP_URL over AUTH_URL", () => {
     clearEnv();
-    process.env.APP_URL = "https://app.example.com";
-    process.env.AUTH_URL = "https://auth.example.com";
+    vi.stubEnv("APP_URL", "https://app.example.com");
+    vi.stubEnv("AUTH_URL", "https://auth.example.com");
     expect(getScimBaseUrl()).toBe("https://app.example.com/api/scim/v2");
   });
 
   it("falls back to AUTH_URL when APP_URL is not set", () => {
     clearEnv();
-    process.env.AUTH_URL = "https://auth.example.com";
+    vi.stubEnv("AUTH_URL", "https://auth.example.com");
     expect(getScimBaseUrl()).toBe("https://auth.example.com/api/scim/v2");
   });
 
@@ -118,35 +114,35 @@ describe("getScimBaseUrl", () => {
 
   it("strips trailing slash from origin", () => {
     clearEnv();
-    process.env.AUTH_URL = "https://example.com/";
+    vi.stubEnv("AUTH_URL", "https://example.com/");
     expect(getScimBaseUrl()).toBe("https://example.com/api/scim/v2");
   });
 
   it("includes NEXT_PUBLIC_BASE_PATH in URL", () => {
     clearEnv();
-    process.env.AUTH_URL = "https://example.com";
-    process.env.NEXT_PUBLIC_BASE_PATH = "/passwd-sso";
+    vi.stubEnv("AUTH_URL", "https://example.com");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/passwd-sso");
     expect(getScimBaseUrl()).toBe("https://example.com/passwd-sso/api/scim/v2");
   });
 
   it("strips trailing slash from NEXT_PUBLIC_BASE_PATH", () => {
     clearEnv();
-    process.env.AUTH_URL = "https://example.com";
-    process.env.NEXT_PUBLIC_BASE_PATH = "/passwd-sso/";
+    vi.stubEnv("AUTH_URL", "https://example.com");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/passwd-sso/");
     expect(getScimBaseUrl()).toBe("https://example.com/passwd-sso/api/scim/v2");
   });
 
   it("prepends leading slash when NEXT_PUBLIC_BASE_PATH lacks one", () => {
     clearEnv();
-    process.env.AUTH_URL = "https://example.com";
-    process.env.NEXT_PUBLIC_BASE_PATH = "passwd-sso";
+    vi.stubEnv("AUTH_URL", "https://example.com");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "passwd-sso");
     expect(getScimBaseUrl()).toBe("https://example.com/passwd-sso/api/scim/v2");
   });
 
   it("uses APP_URL with basePath", () => {
     clearEnv();
-    process.env.APP_URL = "https://public.example.com";
-    process.env.NEXT_PUBLIC_BASE_PATH = "/passwd-sso";
+    vi.stubEnv("APP_URL", "https://public.example.com");
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/passwd-sso");
     expect(getScimBaseUrl()).toBe("https://public.example.com/passwd-sso/api/scim/v2");
   });
 });

--- a/src/lib/scim/response.ts
+++ b/src/lib/scim/response.ts
@@ -48,6 +48,7 @@ export function scimError(
   status: number,
   detail: string,
   scimType?: string,
+  headers?: Record<string, string>,
 ): NextResponse {
   const body: Record<string, unknown> = {
     schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
@@ -58,7 +59,9 @@ export function scimError(
 
   return NextResponse.json(body, {
     status,
-    headers: { "Content-Type": SCIM_CONTENT_TYPE },
+    // Content-Type last so a caller-supplied headers object can never
+    // override the SCIM media type.
+    headers: { ...headers, "Content-Type": SCIM_CONTENT_TYPE },
   });
 }
 

--- a/src/lib/scim/with-scim-auth.test.ts
+++ b/src/lib/scim/with-scim-auth.test.ts
@@ -176,7 +176,7 @@ describe("authorizeScim", () => {
           status: "503",
           detail: "Service temporarily unavailable",
         },
-        retryAfter: "forbidden",
+        retryAfter: "required",
       },
       assertNoMutation: [tenantLookupSpy],
       limiterFactory: scimLimiterFactorySnapshot.replay(),

--- a/src/lib/scim/with-scim-auth.test.ts
+++ b/src/lib/scim/with-scim-auth.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Mock } from "vitest";
 import type { NextRequest } from "next/server";
 import { assertRedisFailClosed, snapshotFactory } from "@/__tests__/helpers/fail-closed";
 import { AUDIT_ACTION } from "@/lib/constants";

--- a/src/lib/scim/with-scim-auth.ts
+++ b/src/lib/scim/with-scim-auth.ts
@@ -1,6 +1,7 @@
 import type { NextRequest, NextResponse } from "next/server";
 import { validateScimToken, type ValidatedScimToken } from "@/lib/auth/tokens/scim-token";
 import { scimError } from "@/lib/scim/response";
+import { retryAfterSecondsOrDefault } from "@/lib/http/api-response";
 import { enforceAccessRestriction } from "@/lib/auth/policy/access-restriction";
 import { checkScimRateLimit } from "@/lib/scim/rate-limit";
 import { emitRateLimitFailClosed } from "@/lib/security/rate-limit-audit";
@@ -31,7 +32,12 @@ export async function authorizeScim(
   if (rl.redisErrored) {
     // fail-closed: Redis is the only place a global cap can hold across Pods.
     void emitRateLimitFailClosed({ req, scope: "scim", userId: null, tenantId });
-    return { ok: false, response: scimError(503, "Service temporarily unavailable") };
+    return {
+      ok: false,
+      response: scimError(503, "Service temporarily unavailable", undefined, {
+        "Retry-After": retryAfterSecondsOrDefault(),
+      }),
+    };
   }
   if (!rl.allowed) {
     return { ok: false, response: scimError(429, "Too many requests") };


### PR DESCRIPTION
## Summary
- Closes the final four SC-T3 backlog items (SC-T3-2 through SC-T3-5) so the fail-closed invariant now holds across every 503-producing path.
- Adds `Retry-After` to the SCIM fail-closed 503, making it the last producer to satisfy the repo's operator contract that every service-unavailable envelope carries a back-off hint (RFC 9110 §15.6.4 permits it; RFC 7644 body is untouched).
- Splits the magic-link Redis-outage log into a dedicated `error` channel while strictly preserving the silent-drop contract and keeping PII out of the log line.
- Migrates v1/passwords fail-closed tests to the shared helper with per-instance limiter attribution, and proves the verify-access `tokenLimiter` fail-closed path via a selective-failure Redis wrapper without mocking the production rate-limit chain.

## Motivation
The fail-closed initiative requires any rate-limiter failure (including Redis connectivity loss) to degrade to a `503` with consistent observability and client retry semantics. Four SC-T3 backlog items remained open: SCIM was the last 503 producer missing `Retry-After`, the magic-link path produced indistinguishable log noise for infrastructure failures vs. expected over-limit drops, the v1/passwords tests could not prove which limiter the route was wired to, and the verify-access `tokenLimiter` had no route-tier fail-closed proof. This PR closes those gaps. Full scope: `./docs/archive/review/fail-closed-sc-t3-remaining-plan.md`.

## Implementation notes
- **SC-T3-2 (SCIM Retry-After)** — `scimError` (`src/lib/scim/response.ts`) gains an additive optional `headers` param, merged as `{ ...headers, "Content-Type": SCIM_CONTENT_TYPE }` so a caller can never override the SCIM media type. The 30 s default is single-owned by exporting `retryAfterSecondsOrDefault()` from `src/lib/http/api-response.ts` (no new literal). The `redisErrored → 503` producer class is now exactly 5 members, all carrying `Retry-After`.
- **SC-T3-3 (v1/passwords test migration)** — recording factory + `snapshotFactory` + `assertRedisFailClosed`; the limiter under test is resolved by factory arguments (`windowMs`/`max`/`failClosedOnRedisError`), not positional index, and a guarded lookup throws a descriptive error on option drift instead of an opaque `TypeError`. Each factory call now returns a distinct `check` mock so a route miswired to the fail-open `migrateLimiter` fails the test instead of borrowing the armed failure.
- **SC-T3-5 (magic-link log split)** — a `redisErrored` branch precedes `!rl.allowed` in `src/auth.config.ts`, emitting `error("magic-link.rate-limit.fail_closed")` for the operator-actionable outage vs. `warn("magic-link.rate-limited")` for expected over-limit noise. Both branches resolve `undefined` and skip `sendEmail`; the log call is a bare literal (no email/PII).
- **SC-T3-4 (verify-access integration proof)** — `createSelectiveRedis` routes `pipeline`/`del` to a real or broken `IORedis` by key predicate (`rl:share_verify_token:` → broken), driving the request past a genuinely-passing IP limiter into the token leg with the production chain unmocked. A red-proof runs the identical fixture whole-real and expects `404`, isolating the `503` to the token leg. Cleanup deletes only an exact-key ledger computed from each case's reserved IP and per-run random token — no `KEYS` scan, so pointing `REDIS_URL` at a shared/staging instance cannot reset unrelated counters.

## Review artifacts
- [plan](./docs/archive/review/fail-closed-sc-t3-remaining-plan.md) · [plan review](./docs/archive/review/fail-closed-sc-t3-remaining-review.md) · [code review](./docs/archive/review/fail-closed-sc-t3-remaining-code-review.md) · [deviation log](./docs/archive/review/fail-closed-sc-t3-remaining-deviation.md)

## Test plan
- [x] Full unit suite: `npx vitest run` — 12,772 passed / 1 skipped
- [x] Production build: `npx next build` — succeeded
- [x] Integration suite against local Postgres+Redis: `npm run test:integration` — 89 files passed (verify-access selective-Redis C4 pair + exact-key cleanup; stable across 3 consecutive runs)
- [x] Fail-closed route gate: `bash scripts/checks/check-fail-closed-routes-have-test.sh` — exit 0, zero manifest diffs
- [x] `scripts/pre-pr.sh` aggregate — 51/51 pass; `tsc --noEmit` clean; ESLint clean
- [ ] (Deferred, VE3) Validate SCIM `Retry-After` against a real Okta/Entra provisioning client in staging — see plan Scope contract SC4

🤖 Generated with [Claude Code](https://claude.com/claude-code)