### PR TITLE
fix(ui): close truncate-overflow class + align dashboard banner width

### DIFF
--- a/docs/archive/review/fix-attachment-edit-dialog-overflow-code-review.md
+++ b/docs/archive/review/fix-attachment-edit-dialog-overflow-code-review.md
@@ -100,3 +100,47 @@ verifiable in local dev).
 
 All findings resolved. No Critical/Major findings in any round. Code diff unchanged by
 this round (both findings were plan documentation-accuracy notes).
+
+## Post-review scope expansion (2026-07-20)
+
+### Process note — R42 should have run at Phase 1, not after the user asked
+The original bug ("long attachment filename → horizontal scrollbar in the entry edit
+dialog") was treated as a single-instance fix, and the whole Phase-1 plan + 3-expert
+review ran inside that narrow scope. It is actually one member of a defect class:
+"a flex/grid item defaults to `min-width:auto`, so a descendant `truncate` cannot shrink
+and a long unbroken string overflows its container." Per R42 clause (b) — "a one-line
+user remark" can declare a class — the member-set grep should have run BEFORE writing the
+plan. It did not; the class-wide sweep only ran when the user asked "同様の箇所は他に
+ないですよね？". This is the process failure recorded in
+`feedback_r42_applies_to_review_findings_not_just_plan_classes` and
+`feedback_close_defect_class_not_instances`. Lesson folded back into those memories.
+
+### Class 1 — truncate-overflow, swept and closed
+Members found by grepping the class (flex/grid ancestor + `truncate` with a shrink-blocked
+intermediate) and fixed in this branch:
+- `EntryDialogShell` grid — `[&>*]:min-w-0` (original fix)
+- `base-webhook-card` (URL), `mcp-client-card` (name), `service-account-card` (4 sites:
+  SA name+description ×2, token name ×2), `emergency-access/grant-card` (member),
+  `tenant-audit-log-card` (actor), `member-info` (name/email — shared, broad coverage),
+  `folder-tree` + `sidebar-shared` (folder/tag names)
+
+Deliberately NOT changed (scope-out, verified):
+- `entry-secondary-line` — its truncate spans sit inside a `flex-1 min-w-0` boundary in
+  both call sites (`password-card.tsx:519`, `password-row.tsx:275`), so a long value clips
+  internally and never produces a pane-level scrollbar. Not a member of the reported class.
+- global `ui/dialog.tsx` primitive — blast radius; scoped fixes only.
+- `AlertDialogContent` — same grid shape as `DialogContent`, but its long-string case is
+  already handled by a different fix (`AlertDialogDescription` `wrap-anywhere` — wrap, not
+  truncate). Different class, out of scope here.
+
+### Class 2 — dashboard banner width
+Second class surfaced by the user: recovery-key and delegation-revoke banners rendered as
+direct `<main>` children with `mx-4 md:mx-6` and no max-width, spanning the full right
+pane instead of matching the entry list. Both use the identical shrink-less class → same
+class. Fixed by extracting `DashboardBanner` (reuses `useLayoutMode` for the entry area's
+layout-mode-dependent centered max-width) and wrapping both banners. Added `mockMatchMedia`
+test helper + `DashboardBanner` test (width-switch is a real `useLayoutMode` branch, not a
+decorative layout assertion).
+
+Verification: `npx vitest run` (12780 passed), `npx next build` (passed), pre-PR gate (51
+checks passed). PR #687.

--- a/docs/archive/review/fix-attachment-edit-dialog-overflow-code-review.md
+++ b/docs/archive/review/fix-attachment-edit-dialog-overflow-code-review.md
@@ -1,0 +1,102 @@
+# Code Review: fix-attachment-edit-dialog-overflow
+Date: 2026-07-20
+Review round: 1
+
+## Changes from Previous Round
+Initial code review. Diff is a single one-line CSS class change
+(`entry-dialog-shell.tsx:27` gains `[&>*]:min-w-0`) plus documentation-only `*.md` edits.
+
+## Functionality Findings
+
+**No findings.** Fix correct, complete, matches locked contract C1 exactly, no regression.
+- I1/I2/I3 all satisfied; no forbidden patterns present in the diff.
+- `[&>*]:min-w-0` correctly targets the grid items (DialogHeader + form children) of the
+  DialogContent grid (`ui/dialog.tsx:70` `grid ... gap-4`), overriding the grid-item
+  `min-width:auto` default so the `min-w-0`/`truncate` chain inside the attachment row
+  can shrink and engage.
+- Regression check: the Close button is `absolute top-4 right-4` (`ui/dialog.tsx:85`) —
+  out of grid flow, not a grid item, so the variant does not affect it. `DialogHeader`
+  shrink is benign (only title text, wraps naturally; `sr-only` description).
+- Coverage complete: `PersonalEntryDialogShell` and `TeamEntryDialogShell` are bare
+  re-exports of the one `EntryDialogShell`; all personal + team, new + edit dialogs and
+  all entry types route through it. No divergent shell to sync (R8/R3 clean).
+
+## Security Findings
+
+**No findings.** Implemented diff matches the plan-stage security review exactly.
+- Source diff is exactly the one class addition; no logic/data-handling/event-handler/
+  import change.
+- `min-w-0` on direct children hides/removes nothing. The one security-relevant element
+  in this tree, `legacyAttachmentHint` (`attachment-section.tsx:414`), is a static
+  translation string in a sibling `<p>`; column shrink lets it wrap, not clip. No warning
+  banner / step-up reauth prompt lives in this shell's direct-child grid.
+- No new info-disclosure or XSS surface: `{att.filename}` is auto-escaped React text
+  (`attachment-section.tsx:408`); no `dangerouslySetInnerHTML`, no new attribute
+  interpolation. Download is keyed on `att.id` (line 422), not the visual label.
+
+## Testing Findings
+
+No-new-test decision **confirmed correct as implemented** — no cheap, reliable,
+non-decorative test exists for a CSS grid min-width fix (jsdom has no layout engine; a
+class-presence assertion is decorative; the only valid fail-before/pass-after is a
+real-browser Playwright `scrollWidth <= clientWidth` check). Two Minor documentation-
+accuracy findings, both fixed in the plan this round:
+
+**T1 — Minor** (fixed): the plan cited `attachment-section.test.tsx` /
+`team-attachment-section.test.tsx` as a regression guard, but neither renders
+`EntryDialogShell` (verified — no import), so they don't guard this change. The renderer
+test is `entry-dialog-shell.test.tsx`, which correctly asserts only title/children (no
+decorative className check). Plan's Regression-guard bullet corrected.
+
+**T2 — Minor** (fixed): the E2E deferral note now names the existing `seedAttachment`
+helper (`e2e/helpers/password-entry.ts:163`), so the future-cost estimate is honest
+("one new spec using the existing helper", not "build fixtures from scratch").
+
+RT6 (new-code-untested) is accepted and recorded (not silent): the layout effect is
+intentionally unguarded because no non-decorative automated test is possible; verification
+is manual-visual + `npx vitest run` (12778 passed) + `npx next build` (passed).
+
+## Adjacent Findings
+- [Adjacent] Security→UX (plan stage): a `title`/tooltip showing the full filename on
+  hover would aid readability of truncated names. Explicitly scoped out; possible future
+  enhancement.
+
+## Quality Warnings
+None.
+
+## Recurring Issue Check
+### Functionality expert
+- R8 shared-component consistency: PASS (re-exports of one shell)
+- R3 propagation: PASS (single shared shell covers all instances)
+- Regression scope: PASS ([&>*] direct children only; absolute close button unaffected)
+
+### Security expert
+- RS1: N/A. RS2: N/A. RS3: PASS (escaped text, no innerHTML). RS4: PASS (downloads keyed
+  on att.id). RS5: PASS (visual-only truncation). RS6: N/A.
+- feedback_tailwind_standard_palette: PASS (standard utility class)
+
+### Testing expert
+- RT1: N/A. RT2: OK (shell test by text/role). RT5: OK (full suite 12778 passed).
+- RT6 new-code-untested: FLAGGED-accepted (no non-decorative test possible; recorded).
+- RT7 orphaned-check: FLAGGED (T1, doc-level, fixed). RT9: OK (no snapshots).
+- Anti-Deferral: SATISFIED (T2 refines E2E cost estimate; SC3 records the deferral).
+
+## Environment Verification Report
+N/A — no environment constraints declared in Phase 1 (the plan's "Verification
+environment constraints" section is "none blocking"; the fix is a CSS-only change
+verifiable in local dev).
+
+## Resolution Status
+### T1 [Minor] Plan cited non-rendering tests as regression guard
+- Action: corrected the Regression-guard bullet in the plan's Testing strategy to state
+  the attachment-section tests do NOT render EntryDialogShell and name
+  entry-dialog-shell.test.tsx as the actual (className-free) renderer test.
+- Modified file: docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
+
+### T2 [Minor] E2E deferral cost estimate understated existing helper
+- Action: updated the E2E-decision bullet to name the existing `seedAttachment` helper
+  (e2e/helpers/password-entry.ts:163) so the remaining-cost estimate is accurate.
+- Modified file: docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
+
+All findings resolved. No Critical/Major findings in any round. Code diff unchanged by
+this round (both findings were plan documentation-accuracy notes).

--- a/docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
+++ b/docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
@@ -151,9 +151,15 @@ other code. No consumer reads a field from this change.
 - **Primary verification is visual** (CSS layout bug): run the dev server, open an entry
   that has an attachment with a deliberately long filename, confirm no horizontal
   scrollbar and single-line ellipsis truncation in both personal and team edit dialogs.
-- **Regression guard**: `npx vitest run` for the existing attachment-section and
-  team-attachment-section suites (they already mount the filename node) confirms no
-  markup regression. `npx next build` confirms no TS/build break.
+- **Regression guard (scope caveat)**: `npx next build` confirms no TS/build break, and
+  the full `npx vitest run` confirms nothing else regresses. Note that the
+  attachment-section / team-attachment-section suites do NOT render `EntryDialogShell`
+  (verified: neither test imports it), so they do not guard *this* change — the fix
+  touches only the shell, not the attachment-section markup. The test that renders the
+  changed component is `src/components/passwords/entry/entry-dialog-shell.test.tsx`, and
+  it correctly asserts only title/children presence, NOT the className (a class assertion
+  there would be decorative). Net: the layout effect of this change is intentionally
+  unguarded by automated tests — see the E2E decision below and RT6 acceptance.
 - **No new unit test asserting CSS classes**: asserting the literal presence of
   `[&>*]:min-w-0` in a snapshot would be a decorative test (it re-states the source, and
   removing the assertion would still leave the "test" green against the real bug — jsdom
@@ -166,12 +172,15 @@ other code. No consumer reads a field from this change.
   `scrollWidth <= clientWidth` on `[role='dialog']` with a long-filename fixture is the
   only test that would fail-before/pass-after. Resolved after checking the repo: an
   entry-edit-dialog E2E path exists (`e2e/page-objects/password-entry.page.ts`
-  `openEditDialog()`, driven by `e2e/tests/password-crud.spec.ts`), but **no
-  entry-attachment E2E fixture exists** — the only `setInputFiles` in `e2e/` is the CSV
-  *import* input (`import.page.ts`), and there is no attachment seed helper. Attachments
-  are client-side-encrypted, so a DB/blob seed is not a one-liner (it must produce a
-  decryptable blob or the row won't render). **Decision: adding an attachment-upload E2E
-  fixture is out of scope for this one-class CSS fix (SC3). Primary verification is
+  `openEditDialog()`, driven by `e2e/tests/password-crud.spec.ts`), and a
+  `seedAttachment` helper exists (`e2e/helpers/password-entry.ts:163`, encrypts +
+  DB-inserts an attachment row), but **no E2E spec opens the entry edit dialog and renders
+  a seeded attachment** — the only `setInputFiles` in `e2e/` is the CSV *import* input
+  (`import.page.ts`), and `seedAttachment` is exercised only by its own unit test. So the
+  remaining cost of an E2E is "one new spec that seeds a long-filename attachment via the
+  existing helper, opens the edit dialog, and asserts `scrollWidth <= clientWidth`" — not
+  building attachment fixtures from scratch. **Decision: adding that E2E spec is out of
+  scope for this one-class CSS fix (SC3). Primary verification is
   manual-visual per the User operation scenarios below + `npx vitest run` + `npx next
   build`.** The manual check MUST use a long UNBROKEN filename (≈200 chars, no
   whitespace) — a name with break opportunities won't reproduce the bug and would

--- a/docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
+++ b/docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md
@@ -1,0 +1,208 @@
+# Plan: Fix entry edit dialog horizontal scrollbar from long attachment filenames
+
+## Project context
+
+- **Type**: web app (Next.js 16 App Router + React + Tailwind 4.1 + shadcn/ui)
+- **Test infrastructure**: unit + integration (vitest) + E2E (Playwright) + CI/CD
+- **Verification environment constraints**: none blocking. CSS-only fix in one shared
+  shell component; visually verifiable in local dev (`npm run dev -- -p 3001`). No
+  paid-tier APIs, external services, or hardware paths involved.
+
+## Objective
+
+When an attachment with a long, unbroken filename (e.g. a 200-char name, or a long
+hex/base64 token with no whitespace) is present in a password entry, opening the
+**entry edit dialog** produces a horizontal scrollbar across the whole dialog. The
+filename `<p>` already carries `truncate`, so the intended behavior (single-line
+ellipsis) is defined but never engages. The dialog stretches to the filename's
+intrinsic width instead. Fix so the attachment row truncates within the dialog bounds
+— once, in the shared entry-dialog shell that both personal and team edit dialogs use.
+
+This is a distinct instance from the already-fixed delete-confirmation overflow
+(`docs/archive/review/fix-attachment-delete-dialog-overflow-plan.md`): that one *wraps*
+a filename in an `AlertDialog` description via `wrap-anywhere`; this one needs the
+existing `truncate` in the edit dialog's attachment *list* to actually engage.
+
+## Root cause
+
+The filename node already has the correct truncation classes:
+
+- Personal: `src/components/passwords/entry/attachment-section.tsx:407-408`
+  — `<div className="flex-1 min-w-0"><p className="text-sm truncate">{att.filename}</p>`
+- Team: `src/components/team/forms/team-attachment-section.tsx:301-302` — identical.
+
+`truncate` (`overflow: hidden; text-overflow: ellipsis; white-space: nowrap`) requires
+every ancestor between the flex/grid container and the text node to be allowed to shrink
+below its content width. The chain breaks higher up:
+
+1. `DialogContent` (`src/components/ui/dialog.tsx:70`) is a **CSS grid** (`grid ...
+   max-w-[calc(100%-2rem)] ... sm:max-w-lg`; `EntryDialogShell` overrides width to
+   `sm:max-w-2xl`, `entry-dialog-shell.tsx:27`).
+2. Its direct children are grid items. Grid (and flex) items default to
+   `min-width: auto`, which means "do not shrink below the content's intrinsic min
+   size." A long unbroken filename gives that subtree a large intrinsic min-width.
+3. The attachment section is mounted inside a wrapper `<div className="border-t pt-4
+   mt-2">` (`src/components/passwords/dialogs/personal-password-edit-dialog.tsx:271`;
+   eight team-form equivalents) which is itself a grid item with **no `min-w-0`**. That
+   wrapper refuses to shrink, so the
+   grid track expands to the filename width and the whole dialog overflows — the inner
+   `truncate` never gets a constrained width to truncate against.
+
+So the bug is not a missing `truncate`; it is a missing `min-w-0` on the grid-item
+layer directly under the `DialogContent` grid.
+
+## Technical approach
+
+Add `min-w-0` to every direct child of the `DialogContent` grid **within the shared
+entry-dialog shell only**, via the arbitrary-variant class `[&>*]:min-w-0` on the
+`DialogContent` in `EntryDialogShell`. This lets any grid-item child (the form, the
+attachment-section wrapper, headers) shrink below its intrinsic content width, so the
+already-present `truncate` on the filename engages and the dialog honours its `max-w`.
+
+Why this approach:
+
+- **Single shared point, correct blast radius.** `EntryDialogShell`
+  (`src/components/passwords/entry/entry-dialog-shell.tsx`) is the one file both the
+  personal shell and the team shell re-export. Fixing there covers personal AND team
+  edit dialogs and every current/future entry type (login, secure-note, passkey,
+  identity, bank-account, ssh-key, credit-card, software-license) without editing the
+  nine individual wrapper `<div>`s at each call site. Per-call-site `min-w-0` would
+  leave the bug latent in the next form someone adds — the same R8 inconsistency the
+  delete-dialog review flagged.
+- **Not global `DialogContent`.** Adding `min-w-0` to the shared `DialogContent`
+  primitive (`ui/dialog.tsx`) would change grid-item shrink behavior for *every* dialog
+  in the app (confirmations, settings, pickers). That is a larger blast radius than the
+  reported bug warrants and risks regressing dialogs that rely on the default
+  `min-width: auto`. Scope the fix to the entry-dialog shell.
+- **`[&>*]:min-w-0` vs `min-w-0` on the content box itself.** The overflow comes from a
+  grid *track* sized by its *item's* min-width, so the `min-w-0` must land on the grid
+  *items* (the `> *` children), not only on the grid container. `[&>*]:min-w-0` targets
+  exactly those direct children. (Adding `min-w-0` to the `DialogContent` box too is
+  harmless but not what unblocks the truncate; the item-level rule is the load-bearing
+  one.)
+- **`truncate`, not `wrap-anywhere`.** A list row should stay single-line with an
+  ellipsis (the design already chose `truncate`). Wrapping a long filename across many
+  lines in an edit-form list would be worse UX and inconsistent with the existing
+  intent. We make the existing `truncate` work rather than change the truncation style.
+  (The delete *dialog* wraps because a confirmation sentence reads better wrapped than
+  ellipsised — a different context, already handled by its own fix.)
+
+`min-w-0` and arbitrary-variant `[&>*]:` are core Tailwind, no config change.
+
+## Contracts
+
+### C1 — `EntryDialogShell`'s `DialogContent` lets grid-item children shrink
+
+**File**: `src/components/passwords/entry/entry-dialog-shell.tsx:27`
+
+**Signature (JSX className change only)**:
+
+```
+- <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto">
++ <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto [&>*]:min-w-0">
+```
+
+**Invariants** (app/CSS-enforced — this is a presentational component with no schema layer):
+- I1: Every direct child of the entry `DialogContent` grid has `min-width: 0`, so a
+  descendant with `truncate` truncates instead of forcing the grid track wider than
+  the dialog's `max-w`.
+- I2: No change to dialog width, max-height, vertical scroll, header, or any child
+  component's markup. The only observable change is that over-wide unbroken content
+  now truncates/clips within bounds instead of introducing a horizontal scrollbar.
+- I3: The existing `truncate` + `min-w-0` on the attachment filename node
+  (attachment-section.tsx:407-408, team-attachment-section.tsx:301-302) is retained
+  unchanged — the fix unblocks it, it does not replace it.
+
+**Forbidden patterns** (grep keys for Phase 2-4 conformance):
+- pattern: `min-w-0` added to `src/components/ui/dialog.tsx` — reason: fix must be
+  scoped to the entry-dialog shell, not the global `DialogContent` primitive.
+- pattern: per-call-site wrapper edits adding `min-w-0` to the `border-t pt-4` wrapper
+  `<div>`s in `src/components/passwords/dialogs/personal-password-edit-dialog.tsx` or any
+  `team-*-form.tsx` — reason:
+  the class fix lives once in the shell; per-site edits are the inconsistency this
+  plan avoids.
+- pattern: `break-all` or `wrap-anywhere` added to the attachment filename `<p>` —
+  reason: the list row must stay single-line ellipsis (`truncate`), not wrap.
+- pattern: removal or alteration of `truncate` on the filename `<p>` — reason: the
+  existing truncation is correct; only its ancestor shrink-blocking is the bug.
+
+**Acceptance criteria**:
+- A1: With an attachment whose filename is a 200-char unbroken string, the personal
+  entry edit dialog shows no horizontal scrollbar; the filename renders on one line
+  ending in an ellipsis, constrained to the dialog width.
+- A2: Same for the team entry edit dialog (any entry type that renders
+  `TeamAttachmentSection`).
+- A3: Ordinary short filenames and all other dialog content render identically to
+  before (no visual regression to width, spacing, or the form fields).
+- A4: `npx vitest run` passes; `npx next build` succeeds.
+
+**Consumer-flow walkthrough**: N/A — C1 changes a CSS utility class on a presentational
+shell. It defines no API response shape, persisted-state shape, or payload consumed by
+other code. No consumer reads a field from this change.
+
+## Go/No-Go Gate
+
+| ID | Subject                                                      | Status |
+|----|-------------------------------------------------------------|--------|
+| C1 | `EntryDialogShell` DialogContent gains `[&>*]:min-w-0`       | locked |
+
+## Testing strategy
+
+- **Primary verification is visual** (CSS layout bug): run the dev server, open an entry
+  that has an attachment with a deliberately long filename, confirm no horizontal
+  scrollbar and single-line ellipsis truncation in both personal and team edit dialogs.
+- **Regression guard**: `npx vitest run` for the existing attachment-section and
+  team-attachment-section suites (they already mount the filename node) confirms no
+  markup regression. `npx next build` confirms no TS/build break.
+- **No new unit test asserting CSS classes**: asserting the literal presence of
+  `[&>*]:min-w-0` in a snapshot would be a decorative test (it re-states the source, and
+  removing the assertion would still leave the "test" green against the real bug — jsdom
+  does not compute grid track sizing). The behavior is only observable in a real layout
+  engine, which jsdom does not provide. (The global vitest environment is `node`; the
+  attachment-section component tests opt into jsdom via a per-file
+  `// @vitest-environment jsdom` pragma — either way there is no layout engine, so
+  `scrollWidth`/`clientWidth` are 0 and a layout assertion is meaningless.)
+- **E2E decision (recorded, not deferred)**: an E2E Playwright check asserting
+  `scrollWidth <= clientWidth` on `[role='dialog']` with a long-filename fixture is the
+  only test that would fail-before/pass-after. Resolved after checking the repo: an
+  entry-edit-dialog E2E path exists (`e2e/page-objects/password-entry.page.ts`
+  `openEditDialog()`, driven by `e2e/tests/password-crud.spec.ts`), but **no
+  entry-attachment E2E fixture exists** — the only `setInputFiles` in `e2e/` is the CSV
+  *import* input (`import.page.ts`), and there is no attachment seed helper. Attachments
+  are client-side-encrypted, so a DB/blob seed is not a one-liner (it must produce a
+  decryptable blob or the row won't render). **Decision: adding an attachment-upload E2E
+  fixture is out of scope for this one-class CSS fix (SC3). Primary verification is
+  manual-visual per the User operation scenarios below + `npx vitest run` + `npx next
+  build`.** The manual check MUST use a long UNBROKEN filename (≈200 chars, no
+  whitespace) — a name with break opportunities won't reproduce the bug and would
+  false-pass.
+
+## Considerations & constraints
+
+- **Scope contract**:
+  - SC1 — Global `DialogContent` grid-item shrink behavior is deliberately NOT changed;
+    owned by any future "make all dialogs shrink-safe" initiative. Out of scope here to
+    keep blast radius at the entry dialog.
+  - SC2 — The eight team-form wrapper `<div>`s and the personal wrapper `<div>` are NOT
+    individually edited; the shell fix covers them. Not deferred work — deliberately
+    avoided as the wrong layer.
+  - SC3 — (a) Other potentially-overflowing dialogs in the app (settings, pickers) are
+    not audited in this PR; only the reported entry-edit-dialog instance is fixed.
+    (b) A new entry-attachment E2E fixture is NOT built (none exists; disproportionate for
+    a one-class CSS fix — see Testing strategy); verification is manual-visual + build/lint.
+- **Known risk**: `[&>*]:min-w-0` applies to *all* direct grid children, including
+  `DialogHeader`. `DialogHeader` contains the title/description and does not rely on
+  `min-width: auto` for its layout, so allowing it to shrink to 0 min-width is safe (its
+  content wraps normally). Verify visually in A3.
+- **Out of scope**: changing truncation style, adding tooltips showing the full filename
+  on hover/focus (a possible UX enhancement, not part of this bug fix).
+
+## User operation scenarios
+
+1. Personal vault → open an entry that has an attachment named e.g.
+   `verylongfilename_<180 more chars>.pdf` → click edit → observe the attachment row.
+   Expect: single-line ellipsis, no horizontal scrollbar on the dialog.
+2. Team vault → same, for an entry rendering `TeamAttachmentSection` (e.g. a team login
+   entry with an attachment) → edit → observe.
+3. Regression: any entry with only short filenames and no attachments → edit → the
+   dialog looks identical to before the change.

--- a/docs/archive/review/fix-attachment-edit-dialog-overflow-review.md
+++ b/docs/archive/review/fix-attachment-edit-dialog-overflow-review.md
@@ -1,0 +1,95 @@
+# Plan Review: fix-attachment-edit-dialog-overflow
+Date: 2026-07-20
+Review round: 1
+
+## Changes from Previous Round
+Initial review.
+
+## Functionality Findings
+
+Root-cause analysis confirmed CORRECT. Full ancestor chain traced on both personal and
+team paths. `[&>*]:min-w-0` on the DialogContent grid correctly targets the grid ITEMS:
+- Personal (personal-password-edit-dialog.tsx:262-278): form + `border-t pt-4 mt-2`
+  wrapper are sibling JSX children → direct grid items.
+- Team (team-login-form.tsx etc.): form returns a React Fragment `<>`, so `<form>` and
+  the `border-t pt-4` wrapper both become separate direct grid-item children.
+No deeper `min-w-0` propagation needed — the `space-y-*` blocks are ordinary block
+containers (already `min-width:0`); the only nested flex (the row) already has `min-w-0`
+on its child. No form wide-content regression (only one `font-mono` block, uses
+`break-all whitespace-pre-wrap`). `overflow-y-auto` interaction safe. Member-set complete:
+personal + team + all 8 entry types via the shared shell; the `new` dialog shares the
+shell but has no attachment section pre-creation (harmlessly covered).
+
+**F1 — Minor**: Plan cites `personal-password-edit-dialog.tsx:271` without its full path.
+Actual: `src/components/passwords/dialogs/personal-password-edit-dialog.tsx`. Team count
+of 8 confirmed correct. No effect on the fix (fix only touches entry-dialog-shell.tsx);
+doc accuracy only. → Correct the path in Root cause + Forbidden-patterns sections.
+
+## Security Findings
+
+**No findings.** Presentational CSS-only change.
+- Truncation homograph/extension-spoofing: NOT a new risk — `truncate` pre-exists on the
+  filename `<p>`; long deceptive names could already clip under narrow viewports. Security
+  boundary does not rest on the visual label — downloads use `att.id`
+  (attachment-section.tsx:422), not the rendered string. No spoofing-to-action path.
+- Escaping unchanged: `{att.filename}` is React JSX text interpolation (auto-escaped);
+  change touches only a className string. No XSS surface change.
+- No security-critical control in the entry dialog depends on `min-width:auto`; header
+  wraps rather than clips.
+- Filename is non-secret user-attached metadata; ellipsis crosses no confidentiality
+  boundary. Blast radius correctly bounded to the entry-dialog shell (not global
+  ui/dialog.tsx).
+
+## Testing Findings
+
+Testing strategy confirmed CORRECT. jsdom truly cannot validate this layout fix (no
+layout engine — `scrollWidth`/`clientWidth` = 0). A class-presence assertion would be
+decorative per common/testing.md. The canonical E2E `scrollWidth <= clientWidth` probe is
+the right shape but NO entry-attachment E2E fixture exists (only CSV-import
+`setInputFiles`); building one for client-side-encrypted blobs is disproportionate for a
+one-class CSS fix. Existing unit suites are layout-blind but provide the narrow
+markup-regression guard the plan claims (I3). No cheap fail-before/pass-after test exists →
+not Critical.
+
+**T1 — Minor**: Convert the Phase-2 E2E hedge into a recorded decision (Anti-Deferral):
+"no entry-attachment E2E fixture exists; adding one is out of scope for this CSS-only fix;
+verification is manual-visual per scenarios + build/lint."
+
+**T2 — Minor**: Prose says "vitest/jsdom" but the global vitest env is `node`; the
+component tests opt into jsdom via a per-file `// @vitest-environment jsdom` pragma.
+Conclusion (no layout engine) unchanged — wording precision only.
+
+Also (informational): manual verification MUST use a long UNBROKEN filename (200-char, no
+whitespace) or the bug won't reproduce and the check false-passes.
+
+## Adjacent Findings
+- [Adjacent] Security (usability): a `title`/tooltip showing the full filename on
+  hover/focus would help users read truncated names. Plan explicitly scopes it out. Not a
+  security finding; noted for possible future UX enhancement.
+
+## Quality Warnings
+None.
+
+## Recurring Issue Check
+
+### Functionality expert
+- R8 shared-component-consistency: PASS (single shared EntryDialogShell)
+- Incomplete member-set coverage: PASS (8 team forms + personal all route through shell)
+- Blast-radius / global-primitive regression: PASS (scoped to shell, not ui/dialog.tsx)
+- Ancestor-chain completeness: PASS
+- Effective-default / distributed-contract: N/A
+
+### Security expert
+- project_no_store_secret_response_class: clear (non-secret metadata)
+- feedback_body_cast_not_schema_validation: N/A
+- XSS / raw-HTML sink: clear (auto-escaped, no dangerouslySetInnerHTML)
+- feedback_child_model_parent_fk_scoping: N/A (no data-access code)
+- Spoofing-to-action via truncated display: clear (download uses att.id)
+- feedback_close_defect_class_not_instances: clear (shell covers personal+team+all types)
+
+### Testing expert
+- Decorative test: OK (plan refuses class-presence test)
+- Anti-Deferral / decision-not-recorded: flagged T1
+- fail-before/pass-after rigor: OK
+- Coverage-gap-with-cheap-test (Critical trigger): not Critical (no cheap test exists)
+- Test env misstatement: T2 minor wording

--- a/src/__tests__/helpers/mock-match-media.ts
+++ b/src/__tests__/helpers/mock-match-media.ts
@@ -1,0 +1,27 @@
+import { vi } from "vitest";
+
+/**
+ * Installs a jsdom `window.matchMedia` stub so components that call
+ * `useLayoutMode` (or otherwise read a media query) can render in tests.
+ * jsdom does not implement matchMedia; without this, `useSyncExternalStore`'s
+ * client snapshot throws.
+ *
+ * @param matches - value returned for `.matches` (default false → "accordion"
+ *   layout mode). Pass true to simulate the ≥1024px "master-detail" viewport.
+ */
+export function mockMatchMedia(matches = false): void {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+}

--- a/src/components/emergency-access/grant-card.tsx
+++ b/src/components/emergency-access/grant-card.tsx
@@ -17,6 +17,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import { Copy, ShieldOff, ShieldAlert, ShieldCheck, ShieldX, KeyRound, Lock, Loader2, Info } from "lucide-react";
 import { MS_PER_DAY, MS_PER_HOUR } from "@/lib/constants/time";
 import { useRouter } from "@/i18n/navigation";
@@ -317,9 +318,9 @@ export function GrantCard({ grant, currentUserId, onRefresh }: GrantCardProps) {
         {/* Header row: name + badge + actions */}
         <div className="flex items-center justify-between gap-4">
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 min-w-0">
               <span className="truncate font-medium">{displayName}</span>
-              <Badge variant="outline" className={statusColors[grant.status]}>
+              <Badge variant="outline" className={cn("shrink-0", statusColors[grant.status])}>
                 {t(`status${grant.status.charAt(0) + grant.status.slice(1).toLowerCase()}`)}
               </Badge>
             </div>

--- a/src/components/folders/folder-tree.tsx
+++ b/src/components/folders/folder-tree.tsx
@@ -62,7 +62,7 @@ function FolderNode({
           onClick={() => onNavigate?.()}
         >
           <FolderOpen className="h-4 w-4 shrink-0" />
-          <span className="truncate">{node.name}</span>
+          <span className="truncate min-w-0">{node.name}</span>
           {node.entryCount > 0 && (
             <span className="ml-auto text-xs text-muted-foreground">
               {node.entryCount}

--- a/src/components/layout/sidebar-shared.tsx
+++ b/src/components/layout/sidebar-shared.tsx
@@ -104,7 +104,7 @@ export function FolderTreeNode({
             ) : (
               <FolderOpen className="h-4 w-4 shrink-0" />
             )}
-            <span className="truncate">{folder.name}</span>
+            <span className="truncate min-w-0">{folder.name}</span>
           </Link>
         </Button>
         {showMenu !== false ? (
@@ -266,7 +266,7 @@ export function TagTreeNode({
                 className={cn("h-3 w-3 rounded-full p-0 shrink-0", colorClass && "tag-color-bg", colorClass)}
               />
             )}
-            <span className="truncate">{tag.name}</span>
+            <span className="truncate min-w-0">{tag.name}</span>
           </Link>
         </Button>
         {showMenu ? (

--- a/src/components/member-info.tsx
+++ b/src/components/member-info.tsx
@@ -40,7 +40,7 @@ export function MemberInfo({
         </AvatarFallback>
       </Avatar>
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-0">
           <p className="text-sm font-medium truncate">
             {name ?? email}
             {isCurrentUser && (

--- a/src/components/passwords/entry/entry-dialog-shell.tsx
+++ b/src/components/passwords/entry/entry-dialog-shell.tsx
@@ -24,7 +24,7 @@ export function EntryDialogShell({
 }: EntryDialogShellProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto [&>*]:min-w-0">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription className="sr-only">{title}</DialogDescription>

--- a/src/components/settings/account/tenant-audit-log-card.tsx
+++ b/src/components/settings/account/tenant-audit-log-card.tsx
@@ -186,7 +186,7 @@ export function TenantAuditLogCard({ variant }: TenantAuditLogCardProps) {
       detail={
         <>
           <AuditDelegationDetail action={log.action} metadata={log.metadata} />
-          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground min-w-0">
             {log.user && (
               <span className="truncate">{formatUserName(log.user)}</span>
             )}

--- a/src/components/settings/developer/base-webhook-card.tsx
+++ b/src/components/settings/developer/base-webhook-card.tsx
@@ -264,7 +264,7 @@ export function BaseWebhookCard({ config }: Props) {
       className="flex items-center justify-between border rounded-md p-3"
     >
       <div className="space-y-1 min-w-0 flex-1">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-0">
           <span className="text-sm font-medium truncate">
             {w.url}
           </span>

--- a/src/components/settings/developer/mcp-client-card.tsx
+++ b/src/components/settings/developer/mcp-client-card.tsx
@@ -428,7 +428,7 @@ const toastUpdateApiError = (errorCode: unknown) => {
       className="flex items-center justify-between border rounded-md p-3"
     >
       <div className="space-y-1 min-w-0 flex-1">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-0">
           <span className="text-sm font-medium truncate">{client.name}</span>
           <Badge
             variant={client.isActive ? "default" : "secondary"}

--- a/src/components/settings/developer/service-account-card.tsx
+++ b/src/components/settings/developer/service-account-card.tsx
@@ -468,9 +468,9 @@ export function ServiceAccountCard() {
                         <ChevronDown
                           className={`h-4 w-4 shrink-0 transition-transform text-muted-foreground ${expandedSa.has(sa.id) ? "rotate-0" : "-rotate-90"}`}
                         />
-                        <span className="text-sm font-medium truncate">{sa.name}</span>
+                        <span className="text-sm font-medium truncate min-w-0">{sa.name}</span>
                         {sa.description && (
-                          <span className="text-xs text-muted-foreground truncate hidden sm:block">
+                          <span className="text-xs text-muted-foreground truncate hidden sm:block min-w-0">
                             {sa.description}
                           </span>
                         )}
@@ -550,7 +550,7 @@ export function ServiceAccountCard() {
                             className="flex items-center justify-between border rounded p-2 bg-background"
                           >
                             <div className="space-y-0.5 min-w-0 flex-1">
-                              <div className="flex items-center gap-1.5">
+                              <div className="flex items-center gap-1.5 min-w-0">
                                 <span className="text-xs font-medium truncate">
                                   {token.name}
                                 </span>
@@ -638,9 +638,9 @@ export function ServiceAccountCard() {
                               <ChevronDown
                                 className={`h-4 w-4 shrink-0 transition-transform text-muted-foreground ${expandedSa.has(sa.id) ? "rotate-0" : "-rotate-90"}`}
                               />
-                              <span className="text-sm font-medium truncate">{sa.name}</span>
+                              <span className="text-sm font-medium truncate min-w-0">{sa.name}</span>
                               {sa.description && (
-                                <span className="text-xs text-muted-foreground truncate hidden sm:block">
+                                <span className="text-xs text-muted-foreground truncate hidden sm:block min-w-0">
                                   {sa.description}
                                 </span>
                               )}

--- a/src/components/vault/dashboard-banner.test.tsx
+++ b/src/components/vault/dashboard-banner.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { mockMatchMedia } from "@/__tests__/helpers/mock-match-media";
+import { DashboardBanner } from "./dashboard-banner";
+
+describe("DashboardBanner", () => {
+  beforeEach(() => {
+    mockMatchMedia();
+  });
+
+  it("uses the master-detail max-width when the viewport is >=1024px", () => {
+    mockMatchMedia(true);
+    render(
+      <DashboardBanner>
+        <div data-testid="content" />
+      </DashboardBanner>,
+    );
+
+    const inner = screen.getByTestId("content").parentElement;
+    expect(inner).toHaveClass("max-w-[1024px]");
+    expect(inner).not.toHaveClass("max-w-4xl");
+  });
+
+  it("uses the accordion max-width when the viewport is <1024px", () => {
+    mockMatchMedia(false);
+    render(
+      <DashboardBanner>
+        <div data-testid="content" />
+      </DashboardBanner>,
+    );
+
+    const inner = screen.getByTestId("content").parentElement;
+    expect(inner).toHaveClass("max-w-4xl");
+    expect(inner).not.toHaveClass("max-w-[1024px]");
+  });
+});

--- a/src/components/vault/dashboard-banner.tsx
+++ b/src/components/vault/dashboard-banner.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useLayoutMode } from "@/hooks/use-layout-mode";
+import { cn } from "@/lib/utils";
+
+/**
+ * Width wrapper for dashboard-level banners (recovery-key, delegation-revoke).
+ *
+ * Aligns a banner's horizontal extent with the entry-display area below it:
+ * same outer padding (`px-4 md:px-6`) and the same layout-mode-dependent
+ * centered max-width used by PasswordDashboard (`max-w-[1024px]` in
+ * master-detail, `max-w-4xl` in accordion). Without this, a banner rendered as
+ * a direct child of `<main>` spans the full right pane and looks wider than the
+ * entry list.
+ */
+export function DashboardBanner({ children }: { children: ReactNode }) {
+  const layoutMode = useLayoutMode();
+
+  return (
+    <div className="px-4 pt-4 md:px-6 md:pt-6">
+      <div
+        className={cn(
+          "mx-auto w-full",
+          layoutMode === "master-detail" ? "max-w-[1024px]" : "max-w-4xl",
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/vault/delegation-revoke-banner.test.tsx
+++ b/src/components/vault/delegation-revoke-banner.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { mockI18nNavigation } from "@/__tests__/helpers/mock-app-navigation";
+import { mockMatchMedia } from "@/__tests__/helpers/mock-match-media";
 
 const { mockUseVault, mockFetchApi, routerPush } = vi.hoisted(() => ({
   mockUseVault: vi.fn(),
@@ -40,6 +41,7 @@ import { VAULT_STATUS } from "@/lib/constants";
 describe("DelegationRevokeBanner", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMatchMedia();
   });
 
   afterEach(() => {

--- a/src/components/vault/delegation-revoke-banner.tsx
+++ b/src/components/vault/delegation-revoke-banner.tsx
@@ -10,6 +10,7 @@ import { MS_PER_MINUTE } from "@/lib/constants/time";
 import { useRouter } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
 import { Shield } from "lucide-react";
+import { DashboardBanner } from "./dashboard-banner";
 
 export function DelegationRevokeBanner() {
   const t = useTranslations("MachineIdentity.delegation");
@@ -48,18 +49,20 @@ export function DelegationRevokeBanner() {
   if (count === 0) return null;
 
   return (
-    <div className="mx-4 mt-4 flex items-center gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm md:mx-6 md:mt-6">
-      <Shield className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
-      <p className="flex-1 text-amber-800 dark:text-amber-300">
-        {t("bannerActive", { count })}
-      </p>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => router.push("/dashboard/settings/vault/delegation")}
-      >
-        {t("bannerManage")}
-      </Button>
-    </div>
+    <DashboardBanner>
+      <div className="flex items-center gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm">
+        <Shield className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+        <p className="flex-1 text-amber-800 dark:text-amber-300">
+          {t("bannerActive", { count })}
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.push("/dashboard/settings/vault/delegation")}
+        >
+          {t("bannerManage")}
+        </Button>
+      </div>
+    </DashboardBanner>
   );
 }

--- a/src/components/vault/recovery-key-banner.tsx
+++ b/src/components/vault/recovery-key-banner.tsx
@@ -7,6 +7,7 @@ import { VAULT_STATUS, LOCAL_STORAGE_KEY } from "@/lib/constants";
 import { MS_PER_DAY } from "@/lib/constants/time";
 import { Button } from "@/components/ui/button";
 import { AlertTriangle, X } from "lucide-react";
+import { DashboardBanner } from "./dashboard-banner";
 import { RecoveryKeyDialog } from "./recovery-key-dialog";
 
 const DISMISS_DURATION_MS = MS_PER_DAY;
@@ -50,29 +51,31 @@ export function RecoveryKeyBanner() {
 
   return (
     <>
-      <div className="mx-4 mt-4 flex items-center gap-3 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm md:mx-6 md:mt-6">
-        <AlertTriangle className="h-4 w-4 shrink-0 text-yellow-600 dark:text-yellow-400" />
-        <p className="flex-1 text-yellow-800 dark:text-yellow-300">
-          {recoveryKeyInvalidated
-            ? t("recoveryKeyBannerMessageInvalidated")
-            : t("recoveryKeyBannerMessage")}
-        </p>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setDialogOpen(true)}
-        >
-          {t("recoveryKeyBannerAction")}
-        </Button>
-        <button
-          type="button"
-          onClick={handleDismiss}
-          aria-label={t("recoveryKeyBannerDismiss")}
-          className="ml-1 text-yellow-600 hover:text-yellow-800 dark:text-yellow-400 dark:hover:text-yellow-200"
-        >
-          <X className="h-4 w-4" />
-        </button>
-      </div>
+      <DashboardBanner>
+        <div className="flex items-center gap-3 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-yellow-600 dark:text-yellow-400" />
+          <p className="flex-1 text-yellow-800 dark:text-yellow-300">
+            {recoveryKeyInvalidated
+              ? t("recoveryKeyBannerMessageInvalidated")
+              : t("recoveryKeyBannerMessage")}
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setDialogOpen(true)}
+          >
+            {t("recoveryKeyBannerAction")}
+          </Button>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label={t("recoveryKeyBannerDismiss")}
+            className="ml-1 text-yellow-600 hover:text-yellow-800 dark:text-yellow-400 dark:hover:text-yellow-200"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </DashboardBanner>
 
       <RecoveryKeyDialog open={dialogOpen} onOpenChange={setDialogOpen} />
     </>


### PR DESCRIPTION
## Summary
Fixes horizontal-overflow / width issues in the right pane, treated as whole defect classes rather than the single reported instance.

Two related classes:
1. **`truncate` that never engages.** A `flex`/`grid` item defaults to `min-width: auto` and refuses to shrink below its content's intrinsic width, so a long unbroken user string (filename, URL, name) forces its row wider than the container despite `truncate` being present.
2. **Dashboard banners wider than the entry list.** The recovery-key and delegation-revoke banners rendered full-width in the right pane, not aligned with the entry-display area.

## Class 1 — `truncate`-overflow

The originally reported bug (long attachment filename → horizontal scrollbar in the entry edit dialog) was one member of this class. Fixed at the shared `EntryDialogShell` grid (`[&>*]:min-w-0`), then swept the codebase for the same root cause and fixed every member found:

- `EntryDialogShell` grid — `[&>*]:min-w-0` (covers personal + team + all entry types)
- `base-webhook-card` (webhook URL), `mcp-client-card` (client name), `service-account-card` (SA name/description + token names, 4 sites), `emergency-access/grant-card` (member name/email), `tenant-audit-log-card` (audit actor), `member-info` (name/email — shared, covers many team screens), `folder-tree` + `sidebar-shared` (folder/tag names)

Each fix adds `min-w-0` to the nested flex row (or the `truncate` span itself where it is a direct flex item) so the existing `truncate` engages.

Deliberately **not** changed: `entry-secondary-line` (its truncate spans sit inside a `flex-1 min-w-0` boundary in both call sites, so a long value clips internally and never produces a pane-level scrollbar), and the global `ui/dialog.tsx` primitive (blast radius — scoped fixes only).

## Class 2 — dashboard banner width

Extracted a shared `DashboardBanner` wrapper that reuses `useLayoutMode` to match the entry area's padding and layout-mode-dependent centered max-width (`max-w-[1024px]` in master-detail ≥1024px, `max-w-4xl` in accordion). Both the recovery-key and delegation-revoke banners now wrap in it, so their width tracks the entry list. Added a reusable `mockMatchMedia` test helper since the banners now read a media query, plus a `DashboardBanner` test asserting the max-width switches with the viewport.

## Review artifacts
- [plan](./docs/archive/review/fix-attachment-edit-dialog-overflow-plan.md)
- [plan review](./docs/archive/review/fix-attachment-edit-dialog-overflow-review.md)
- [code review](./docs/archive/review/fix-attachment-edit-dialog-overflow-code-review.md)

## Test plan
- [ ] Personal & team entry edit dialog with a ~200-char unbroken attachment filename → no horizontal scrollbar, single-line ellipsis.
- [ ] Settings → Developer cards (webhook, MCP client, service account) and Emergency Access with long names/URLs → row truncates, no overflow.
- [ ] Sidebar with a very long folder/tag name → truncates within the sidebar.
- [ ] Trigger the recovery-key banner (unlocked vault, no recovery key) and the delegation-revoke banner (active delegation sessions) at ≥1024px → banner width matches the entry list, not the full right pane; re-check <1024px.
- [ ] `npx vitest run` (12780 passed) and `npx next build` succeed.

Note: the CSS-layout effect of the `min-w-0` changes is not asserted by automated tests (jsdom has no layout engine; a class-presence assertion would be decorative). The `DashboardBanner` width-switch logic IS tested (it is a `useLayoutMode` branch, not a layout computation). Verified manually + full suite + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
