### PR TITLE
ci: raise App job timeout 15m → 20m to absorb runner variance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
-    timeout-minutes: 15
+    # test:coverage + build + basePath build already land at ~13–14m on a
+    # healthy runner; slower runners tipped several green dependency PRs over the
+    # old 15m cap mid-`build with basePath` (e.g. #701, #706). 20m keeps the same
+    # ceiling class as the iOS (25m) / refactor-verify (20m) jobs while absorbing
+    # runner variance instead of flaking.
+    timeout-minutes: 20
     services:
       redis:
         image: redis:7-alpine


### PR DESCRIPTION
The `App: Lint → Test → Build` job runs three heavy back-to-back steps — `test:coverage`, `npm run build`, and the basePath `npm run build` — which already land at ~13–14m on a healthy runner (e.g. the green runs on `#701` at 14m19s and `#704` at 13m51s).

That leaves almost no headroom under the old 15m cap. On slower runners the job was cancelled mid-`build with basePath` at exactly 15m0s — a red build with no real failure. Recent all-green dependency PRs (`#701`, `#706`) both hit this.

## Change
Raise the App job `timeout-minutes` from 15 to 20. That is the same ceiling class as the existing iOS (25m) and refactor-verify (20m) jobs, so it absorbs runner variance without masking a genuinely hung build.

No app or test code changes — CI configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)