### PR TITLE
fix(deps): bump brace-expansion override to 5.0.7 for GHSA-3jxr-9vmj-r5cp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10632,9 +10632,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14692,9 +14692,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -20326,9 +20326,9 @@
       }
     },
     "node_modules/shadcn/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "nodemailer": "^9.0.1",
     "effect": ">=3.20.0",
     "postcss": ">=8.5.10",
-    "brace-expansion@>=5.0.0 <5.0.6": "^5.0.6",
+    "brace-expansion@>=5.0.0 <5.0.7": "^5.0.7",
     "esbuild": ">=0.28.1"
   }
 }


### PR DESCRIPTION
## Summary

The CI `Audit: App dependencies` job (`npm audit --omit=dev --audit-level=high`) fails on advisory GHSA-3jxr-9vmj-r5cp (high — brace-expansion DoS via exponential-time expansion of consecutive non-expanding `{}` groups).

The repo already had an override `"brace-expansion@>=5.0.0 <5.0.6": "^5.0.6"` from a *previous* brace-expansion advisory, but the new advisory covers `3.0.0 - 5.0.6` — **including 5.0.6 itself** — so the pinned `^5.0.6` resolution stays vulnerable. The flagged prod path is `@sentry/nextjs → glob → minimatch → brace-expansion@5.0.6`.

## Why no Dependabot PR fixes this

None of the open Dependabot PRs resolve it: bumping `@sentry/nextjs` leaves the transitive `glob → minimatch → brace-expansion` at 5.0.6, and Dependabot does not touch the `overrides` block. The fix must widen the override to the patched version.

## Change

- `package.json`: override `"brace-expansion@>=5.0.0 <5.0.7": "^5.0.7"` (5.0.7 is the patched release).
- `package-lock.json`: the three `brace-expansion@5.0.6` entries (glob prod path + `@ts-morph/common` + `shadcn` dev paths) move to 5.0.7. Surgical edit — no other dependency churn.

## Verification

- `npm ci --ignore-scripts` — passes (integrity hashes verified against the registry for the 5.0.7 tarball).
- `npm audit --omit=dev --audit-level=high` — **found 0 vulnerabilities**.
- `npm audit signatures` — 510 packages have verified attestations (5.0.7 attested).
- `scripts/pre-pr.sh` — all 51 checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
