### PR TITLE
fix(security): patch hono + @hono/node-server DoS CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1738,13 +1738,13 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -15479,9 +15479,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -123,8 +123,8 @@
   },
   "overrides": {
     "qs": "6.15.2",
-    "hono": "4.12.25",
-    "@hono/node-server": "1.19.13",
+    "hono": "^4.12.27",
+    "@hono/node-server": "^2.0.5",
     "lodash": "^4.18.1",
     "cross-spawn": "7.0.6",
     "@babel/core": "^7.29.6",


### PR DESCRIPTION
Resolves the four open moderate Dependabot alerts on the default branch.

## Alerts
| Alert | Package | Vulnerable | Patched |
|-------|---------|-----------|---------|
| `#146` | @hono/node-server | `< 2.0.5` | 2.0.5 |
| `#147` | hono | `>= 4.3.3, < 4.12.27` | 4.12.27 |
| `#148` | hono | `>= 4.0.0, < 4.12.27` | 4.12.27 |
| `#149` | hono | `>= 4.11.8, < 4.12.27` | 4.12.27 |

All are DoS advisories, and both packages reach the tree only through shadcn's bundled `@modelcontextprotocol/sdk` — **dev scope, never in the production bundle**. The existing overrides had pinned the now-vulnerable versions (hono `4.12.25`, @hono/node-server `1.19.13`).

## Fix
Raise the overrides:
- `hono` → `^4.12.27` (resolves to 4.12.31)
- `@hono/node-server` → `^2.0.5` (resolves to 2.0.11)

The node-server `1.x → 2.x` major crosses the MCP SDK's `^1.19.9` peer range, but the override is authoritative and the package is dev-only, so there is no runtime impact.

## Verification
- `scripts/pre-pr.sh` — passed (lint, typecheck, vitest 12803 passed, next build, extension build, dependency audit)
- `npm audit --audit-level=high` — clean (one unrelated `body-parser` low remains, out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)