### PR TITLE
test(worker): deterministically prove audit-outbox sweep caps

### DIFF
--- a/src/__tests__/db-integration/audit-outbox-sweep-caps.integration.test.ts
+++ b/src/__tests__/db-integration/audit-outbox-sweep-caps.integration.test.ts
@@ -1,16 +1,49 @@
 /**
  * C8: cap regression tests for C1 (reapStuckRows), C2 (reapStuckDeliveries),
- * and C3 (purgeRetention) — each must transition at most `limit` rows per
- * call, drain the remainder on a subsequent call, and (purgeRetention only)
+ * and C3 (purgeRetention) — each must transition/purge EXACTLY `limit` rows on
+ * one call, drain the remainder on a subsequent call, and (purgeRetention only)
  * never let a starved FAILED-aged budget be crowded out by SENT-aged rows
  * (S1 — the two-branch split gives FAILED its own cap).
+ *
+ * Determinism vs. the live worker: this suite runs against the shared dev DB,
+ * which a live audit-outbox-worker (30s reaper, REAP_BATCH_SIZE=1000) sweeps
+ * globally with no tenant/test-only marker. Asserting on the observed state of
+ * the test's own rows after a call is therefore racy — the worker can reap all
+ * of them at once. Asserting only `reaped <= limit` on the return value is
+ * deterministic but a false negative: if the worker reaps my rows first, my
+ * call returns 0 and `0 <= limit` passes even with a broken `LIMIT`.
+ *
+ * The fix: create the test's `limit + 1` eligible rows INSIDE a holding
+ * transaction that ALWAYS rolls back (runInRolledBackTx), and run the real
+ * sweep SQL (the exported `*InTx` seams) in that SAME transaction. Uncommitted
+ * rows are invisible to every other transaction (MVCC), so the live worker
+ * cannot see or reap them — the test is the sole sweeper of its own rows. The
+ * `LIMIT` is then the ONLY thing bounding the count, so we can assert it
+ * EXACTLY: one call returns `limit`, the next returns the remaining `1`. A
+ * removed `LIMIT` would return `limit + 1` and fail — no false negative.
+ * The rollback also guarantees zero side effects: the production sweep is
+ * global (not tenant-scoped, by design), so if it happens to catch another
+ * tenant's committed row, the rollback undoes that write.
+ *
+ * The S1 orchestration guard (FAILED branch runs even when the SENT branch
+ * saturates its cap) is a different concern — proven at the orchestrator level
+ * in the worker unit test, not here (this file exercises the branch helpers
+ * directly, so it proves per-branch cap independence, not their sequencing).
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 import { randomUUID } from "node:crypto";
+import { Prisma } from "@prisma/client";
 import { createTestContext, setBypassRlsGucs, type TestContext } from "./helpers";
 import { AUDIT_OUTBOX, AUDIT_SCOPE, AUDIT_ACTION, ACTOR_TYPE } from "@/lib/constants/audit/audit";
-import { reapStuckRows, reapStuckDeliveries, purgeRetention } from "@/workers/audit-outbox-worker";
+import {
+  reapStuckRowsInTx,
+  reapStuckDeliveriesInTx,
+  purgeSentAgedInTx,
+  purgeFailedAgedInTx,
+} from "@/workers/audit-outbox-worker";
+
+type PrismaTx = Prisma.TransactionClient;
 
 describe("audit-outbox sweep caps (C8)", () => {
   let ctx: TestContext;
@@ -39,296 +72,185 @@ describe("audit-outbox sweep caps (C8)", () => {
       actorType: ACTOR_TYPE.HUMAN,
     });
 
+  // Run `body` inside a holding transaction that ALWAYS rolls back. Two
+  // guarantees this buys the cap assertions:
+  //   1. Rows created in `body` are never committed, so they are invisible
+  //      (MVCC) to the live audit-outbox-worker — the test is the sole sweeper
+  //      of its own rows and the `LIMIT` cap is the only thing bounding the
+  //      count, so it can be asserted exactly (2 → 1 → 0).
+  //   2. The production sweep is a GLOBAL sweep (no tenant scoping, by design).
+  //      If any other tenant's committed eligible rows happen to be caught by
+  //      the sweep here, the rollback undoes those writes — the test has zero
+  //      side effects on shared data. (Such rows can still consume the `LIMIT`
+  //      on a shared dev DB, which would make an assertion FAIL loudly, never
+  //      pass a broken cap; CI runs against a fresh DB with no other rows.)
+  // A vitest assertion failure inside `body` propagates out (the tx still
+  // rolls back), so failures are reported normally.
+  const ROLLBACK = Symbol("rollback");
+  async function runInRolledBackTx(
+    body: (tx: PrismaTx) => Promise<void>,
+  ): Promise<void> {
+    try {
+      await ctx.su.prisma.$transaction(async (tx) => {
+        await setBypassRlsGucs(tx);
+        await body(tx);
+        throw ROLLBACK;
+      });
+    } catch (err) {
+      if (err !== ROLLBACK) throw err;
+    }
+  }
+
   // ─── reapStuckRows ──────────────────────────────────────────────
 
   describe("reapStuckRows", () => {
-    async function insertStuckRow(): Promise<string> {
-      const outboxId = randomUUID();
+    // The cap is proven exactly: 3 eligible rows, LIMIT 2 → first call reaps
+    // exactly 2, second reaps the remaining 1. The 3 rows are created inside a
+    // rolled-back holding transaction (see runInRolledBackTx), so they are
+    // invisible (MVCC) to the live worker — the test is the sole reaper of its
+    // own rows. A removed production `LIMIT` would make the first call reap all
+    // 3 and fail `toBe(2)`.
+    it("reaps exactly `limit` of 3 eligible rows per call, draining the remainder next call", async () => {
       const timeoutSeconds = AUDIT_OUTBOX.PROCESSING_TIMEOUT_MS / 1000;
-      await ctx.su.prisma.$transaction(async (tx) => {
-        await setBypassRlsGucs(tx);
-        await tx.$executeRawUnsafe(
-          `INSERT INTO audit_outbox (id, tenant_id, payload, status, attempt_count, max_attempts, processing_started_at, created_at, next_retry_at)
-           VALUES ($1::uuid, $2::uuid, $3::jsonb, 'PROCESSING', 0, 8,
-                   now() - make_interval(secs => $4::double precision) - interval '60 seconds',
-                   now(), now())`,
-          outboxId,
-          tenantId,
-          makePayload(),
-          timeoutSeconds,
-        );
+
+      await runInRolledBackTx(async (txH) => {
+        for (let i = 0; i < 3; i++) {
+          await txH.$executeRawUnsafe(
+            `INSERT INTO audit_outbox (id, tenant_id, payload, status, attempt_count, max_attempts, processing_started_at, created_at, next_retry_at)
+             VALUES ($1::uuid, $2::uuid, $3::jsonb, 'PROCESSING', 0, 8,
+                     now() - make_interval(secs => $4::double precision) - interval '60 seconds',
+                     now(), now())`,
+            randomUUID(),
+            tenantId,
+            makePayload(),
+            timeoutSeconds,
+          );
+        }
+
+        // First call: exactly `limit` (2) of the 3 eligible rows. Broken LIMIT ⇒ 3.
+        expect(await reapStuckRowsInTx(txH, 2)).toBe(2);
+        // Second call: drains the last 1.
+        expect(await reapStuckRowsInTx(txH, 2)).toBe(1);
+        // Nothing left eligible in this fenced set.
+        expect(await reapStuckRowsInTx(txH, 2)).toBe(0);
       });
-      return outboxId;
-    }
-
-    async function getStatuses(ids: string[]): Promise<string[]> {
-      const rows = await ctx.su.prisma.$transaction(async (tx) => {
-        await setBypassRlsGucs(tx);
-        return tx.$queryRawUnsafe<{ status: string }[]>(
-          `SELECT status::text FROM audit_outbox WHERE id = ANY($1::uuid[])`,
-          ids,
-        );
-      });
-      return rows.map((r) => r.status);
-    }
-
-    // reapStuckRows is a GLOBAL sweep (SC6 — no per-tenant partitioning), so
-    // in a shared dev DB another process (e.g. a live worker) can concurrently
-    // reap OTHER tenants' stuck rows and consume part of the `limit` budget.
-    // Scope assertions to THIS test's own row ids (never global counts) so
-    // the cap behavior is verified regardless of unrelated background
-    // activity in the database.
-    it("transitions exactly `limit` of 3 eligible stuck rows, and a 2nd call drains the remainder", async () => {
-      const ids = [await insertStuckRow(), await insertStuckRow(), await insertStuckRow()];
-
-      expect(await getStatuses(ids)).toEqual(["PROCESSING", "PROCESSING", "PROCESSING"]);
-
-      await reapStuckRows(ctx.su.prisma, 2);
-      const afterFirst = await getStatuses(ids);
-      const pendingAfterFirst = afterFirst.filter((s) => s === "PENDING").length;
-      const processingAfterFirst = afterFirst.filter((s) => s === "PROCESSING").length;
-      // At most `limit` (2) of MY 3 rows can have transitioned this call —
-      // a global cap can never reap more of mine than its own limit allows.
-      expect(pendingAfterFirst).toBeLessThanOrEqual(2);
-      expect(pendingAfterFirst + processingAfterFirst).toBe(3);
-      expect(processingAfterFirst).toBeGreaterThanOrEqual(1);
-
-      // Drain: repeat capped calls until all of mine have transitioned —
-      // bounded iteration count proves the cap, not an unbounded single call.
-      let iterations = 1;
-      while ((await getStatuses(ids)).some((s) => s === "PROCESSING") && iterations < 5) {
-        await reapStuckRows(ctx.su.prisma, 2);
-        iterations++;
-      }
-      expect(await getStatuses(ids)).toEqual(["PENDING", "PENDING", "PENDING"]);
-      // Draining 3 rows at cap=2 must take at least 2 calls (ceil(3/2)) —
-      // proves a single call could not have drained all 3 (RT7 cap evidence).
-      expect(iterations).toBeGreaterThanOrEqual(2);
     });
   });
 
   // ─── reapStuckDeliveries ────────────────────────────────────────
 
   describe("reapStuckDeliveries", () => {
-    async function insertOutboxRow(): Promise<string> {
-      const id = randomUUID();
-      await ctx.su.prisma.$transaction(async (tx) => {
-        await setBypassRlsGucs(tx);
-        await tx.$executeRawUnsafe(
-          `INSERT INTO audit_outbox (id, tenant_id, payload, status, sent_at)
-           VALUES ($1::uuid, $2::uuid, $3::jsonb, 'SENT', now())`,
-          id,
-          tenantId,
-          JSON.stringify({
-            scope: "PERSONAL",
-            action: "ENTRY_CREATE",
-            userId,
-            actorType: "HUMAN",
-          }),
-        );
-      });
-      return id;
-    }
+    // Same fenced-holding-transaction design as reapStuckRows: the target,
+    // outbox parents, and 3 stuck deliveries are all created inside `txH` and
+    // never committed, so the live worker cannot see or reap them. The cap is
+    // asserted exactly against the delivery reaper's own `LIMIT`.
+    it("reaps exactly `limit` of 3 eligible deliveries per call, draining the remainder next call", async () => {
+      const processingStartedAt = new Date(Date.now() - AUDIT_OUTBOX.PROCESSING_TIMEOUT_MS - 60_000);
 
-    async function insertTarget(kind: string): Promise<string> {
-      const id = randomUUID();
-      await ctx.su.prisma.$transaction(async (tx) => {
-        await setBypassRlsGucs(tx);
-        await tx.$executeRawUnsafe(
+      await runInRolledBackTx(async (txH) => {
+        const targetId = randomUUID();
+        await txH.$executeRawUnsafe(
           `INSERT INTO audit_delivery_targets (
             id, tenant_id, kind, config_encrypted, config_iv, config_auth_tag,
             master_key_version, is_active, created_at
-          ) VALUES ($1::uuid, $2::uuid, $3::"AuditDeliveryTargetKind", 'test_enc', 'test_iv', 'test_tag', 1, true, now())`,
-          id,
-          tenantId,
-          kind,
-        );
-      });
-      return id;
-    }
-
-    async function insertStuckDelivery(outboxId: string, targetId: string): Promise<string> {
-      const id = randomUUID();
-      const processingStartedAt = new Date(Date.now() - AUDIT_OUTBOX.PROCESSING_TIMEOUT_MS - 60_000);
-      await ctx.su.prisma.$transaction(async (tx) => {
-        await setBypassRlsGucs(tx);
-        await tx.$executeRawUnsafe(
-          `INSERT INTO audit_deliveries (
-            id, outbox_id, target_id, tenant_id, status,
-            attempt_count, max_attempts, processing_started_at
-          ) VALUES (
-            $1::uuid, $2::uuid, $3::uuid, $4::uuid, 'PROCESSING',
-            0, 8, $5::timestamptz
-          )`,
-          id,
-          outboxId,
+          ) VALUES ($1::uuid, $2::uuid, 'WEBHOOK'::"AuditDeliveryTargetKind", 'test_enc', 'test_iv', 'test_tag', 1, true, now())`,
           targetId,
           tenantId,
-          processingStartedAt.toISOString(),
         );
+
+        for (let i = 0; i < 3; i++) {
+          const outboxId = randomUUID();
+          await txH.$executeRawUnsafe(
+            `INSERT INTO audit_outbox (id, tenant_id, payload, status, sent_at)
+             VALUES ($1::uuid, $2::uuid, $3::jsonb, 'SENT', now())`,
+            outboxId,
+            tenantId,
+            JSON.stringify({ scope: "PERSONAL", action: "ENTRY_CREATE", userId, actorType: "HUMAN" }),
+          );
+          await txH.$executeRawUnsafe(
+            `INSERT INTO audit_deliveries (
+              id, outbox_id, target_id, tenant_id, status,
+              attempt_count, max_attempts, processing_started_at
+            ) VALUES ($1::uuid, $2::uuid, $3::uuid, $4::uuid, 'PROCESSING', 0, 8, $5::timestamptz)`,
+            randomUUID(),
+            outboxId,
+            targetId,
+            tenantId,
+            processingStartedAt.toISOString(),
+          );
+        }
+
+        // First call: exactly `limit` (2) of the 3 eligible deliveries. Broken LIMIT ⇒ 3.
+        expect(await reapStuckDeliveriesInTx(txH, 2)).toBe(2);
+        // Second call: drains the last 1.
+        expect(await reapStuckDeliveriesInTx(txH, 2)).toBe(1);
+        expect(await reapStuckDeliveriesInTx(txH, 2)).toBe(0);
       });
-      return id;
-    }
-
-    async function getDeliveryStatuses(ids: string[]): Promise<string[]> {
-      const rows = await ctx.su.prisma.$transaction(async (tx) => {
-        await setBypassRlsGucs(tx);
-        return tx.$queryRawUnsafe<{ status: string }[]>(
-          `SELECT status::text FROM "audit_deliveries" WHERE id = ANY($1::uuid[])`,
-          ids,
-        );
-      });
-      return rows.map((r) => r.status);
-    }
-
-    // Same GLOBAL-sweep caveat as reapStuckRows above — scope assertions to
-    // this test's own delivery ids, not tenant-wide counts.
-    it("transitions exactly `limit` of 3 eligible stuck deliveries, and a 2nd call drains the remainder", async () => {
-      const targetId = await insertTarget("WEBHOOK");
-      const outboxId1 = await insertOutboxRow();
-      const outboxId2 = await insertOutboxRow();
-      const outboxId3 = await insertOutboxRow();
-      const ids = [
-        await insertStuckDelivery(outboxId1, targetId),
-        await insertStuckDelivery(outboxId2, targetId),
-        await insertStuckDelivery(outboxId3, targetId),
-      ];
-
-      expect(await getDeliveryStatuses(ids)).toEqual(["PROCESSING", "PROCESSING", "PROCESSING"]);
-
-      await reapStuckDeliveries(ctx.su.prisma, 2);
-      const afterFirst = await getDeliveryStatuses(ids);
-      const pendingAfterFirst = afterFirst.filter((s) => s === "PENDING").length;
-      const processingAfterFirst = afterFirst.filter((s) => s === "PROCESSING").length;
-      expect(pendingAfterFirst).toBeLessThanOrEqual(2);
-      expect(pendingAfterFirst + processingAfterFirst).toBe(3);
-      expect(processingAfterFirst).toBeGreaterThanOrEqual(1);
-
-      let iterations = 1;
-      while ((await getDeliveryStatuses(ids)).some((s) => s === "PROCESSING") && iterations < 5) {
-        await reapStuckDeliveries(ctx.su.prisma, 2);
-        iterations++;
-      }
-      expect(await getDeliveryStatuses(ids)).toEqual(["PENDING", "PENDING", "PENDING"]);
-      expect(iterations).toBeGreaterThanOrEqual(2);
     });
   });
 
   // ─── purgeRetention ─────────────────────────────────────────────
 
   describe("purgeRetention", () => {
-    async function insertSentAgedRow(): Promise<string> {
-      const id = randomUUID();
-      const retentionHours = AUDIT_OUTBOX.RETENTION_HOURS;
-      await ctx.su.prisma.$transaction(async (tx) => {
-        await setBypassRlsGucs(tx);
-        await tx.$executeRawUnsafe(
-          `INSERT INTO audit_outbox (id, tenant_id, payload, status, attempt_count, max_attempts, created_at, next_retry_at, sent_at)
-           VALUES ($1::uuid, $2::uuid, $3::jsonb, 'SENT', 1, 8, now() - interval '48 hours', now(),
-                   now() - make_interval(hours => $4) - interval '1 hour')`,
-          id,
-          tenantId,
-          makePayload(),
-          retentionHours,
-        );
-      });
-      return id;
+    async function insertSentAgedRow(tx: PrismaTx): Promise<void> {
+      await tx.$executeRawUnsafe(
+        `INSERT INTO audit_outbox (id, tenant_id, payload, status, attempt_count, max_attempts, created_at, next_retry_at, sent_at)
+         VALUES ($1::uuid, $2::uuid, $3::jsonb, 'SENT', 1, 8, now() - interval '48 hours', now(),
+                 now() - make_interval(hours => $4) - interval '1 hour')`,
+        randomUUID(),
+        tenantId,
+        makePayload(),
+        AUDIT_OUTBOX.RETENTION_HOURS,
+      );
     }
 
-    async function insertFailedAgedRow(): Promise<string> {
-      const id = randomUUID();
-      const failedRetentionDays = AUDIT_OUTBOX.FAILED_RETENTION_DAYS;
-      await ctx.su.prisma.$transaction(async (tx) => {
-        await setBypassRlsGucs(tx);
-        await tx.$executeRawUnsafe(
-          `INSERT INTO audit_outbox (id, tenant_id, payload, status, attempt_count, max_attempts, created_at, next_retry_at)
-           VALUES ($1::uuid, $2::uuid, $3::jsonb, 'FAILED', 8, 8,
-                   now() - make_interval(days => $4) - interval '1 day', now())`,
-          id,
-          tenantId,
-          makePayload(),
-          failedRetentionDays,
-        );
-      });
-      return id;
+    async function insertFailedAgedRow(tx: PrismaTx): Promise<void> {
+      await tx.$executeRawUnsafe(
+        `INSERT INTO audit_outbox (id, tenant_id, payload, status, attempt_count, max_attempts, created_at, next_retry_at)
+         VALUES ($1::uuid, $2::uuid, $3::jsonb, 'FAILED', 8, 8,
+                 now() - make_interval(days => $4) - interval '1 day', now())`,
+        randomUUID(),
+        tenantId,
+        makePayload(),
+        AUDIT_OUTBOX.FAILED_RETENTION_DAYS,
+      );
     }
 
-    async function getRemainingIds(): Promise<{ id: string; status: string }[]> {
-      return ctx.su.prisma.$transaction(async (tx) => {
-        await setBypassRlsGucs(tx);
-        return tx.$queryRawUnsafe<{ id: string; status: string }[]>(
-          `SELECT id, status::text FROM audit_outbox WHERE tenant_id = $1::uuid`,
-          tenantId,
-        );
+    // Same fenced-holding-transaction design: SENT-aged rows are created inside
+    // `txH` and never committed, so the live worker cannot purge them. The
+    // SENT branch's own `LIMIT` is asserted exactly.
+    it("purges exactly `limit` of 3 SENT-aged rows per call, draining the remainder next call", async () => {
+      await runInRolledBackTx(async (txH) => {
+        for (let i = 0; i < 3; i++) await insertSentAgedRow(txH);
+
+        // First call: exactly `limit` (2) of the 3 SENT-aged rows. Broken LIMIT ⇒ 3.
+        expect(await purgeSentAgedInTx(txH, 2)).toBe(2);
+        // Second call: drains the last 1.
+        expect(await purgeSentAgedInTx(txH, 2)).toBe(1);
+        expect(await purgeSentAgedInTx(txH, 2)).toBe(0);
       });
-    }
-
-    // purgeRetention is a GLOBAL sweep (SC6): in a shared dev DB, another
-    // tenant's eligible rows can share the same per-call budget as this
-    // test's own rows. Scope survival assertions to THIS test's own row ids
-    // (never a bare "exactly 1 remains" on the whole tenant-scoped result
-    // set beyond what's attributable to my own ids) so the cap behavior is
-    // verified regardless of unrelated background activity in the database.
-    it("caps SENT-aged purge at `limit` per call, draining the remainder on a 2nd call", async () => {
-      const myIds = [await insertSentAgedRow(), await insertSentAgedRow(), await insertSentAgedRow()];
-
-      await purgeRetention(ctx.su.prisma, { limit: 2 });
-
-      const survivingAfterFirst = (await getRemainingIds())
-        .map((r) => r.id)
-        .filter((id) => myIds.includes(id));
-      // At most `limit` (2) of MY 3 rows can have been purged this call.
-      expect(survivingAfterFirst.length).toBeGreaterThanOrEqual(1);
-      expect(survivingAfterFirst.length).toBeLessThanOrEqual(3);
-      expect(survivingAfterFirst.length).not.toBe(0);
-
-      // Drain: repeat capped calls until all of mine are gone.
-      let iterations = 1;
-      while (
-        (await getRemainingIds()).some((r) => myIds.includes(r.id)) &&
-        iterations < 5
-      ) {
-        await purgeRetention(ctx.su.prisma, { limit: 2 });
-        iterations++;
-      }
-      expect((await getRemainingIds()).filter((r) => myIds.includes(r.id))).toHaveLength(0);
-      // Draining 3 rows at cap=2 must take at least 2 calls (ceil(3/2)) —
-      // proves a single call could not have drained all 3 (RT7 cap evidence).
-      expect(iterations).toBeGreaterThanOrEqual(2);
     });
 
-    it("S1 starvation guard: a FAILED-aged row is purged in the same call even when >= limit SENT-aged rows are also eligible", async () => {
-      // 3 SENT-aged rows (>= limit=2) competing for the SENT branch's budget,
-      // plus 1 FAILED-aged row that must not be starved by the SENT backlog —
-      // the two-branch split gives FAILED its own independent cap.
-      const sentIds = [await insertSentAgedRow(), await insertSentAgedRow(), await insertSentAgedRow()];
-      const failedId = await insertFailedAgedRow();
+    // S1 per-branch cap independence: with 3 SENT-aged rows (> limit=2) the
+    // SENT branch purges exactly `limit` and leaves a backlog, yet the FAILED
+    // branch still purges its own aged row — the two branches carry independent
+    // caps, so a SENT backlog can never starve FAILED of its budget. (That the
+    // orchestrator *runs* the FAILED branch even after the SENT branch
+    // saturates is covered in the worker unit test — see "purgeRetention runs
+    // the FAILED branch even when the SENT branch saturates its cap".)
+    it("S1: the FAILED-aged branch purges its own row despite a SENT backlog exceeding the cap", async () => {
+      await runInRolledBackTx(async (txH) => {
+        for (let i = 0; i < 3; i++) await insertSentAgedRow(txH);
+        await insertFailedAgedRow(txH);
 
-      await purgeRetention(ctx.su.prisma, { limit: 2 });
-
-      const remainingIdsAfterFirst = (await getRemainingIds()).map((r) => r.id);
-
-      // The FAILED-aged row must be gone despite the SENT backlog exceeding the cap.
-      expect(remainingIdsAfterFirst).not.toContain(failedId);
-
-      // At most `limit` (2) of MY 3 SENT-aged rows can have been purged this
-      // call — at least 1 of mine must remain (proves the SENT branch is
-      // itself capped, not unbounded).
-      const survivingSentIds = sentIds.filter((id) => remainingIdsAfterFirst.includes(id));
-      expect(survivingSentIds.length).toBeGreaterThanOrEqual(1);
-
-      // A 2nd (and if needed further) call drains the remaining SENT-aged
-      // rows of mine — re-querying live state each iteration.
-      let iterations = 1;
-      while (iterations < 5) {
-        const stillRemaining = (await getRemainingIds()).map((r) => r.id);
-        if (!sentIds.some((id) => stillRemaining.includes(id))) break;
-        await purgeRetention(ctx.su.prisma, { limit: 2 });
-        iterations++;
-      }
-      const finalRemaining = (await getRemainingIds()).map((r) => r.id);
-      expect(sentIds.some((id) => finalRemaining.includes(id))).toBe(false);
-      expect(iterations).toBeGreaterThanOrEqual(2);
+        // SENT branch is capped at `limit` even with a backlog (leaves 1).
+        expect(await purgeSentAgedInTx(txH, 2)).toBe(2);
+        // FAILED branch has its own budget: its 1 aged row is purged, not starved.
+        expect(await purgeFailedAgedInTx(txH, 2)).toBe(1);
+        // Drain the remaining SENT-aged row.
+        expect(await purgeSentAgedInTx(txH, 2)).toBe(1);
+        expect(await purgeSentAgedInTx(txH, 2)).toBe(0);
+      });
     });
   });
 });

--- a/src/workers/audit-outbox-worker.test.ts
+++ b/src/workers/audit-outbox-worker.test.ts
@@ -171,7 +171,11 @@ vi.mock("@/lib/webhook-dispatcher", () => ({
   deliverToWebhookRecords: mockDeliverToWebhookRecords,
 }));
 
-import { createWorker } from "./audit-outbox-worker";
+import { createWorker, purgeRetention } from "./audit-outbox-worker";
+// PrismaClient is mocked to MockPrismaClient by vi.mock("@prisma/client") above;
+// importing it here gives `new PrismaClient(...)` a real construct signature at
+// type-check time while resolving to the mock at runtime.
+import { PrismaClient } from "@prisma/client";
 import { NIL_UUID } from "@/lib/constants/app";
 import { BYPASS_PURPOSE } from "@/lib/tenant-rls";
 
@@ -1278,6 +1282,53 @@ describe("reaper — invoked on first loop tick", () => {
     const metadata = JSON.parse(purgeInsert![7] as string);
     expect(metadata.purgedCount).toBe(5);
   }, 15000);
+
+  it("purgeRetention runs the FAILED branch even when the SENT branch saturates its cap", async () => {
+    // S1 orchestration guard (Medium-2): the two purge branches must be
+    // unconditionally sequential. A regression that skipped the FAILED branch
+    // when the SENT branch saturated its `limit` would silently let PII-bearing
+    // FAILED rows outlive their retention. Drive purgeRetention directly with a
+    // SENT branch that returns exactly `limit` rows and assert the FAILED-branch
+    // DELETE is still issued.
+    const limit = 2;
+    const sentDeletes: string[] = [];
+    const failedDeletes: string[] = [];
+
+    // purgeRetention issues 4 sequential $transaction calls: SENT, FAILED,
+    // delivery-purge, webhook-purge. Route each branch's DELETE CTE by its
+    // status literal and record it; the SENT branch returns `limit` rows
+    // (per-tenant GROUP BY) to simulate a saturated cap.
+    mockTransaction.mockImplementation(async function (fn: TxFn) {
+      const txQueryRaw = vi.fn(async (sql: string, ...args: unknown[]) => {
+        if (sql.includes("DELETE FROM audit_outbox") && sql.includes("status = 'SENT'")) {
+          sentDeletes.push(sql);
+          return [{ tenant_id: TENANT_ID, purged: BigInt(limit) }];
+        }
+        if (sql.includes("DELETE FROM audit_outbox") && sql.includes("status = 'FAILED'")) {
+          failedDeletes.push(sql);
+          return [{ tenant_id: TENANT_ID, purged: BigInt(1) }];
+        }
+        return mockQueryRawUnsafe(sql, ...args);
+      });
+      return fn({
+        $executeRaw: mockExecuteRaw,
+        $queryRawUnsafe: txQueryRaw,
+        $executeRawUnsafe: mockExecuteRawUnsafe,
+        auditDeliveryTarget: { findMany: vi.fn().mockResolvedValue([]) },
+        auditDelivery: { upsert: vi.fn().mockResolvedValue({}), findMany: vi.fn().mockResolvedValue([]), update: vi.fn().mockResolvedValue({}) },
+      });
+    });
+
+    const prisma = new PrismaClient();
+    const result = await purgeRetention(prisma, { limit });
+
+    // SENT branch saturated its cap...
+    expect(result.sentPurged).toBe(limit);
+    expect(sentDeletes).toHaveLength(1);
+    // ...and the FAILED branch still ran and purged its own row.
+    expect(failedDeletes).toHaveLength(1);
+    expect(result.failedPurged).toBe(1);
+  });
 
   it("reaper errors do not crash the worker loop", async () => {
     // If reapStuckRows throws, the worker should swallow the error (runReaper catches it)

--- a/src/workers/audit-outbox-worker.ts
+++ b/src/workers/audit-outbox-worker.ts
@@ -1275,63 +1275,79 @@ export async function reapStuckRows(
   prisma: PrismaClient,
   limit: number = AUDIT_OUTBOX.REAP_BATCH_SIZE,
 ): Promise<number> {
-  const timeoutSeconds = AUDIT_OUTBOX.PROCESSING_TIMEOUT_MS / MS_PER_SECOND;
-
-  // Reset stuck PROCESSING rows: those under max_attempts go back to PENDING,
-  // those at or over max_attempts transition to FAILED (dead-letter).
   // The reap transition (FAILED/PENDING) and every row's audit event
   // (AUDIT_OUTBOX_DEAD_LETTER / AUDIT_OUTBOX_REAPED) commit in ONE tx via the
   // in-tx audit writer, so a reaped/dead-lettered row can never exist without
   // its audit record. If any audit insert throws, the whole batch rolls back and
-  // is retried on the next reaper tick. Both actions are in
-  // OUTBOX_BYPASS_AUDIT_ACTIONS, so the direct write never re-enters the outbox.
-  const reaped = await prisma.$transaction(async (tx) => {
-    await setBypassRlsGucs(tx);
-    const rows = await tx.$queryRawUnsafe<{
-      id: string;
-      tenant_id: string;
-      attempt_count: number;
-      new_status: string;
-    }[]>(
-      `UPDATE audit_outbox
-       SET status = CASE
-             WHEN attempt_count + 1 >= max_attempts THEN 'FAILED'::"AuditOutboxStatus"
-             ELSE 'PENDING'::"AuditOutboxStatus"
-           END,
-           processing_started_at = NULL,
-           attempt_count = attempt_count + 1,
-           last_error = LEFT('[reaped after timeout, attempt ' || (attempt_count + 1)::text || ']', 1024)
-       WHERE id IN (
-         SELECT id FROM audit_outbox
-         WHERE status = 'PROCESSING'
-           AND processing_started_at < now() - make_interval(secs => $1)
-         ORDER BY processing_started_at ASC
-         LIMIT $2
-         FOR UPDATE SKIP LOCKED
-       )
-       RETURNING id, tenant_id, attempt_count, status::text AS new_status`,
-      timeoutSeconds,
-      limit,
-    );
-    for (const row of rows) {
-      if (row.new_status === "FAILED") {
-        await writeDirectAuditLogInTx(tx, row.tenant_id, AUDIT_ACTION.AUDIT_OUTBOX_DEAD_LETTER, {
-          outboxId: row.id,
-          attemptCount: row.attempt_count,
-          reason: "reaped_max_attempts",
-        });
-      } else {
-        await writeDirectAuditLogInTx(tx, row.tenant_id, AUDIT_ACTION.AUDIT_OUTBOX_REAPED, {
-          outboxId: row.id,
-          attemptCount: row.attempt_count,
-        });
-      }
+  // is retried on the next reaper tick.
+  return prisma.$transaction((tx) => reapStuckRowsInTx(tx, limit));
+}
+
+/**
+ * In-transaction body of {@link reapStuckRows}. Runs the real reap UPDATE +
+ * co-committed audit writes on a caller-supplied transaction client instead of
+ * opening its own transaction.
+ *
+ * Exported so cap regression tests can run the real SQL inside a transaction
+ * that has already `FOR UPDATE`-locked the test's own rows, fencing the live
+ * worker out (its `FOR UPDATE SKIP LOCKED` skips the locked rows) so the cap
+ * can be asserted deterministically. Production always reaches this via the
+ * `reapStuckRows` wrapper above — behavior is identical.
+ */
+export async function reapStuckRowsInTx(
+  tx: Prisma.TransactionClient,
+  limit: number = AUDIT_OUTBOX.REAP_BATCH_SIZE,
+): Promise<number> {
+  const timeoutSeconds = AUDIT_OUTBOX.PROCESSING_TIMEOUT_MS / MS_PER_SECOND;
+
+  await setBypassRlsGucs(tx);
+  // Reset stuck PROCESSING rows: those under max_attempts go back to PENDING,
+  // those at or over max_attempts transition to FAILED (dead-letter). Both
+  // actions are in OUTBOX_BYPASS_AUDIT_ACTIONS, so the direct write never
+  // re-enters the outbox.
+  const rows = await tx.$queryRawUnsafe<{
+    id: string;
+    tenant_id: string;
+    attempt_count: number;
+    new_status: string;
+  }[]>(
+    `UPDATE audit_outbox
+     SET status = CASE
+           WHEN attempt_count + 1 >= max_attempts THEN 'FAILED'::"AuditOutboxStatus"
+           ELSE 'PENDING'::"AuditOutboxStatus"
+         END,
+         processing_started_at = NULL,
+         attempt_count = attempt_count + 1,
+         last_error = LEFT('[reaped after timeout, attempt ' || (attempt_count + 1)::text || ']', 1024)
+     WHERE id IN (
+       SELECT id FROM audit_outbox
+       WHERE status = 'PROCESSING'
+         AND processing_started_at < now() - make_interval(secs => $1)
+       ORDER BY processing_started_at ASC
+       LIMIT $2
+       FOR UPDATE SKIP LOCKED
+     )
+     RETURNING id, tenant_id, attempt_count, status::text AS new_status`,
+    timeoutSeconds,
+    limit,
+  );
+  for (const row of rows) {
+    if (row.new_status === "FAILED") {
+      await writeDirectAuditLogInTx(tx, row.tenant_id, AUDIT_ACTION.AUDIT_OUTBOX_DEAD_LETTER, {
+        outboxId: row.id,
+        attemptCount: row.attempt_count,
+        reason: "reaped_max_attempts",
+      });
+    } else {
+      await writeDirectAuditLogInTx(tx, row.tenant_id, AUDIT_ACTION.AUDIT_OUTBOX_REAPED, {
+        outboxId: row.id,
+        attemptCount: row.attempt_count,
+      });
     }
-    return rows;
-  });
+  }
 
   const log = getLogger();
-  for (const row of reaped) {
+  for (const row of rows) {
     if (row.new_status === "FAILED") {
       log.warn({ outboxId: row.id, attemptCount: row.attempt_count }, "worker.reaped_dead_letter");
       deadLetterLogger.warn(
@@ -1343,7 +1359,7 @@ export async function reapStuckRows(
     }
   }
 
-  return reaped.length;
+  return rows.length;
 }
 
 /**
@@ -1357,53 +1373,63 @@ export async function reapStuckDeliveries(
   prisma: PrismaClient,
   limit: number = AUDIT_OUTBOX.REAP_BATCH_SIZE,
 ): Promise<number> {
-  const timeout = AUDIT_OUTBOX.PROCESSING_TIMEOUT_MS;
-  const cutoff = new Date(Date.now() - timeout);
-
   // Reap transition + dead-letter audit for rows that hit FAILED co-commit in one
   // tx (parity with reapStuckRows), so a reaper-driven delivery dead-letter can
   // never be silent in the audit trail.
-  const reaped = await prisma.$transaction(async (tx) => {
-    await setBypassRlsGucs(tx);
-    const rows = await tx.$queryRawUnsafe<{
-      id: string;
-      tenant_id: string;
-      attempt_count: number;
-      new_status: string;
-    }[]>(
-      `UPDATE "audit_deliveries"
-       SET "status" = CASE
-         WHEN "attempt_count" + 1 >= "max_attempts" THEN 'FAILED'::"AuditDeliveryStatus"
-         ELSE 'PENDING'::"AuditDeliveryStatus"
-       END,
-       "attempt_count" = "attempt_count" + 1,
-       "processing_started_at" = NULL,
-       "last_error" = 'reaped: processing timeout exceeded'
-       WHERE "id" IN (
-         SELECT "id" FROM "audit_deliveries"
-         WHERE "status" = 'PROCESSING'
-           AND "processing_started_at" < $1
-         ORDER BY "processing_started_at" ASC
-         LIMIT $2
-         FOR UPDATE SKIP LOCKED
-       )
-       RETURNING "id", "tenant_id", "attempt_count", "status"::text AS new_status`,
-      cutoff,
-      limit,
-    );
-    for (const row of rows) {
-      if (row.new_status === "FAILED") {
-        await writeDirectAuditLogInTx(tx, row.tenant_id, AUDIT_ACTION.AUDIT_DELIVERY_DEAD_LETTER, {
-          deliveryId: row.id,
-          attemptCount: row.attempt_count,
-          reason: "reaped_max_attempts",
-        });
-      }
-    }
-    return rows;
-  });
+  return prisma.$transaction((tx) => reapStuckDeliveriesInTx(tx, limit));
+}
 
-  const count = reaped.length;
+/**
+ * In-transaction body of {@link reapStuckDeliveries}. See
+ * {@link reapStuckRowsInTx} for why this seam is exported (deterministic cap
+ * regression tests fence the live worker with a `FOR UPDATE` lock and run the
+ * real SQL inside the same transaction). Production reaches it via the wrapper.
+ */
+export async function reapStuckDeliveriesInTx(
+  tx: Prisma.TransactionClient,
+  limit: number = AUDIT_OUTBOX.REAP_BATCH_SIZE,
+): Promise<number> {
+  const timeout = AUDIT_OUTBOX.PROCESSING_TIMEOUT_MS;
+  const cutoff = new Date(Date.now() - timeout);
+
+  await setBypassRlsGucs(tx);
+  const rows = await tx.$queryRawUnsafe<{
+    id: string;
+    tenant_id: string;
+    attempt_count: number;
+    new_status: string;
+  }[]>(
+    `UPDATE "audit_deliveries"
+     SET "status" = CASE
+       WHEN "attempt_count" + 1 >= "max_attempts" THEN 'FAILED'::"AuditDeliveryStatus"
+       ELSE 'PENDING'::"AuditDeliveryStatus"
+     END,
+     "attempt_count" = "attempt_count" + 1,
+     "processing_started_at" = NULL,
+     "last_error" = 'reaped: processing timeout exceeded'
+     WHERE "id" IN (
+       SELECT "id" FROM "audit_deliveries"
+       WHERE "status" = 'PROCESSING'
+         AND "processing_started_at" < $1
+       ORDER BY "processing_started_at" ASC
+       LIMIT $2
+       FOR UPDATE SKIP LOCKED
+     )
+     RETURNING "id", "tenant_id", "attempt_count", "status"::text AS new_status`,
+    cutoff,
+    limit,
+  );
+  for (const row of rows) {
+    if (row.new_status === "FAILED") {
+      await writeDirectAuditLogInTx(tx, row.tenant_id, AUDIT_ACTION.AUDIT_DELIVERY_DEAD_LETTER, {
+        deliveryId: row.id,
+        attemptCount: row.attempt_count,
+        reason: "reaped_max_attempts",
+      });
+    }
+  }
+
+  const count = rows.length;
   if (count > 0) {
     getLogger().info({ count }, "reaped stuck delivery rows");
   }
@@ -1497,7 +1523,7 @@ export async function reapStuckWebhookDeliveries(
 export async function purgeRetention(
   prisma: PrismaClient,
   opts?: { limit?: number },
-): Promise<void> {
+): Promise<{ sentPurged: number; failedPurged: number }> {
   const limit = opts?.limit ?? AUDIT_OUTBOX.PURGE_BATCH_SIZE;
   const retentionHours = AUDIT_OUTBOX.RETENTION_HOURS;
   const failedRetentionDays = AUDIT_OUTBOX.FAILED_RETENTION_DAYS;
@@ -1509,84 +1535,8 @@ export async function purgeRetention(
   // atomically in the SAME tx. A destructive delete must never succeed without
   // a matching audit record: if the FAILED-branch tx later throws, the
   // SENT-branch delete + its audit event have already committed together.
-  const sentPurged = await prisma.$transaction(async (tx) => {
-    await setBypassRlsGucs(tx);
-    // Aggregate the deleted rows per tenant (not MIN): a purge batch spans many
-    // tenants, and each tenant's own AUDIT_OUTBOX_RETENTION_PURGED event must be
-    // attributed to that tenant with only that tenant's count. Attributing the
-    // whole batch to MIN(tenant_id) both hid the purge from the other tenants
-    // and leaked their counts into one tenant's audit metadata.
-    const rows = await tx.$queryRawUnsafe<{ tenant_id: string; purged: bigint }[]>(
-      `WITH deleted AS (
-        DELETE FROM audit_outbox
-        WHERE id IN (
-          SELECT id FROM audit_outbox
-          WHERE status = 'SENT'
-            AND sent_at < now() - make_interval(hours => $1)
-            AND NOT EXISTS (
-              SELECT 1 FROM "audit_deliveries"
-              WHERE "audit_deliveries"."outbox_id" = "audit_outbox"."id"
-                AND "audit_deliveries"."status" IN ('PENDING', 'PROCESSING')
-            )
-            AND NOT EXISTS (
-              SELECT 1 FROM "webhook_deliveries"
-              WHERE "webhook_deliveries"."outbox_id" = "audit_outbox"."id"
-                AND "webhook_deliveries"."status" IN ('PENDING', 'PROCESSING')
-            )
-          ORDER BY sent_at ASC
-          LIMIT $2
-        )
-        RETURNING id, tenant_id
-      )
-      SELECT tenant_id::text AS tenant_id, COUNT(*) AS purged FROM deleted GROUP BY tenant_id`,
-      retentionHours,
-      limit,
-    );
-    let purged = 0;
-    for (const row of rows) {
-      const count = Number(row.purged);
-      purged += count;
-      await writeDirectAuditLogInTx(tx, row.tenant_id, AUDIT_ACTION.AUDIT_OUTBOX_RETENTION_PURGED, {
-        purgedCount: count,
-        retentionHours,
-        failedRetentionDays,
-        branch: "SENT",
-      });
-    }
-    return purged;
-  });
-
-  const failedPurged = await prisma.$transaction(async (tx) => {
-    await setBypassRlsGucs(tx);
-    const rows = await tx.$queryRawUnsafe<{ tenant_id: string; purged: bigint }[]>(
-      `WITH deleted AS (
-        DELETE FROM audit_outbox
-        WHERE id IN (
-          SELECT id FROM audit_outbox
-          WHERE status = 'FAILED'
-            AND created_at < now() - make_interval(days => $1)
-          ORDER BY created_at ASC
-          LIMIT $2
-        )
-        RETURNING id, tenant_id
-      )
-      SELECT tenant_id::text AS tenant_id, COUNT(*) AS purged FROM deleted GROUP BY tenant_id`,
-      failedRetentionDays,
-      limit,
-    );
-    let purged = 0;
-    for (const row of rows) {
-      const count = Number(row.purged);
-      purged += count;
-      await writeDirectAuditLogInTx(tx, row.tenant_id, AUDIT_ACTION.AUDIT_OUTBOX_RETENTION_PURGED, {
-        purgedCount: count,
-        retentionHours,
-        failedRetentionDays,
-        branch: "FAILED",
-      });
-    }
-    return purged;
-  });
+  const sentPurged = await prisma.$transaction((tx) => purgeSentAgedInTx(tx, limit));
+  const failedPurged = await prisma.$transaction((tx) => purgeFailedAgedInTx(tx, limit));
 
   const totalPurged = sentPurged + failedPurged;
   if (totalPurged > 0) {
@@ -1634,6 +1584,114 @@ export async function purgeRetention(
   if (Number(webhookDeliveryPurged) > 0) {
     getLogger().info({ webhookDeliveryPurged }, "purged webhook delivery retention rows");
   }
+
+  // Return the per-branch outbox purge counts. Each is bounded by `limit`
+  // (the SENT and FAILED DELETEs each carry their own `LIMIT $2`); cap
+  // regression tests read them to assert the bound on their own call.
+  return { sentPurged, failedPurged };
+}
+
+/**
+ * SENT-aged purge branch of {@link purgeRetention}, on a caller-supplied tx.
+ *
+ * Exported so cap regression tests can run the real DELETE inside a
+ * transaction that has already `FOR UPDATE`-locked the test's own SENT-aged
+ * rows, fencing the live worker out so the `LIMIT` cap is assertable exactly.
+ * Production reaches it via the `purgeRetention` wrapper.
+ */
+export async function purgeSentAgedInTx(
+  tx: Prisma.TransactionClient,
+  limit: number = AUDIT_OUTBOX.PURGE_BATCH_SIZE,
+): Promise<number> {
+  const retentionHours = AUDIT_OUTBOX.RETENTION_HOURS;
+  const failedRetentionDays = AUDIT_OUTBOX.FAILED_RETENTION_DAYS;
+
+  await setBypassRlsGucs(tx);
+  // Aggregate the deleted rows per tenant (not MIN): a purge batch spans many
+  // tenants, and each tenant's own AUDIT_OUTBOX_RETENTION_PURGED event must be
+  // attributed to that tenant with only that tenant's count. Attributing the
+  // whole batch to MIN(tenant_id) both hid the purge from the other tenants
+  // and leaked their counts into one tenant's audit metadata.
+  const rows = await tx.$queryRawUnsafe<{ tenant_id: string; purged: bigint }[]>(
+    `WITH deleted AS (
+      DELETE FROM audit_outbox
+      WHERE id IN (
+        SELECT id FROM audit_outbox
+        WHERE status = 'SENT'
+          AND sent_at < now() - make_interval(hours => $1)
+          AND NOT EXISTS (
+            SELECT 1 FROM "audit_deliveries"
+            WHERE "audit_deliveries"."outbox_id" = "audit_outbox"."id"
+              AND "audit_deliveries"."status" IN ('PENDING', 'PROCESSING')
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM "webhook_deliveries"
+            WHERE "webhook_deliveries"."outbox_id" = "audit_outbox"."id"
+              AND "webhook_deliveries"."status" IN ('PENDING', 'PROCESSING')
+          )
+        ORDER BY sent_at ASC
+        LIMIT $2
+      )
+      RETURNING id, tenant_id
+    )
+    SELECT tenant_id::text AS tenant_id, COUNT(*) AS purged FROM deleted GROUP BY tenant_id`,
+    retentionHours,
+    limit,
+  );
+  let purged = 0;
+  for (const row of rows) {
+    const count = Number(row.purged);
+    purged += count;
+    await writeDirectAuditLogInTx(tx, row.tenant_id, AUDIT_ACTION.AUDIT_OUTBOX_RETENTION_PURGED, {
+      purgedCount: count,
+      retentionHours,
+      failedRetentionDays,
+      branch: "SENT",
+    });
+  }
+  return purged;
+}
+
+/**
+ * FAILED-aged purge branch of {@link purgeRetention}, on a caller-supplied tx.
+ * See {@link purgeSentAgedInTx} for why this seam is exported.
+ */
+export async function purgeFailedAgedInTx(
+  tx: Prisma.TransactionClient,
+  limit: number = AUDIT_OUTBOX.PURGE_BATCH_SIZE,
+): Promise<number> {
+  const retentionHours = AUDIT_OUTBOX.RETENTION_HOURS;
+  const failedRetentionDays = AUDIT_OUTBOX.FAILED_RETENTION_DAYS;
+
+  await setBypassRlsGucs(tx);
+  const rows = await tx.$queryRawUnsafe<{ tenant_id: string; purged: bigint }[]>(
+    `WITH deleted AS (
+      DELETE FROM audit_outbox
+      WHERE id IN (
+        SELECT id FROM audit_outbox
+        WHERE status = 'FAILED'
+          AND created_at < now() - make_interval(days => $1)
+        ORDER BY created_at ASC
+        LIMIT $2
+      )
+      RETURNING id, tenant_id
+    )
+    SELECT tenant_id::text AS tenant_id, COUNT(*) AS purged FROM deleted GROUP BY tenant_id`,
+    failedRetentionDays,
+    limit,
+  );
+  let purged = 0;
+  for (const row of rows) {
+    const count = Number(row.purged);
+    purged += count;
+    await writeDirectAuditLogInTx(tx, row.tenant_id, AUDIT_ACTION.AUDIT_OUTBOX_RETENTION_PURGED, {
+      purgedCount: count,
+      retentionHours,
+      failedRetentionDays,
+      branch: "FAILED",
+    });
+  }
+  return purged;
 }
 
 /**


### PR DESCRIPTION
## Summary

Deflake the `audit-outbox-sweep-caps` integration test and turn it into a deterministic, false-negative-free proof of the per-call sweep `LIMIT` cap.

The cap regression tests asserted `<= limit` on the observed state of their own rows after a single sweep call. On a shared dev DB the live `audit-outbox-worker` (30s reaper, `REAP_BATCH_SIZE=1000`) can reap those rows in the window between insert and assert, tripping the `3 <= 2` assertion — the CI flake seen on `PR #683`. Weakening the assertion to `reaped <= limit` on the return value would remove the flake but is a false negative: if the worker reaps the rows first, the call returns `0` and `0 <= limit` passes even with a broken `LIMIT`.

## Approach

Create the `limit + 1` eligible rows inside a holding transaction that **always rolls back**, and run the real sweep SQL in that **same** transaction. Uncommitted rows are invisible (MVCC) to the live worker, so the test is the sole sweeper of its own rows and the `LIMIT` is the only thing bounding the count. The cap is then asserted **exactly** — one call returns `limit`, the next returns the remaining `1`. A removed production `LIMIT` returns `limit + 1` and fails (verified by mutation). The rollback also gives the test **zero side effects**: the sweep is global (not tenant-scoped, by design), so if it catches another tenant's row the rollback undoes that write.

To run the real SQL inside the test's transaction without duplicating it, each sweep is split into a thin `X(prisma)` wrapper that opens its own transaction and an exported `XInTx(tx)` that holds the SQL. Production always reaches the SQL via the wrapper — behavior is identical. `purgeRetention` additionally returns its per-branch counts (was `void`; the sole caller ignores the return).

## S1 starvation guard

The S1 property — the FAILED purge branch runs even when the SENT branch saturates its cap — is an orchestration property of `purgeRetention`, not of the branch helpers. It is now proven in the worker unit test, also verified by mutation (skipping the FAILED branch on SENT saturation fails the test).

## Verification

- Sweep-cap integration test: green across repeated consecutive runs under the live worker.
- Mutation checks: removing the reap `LIMIT` fails the cap test; skipping the FAILED branch on SENT saturation fails the S1 test.
- Full unit suite, related outbox integration tests, typecheck, lint, and production build all pass (`scripts/pre-pr.sh`: 51/51).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
