### PR TITLE
fix(security): patch brace-expansion (1.x/2.x) + js-yaml DoS CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11099,9 +11099,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12136,9 +12136,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15972,9 +15972,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,10 @@
     "nodemailer": "^9.0.1",
     "effect": ">=3.20.0",
     "postcss": ">=8.5.10",
+    "brace-expansion@1": "^1.1.16",
+    "brace-expansion@2": "^2.1.2",
     "brace-expansion@>=5.0.0 <5.0.7": "^5.0.7",
+    "js-yaml@>=4.0.0 <4.3.0": "^4.3.0",
     "esbuild": ">=0.28.1"
   }
 }


### PR DESCRIPTION
Resolves the three open high-severity Dependabot alerts left over on the default branch.

## Alerts

| Alert | Package | Advisory | Lock had | Patched |
|-------|---------|----------|----------|---------|
| `#142` | brace-expansion | GHSA-3jxr-9vmj-r5cp | 1.1.13 | 1.1.16 |
| `#143` | brace-expansion | GHSA-3jxr-9vmj-r5cp | 2.0.3 | 2.1.2 |
| `#144` | js-yaml | GHSA-52cp-r559-cp3m | 4.2.0 | 4.3.0 |

All three are algorithmic-complexity DoS issues (quadratic/exponential CPU on crafted input).

## Why they survived the earlier patch

The prior `brace-expansion` override only pinned the `>=5.0.0 <5.0.7` range. The 1.x and 2.x copies pulled in transitively (via eslint / glob / typescript-eslint) stayed on vulnerable versions, and `js-yaml` (via eslint's `@eslint/eslintrc` and shadcn's cosmiconfig) was never overridden.

## Fix

Add npm `overrides` covering every affected major:
- `brace-expansion@1` → `^1.1.16`
- `brace-expansion@2` → `^2.1.2`
- `js-yaml` (`<4.3.0`) → `^4.3.0`

The existing `>=5.0.0 <5.0.7` → `^5.0.7` override is kept. Only `package.json` and `package-lock.json` change; no source or test edits.

## Scope

Every affected package is a **dev-scope transitive dependency** (eslint / shadcn tooling) — no production runtime path — so this is alert hygiene, not an exploitable runtime fix. `npm audit --audit-level=high` is now clean (one unrelated `body-parser` **low** remains, below the alert threshold and out of scope here).

## Verification
- `scripts/pre-pr.sh` — 52/52 passed (lint, typecheck, vitest, next build, extension build, dependency audit)
- Lock re-verified: no brace-expansion `<1.1.16`/`<2.1.2`/`<5.0.7` and no js-yaml `<4.3.0` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)