### PR TITLE
fix(ui): truncate long attachment filenames in entry edit dialog

### DIFF
--- a/docs/archive/review/fix-attachment-edit-dialog-overflow-code-review.md
+++ b/docs/archive/review/fix-attachment-edit-dialog-overflow-code-review.md
@@ -1,0 +1,102 @@
+# Code Review: fix-attachment-edit-dialog-overflow
+Date: 2026-07-20
+Review round: 1
+
+## Changes from Previous Round
+Initial code review. Diff is a single one-line CSS class change
+(`entry-dialog-shell.tsx:27` gains `[&>*]:min-w-0`) plus documentation-only `*.md` edits.
+
+## Functionality Findings
+
+**No findings.** Fix correct, complete, matches locked contract C1 exactly, no regression.
+- I1/I2/I3 all satisfied; no forbidden patterns present in the diff.
+- `[&>*]:min-w-0` correctly targets the grid items (DialogHeader + form children) of the
+  DialogContent grid (`ui/dialog.tsx:70` `grid ... gap-4`), overriding the grid-item
+  `min-width:auto` default so the `min-w-0`/`truncate` chain inside the attachment row
+  can shrink and engage.
+- Regression check: the Close button is `absolute top-4 right-4` (`ui/dialog.tsx:85`) —
+  out of grid flow, not a grid item, so the variant does not affect it. `DialogHeader`
+  shrink is benign (only title text, wraps naturally; `sr-only` description).
+- Coverage complete: `PersonalEntryDialogShell` and `TeamEntryDialogShell` are bare
+  re-exports of the one `EntryDialogShell`; all personal + team, new + edit dialogs and
+  all entry types route through it. No divergent shell to sync (R8/R3 clean).
+
+## Security Findings
+
+**No findings.** Implemented diff matches the plan-stage security review exactly.
+- Source diff is exactly the one class addition; no logic/data-handling/event-handler/
+  import change.
+- `min-w-0` on direct children hides/removes nothing. The one security-relevant element
+  in this tree, `legacyAttachmentHint` (`attachment-section.tsx:414`), is a static
+  translation string in a sibling `<p>`; column shrink lets it wrap, not clip. No warning
+  banner / step-up reauth prompt lives in this shell's direct-child grid.
+- No new info-disclosure or XSS surface: `{att.filename}` is auto-escaped React text
+  (`attachment-section.tsx:408`); no `dangerouslySetInnerHTML`, no new attribute
+  interpolation. Download is keyed on `att.id` (line 422), not the visual label.
+
+## Testing Findings
+
+No-new-test decision **confirmed correct as implemented** — no cheap, reliable,
+non-decorative test exists for a CSS grid min-width fix (jsdom has no layout engine; a
+class-presence assertion is decorative; the only valid fail-before/pass-after is a
+real-browser Playwright `scrollWidth <= clientWidth` check). Two Minor documentation-
+accuracy findings, both fixed in the plan this round:
+
+**T1 — Minor** (fixed): the plan cited `attachment-section.test.tsx` /
+`team-attachment-section.test.tsx` as a regression guard, but neither renders
+`EntryDialogShell` (verified — no import), so they don't guard this change. The renderer
+test is `entry-dialog-shell.test.tsx`, which correctly asserts only title/children (no
+decorative className check). Plan's Regression-guard bullet corrected.
+
+**T2 — Minor** (fixed): the E2E deferral note now names the existing `seedAttachment`
+helper (`e2e/helpers/password-entry.ts:163`), so the future-cost estimate is honest
+("one new spec using the existing helper", not "build fixtures from scratch").
+
+RT6 (new-code-untested) is accepted and recorded (not silent): the layout effect is
+intentionally unguarded because no non-decorative automated test is possible; verification
+is manual-visual + `npx vitest run` (12778 passed) + `npx next build` (passed).
+
+## Adjacent Findings
+- [Adjacent] Security→UX (plan stage): a `title`/tooltip showing the full filename on
+  hover would aid readability of truncated names. Explicitly scoped out; possible future
+  enhancement.
+
+## Quality Warnings
+None.
+
+## Recurring Issue Check
+### Functionality expert
+- R8 shared-component consistency: PASS (re-exports of one shell)
+- R3 propagation: PASS (single shared shell covers all instances)
+- Regression scope: PASS ([&>*] direct children only; absolute close button unaffected)
+
+### Security expert
+- RS1: N/A. RS2: N/A. RS3: PASS (escaped text, no innerHTML). RS4: PASS (downloads keyed
+  on att.id). RS5: PASS (visual-only truncation). RS6: N/A.
+- feedback_tailwind_standard_palette: PASS (standard utility class)
+
+### Testing expert
+- RT1: N/A. RT2: OK (shell test by text/role). RT5: OK (full suite 12778 passed).
+- RT6 new-code-untested: FLAGGED-accepted (no non-decorative test possible; recorded).
+- RT7 orphaned-check: FLAGGED (T1, doc-level, fixed). RT9: OK (no snapshots).
+- Anti-Deferral: SATISFIED (T2 refines E2E cost estimate; SC3 records the deferral).
+
+## Environment Verification Report
+N/A — no environment constraints declared in Phase 1 (the plan's "Verification
+environment constraints" section is "none blocking"; the fix is a CSS-only change
+verifiable in local dev).
+
+## Resolution Status
+### T1 [Minor] Plan cited non-rendering tests as regression guard
+- Action: corrected the Regression-guard bullet in the plan's Testing strategy to state
+  the attachment-section tests do NOT render EntryDialogShell and name
+  entry-dialog-shell.test.tsx as the actual (className-free) renderer test.
+- Modified file: docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
+
+### T2 [Minor] E2E deferral cost estimate understated existing helper
+- Action: updated the E2E-decision bullet to name the existing `seedAttachment` helper
+  (e2e/helpers/password-entry.ts:163) so the remaining-cost estimate is accurate.
+- Modified file: docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
+
+All findings resolved. No Critical/Major findings in any round. Code diff unchanged by
+this round (both findings were plan documentation-accuracy notes).

--- a/docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
+++ b/docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
@@ -151,9 +151,15 @@ other code. No consumer reads a field from this change.
 - **Primary verification is visual** (CSS layout bug): run the dev server, open an entry
   that has an attachment with a deliberately long filename, confirm no horizontal
   scrollbar and single-line ellipsis truncation in both personal and team edit dialogs.
-- **Regression guard**: `npx vitest run` for the existing attachment-section and
-  team-attachment-section suites (they already mount the filename node) confirms no
-  markup regression. `npx next build` confirms no TS/build break.
+- **Regression guard (scope caveat)**: `npx next build` confirms no TS/build break, and
+  the full `npx vitest run` confirms nothing else regresses. Note that the
+  attachment-section / team-attachment-section suites do NOT render `EntryDialogShell`
+  (verified: neither test imports it), so they do not guard *this* change — the fix
+  touches only the shell, not the attachment-section markup. The test that renders the
+  changed component is `src/components/passwords/entry/entry-dialog-shell.test.tsx`, and
+  it correctly asserts only title/children presence, NOT the className (a class assertion
+  there would be decorative). Net: the layout effect of this change is intentionally
+  unguarded by automated tests — see the E2E decision below and RT6 acceptance.
 - **No new unit test asserting CSS classes**: asserting the literal presence of
   `[&>*]:min-w-0` in a snapshot would be a decorative test (it re-states the source, and
   removing the assertion would still leave the "test" green against the real bug — jsdom
@@ -166,12 +172,15 @@ other code. No consumer reads a field from this change.
   `scrollWidth <= clientWidth` on `[role='dialog']` with a long-filename fixture is the
   only test that would fail-before/pass-after. Resolved after checking the repo: an
   entry-edit-dialog E2E path exists (`e2e/page-objects/password-entry.page.ts`
-  `openEditDialog()`, driven by `e2e/tests/password-crud.spec.ts`), but **no
-  entry-attachment E2E fixture exists** — the only `setInputFiles` in `e2e/` is the CSV
-  *import* input (`import.page.ts`), and there is no attachment seed helper. Attachments
-  are client-side-encrypted, so a DB/blob seed is not a one-liner (it must produce a
-  decryptable blob or the row won't render). **Decision: adding an attachment-upload E2E
-  fixture is out of scope for this one-class CSS fix (SC3). Primary verification is
+  `openEditDialog()`, driven by `e2e/tests/password-crud.spec.ts`), and a
+  `seedAttachment` helper exists (`e2e/helpers/password-entry.ts:163`, encrypts +
+  DB-inserts an attachment row), but **no E2E spec opens the entry edit dialog and renders
+  a seeded attachment** — the only `setInputFiles` in `e2e/` is the CSV *import* input
+  (`import.page.ts`), and `seedAttachment` is exercised only by its own unit test. So the
+  remaining cost of an E2E is "one new spec that seeds a long-filename attachment via the
+  existing helper, opens the edit dialog, and asserts `scrollWidth <= clientWidth`" — not
+  building attachment fixtures from scratch. **Decision: adding that E2E spec is out of
+  scope for this one-class CSS fix (SC3). Primary verification is
   manual-visual per the User operation scenarios below + `npx vitest run` + `npx next
   build`.** The manual check MUST use a long UNBROKEN filename (≈200 chars, no
   whitespace) — a name with break opportunities won't reproduce the bug and would

--- a/docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
+++ b/docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
@@ -1,0 +1,208 @@
+# Plan: Fix entry edit dialog horizontal scrollbar from long attachment filenames
+
+## Project context
+
+- **Type**: web app (Next.js 16 App Router + React + Tailwind 4.1 + shadcn/ui)
+- **Test infrastructure**: unit + integration (vitest) + E2E (Playwright) + CI/CD
+- **Verification environment constraints**: none blocking. CSS-only fix in one shared
+  shell component; visually verifiable in local dev (`npm run dev -- -p 3001`). No
+  paid-tier APIs, external services, or hardware paths involved.
+
+## Objective
+
+When an attachment with a long, unbroken filename (e.g. a 200-char name, or a long
+hex/base64 token with no whitespace) is present in a password entry, opening the
+**entry edit dialog** produces a horizontal scrollbar across the whole dialog. The
+filename `<p>` already carries `truncate`, so the intended behavior (single-line
+ellipsis) is defined but never engages. The dialog stretches to the filename's
+intrinsic width instead. Fix so the attachment row truncates within the dialog bounds
+— once, in the shared entry-dialog shell that both personal and team edit dialogs use.
+
+This is a distinct instance from the already-fixed delete-confirmation overflow
+(`docs/archive/review/fix-attachment-delete-dialog-overflow-plan.md`): that one *wraps*
+a filename in an `AlertDialog` description via `wrap-anywhere`; this one needs the
+existing `truncate` in the edit dialog's attachment *list* to actually engage.
+
+## Root cause
+
+The filename node already has the correct truncation classes:
+
+- Personal: `src/components/passwords/entry/attachment-section.tsx:407-408`
+  — `<div className="flex-1 min-w-0"><p className="text-sm truncate">{att.filename}</p>`
+- Team: `src/components/team/forms/team-attachment-section.tsx:301-302` — identical.
+
+`truncate` (`overflow: hidden; text-overflow: ellipsis; white-space: nowrap`) requires
+every ancestor between the flex/grid container and the text node to be allowed to shrink
+below its content width. The chain breaks higher up:
+
+1. `DialogContent` (`src/components/ui/dialog.tsx:70`) is a **CSS grid** (`grid ...
+   max-w-[calc(100%-2rem)] ... sm:max-w-lg`; `EntryDialogShell` overrides width to
+   `sm:max-w-2xl`, `entry-dialog-shell.tsx:27`).
+2. Its direct children are grid items. Grid (and flex) items default to
+   `min-width: auto`, which means "do not shrink below the content's intrinsic min
+   size." A long unbroken filename gives that subtree a large intrinsic min-width.
+3. The attachment section is mounted inside a wrapper `<div className="border-t pt-4
+   mt-2">` (`src/components/passwords/dialogs/personal-password-edit-dialog.tsx:271`;
+   eight team-form equivalents) which is itself a grid item with **no `min-w-0`**. That
+   wrapper refuses to shrink, so the
+   grid track expands to the filename width and the whole dialog overflows — the inner
+   `truncate` never gets a constrained width to truncate against.
+
+So the bug is not a missing `truncate`; it is a missing `min-w-0` on the grid-item
+layer directly under the `DialogContent` grid.
+
+## Technical approach
+
+Add `min-w-0` to every direct child of the `DialogContent` grid **within the shared
+entry-dialog shell only**, via the arbitrary-variant class `[&>*]:min-w-0` on the
+`DialogContent` in `EntryDialogShell`. This lets any grid-item child (the form, the
+attachment-section wrapper, headers) shrink below its intrinsic content width, so the
+already-present `truncate` on the filename engages and the dialog honours its `max-w`.
+
+Why this approach:
+
+- **Single shared point, correct blast radius.** `EntryDialogShell`
+  (`src/components/passwords/entry/entry-dialog-shell.tsx`) is the one file both the
+  personal shell and the team shell re-export. Fixing there covers personal AND team
+  edit dialogs and every current/future entry type (login, secure-note, passkey,
+  identity, bank-account, ssh-key, credit-card, software-license) without editing the
+  nine individual wrapper `<div>`s at each call site. Per-call-site `min-w-0` would
+  leave the bug latent in the next form someone adds — the same R8 inconsistency the
+  delete-dialog review flagged.
+- **Not global `DialogContent`.** Adding `min-w-0` to the shared `DialogContent`
+  primitive (`ui/dialog.tsx`) would change grid-item shrink behavior for *every* dialog
+  in the app (confirmations, settings, pickers). That is a larger blast radius than the
+  reported bug warrants and risks regressing dialogs that rely on the default
+  `min-width: auto`. Scope the fix to the entry-dialog shell.
+- **`[&>*]:min-w-0` vs `min-w-0` on the content box itself.** The overflow comes from a
+  grid *track* sized by its *item's* min-width, so the `min-w-0` must land on the grid
+  *items* (the `> *` children), not only on the grid container. `[&>*]:min-w-0` targets
+  exactly those direct children. (Adding `min-w-0` to the `DialogContent` box too is
+  harmless but not what unblocks the truncate; the item-level rule is the load-bearing
+  one.)
+- **`truncate`, not `wrap-anywhere`.** A list row should stay single-line with an
+  ellipsis (the design already chose `truncate`). Wrapping a long filename across many
+  lines in an edit-form list would be worse UX and inconsistent with the existing
+  intent. We make the existing `truncate` work rather than change the truncation style.
+  (The delete *dialog* wraps because a confirmation sentence reads better wrapped than
+  ellipsised — a different context, already handled by its own fix.)
+
+`min-w-0` and arbitrary-variant `[&>*]:` are core Tailwind, no config change.
+
+## Contracts
+
+### C1 — `EntryDialogShell`'s `DialogContent` lets grid-item children shrink
+
+**File**: `src/components/passwords/entry/entry-dialog-shell.tsx:27`
+
+**Signature (JSX className change only)**:
+
+```
+- <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto">
++ <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto [&>*]:min-w-0">
+```
+
+**Invariants** (app/CSS-enforced — this is a presentational component with no schema layer):
+- I1: Every direct child of the entry `DialogContent` grid has `min-width: 0`, so a
+  descendant with `truncate` truncates instead of forcing the grid track wider than
+  the dialog's `max-w`.
+- I2: No change to dialog width, max-height, vertical scroll, header, or any child
+  component's markup. The only observable change is that over-wide unbroken content
+  now truncates/clips within bounds instead of introducing a horizontal scrollbar.
+- I3: The existing `truncate` + `min-w-0` on the attachment filename node
+  (attachment-section.tsx:407-408, team-attachment-section.tsx:301-302) is retained
+  unchanged — the fix unblocks it, it does not replace it.
+
+**Forbidden patterns** (grep keys for Phase 2-4 conformance):
+- pattern: `min-w-0` added to `src/components/ui/dialog.tsx` — reason: fix must be
+  scoped to the entry-dialog shell, not the global `DialogContent` primitive.
+- pattern: per-call-site wrapper edits adding `min-w-0` to the `border-t pt-4` wrapper
+  `<div>`s in `src/components/passwords/dialogs/personal-password-edit-dialog.tsx` or any
+  `team-*-form.tsx` — reason:
+  the class fix lives once in the shell; per-site edits are the inconsistency this
+  plan avoids.
+- pattern: `break-all` or `wrap-anywhere` added to the attachment filename `<p>` —
+  reason: the list row must stay single-line ellipsis (`truncate`), not wrap.
+- pattern: removal or alteration of `truncate` on the filename `<p>` — reason: the
+  existing truncation is correct; only its ancestor shrink-blocking is the bug.
+
+**Acceptance criteria**:
+- A1: With an attachment whose filename is a 200-char unbroken string, the personal
+  entry edit dialog shows no horizontal scrollbar; the filename renders on one line
+  ending in an ellipsis, constrained to the dialog width.
+- A2: Same for the team entry edit dialog (any entry type that renders
+  `TeamAttachmentSection`).
+- A3: Ordinary short filenames and all other dialog content render identically to
+  before (no visual regression to width, spacing, or the form fields).
+- A4: `npx vitest run` passes; `npx next build` succeeds.
+
+**Consumer-flow walkthrough**: N/A — C1 changes a CSS utility class on a presentational
+shell. It defines no API response shape, persisted-state shape, or payload consumed by
+other code. No consumer reads a field from this change.
+
+## Go/No-Go Gate
+
+| ID | Subject                                                      | Status |
+|----|-------------------------------------------------------------|--------|
+| C1 | `EntryDialogShell` DialogContent gains `[&>*]:min-w-0`       | locked |
+
+## Testing strategy
+
+- **Primary verification is visual** (CSS layout bug): run the dev server, open an entry
+  that has an attachment with a deliberately long filename, confirm no horizontal
+  scrollbar and single-line ellipsis truncation in both personal and team edit dialogs.
+- **Regression guard**: `npx vitest run` for the existing attachment-section and
+  team-attachment-section suites (they already mount the filename node) confirms no
+  markup regression. `npx next build` confirms no TS/build break.
+- **No new unit test asserting CSS classes**: asserting the literal presence of
+  `[&>*]:min-w-0` in a snapshot would be a decorative test (it re-states the source, and
+  removing the assertion would still leave the "test" green against the real bug — jsdom
+  does not compute grid track sizing). The behavior is only observable in a real layout
+  engine, which jsdom does not provide. (The global vitest environment is `node`; the
+  attachment-section component tests opt into jsdom via a per-file
+  `// @vitest-environment jsdom` pragma — either way there is no layout engine, so
+  `scrollWidth`/`clientWidth` are 0 and a layout assertion is meaningless.)
+- **E2E decision (recorded, not deferred)**: an E2E Playwright check asserting
+  `scrollWidth <= clientWidth` on `[role='dialog']` with a long-filename fixture is the
+  only test that would fail-before/pass-after. Resolved after checking the repo: an
+  entry-edit-dialog E2E path exists (`e2e/page-objects/password-entry.page.ts`
+  `openEditDialog()`, driven by `e2e/tests/password-crud.spec.ts`), but **no
+  entry-attachment E2E fixture exists** — the only `setInputFiles` in `e2e/` is the CSV
+  *import* input (`import.page.ts`), and there is no attachment seed helper. Attachments
+  are client-side-encrypted, so a DB/blob seed is not a one-liner (it must produce a
+  decryptable blob or the row won't render). **Decision: adding an attachment-upload E2E
+  fixture is out of scope for this one-class CSS fix (SC3). Primary verification is
+  manual-visual per the User operation scenarios below + `npx vitest run` + `npx next
+  build`.** The manual check MUST use a long UNBROKEN filename (≈200 chars, no
+  whitespace) — a name with break opportunities won't reproduce the bug and would
+  false-pass.
+
+## Considerations & constraints
+
+- **Scope contract**:
+  - SC1 — Global `DialogContent` grid-item shrink behavior is deliberately NOT changed;
+    owned by any future "make all dialogs shrink-safe" initiative. Out of scope here to
+    keep blast radius at the entry dialog.
+  - SC2 — The eight team-form wrapper `<div>`s and the personal wrapper `<div>` are NOT
+    individually edited; the shell fix covers them. Not deferred work — deliberately
+    avoided as the wrong layer.
+  - SC3 — (a) Other potentially-overflowing dialogs in the app (settings, pickers) are
+    not audited in this PR; only the reported entry-edit-dialog instance is fixed.
+    (b) A new entry-attachment E2E fixture is NOT built (none exists; disproportionate for
+    a one-class CSS fix — see Testing strategy); verification is manual-visual + build/lint.
+- **Known risk**: `[&>*]:min-w-0` applies to *all* direct grid children, including
+  `DialogHeader`. `DialogHeader` contains the title/description and does not rely on
+  `min-width: auto` for its layout, so allowing it to shrink to 0 min-width is safe (its
+  content wraps normally). Verify visually in A3.
+- **Out of scope**: changing truncation style, adding tooltips showing the full filename
+  on hover/focus (a possible UX enhancement, not part of this bug fix).
+
+## User operation scenarios
+
+1. Personal vault → open an entry that has an attachment named e.g.
+   `verylongfilename_<180 more chars>.pdf` → click edit → observe the attachment row.
+   Expect: single-line ellipsis, no horizontal scrollbar on the dialog.
+2. Team vault → same, for an entry rendering `TeamAttachmentSection` (e.g. a team login
+   entry with an attachment) → edit → observe.
+3. Regression: any entry with only short filenames and no attachments → edit → the
+   dialog looks identical to before the change.

--- a/docs/archive/review/fix-attachment-edit-dialog-overflow-review.md
+++ b/docs/archive/review/fix-attachment-edit-dialog-overflow-review.md
@@ -1,0 +1,95 @@
+# Plan Review: fix-attachment-edit-dialog-overflow
+Date: 2026-07-20
+Review round: 1
+
+## Changes from Previous Round
+Initial review.
+
+## Functionality Findings
+
+Root-cause analysis confirmed CORRECT. Full ancestor chain traced on both personal and
+team paths. `[&>*]:min-w-0` on the DialogContent grid correctly targets the grid ITEMS:
+- Personal (personal-password-edit-dialog.tsx:262-278): form + `border-t pt-4 mt-2`
+  wrapper are sibling JSX children → direct grid items.
+- Team (team-login-form.tsx etc.): form returns a React Fragment `<>`, so `<form>` and
+  the `border-t pt-4` wrapper both become separate direct grid-item children.
+No deeper `min-w-0` propagation needed — the `space-y-*` blocks are ordinary block
+containers (already `min-width:0`); the only nested flex (the row) already has `min-w-0`
+on its child. No form wide-content regression (only one `font-mono` block, uses
+`break-all whitespace-pre-wrap`). `overflow-y-auto` interaction safe. Member-set complete:
+personal + team + all 8 entry types via the shared shell; the `new` dialog shares the
+shell but has no attachment section pre-creation (harmlessly covered).
+
+**F1 — Minor**: Plan cites `personal-password-edit-dialog.tsx:271` without its full path.
+Actual: `src/components/passwords/dialogs/personal-password-edit-dialog.tsx`. Team count
+of 8 confirmed correct. No effect on the fix (fix only touches entry-dialog-shell.tsx);
+doc accuracy only. → Correct the path in Root cause + Forbidden-patterns sections.
+
+## Security Findings
+
+**No findings.** Presentational CSS-only change.
+- Truncation homograph/extension-spoofing: NOT a new risk — `truncate` pre-exists on the
+  filename `<p>`; long deceptive names could already clip under narrow viewports. Security
+  boundary does not rest on the visual label — downloads use `att.id`
+  (attachment-section.tsx:422), not the rendered string. No spoofing-to-action path.
+- Escaping unchanged: `{att.filename}` is React JSX text interpolation (auto-escaped);
+  change touches only a className string. No XSS surface change.
+- No security-critical control in the entry dialog depends on `min-width:auto`; header
+  wraps rather than clips.
+- Filename is non-secret user-attached metadata; ellipsis crosses no confidentiality
+  boundary. Blast radius correctly bounded to the entry-dialog shell (not global
+  ui/dialog.tsx).
+
+## Testing Findings
+
+Testing strategy confirmed CORRECT. jsdom truly cannot validate this layout fix (no
+layout engine — `scrollWidth`/`clientWidth` = 0). A class-presence assertion would be
+decorative per common/testing.md. The canonical E2E `scrollWidth <= clientWidth` probe is
+the right shape but NO entry-attachment E2E fixture exists (only CSV-import
+`setInputFiles`); building one for client-side-encrypted blobs is disproportionate for a
+one-class CSS fix. Existing unit suites are layout-blind but provide the narrow
+markup-regression guard the plan claims (I3). No cheap fail-before/pass-after test exists →
+not Critical.
+
+**T1 — Minor**: Convert the Phase-2 E2E hedge into a recorded decision (Anti-Deferral):
+"no entry-attachment E2E fixture exists; adding one is out of scope for this CSS-only fix;
+verification is manual-visual per scenarios + build/lint."
+
+**T2 — Minor**: Prose says "vitest/jsdom" but the global vitest env is `node`; the
+component tests opt into jsdom via a per-file `// @vitest-environment jsdom` pragma.
+Conclusion (no layout engine) unchanged — wording precision only.
+
+Also (informational): manual verification MUST use a long UNBROKEN filename (200-char, no
+whitespace) or the bug won't reproduce and the check false-passes.
+
+## Adjacent Findings
+- [Adjacent] Security (usability): a `title`/tooltip showing the full filename on
+  hover/focus would help users read truncated names. Plan explicitly scopes it out. Not a
+  security finding; noted for possible future UX enhancement.
+
+## Quality Warnings
+None.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R8 shared-component-consistency: PASS (single shared EntryDialogShell)
+- Incomplete member-set coverage: PASS (8 team forms + personal all route through shell)
+- Blast-radius / global-primitive regression: PASS (scoped to shell, not ui/dialog.tsx)
+- Ancestor-chain completeness: PASS
+- Effective-default / distributed-contract: N/A
+
+### Security expert
+- project_no_store_secret_response_class: clear (non-secret metadata)
+- feedback_body_cast_not_schema_validation: N/A
+- XSS / raw-HTML sink: clear (auto-escaped, no dangerouslySetInnerHTML)
+- feedback_child_model_parent_fk_scoping: N/A (no data-access code)
+- Spoofing-to-action via truncated display: clear (download uses att.id)
+- feedback_close_defect_class_not_instances: clear (shell covers personal+team+all types)
+
+### Testing expert
+- Decorative test: OK (plan refuses class-presence test)
+- Anti-Deferral / decision-not-recorded: flagged T1
+- fail-before/pass-after rigor: OK
+- Coverage-gap-with-cheap-test (Critical trigger): not Critical (no cheap test exists)
+- Test env misstatement: T2 minor wording

--- a/src/components/passwords/entry/entry-dialog-shell.tsx
+++ b/src/components/passwords/entry/entry-dialog-shell.tsx
@@ -24,7 +24,7 @@ export function EntryDialogShell({
 }: EntryDialogShellProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto [&>*]:min-w-0">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription className="sr-only">{title}</DialogDescription>


### PR DESCRIPTION
## Summary
Long, unbroken attachment filenames caused a horizontal scrollbar across the whole entry edit dialog. The filename `<p>` already carried `truncate`, but it never engaged. This fix makes it engage by allowing the dialog's grid-item children to shrink.

## Root cause
`DialogContent` (`src/components/ui/dialog.tsx`) is a CSS grid. Grid items default to `min-width: auto`, so they refuse to shrink below their content's intrinsic width. The attachment section is mounted inside a wrapper `<div>` that is a direct grid-item child with no `min-w-0`, so a long unbroken filename expanded the grid track past the dialog's `max-w` and the inner `truncate` never received a constrained width to truncate against.

## Fix
Add `[&>*]:min-w-0` to the `DialogContent` in the shared `EntryDialogShell` (`src/components/passwords/entry/entry-dialog-shell.tsx:27`). This overrides `min-width: auto` on the direct grid-item children so the existing `truncate` on the filename engages and the dialog honours its `max-w`.

- Scoped to the shared shell, which both personal and team edit dialogs re-export, so the one change covers personal + team + all entry types (login, secure-note, passkey, identity, bank-account, ssh-key, credit-card, software-license) — no per-call-site edits.
- Deliberately NOT applied to the global `ui/dialog.tsx` primitive, to keep the blast radius at the entry dialog and avoid altering every other dialog in the app.
- Keeps the existing `truncate` (single-line ellipsis) rather than switching to `break-all` / `wrap-anywhere` — a list row should stay single-line.

## Review artifacts
- [plan](./docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md)
- [plan review](./docs/archive/review/fix-attachment-edit-dialog-overflow-review.md)
- [code review](./docs/archive/review/fix-attachment-edit-dialog-overflow-code-review.md)

Reviewed via triangulate (functionality / security / testing) at both plan and code stages — no Critical/Major findings; all Minor findings (documentation accuracy) resolved.

## Test plan
- [ ] Open a personal entry that has an attachment with a ~200-char unbroken filename → edit → verify no horizontal scrollbar, single-line ellipsis truncation.
- [ ] Repeat for a team entry rendering `TeamAttachmentSection`.
- [ ] Regression: edit an entry with only short filenames / no attachments → dialog looks identical to before.
- [ ] `npx vitest run` (12778 passed) and `npx next build` succeed.

Note: no automated test was added — the effect is a CSS grid layout behavior that jsdom (no layout engine) cannot assert, and a class-presence assertion would be decorative. The only fail-before/pass-after test is a real-browser Playwright `scrollWidth <= clientWidth` check, which is out of scope for this one-class fix (no entry-attachment E2E spec exists yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
