### PR TITLE
fix(ci): require throw in null-tenant guard body; catch || lenient fallback

### DIFF
--- a/docs/archive/review/null-tenant-gate-throw-only-code-review.md
+++ b/docs/archive/review/null-tenant-gate-throw-only-code-review.md
@@ -1,0 +1,191 @@
+# Code Review: null-tenant-gate-throw-only
+
+Date: 2026-07-22
+Review rounds: 2 (converged — Round 2: No findings)
+
+## Origin
+
+External reviewer findings against the null-tenant fail-open class closure (PR #693 line):
+
+1. **Medium** — `check-null-tenant-fail-closed.mjs` `hasNullTenantThrowGuard()` accepted ANY
+   `return` inside a null-tenant guard as fail-closed, so a future softening of
+   `if (!tenant) throw` to `return []` / `return null` / `return { allowed: true }`
+   would false-green CI. **CONFIRMED by mutation experiment** (all 3 shapes exit 0
+   against the pre-fix gate).
+2. **Low** — strictest lockout fallback could lock legitimate users during a transient
+   DB outage; requested metrics/alerts, admin release path, and a regression test that
+   the fallback is not cached. **Verified mostly implemented**: fallback is already
+   non-cached on all three paths (`account-lockout.ts:87-93,108-118`) and observable
+   via dedicated warn events (`vault.lockout.tenantRowMissing.usingStrictest`,
+   `vault.lockout.thresholdsFetchFailed.usingStrictest`). Only the no-cache
+   regression test was missing. Admin instant-release API is a new feature, out of
+   scope per user decision (regression test only).
+
+User decisions (AskUserQuestion):
+- Gate fix: **throw-only** (all 8 real manifest throw-files throw; no return guard
+  exists — denial-shaped-return AST allowlist deferred until an actual member needs it).
+- Low scope: **regression test only**.
+
+## Changes (initial fix)
+
+- `scripts/checks/check-null-tenant-fail-closed.mjs` — throw-disposition guard body
+  must contain a ThrowStatement (ReturnStatement acceptance removed); comments +
+  violation message updated.
+- `scripts/__tests__/check-null-tenant-fail-closed.test.mjs` — 3 negative `it.each`
+  self-tests (`return []` / `return null` / `return { allowed: true }` → exit 1).
+- `src/lib/auth/policy/account-lockout.test.ts` — regression test: strictest fallback
+  is NOT cached; DB recovery restores the tenant's real thresholds
+  (`findUnique` called twice, second call applies lenient policy).
+
+All mutation-verified red before Round 1 (returns re-accepted → 3 tests fail;
+fallback cached in catch branch → lockout test fails).
+
+## Round 1 — Functionality Findings
+
+- **F1 Minor** — gate comment "only `throw` proves fail-closed" overstates: throw in
+  dead branch / swallowed by try/catch / nested callback still greens (pre-existing
+  dominance residual, evasion-shaped). Fix: soften wording, record accepted residual.
+- **F2 Minor [Adjacent→testing]** — no positive self-test pins the block-body throw
+  shape all 8 real files use (converges with Testing F1).
+- Edge-matrix verified: strict shrink of false-green surface, no new false-green /
+  false-red. All 8 real guards block-throw ✓. Lockout test mock choreography correct.
+
+## Round 1 — Security Findings
+
+- **NT-SEC-1 Minor** — dominance-blind throw acceptance (dead-branch / swallowed /
+  ordering / unreachable-closure) — pre-existing ACCEPTED residual per
+  `project_null_tenant_fail_open_class` ("early-warning, not a proof").
+- **NT-SEC-2 Minor (top)** — `hasPermissiveEnforcementCoalesce` only matched `??`;
+  `||` and ternary lenient shapes green a failsafe-default file. Pre-existing but
+  UNDOCUMENTED residual; `??`→`||` is a one-character ordinary edit. R42
+  follow-through: fix `||` (2-line + red-proven test), ternary rides the
+  accepted-residual umbrella with recorded disposition.
+- **NT-SEC-3 [Adjacent→testing]** — negative it.each cases cannot distinguish
+  over-tight regression from correct rejection; existing positive control mitigates.
+- Verified sound: strict tightening; inverted-guard/ternary guard shapes fail-closed
+  at gate level (probed); gate wired (pre-pr.sh:195, ci.yml static-checks,
+  vitest.config includes self-test, check-gate-selftest-coverage meta-gate).
+
+## Round 1 — Testing Findings
+
+- **F1 Major** — no positive self-test fixture for block-body throw guard; the
+  surviving descendants clause of the just-edited expression is unpinned (RT7
+  green-on-real-shapes gap). Perspective convergence with Functionality F2 →
+  severity floor Major.
+- **F2 Minor** — `during!`/`after!` dereferenced without preceding
+  `expect(x).not.toBeNull()`, diverging from sibling convention.
+- Independent RT7 red-direction re-verification performed by the expert (both new
+  tests; mutations restored, residue-checked). CI inclusion confirmed. Parse-failure
+  false-pass ruled out.
+
+## Merged Findings (Round 1)
+
+| ID | Sev | Summary | Source |
+|---|---|---|---|
+| M1 | Major | Block-body throw positive self-test missing (RT7 green-on-real-shapes) | Test F1 + Func F2 (convergence) |
+| M2 | Minor | Gate comment overstates guarantee (dominance residual undocumented) | Func F1 + Sec NT-SEC-1 |
+| M3 | Minor | Coalesce check misses `\|\|` (undocumented residual, one-char edit) | Sec NT-SEC-2 |
+| M4 | Minor | `!` dereference without `not.toBeNull()` | Test F2 |
+| M5 | info | Negative tests can't distinguish over-tight regression | Sec NT-SEC-3 (resolved by M1 fix) |
+
+## Resolution Status
+
+### M1 [Major] Block-body throw positive self-test missing
+- Action: `THROW_SRC` baseline fixture converted to block body with a statement
+  before the throw (pins descendants clause on every green-path run); added
+  dedicated positive test "accepts a bare (unbraced) `if (!tenant) throw` guard"
+  (pins direct-kind clause). Mutation-verified: dropping the descendants clause →
+  4 tests red; restore → 15 pass.
+- Modified file: `scripts/__tests__/check-null-tenant-fail-closed.test.mjs:49-67,120-136`
+
+### M2 [Minor] Comment overstates guarantee
+- Action: reworded to "a `throw` in the guard body is the accepted signal" with an
+  explicit accepted-residual paragraph (dead branch / try-swallowed / nested
+  callback = deliberate evasion, out of the gate's anti-regression threat model;
+  covered by review + mutation-verified unit tests over the real files).
+- Modified file: `scripts/checks/check-null-tenant-fail-closed.mjs` (guard comment)
+
+### M3 [Minor] Coalesce check misses `||`
+- Action: `LENIENT_FALLBACK_TOKENS` set accepts `??` and `||`; ternary recorded as
+  accepted residual in the same comment (not reachable by one-character edit;
+  runtime pinned by mutation-verified unit tests); violation message mentions both
+  operators; red-proven self-test added (`|| 5` in a failsafe file → exit 1;
+  mutation reverting to `??`-only → that test fails). Real-repo gate remains green
+  (no false-red on the 16 live reads).
+- Modified file: `scripts/checks/check-null-tenant-fail-closed.mjs`,
+  `scripts/__tests__/check-null-tenant-fail-closed.test.mjs`
+
+### M4 [Minor] `!` dereference without null assertion
+- Action: `expect(during).not.toBeNull()` / `expect(after).not.toBeNull()` inserted
+  before the `!` dereferences, matching sibling-test convention.
+- Modified file: `src/lib/auth/policy/account-lockout.test.ts`
+
+### M5 [info] Over-tight-regression indistinguishability
+- Action: resolved by the M1 positive controls (block-body baseline + bare-throw
+  positive) — an over-tight check now reds the positives.
+
+### NT-SEC-1 [Minor] Dominance-blind residual — Accepted (pre-existing)
+- Anti-Deferral check: **Accepted residual.** Worst case: a deliberately-evasive
+  edit (dead-branch throw / try-swallow) greens the gate while being fail-open.
+  Likelihood: low — requires intentional authorship in a human-reviewed codebase;
+  ordinary refactors hit the tightened checks. Cost-to-fix: control-flow dominance
+  analysis (high). Mitigation: mutation-verified unit tests over every real member
+  pin runtime behavior; residual now DOCUMENTED in the gate comment (M2 fix) and in
+  `project_null_tenant_fail_open_class`. Consistent with the previously-approved
+  disposition of the same residual.
+
+### Ternary lenient fallback — Accepted (recorded per NT-SEC-2 recommendation)
+- Anti-Deferral check: **Accepted residual.** Worst case: `tenant ? tenant.x :
+  lenient` in a failsafe file greens the gate. Likelihood: low — not reachable by a
+  one-character edit, unlike `??`→`||` (now closed). Cost-to-fix: ternary AST case
+  (~10 lines) with whichever-branch-is-lenient heuristics (false-red prone).
+  Mitigation: runtime behavior pinned by mutation-verified unit tests over both
+  failsafe files; disposition recorded in the gate comment.
+
+## Verification (Round 1 fixes)
+
+- `node scripts/checks/check-null-tenant-fail-closed.mjs` → exit 0 (16 reads)
+- Self-test suite: 15/15; lockout suite: 37/37
+- RT7 mutations: drop-descendants-clause → 4 red; re-accept-returns → 3 red;
+  revert-`||` → 1 red; all restored, gate file byte-identical to backup, residue
+  check clean (3 intended modified files only)
+- Full suite: 967 files / 12,809 tests pass (1 skipped)
+- pre-pr: 52/52 pass
+
+## Environment Verification Report
+
+N/A — no environment constraints declared (no Phase 1; external-review-driven fix).
+All verification `verified-local` (commands cited above); CI re-runs the same gates
+(static-checks runs the gate via pre-pr.sh; vitest includes both test files).
+
+## Round 2 (incremental — No findings)
+
+All Round 1 fixes verified RESOLVED by an independent reviewer pass:
+
+- **M1**: both acceptance clauses now independently pinned — dropping the
+  descendants clause reds 4 tests; dropping the direct-kind clause reds 2 tests
+  (bare-throw + Promise.all fixtures; `getDescendantsOfKind` excludes self, so the
+  direct-kind clause is genuinely load-bearing). `console.error` in the fixture
+  collides with no checker heuristic.
+- **M2**: comment claims verified against implementation — the IfStatement
+  descendant scan has no reachability analysis, so the documented residual shapes
+  green exactly as stated.
+- **M3**: `??`-only revert reds only the new `||` test; `||`-only reds only the
+  original `??` test (independent failure). False-red audit across all 16 manifest
+  files: the coalesce check runs only for the 2 failsafe files; account-lockout.ts
+  has one `||` with no enforcement-field left operand; session-timeout.ts has zero
+  `??`/`||`; display-exempt / throw files are never coalesce-checked. Bonus: the
+  extension now protects the plausible future `|| lenient` edit at
+  `session-timeout.ts:112`.
+- **M4**: null guards present; return type `RecordFailureResult | null` warrants
+  them.
+- **R43**: none — M3 strictly tightens (superset token set), M1/M4 test-only,
+  M2 comment-only; every pre-existing rejection test still passes.
+- **RT7**: every clause added/changed is mutation-proven red and restored green.
+
+Observed (not a finding): the coalesce check flags any `??`/`||` on an enforcement
+field in a failsafe file regardless of the right operand's strictness (a
+`|| STRICTEST` would also red). Pre-existing Round-1 design ("returns a restrictive
+default some other way"); both real files comply.
+
+Termination: all experts No findings at Round 2 → converged.

--- a/scripts/__tests__/check-null-tenant-fail-closed.test.mjs
+++ b/scripts/__tests__/check-null-tenant-fail-closed.test.mjs
@@ -46,6 +46,10 @@ const DISPLAY_PATHS = [
 ];
 
 // A throw-disposition read: enforcement select + null-tenant throw guard.
+// Block body with a statement before the throw — the shape every real manifest
+// throw-file uses — so the baseline pins the descendant-ThrowStatement clause
+// (a bare `if (!t) throw` only exercises the direct-kind clause; see the
+// dedicated bare-throw positive test below).
 const THROW_SRC = `
 import { prisma } from "@/lib/prisma";
 export async function read(id: string) {
@@ -53,7 +57,10 @@ export async function read(id: string) {
     where: { id },
     select: { allowedCidrs: true },
   });
-  if (!tenant) throw new Error("tenant not found");
+  if (!tenant) {
+    console.error("tenant row missing", id);
+    throw new Error("tenant not found");
+  }
   return tenant.allowedCidrs;
 }`;
 
@@ -151,6 +158,51 @@ describe("check-null-tenant-fail-closed (AST)", () => {
     expect(r.stderr).toContain("src/lib/auth/policy/access-restriction.ts");
   });
 
+  // Positive control for the OTHER acceptance clause: the baseline THROW_SRC
+  // uses a block-body guard (descendant-ThrowStatement clause); this pins the
+  // bare unbraced `if (!tenant) throw ...` shape (direct-kind clause). Together
+  // they prove the throw-only tightening did not over-tighten either accepted
+  // guard shape — a rejection-only suite could not tell "correctly rejects
+  // permissive returns" from "rejects everything".
+  it("accepts a bare (unbraced) `if (!tenant) throw` guard", () => {
+    writeFile(
+      "src/lib/auth/policy/access-restriction.ts",
+      `import { prisma } from "@/lib/prisma";
+       export async function read(id: string) {
+         const tenant = await prisma.tenant.findUnique({ where: { id }, select: { allowedCidrs: true } });
+         if (!tenant) throw new Error("tenant not found");
+         return tenant.allowedCidrs;
+       }`,
+    );
+    const r = run();
+    expect(r.code).toBe(0);
+  });
+
+  // External review Medium #2: the earlier check accepted ANY `return` in the
+  // null guard as fail-closed, so `if (!tenant) return []` (permissive empty
+  // allowlist), `return null`, and `return { allowed: true }` all false-greened.
+  // A throw-disposition guard body must THROW — a return, whatever its value,
+  // cannot be proven to be the denial side.
+  it.each([
+    ["return []", "return [];"],
+    ["return null", "return null;"],
+    ["return { allowed: true }", "return { allowed: true };"],
+  ])("fails a throw-disposition guard softened to a permissive `%s`", (_label, guardBody) => {
+    writeFile(
+      "src/lib/auth/policy/access-restriction.ts",
+      `import { prisma } from "@/lib/prisma";
+       export async function read(id: string) {
+         const tenant = await prisma.tenant.findUnique({ where: { id }, select: { allowedCidrs: true } });
+         if (!tenant) ${guardBody}
+         return tenant.allowedCidrs;
+       }`,
+    );
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('disposition "throw"');
+    expect(r.stderr).toContain("src/lib/auth/policy/access-restriction.ts");
+  });
+
   it("fails a failsafe-default file that introduces a permissive enforcement coalesce", () => {
     writeFile(
       "src/lib/auth/policy/account-lockout.ts",
@@ -158,6 +210,23 @@ describe("check-null-tenant-fail-closed (AST)", () => {
        export async function read(id: string) {
          const tenant = await prisma.tenant.findUnique({ where: { id }, select: { lockoutThreshold1: true } });
          return tenant?.lockoutThreshold1 ?? 5;
+       }`,
+    );
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('disposition "failsafe-default"');
+  });
+
+  // `?? lenient` -> `|| lenient` is a one-character ordinary edit (a plausible
+  // "handle 0/falsy" tweak) with the same fail-open effect; the coalesce check
+  // must catch both operators.
+  it("fails a failsafe-default file whose lenient fallback uses `||` instead of `??`", () => {
+    writeFile(
+      "src/lib/auth/policy/account-lockout.ts",
+      `import { prisma } from "@/lib/prisma";
+       export async function read(id: string) {
+         const tenant = await prisma.tenant.findUnique({ where: { id }, select: { lockoutThreshold1: true } });
+         return tenant?.lockoutThreshold1 || 5;
        }`,
     );
     const r = run();

--- a/scripts/checks/check-null-tenant-fail-closed.mjs
+++ b/scripts/checks/check-null-tenant-fail-closed.mjs
@@ -20,13 +20,20 @@
  * verifies its declared MANIFEST disposition against the implementation:
  *
  *   "throw"            - the read's enclosing function MUST contain a null-tenant
- *                        guard that throws / returns-invalid (`if (!<tenantVar>)
- *                        { throw ... | return ... }`). Reverting the throw to a
- *                        permissive coalesce removes the guard -> FAIL.
+ *                        guard whose body THROWS (`if (!<tenantVar>) { throw ... }`).
+ *                        A bare `return` in the guard body does NOT count: `return
+ *                        []` / `return null` / `return { allowed: true }` are all
+ *                        fail-open shapes that a return-accepting check would
+ *                        false-green (external review Medium #2). All current
+ *                        manifest throw-files throw; if a denial-shaped return
+ *                        (401/403 Response, { valid: false }) ever becomes
+ *                        necessary, add an explicit AST allowlist for it then.
+ *                        Reverting the throw to a permissive coalesce or a
+ *                        permissive return removes the guard -> FAIL.
  *   "failsafe-default" - the file MUST NOT read an enforcement field through a
- *                        permissive null-coalesce (`tenant?.<field> ?? <lenient>`);
- *                        it returns a restrictive default some other way.
- *                        Introducing a permissive coalesce -> FAIL.
+ *                        permissive lenient fallback (`tenant?.<field> ?? <lenient>`
+ *                        or `|| <lenient>`); it returns a restrictive default some
+ *                        other way. Introducing a permissive fallback -> FAIL.
  *   "display-exempt"   - the file must NOT call an access-restriction / deny
  *                        primitive. Turning an echo into an access decision -> FAIL.
  *
@@ -226,9 +233,17 @@ function promiseAllDestructuredName(call) {
 }
 
 // Does the enclosing function of `read.node` contain a null guard on the SAME
-// variable the read is bound to, that throws / returns (fail closed)?
-//   plain read `const t = ...findUnique(...)`  -> guard `if (!t) { throw|return }`
+// variable the read is bound to, whose body THROWS (fail closed)?
+//   plain read `const t = ...findUnique(...)`  -> guard `if (!t) { throw ... }`
 //   relation join bound to `const u = ...`      -> guard `if (!u) | if (!u.tenant)`
+// A `return` in the guard body is NOT accepted: any return value (`[]`, `null`,
+// `{ allowed: true }`) can be the permissive side, and this check cannot tell a
+// denial-shaped return from a fail-open one — a `throw` in the guard body is the
+// accepted signal. Accepted residual (not full control-flow dominance): a throw
+// in a dead branch, swallowed by try/catch, or inside a nested callback still
+// greens; those shapes require deliberate evasion, which is out of this gate's
+// anti-regression threat model — code review + the mutation-verified unit tests
+// over the real files cover them.
 // A read with no bindable variable (guardVar null) is treated as UNGUARDED.
 function hasNullTenantThrowGuard(read) {
   const v = read.guardVar;
@@ -254,18 +269,25 @@ function hasNullTenantThrowGuard(read) {
     const opText = operand.getText().replace(/\s+/g, "");
     if (!wanted.has(opText) && !wanted.has(opText.replace(/\?\./g, "."))) continue;
     const body = ifStmt.getThenStatement();
-    const bk = body.getKind();
-    if (bk === SyntaxKind.ThrowStatement ||
-        bk === SyntaxKind.ReturnStatement ||
-        body.getDescendantsOfKind(SyntaxKind.ThrowStatement).length > 0 ||
-        body.getDescendantsOfKind(SyntaxKind.ReturnStatement).length > 0) return true;
+    if (body.getKind() === SyntaxKind.ThrowStatement ||
+        body.getDescendantsOfKind(SyntaxKind.ThrowStatement).length > 0) return true;
   }
   return false;
 }
 
+// `??` and `||` are both one-edit-apart lenient fallbacks (`?? lenient` ->
+// `|| lenient` is a plausible "handle 0/falsy" tweak); flag either. A ternary
+// (`tenant ? tenant.x : lenient`) remains an accepted residual — it is not
+// reachable by an ordinary one-character edit, and runtime behavior is pinned
+// by the mutation-verified unit tests over the failsafe files.
+const LENIENT_FALLBACK_TOKENS = new Set([
+  SyntaxKind.QuestionQuestionToken,
+  SyntaxKind.BarBarToken,
+]);
+
 function hasPermissiveEnforcementCoalesce(sf) {
   for (const bin of sf.getDescendantsOfKind(SyntaxKind.BinaryExpression)) {
-    if (bin.getOperatorToken().getKind() !== SyntaxKind.QuestionQuestionToken) continue;
+    if (!LENIENT_FALLBACK_TOKENS.has(bin.getOperatorToken().getKind())) continue;
     const left = bin.getLeft();
     const paList = left.getKind() === SyntaxKind.PropertyAccessExpression
       ? [left] : left.getDescendantsOfKind(SyntaxKind.PropertyAccessExpression);
@@ -318,11 +340,11 @@ for (const file of targets) {
 
   if (disposition === "throw") {
     if (!reads.every((r) => hasNullTenantThrowGuard(r))) {
-      violations.push(`${rel}: disposition "throw" but an enforcement read has no null-tenant guard (if (!tenant) { throw|return }). A reverted throw is a fail-open regression.`);
+      violations.push(`${rel}: disposition "throw" but an enforcement read has no null-tenant guard whose body throws (if (!tenant) { throw ... }). A reverted or return-softened throw is a fail-open regression.`);
     }
   } else if (disposition === "failsafe-default") {
     if (hasPermissiveEnforcementCoalesce(sf)) {
-      violations.push(`${rel}: disposition "failsafe-default" but an enforcement field is read through a permissive '?? <lenient>' coalesce - the fail-open shape. Return a RESTRICTIVE default instead.`);
+      violations.push(`${rel}: disposition "failsafe-default" but an enforcement field is read through a permissive '?? <lenient>' / '|| <lenient>' fallback - the fail-open shape. Return a RESTRICTIVE default instead.`);
     }
   } else if (disposition === "display-exempt") {
     if (callsAccessDecision(sf)) {

--- a/src/lib/auth/policy/account-lockout.test.ts
+++ b/src/lib/auth/policy/account-lockout.test.ts
@@ -667,6 +667,49 @@ describe("getLockoutThresholds (via recordFailure with tenantId)", () => {
     invalidateLockoutThresholdCache("tenant-dberr");
   });
 
+  // Regression (external review Low): the strictest fallback must NOT be cached.
+  // If a transient DB failure pinned STRICTEST into the 60s TTL cache, users of
+  // a lenient tenant would keep locking at 1 attempt after the DB recovered.
+  // The next call after recovery must re-query and apply the tenant's real
+  // thresholds. Mutation check: cache the fallback in the catch/null branches of
+  // getLockoutThresholds and the second call here locks at 1, not 5.
+  it("does not cache the strictest fallback — recovers to real thresholds on the next call", async () => {
+    invalidateLockoutThresholdCache("tenant-recover");
+
+    // First call: fetch fails → strictest fallback (locks at 1 attempt)
+    mockPrismaTenant.findUnique.mockRejectedValueOnce(new Error("DB down"));
+    setupTransaction({
+      failed_unlock_attempts: 0,
+      last_failed_unlock_at: null,
+      account_locked_until: null,
+    });
+    const during = await recordFailure("user-1", undefined, "tenant-recover");
+    expect(during).not.toBeNull();
+    expect(during!.locked).toBe(true); // strictest applied during the outage
+
+    // Second call: DB recovered → tenant's lenient thresholds (lock at 5) apply
+    mockPrismaTenant.findUnique.mockResolvedValue({
+      lockoutThreshold1: 5,
+      lockoutDuration1Minutes: 15,
+      lockoutThreshold2: 10,
+      lockoutDuration2Minutes: 60,
+      lockoutThreshold3: 15,
+      lockoutDuration3Minutes: 1440,
+    });
+    setupTransaction({
+      failed_unlock_attempts: 1, // 1 previous → 2 after increment, below threshold1=5
+      last_failed_unlock_at: new Date(),
+      account_locked_until: null,
+    });
+    const after = await recordFailure("user-1", undefined, "tenant-recover");
+
+    expect(after).not.toBeNull();
+    expect(mockPrismaTenant.findUnique).toHaveBeenCalledTimes(2); // fallback was not cached
+    expect(after!.attempts).toBe(2);
+    expect(after!.locked).toBe(false); // real (lenient) policy applies again
+    invalidateLockoutThresholdCache("tenant-recover");
+  });
+
   it("re-queries the DB after invalidateLockoutThresholdCache", async () => {
     // First call: return custom thresholds, cache them
     mockPrismaTenant.findUnique.mockResolvedValue({


### PR DESCRIPTION
## Summary
- Tightened the CI guard in `check-null-tenant-fail-closed.mjs` to strictly require a `throw` in the null-tenant guard body, rejecting `return` fallbacks that previously caused false-green results (external review Medium).
- Closed a coalesce operator gap by expanding lenient fallback detection to include `||`, while formally accepting the ternary residual with documented mitigation.
- Added mutation-verified positive/negative self-tests and a lockout cache-regression test verifying the strictest fallback is not cached across DB recovery (external review Low).

## Motivation
The gate accepted any `return` statement inside a null-tenant guard as fail-closed, creating a false-green risk if guards were softened (e.g., `return []`, `return null`, or `return { allowed: true }`). Additionally, the coalesce check only matched `??`, allowing a one-character `|| lenient` edit to bypass detection. These gaps undermined the anti-regression threat model. All 8 real manifest throw-files actually throw, so throw-only closes the hole with zero repo churn; a denial-shaped-return AST allowlist is deferred until a member needs one.

## Implementation notes
- `hasNullTenantThrowGuard` now accepts only `ThrowStatement` (direct or descendant); `ReturnStatement` acceptance removed.
- `LENIENT_FALLBACK_TOKENS` covers `??` + `||`; ternary recorded as accepted residual (not reachable by one-character edit; runtime pinned by mutation-verified unit tests). Violation messages reference both operators.
- Gate comments document the dominance-blind residuals (dead branch, try-swallowed, nested-callback throw) as intentional out-of-scope evasion.
- Self-test suite: both guard-acceptance clauses (block-body descendants / bare direct-kind) now have positive controls; permissive-return trio + `||` have red-proven negatives (10 → 15 cases).
- `account-lockout.test.ts`: regression test pins that the strictest fallback is never cached — `findUnique` called twice, DB recovery restores the tenant's real (lenient) thresholds.

## Review artifacts
- [null-tenant-gate-throw-only-code-review.md](./docs/archive/review/null-tenant-gate-throw-only-code-review.md) — 2 triangulated rounds, converged (Round 2: No findings); external reviewer confirmed merge-ready.

## Test plan
- [x] `node scripts/checks/check-null-tenant-fail-closed.mjs` — exit 0, 16 manifest reads
- [x] Self-test suite 15/15; lockout suite 37/37
- [x] Mutation-verified red: descendants clause (4 red), direct-kind clause (2 red), `||` token (1 red), returns re-accepted (3 red), fallback-cached (1 red)
- [x] Full unit suite 12,809 pass; real-DB integration 357 pass; pre-pr 52/52

🤖 Generated with [Claude Code](https://claude.com/claude-code)