### PR TITLE
fix: resolve CodeQL trivial-conditional in null-tenant guard

### DIFF
--- a/scripts/checks/check-null-tenant-fail-closed.mjs
+++ b/scripts/checks/check-null-tenant-fail-closed.mjs
@@ -145,8 +145,10 @@ function bindingVarName(call) {
   const viaPromiseAll = promiseAllDestructuredName(call);
   if (viaPromiseAll !== undefined) return viaPromiseAll;
 
+  // Same climb shape as promiseAllDestructuredName: terminates via an inner
+  // return, `cur` is only reassigned to a non-null parent, so `for (;;)`.
   let cur = call;
-  while (cur) {
+  for (;;) {
     const parent = cur.getParent?.();
     if (!parent) return null;
     const pk = parent.getKind();
@@ -170,7 +172,6 @@ function bindingVarName(call) {
     }
     return null;
   }
-  return null;
 }
 
 // If `call` is the Nth element of an array literal passed to `Promise.all(...)`
@@ -191,9 +192,11 @@ function promiseAllDestructuredName(call) {
   if (callee.getKind() !== SyntaxKind.PropertyAccessExpression) return undefined;
   if (callee.getName?.() !== "all") return undefined;
   if (callee.getExpression?.().getText?.() !== "Promise") return undefined;
-  // Walk out to the VariableDeclaration with an array-binding pattern.
+  // Walk out to the VariableDeclaration with an array-binding pattern. The
+  // climb always terminates via an inner return: `cur` is reassigned only to a
+  // non-null parent, so a `while (cur)` guard would never fire — use `for (;;)`.
   let cur = paCall;
-  while (cur) {
+  for (;;) {
     const parent = cur.getParent?.();
     if (!parent) return null;
     const pk = parent.getKind();
@@ -220,7 +223,6 @@ function promiseAllDestructuredName(call) {
     }
     return null;
   }
-  return null;
 }
 
 // Does the enclosing function of `read.node` contain a null guard on the SAME


### PR DESCRIPTION
Resolves CodeQL alert `#224` (`js/trivial-conditional`) on [check-null-tenant-fail-closed.mjs](scripts/checks/check-null-tenant-fail-closed.mjs).

## What CodeQL flagged
The two parent-climb loops (`bindingVarName`, `promiseAllDestructuredName`) are written as `while (cur) { ... }`, but `cur` starts truthy and is only ever reassigned to a `parent` that was already null-checked (`if (!parent) return null`). The loop condition can therefore never be false — CodeQL reads `while (cur)` as a useless conditional. The loops always terminate via an inner `return`.

## Fix
- Switch both loops to `for (;;)`, matching the existing `for (;;)` climb in [check-raw-sql-usage.mjs](scripts/checks/check-raw-sql-usage.mjs).
- Drop the now-unreachable trailing `return null` after each loop.

Behavior is unchanged — this is the same defect class in two sites, fixed in both.

## Verification
- Guard run against the repo: OK (16 enforcement reads, all classified + disposition-verified — same as before)
- `scripts/__tests__` suite: 588 passed / 1 skipped
- `eslint` on the file: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)