### PR TITLE
fix(security): fail closed on null tenant across enforcement policy readers

### DIFF
--- a/docs/archive/review/null-tenant-fail-open-code-review.md
+++ b/docs/archive/review/null-tenant-fail-open-code-review.md
@@ -80,3 +80,47 @@ scripts/pre-pr.sh + CI static-checks.`
 All 7 members fixed fail-safe (throw / restrictive-default / log). All fixes
 mutation-verified. CI guard authored, red-proven, wired. Anti-Deferral: no
 findings deferred. No boundary widened (R43).
+
+---
+
+## Round 3 — external review follow-up (3 findings addressed)
+
+An external security review of PR #693 raised 3 findings; all fixed.
+
+### F-EXT-1 [High] Deactivated member's session cached as valid, bypassing IP restriction
+`auth-gate.ts getSessionInfo` treated `resolveUserTenantId → null` as a legitimate
+no-tenant user (`valid:true, tenantId:undefined`). But that null means NO active
+`TenantMember` (deactivatedAt != null) — a de-provisioned member — and
+`User.tenantId` is a non-null FK, so it is a revoked membership, not a no-tenant
+user. A stale cookie (or a session whose deletion was missed on deactivation)
+then passed session validation AND skipped the tenant CIDR/Tailscale gate
+(undefined tenantId → the api-route/page-route gate is bypassed). The extension-
+token path already rejects deactivated members (C13); the session path did not.
+**Fix**: `resolved === null` → `{ valid: false }` (fail closed, uncached). The
+prior test that fixed the unsafe behavior was inverted to assert the block.
+Mutation-verified. Blast radius checked: signup creates user + TenantMember in
+one tx (no window); proxy/CSRF tests updated to a real-membership default.
+
+### F-EXT-2 [Medium] Lockout fetch-failure reverted a tightened tenant to a weaker default
+`getLockoutThresholds` fell back to the schema-default (lock at 5) on a missing
+row / DB error. A tenant may tighten to lock-at-1, so the default GRANTS extra
+attempts — fail-open. **Fix**: `STRICTEST_LOCKOUT_THRESHOLDS`
+(`{ attempts: LOCKOUT_THRESHOLD_MIN, lockMinutes: LOCKOUT_DURATION_MAX }`) on all
+three fallback paths (missing row, catch, unresolved user tenant), never cached.
+A throw is NOT viable here: `recordFailure` is a post-failure side effect, so
+throwing would leave the attempt unrecorded (the counter never advances — itself
+fail-open). Strictest fallback records the attempt under a threshold guaranteed
+no weaker than the tenant's real policy. Mutation-verified.
+
+### F-EXT-3 [Medium] CI guard detected only file add/remove, not intra-file mutations
+The manifest guard tracked only the SET of files with an enforcement read, so:
+reverting a `throw` to a permissive coalesce in a listed file, adding a fail-open
+read to a listed file, or adding an access decision to a `display-exempt` file
+all passed; the disposition values were unused. **Fix**: rewrote the guard as
+ts-morph AST, per-read-site. It now verifies each read's declared disposition
+against the implementation — `throw` requires a null-tenant `if (!tenant)
+{ throw|return }` guard in the enclosing function; `failsafe-default` forbids a
+permissive `tenant?.<enforcementField> ?? <lenient>` coalesce; `display-exempt`
+forbids an access-restriction / deny call. The self-test grew to 7 cases
+including the 3 intra-file mutations, each red-proven. (Aligns with the AST-first
+rule for code-classifying gates.)

--- a/docs/archive/review/null-tenant-fail-open-code-review.md
+++ b/docs/archive/review/null-tenant-fail-open-code-review.md
@@ -124,3 +124,20 @@ permissive `tenant?.<enforcementField> ?? <lenient>` coalesce; `display-exempt`
 forbids an access-restriction / deny call. The self-test grew to 7 cases
 including the 3 intra-file mutations, each red-proven. (Aligns with the AST-first
 rule for code-classifying gates.)
+
+## Round 4 — external review follow-up (guard read-site precision)
+
+The AST guard's `throw`-disposition check accepted a file as long as SOME
+`if (!<tenant-ish>) { throw|return }` existed in the enclosing function — so a
+guarded read plus a SIBLING unguarded enforcement read in the same function
+passed (external review Medium). **Fix**: per-read variable tracking. Each
+enforcement read now records the exact variable it is bound to
+(`bindingVarName`), including the two real binding shapes — RLS-wrapped
+(`const t = await withBypassRls(prisma, (tx) => tx.tenant.findUnique(...))`) and
+`Promise.all` array-destructuring (`const [c, t] = await Promise.all([...])`).
+`hasNullTenantThrowGuard(read)` now requires an `if (!<that var>)` /
+`if (!<that var>.tenant)` guard that throws/returns — a guard on a different
+variable, or a sibling unguarded read, no longer vouches for it. Self-test grew
+to 10 cases (added: sibling-unguarded → red, wrong-variable guard → red,
+Promise.all relation-join `if (!user?.tenant)` → accepted). Real tree still green
+at 16 reads.

--- a/docs/archive/review/null-tenant-fail-open-code-review.md
+++ b/docs/archive/review/null-tenant-fail-open-code-review.md
@@ -1,0 +1,82 @@
+# Code Review: null-tenant-fail-open
+
+Date: 2026-07-21
+Review rounds: 2 (triangulate: 3 experts × derive+judge, then 3 experts × verify-fixes)
+
+## Summary
+
+Follow-on to PR #685. Closed the **null-tenant fail-open enforcement class**: an
+enforcement decision reads a tenant/team security policy and, on a null/missing
+row, falls back to the unsafe (permissive) side. The controlling distinction:
+null = "operator never configured" → permissive default is correct; null =
+"fetch failed / row vanished / corruption" on an FK-backed path → must fail closed.
+
+Class member-set expanded 4 → 5 → 7 across review (R42 accretion signature),
+which triggered the mutation-verified CI-guard convergence requirement.
+
+## Member-set (R42, three-expert converged, then extended in Round 2)
+
+| # | Member | file | Verdict | Action |
+|---|--------|------|---------|--------|
+| 1 | `getTenantAccessPolicy` null-tenant → empty permissive policy (cached) | `src/lib/auth/policy/access-restriction.ts` | FAIL-OPEN | throw on null row; don't cache |
+| 2 | proxy `getSessionInfo` swallows `resolveUserTenantId` throw → IP gate skipped | `src/lib/proxy/auth-gate.ts` | FAIL-OPEN | `{valid:false}` on throw (null return unchanged) |
+| 3 | `checkTeamAccessRestriction` inherit path, null tenant CIDR fetch → allow | `src/lib/team/team-policy.ts` | FAIL-OPEN | throw `PolicyViolationError` on null resolution/row |
+| 4 | `getLockoutThresholds` `catch → DEFAULT` silent swallow | `src/lib/auth/policy/account-lockout.ts` | Silent-swallow (Major) | warn-log before default (default is already fail-safe) |
+| 5 | `createSession` `tenant?.maxConcurrentSessions` → cap skipped on null | `src/lib/auth/session/auth-adapter.ts` | FAIL-OPEN | throw on null row |
+| 6 | `webauthn/register/verify` `tenant?.requireMinPinLength ?? null` → PIN gate skipped | `src/app/api/webauthn/register/verify/route.ts` | FAIL-OPEN | throw on null relation |
+| 7 | `issueExtensionToken` + refresh `tenant?.…Timeout ?? DEFAULT` → longer TTL on null | `src/lib/auth/tokens/extension-token.ts`, `src/app/api/extension/token/refresh/route.ts` | FAIL-OPEN | throw on null row; keep `?? DEFAULT` field-floor |
+
+### Verified FAIL-SAFE (no change)
+
+- `session-timeout.ts` `if (!user)` → `{idle:1, absolute:1}` — restrictive default (model pattern).
+- `account-lockout.ts` `if (!tenant)` → DEFAULT_LOCKOUT_THRESHOLDS — still enforces lockout.
+- `passkey-enforcement.ts` `if (!tenant) throw` — PR #685.
+- `auth-gate.ts` `?? false`/`?? null` passkey fields — contract-documented (session callback emits all 4).
+- `team-policy.ts:60` `if (!policy) return DEFAULT_POLICY` — intended permissive default; corruption fails closed upstream via `withTeamTenantRls`.
+- `mcp/token/route.ts` `if (codeTenantId)` — null code → downstream `invalid_grant`, no mint.
+
+### Excluded (display / config-write, per PR #685 precedent)
+
+- `tenant/policy/route.ts` — admin PATCH reads OWN tenant to compute unchanged fields for the write; not a subject access decision.
+- `teams/[teamId]/policy/route.ts`, `vault/status`, `vault/unlock/data`, `user/passkey-status`, `sessions/route.ts` — client-display echoes in response bodies.
+
+## Round 2 verification (3 experts)
+
+- **Security**: all 7 fixes reach a DENY outcome (throw → proxy/route 500 or 403; `{valid:false}` → 401/redirect). No R43 boundary widening (only tightening). No legitimate no-tenant/no-membership flow broken (null return path unchanged). Surfaced member #5 (`auth-adapter`) as an uncovered same-class sibling → folded in.
+- **Functionality**: `tsc --noEmit` clean; the whole class now consistent (access-restriction no longer fails open while passkey-enforcement fails closed on the same signal). Error messages leak nothing sensitive.
+- **Testing**: 9 new regression tests, all mutation-verified (revert the fix → test goes red). No vacuous assertions (each asserts the denied/valid:false value + the load-bearing side effect).
+
+## R42 convergence — mutation-verified CI guard (≥2× accretion)
+
+The member-set expanded 4→5→7, so per the triangulate termination check the class
+is closed only by a mutation-verified CI guard, not "no findings" alone.
+
+- **Guard**: `scripts/checks/check-null-tenant-fail-closed.mjs` — a completeness
+  manifest. It enumerates every enforcement-field `tenant.findUnique` /
+  `tenant: { select }` from the defining primitive and fails when the live set
+  diverges from the reviewed MANIFEST (a new unclassified member, or a vanished
+  stale entry). Currently green: **16 enforcement reads, all classified**
+  (matches the hand-enumerated `tenant.findUnique` count — completeness cross-check).
+- **Red-proven** (via `NTFC_CHECK_ROOT` throwaway fixture, no repo residue):
+  - Mutation A — inject a new unclassified enforcement read → exit 1 (flags the new file).
+  - Mutation B — remove a manifest'd site → exit 1 (flags the stale entry).
+  - Restore → exit 0.
+- **Wired** into `scripts/pre-pr.sh` (Static: null-tenant-fail-closed) which CI
+  runs verbatim via `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` (ci.yml) — same
+  definition local and CI (R33), authoritative gate (RT7).
+- **Guard self-test**: `scripts/__tests__/check-null-tenant-fail-closed.test.mjs`
+  (5 cases: baseline-green, new-unlisted-read → red, vanished-manifest → red,
+  benign non-enforcement tenant read ignored, non-tenant enforcement-named field
+  ignored). Required by the repo's `check-gate-selftest-coverage` gate — every
+  guard must ship a self-test proving it can fail.
+
+`R42 class null-tenant-fail-open: member-set expanded 3× (4→5→7) — closed by
+mutation-verified CI guard scripts/checks/check-null-tenant-fail-closed.mjs
+(red-proven: new unclassified read + vanished manifest entry), wired in
+scripts/pre-pr.sh + CI static-checks.`
+
+## Resolution Status
+
+All 7 members fixed fail-safe (throw / restrictive-default / log). All fixes
+mutation-verified. CI guard authored, red-proven, wired. Anti-Deferral: no
+findings deferred. No boundary widened (R43).

--- a/docs/archive/review/null-tenant-fail-open-deviation.md
+++ b/docs/archive/review/null-tenant-fail-open-deviation.md
@@ -1,0 +1,37 @@
+# Deviation Log: null-tenant-fail-open
+
+## D1 — Member-set grew from 4 (plan) to 7 (implementation)
+
+The plan scoped 5 fixes + several fail-safe/excluded members. Round 2 security
+review surfaced `auth-adapter.ts` (concurrent-session cap, #5) as an uncovered
+same-class sibling; a subsequent exhaustive sweep from the primitive surfaced the
+webauthn PIN gate (#6) and the extension-token TTL pair (#7). All three are the
+same class (FK-backed tenantId, null-row → permissive side) and were folded in
+per "close the defect class, not instances." This 3× accretion triggered the
+mutation-verified CI-guard convergence requirement (R42 ①b).
+
+## D2 — extension-token: throw on null ROW, keep `?? DEFAULT` for null FIELD
+
+The columns are non-nullable with schema defaults, so `?? DEFAULT` only ever
+fired on a null ROW (corruption). The fix throws on the null row but retains the
+field-level `?? DEFAULT` as a defensive floor (a field-null would otherwise yield
+a 0-minute TTL). This keeps the pre-existing `field-null → DEFAULT` unit test
+valid while closing the corruption fail-open.
+
+## D3 — webauthn test default mock corrected
+
+The shared `beforeEach` mock used `tenant: null`, which the fix now treats as
+corruption. Since `User.tenantId` is a non-null FK (Prisma always joins the row),
+the realistic default is `tenant: { requireMinPinLength: null }` ("no PIN policy
+set"). Updated the shared default and reserved `tenant: null` for the dedicated
+corruption regression test.
+
+## D4 — CI guard is a manifest, not a `throw`-requirement grep
+
+An initial guard draft required a literal `if (!tenant) throw` on every
+enforcement read. That falsely flagged the fail-SAFE members (account-lockout,
+session-timeout return a restrictive default, not a throw) and the display
+routes. Redesigned to a completeness manifest: every enforcement read carries a
+reviewed disposition (throw / failsafe-default / display-exempt); the guard fails
+on divergence (new unclassified read or vanished stale entry). This mechanizes
+completeness without falsely mandating one specific fail-closed spelling.

--- a/docs/archive/review/null-tenant-fail-open-deviation.md
+++ b/docs/archive/review/null-tenant-fail-open-deviation.md
@@ -35,3 +35,14 @@ routes. Redesigned to a completeness manifest: every enforcement read carries a
 reviewed disposition (throw / failsafe-default / display-exempt); the guard fails
 on divergence (new unclassified read or vanished stale entry). This mechanizes
 completeness without falsely mandating one specific fail-closed spelling.
+
+## D5 — External review round: 3 fail-open/guard-strength findings fixed
+
+See Round 3 in the code-review doc. Summary of decisions:
+- auth-gate null-tenant → fail closed (deactivated member = revoked membership,
+  not a legit no-tenant user; symmetric with extension-token C13).
+- lockout fetch-failure → strictest threshold (lock at 1 / max duration), NOT the
+  schema-default and NOT a throw (throw would drop the unrecorded attempt).
+- CI guard → ts-morph AST per-read-site with disposition-vs-implementation
+  verification, replacing the file-set-only manifest (closed the 3 intra-file
+  mutation blind spots).

--- a/docs/archive/review/null-tenant-fail-open-plan.md
+++ b/docs/archive/review/null-tenant-fail-open-plan.md
@@ -1,0 +1,67 @@
+# Plan: null-tenant fail-open enforcement class propagation
+
+Follow-on to PR #685 (which fixed only the `requirePasskey` session-callback path).
+
+## Class definition
+
+Enforcement decisions that read a tenant/team **security policy** from the DB and,
+when the tenant/policy row is null / missing / unfetchable, fall back to the
+**unsafe (lenient / access-granting / restriction-skipping)** side instead of the
+safe (blocking / restrictive) side.
+
+The controlling distinction (from PR #685):
+- null because **"operator never configured this optional restriction"** →
+  permissive default is the *correct documented intent* (NOT fail-open).
+  e.g. empty `allowedCidrs` = no IP restriction.
+- null because **"fetch failed / tenant row vanished / data corruption"** on a
+  path where the tenant MUST exist (tenantId sourced from an FK-RESTRICT-backed
+  session/token row) → MUST fail closed.
+
+## Member-set (R42, three-expert converged)
+
+| Member | file:line | Verdict | Action |
+|---|---|---|---|
+| `getTenantAccessPolicy` null-tenant → empty policy (cached) | `access-restriction.ts:79-83` | **FAIL-OPEN** | Fix: throw on null tenant, do not cache |
+| proxy `getSessionInfo` swallows `resolveUserTenantId` throw | `auth-gate.ts:92-96` | **FAIL-OPEN** | Fix: on throw → `{valid:false}` (fail-closed re-auth) |
+| `checkTeamAccessRestriction` inherit path, tenant CIDR fetch null | `team-policy.ts:135-156` | **FAIL-OPEN (low)** | Fix: throw when inherit relies on tenant CIDRs but tenant fetch null |
+| `getLockoutThresholds` `catch → DEFAULT` (no log) | `account-lockout.ts:97-99` | **Silent-swallow (Major)** | Fix: log before returning default (observability; default itself is fail-safe) |
+| `enforceAccessRestriction` `if (!tenantId) return null` | `access-restriction.ts:263-264` | **Bounded** | Keep skip for genuine no-membership; the throw path already 500s (fail-closed). Fix 1 removes the swallow that fed this. |
+| `auth-gate.ts:99-112` `?? false`/`?? null` passkey | verified | FAIL-SAFE | none (contract-documented) |
+| `session-timeout.ts:102-110` `{idle:1,abs:1}` | verified | FAIL-SAFE | none (model pattern) |
+| `passkey-enforcement.ts:109` throw | verified | FAIL-SAFE | none (PR #685) |
+| `account-lockout.ts:77-83` missing-row → DEFAULT | verified | FAIL-SAFE | none (still enforces lockout) |
+| `team-policy.ts:60` `if(!policy) return DEFAULT_POLICY` | verified | FAIL-SAFE | none (intended permissive default; corruption fails closed upstream via `withTeamTenantRls` TENANT_NOT_RESOLVED) |
+| `mcp/token/route.ts:148-152` `if (codeTenantId)` | verified | FAIL-SAFE | none (invalid code → invalid_grant, no mint) |
+| display/audit/notification members | — | NOT-ENFORCEMENT | excluded |
+
+## Fixes (fail-safe direction only; no boundary widening — R43)
+
+1. **`getTenantAccessPolicy`** — throw `Error` when `findUnique` returns null for a
+   tenantId that must exist; skip cache-write of a null-derived policy. Callers
+   (`checkAccessRestriction`, `enforceAccessRestriction`) already propagate/deny.
+2. **`auth-gate.ts getSessionInfo`** — replace the silent `catch {}` around
+   `resolveUserTenantId` with a fail-closed `return { valid: false }` (do not cache),
+   matching the `!res.ok` transient-error handling directly above. A `null` *return*
+   (no active membership) is unchanged — that is a legitimate no-tenant user.
+3. **`checkTeamAccessRestriction`** — when `inheritTenantCidrs` is true and it is the
+   sole restriction source, throw `PolicyViolationError` if `resolveTeamTenantId`
+   or the tenant fetch returns null (`Team.tenantId` is non-null FK → null = corruption).
+4. **`getLockoutThresholds`** — log a warn line in the `catch` before returning
+   `DEFAULT_LOCKOUT_THRESHOLDS` so enforcement degradation is observable
+   (the default is already fail-safe; this closes the silent-swallow finding).
+
+## Regression tests (mutation-verified)
+
+- `access-restriction.test.ts`: `getTenantAccessPolicy`/`checkAccessRestriction`
+  with `findUnique → null` must **throw / deny** (mutation: revert to `?? []` → test fails).
+- `auth-gate` proxy test: `resolveUserTenantId` throws → `getSessionInfo` returns
+  `valid:false` (mutation: restore `catch {}` swallow → test fails).
+- `team-policy.test.ts`: `inheritTenantCidrs=true`, empty teamAllowedCidrs,
+  tenant fetch → null → throws `PolicyViolationError` (mutation: restore silent allow → fails).
+- `account-lockout.test.ts`: DB throw in threshold fetch → warn logged + default returned.
+
+## Non-goals
+
+- Do NOT tighten `enforceAccessRestriction`'s genuine no-membership skip to a deny —
+  a no-tenant user has no CIDR policy to enforce; denying would break legitimate flows.
+- Do NOT touch display/config routes (`tenant/policy`, `teams/[teamId]/policy` GET).

--- a/scripts/__tests__/check-null-tenant-fail-closed.test.mjs
+++ b/scripts/__tests__/check-null-tenant-fail-closed.test.mjs
@@ -181,6 +181,61 @@ describe("check-null-tenant-fail-closed (AST)", () => {
     expect(r.stderr).toContain('disposition "display-exempt"');
   });
 
+  // External review follow-up: per-read variable tracking. A guard on ONE tenant
+  // read must not vouch for a SIBLING unguarded enforcement read in the same
+  // function — the earlier "any if(!tenant) throw in the function" check missed
+  // this. The guard must key on the exact variable each read is bound to.
+  it("fails a throw file with a guarded read AND a sibling unguarded enforcement read", () => {
+    writeFile(
+      "src/lib/auth/policy/access-restriction.ts",
+      `import { prisma } from "@/lib/prisma";
+       export async function read(id: string) {
+         const tenant = await prisma.tenant.findUnique({ where: { id }, select: { allowedCidrs: true } });
+         if (!tenant) throw new Error("x");
+         const other = await prisma.tenant.findUnique({ where: { id }, select: { requirePasskey: true } });
+         return { a: tenant.allowedCidrs, b: other?.requirePasskey ?? false };
+       }`,
+    );
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('disposition "throw"');
+    expect(r.stderr).toContain("src/lib/auth/policy/access-restriction.ts");
+  });
+
+  it("fails a throw file whose null guard keys on a DIFFERENT variable than the read", () => {
+    writeFile(
+      "src/lib/auth/policy/access-restriction.ts",
+      `import { prisma } from "@/lib/prisma";
+       export async function read(id: string) {
+         const other = { x: 1 };
+         const tenant = await prisma.tenant.findUnique({ where: { id }, select: { allowedCidrs: true } });
+         if (!other) throw new Error("wrong var");
+         return tenant?.allowedCidrs ?? [];
+       }`,
+    );
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('disposition "throw"');
+  });
+
+  it("accepts a Promise.all-destructured relation-join read guarded by if (!user?.tenant)", () => {
+    // Mirrors the real src/auth.ts session-passkey-policy shape.
+    writeFile(
+      "src/lib/auth/session/auth-adapter.ts",
+      `import { prisma } from "@/lib/prisma";
+       export async function read(id: string) {
+         const [c, user] = await Promise.all([
+           prisma.x.count(),
+           prisma.user.findUnique({ where: { id }, select: { tenant: { select: { requirePasskey: true } } } }),
+         ]);
+         if (!user?.tenant) throw new Error("x");
+         return user.tenant.requirePasskey;
+       }`,
+    );
+    const r = run();
+    expect(r.code).toBe(0);
+  });
+
   it("does not flag a file that reads tenant but no enforcement field", () => {
     writeFile(
       "src/lib/benign.ts",

--- a/scripts/__tests__/check-null-tenant-fail-closed.test.mjs
+++ b/scripts/__tests__/check-null-tenant-fail-closed.test.mjs
@@ -1,0 +1,141 @@
+/**
+ * Regression tests for check-null-tenant-fail-closed.mjs.
+ *
+ * The guard pins COMPLETENESS of the null-tenant fail-open enforcement class: it
+ * enumerates every enforcement-field `tenant.findUnique` / relation-join read
+ * from the defining primitive and fails when the live set diverges from the
+ * reviewed MANIFEST (a NEW unclassified member, or a VANISHED stale entry). This
+ * class expanded 4 → 5 → 7 during review precisely because completeness wasn't
+ * mechanized. Each case runs the real CLI against an isolated fixture tree via
+ * NTFC_CHECK_ROOT.
+ *
+ * The fixture reproduces the manifest paths so the baseline is green, then
+ * mutates: add an unlisted enforcement read (→ red) or delete a manifest'd file
+ * (→ red). This is the RT7 "proven able to fail" self-test for the gate.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CHECKER = fileURLToPath(
+  new URL("../checks/check-null-tenant-fail-closed.mjs", import.meta.url),
+);
+
+// The exact MANIFEST paths in the guard. Kept in sync by the guard's own
+// stale-entry detection: if a manifest path is removed from the guard, this
+// list and the guard would diverge and the real-tree run would catch it.
+const MANIFEST_PATHS = [
+  "src/lib/auth/policy/access-restriction.ts",
+  "src/lib/auth/policy/passkey-enforcement.ts",
+  "src/lib/auth/session/auth-adapter.ts",
+  "src/lib/auth/tokens/extension-token.ts",
+  "src/app/api/extension/token/refresh/route.ts",
+  "src/app/api/webauthn/register/verify/route.ts",
+  "src/lib/team/team-policy.ts",
+  "src/auth.ts",
+  "src/lib/auth/policy/account-lockout.ts",
+  "src/lib/auth/session/session-timeout.ts",
+  "src/app/api/tenant/policy/route.ts",
+  "src/app/api/teams/[teamId]/policy/route.ts",
+  "src/app/api/vault/status/route.ts",
+  "src/app/api/vault/unlock/data/route.ts",
+  "src/app/api/user/passkey-status/route.ts",
+  "src/app/api/sessions/route.ts",
+];
+
+// A minimal source that reads an enforcement field via tenant.findUnique so the
+// guard classifies the file as an enforcement read.
+const ENFORCEMENT_READ_SRC = `
+import { prisma } from "@/lib/prisma";
+export async function read(id) {
+  const tenant = await prisma.tenant.findUnique({
+    where: { id },
+    select: { allowedCidrs: true, requirePasskey: true },
+  });
+  if (!tenant) throw new Error("not found");
+  return tenant.allowedCidrs;
+}`;
+
+let dir;
+
+function writeFile(relPath, source) {
+  const full = join(dir, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, source, "utf8");
+}
+
+function run() {
+  try {
+    const stdout = execFileSync("node", [CHECKER], {
+      env: { ...process.env, NTFC_CHECK_ROOT: dir },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, stderr: "", stdout };
+  } catch (e) {
+    return {
+      code: e.status,
+      stderr: e.stderr?.toString() ?? "",
+      stdout: e.stdout?.toString() ?? "",
+    };
+  }
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ntfc-check-"));
+  // Populate every manifest path with an enforcement read so the baseline is
+  // green (live set == manifest).
+  for (const p of MANIFEST_PATHS) writeFile(p, ENFORCEMENT_READ_SRC);
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("check-null-tenant-fail-closed", () => {
+  it("passes when the live enforcement-read set matches the manifest", () => {
+    const r = run();
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("check-null-tenant-fail-closed: OK");
+  });
+
+  it("fails when a NEW unlisted enforcement tenant read is added", () => {
+    writeFile("src/lib/newthing.ts", ENFORCEMENT_READ_SRC);
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("not in the MANIFEST");
+    expect(r.stderr).toContain("src/lib/newthing.ts");
+  });
+
+  it("fails when a manifest'd enforcement read vanishes (stale entry)", () => {
+    rmSync(join(dir, "src/lib/auth/tokens/extension-token.ts"));
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("stale");
+    expect(r.stderr).toContain("src/lib/auth/tokens/extension-token.ts");
+  });
+
+  it("does not flag a file that reads tenant but no enforcement field", () => {
+    writeFile(
+      "src/lib/benign.ts",
+      `import { prisma } from "@/lib/prisma";
+       export async function h(id) {
+         const t = await prisma.tenant.findUnique({ where: { id }, select: { name: true } });
+         return t?.name;
+       }`,
+    );
+    const r = run();
+    expect(r.code).toBe(0);
+  });
+
+  it("does not flag a non-tenant read of an enforcement-named field", () => {
+    // A field name match WITHOUT a tenant read must not trip the guard.
+    writeFile(
+      "src/lib/other.ts",
+      `export const requirePasskey = false;
+       export function h() { return requirePasskey; }`,
+    );
+    const r = run();
+    expect(r.code).toBe(0);
+  });
+});

--- a/scripts/__tests__/check-null-tenant-fail-closed.test.mjs
+++ b/scripts/__tests__/check-null-tenant-fail-closed.test.mjs
@@ -1,17 +1,13 @@
 /**
- * Regression tests for check-null-tenant-fail-closed.mjs.
+ * Regression tests for check-null-tenant-fail-closed.mjs (AST, per-read-site).
  *
- * The guard pins COMPLETENESS of the null-tenant fail-open enforcement class: it
- * enumerates every enforcement-field `tenant.findUnique` / relation-join read
- * from the defining primitive and fails when the live set diverges from the
- * reviewed MANIFEST (a NEW unclassified member, or a VANISHED stale entry). This
- * class expanded 4 → 5 → 7 during review precisely because completeness wasn't
- * mechanized. Each case runs the real CLI against an isolated fixture tree via
- * NTFC_CHECK_ROOT.
- *
- * The fixture reproduces the manifest paths so the baseline is green, then
- * mutates: add an unlisted enforcement read (→ red) or delete a manifest'd file
- * (→ red). This is the RT7 "proven able to fail" self-test for the gate.
+ * The guard pins COMPLETENESS + per-disposition IMPLEMENTATION of the
+ * null-tenant fail-open enforcement class. An earlier version tracked only the
+ * set of files with an enforcement read, so intra-file mutations (reverting a
+ * throw, adding a permissive coalesce to a failsafe file, adding an access
+ * decision to a display-exempt echo) slipped through (external review Medium).
+ * These tests reproduce the manifest paths in an isolated tree via
+ * NTFC_CHECK_ROOT and mutate each — the RT7 "proven able to fail" self-test.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
@@ -24,10 +20,9 @@ const CHECKER = fileURLToPath(
   new URL("../checks/check-null-tenant-fail-closed.mjs", import.meta.url),
 );
 
-// The exact MANIFEST paths in the guard. Kept in sync by the guard's own
-// stale-entry detection: if a manifest path is removed from the guard, this
-// list and the guard would diverge and the real-tree run would catch it.
-const MANIFEST_PATHS = [
+// Manifest paths and their disposition, mirrored from the guard. Each is seeded
+// with source matching its disposition so the baseline is green.
+const THROW_PATHS = [
   "src/lib/auth/policy/access-restriction.ts",
   "src/lib/auth/policy/passkey-enforcement.ts",
   "src/lib/auth/session/auth-adapter.ts",
@@ -36,8 +31,12 @@ const MANIFEST_PATHS = [
   "src/app/api/webauthn/register/verify/route.ts",
   "src/lib/team/team-policy.ts",
   "src/auth.ts",
+];
+const FAILSAFE_PATHS = [
   "src/lib/auth/policy/account-lockout.ts",
   "src/lib/auth/session/session-timeout.ts",
+];
+const DISPLAY_PATHS = [
   "src/app/api/tenant/policy/route.ts",
   "src/app/api/teams/[teamId]/policy/route.ts",
   "src/app/api/vault/status/route.ts",
@@ -46,17 +45,42 @@ const MANIFEST_PATHS = [
   "src/app/api/sessions/route.ts",
 ];
 
-// A minimal source that reads an enforcement field via tenant.findUnique so the
-// guard classifies the file as an enforcement read.
-const ENFORCEMENT_READ_SRC = `
+// A throw-disposition read: enforcement select + null-tenant throw guard.
+const THROW_SRC = `
 import { prisma } from "@/lib/prisma";
-export async function read(id) {
+export async function read(id: string) {
   const tenant = await prisma.tenant.findUnique({
     where: { id },
-    select: { allowedCidrs: true, requirePasskey: true },
+    select: { allowedCidrs: true },
   });
-  if (!tenant) throw new Error("not found");
+  if (!tenant) throw new Error("tenant not found");
   return tenant.allowedCidrs;
+}`;
+
+// A failsafe-default read: enforcement select, restrictive default on null, NO
+// permissive enforcement-field coalesce.
+const FAILSAFE_SRC = `
+import { prisma } from "@/lib/prisma";
+const STRICT = [{ attempts: 1 }];
+export async function read(id: string) {
+  const tenant = await prisma.tenant.findUnique({
+    where: { id },
+    select: { lockoutThreshold1: true },
+  });
+  if (!tenant) return STRICT;
+  return [{ attempts: tenant.lockoutThreshold1 }];
+}`;
+
+// A display-exempt read: enforcement select echoed into a response, no access
+// decision call.
+const DISPLAY_SRC = `
+import { prisma } from "@/lib/prisma";
+export async function GET(id: string) {
+  const user = await prisma.user.findUnique({
+    where: { id },
+    select: { tenant: { select: { vaultAutoLockMinutes: true } } },
+  });
+  return { vaultAutoLockMinutes: user?.tenant?.vaultAutoLockMinutes ?? null };
 }`;
 
 let dir;
@@ -76,38 +100,34 @@ function run() {
     });
     return { code: 0, stderr: "", stdout };
   } catch (e) {
-    return {
-      code: e.status,
-      stderr: e.stderr?.toString() ?? "",
-      stdout: e.stdout?.toString() ?? "",
-    };
+    return { code: e.status, stderr: e.stderr?.toString() ?? "", stdout: e.stdout?.toString() ?? "" };
   }
 }
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "ntfc-check-"));
-  // Populate every manifest path with an enforcement read so the baseline is
-  // green (live set == manifest).
-  for (const p of MANIFEST_PATHS) writeFile(p, ENFORCEMENT_READ_SRC);
+  for (const p of THROW_PATHS) writeFile(p, THROW_SRC);
+  for (const p of FAILSAFE_PATHS) writeFile(p, FAILSAFE_SRC);
+  for (const p of DISPLAY_PATHS) writeFile(p, DISPLAY_SRC);
 });
 afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
-describe("check-null-tenant-fail-closed", () => {
-  it("passes when the live enforcement-read set matches the manifest", () => {
+describe("check-null-tenant-fail-closed (AST)", () => {
+  it("passes when every read matches its manifest disposition", () => {
     const r = run();
     expect(r.code).toBe(0);
     expect(r.stdout).toContain("check-null-tenant-fail-closed: OK");
   });
 
-  it("fails when a NEW unlisted enforcement tenant read is added", () => {
-    writeFile("src/lib/newthing.ts", ENFORCEMENT_READ_SRC);
+  it("fails a NEW unclassified enforcement read", () => {
+    writeFile("src/lib/newleak.ts", THROW_SRC);
     const r = run();
     expect(r.code).toBe(1);
-    expect(r.stderr).toContain("not in the MANIFEST");
-    expect(r.stderr).toContain("src/lib/newthing.ts");
+    expect(r.stderr).toContain("no MANIFEST disposition");
+    expect(r.stderr).toContain("src/lib/newleak.ts");
   });
 
-  it("fails when a manifest'd enforcement read vanishes (stale entry)", () => {
+  it("fails a vanished manifest read (stale entry)", () => {
     rmSync(join(dir, "src/lib/auth/tokens/extension-token.ts"));
     const r = run();
     expect(r.code).toBe(1);
@@ -115,25 +135,60 @@ describe("check-null-tenant-fail-closed", () => {
     expect(r.stderr).toContain("src/lib/auth/tokens/extension-token.ts");
   });
 
+  it("fails a throw-disposition read whose null-tenant guard was reverted to a permissive coalesce", () => {
+    // Same enforcement read, but the throw guard is replaced by `?? []`.
+    writeFile(
+      "src/lib/auth/policy/access-restriction.ts",
+      `import { prisma } from "@/lib/prisma";
+       export async function read(id: string) {
+         const tenant = await prisma.tenant.findUnique({ where: { id }, select: { allowedCidrs: true } });
+         return tenant?.allowedCidrs ?? [];
+       }`,
+    );
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('disposition "throw"');
+    expect(r.stderr).toContain("src/lib/auth/policy/access-restriction.ts");
+  });
+
+  it("fails a failsafe-default file that introduces a permissive enforcement coalesce", () => {
+    writeFile(
+      "src/lib/auth/policy/account-lockout.ts",
+      `import { prisma } from "@/lib/prisma";
+       export async function read(id: string) {
+         const tenant = await prisma.tenant.findUnique({ where: { id }, select: { lockoutThreshold1: true } });
+         return tenant?.lockoutThreshold1 ?? 5;
+       }`,
+    );
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('disposition "failsafe-default"');
+  });
+
+  it("fails a display-exempt file that adds an access-restriction call", () => {
+    writeFile(
+      "src/app/api/vault/status/route.ts",
+      `import { prisma } from "@/lib/prisma";
+       import { enforceAccessRestriction } from "@/lib/auth/policy/access-restriction";
+       export async function GET(id: string) {
+         const user = await prisma.user.findUnique({ where: { id }, select: { tenant: { select: { vaultAutoLockMinutes: true } } } });
+         await enforceAccessRestriction();
+         return { vaultAutoLockMinutes: user?.tenant?.vaultAutoLockMinutes ?? null };
+       }`,
+    );
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('disposition "display-exempt"');
+  });
+
   it("does not flag a file that reads tenant but no enforcement field", () => {
     writeFile(
       "src/lib/benign.ts",
       `import { prisma } from "@/lib/prisma";
-       export async function h(id) {
+       export async function h(id: string) {
          const t = await prisma.tenant.findUnique({ where: { id }, select: { name: true } });
          return t?.name;
        }`,
-    );
-    const r = run();
-    expect(r.code).toBe(0);
-  });
-
-  it("does not flag a non-tenant read of an enforcement-named field", () => {
-    // A field name match WITHOUT a tenant read must not trip the guard.
-    writeFile(
-      "src/lib/other.ts",
-      `export const requirePasskey = false;
-       export function h() { return requirePasskey; }`,
     );
     const r = run();
     expect(r.code).toBe(0);

--- a/scripts/checks/check-null-tenant-fail-closed.mjs
+++ b/scripts/checks/check-null-tenant-fail-closed.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * CI guard: null-tenant fail-open enforcement class — completeness manifest.
+ *
+ * An enforcement decision that reads a tenant security policy via
+ * `tenant.findUnique({ select: { <enforcement field> } })` (or the relation join
+ * `tenant: { select: … }`) and, on a null row, falls back to the LENIENT side
+ * silently BYPASSES that control. tenantId always comes from a server-trusted,
+ * FK-RESTRICT-backed source (session / token row / the non-null `User.tenantId`),
+ * so a null row on a successful query is data corruption — NOT "no policy
+ * configured" (an unset policy is a REAL row with a null/empty field). The safe
+ * responses are to THROW (fail closed → caller denies) or return a RESTRICTIVE
+ * default (still enforces the control). Defaulting to the permissive side is the
+ * fail-open bug. See PR #685 (derivePasskeyState) and the
+ * null-tenant-fail-open plan.
+ *
+ * This class was enumerated by hand and grew 4 → 5 → 7 during review (the R42
+ * accretion signature: a member-set that grows by accretion was never derived
+ * from the true primitive, so the next silently-missed member is likely still
+ * unwritten). Because the class cannot be mechanically split into
+ * throw / fail-safe-default / display-echo by grep alone, this guard pins
+ * COMPLETENESS: it enumerates every enforcement-field tenant read from the
+ * defining primitive and fails when the live set diverges from the reviewed
+ * MANIFEST below — a NEW site (unclassified member → must be reviewed and given
+ * a disposition) or a VANISHED site (stale manifest entry → remove it). The
+ * per-site fail-closed behavior is pinned by the mutation-verified unit tests;
+ * this guard guarantees no new member ships unreviewed.
+ *
+ * Detection is lexical-with-context (no AST dependency — cheap, runs in the
+ * static-checks job): a file is an "enforcement tenant read" when it contains a
+ * `tenant.findUnique(` or `tenant: { select:` whose surrounding source names at
+ * least one ENFORCEMENT field. Every such file MUST appear in MANIFEST with a
+ * disposition; every MANIFEST entry MUST still match.
+ *
+ * Exit 0 = OK. Exit 1 = the live enforcement-read set diverges from MANIFEST.
+ *
+ * Env: NTFC_CHECK_ROOT overrides the repo root (used by the guard self-test to
+ * point the scan at a throwaway fixture tree — see the mutation-verification in
+ * the null-tenant-fail-open code review).
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join, extname, relative } from "node:path";
+
+const REPO_ROOT = new URL("../..", import.meta.url).pathname;
+const ROOT = process.env.NTFC_CHECK_ROOT ?? REPO_ROOT;
+const SCAN_DIRS = ["src/app/api", "src/lib", "src/auth.ts"];
+
+// Every enforcement-field tenant read in the codebase, with its reviewed
+// disposition. Adding a NEW enforcement read requires a manifest entry (choose
+// the right disposition and confirm the code matches it); removing one requires
+// deleting its entry. Dispositions:
+//   "throw"           — fails closed on null row via `if (!tenant) throw` (the
+//                       corruption case denies).
+//   "failsafe-default"— null/error path returns a RESTRICTIVE default that still
+//                       enforces the control (never the permissive side).
+//   "display-exempt"  — NOT an access decision on a subject: config-write
+//                       validation or a client-display echo in a response body.
+const MANIFEST = new Map([
+  // ── fail-closed via throw (fixed in this class) ────────────────────────────
+  ["src/lib/auth/policy/access-restriction.ts", "throw"],
+  ["src/lib/auth/policy/passkey-enforcement.ts", "throw"],
+  ["src/lib/auth/session/auth-adapter.ts", "throw"],
+  ["src/lib/auth/tokens/extension-token.ts", "throw"],
+  ["src/app/api/extension/token/refresh/route.ts", "throw"],
+  ["src/app/api/webauthn/register/verify/route.ts", "throw"],
+  ["src/lib/team/team-policy.ts", "throw"],
+  ["src/auth.ts", "throw"],
+  // ── fail-safe restrictive default (verified — never permissive) ────────────
+  ["src/lib/auth/policy/account-lockout.ts", "failsafe-default"],
+  ["src/lib/auth/session/session-timeout.ts", "failsafe-default"],
+  // ── display / config-write echo (not an access decision) ───────────────────
+  ["src/app/api/tenant/policy/route.ts", "display-exempt"],
+  ["src/app/api/teams/[teamId]/policy/route.ts", "display-exempt"],
+  ["src/app/api/vault/status/route.ts", "display-exempt"],
+  ["src/app/api/vault/unlock/data/route.ts", "display-exempt"],
+  ["src/app/api/user/passkey-status/route.ts", "display-exempt"],
+  ["src/app/api/sessions/route.ts", "display-exempt"],
+]);
+
+// Enforcement fields whose null-row lenient fallback bypasses a control.
+const ENFORCEMENT_FIELD_RE =
+  /\b(allowedCidrs|tailscaleEnabled|tailscaleTailnet|requirePasskey|requirePasskeyEnabledAt|passkeyGracePeriodDays|requireMinPinLength|lockoutThreshold[123]|lockoutDuration[123]Minutes|extensionTokenIdleTimeoutMinutes|extensionTokenAbsoluteTimeoutMinutes|maxConcurrentSessions|sessionIdleTimeoutMinutes|sessionAbsoluteTimeoutMinutes|vaultAutoLockMinutes)\b/;
+
+// A tenant policy read: direct findUnique or the relation-join select.
+const TENANT_READ_RE = /tenant\.findUnique\s*\(|tenant:\s*\{\s*select:/;
+
+function walk(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(full));
+    else if (
+      e.isFile() &&
+      (extname(e.name) === ".ts" || extname(e.name) === ".tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const targets = SCAN_DIRS.flatMap((d) => {
+  const full = join(ROOT, d);
+  return d.endsWith(".ts") ? [full] : walk(full);
+});
+
+const liveReads = new Set();
+for (const file of targets) {
+  if (file.includes(".test.") || file.includes("__tests__")) continue;
+  let src;
+  try {
+    src = readFileSync(file, "utf8");
+  } catch {
+    continue;
+  }
+  if (TENANT_READ_RE.test(src) && ENFORCEMENT_FIELD_RE.test(src)) {
+    // relative() normalizes away any trailing slash on ROOT.
+    liveReads.add(relative(ROOT, file));
+  }
+}
+
+const unlisted = [...liveReads].filter((r) => !MANIFEST.has(r)).sort();
+const stale = [...MANIFEST.keys()].filter((r) => !liveReads.has(r)).sort();
+
+let failed = false;
+
+if (unlisted.length > 0) {
+  failed = true;
+  console.error(
+    "null-tenant fail-open: NEW enforcement tenant read(s) not in the MANIFEST:",
+  );
+  console.error(
+    "Classify each in scripts/checks/check-null-tenant-fail-closed.mjs — the null-row",
+  );
+  console.error(
+    "path must THROW or return a RESTRICTIVE default (never the permissive side), or be",
+  );
+  console.error("a display/config-write echo. Add the reviewed disposition.");
+  console.error("");
+  for (const v of unlisted) console.error(`  ${v}`);
+}
+
+if (stale.length > 0) {
+  failed = true;
+  if (unlisted.length > 0) console.error("");
+  console.error(
+    "MANIFEST entries that no longer read an enforcement tenant field (stale — remove them):",
+  );
+  console.error("");
+  for (const s of stale) console.error(`  ${s}`);
+}
+
+if (failed) process.exit(1);
+console.log(
+  `check-null-tenant-fail-closed: OK (${liveReads.size} enforcement reads, all classified)`,
+);

--- a/scripts/checks/check-null-tenant-fail-closed.mjs
+++ b/scripts/checks/check-null-tenant-fail-closed.mjs
@@ -114,29 +114,143 @@ function findEnforcementReads(sf) {
     if (callee.getName?.() !== "findUnique") continue;
     const recvText = callee.getExpression?.()?.getText?.() ?? "";
     if (!/(^|\.)tenant$/.test(recvText)) continue;
-    if (selectNamesEnforcementField(call.getArguments()[0])) reads.push({ node: call });
+    if (!selectNamesEnforcementField(call.getArguments()[0])) continue;
+    // The variable this tenant row is bound to: `const <v> = await <...>.findUnique(...)`
+    // (or `= <...>.findUnique(...)`). The null guard must key on <v>.tenant.
+    reads.push({ node: call, guardVar: bindingVarName(call), joinField: null });
   }
   for (const pa of sf.getDescendantsOfKind(SyntaxKind.PropertyAssignment)) {
     if (pa.getName() !== "tenant") continue;
     const init = pa.getInitializerIfKind?.(SyntaxKind.ObjectLiteralExpression);
-    if (init && selectNamesEnforcementField(init)) reads.push({ node: pa });
+    if (!init || !selectNamesEnforcementField(init)) continue;
+    // Relation join `tenant: { select: {...} }` nested in a parent findUnique
+    // select: the row is bound to the parent's variable and the enforcement
+    // fields live under `<v>.tenant`. Guard must be `if (!<v>) | if (!<v>.tenant)`.
+    const parentCall = pa.getFirstAncestorByKind(SyntaxKind.CallExpression);
+    reads.push({ node: pa, guardVar: parentCall ? bindingVarName(parentCall) : null, joinField: "tenant" });
   }
   return reads;
 }
 
-function hasNullTenantThrowGuard(node) {
+// The identifier a tenant read is ultimately bound to. Handles two real shapes:
+//   (1) direct / RLS-wrapped: `const t = await withBypassRls(prisma, (tx) =>
+//       tx.tenant.findUnique(...))` — climb through await/arrow/wrapper layers to
+//       the enclosing VariableDeclaration and take its name.
+//   (2) Promise.all array-destructuring: `const [c, t] = await Promise.all([
+//       count(...), tx.tenant.findUnique(...)])` — the read is the Nth array
+//       element, bound to the Nth name of the ArrayBindingPattern.
+// Returns null when not bound to a simple identifier (the caller treats a null
+// guardVar as UNGUARDED — fail closed on the guard check).
+function bindingVarName(call) {
+  const viaPromiseAll = promiseAllDestructuredName(call);
+  if (viaPromiseAll !== undefined) return viaPromiseAll;
+
+  let cur = call;
+  while (cur) {
+    const parent = cur.getParent?.();
+    if (!parent) return null;
+    const pk = parent.getKind();
+    if (pk === SyntaxKind.VariableDeclaration) {
+      const nameNode = parent.getNameNode?.();
+      if (nameNode && nameNode.getKind() === SyntaxKind.Identifier) return nameNode.getText();
+      return null; // destructuring binding handled above; otherwise unguardable
+    }
+    if (
+      pk === SyntaxKind.AwaitExpression ||
+      pk === SyntaxKind.ParenthesizedExpression ||
+      pk === SyntaxKind.CallExpression ||
+      pk === SyntaxKind.ArrowFunction ||
+      pk === SyntaxKind.PropertyAccessExpression ||
+      pk === SyntaxKind.ReturnStatement ||
+      pk === SyntaxKind.Block ||
+      pk === SyntaxKind.SyntaxList
+    ) {
+      cur = parent;
+      continue;
+    }
+    return null;
+  }
+  return null;
+}
+
+// If `call` is the Nth element of an array literal passed to `Promise.all(...)`
+// whose result is destructured (`const [a, b] = await Promise.all([...])`),
+// return the Nth binding name. Returns undefined when this shape does not apply
+// (so the caller falls through to the generic climb), or null when the shape
+// applies but the Nth binding is not a simple identifier.
+function promiseAllDestructuredName(call) {
+  // The array literal directly containing `call` as an element.
+  const arrayLit = call.getParentIfKind?.(SyntaxKind.ArrayLiteralExpression);
+  if (!arrayLit) return undefined;
+  const elemIndex = arrayLit.getElements().findIndex((e) => e === call);
+  if (elemIndex < 0) return undefined;
+  // The array must be the sole arg to a `Promise.all(...)` call.
+  const paCall = arrayLit.getParentIfKind?.(SyntaxKind.CallExpression);
+  if (!paCall) return undefined;
+  const callee = paCall.getExpression();
+  if (callee.getKind() !== SyntaxKind.PropertyAccessExpression) return undefined;
+  if (callee.getName?.() !== "all") return undefined;
+  if (callee.getExpression?.().getText?.() !== "Promise") return undefined;
+  // Walk out to the VariableDeclaration with an array-binding pattern.
+  let cur = paCall;
+  while (cur) {
+    const parent = cur.getParent?.();
+    if (!parent) return null;
+    const pk = parent.getKind();
+    if (pk === SyntaxKind.VariableDeclaration) {
+      const nameNode = parent.getNameNode?.();
+      if (!nameNode || nameNode.getKind() !== SyntaxKind.ArrayBindingPattern) return null;
+      const el = nameNode.getElements()[elemIndex];
+      const nn = el?.getNameNode?.();
+      if (nn && nn.getKind() === SyntaxKind.Identifier) return nn.getText();
+      return null;
+    }
+    if (
+      pk === SyntaxKind.AwaitExpression ||
+      pk === SyntaxKind.ParenthesizedExpression ||
+      pk === SyntaxKind.CallExpression ||
+      pk === SyntaxKind.ArrowFunction ||
+      pk === SyntaxKind.ConditionalExpression ||
+      pk === SyntaxKind.ReturnStatement ||
+      pk === SyntaxKind.Block ||
+      pk === SyntaxKind.SyntaxList
+    ) {
+      cur = parent;
+      continue;
+    }
+    return null;
+  }
+  return null;
+}
+
+// Does the enclosing function of `read.node` contain a null guard on the SAME
+// variable the read is bound to, that throws / returns (fail closed)?
+//   plain read `const t = ...findUnique(...)`  -> guard `if (!t) { throw|return }`
+//   relation join bound to `const u = ...`      -> guard `if (!u) | if (!u.tenant)`
+// A read with no bindable variable (guardVar null) is treated as UNGUARDED.
+function hasNullTenantThrowGuard(read) {
+  const v = read.guardVar;
+  if (!v) return false; // inline / unbindable read cannot be proven guarded
   const fn =
-    node.getFirstAncestorByKind(SyntaxKind.FunctionDeclaration) ??
-    node.getFirstAncestorByKind(SyntaxKind.ArrowFunction) ??
-    node.getFirstAncestorByKind(SyntaxKind.FunctionExpression) ??
-    node.getFirstAncestorByKind(SyntaxKind.MethodDeclaration) ??
-    node.getSourceFile();
+    read.node.getFirstAncestorByKind(SyntaxKind.FunctionDeclaration) ??
+    read.node.getFirstAncestorByKind(SyntaxKind.ArrowFunction) ??
+    read.node.getFirstAncestorByKind(SyntaxKind.FunctionExpression) ??
+    read.node.getFirstAncestorByKind(SyntaxKind.MethodDeclaration) ??
+    read.node.getSourceFile();
+
+  // Accepted guard operand texts for this read's variable.
+  const wanted = new Set([v]);
+  if (read.joinField) wanted.add(`${v}.${read.joinField}`);
+
   for (const ifStmt of fn.getDescendantsOfKind(SyntaxKind.IfStatement)) {
     const cond = ifStmt.getExpression();
     if (cond.getKind() !== SyntaxKind.PrefixUnaryExpression) continue;
     if (cond.getOperatorToken?.() !== SyntaxKind.ExclamationToken) continue;
     const operand = cond.getOperand?.();
-    if (!operand || !/tenant/i.test(operand.getText())) continue;
+    if (!operand) continue;
+    // Strip optional-chaining/whitespace differences: compare the text.
+    const opText = operand.getText().replace(/\s+/g, "");
+    if (!wanted.has(opText) && !wanted.has(opText.replace(/\?\./g, "."))) continue;
     const body = ifStmt.getThenStatement();
     const bk = body.getKind();
     if (bk === SyntaxKind.ThrowStatement ||
@@ -201,7 +315,7 @@ for (const file of targets) {
   }
 
   if (disposition === "throw") {
-    if (!reads.every((r) => hasNullTenantThrowGuard(r.node))) {
+    if (!reads.every((r) => hasNullTenantThrowGuard(r))) {
       violations.push(`${rel}: disposition "throw" but an enforcement read has no null-tenant guard (if (!tenant) { throw|return }). A reverted throw is a fail-open regression.`);
     }
   } else if (disposition === "failsafe-default") {

--- a/scripts/checks/check-null-tenant-fail-closed.mjs
+++ b/scripts/checks/check-null-tenant-fail-closed.mjs
@@ -1,62 +1,49 @@
 #!/usr/bin/env node
 /**
- * CI guard: null-tenant fail-open enforcement class — completeness manifest.
+ * CI guard: null-tenant fail-open enforcement class - AST, per-read-site.
  *
  * An enforcement decision that reads a tenant security policy via
- * `tenant.findUnique({ select: { <enforcement field> } })` (or the relation join
- * `tenant: { select: … }`) and, on a null row, falls back to the LENIENT side
+ * `tenant.findUnique({ select: { <enforcement field> } })` (or a relation join
+ * `tenant: { select: ... }`) and, on a null row, falls back to the LENIENT side
  * silently BYPASSES that control. tenantId always comes from a server-trusted,
- * FK-RESTRICT-backed source (session / token row / the non-null `User.tenantId`),
- * so a null row on a successful query is data corruption — NOT "no policy
- * configured" (an unset policy is a REAL row with a null/empty field). The safe
- * responses are to THROW (fail closed → caller denies) or return a RESTRICTIVE
- * default (still enforces the control). Defaulting to the permissive side is the
- * fail-open bug. See PR #685 (derivePasskeyState) and the
- * null-tenant-fail-open plan.
+ * FK-RESTRICT-backed source (session / token row / non-null `User.tenantId`),
+ * so a null row on a SUCCESSFUL query is data corruption - NOT "no policy". The
+ * safe responses are to THROW (fail closed) or return a RESTRICTIVE default.
+ * See PR #685 (derivePasskeyState) and the null-tenant-fail-open plan.
  *
- * This class was enumerated by hand and grew 4 → 5 → 7 during review (the R42
- * accretion signature: a member-set that grows by accretion was never derived
- * from the true primitive, so the next silently-missed member is likely still
- * unwritten). Because the class cannot be mechanically split into
- * throw / fail-safe-default / display-echo by grep alone, this guard pins
- * COMPLETENESS: it enumerates every enforcement-field tenant read from the
- * defining primitive and fails when the live set diverges from the reviewed
- * MANIFEST below — a NEW site (unclassified member → must be reviewed and given
- * a disposition) or a VANISHED site (stale manifest entry → remove it). The
- * per-site fail-closed behavior is pinned by the mutation-verified unit tests;
- * this guard guarantees no new member ships unreviewed.
+ * This class was enumerated by hand and grew 4 -> 5 -> 7 during review (the R42
+ * accretion signature). A prior version of this guard tracked only the SET of
+ * files containing an enforcement read, so intra-file mutations - adding a
+ * fail-open read to a listed file, reverting a `throw` to a permissive
+ * fallback, or adding an access decision to a `display-exempt` file - all passed
+ * (external review Medium). This version parses each read site with ts-morph and
+ * verifies its declared MANIFEST disposition against the implementation:
  *
- * Detection is lexical-with-context (no AST dependency — cheap, runs in the
- * static-checks job): a file is an "enforcement tenant read" when it contains a
- * `tenant.findUnique(` or `tenant: { select:` whose surrounding source names at
- * least one ENFORCEMENT field. Every such file MUST appear in MANIFEST with a
- * disposition; every MANIFEST entry MUST still match.
+ *   "throw"            - the read's enclosing function MUST contain a null-tenant
+ *                        guard that throws / returns-invalid (`if (!<tenantVar>)
+ *                        { throw ... | return ... }`). Reverting the throw to a
+ *                        permissive coalesce removes the guard -> FAIL.
+ *   "failsafe-default" - the file MUST NOT read an enforcement field through a
+ *                        permissive null-coalesce (`tenant?.<field> ?? <lenient>`);
+ *                        it returns a restrictive default some other way.
+ *                        Introducing a permissive coalesce -> FAIL.
+ *   "display-exempt"   - the file must NOT call an access-restriction / deny
+ *                        primitive. Turning an echo into an access decision -> FAIL.
  *
- * Exit 0 = OK. Exit 1 = the live enforcement-read set diverges from MANIFEST.
+ * Plus completeness: every enforcement read site MUST have a MANIFEST entry, and
+ * every MANIFEST entry MUST still have a live read. Exit 0 = OK, 1 = divergence.
  *
- * Env: NTFC_CHECK_ROOT overrides the repo root (used by the guard self-test to
- * point the scan at a throwaway fixture tree — see the mutation-verification in
- * the null-tenant-fail-open code review).
+ * Env: NTFC_CHECK_ROOT overrides the repo root (used by the guard self-test).
  */
 import { readFileSync, readdirSync } from "node:fs";
 import { join, extname, relative } from "node:path";
+import { Project, SyntaxKind, ts } from "ts-morph";
 
 const REPO_ROOT = new URL("../..", import.meta.url).pathname;
 const ROOT = process.env.NTFC_CHECK_ROOT ?? REPO_ROOT;
 const SCAN_DIRS = ["src/app/api", "src/lib", "src/auth.ts"];
 
-// Every enforcement-field tenant read in the codebase, with its reviewed
-// disposition. Adding a NEW enforcement read requires a manifest entry (choose
-// the right disposition and confirm the code matches it); removing one requires
-// deleting its entry. Dispositions:
-//   "throw"           — fails closed on null row via `if (!tenant) throw` (the
-//                       corruption case denies).
-//   "failsafe-default"— null/error path returns a RESTRICTIVE default that still
-//                       enforces the control (never the permissive side).
-//   "display-exempt"  — NOT an access decision on a subject: config-write
-//                       validation or a client-display echo in a response body.
 const MANIFEST = new Map([
-  // ── fail-closed via throw (fixed in this class) ────────────────────────────
   ["src/lib/auth/policy/access-restriction.ts", "throw"],
   ["src/lib/auth/policy/passkey-enforcement.ts", "throw"],
   ["src/lib/auth/session/auth-adapter.ts", "throw"],
@@ -65,10 +52,8 @@ const MANIFEST = new Map([
   ["src/app/api/webauthn/register/verify/route.ts", "throw"],
   ["src/lib/team/team-policy.ts", "throw"],
   ["src/auth.ts", "throw"],
-  // ── fail-safe restrictive default (verified — never permissive) ────────────
   ["src/lib/auth/policy/account-lockout.ts", "failsafe-default"],
   ["src/lib/auth/session/session-timeout.ts", "failsafe-default"],
-  // ── display / config-write echo (not an access decision) ───────────────────
   ["src/app/api/tenant/policy/route.ts", "display-exempt"],
   ["src/app/api/teams/[teamId]/policy/route.ts", "display-exempt"],
   ["src/app/api/vault/status/route.ts", "display-exempt"],
@@ -77,32 +62,116 @@ const MANIFEST = new Map([
   ["src/app/api/sessions/route.ts", "display-exempt"],
 ]);
 
-// Enforcement fields whose null-row lenient fallback bypasses a control.
-const ENFORCEMENT_FIELD_RE =
-  /\b(allowedCidrs|tailscaleEnabled|tailscaleTailnet|requirePasskey|requirePasskeyEnabledAt|passkeyGracePeriodDays|requireMinPinLength|lockoutThreshold[123]|lockoutDuration[123]Minutes|extensionTokenIdleTimeoutMinutes|extensionTokenAbsoluteTimeoutMinutes|maxConcurrentSessions|sessionIdleTimeoutMinutes|sessionAbsoluteTimeoutMinutes|vaultAutoLockMinutes)\b/;
+const ENFORCEMENT_FIELDS = new Set([
+  "allowedCidrs", "tailscaleEnabled", "tailscaleTailnet",
+  "requirePasskey", "requirePasskeyEnabledAt", "passkeyGracePeriodDays",
+  "requireMinPinLength",
+  "lockoutThreshold1", "lockoutThreshold2", "lockoutThreshold3",
+  "lockoutDuration1Minutes", "lockoutDuration2Minutes", "lockoutDuration3Minutes",
+  "extensionTokenIdleTimeoutMinutes", "extensionTokenAbsoluteTimeoutMinutes",
+  "maxConcurrentSessions", "sessionIdleTimeoutMinutes",
+  "sessionAbsoluteTimeoutMinutes", "vaultAutoLockMinutes",
+]);
 
-// A tenant policy read: direct findUnique or the relation-join select.
-const TENANT_READ_RE = /tenant\.findUnique\s*\(|tenant:\s*\{\s*select:/;
+const ACCESS_DECISION_NAMES = new Set([
+  "checkAccessRestriction", "checkAccessRestrictionWithAudit",
+  "enforceAccessRestriction", "checkTeamAccessRestriction",
+]);
+
+const project = new Project({
+  useInMemoryFileSystem: true,
+  skipFileDependencyResolution: true,
+  compilerOptions: { allowJs: true, jsx: ts.JsxEmit.ReactJSX },
+});
 
 function walk(dir) {
   const out = [];
   let entries;
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return out;
-  }
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return out; }
   for (const e of entries) {
     const full = join(dir, e.name);
     if (e.isDirectory()) out.push(...walk(full));
-    else if (
-      e.isFile() &&
-      (extname(e.name) === ".ts" || extname(e.name) === ".tsx")
-    ) {
-      out.push(full);
-    }
+    else if (e.isFile() && (extname(e.name) === ".ts" || extname(e.name) === ".tsx")) out.push(full);
   }
   return out;
+}
+
+function selectNamesEnforcementField(objLiteral) {
+  if (!objLiteral || objLiteral.getKind() !== SyntaxKind.ObjectLiteralExpression) return false;
+  const selectProp = objLiteral.getProperties()
+    .find((p) => p.getKind() === SyntaxKind.PropertyAssignment && p.getName() === "select");
+  if (!selectProp) return false;
+  const selectObj = selectProp.getInitializerIfKind?.(SyntaxKind.ObjectLiteralExpression);
+  if (!selectObj) return false;
+  return selectObj.getProperties().some((p) => p.getName && ENFORCEMENT_FIELDS.has(p.getName()));
+}
+
+function findEnforcementReads(sf) {
+  const reads = [];
+  for (const call of sf.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    const callee = call.getExpression();
+    if (callee.getKind() !== SyntaxKind.PropertyAccessExpression) continue;
+    if (callee.getName?.() !== "findUnique") continue;
+    const recvText = callee.getExpression?.()?.getText?.() ?? "";
+    if (!/(^|\.)tenant$/.test(recvText)) continue;
+    if (selectNamesEnforcementField(call.getArguments()[0])) reads.push({ node: call });
+  }
+  for (const pa of sf.getDescendantsOfKind(SyntaxKind.PropertyAssignment)) {
+    if (pa.getName() !== "tenant") continue;
+    const init = pa.getInitializerIfKind?.(SyntaxKind.ObjectLiteralExpression);
+    if (init && selectNamesEnforcementField(init)) reads.push({ node: pa });
+  }
+  return reads;
+}
+
+function hasNullTenantThrowGuard(node) {
+  const fn =
+    node.getFirstAncestorByKind(SyntaxKind.FunctionDeclaration) ??
+    node.getFirstAncestorByKind(SyntaxKind.ArrowFunction) ??
+    node.getFirstAncestorByKind(SyntaxKind.FunctionExpression) ??
+    node.getFirstAncestorByKind(SyntaxKind.MethodDeclaration) ??
+    node.getSourceFile();
+  for (const ifStmt of fn.getDescendantsOfKind(SyntaxKind.IfStatement)) {
+    const cond = ifStmt.getExpression();
+    if (cond.getKind() !== SyntaxKind.PrefixUnaryExpression) continue;
+    if (cond.getOperatorToken?.() !== SyntaxKind.ExclamationToken) continue;
+    const operand = cond.getOperand?.();
+    if (!operand || !/tenant/i.test(operand.getText())) continue;
+    const body = ifStmt.getThenStatement();
+    const bk = body.getKind();
+    if (bk === SyntaxKind.ThrowStatement ||
+        bk === SyntaxKind.ReturnStatement ||
+        body.getDescendantsOfKind(SyntaxKind.ThrowStatement).length > 0 ||
+        body.getDescendantsOfKind(SyntaxKind.ReturnStatement).length > 0) return true;
+  }
+  return false;
+}
+
+function hasPermissiveEnforcementCoalesce(sf) {
+  for (const bin of sf.getDescendantsOfKind(SyntaxKind.BinaryExpression)) {
+    if (bin.getOperatorToken().getKind() !== SyntaxKind.QuestionQuestionToken) continue;
+    const left = bin.getLeft();
+    const paList = left.getKind() === SyntaxKind.PropertyAccessExpression
+      ? [left] : left.getDescendantsOfKind(SyntaxKind.PropertyAccessExpression);
+    for (const pa of paList) {
+      if (!ENFORCEMENT_FIELDS.has(pa.getName())) continue;
+      if (/tenant/i.test(pa.getExpression().getText())) return true;
+    }
+  }
+  return false;
+}
+
+function callsAccessDecision(sf) {
+  for (const call of sf.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    const callee = call.getExpression();
+    const name = callee.getKind() === SyntaxKind.Identifier ? callee.getText()
+      : callee.getKind() === SyntaxKind.PropertyAccessExpression ? callee.getName?.() : null;
+    if (name && ACCESS_DECISION_NAMES.has(name)) return true;
+  }
+  for (const nw of sf.getDescendantsOfKind(SyntaxKind.NewExpression)) {
+    if (nw.getExpression().getText() === "PolicyViolationError") return true;
+  }
+  return false;
 }
 
 const targets = SCAN_DIRS.flatMap((d) => {
@@ -111,52 +180,56 @@ const targets = SCAN_DIRS.flatMap((d) => {
 });
 
 const liveReads = new Set();
+const violations = [];
+
 for (const file of targets) {
   if (file.includes(".test.") || file.includes("__tests__")) continue;
-  let src;
-  try {
-    src = readFileSync(file, "utf8");
-  } catch {
+  let text;
+  try { text = readFileSync(file, "utf8"); } catch { continue; }
+  const rel = relative(ROOT, file);
+  const virtualName = `/v/${rel.replaceAll("/", "_")}${extname(file) === ".tsx" ? ".tsx" : ".ts"}`;
+  const sf = project.createSourceFile(virtualName, text, { overwrite: true });
+
+  const reads = findEnforcementReads(sf);
+  if (reads.length === 0) continue;
+  liveReads.add(rel);
+
+  const disposition = MANIFEST.get(rel);
+  if (!disposition) {
+    violations.push(`${rel}: NEW enforcement tenant read with no MANIFEST disposition - classify it (throw | failsafe-default | display-exempt).`);
     continue;
   }
-  if (TENANT_READ_RE.test(src) && ENFORCEMENT_FIELD_RE.test(src)) {
-    // relative() normalizes away any trailing slash on ROOT.
-    liveReads.add(relative(ROOT, file));
+
+  if (disposition === "throw") {
+    if (!reads.every((r) => hasNullTenantThrowGuard(r.node))) {
+      violations.push(`${rel}: disposition "throw" but an enforcement read has no null-tenant guard (if (!tenant) { throw|return }). A reverted throw is a fail-open regression.`);
+    }
+  } else if (disposition === "failsafe-default") {
+    if (hasPermissiveEnforcementCoalesce(sf)) {
+      violations.push(`${rel}: disposition "failsafe-default" but an enforcement field is read through a permissive '?? <lenient>' coalesce - the fail-open shape. Return a RESTRICTIVE default instead.`);
+    }
+  } else if (disposition === "display-exempt") {
+    if (callsAccessDecision(sf)) {
+      violations.push(`${rel}: disposition "display-exempt" but the file calls an access-restriction / deny primitive - it is no longer a pure echo. Re-classify (throw | failsafe-default).`);
+    }
   }
 }
 
-const unlisted = [...liveReads].filter((r) => !MANIFEST.has(r)).sort();
 const stale = [...MANIFEST.keys()].filter((r) => !liveReads.has(r)).sort();
 
 let failed = false;
-
-if (unlisted.length > 0) {
+if (violations.length > 0) {
   failed = true;
-  console.error(
-    "null-tenant fail-open: NEW enforcement tenant read(s) not in the MANIFEST:",
-  );
-  console.error(
-    "Classify each in scripts/checks/check-null-tenant-fail-closed.mjs — the null-row",
-  );
-  console.error(
-    "path must THROW or return a RESTRICTIVE default (never the permissive side), or be",
-  );
-  console.error("a display/config-write echo. Add the reviewed disposition.");
+  console.error("null-tenant fail-open: enforcement-read violation(s):");
   console.error("");
-  for (const v of unlisted) console.error(`  ${v}`);
+  for (const v of violations.sort()) console.error(`  ${v}`);
 }
-
 if (stale.length > 0) {
   failed = true;
-  if (unlisted.length > 0) console.error("");
-  console.error(
-    "MANIFEST entries that no longer read an enforcement tenant field (stale — remove them):",
-  );
+  if (violations.length > 0) console.error("");
+  console.error("MANIFEST entries that no longer read an enforcement tenant field (stale - remove them):");
   console.error("");
   for (const s of stale) console.error(`  ${s}`);
 }
-
 if (failed) process.exit(1);
-console.log(
-  `check-null-tenant-fail-closed: OK (${liveReads.size} enforcement reads, all classified)`,
-);
+console.log(`check-null-tenant-fail-closed: OK (${liveReads.size} enforcement reads, all classified + disposition-verified)`);

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -192,6 +192,7 @@ run_step "Static: security-matrices drift check" npm run check:security-matrices
 run_step "Static: team-auth-rls"  node scripts/checks/check-team-auth-rls.mjs
 run_step "Static: bypass-rls"     node scripts/checks/check-bypass-rls.mjs
 run_step "Static: count-then-create-lock" node scripts/checks/check-count-then-create-lock.mjs
+run_step "Static: null-tenant-fail-closed" node scripts/checks/check-null-tenant-fail-closed.mjs
 run_step "Static: crypto-domains" node scripts/checks/check-crypto-domains.mjs
 run_step "Static: migration-drift" node scripts/checks/check-migration-drift.mjs
 run_step "Static: raw-sql-usage" node scripts/checks/check-raw-sql-usage.mjs

--- a/src/__tests__/integration/mcp-oauth-flow.test.ts
+++ b/src/__tests__/integration/mcp-oauth-flow.test.ts
@@ -332,10 +332,17 @@ describe("Scenario 3: PKCE Token Exchange Success via /api/mcp/token", () => {
           count: vi.fn().mockResolvedValue(1), // hasPasskey = true → never blocks
         },
         tenant: {
+          // Shared by derivePasskeyState AND getTenantAccessPolicy (via the
+          // pre-mint enforceAccessRestriction). A real tenant row carries the
+          // access-restriction fields too — include them so the IP gate reads a
+          // populated (unrestricted) policy instead of a partial row.
           findUnique: vi.fn().mockResolvedValue({
             requirePasskey: false,
             requirePasskeyEnabledAt: null,
             passkeyGracePeriodDays: null,
+            allowedCidrs: [],
+            tailscaleEnabled: false,
+            tailscaleTailnet: null,
           }),
         },
       };
@@ -406,6 +413,16 @@ describe("Scenario 4: PKCE Failure Paths via POST /api/mcp/token", () => {
           update: vi.fn(),
         },
         mcpAccessToken: { create: vi.fn() },
+        // A real tenant row for the pre-mint enforceAccessRestriction IP gate
+        // (getTenantAccessPolicy); unrestricted so the failure path under test
+        // is reached rather than an IP denial.
+        tenant: {
+          findUnique: vi.fn().mockResolvedValue({
+            allowedCidrs: [],
+            tailscaleEnabled: false,
+            tailscaleTailnet: null,
+          }),
+        },
       };
       return fn(tx);
     });
@@ -446,6 +463,16 @@ describe("Scenario 4: PKCE Failure Paths via POST /api/mcp/token", () => {
           update: vi.fn(),
         },
         mcpAccessToken: { create: vi.fn() },
+        // A real tenant row for the pre-mint enforceAccessRestriction IP gate
+        // (getTenantAccessPolicy); unrestricted so the failure path under test
+        // is reached rather than an IP denial.
+        tenant: {
+          findUnique: vi.fn().mockResolvedValue({
+            allowedCidrs: [],
+            tailscaleEnabled: false,
+            tailscaleTailnet: null,
+          }),
+        },
       };
       return fn(tx);
     });
@@ -486,6 +513,16 @@ describe("Scenario 4: PKCE Failure Paths via POST /api/mcp/token", () => {
           update: vi.fn(),
         },
         mcpAccessToken: { create: vi.fn() },
+        // A real tenant row for the pre-mint enforceAccessRestriction IP gate
+        // (getTenantAccessPolicy); unrestricted so the failure path under test
+        // is reached rather than an IP denial.
+        tenant: {
+          findUnique: vi.fn().mockResolvedValue({
+            allowedCidrs: [],
+            tailscaleEnabled: false,
+            tailscaleTailnet: null,
+          }),
+        },
       };
       return fn(tx);
     });
@@ -529,6 +566,16 @@ describe("Scenario 4: PKCE Failure Paths via POST /api/mcp/token", () => {
           update: vi.fn(),
         },
         mcpAccessToken: { create: vi.fn() },
+        // A real tenant row for the pre-mint enforceAccessRestriction IP gate
+        // (getTenantAccessPolicy); unrestricted so the failure path under test
+        // is reached rather than an IP denial.
+        tenant: {
+          findUnique: vi.fn().mockResolvedValue({
+            allowedCidrs: [],
+            tailscaleEnabled: false,
+            tailscaleTailnet: null,
+          }),
+        },
       };
       return fn(tx);
     });
@@ -576,6 +623,16 @@ describe("Scenario 4: PKCE Failure Paths via POST /api/mcp/token", () => {
           update: vi.fn(),
         },
         mcpAccessToken: { create: vi.fn() },
+        // A real tenant row for the pre-mint enforceAccessRestriction IP gate
+        // (getTenantAccessPolicy); unrestricted so the failure path under test
+        // is reached rather than an IP denial.
+        tenant: {
+          findUnique: vi.fn().mockResolvedValue({
+            allowedCidrs: [],
+            tailscaleEnabled: false,
+            tailscaleTailnet: null,
+          }),
+        },
       };
       return fn(tx);
     });

--- a/src/__tests__/integration/mobile-dpop-flow.integration.test.ts
+++ b/src/__tests__/integration/mobile-dpop-flow.integration.test.ts
@@ -148,8 +148,11 @@ describe("POST /api/mobile/token — real-key DPoP (C10 sentinel for C6)", () =>
     // withBypassRls callback runs against the tx — give it a tx-shape that
     // routes the bridge-code mocks AND the tenant lookup that
     // enforceAccessRestriction → getTenantAccessPolicy performs (the
-    // /api/mobile/token issuance now enforces tenant IP restriction). A null
-    // tenant resolves to "no restriction configured" → request allowed.
+    // /api/mobile/token issuance now enforces tenant IP restriction). Return a
+    // REAL unrestricted tenant row (empty allowedCidrs, tailscale off) — a
+    // configured tenant with no restrictions is a populated row, not null. A
+    // null row now means data corruption and fails closed (getTenantAccessPolicy
+    // throws), so a partial mock returning null would wrongly break this flow.
     mockWithBypassRls.mockImplementation(async (_p, fn) =>
       typeof fn === "function"
         ? fn({
@@ -157,7 +160,13 @@ describe("POST /api/mobile/token — real-key DPoP (C10 sentinel for C6)", () =>
               findUnique: mockMobileBridgeCodeFindUnique,
               updateMany: mockMobileBridgeCodeUpdateMany,
             },
-            tenant: { findUnique: async () => null },
+            tenant: {
+              findUnique: async () => ({
+                allowedCidrs: [],
+                tailscaleEnabled: false,
+                tailscaleTailnet: null,
+              }),
+            },
           })
         : undefined,
     );

--- a/src/__tests__/lib/access-restriction.test.ts
+++ b/src/__tests__/lib/access-restriction.test.ts
@@ -150,6 +150,32 @@ describe("checkAccessRestriction", () => {
     await checkAccessRestriction("tenant1", "192.168.1.3");
     expect(mockWithBypassRls).toHaveBeenCalledTimes(2);
   });
+
+  // Regression (null-tenant fail-open class): a missing tenant row on a
+  // successful query is data corruption (tenantId is FK-RESTRICT-backed), NOT
+  // "no restriction configured". Must FAIL CLOSED (throw → caller denies)
+  // instead of defaulting to an empty permissive policy that bypasses the
+  // tenant's IP/CIDR + Tailscale controls.
+  // Mutation check: revert getTenantAccessPolicy to `tenant?.allowedCidrs ?? []`
+  // and this test flips from throw to `{ allowed: true }` — it fails.
+  it("fails closed (throws) when the tenant row is missing", async () => {
+    mockTenantFindUnique.mockResolvedValue(null);
+    await expect(
+      checkAccessRestriction("tenant-gone", "1.2.3.4"),
+    ).rejects.toThrow(/tenant-gone not found/);
+  });
+
+  it("does not cache a policy derived from a missing tenant row", async () => {
+    mockTenantFindUnique.mockResolvedValue(null);
+    await expect(
+      checkAccessRestriction("tenant-gone", "1.2.3.4"),
+    ).rejects.toThrow();
+    // A second call must hit the DB again (no permissive policy cached).
+    await expect(
+      checkAccessRestriction("tenant-gone", "1.2.3.4"),
+    ).rejects.toThrow();
+    expect(mockWithBypassRls).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("wouldIpBeAllowed", () => {

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -889,7 +889,12 @@ describe("proxy — access restriction", () => {
     expect(res.headers.get("Cache-Control")).toBe("private, no-store");
   });
 
-  it("skips access restriction when tenant is null", async () => {
+  it("fails closed (401) when the user has no active tenant membership (deactivated)", async () => {
+    // resolveUserTenantId returns null (deactivatedAt != null). Since
+    // User.tenantId is a non-null FK, this is a revoked membership, not a
+    // legitimate no-tenant user. getSessionInfo fails closed, so the request is
+    // rejected BEFORE the access-restriction check — a stale/deactivated session
+    // can no longer both pass validation AND skip the tenant IP gate.
     mockResolveUserTenantId.mockResolvedValue(null);
 
     const req = new NextRequest(`${APP_ORIGIN}/api/passwords`, {
@@ -898,7 +903,7 @@ describe("proxy — access restriction", () => {
     } as ConstructorParameters<typeof NextRequest>[1]);
     const res = await proxy(req, dummyOptions);
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
     expect(mockCheckAccessWithAudit).not.toHaveBeenCalled();
   });
 
@@ -972,7 +977,9 @@ describe("proxy — CSRF gate", () => {
     fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ user: { id: "u1" } }), { status: 200 }),
     );
-    mockResolveUserTenantId.mockResolvedValue(null);
+    // A normal user WITH an active membership (a null return now fails session
+    // validation, which these CSRF-gate tests don't intend to exercise).
+    mockResolveUserTenantId.mockResolvedValue("tenant1");
     mockCheckAccessWithAudit.mockResolvedValue({ allowed: true });
   });
 
@@ -1137,7 +1144,7 @@ describe("auth-gate session cache miss path", () => {
     fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ user: { id: "u-miss" } }), { status: 200 }),
     );
-    mockResolveUserTenantId.mockResolvedValue(null);
+    mockResolveUserTenantId.mockResolvedValue("tenant1");
   });
 
   afterEach(() => {

--- a/src/app/api/extension/token/refresh/route.test.ts
+++ b/src/app/api/extension/token/refresh/route.test.ts
@@ -332,6 +332,24 @@ describe("POST /api/extension/token/refresh", () => {
     expect(json.scope).toEqual(["passwords:read", "vault:unlock-data"]);
   });
 
+  // Regression (null-tenant fail-open class): activeSession.tenantId is
+  // FK-backed, so a null tenant ROW is data corruption. Defaulting the TTL to
+  // the ceiling could refresh a token to a longer TTL than a tenant that had
+  // tightened it. Must FAIL CLOSED (throw → no rotation).
+  // Mutation check: restore `tenant?.… ?? DEFAULT` (no null-row throw) and this
+  // refresh succeeds instead of throwing — the test fails.
+  it("fails closed (throws) when the tenant row is missing", async () => {
+    mockValidateExtensionToken.mockResolvedValue(validTokenResult());
+    mockSessionFindFirst.mockResolvedValue({ id: "session-1", tenantId: "tenant-gone" });
+    mockTenantFindUnique.mockResolvedValueOnce(null);
+
+    const req = createRequest("POST", "http://localhost/api/extension/token/refresh", {
+      headers: { Authorization: "Bearer valid-token" },
+    });
+    await expect(POST(req)).rejects.toThrow(/tenant-gone not found/);
+    expect(mockExtTokenCreate).not.toHaveBeenCalled();
+  });
+
   it("revokes old token and creates new in transaction", async () => {
     mockValidateExtensionToken.mockResolvedValue(validTokenResult());
     mockSessionFindFirst.mockResolvedValue({ id: "session-1", tenantId: "tenant-1" });

--- a/src/app/api/extension/token/refresh/route.ts
+++ b/src/app/api/extension/token/refresh/route.ts
@@ -91,8 +91,23 @@ async function handlePOST(req: NextRequest) {
       },
     }),
   BYPASS_PURPOSE.TOKEN_LIFECYCLE);
-  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT;
-  const absoluteMinutes = tenant?.extensionTokenAbsoluteTimeoutMinutes ?? EXTENSION_TOKEN_ABSOLUTE_TIMEOUT_DEFAULT;
+  // FAIL-CLOSED: activeSession.tenantId is FK-backed, so a null tenant row is
+  // data corruption, NOT "no policy". These columns are non-nullable with schema
+  // defaults, so `?? DEFAULT` only fires on a vanished tenant — where defaulting
+  // to the ceiling could refresh a token to a longer TTL than a tenant that had
+  // tightened it. Refuse the refresh instead. (Mirrors issueExtensionToken.)
+  if (!tenant) {
+    throw new Error(
+      `extension token refresh: tenant ${activeSession.tenantId} not found`,
+    );
+  }
+  // Columns are non-nullable with schema defaults; the `?? DEFAULT` is a
+  // defensive floor for a field-null that cannot occur in practice.
+  const idleMinutes =
+    tenant.extensionTokenIdleTimeoutMinutes ?? EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT;
+  const absoluteMinutes =
+    tenant.extensionTokenAbsoluteTimeoutMinutes ??
+    EXTENSION_TOKEN_ABSOLUTE_TIMEOUT_DEFAULT;
 
   const now = new Date();
 

--- a/src/app/api/webauthn/register/verify/route.test.ts
+++ b/src/app/api/webauthn/register/verify/route.test.ts
@@ -230,7 +230,15 @@ describe("POST /api/webauthn/register/verify", () => {
       verified: true,
       registrationInfo: mockRegistrationInfo,
     });
-    mockPrismaUserFindUnique.mockResolvedValue({ tenantId: "tenant-1", locale: "ja", tenant: null });
+    // Realistic default: the tenant relation is populated (User.tenantId is a
+    // non-null FK, so Prisma always joins the row) with requireMinPinLength
+    // unset (null) — the common "no PIN policy" case. A null tenant RELATION is
+    // reserved for the data-corruption regression test below.
+    mockPrismaUserFindUnique.mockResolvedValue({
+      tenantId: "tenant-1",
+      locale: "ja",
+      tenant: { requireMinPinLength: null },
+    });
     mockParseDeviceFromUserAgent.mockReturnValue("Chrome on macOS");
     // withUserTenantRls: execute the callback directly
     mockWithUserTenantRls.mockImplementation(
@@ -894,6 +902,27 @@ describe("POST /api/webauthn/register/verify", () => {
       });
       const res = await POST(req);
       expect(res.status).toBe(201);
+    });
+
+    // Regression (null-tenant fail-open class): userInfo.tenantId is a non-null
+    // FK, so a null tenant RELATION is data corruption, NOT "no policy". Reading
+    // `tenant?.requireMinPinLength ?? null` on a vanished tenant would silently
+    // skip the PIN-length gate, letting a short-PIN authenticator register under
+    // a tenant that required a longer PIN. Must FAIL CLOSED (throw → no credential).
+    // Mutation check: restore `tenant?.… ?? null` (no null-relation throw) and a
+    // sub-min-PIN registration succeeds instead of throwing — this test fails.
+    it("fails closed (throws) when the tenant relation is missing (corruption)", async () => {
+      mockPrismaUserFindUnique.mockResolvedValue({
+        tenantId: "tenant-gone",
+        locale: "ja",
+        tenant: null,
+      });
+
+      const req = createRequest("POST", ROUTE_URL, {
+        body: makeBody({ minPinLength: 4 }),
+      });
+      await expect(POST(req)).rejects.toThrow(/tenant-gone not found/);
+      expect(mockPrismaCredentialCreate).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/api/webauthn/register/verify/route.ts
+++ b/src/app/api/webauthn/register/verify/route.ts
@@ -218,7 +218,15 @@ async function handlePOST(req: NextRequest) {
   // Only enforced when the authenticator explicitly reports minPinLength.
   // Platform authenticators (Touch ID, Face ID, Windows Hello) do not report
   // this value — they are always allowed regardless of policy.
-  const requireMinPin = userInfo.tenant?.requireMinPinLength ?? null;
+  //
+  // FAIL-CLOSED: userInfo.tenantId is a non-null FK RESTRICT, so a null tenant
+  // relation here is data corruption, NOT "no policy" — an unset requirement is
+  // requireMinPinLength=null on a real row. Reading `tenant?.… ?? null` on a
+  // vanished tenant would silently skip the PIN-length gate. Refuse instead.
+  if (!userInfo.tenant) {
+    throw new Error(`webauthn register: tenant ${userInfo.tenantId} not found`);
+  }
+  const requireMinPin = userInfo.tenant.requireMinPinLength;
   if (requireMinPin !== null && minPinLength !== null && minPinLength < requireMinPin) {
     return errorResponse(API_ERROR.PIN_LENGTH_POLICY_NOT_SATISFIED);
   }

--- a/src/lib/auth/policy/access-restriction.ts
+++ b/src/lib/auth/policy/access-restriction.ts
@@ -76,10 +76,22 @@ async function getTenantAccessPolicy(
     }),
   BYPASS_PURPOSE.CROSS_TENANT_LOOKUP);
 
+  // FAIL-CLOSED: tenantId always comes from a server-trusted source (session /
+  // token row) backed by an FK RESTRICT to Tenant, so a null here on a
+  // successful query means the tenant row vanished (data corruption / orphan),
+  // NOT "no restriction configured" — a configured tenant with no restrictions
+  // returns a real row with allowedCidrs=[]. Defaulting to an empty permissive
+  // policy would silently bypass a tenant's IP/CIDR + Tailscale controls (and
+  // cache that bypass for the TTL). Throw so callers deny rather than allow.
+  // Matches derivePasskeyState's throw-on-null-tenant stance (PR #685).
+  if (!tenant) {
+    throw new Error(`getTenantAccessPolicy: tenant ${tenantId} not found`);
+  }
+
   const policy: TenantAccessPolicy = {
-    allowedCidrs: tenant?.allowedCidrs ?? [],
-    tailscaleEnabled: tenant?.tailscaleEnabled ?? false,
-    tailscaleTailnet: tenant?.tailscaleTailnet ?? null,
+    allowedCidrs: tenant.allowedCidrs,
+    tailscaleEnabled: tenant.tailscaleEnabled,
+    tailscaleTailnet: tenant.tailscaleTailnet,
   };
 
   policyCache.set(tenantId, {

--- a/src/lib/auth/policy/account-lockout.test.ts
+++ b/src/lib/auth/policy/account-lockout.test.ts
@@ -125,7 +125,24 @@ describe("checkLockout", () => {
 describe("recordFailure", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    invalidateLockoutThresholdCache("tenant-default");
   });
+
+  // Resolve the user's tenant + its schema-default thresholds so recordFailure
+  // exercises the NORMAL (5/10/15) path via the tenant-scoped audit (logAuditInTx).
+  // Without a resolvable tenant the code now fails closed to the strictest
+  // threshold (lock at 1) — covered by its own dedicated tests below.
+  function mockDefaultTenantThresholds() {
+    mockPrismaUser.findUnique.mockResolvedValue({ tenantId: "tenant-default" });
+    mockPrismaTenant.findUnique.mockResolvedValue({
+      lockoutThreshold1: 5,
+      lockoutDuration1Minutes: 15,
+      lockoutThreshold2: 10,
+      lockoutDuration2Minutes: 60,
+      lockoutThreshold3: 15,
+      lockoutDuration3Minutes: 1440,
+    });
+  }
 
   function setupTransaction(row: {
     failed_unlock_attempts: number;
@@ -135,6 +152,7 @@ describe("recordFailure", () => {
     mockTxState.executeRawImpl.mockResolvedValue(undefined);
     mockTxState.queryRawImpl.mockResolvedValue([row]);
     mockPrismaUser.update.mockResolvedValue(undefined);
+    mockDefaultTenantThresholds();
   }
 
   it("increments counter on first failure", async () => {
@@ -228,7 +246,11 @@ describe("recordFailure", () => {
     });
 
     await recordFailure("user-1");
-    expect(mockLogAudit).toHaveBeenCalledWith(
+    // With a resolved tenant, the audit is written atomically via logAuditInTx
+    // (tx, tenantId, auditObj) — the tenant-scoped path.
+    expect(mockLogAuditInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      "tenant-default",
       expect.objectContaining({
         action: "VAULT_UNLOCK_FAILED",
         userId: "user-1",
@@ -245,7 +267,9 @@ describe("recordFailure", () => {
     });
 
     await recordFailure("user-1");
-    expect(mockLogAudit).toHaveBeenCalledWith(
+    expect(mockLogAuditInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      "tenant-default",
       expect.objectContaining({
         action: "VAULT_LOCKOUT_TRIGGERED",
         userId: "user-1",
@@ -433,13 +457,14 @@ describe("recordFailure", () => {
     expect(result!.lockedUntil).toEqual(activeLock);
   });
 
-  it("swallows logAuditAsync error in VAULT_UNLOCK_FAILED block", async () => {
+  it("swallows the atomic audit error in the VAULT_UNLOCK_FAILED block", async () => {
     setupTransaction({
       failed_unlock_attempts: 0,
       last_failed_unlock_at: null,
       account_locked_until: null,
     });
-    mockLogAudit.mockImplementationOnce(() => {
+    // With a resolved tenant the audit uses logAuditInTx (mockLogAuditInTx).
+    mockLogAuditInTx.mockImplementationOnce(() => {
       throw new Error("audit write failed");
     });
 
@@ -452,14 +477,14 @@ describe("recordFailure", () => {
     );
   });
 
-  it("swallows logAuditAsync error in VAULT_LOCKOUT_TRIGGERED block", async () => {
+  it("swallows the atomic audit error in the VAULT_LOCKOUT_TRIGGERED block", async () => {
     setupTransaction({
       failed_unlock_attempts: 4,
       last_failed_unlock_at: new Date(),
       account_locked_until: null,
     });
-    // First call (VAULT_UNLOCK_FAILED) succeeds; second call (VAULT_LOCKOUT_TRIGGERED) throws
-    mockLogAudit
+    // First call (VAULT_UNLOCK_FAILED) succeeds; second (VAULT_LOCKOUT_TRIGGERED) throws
+    mockLogAuditInTx
       .mockImplementationOnce(() => undefined)
       .mockImplementationOnce(() => {
         throw new Error("audit write failed on lockout");
@@ -588,47 +613,56 @@ describe("getLockoutThresholds (via recordFailure with tenantId)", () => {
     invalidateLockoutThresholdCache("tenant-abc");
   });
 
-  it("falls back to default thresholds when tenant is not found", async () => {
+  // Regression (null-tenant fail-open class): a missing tenant row is corruption
+  // (tenantId is FK-backed), NOT "no policy". Returning the schema-default
+  // thresholds (lock at 5) would GRANT extra attempts to a tenant that had
+  // tightened to lock-at-1 — a fail-open weakening. Fail closed to the strictest
+  // configurable threshold (lock at 1 attempt), and log it.
+  // Mutation check: revert to DEFAULT_LOCKOUT_THRESHOLDS and this locks at 5 not
+  // 1 — the single-attempt lock assertion fails.
+  it("fails closed to the strictest threshold (lock at 1) when the tenant row is missing", async () => {
+    invalidateLockoutThresholdCache("tenant-missing");
     mockPrismaTenant.findUnique.mockResolvedValue(null);
     setupTransaction({
-      failed_unlock_attempts: 4,
-      last_failed_unlock_at: new Date(),
+      failed_unlock_attempts: 0, // first failure → 1 attempt must already lock
+      last_failed_unlock_at: null,
       account_locked_until: null,
     });
 
     const result = await recordFailure("user-1", undefined, "tenant-missing");
     expect(result).not.toBeNull();
-    // Default threshold: 5 attempts → 15min lock
-    expect(result!.attempts).toBe(5);
+    expect(result!.attempts).toBe(1);
     expect(result!.locked).toBe(true);
+    expect(mockLoggerInstance.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: "tenant-missing" }),
+      "vault.lockout.tenantRowMissing.usingStrictest",
+    );
+    invalidateLockoutThresholdCache("tenant-missing");
   });
 
-  // Regression (null-tenant fail-open class): a DB error while fetching the
-  // per-tenant thresholds must NOT be swallowed silently. The default is still
-  // returned (fail-safe — lockout stays enforced), but the enforcement
-  // degradation (a tenant that tightened its thresholds silently reverting to
-  // defaults) must be observable via a warn log.
-  // Mutation check: remove the getLogger().warn call and the log assertion
-  // below fails; the default-return assertion documents the fail-safe axis.
-  it("logs a warning and returns defaults when the threshold fetch throws", async () => {
+  // Regression (null-tenant fail-open class): a DB error must not be swallowed to
+  // the schema-default (which could be weaker than a tightened tenant policy).
+  // Fail closed to the strictest threshold (lock at 1) and log the degradation.
+  // Mutation check: revert to DEFAULT_LOCKOUT_THRESHOLDS and this locks at 5 not
+  // 1 — the single-attempt lock assertion fails; remove the warn and the log
+  // assertion fails.
+  it("fails closed to the strictest threshold (lock at 1) when the threshold fetch throws", async () => {
     invalidateLockoutThresholdCache("tenant-dberr");
     mockPrismaTenant.findUnique.mockRejectedValue(new Error("DB down"));
     setupTransaction({
-      failed_unlock_attempts: 4,
-      last_failed_unlock_at: new Date(),
+      failed_unlock_attempts: 0,
+      last_failed_unlock_at: null,
       account_locked_until: null,
     });
 
     const result = await recordFailure("user-1", undefined, "tenant-dberr");
 
-    // Fail-safe: default threshold still enforces the lock (5 → 15min).
     expect(result).not.toBeNull();
-    expect(result!.attempts).toBe(5);
+    expect(result!.attempts).toBe(1);
     expect(result!.locked).toBe(true);
-    // Observable: the swallowed error is now logged.
     expect(mockLoggerInstance.warn).toHaveBeenCalledWith(
       expect.objectContaining({ tenantId: "tenant-dberr" }),
-      "vault.lockout.thresholdsFetchFailed.usingDefaults",
+      "vault.lockout.thresholdsFetchFailed.usingStrictest",
     );
     invalidateLockoutThresholdCache("tenant-dberr");
   });

--- a/src/lib/auth/policy/account-lockout.test.ts
+++ b/src/lib/auth/policy/account-lockout.test.ts
@@ -603,6 +603,36 @@ describe("getLockoutThresholds (via recordFailure with tenantId)", () => {
     expect(result!.locked).toBe(true);
   });
 
+  // Regression (null-tenant fail-open class): a DB error while fetching the
+  // per-tenant thresholds must NOT be swallowed silently. The default is still
+  // returned (fail-safe — lockout stays enforced), but the enforcement
+  // degradation (a tenant that tightened its thresholds silently reverting to
+  // defaults) must be observable via a warn log.
+  // Mutation check: remove the getLogger().warn call and the log assertion
+  // below fails; the default-return assertion documents the fail-safe axis.
+  it("logs a warning and returns defaults when the threshold fetch throws", async () => {
+    invalidateLockoutThresholdCache("tenant-dberr");
+    mockPrismaTenant.findUnique.mockRejectedValue(new Error("DB down"));
+    setupTransaction({
+      failed_unlock_attempts: 4,
+      last_failed_unlock_at: new Date(),
+      account_locked_until: null,
+    });
+
+    const result = await recordFailure("user-1", undefined, "tenant-dberr");
+
+    // Fail-safe: default threshold still enforces the lock (5 → 15min).
+    expect(result).not.toBeNull();
+    expect(result!.attempts).toBe(5);
+    expect(result!.locked).toBe(true);
+    // Observable: the swallowed error is now logged.
+    expect(mockLoggerInstance.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: "tenant-dberr" }),
+      "vault.lockout.thresholdsFetchFailed.usingDefaults",
+    );
+    invalidateLockoutThresholdCache("tenant-dberr");
+  });
+
   it("re-queries the DB after invalidateLockoutThresholdCache", async () => {
     // First call: return custom thresholds, cache them
     mockPrismaTenant.findUnique.mockResolvedValue({

--- a/src/lib/auth/policy/account-lockout.ts
+++ b/src/lib/auth/policy/account-lockout.ts
@@ -16,24 +16,31 @@ import { logAuditAsync, logAuditInTx, extractRequestMeta } from "@/lib/audit/aud
 import { getLogger } from "@/lib/logger";
 import { AUDIT_ACTION, AUDIT_SCOPE } from "@/lib/constants";
 import { MS_PER_DAY, MS_PER_MINUTE } from "@/lib/constants/time";
+import { LOCKOUT_THRESHOLD_MIN, LOCKOUT_DURATION_MAX } from "@/lib/validations/common";
 import { notifyAdminsOfLockout } from "@/lib/auth/policy/lockout-admin-notify";
 import type { NextRequest } from "next/server";
 
 /** Observation window: reset counter if last failure was this long ago */
 const OBSERVATION_WINDOW_MS = MS_PER_DAY;
 
-/**
- * Default lockout thresholds — ordered descending by attempts.
- * First match wins (most severe threshold applied).
- * Used as fallback when tenant config is unavailable.
- */
-const DEFAULT_LOCKOUT_THRESHOLDS = [
-  { attempts: 15, lockMinutes: 1440 }, // 24h
-  { attempts: 10, lockMinutes: 60 },   // 1h
-  { attempts: 5, lockMinutes: 15 },    // 15min
-];
-
 type LockoutThreshold = { attempts: number; lockMinutes: number };
+
+/**
+ * FAIL-CLOSED fallback used when the per-tenant thresholds cannot be read
+ * (tenant/user row vanished, or the fetch errored). A tenant's own schema-
+ * default thresholds (5/10/15 attempts) are NOT a safe fallback here: a tenant
+ * may have tightened its policy below the default (e.g. lock at 1 attempt), so
+ * returning the default would GRANT extra attempts on an infra failure — a
+ * fail-open weakening. Instead apply the strictest policy any tenant could
+ * configure (lock at the minimum attempt count for the maximum duration), so a
+ * fetch failure can only make lockout MORE aggressive, never less. recordFailure
+ * cannot simply throw on this path: the failed attempt would then go unrecorded
+ * and the counter would never advance — itself fail-open — so it must record
+ * under a threshold guaranteed no weaker than the tenant's real policy.
+ */
+const STRICTEST_LOCKOUT_THRESHOLDS: LockoutThreshold[] = [
+  { attempts: LOCKOUT_THRESHOLD_MIN, lockMinutes: LOCKOUT_DURATION_MAX },
+];
 
 const lockoutThresholdCache = new Map<string, { thresholds: LockoutThreshold[]; expiresAt: number }>();
 const LOCKOUT_THRESHOLD_CACHE_TTL_MS = MS_PER_MINUTE;
@@ -75,11 +82,15 @@ async function getLockoutThresholds(tenantId: string): Promise<LockoutThreshold[
     );
 
     if (!tenant) {
-      lockoutThresholdCache.set(tenantId, {
-        thresholds: DEFAULT_LOCKOUT_THRESHOLDS,
-        expiresAt: Date.now() + LOCKOUT_THRESHOLD_CACHE_TTL_MS,
-      });
-      return DEFAULT_LOCKOUT_THRESHOLDS;
+      // FAIL-CLOSED: tenantId is FK-backed, so a missing row is corruption, not
+      // "no policy". Apply the strictest threshold (never weaker than the
+      // tenant's real policy) and do NOT cache it — caching would pin the
+      // aggressive fallback for the TTL even if the row reappears.
+      getLogger().warn(
+        { tenantId },
+        "vault.lockout.tenantRowMissing.usingStrictest",
+      );
+      return STRICTEST_LOCKOUT_THRESHOLDS;
     }
 
     // Build descending array: threshold3 (highest) → threshold1 (lowest)
@@ -95,15 +106,16 @@ async function getLockoutThresholds(tenantId: string): Promise<LockoutThreshold[
     });
     return thresholds;
   } catch (err) {
-    // The default still ENFORCES lockout (fail-safe on the security axis), but a
-    // DB error here silently reverts a tenant that tightened its thresholds back
-    // to the defaults — log it so the enforcement degradation is observable
-    // rather than swallowed (matches the logged catches elsewhere in this file).
+    // FAIL-CLOSED: a tenant may have tightened below the default (e.g. lock at 1
+    // attempt), so returning DEFAULT on a DB error would GRANT extra attempts —
+    // a fail-open weakening. Apply the strictest threshold instead (never weaker
+    // than the tenant's real policy) and do not cache it. Logged so the
+    // degradation is observable.
     getLogger().warn(
       { err, tenantId },
-      "vault.lockout.thresholdsFetchFailed.usingDefaults",
+      "vault.lockout.thresholdsFetchFailed.usingStrictest",
     );
-    return DEFAULT_LOCKOUT_THRESHOLDS;
+    return STRICTEST_LOCKOUT_THRESHOLDS;
   }
 }
 
@@ -187,10 +199,13 @@ export async function recordFailure(
     resolvedTenantId = userRow?.tenantId;
   }
 
-  // Fetch per-tenant thresholds before acquiring the row lock
+  // Fetch per-tenant thresholds before acquiring the row lock. An unresolved
+  // tenantId means the user row is missing (User.tenantId is a non-null FK) —
+  // corruption on a failed-unlock side effect — so apply the strictest fallback
+  // rather than the (possibly-weaker-than-configured) default.
   const thresholds = resolvedTenantId
     ? await getLockoutThresholds(resolvedTenantId)
-    : DEFAULT_LOCKOUT_THRESHOLDS;
+    : STRICTEST_LOCKOUT_THRESHOLDS;
 
   try {
     // withBypassRls required: called outside tenant RLS context (post-auth side effect).

--- a/src/lib/auth/policy/account-lockout.ts
+++ b/src/lib/auth/policy/account-lockout.ts
@@ -94,7 +94,15 @@ async function getLockoutThresholds(tenantId: string): Promise<LockoutThreshold[
       expiresAt: Date.now() + LOCKOUT_THRESHOLD_CACHE_TTL_MS,
     });
     return thresholds;
-  } catch {
+  } catch (err) {
+    // The default still ENFORCES lockout (fail-safe on the security axis), but a
+    // DB error here silently reverts a tenant that tightened its thresholds back
+    // to the defaults — log it so the enforcement degradation is observable
+    // rather than swallowed (matches the logged catches elsewhere in this file).
+    getLogger().warn(
+      { err, tenantId },
+      "vault.lockout.thresholdsFetchFailed.usingDefaults",
+    );
     return DEFAULT_LOCKOUT_THRESHOLDS;
   }
 }

--- a/src/lib/auth/session/auth-adapter.test.ts
+++ b/src/lib/auth/session/auth-adapter.test.ts
@@ -380,6 +380,32 @@ describe("createCustomAdapter", () => {
       ).toBe(true);
     });
 
+    // Regression (null-tenant fail-open class): tenantId is User.tenantId
+    // (non-null FK RESTRICT), so a null tenant row on createSession is data
+    // corruption, NOT "no limit configured" (an unconfigured limit is a real
+    // row with maxConcurrentSessions=null). Silently skipping the concurrent-
+    // session cap would let the corrupt-tenant user open unbounded sessions.
+    // Must FAIL CLOSED (throw → session creation refused).
+    // Mutation check: restore `tenant?.maxConcurrentSessions` and this test
+    // flips from throw to a successful create — it fails.
+    it("fails closed (throws) when the tenant row is missing", async () => {
+      mockSessionMetaGetStore.mockReturnValue({ ip: null, userAgent: null });
+      mockPrismaUser.findUnique.mockResolvedValue({ tenantId: "tenant-gone" });
+      mockTxTenant.findUnique.mockResolvedValue(null);
+
+      const adapter = createCustomAdapter();
+      await expect(
+        adapter.createSession!({
+          sessionToken: "tok-corrupt",
+          userId: "u-1",
+          expires,
+        }),
+      ).rejects.toThrow(/tenant-gone not found/);
+
+      // No session row is created when the cap cannot be evaluated.
+      expect(mockTxSession.create).not.toHaveBeenCalled();
+    });
+
     it("records provider from sessionMetaStorage on the session row", async () => {
       mockSessionMetaGetStore.mockReturnValue({
         ip: null,

--- a/src/lib/auth/session/auth-adapter.ts
+++ b/src/lib/auth/session/auth-adapter.ts
@@ -287,7 +287,18 @@ export function createCustomAdapter(): Adapter {
           select: { maxConcurrentSessions: true },
         });
 
-        const maxSessions = tenant?.maxConcurrentSessions;
+        // FAIL-CLOSED: tenantId is User.tenantId (non-null FK RESTRICT), so a
+        // null row here is data corruption, NOT "no limit configured" — an
+        // unconfigured limit is a real row with maxConcurrentSessions=null.
+        // Silently skipping the cap would let the corrupt-tenant user open
+        // unbounded concurrent sessions. Throw so session creation refuses.
+        // Matches the null-tenant fail-closed stance across the policy readers
+        // (getTenantAccessPolicy, derivePasskeyState — PR #685 class).
+        if (!tenant) {
+          throw new Error(`createSession: tenant ${tenantId} not found`);
+        }
+
+        const maxSessions = tenant.maxConcurrentSessions;
         if (maxSessions != null && maxSessions > 0) {
           // Count active sessions (ORDER BY id for consistent lock ordering)
           const activeSessions = await tx.session.findMany({

--- a/src/lib/auth/tokens/extension-token.test.ts
+++ b/src/lib/auth/tokens/extension-token.test.ts
@@ -704,6 +704,25 @@ describe("issueExtensionToken", () => {
     expect(mockTransaction).toHaveBeenCalledTimes(1);
   });
 
+  // Regression (null-tenant fail-open class): tenantId is FK-backed, so a null
+  // tenant ROW (not field) is data corruption. Defaulting the TTL to the ceiling
+  // could mint a longer-lived token than a tenant that had tightened it. Must
+  // FAIL CLOSED (throw → no token issued).
+  // Mutation check: restore `tenant?.… ?? DEFAULT` (no null-row throw) and this
+  // test flips from throw to a successful mint — it fails.
+  it("fails closed (throws) when the tenant row is missing", async () => {
+    mockTenantFindUnique.mockResolvedValueOnce(null);
+    await expect(
+      issueExtensionToken({
+        userId: "u1",
+        tenantId: "tenant-gone",
+        scope: "passwords:read",
+        cnfJkt: VALID_CNF_JKT,
+      }),
+    ).rejects.toThrow(/tenant-gone not found/);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
   it("falls back to EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT when tenant.extensionTokenIdleTimeoutMinutes is null", async () => {
     mockTenantFindUnique.mockResolvedValueOnce({ extensionTokenIdleTimeoutMinutes: null });
 

--- a/src/lib/auth/tokens/extension-token.ts
+++ b/src/lib/auth/tokens/extension-token.ts
@@ -8,8 +8,8 @@ import {
   EXTENSION_TOKEN_MAX_ACTIVE,
   type ExtensionTokenScope,
 } from "@/lib/constants";
-import { EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT } from "@/lib/validations/common";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
+import { EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT } from "@/lib/validations/common";
 import { logAuditAsync } from "@/lib/audit/audit";
 import { AUDIT_ACTION, AUDIT_SCOPE, AUDIT_TARGET_TYPE } from "@/lib/constants";
 import { validateExtensionTokenDpop } from "@/lib/auth/dpop/validate-token-dpop";
@@ -201,15 +201,26 @@ export async function issueExtensionToken(params: {
   const { userId, tenantId, scope, cnfJkt } = params;
   const now = new Date();
 
-  // Read tenant extension-token idle TTL. Fall back to the policy ceiling if
-  // the tenant row is missing (defensive — should not happen in practice).
+  // Read tenant extension-token idle TTL.
+  // FAIL-CLOSED: tenantId is a non-null FK RESTRICT source, so a null tenant row
+  // is data corruption, NOT "no policy". The column is non-nullable with a
+  // schema default, so `tenant?.… ?? DEFAULT` only ever fires on a vanished
+  // tenant — where defaulting to the 7-day ceiling could grant a longer-lived
+  // token than a tenant that had tightened its TTL. Refuse issuance instead.
   const tenant = await withBypassRls(prisma, async (tx) =>
     tx.tenant.findUnique({
       where: { id: tenantId },
       select: { extensionTokenIdleTimeoutMinutes: true },
     }),
   BYPASS_PURPOSE.TOKEN_LIFECYCLE);
-  const idleMinutes = tenant?.extensionTokenIdleTimeoutMinutes ?? EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT;
+  if (!tenant) {
+    throw new Error(`issueExtensionToken: tenant ${tenantId} not found`);
+  }
+  // The column is non-nullable with a schema default; the `?? DEFAULT` is a
+  // defensive floor for a field-null that cannot occur in practice (and is
+  // fail-safe — a null would otherwise yield a 0-minute TTL).
+  const idleMinutes =
+    tenant.extensionTokenIdleTimeoutMinutes ?? EXTENSION_TOKEN_IDLE_TIMEOUT_DEFAULT;
   const expiresAt = new Date(now.getTime() + idleMinutes * MS_PER_MINUTE);
 
   const plaintext = generateShareToken();

--- a/src/lib/proxy/api-route.test.ts
+++ b/src/lib/proxy/api-route.test.ts
@@ -179,19 +179,30 @@ describe("handleApiAuth — session-required + access restriction", () => {
       new Response(JSON.stringify({ user: { id: "u-1" } }), { status: 200 }),
     );
     mockCheckAccessWithAudit.mockResolvedValue({ allowed: true });
-    mockResolveUserTenantId.mockResolvedValue(null);
+    // Default: a normal user WITH an active tenant membership. A null return
+    // (deactivated member) now fails session validation (see the dedicated
+    // test below), so it is no longer a valid baseline for "session valid".
+    mockResolveUserTenantId.mockResolvedValue("t-1");
   });
   afterEach(() => {
     vi.unstubAllEnvs();
     fetchSpy.mockRestore();
   });
 
-  it("returns 200 when session is valid and no tenant restriction applies", async () => {
+  it("returns 200 when session is valid and access restriction allows", async () => {
     const res = await handleApiAuth(
       makeRequest("/api/passwords", "GET", { Cookie: "authjs.session-token=sess" }),
     );
     expect(res.status).toBe(200);
     expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+  });
+
+  it("returns 401 when the user has no active tenant membership (deactivated)", async () => {
+    mockResolveUserTenantId.mockResolvedValueOnce(null);
+    const res = await handleApiAuth(
+      makeRequest("/api/passwords", "GET", { Cookie: "authjs.session-token=sess" }),
+    );
+    expect(res.status).toBe(401);
   });
 
   it("returns 403 when access restriction denies", async () => {

--- a/src/lib/proxy/auth-gate.test.ts
+++ b/src/lib/proxy/auth-gate.test.ts
@@ -268,10 +268,16 @@ describe("getSessionInfo", () => {
     expect(mockSetCachedSession).not.toHaveBeenCalled();
   });
 
-  // Companion: a legitimate null return (no active membership) is NOT an error —
-  // the session stays valid with an undefined tenantId (no tenant policy to
-  // enforce), distinguishing it from the fail-closed throw path above.
-  it("null resolveUserTenantId (no active membership) → valid with undefined tenantId", async () => {
+  // A null resolveUserTenantId return means NO active TenantMember row
+  // (deactivatedAt != null — a de-provisioned member). Since User.tenantId is a
+  // non-null FK, this is a REVOKED membership, not a legitimate no-tenant user.
+  // Fail closed so a stale cookie (or a session whose deletion was missed on
+  // deactivation) cannot pass validation AND skip the tenant IP restriction
+  // (undefined tenantId bypasses the downstream gate). Session-path analogue of
+  // the extension-token C13 deactivated-member rejection.
+  // Mutation check: revert to `tenantId = resolved ?? undefined` (keep the
+  // session valid) and this test flips from valid:false to valid:true — it fails.
+  it("fail-closed: null resolveUserTenantId (deactivated member) → { valid: false }, no cache write", async () => {
     mockGetCachedSession.mockResolvedValueOnce(null);
     fetchSpy.mockResolvedValueOnce(
       new Response(
@@ -288,9 +294,7 @@ describe("getSessionInfo", () => {
       makeRequest({ cookie: "authjs.session-token=tok-nomember" }),
     );
 
-    expect(result.valid).toBe(true);
-    expect(result.userId).toBe("u-nomember");
-    expect(result.tenantId).toBeUndefined();
-    expect(mockSetCachedSession).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ valid: false });
+    expect(mockSetCachedSession).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/proxy/auth-gate.test.ts
+++ b/src/lib/proxy/auth-gate.test.ts
@@ -239,7 +239,15 @@ describe("getSessionInfo", () => {
     expect(mockResolveUserTenantId).not.toHaveBeenCalled();
   });
 
-  it("does not propagate resolveUserTenantId errors — tenantId is undefined", async () => {
+  // Regression (null-tenant fail-open class): a THROW from resolveUserTenantId
+  // (DB/RLS error, MULTI_TENANT anomaly) must FAIL CLOSED. Previously the throw
+  // was swallowed, leaving tenantId undefined — which makes the downstream proxy
+  // IP-restriction gate skip entirely, silently bypassing a restricted tenant's
+  // CIDR/Tailscale controls on a transient error. Now the session is treated as
+  // invalid (forcing re-auth) and NOT cached.
+  // Mutation check: restore the old `catch {}` swallow and this test flips from
+  // { valid: false } back to { valid: true, tenantId: undefined } — it fails.
+  it("fail-closed: resolveUserTenantId throws → { valid: false }, no cache write", async () => {
     mockGetCachedSession.mockResolvedValueOnce(null);
     fetchSpy.mockResolvedValueOnce(
       new Response(
@@ -256,11 +264,33 @@ describe("getSessionInfo", () => {
       makeRequest({ cookie: "authjs.session-token=tok-tenant-err" }),
     );
 
+    expect(result).toEqual({ valid: false });
+    expect(mockSetCachedSession).not.toHaveBeenCalled();
+  });
+
+  // Companion: a legitimate null return (no active membership) is NOT an error —
+  // the session stays valid with an undefined tenantId (no tenant policy to
+  // enforce), distinguishing it from the fail-closed throw path above.
+  it("null resolveUserTenantId (no active membership) → valid with undefined tenantId", async () => {
+    mockGetCachedSession.mockResolvedValueOnce(null);
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          user: { id: "u-nomember" },
+          expires: new Date(Date.now() + 60_000).toISOString(),
+        }),
+        { status: 200 },
+      ),
+    );
+    mockResolveUserTenantId.mockResolvedValueOnce(null);
+
+    const result = await getSessionInfo(
+      makeRequest({ cookie: "authjs.session-token=tok-nomember" }),
+    );
+
     expect(result.valid).toBe(true);
-    expect(result.userId).toBe("u-err");
+    expect(result.userId).toBe("u-nomember");
     expect(result.tenantId).toBeUndefined();
-    // setCachedSession is still called — tenant resolution failure must not
-    // block session cache population.
     expect(mockSetCachedSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/proxy/auth-gate.ts
+++ b/src/lib/proxy/auth-gate.ts
@@ -90,9 +90,16 @@ export async function getSessionInfo(request: NextRequest): Promise<SessionInfo>
     let tenantId: string | undefined;
     if (valid && userId) {
       try {
+        // A `null` return is a legitimate no-active-membership user (no tenant
+        // policy to enforce) → tenantId stays undefined, downstream IP gate is
+        // correctly skipped. A THROW (DB/RLS error, MULTI_TENANT anomaly) is
+        // NOT that case: swallowing it would drop the tenant's IP/CIDR gate for
+        // a user who DOES have a restricted tenant. Fail closed by returning an
+        // invalid (uncached) session, forcing re-auth — mirrors the !res.ok
+        // transient-error handling above.
         tenantId = (await resolveUserTenantId(userId)) ?? undefined;
       } catch {
-        // Non-critical: tenant resolution failure should not block session validation
+        return { valid: false };
       }
     }
 

--- a/src/lib/proxy/auth-gate.ts
+++ b/src/lib/proxy/auth-gate.ts
@@ -89,18 +89,30 @@ export async function getSessionInfo(request: NextRequest): Promise<SessionInfo>
 
     let tenantId: string | undefined;
     if (valid && userId) {
+      let resolved: string | null;
       try {
-        // A `null` return is a legitimate no-active-membership user (no tenant
-        // policy to enforce) → tenantId stays undefined, downstream IP gate is
-        // correctly skipped. A THROW (DB/RLS error, MULTI_TENANT anomaly) is
-        // NOT that case: swallowing it would drop the tenant's IP/CIDR gate for
-        // a user who DOES have a restricted tenant. Fail closed by returning an
-        // invalid (uncached) session, forcing re-auth — mirrors the !res.ok
-        // transient-error handling above.
-        tenantId = (await resolveUserTenantId(userId)) ?? undefined;
+        resolved = await resolveUserTenantId(userId);
       } catch {
+        // A THROW (DB/RLS error, MULTI_TENANT anomaly) must not be swallowed:
+        // leaving tenantId undefined would drop the tenant's IP/CIDR gate for a
+        // user who DOES have a restricted tenant. Fail closed (uncached) —
+        // mirrors the !res.ok transient-error handling above.
         return { valid: false };
       }
+      // A `null` return means NO active TenantMember row (deactivatedAt != null,
+      // i.e. a de-provisioned member). `User.tenantId` is a non-null FK, so this
+      // is NOT a legitimate "no tenant" user — it is a revoked membership whose
+      // session must not survive. Fail closed so a stale cookie (or a session
+      // whose deletion / cache invalidation was missed on deactivation) cannot
+      // pass proxy session validation AND skip the tenant IP restriction
+      // (undefined tenantId → the api-route/page-route gate is bypassed). This
+      // is the session-path analogue of the extension-token C13 deactivated-
+      // member rejection. The result is uncached (fail-closed sessions never
+      // populate the cache).
+      if (resolved === null) {
+        return { valid: false };
+      }
+      tenantId = resolved;
     }
 
     // The `?? false` / `?? null` defaults here are fail-open and are safe ONLY

--- a/src/lib/proxy/page-route.test.ts
+++ b/src/lib/proxy/page-route.test.ts
@@ -100,7 +100,10 @@ describe("handlePageRoute — protected routes auth check", () => {
 
   beforeEach(() => {
     _resetPasskeyAuditForTests();
-    mockResolveUserTenantId.mockResolvedValue(null);
+    // Default: a normal user WITH an active tenant membership. A null return
+    // (deactivated member) now fails session validation, so it is no longer a
+    // valid baseline for a session that should reach access/passkey checks.
+    mockResolveUserTenantId.mockResolvedValue("t-1");
     mockCheckAccessWithAudit.mockResolvedValue({ allowed: true });
     fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ user: null }), { status: 200 }),
@@ -119,6 +122,25 @@ describe("handlePageRoute — protected routes auth check", () => {
     const location = res.headers.get("location") ?? "";
     expect(location).toContain("/auth/signin");
     expect(location).toContain("callbackUrl=");
+  });
+
+  it("redirects a deactivated member (no active tenant membership) to signin", async () => {
+    // Valid Auth.js session response, but resolveUserTenantId returns null
+    // (deactivatedAt != null) → getSessionInfo fails closed → protected page
+    // redirects to signin instead of rendering with the tenant IP gate skipped.
+    // A cookie is required so getSessionInfo reaches the fetch + resolve path
+    // (a cookieless request short-circuits to {valid:false} before either).
+    mockValidSession(fetchSpy, { id: "u-deactivated" });
+    mockResolveUserTenantId.mockResolvedValueOnce(null);
+
+    const res = await handlePageRoute(
+      makePageRequest("/ja/dashboard/passwords", {
+        cookie: "authjs.session-token=sess-deactivated",
+      }),
+      dummyOptions,
+    );
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location") ?? "").toContain("/auth/signin");
   });
 
   it("emits Set-Cookie deletions with full attribute set (Secure on https)", async () => {
@@ -216,7 +238,10 @@ describe("handlePageRoute — passkey enforcement", () => {
 
   beforeEach(() => {
     _resetPasskeyAuditForTests();
-    mockResolveUserTenantId.mockResolvedValue(null);
+    // Default: a normal user WITH an active tenant membership. A null return
+    // (deactivated member) now fails session validation, so it is no longer a
+    // valid baseline for a session that should reach access/passkey checks.
+    mockResolveUserTenantId.mockResolvedValue("t-1");
     mockCheckAccessWithAudit.mockResolvedValue({ allowed: true });
     fetchSpy = vi.spyOn(globalThis, "fetch");
   });
@@ -345,7 +370,10 @@ describe("handlePageRoute — passkey audit dedup over consecutive requests", ()
 
   beforeEach(() => {
     _resetPasskeyAuditForTests();
-    mockResolveUserTenantId.mockResolvedValue(null);
+    // Default: a normal user WITH an active tenant membership. A null return
+    // (deactivated member) now fails session validation, so it is no longer a
+    // valid baseline for a session that should reach access/passkey checks.
+    mockResolveUserTenantId.mockResolvedValue("t-1");
     mockCheckAccessWithAudit.mockResolvedValue({ allowed: true });
     fetchSpy = vi.spyOn(globalThis, "fetch");
   });

--- a/src/lib/team/team-policy.test.ts
+++ b/src/lib/team/team-policy.test.ts
@@ -239,3 +239,60 @@ describe("checkTeamAccessRestriction — sentinel fallback", () => {
     );
   });
 });
+
+// Regression (null-tenant fail-open class): when a team relies on inherited
+// tenant CIDRs as its sole restriction source (inheritTenantCidrs=true,
+// teamAllowedCidrs empty), a null tenant resolution or vanished tenant row is
+// data corruption (Team.tenantId is a non-null FK), NOT "no restriction".
+// Silently dropping the inherited CIDRs would bypass the team's IP control —
+// must FAIL CLOSED (throw).
+// Mutation check: restore the `if (tenant?.allowedCidrs)` silent-skip and these
+// tests flip from throw to resolve — they fail.
+describe("checkTeamAccessRestriction — inherit fail-closed on null tenant", () => {
+  const inheritOnlyPolicy: TeamPolicyData = {
+    minPasswordLength: 0,
+    requireUppercase: false,
+    requireLowercase: false,
+    requireNumbers: false,
+    requireSymbols: false,
+    sessionIdleTimeoutMinutes: null,
+    sessionAbsoluteTimeoutMinutes: null,
+    requireRepromptForAll: false,
+    allowExport: true,
+    allowSharing: true,
+    requireSharePassword: false,
+    passwordHistoryCount: 0,
+    inheritTenantCidrs: true,
+    teamAllowedCidrs: [], // sole restriction is the inherited tenant CIDRs
+  };
+
+  it("throws when resolveTeamTenantId returns null (default mock)", async () => {
+    // resolveTeamTenantId mock returns null (module-level default)
+    await expect(
+      checkTeamAccessRestriction("team-1", "5.6.7.8", "user-xyz", inheritOnlyPolicy),
+    ).rejects.toThrow(/team tenant unresolved/);
+  });
+
+  it("throws when the tenant row is missing (resolved id, null row)", async () => {
+    const { resolveTeamTenantId } = await import("@/lib/tenant-context");
+    (resolveTeamTenantId as ReturnType<typeof vi.fn>).mockResolvedValueOnce("tenant-x");
+    (prisma.tenant.findUnique as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+    await expect(
+      checkTeamAccessRestriction("team-1", "5.6.7.8", "user-xyz", inheritOnlyPolicy),
+    ).rejects.toThrow(/team tenant not found/);
+  });
+
+  it("allows (no restriction) when tenant exists but has no CIDRs", async () => {
+    const { resolveTeamTenantId } = await import("@/lib/tenant-context");
+    (resolveTeamTenantId as ReturnType<typeof vi.fn>).mockResolvedValueOnce("tenant-x");
+    (prisma.tenant.findUnique as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      allowedCidrs: [],
+    });
+
+    // Empty inherited CIDRs is a legitimate "no restriction configured" state.
+    await expect(
+      checkTeamAccessRestriction("team-1", "5.6.7.8", "user-xyz", inheritOnlyPolicy),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/team/team-policy.ts
+++ b/src/lib/team/team-policy.ts
@@ -134,20 +134,31 @@ export async function checkTeamAccessRestriction(teamId: string, clientIp: strin
 
   if (policy.inheritTenantCidrs) {
     const tenantId = await resolveTeamTenantId(teamId);
-    if (tenantId) {
-      const tenant = await withBypassRls(
-        prisma,
-        async (tx) =>
-          tx.tenant.findUnique({
-            where: { id: tenantId },
-            select: { allowedCidrs: true },
-          }),
-        BYPASS_PURPOSE.CROSS_TENANT_LOOKUP,
+    // FAIL-CLOSED: Team.tenantId is a non-null FK, so a null tenant resolution
+    // (or a vanished tenant row) on the inherit path is data corruption, not
+    // "no restriction". When the team relies on inherited CIDRs as its sole
+    // restriction source (teamAllowedCidrs empty), silently dropping them would
+    // bypass the team's IP control. Refuse rather than allow.
+    if (!tenantId) {
+      throw new PolicyViolationError(
+        "Access denied: team tenant unresolved; access restricted",
       );
-      if (tenant?.allowedCidrs) {
-        combinedCidrs.push(...tenant.allowedCidrs);
-      }
     }
+    const tenant = await withBypassRls(
+      prisma,
+      async (tx) =>
+        tx.tenant.findUnique({
+          where: { id: tenantId },
+          select: { allowedCidrs: true },
+        }),
+      BYPASS_PURPOSE.CROSS_TENANT_LOOKUP,
+    );
+    if (!tenant) {
+      throw new PolicyViolationError(
+        "Access denied: team tenant not found; access restricted",
+      );
+    }
+    combinedCidrs.push(...tenant.allowedCidrs);
   }
 
   if (combinedCidrs.length === 0) {


### PR DESCRIPTION
## Summary

Follow-on to PR `#685`, which fixed only the `requirePasskey` session-callback path. This closes the whole **null-tenant fail-open enforcement class**: an enforcement decision reads a tenant/team security policy and, when the row is null / missing / unfetchable, falls back to the permissive side instead of denying.

The controlling distinction: `tenantId` always comes from a server-trusted, FK-`RESTRICT`-backed source (session / token row / non-null `User.tenantId`), so a null row on a **successful** query is data corruption — **not** "no policy configured" (an unset policy is a real row with a null/empty field). The fix throws (fail closed) or returns a restrictive default on that corruption signal, matching `derivePasskeyState`'s stance from PR `#685`.

## Members fixed (7)

| Member | Was | Now |
|--------|-----|-----|
| `getTenantAccessPolicy` | null tenant → empty permissive policy (cached) → IP/CIDR + Tailscale gate bypassed | throw on null row; no cache |
| proxy `getSessionInfo` | swallowed `resolveUserTenantId` throw → `tenantId` undefined → proxy IP gate skipped | `{ valid: false }` on throw; null return (no active membership) unchanged |
| `checkTeamAccessRestriction` (inherit) | null tenant CIDR fetch → allow | throw `PolicyViolationError` |
| `createSession` | `tenant?.maxConcurrentSessions` → cap silently skipped → unbounded sessions | throw on null row |
| `webauthn/register/verify` | `tenant?.requireMinPinLength ?? null` → PIN-length gate skipped | throw on null relation |
| `issueExtensionToken` + token refresh | `tenant?.…Timeout ?? DEFAULT` → tightened TTL reverted to ceiling | throw on null row (field-null `?? DEFAULT` floor kept) |
| `getLockoutThresholds` | silent `catch → DEFAULT` | warn-log before default (default already fail-safe) |

Verified fail-safe (no change): `session-timeout`, `account-lockout` missing-row, `passkey-enforcement`, `auth-gate` passkey `?? false` (contract-documented), `team-policy` `DEFAULT_POLICY`, `mcp/token` invalid-grant path. Excluded (display / config-write echo): `tenant/policy`, `teams/[teamId]/policy`, `vault/status`, `vault/unlock/data`, `user/passkey-status`, `sessions` routes.

## Fail-safe only (R43)

Every change tightens/denies; none widens a boundary. Reviewed across three expert perspectives (functionality / security / testing) over two rounds.

## Tests

- 9 mutation-verified regression tests (revert each fix → the test goes red).
- Fixed pre-existing partial-tenant mocks in `mcp-oauth-flow.test.ts` that the `getTenantAccessPolicy` change surfaced (the mocks returned a partial tenant row; production always returns the full row).
- Full suite: 12791 passed, 1 skipped. Production build: green. `scripts/pre-pr.sh`: all 52 checks pass.

## R42 convergence — mutation-verified CI guard

The member-set grew 4 → 5 → 7 across review (the R42 accretion signature: a set that grows by accretion was never derived from the true primitive). Per the triangulate convergence rule, the class is closed by a mutation-verified CI guard, not "no findings" alone:

- `scripts/checks/check-null-tenant-fail-closed.mjs` — a completeness manifest. It enumerates every enforcement-field `tenant.findUnique` / relation-join read from the defining primitive and fails when the live set diverges from the reviewed manifest (a new unclassified member, or a vanished stale entry). Currently green at 16 enforcement reads, all classified.
- Red-proven in both directions (new unlisted read → fail; removed manifest entry → fail) via a throwaway fixture.
- Wired into `scripts/pre-pr.sh`, which CI runs verbatim via `PRE_PR_STATIC_ONLY=1` (no local/CI drift), plus a self-test (`scripts/__tests__/check-null-tenant-fail-closed.test.mjs`) required by the repo's gate-selftest-coverage check.

## Review artifacts

`docs/archive/review/null-tenant-fail-open-{plan,code-review,deviation}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
