### PR TITLE
perf(pre-pr): de-spawn two static gates and run independent steps concurrently (~160s -> ~88s)

### DIFF
--- a/docs/archive/review/pre-pr-parallelization-plan.md
+++ b/docs/archive/review/pre-pr-parallelization-plan.md
@@ -1,0 +1,309 @@
+# Plan: pre-pr-parallelization
+
+Speed up `scripts/pre-pr.sh` without removing or weakening a single check.
+
+## Project context
+
+- **Type**: mixed (web app + CLI + extension + iOS; this change targets the repo's local/CI verification tooling — bash + node gate scripts)
+- **Test infrastructure**: unit + integration + E2E + CI/CD. Gate scripts have their own self-test suite under `scripts/__tests__/*.test.mjs` (vitest), enforced for coverage by `check-gate-selftest-coverage.sh`.
+- **Verification environment constraints**:
+  - `VC1` — `Test` / `Build` / `Integration tests` / `CLI` / `Extension` steps are heavy and mutually exclusive with a concurrently running `pre-pr.sh`. During plan authoring a second `pre-pr.sh` was running in another session, so these steps were **not** re-timed locally. Classification: `verifiable-local` (deferred to an idle machine), not blocked. Their timings are taken from the script's own structure, not measured, and no contract below depends on their exact duration.
+  - `VC2` — `Static: rls-cross-tenant SQL parse` requires a running local docker Postgres (`passwd-sso-db-1`). Absent it, the step self-skips. Classification: `verifiable-local` (requires `npm run docker:up`).
+  - `VC3` — `Secret scan (gitleaks)` behavior depends on which gitleaks generation is installed, and the R35 manual-test / refactor-verify gates are branch-state dependent (only fire on `refactor/*` or admin-IA diffs). Classification: `verifiable-local` under constructed branch states.
+
+## Objective
+
+Reduce `scripts/pre-pr.sh` wall-clock time while preserving **exactly** the current set of checks and their pass/fail semantics.
+
+Non-goal: removing, sampling, or making any check conditional to save time.
+
+## Measured baseline (2026-07-26, 20-core machine)
+
+Static checks only (the `PRE_PR_STATIC_ONLY=1` surface, which is also what CI's `static-checks` job runs):
+
+| Step | Time |
+|---|---|
+| `Static: step-up-client-coverage` | **171.01 s** |
+| `Static: fail-closed-routes-have-test` | 9.82 s |
+| `Static: api-error-codes` | 1.26 s |
+| `Static: session-token-hashed` | 1.07 s |
+| `Static: bound-unknown-ip` | 0.99 s |
+| `Static: destructive-wrapper-derivation` | 0.95 s |
+| `Static: null-tenant-fail-closed` | 0.73 s |
+| `Static: cosign-kms-uri` | 0.68 s |
+| `Static: critical-audit-atomic` | 0.66 s |
+| remaining ~30 static checks | < 0.4 s each, ≈ 2 s total |
+| **Total static** | **≈ 187 s** |
+
+**One check is 91% of the static phase.** Root cause, measured: `check-step-up-client-coverage.sh` spawns **66,176 processes** in a single run (`bash -x … | grep -c '^+* grep'`). Its final loop is O(call-sites × manifest-ids) = **203 × 50 ≈ 10,150 iterations** (call sites counted over the gate's own `CLIENT_DIR="$REPO_ROOT/src"` scope, `:109`), and each iteration spawns 4–6 short-lived `awk`/`grep`/`sed`/`wc` processes. The script's own comment at the `file_marker_ids` line concedes the tradeoff — *"cache per file would be an optimization; correctness first — re-grep is cheap at this file count"* — an assumption that no longer holds at this cardinality.
+
+This is R45 (repo-wide gate scaling super-linearly with the scanned set).
+
+**Consequence for the original request**: parallelism alone cannot fix this. A 171 s serial step is a hard floor — parallelizing everything else yields 187 s → 171 s (≈9%). The hotspot must be fixed for parallelism to have anything to work with.
+
+**Precedent in-repo**: `check-fail-closed-routes-have-test.sh` had this identical defect and was already fixed — its comments at lines 428 and 467-468 record collapsing ~65 per-line `node` spawns into one batched call, worth ~13 s. C1 applies that same proven transformation.
+
+## Requirements
+
+### Functional
+- FR1 — The set of executed checks is identical before and after. No check removed, skipped, sampled, or made conditional.
+- FR2 — Pass/fail outcome is identical for every check, on both green and red inputs.
+- FR3 — `PRE_PR_STATIC_ONLY=1` (CI `static-checks` job, `.github/workflows/ci.yml:228`) keeps identical semantics. R33: this script is the single definition shared by the local hook and CI; a local-only speedup that changes CI behavior is a defect.
+- FR4 — Failure output remains diff-comparable: steps are reported in the current script order with the current `show_failure_context` formatting, regardless of completion order.
+- FR5 — Existing escape hatches (`PRE_PR_FORCE_FULL`, `PREPR_SKIP_INTEGRATION`, `RUN_WEB` auto-skip, docker/gitleaks self-skips) keep working.
+
+### Non-functional
+- NFR1 — Static phase wall-clock, **measured on the 20-core dev machine**, ≤ 15 s (from 187 s). The floor is set by the slowest single remaining step, since parallelism cannot beat `max(step)`: after C1 that is `fail-closed-routes-have-test` at 9.82 s (deliberately out of scope, `SC2`), so ≤10 s would leave ~0.2 s for the other ~35 checks plus scheduler overhead — not achievable. On a 2-core CI runner the two heaviest steps serialize against each other, so **CI's expectation is ≈20 s, not 15 s**; C2-AC1 is asserted against the dev machine only and CI is measured separately (SC3). Both figures are a ~10× improvement over today's 187 s.
+- NFR2 — Bounded concurrency; must not oversubscribe or exhaust file descriptors on a smaller machine (CI runners are 2–4 core, not 20).
+- NFR3 — No new required tooling. GNU `parallel` is **not** installed and must not become a dependency; use bash job control.
+
+## Technical approach
+
+Two independent changes, in this order (C1 first — it is the 91%, and it is independently valuable even if C2 were abandoned).
+
+### C1 — De-spawn the hotspot (`check-step-up-client-coverage.sh`)
+
+Replace per-iteration process spawns with a single pre-pass, keeping the matching logic byte-identical in intent:
+
+1. **Hoist manifest parsing out of the inner loop.** `manifest_line_for`, `method`, and `tokens_raw` are recomputed for all 50 ids at every one of the 203 call sites, though they depend **only on the id**. Parse the manifest **once** into indexed shell arrays before the outer loop (indexed, not associative — see the bash-3.2 constraint below).
+
+2. **Respect the two distinct scopes — do NOT collapse them.** The four window variables are *not* all per-file, and treating them as such silently widens matching:
+
+   | Variable | Line | True scope | Hoist to |
+   |---|---|---|---|
+   | `file_marker_ids` | :498 | per **file** | per-file (safe to hoist) |
+   | `arg_window` | :501 | per **call site** (`l .. l+3`) | must stay per-call-site |
+   | `opt_window` | :502 | per **call site** (`l .. l+10`) | must stay per-call-site |
+   | `suppress_window` | :545 | per **call site** (`l-3 .. l`) | must stay per-call-site |
+
+   Only `file_marker_ids` is file-scoped. Hoisting `arg_window` to per-file scope would widen its window from 4 lines to the whole file, making unrelated tokens match — a semantic change in the *false-positive* direction that violates FR2. The correct transformation is: read each file's lines **once** into an indexed array, then slice each call site's window from memory, preserving the exact `l..l+3` / `l..l+10` / `l-3..l` bounds. The win comes from eliminating repeated `awk`/`grep` **spawns**, not from widening scope.
+
+3. **Short-circuit ordering preserved.** The existing cheap-first ordering (method check before token scan) is retained so that no additional work is performed.
+
+**Constraint — C1 changes performance only.** The comparison semantics (word-boundary token matching, ERE escaping, comment-prefix skip, suppression reason ≥10 chars, exempt-id skip) are preserved exactly. Any change to *what* the gate flags is out of scope for this plan.
+
+**Optional escalation**: if a faithful bash rewrite proves unreadable, port the loop to a `.mjs` gate (the repo already prefers this — `check-destructive-wrapper-derivation.mjs`, `check-null-tenant-fail-closed.mjs` are node-based and run < 1 s). Decision deferred to implementation.
+
+**Escalation is NOT gated on C1-AC1 alone.** A bash→Node port re-implements locale-sensitive `grep -E` / `sed -E` / `awk` semantics in a different regex engine (ERE vs. JS `RegExp`): character-class behavior, `\b` vs. the hand-rolled `([^A-Za-z0-9_]|$)` boundary, greedy/lazy differences, and `LC_ALL`-dependent collation all differ in ways a 30-case suite passing green cannot rule out. A port that silently *narrows* matching turns a security gate fail-open while every test stays green. The escalation path therefore carries an additional, stricter gate:
+
+C1-AC5 (decision-trace differential) and C1-AC6 (per-dimension mutation-proof) were originally scoped to this escalation path only. **They are now mandatory for every C1 path** — see the Acceptance criteria, where they became the primary oracle after the original criteria were empirically defeated. The escalation path additionally carries the JS-vs-ERE regex-equivalence burden described above.
+
+If the escalation criteria prove impractical, the bash-optimization path (hoisting + single-read) is preferred, since it leaves the regex engine and locale semantics untouched by construction — the transformation is *where* the comparison runs, not *how* it compares.
+
+### C2 — Bounded-parallel `run_step`
+
+Add opt-out-able job-parallel execution to `pre-pr.sh` for the **independent** static checks:
+
+- Each step runs as a background job writing to its own `mktemp` logfile (the script already allocates one logfile per step — this structure is already parallel-ready).
+- Concurrency capped at `min(nproc, 8)` by default, overridable via `PRE_PR_JOBS`. `PRE_PR_JOBS=1` restores today's fully-serial behavior as an escape hatch. **`PRE_PR_JOBS` is untrusted input and MUST be clamped**: non-numeric → default; floor 1; cap `min(nproc, 8)`. Unvalidated, `PRE_PR_JOBS=0` makes the slot check (`active >= 0`) block forever or degenerate, and a huge value oversubscribes/exhausts file descriptors (NFR2). Fail closed to serial on anything unparseable rather than to unbounded. CI never sets it (verified: `ci.yml:228` passes only `PRE_PR_STATIC_ONLY=1`), so this is developer-robustness, not a CI bypass — but a mid-run hang reads as "flaky, push anyway", which is its own hazard.
+- Results are **buffered and replayed in script-declaration order** (user-selected), so `passed`/`failed`/`failures[]` accumulate deterministically and `show_failure_context` output is unchanged.
+
+**Scheduling / synchronization mechanism (explicit — no implicit races):**
+
+The naive "background everything, then read the logs" shape has two failure modes: reading a logfile before its writer finished (truncated context), and collecting status in completion order (nondeterministic counts). The design pins both:
+
+1. **Enqueue phase.** `run_step` no longer executes; it appends `(label, cmd…)` to an ordered `steps[]` array and pre-allocates that step's logfile, registering it in `tempfiles[]` **before** any job starts (satisfies I5 — the `EXIT` trap can clean up even on Ctrl-C mid-run).
+2. **Dispatch phase.** A scheduler walks `steps[]` in order, launching each as a background job with its stdout **and stderr** redirected to that step's own logfile (`> "$log" 2>&1` — no `tee`, no shared pipe, so no interleaving and no `PIPESTATUS` masking). It blocks while `active_jobs >= PRE_PR_JOBS` using `wait -n`, launching the next only as a slot frees. **`wait -n`'s return value is used purely as a throttle signal and MUST be discarded** (`wait -n || true`) — see the mis-attribution proof below.
+3. **Join phase.** Each launched job's PID is recorded in `pid[i]` alongside its index. After dispatch, the scheduler reads step *i*'s exit status **per index, in declaration order**. Bare `wait` is a forbidden pattern (see below).
+
+   **The join MUST be `set -e`-safe — red-proven abort otherwise.** `scripts/pre-pr.sh:4` sets `set -euo pipefail` for the whole script, so a bare `wait "${pid[i]}"` returning non-zero is an uncaught failing command that **terminates the script on the spot**. Probe (bash 5.2.21, 2026-07-26): three jobs exiting `0,7,0` joined with a bare per-index `wait` printed `step0 joined ok` and then died with `SCRIPT EXIT=7` — steps 1 and 2 were never joined, the replay never ran, and the `═══ Results ═══` / `═══ Failure Context ═══` blocks never printed. CI still goes red, so this is not fail-open, but it **truncates the gate run**: every check after the first failure is silently never evaluated or reported, so fixing one gate can reveal a second previously-unreported violation with no indication the set was cut short. Violates FR4 and I3.
+
+   Required shape — capture the status through an `if` condition (exempt from `set -e`), or bracket the join in `set +e … set -e` exactly as today's `run_step` already does at `scripts/pre-pr.sh:137-140`:
+
+   ```bash
+   if wait "${pid[i]}"; then ec=0; else ec=$?; fi
+   ```
+
+   **`wait -n` status capture is FORBIDDEN — red-proven mis-attribution** (bash 5.2.21, probe run 2026-07-26). `wait -n` returns *a* status but does not identify *which* job produced it, so assigning it to the dispatch loop's current index blames the wrong step. Probe: three jobs launched in declaration order as `(slow,ok) (slow,ok) (fast,FAIL 7)`; capturing at `wait -n` time yielded **`7 0 0`** against a declaration-order truth of `0 0 7` — the *failing* step reported as passing and an innocent step marked failed. In a security-gate harness that is a fail-open (red gate reports green). The per-index join on the same input yielded exactly `0 0 7`.
+
+   The per-index join is safe even for jobs already reaped by the throttle: bash retains the exit status of an explicitly-tracked PID. Probe: 5 jobs exiting `0,7,0,9,0` under a `JOBS=2` `wait -n` throttle, joined per-index afterwards, yielded exactly `0 7 0 9 0`. Implementation MUST re-run both probes if the target bash differs, since reaped-child status retention is bash-specific, not POSIX-guaranteed.
+
+   **Status 127 is never a control signal.** A step whose command is missing (`node` absent, `bash -c` "command not found") exits 127, which is indistinguishable from `wait`'s "no such job" return. The scheduler MUST treat every `wait` return value as the step's own status and never branch on 127 as a bookkeeping artifact — otherwise a broken/missing check script is silently reclassified as "not a real failure", which is precisely the environment-drift case a static-gate harness must catch. Every PID is `wait`ed exactly once, from the join phase, unconditionally.
+
+   Note the related hazard the probe also confirmed: **a backgrounded job cannot mutate the parent shell's variables** (`{ passed=$((passed+1)); } &` leaves `passed=0`). This is precisely why counters are accumulated in the replay phase in the parent shell, never inside the job. See I7.
+4. **Replay phase.** Only after a step's status is known and its writer has exited is its logfile read and its result printed. Replay walks `steps[]` in declaration order, so `passed`/`failed`/`failures[]` accumulate identically to today regardless of completion order (I3).
+
+Because every job owns a private logfile and nothing writes to a shared stream, there is no output interleaving to serialize against — the ordering guarantee comes from the replay walk, not from constraining execution.
+
+**Stream handling**: each step's stdout and stderr are merged into that step's own logfile (`2>&1`, matching today's `"$@" 2>&1 | tee "$logfile"` which also merges them). No stream is discarded. This matters because `show_failure_context` greps for markers such as `error TS[0-9]+` and `^Error:` that several checks emit on stderr — dropping or splitting stderr would silently blind the failure-context extractor.
+
+**Parallel-safety audit (verified, not assumed):**
+
+**Member-set derivation (R42 — mechanically derived, not asserted).** The writer set was re-derived over the 25 checks in the C2 window with:
+
+```bash
+grep -ln 'mktemp' scripts/checks/*.sh          # → check-api-error-body-drift.sh, check-worker-bundle-smoke.sh
+grep -ln 'mkdtemp\|writeFileSync' scripts/checks/*.mjs   # → (none)
+```
+
+Result: exactly **two** writers, both `mktemp`-based. Two candidates were investigated and cleared: `check-workflow-supply-chain.mjs` has no write calls at all, and `check-dockerignore-secrets.sh`'s `__dockerignore_probe__` paths are **string literals** fed to a matcher, not files created on disk. Every other check in the window is a pure reader of the working tree.
+
+| Concern | Finding |
+|---|---|
+| Shared temp state | Exactly two writers (derivation above); both use `mktemp -d`/`mktemp` (unique per process). Safe. |
+| Repo-`dist/` writes | `check-worker-bundle-smoke.sh` rewrites the esbuild `--outfile` into its own `$TMP_DIR` (verified at its bundling block) — it does **not** write repo `dist/`. Safe. |
+| Ordering dependence | The static checks are pure readers of the working tree. No step's input is another step's output. |
+| Exit-status masking | `run_step` already reads `${PIPESTATUS[0]}`, not the `tee` status (R44-correct today). Backgrounding must preserve this — see C2-AC3. |
+
+**C2 scope is a bounded window, not the whole script.** Parallel scheduling applies **only** to the contiguous run of pure `run_step` calls at `scripts/pre-pr.sh:158-184` (the 25 static checks that contain the entire measured hotspot). Everything from `:186` onward runs exactly as today, unchanged.
+
+Rationale — the script contains **three** kinds of step, and only the first is enqueueable. Member-set derived mechanically (`grep -nE 'printf.*(skip|▸)|passed=\$\(\(|failed=\$\(\(|failures\+=' scripts/pre-pr.sh`), not by inspection:
+
+| Kind | Sites | Enqueueable? |
+|---|---|---|
+| `run_step` calls | ~40 | yes |
+| `printf`-only skip notices | `:187`, `:228`, `:460`, `:503`, `:535-536`, `:540-541` | **no** — emit output but never call `run_step` |
+| Direct counter mutations outside `run_step` | `:478`/`:485-486` (gitleaks fallback), `:512-513`/`:516` (R35 manual-test gate), `:561-562` (CLI deps), `:571-572` (Extension deps) | **no** — mutate `passed`/`failed`/`failures[]` inline |
+
+Under a whole-script enqueue/dispatch split, kinds 2 and 3 would execute at *enqueue* time and therefore print **before** every replayed step result, reordering output versus declaration order and violating FR4/I3. Restricting C2 to `:158-184` sidesteps this entire class: that window contains no conditional notices and no inline counter mutations, so enqueue-time evaluation is vacuous there.
+
+**Explicitly serial (NOT parallelized) in C2:**
+- Everything at `scripts/pre-pr.sh:186` and below — including all conditional/branch-guarded steps, the gitleaks secret scan, the R35 gate, and the Web steps. Recorded as `SC4`.
+- `Test`, `Build`, `Integration tests`, `CLI: *`, `Extension: *` — heavy, memory-hungry, and mutually contending (`next build` and `vitest` each already parallelize internally). Making these concurrent risks OOM and flakiness for little gain. Recorded as `SC1`.
+- `Test` is preceded by `rm -rf node_modules/.vitest` — a repo-global mutation that is unsafe to run beside other steps.
+
+**Passing-step stdout is preserved.** Today `run_step` pipes through `tee` (`scripts/pre-pr.sh:138`), so a *passing* step's output reaches the terminal before its log is deleted at `:152`. Several gates print CI-auditable configuration on success — e.g. `check-gate-selftest-coverage.sh` echoes its resolved `CHECKS_DIR`/`TESTS_DIR`/`DEBT_FILE` paths, and `check-destructive-wrapper-derivation.mjs` echoes `SCAN_ROOT`/`EXEMPT_FILE`/`PATTERNS_FILE`. Dropping `tee` without compensation would silently delete these from both the terminal and CI logs. The replay phase MUST therefore emit each step's captured logfile — **pass and fail alike** — before printing its `✓`/`✗` line, reproducing today's total stdout modulo ordering.
+
+## Contracts
+
+### C1 — `check-step-up-client-coverage.sh` runs in ≤ 5 s with identical verdicts
+
+- **Signature**: unchanged. Same path, same argv (none), same exit codes (`0` pass / `1` fail), same stdout marker strings (`UNMARKED_CALLSITE_CANDIDATE:`, `MANIFEST_ID_MISSING:`, etc.).
+- **Invariants**:
+  - `I1` (app-enforced) — For every input tree, the set of emitted finding lines is identical to the pre-change script's, as sets (order-insensitive within a file, since the outer iteration order is preserved anyway).
+  - `I2` (app-enforced) — Process spawn count is O(files + ids), not O(files × ids).
+- **Forbidden patterns** (the inner `while IFS= read -r mid` loop spawns 4–6 processes per iteration; forbidding only one of them permits a half-fix that still misses I2):
+  - `pattern: grep -r` inside the call-site/id loop bodies — reason: reintroduces the per-iteration repo walk that is the defect.
+  - `pattern: manifest_line_for` called inside the inner `mid` loop — reason: id-only data must be hoisted, not recomputed per call site.
+  - `pattern: grep -oE '"method"` inside the inner `mid` loop — reason: `method` is id-only; the `printf | grep -oE | sed -E` chain is 3 spawns × 9,450 iterations.
+  - `pattern: grep -oE '"pathTokens"` inside the inner `mid` loop — reason: same, `tokens_raw` is id-only; another 3 spawns per iteration.
+  - `pattern: declare -A` anywhere in the rewritten script — reason: revokes the documented bash-3.2 guarantee (see Platform constraints).
+  - `pattern: awk -v l=` inside the inner `mid` loop — reason: window extraction must come from the in-memory line array, not a fresh `awk` per iteration.
+- **Acceptance criteria**:
+  > **The original oracle was empirically defeated — these criteria replace it.** Two independent reviewers converged on this, and one built the counter-example: a single plausible C1-shaped optimization (merging `arg_window` `+3` and `opt_window` `+10` at `:501-502` into one `+3` read — literally what "read each client file once" invites) passed **30/30 self-tests AND produced a byte-identical differential**, while genuinely losing detection (a `"PUT"` literal at offset +6 stopped being flagged). Measured root cause: the gate emits **0 lines / 0 bytes on a clean tree**, so the old C1-AC2 was `diff /dev/null /dev/null` — it passes even for `exit 0 # optimized`. Any criterion that only observes a green tree is worthless here.
+
+  - `C1-AC1` — `npx vitest run scripts/__tests__/check-step-up-client-coverage.test.mjs` passes. The suite is a **necessary floor, not the oracle**: it has **3** (not 5) `UNMARKED_CALLSITE_CANDIDATE` assertions, its call-site × id cross-product is empty (no fixture has two ids reaching one call site), and the word-boundary and ERE-escaping rules are untested. See C1-AC0.
+  - `C1-AC0` (**prerequisite — lands BEFORE C1, as its own commit**) — Extend the suite to cover the rewrite's actual decision surface. Each new case must be **green against today's unmodified script** (proving it encodes current behavior) and **red against a scratchpad copy with the corresponding rule removed** (RT7 — proving it can fail). Required fixtures:
+    - multi-id / one call site: two ids sharing a path token, differing method → assert only the method-matching id is flagged (pins the per-id `method`/`tokens_raw` pairing that hoisting scrambles).
+    - multi-file: file A marked, file B unmarked, same path+method → assert only B flagged (pins the `file_marker_ids` per-file cache).
+    - word boundary: use a **real** live-manifest prefix pair (e.g. `apiPath.tenantBreakglass` / `apiPath.tenantBreakglassById`; **12 such pairs exist on today's tree**) → assert only the correct id is named.
+    - ERE escaping: token `API_PATH.WIDGETS` with a call line containing `API_PATHxWIDGETS` → must PASS (fails if the `.`-escaping at `:536` is dropped).
+    - exempt-id skip (`:512`), comment-prefix skip (`:491-494`, both `//` and `*` forms), and window edges (token at `l+3` flags / `l+4` does not; `method:` at `l+10` / `l+11`; suppression at `l-3` / `l-4`).
+  - `C1-AC2` — Differential on the real tree: stdout byte-identical before/after. **This proves only "no NEW findings appeared" — it is not evidence the matching set was preserved**, because both sides are empty. Retained as a cheap regression tripwire, never as the safety argument.
+  - `C1-AC5` (**now REQUIRED for every C1 path, not escalation-only**) — Decision-trace differential: instrument both implementations to emit one line per `(call-site, id)` pair — `<file>:<line>\t<id>\t<matched|skipped-method|skipped-token|suppressed|exempt>` — and require the two streams byte-identical. This turns a 0-byte comparison into ~10,150 lines of real signal — **203** non-test `fetchApi(` call sites × **50** manifest ids on today's tree, re-verified against the gate's own `CLIENT_DIR="$REPO_ROOT/src"` scope (`:109`). (Two corrections: the plan's earlier "189" undercounted by scoping to a narrower path set; a reviewer's "49 ids" was off by one — the manifest has 50.) This is the primary oracle.
+  - `C1-AC6` (**now REQUIRED for every C1 path, not escalation-only**) — Mutation-proof on a **scratchpad copy** (never the real source): one mutant per independently-narrowable dimension, each required to turn the gate **red**. Corpus derived from the code, not chosen ad hoc (R42): `arg_window` bound (+3), `opt_window` bound (+10), `suppress_window` bound (−3..0), word-boundary suffix (`:537`), ERE escaping (`:536`), comment-prefix skip (`:492-494`), exempt-id skip (`:512`), ≥10-char reason rule (`:550-551`), per-id `method` gating (`:520-524`). A dimension whose mutant leaves the gate green means that dimension is unverified — fix the corpus or the criterion before proceeding.
+  - `C1-AC3` — Wall-clock ≤ 5 s (from 171 s), **best of 3 warm runs on the baseline machine**, measured as the baseline was. Non-blocking performance target, explicitly subordinate to the correctness criteria above: a slow-but-correct rewrite is not blocked, and a fast-but-narrowing one is never waved through.
+  - `C1-AC4` — Spawn count drops from 66,176 to < 1,000, counting **all** spawn types (`grep -cE '^\++ (grep|awk|sed|wc|tr|cut|head|sort)'`), not only `grep` — otherwise converting `grep` spawns into `awk` spawns satisfies the criterion while leaving the O(files × ids) defect intact. Baseline command: `bash -x scripts/checks/check-step-up-client-coverage.sh 2>&1 >/dev/null | grep -oE "^\+* grep" | wc -l`. Diagnostic, not binding.
+  - `C1-AC7` — `bash scripts/checks/check-gate-selftest-coverage.sh` exits 0 after the change (machine-checks the Consumer B binding rather than relying on remembering it).
+- **Consumer-flow walkthrough**: this contract's output is consumed by exactly two readers.
+  - Consumer A (`scripts/pre-pr.sh:166`) reads `{ exit code, stdout }` and uses the exit code to increment `passed`/`failed` and stdout as `show_failure_context` input. No shape change.
+  - Consumer B (`scripts/checks/check-gate-selftest-coverage.sh`) enumerates `scripts/checks/*.sh` and `scripts/checks/*.mjs` and requires a sibling `scripts/__tests__/<basename>.test.mjs` (or a debt entry). C1's bash-optimization path keeps both filenames unchanged, so the binding holds trivially. For the escalation path: a `.sh` → `.mjs` port **preserves the basename**, so the sibling test path is still satisfied automatically — the earlier concern about the test filename needing to move was wrong. The real hazard is the opposite: if the port leaves the old `.sh` in place as a wrapper, **both** files get enumerated and the `.sh` needs its own test or debt entry. A port must therefore *delete* the `.sh`, not wrapper it.
+
+### C2 — `pre-pr.sh` runs independent static checks concurrently, deterministic output
+
+- **Signature**: `run_step <label> <cmd...>` keeps its current call signature at all ~40 existing call sites. Scheduling is internal.
+- **Invariants**:
+  - `I3` (app-enforced) — Reported step order equals script-declaration order, independent of completion order.
+  - `I4` (app-enforced) — Every step's exit status is the direct return of `wait "${pid[i]}"` for that step's own job; **no pipeline may sit between the step command and its status** (R44). The parallel path has no `tee` and therefore no `PIPESTATUS` involvement — the redirect is `> "$log" 2>&1`. (The serial `PRE_PR_JOBS=1` path may keep today's `PIPESTATUS[0]` read if it reuses the existing code path; the two must not be conflated.)
+  - `I8` (app-enforced) — Replay emits each step's captured logfile for **passing** steps too, not only failures. Today's `tee` streams passing-step stdout live; a capture-only design that prints logs solely on failure silently drops CI-auditable success output (verified emitters: `check-gate-selftest-coverage.sh`, `check-destructive-wrapper-derivation.mjs`).
+  - `I5` (app-enforced) — Every backgrounded step's logfile is registered in `tempfiles[]` before the job starts, so the `EXIT` trap cleans up even on interrupt.
+  - `I6` (app-enforced) — `PRE_PR_JOBS=1` produces behavior indistinguishable from today's serial script.
+  - `I7` (app-enforced) — `passed`, `failed`, and `failures[]` are mutated **only in the parent shell during the replay phase**, never inside a backgrounded job. Verified hazard: a `cmd &` subshell's variable writes are discarded on exit, so a counter incremented inside a job silently stays 0 — which would under-report both passes and, critically, **failures**. This is a fail-open shape and is the most probable way a naive implementation breaks.
+- **Forbidden patterns**:
+  - `pattern: ^\s*wait\s*$` (bare `wait` with no job-status read) — reason: discards per-job exit status; a failing check would go green (R44, fail-open).
+  - `pattern: | tee` in the new background path without a `PIPESTATUS` read — reason: same masking defect.
+  - `pattern: status\[[^]]*\]=\$\?` (or any capture of `wait -n`'s status into a per-step slot) in the dispatch loop — reason: **red-proven fail-open**. `wait -n` does not identify which job it reaped, so its status lands on the wrong step: measured `7 0 0` against a truth of `0 0 7`, reporting the failing step as passed. Status is read only in the join phase via per-index `wait "${pid[i]}"`. `wait -n || true` as a pure throttle is the *correct* idiom here, not a defect.
+  - `pattern: -eq 127` / `== 127` applied to a `wait` return value — reason: 127 is a legitimate step exit status (missing interpreter / command-not-found inside a `bash -c` gate). Branching on it as "no such job" reclassifies a broken check as a non-failure (fail-open on environment drift).
+  - `pattern: 2>/dev/null` applied to a step's command in the dispatch path — reason: discards stderr that `show_failure_context` greps for (`^Error:`, `error TS[0-9]+`), blinding failure reporting.
+- **Acceptance criteria**:
+  - `C2-AC1` — Full green run on the 20-core dev machine: static wall-clock ≤ 15 s (see NFR1 for why not 10 s, and for the separate ≈20 s CI expectation); `Passed:` count equals today's count for the same tree.
+  - `C2-AC6` — A step whose command does not exist (e.g. `run_step "probe" nonexistent-binary`, exit 127) is reported **failed**, not silently absorbed. Guards the 127-ambiguity fail-open.
+  - `C2-AC7` — Passing-step stdout is preserved: a green run's total output contains the success-path config lines that `tee` emits today (e.g. `check-gate-selftest-coverage:` and `check-destructive-wrapper-derivation:` prefixed lines). Guards I8.
+  - `C2-AC8` (**step-set integrity — fail-closed**) — The run emits its executed step **labels**, and they are asserted set-equal against a checked-in expected-labels manifest, failing on a difference in **either** direction. Rationale: a scheduler bug that silently fails to enqueue a step lowers the step set *and* the `Passed:` count consistently, so a count-vs-count comparison (C2-AC1) cannot detect it — an un-dispatched gate is indistinguishable from a passing one. Any of ~40 security guards could stop running while the harness reports all-green. This is the R42 completeness treatment the repo already applies in `check-gate-selftest-coverage.sh`, which derives its member set from two independent primitives for exactly this anti-evasion reason. Without C2-AC8, FR1 has no enforcement.
+  - `C2-AC9` (**concurrency actually happened — RT4 vacuous-pass guard**) — Instrument the dispatcher (or a scratchpad harness copy) with N steps recording start/end timestamps; assert **observed peak overlap ≥ 2** and **≤ `PRE_PR_JOBS`**. Rationale: every other C2 criterion passes if the dispatcher silently degenerates to serial — and since C1 alone already brings static under the NFR1 target, **C2 could be a complete no-op and C2-AC1/AC4/AC5 would all still be green**. This criterion also pins NFR2 (no oversubscription), which otherwise has no criterion at all.
+  - `C2-AC10` (**no truncated gate run**) — With gate *k* failing and gates *k+1..n* passing, **all n steps are still reported** and the Results block renders. Guards the `set -e` join abort, which C2-AC2 alone can satisfy coincidentally on a single-failure run.
+  - `C2-AC11` (**`PRE_PR_JOBS` input validation**) — `PRE_PR_JOBS` values `0`, `-1`, `abc`, and `99999` each resolve to a safe bounded value (clamped to `[1, min(nproc,8)]`, non-numeric → default) rather than hanging, forking unbounded, or erroring under `set -u`. CI never sets this variable (verified: `ci.yml:228` passes only `PRE_PR_STATIC_ONLY=1`), so this is a local-developer robustness guard — but an unclear hang mid-run is the kind of result a developer reads as "flaky, push anyway".
+  - `C2-AC2` — Red-proof (RT7), on a scratch copy: the script exits 1, names the failing steps, and prints their context. A single not-last failure is **insufficient** — it can pass by luck even with the red-proven `wait -n` mis-attribution bug. The proof MUST use:
+    - **≥2 failing steps with distinct non-zero exit codes** at **non-adjacent declaration indices** — `failures[]` ordering (I3) is only observable with two or more; a replay that appends in completion order looks correct with exactly one.
+    - **a fast-failing step declared early with ≥2 slow steps declared after it**, so the failure is reaped by the throttle well before dispatch completes. "Not last in declaration order" is under-constrained under bounded concurrency — a step that happens to finish last satisfies it while exercising nothing.
+    - **a named expected `show_failure_context` output path.** That function has three distinct branches (`pre-pr.sh:109-113` vitest anchor, `:115-117` marker fallback, `:121` `tail -20`); the injected failure must be shaped to hit a specific one and the assertion must name expected content — otherwise the criterion passes on the `tail -20` path even if marker extraction broke entirely.
+  - `C2-AC3` — Exit-status fidelity under output pressure: a step emitting **≥1 MB to stdout and ≥100 lines to stderr** before exiting 1 is still reported failed. Volume is pinned deliberately — the `tee` → redirect change alters buffering, and the regression it guards (a truncated/partially-flushed logfile when a job is reaped with output still buffered) only reproduces past the 64 KiB pipe buffer. Assert: (a) status 1 reported, (b) the logfile's **last** line appears in the replay (proves no truncation), (c) a stderr marker such as `^Error:` reaches `show_failure_context` (proves the `2>&1` merge preserved what the extractor greps for).
+  - `C2-AC3` — Exit-status fidelity: a step whose command fails *while writing stdout* is still reported failed (guards the `tee`/`PIPESTATUS` masking regression).
+  - `C2-AC4` — `PRE_PR_JOBS=1` run reports the identical step list and result as the parallel run.
+  - `C2-AC5` — `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` (CI's invocation) passes with identical step set (FR3/R33).
+- **Consumer-flow walkthrough**:
+  - Consumer A (`.github/workflows/ci.yml:228`, `static-checks` job) reads `{ exit code, stdout }` of `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh`. It uses only the exit code to pass/fail the job and stdout for the log. C2 preserves both. It does **not** parse individual step lines, so the buffered-replay change is invisible to it.
+  - Consumer B (developer running `npm run pre-pr`) reads the terminal output — the `▸ label` / `✓`/`✗` lines and the `═══ Failure Context ═══` block. FR4 + I3 keep this diff-comparable to today.
+  - Consumer C (`package.json` `pre-pr` script) reads `{ exit code }` only.
+
+## Go/No-Go Gate
+
+Implementation order is **C1-AC0 → C1 (+C4) → C2 (+C3)**. C1-AC0 is a hard prerequisite: without the extended fixtures, C1 has no working oracle.
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1-AC0 | Extend step-up self-test to cover the rewrite's decision surface (prerequisite, own commit) | locked |
+| C1 | De-spawn `check-step-up-client-coverage.sh` (171 s → ≤5 s), verdicts identical | locked |
+| C2 | Bounded-parallel `run_step` over `pre-pr.sh:158-184`, declaration-order buffered output | locked |
+| C3 | Harness self-test for the scheduler (requires C2 extractability decision) | locked |
+| C4 | `ENV_POLLUTION_GUARD` on the step-up gate's path overrides (folded into C1) | locked |
+
+### C3 — Harness self-test for the parallel scheduler
+
+C2 declares eight machine-checkable invariants (I3–I8) and six forbidden patterns, several annotated *fail-open*, on the harness that runs all ~40 security gates. Today that harness has **zero** automated enforcement, and the gap is structural, not accidental:
+
+- `check-gate-selftest-coverage.sh` enumerates `scripts/checks/*.sh` + `*.mjs` (`:123`) — `scripts/pre-pr.sh` is the *harness*, never a member. The repo's own RT7 meta-gate is blind to the one file C2 rewrites.
+- The two existing pre-pr tests do not touch `run_step`: `pre-pr-env-drift.test.mjs:4` explicitly refuses to spawn the script ("it would recursively invoke vitest") and settles for a source-text grep.
+
+Every gate under `scripts/checks/` carries a self-test precisely because *"a gate with a broken regex/parse path can silently green forever"*. The harness running all of them has a strictly larger blast radius, so a self-test is proportionate.
+
+- **Signature**: `scripts/__tests__/pre-pr-run-step.test.mjs`, driving the scheduler with an **injected fixture step list** — not the real 40-gate list (avoids the vitest-recursion problem that blocked the existing tests).
+- **Testability is a design-time prerequisite (RT2)**: a monolithic `pre-pr.sh` is untestable by construction. C2 MUST therefore either extract the scheduler into a sourceable `scripts/lib/run-steps.sh`, or support an env-injected step list — mirroring the `STEPUP_CLIENT_GUARD_*` fixture-override idiom already used in this repo. **Decide this while designing C2, not after.**
+- **Acceptance criteria**: `C3-AC1` — cases covering I3 (declaration-order replay with 2 non-adjacent failures), I4 (status fidelity under ≥1 MB stdout), I6 (`PRE_PR_JOBS=1` equivalence), I7 (counters survive backgrounding), C2-AC9 (observed overlap), C2-AC11 (`PRE_PR_JOBS` boundary values). `C3-AC2` — each forbidden pattern is red-proven: a fixture harness using bare `wait`, or capturing `wait -n`'s status, must make the suite **fail**. `C3-AC3` — add the extracted lib (or `pre-pr.sh`) to `check-gate-selftest-coverage.sh`'s member set, so the coverage cannot silently regress (R42: otherwise the class is closed for today's file but not the next harness change).
+
+### C4 — Env-pollution guard on the step-up gate (security hardening, folded into C1)
+
+`check-step-up-client-coverage.sh:108-112` honors five path overrides (`STEPUP_CLIENT_GUARD_API_DIR/CLIENT_DIR/PATH_ROOT/EXEMPT_FILE/PATHS_FILE`) plus `STEPUP_CLIENT_GUARD_WINDOW` (`:119`) with **no CI guard** — its comment at `:107` merely *assumes* "Production CI uses the defaults". Pointing `STEPUP_CLIENT_GUARD_CLIENT_DIR` at an empty directory greens the gate completely; `STEPUP_CLIENT_GUARD_WINDOW=0` disables the adjacency check.
+
+The sibling `check-gate-selftest-coverage.sh:63-70` already implements exactly the needed guard (`ENV_POLLUTION_GUARD`), so this gate is the outlier and the pattern is established in-repo. C1 is the moment this file is rewritten and re-reviewed — the cheap time to close it.
+
+- **Acceptance criteria**: `C4-AC1` — under `CI=true`, any `STEPUP_CLIENT_GUARD_*` override without an explicit `STEPUP_CLIENT_GUARD_FIXTURE_MODE=1` acknowledgement exits 1 with an `ENV_POLLUTION_GUARD:` message. `C4-AC2` — a self-test case covers it (the existing suite has none), red-proven.
+
+## Testing strategy
+
+- **C1 — "unchanged and green" is a floor, not a sufficiency proof.** The original strategy ("the suite must stay green unchanged; a self-test edit would itself be a red flag") is sound in one half and unsound in the other, and the distinction is what let the vacuous oracle through. Restated as a sequenced two-part rule:
+  1. **Before C1 lands (separate commit): EXTEND.** Add the C1-AC0 fixtures. Each must be green against today's unmodified script (it encodes current behavior) and red against a scratchpad copy with the relevant rule removed (RT7). Extending is the *opposite* of the red flag: a case red-proven against a narrowed copy is by construction a behavior-preservation assertion that did not previously exist. This step is independently valuable and low-risk, so it can merge even if C1 is later deferred.
+  2. **During C1: FREEZE.** The now-extended suite is frozen. **Editing** an existing case — loosening an assertion, changing an expected string — is exactly the red flag the original strategy described. Forbid it.
+
+  "Unchanged and green" is sufficient only if the suite's coverage is a superset of the rewrite's decision surface. It is not: the call-site × id cross-product is empty, the word-boundary rule is untested against 12 live prefix-pairs, and three loop branches (exempt-id skip, comment-prefix skip, window edges) have no fixture. C1-AC5 (decision-trace) and C1-AC6 (per-dimension mutation-proof) carry the actual safety argument.
+- **C2**: red-proof per C2-AC2 on a **scratchpad copy** of the script, never by mutating the real gate (per prior guidance on mutation-proofs). Serial-equivalence via C2-AC4.
+- **Regression surface**: run the full `npx vitest run scripts/__tests__/` gate-script suite, since C2 touches the harness those gates run under.
+
+## Considerations & constraints
+
+- `SC1` — Heavy Web steps (`Test`, `Build`, `Integration`, `CLI`, `Extension`) stay serial. Deferred deliberately (memory contention + internal parallelism already present). Owner: a future plan if their wall-clock becomes the dominant term after C1/C2 land.
+- `SC2` — `check-fail-closed-routes-have-test.sh` (9.8 s, 479 spawns) is the next hotspot after C1, and is explicitly recorded as **a known repeat member of the R45 scaling class** (plan §Measured baseline notes it already had this identical defect fixed once before). Deferring on a percentage basis alone would be R42-incomplete, so the deferral carries a concrete re-measure trigger rather than a vague "later": re-open when *either* its wall-clock exceeds 15 s *or* the fail-closed manifest grows past ~1.5× its current route count. Not fail-open today; it is a scaling-tail risk. Note it also sets the NFR1 floor (see NFR1), so pulling it into scope is the single change that would move the target below ~10 s.
+- `SC3` — CI runner core count (2–4) is much lower than the 20-core dev machine, so CI's realized speedup from C2 will be proportionally smaller. NFR2's cap exists so CI does not oversubscribe. Not a defect; recorded so the measured-on-dev numbers are not mistaken for CI numbers.
+
+### Platform / runner constraints (verified)
+
+- **bash version — DECIDED: keep bash 3.2 compatibility; `declare -A` is forbidden in C1.** The `static-checks` job runs on `ubuntu-latest` (`.github/workflows/ci.yml:165`), i.e. bash 5.x, and the only `macos-latest` job (`ci.yml:344`, iOS) does not invoke `pre-pr.sh` — so bash-4 features would be safe *in CI*. That is not sufficient grounds to adopt them, because **the script C1 rewrites documents the bash-3.2 constraint as a deliberate design decision, twice**: `check-step-up-client-coverage.sh:154` ("3.2 has no associative arrays — keep parallel newline-delimited lists") and `:203-204` ("bash 3.2 has no associative arrays — same idiom as EXEMPT_MARKERS"). The SC2 sibling repeats it at `check-fail-closed-routes-have-test.sh:84`, `:122`, `:477-478`. No script under `scripts/checks/` uses `declare -A` today.
+
+  A performance refactor is not a licence to silently revoke a stated portability guarantee, and a developer on macOS running `npm run pre-pr` under Apple's stock `/bin/bash` 3.2 is a supported-looking path (`#!/usr/bin/env bash` resolves to system bash unless Homebrew's precedes it on PATH). C1 therefore hoists into **indexed arrays plus a built-once linear-scan index** — the idiom the file already uses via `manifest_line_for`. This costs nothing: the target is O(files + ids), and a linear scan over 50 ids is trivial. It also aligns with C1's own preference for the transformation that leaves semantics untouched by construction.
+
+  Forbidden pattern for C1: `declare -A` — reason: revokes the documented bash-3.2 guarantee at `check-step-up-client-coverage.sh:154`; on bash 3.2 it degrades to a *silent wrong-results* path, not a clean error. If a future decision does raise the floor, it must be made explicitly, propagate to the sibling scripts that document the same constraint (R3), and add a `BASH_VERSINFO` guard.
+- **CI time budget.** `static-checks` declares `timeout-minutes: 8` (`ci.yml:166`). The current 187 s static phase already consumes ~39% of that budget on a fast machine; on a 2-core runner the 171 s hotspot is proportionally worse. This is the R45 exposure that makes C1 a correctness concern and not merely an ergonomics one — a gate that times out in CI does not run at all, which is fail-open. C1 removes that risk margin.
+- **Risk — C1 is a logic-bearing rewrite of a security gate, and the obvious mitigations do not work.** The step-up coverage gate enforces that privileged client call sites carry step-up reauth. A refactor that silently narrows its matching is a fail-open regression.
+
+  This risk was originally mitigated by "the 30-case suite plus a byte-identical differential — a zero-line diff over 189 × 50 pairs is strong evidence the matching set did not move." **That argument was empirically refuted during review and is retracted.** A reviewer built a narrowed gate (merging the `+3` and `+10` windows at `:501-502` — precisely what "read each client file once" invites) that passed **30/30 self-tests and produced a byte-identical differential** while genuinely losing detection. The gate emits **0 lines / 0 bytes on a clean tree**, so the differential compared nothing against nothing; `exit 0 # optimized` passes it too. Zero lines was zero evidence.
+
+  Real mitigation: C1-AC5 (decision-trace differential over ~10,150 real pairs) and C1-AC6 (one mutant per narrowable dimension, each required to turn the gate red), both now mandatory on every path, plus the C1-AC0 fixtures that close the suite's measured blind spots. The general lesson, worth carrying beyond this plan: **for a gate that is silent when healthy, any criterion observing only a green tree is vacuous by construction.**
+- **Risk — R44 masking in the new parallel path.** The current `run_step` is R44-correct via `PIPESTATUS[0]`. Backgrounding is exactly where that correctness is easiest to lose. C2-AC3 exists specifically to pin it.
+
+## User operation scenarios
+
+1. Developer runs `npm run pre-pr` on a Web-touching branch with all checks green → sees the same step list in the same order, static phase completing in seconds rather than ~3 minutes.
+2. Developer runs it with one static check failing → the failing step appears in `═══ Results ═══` and its context block renders as today; exit code 1.
+3. CI `static-checks` job runs `PRE_PR_STATIC_ONLY=1` on a 2-core runner → identical step set, bounded concurrency, no oversubscription.
+4. Developer on an iOS-only branch → `RUN_WEB=0` path still skips Web steps; the iOS static guards still run.
+5. Developer debugging a flaky-looking parallel interaction sets `PRE_PR_JOBS=1` → fully serial, today's exact behavior.

--- a/docs/archive/review/pre-pr-parallelization-review.md
+++ b/docs/archive/review/pre-pr-parallelization-review.md
@@ -1,0 +1,129 @@
+# Plan Review: pre-pr-parallelization
+Date: 2026-07-26
+Review round: 1
+
+## Changes from Previous Round
+
+Initial review. Local LLM pre-screening ran first (3 findings, all fixed before expert review): missing parallel-output synchronization detail, `.mjs`-port behavioral-drift risk, and unspecified stderr handling.
+
+## Headline outcome
+
+Three experts reviewed independently. **Two converged on the same Critical**: the plan's C1 safety argument was a vacuous oracle. Per the perspective-convergence rule this sets a Critical severity floor, and it was the finding that reshaped the plan.
+
+The security expert did not merely assert it — they **built the counter-example**: a narrowed gate (merging the `arg_window` `+3` and `opt_window` `+10` reads at `check-step-up-client-coverage.sh:501-502`, exactly what the plan's own "read each client file once" wording invites) that passed **30/30 self-tests AND produced a byte-identical differential**, while genuinely losing detection of a `"PUT"` literal at offset +6.
+
+Independently re-verified by the orchestrator: the gate emits **0 lines / 0 bytes on a clean tree**, so the original `C1-AC2` reduced to `diff /dev/null /dev/null`. It would have passed `exit 0 # optimized`.
+
+Four defects were red-proven with executable probes rather than argued:
+
+| # | Claim | Probe result |
+|---|---|---|
+| 1 | `wait -n` status capture mis-attributes verdicts | declaration truth `0 0 7` → reported **`7 0 0`** (failing step reported as passing) |
+| 2 | Per-index join under `set -e` aborts the run | `SCRIPT EXIT=7`, steps 1–2 never joined, Results block never printed |
+| 3 | Backgrounded jobs cannot mutate parent counters | `passed=0` after a job incremented it |
+| 4 | Gate is silent when healthy | `0 0` lines/bytes, exit 0 |
+
+## Functionality Findings
+
+**F1 (Critical)** — `wait -n` status capture mis-attributes verdicts. Bash's `wait -n` returns *a* status without identifying which job produced it, so assigning it to the dispatch loop's index blames the wrong step. Orchestrator-verified: `7 0 0` against a truth of `0 0 7` — a failing security gate reported as passing (R44 fail-open). The plan's stated hazard (that a later per-PID `wait` returns 127) was also factually wrong: bash retains reaped-child statuses, verified `0 7 0 9 0` across a `wait -n` throttle. **Resolution**: `wait -n` demoted to a pure throttle with its status discarded; statuses read only in the join phase per index. Old mechanism added to forbidden patterns.
+
+**F2 (Critical)** — Exit status 127 is ambiguous: a step whose interpreter is missing exits 127, indistinguishable from `wait`'s "no such job". Branching on it as a bookkeeping artifact fails open exactly on environment drift. **Resolution**: contract now forbids treating any `wait` return as a control signal; `C2-AC6` added.
+
+**F3 (Major)** — Invariant I4 mandated a `PIPESTATUS[0]` read that the pipeline-free design structurally removes (design deadlock), and dropping `tee` silently loses *passing*-step stdout. Verified: `check-gate-selftest-coverage.sh` and `check-destructive-wrapper-derivation.mjs` both print CI-auditable config on success. **Resolution**: I4 rewritten around `wait`; new I8 + `C2-AC7` require replaying passing-step logs.
+
+**F4 (Major)** — Plan never stated that counters must be mutated only in the parent shell. Verified hazard: a backgrounded increment is silently discarded, yielding `Passed: 0 / Failed: 0` with exit 0. **Resolution**: I7 added.
+
+**F5 (Major)** — The enqueue/dispatch split breaks the script's non-`run_step` steps. Mechanically derived member set: **6 `printf`-only skip notices + 9 inline counter mutations** would execute at enqueue time and print before all replayed results. **Resolution**: C2 scope narrowed to the contiguous `run_step` block at `pre-pr.sh:158-184`; everything from `:186` on is unchanged (`SC4`).
+
+**F6 (Major)** — C1's `declare -A` hoist would silently revoke a documented bash-3.2 guarantee. Verified: the target script states it twice (`:154`, `:203-204`), the SC2 sibling four times. **Resolution**: `declare -A` added to forbidden patterns; indexed-array hoist mandated.
+
+**F7 (Major)** — Forbidden-pattern list named only `manifest_line_for`, permitting a half-fix that leaves 4–6 spawns per iteration; and the plan conflated per-file with per-call-site windows — hoisting `arg_window` to file scope would widen matching from 4 lines to the whole file. **Resolution**: scope table added distinguishing the four windows; four more forbidden patterns added.
+
+**F8 (Minor)** — NFR1's ≤10 s target is arithmetically unreachable: SC2's untouched 9.82 s check alone consumes it. **Resolution**: retargeted to ≤15 s (dev) / ≈20 s (CI), with the reasoning recorded.
+
+**F9 (Minor)** — Parallel-safety table asserted a completeness claim ("only two writers") by inspection. **Resolution**: re-derived mechanically. The suspected third writer (`check-workflow-supply-chain.mjs`) has no write calls, and `check-dockerignore-secrets.sh`'s probe paths are string literals, not files. The two-writer claim held, but is now auditable (R42).
+
+**F10 (Minor)** — Consumer B note was inaccurate: a basename-preserving `.sh`→`.mjs` port *keeps* the self-test binding; the real hazard is leaving the `.sh` as a wrapper. **Resolution**: corrected; `C1-AC7` machine-checks it.
+
+**F11 (Minor, [Adjacent])** — `C2-AC2`'s "not last" red-proof is too weak to catch mis-attribution. **Resolution**: folded into the strengthened `C2-AC2` (see T6).
+
+## Security Findings
+
+**S1 (Critical, escalate: true)** — C1's verification is a vacuous oracle; counter-example built and verified (see Headline outcome). Impact: check 6 is the tripwire catching *new, unmarked* privileged call sites for already-covered ids; a narrowing silently stops enforcing step-up reauth in CI as well as locally, and stays green forever. **Resolution**: `C1-AC5` (decision-trace over ~10,150 pairs) and `C1-AC6` (one mutant per narrowable dimension, corpus code-derived per R42) promoted from escalation-only to **mandatory on every path**; the retracted "zero-line diff is strong evidence" claim is explicitly marked retracted in the plan.
+
+**S2 (Critical, escalate: false)** — The specified join phase aborts under the harness's own `set -euo pipefail` (`pre-pr.sh:4`). Orchestrator-verified: `SCRIPT EXIT=7` with steps 1–2 never joined and no Results block. Not fail-open (CI still reds), but it **truncates the gate run** — every check after the first failure is never evaluated, so fixing one gate can reveal a second previously-unreported violation with no sign the set was cut short. **Resolution**: `set -e`-safe capture (`if wait …; then ec=0; else ec=$?; fi`) mandated with the probe recorded; `C2-AC10` added.
+
+**S3 (Major)** — Restates F1 from the security angle (mis-attribution as R44 fail-open). Merged with F1.
+
+**S4 (Major)** — No criterion pins the executed **step set**. A silently un-dispatched gate lowers both the set and the count consistently, so count-vs-count cannot detect it — any of ~40 guards could stop running while the harness reports all-green. **Resolution**: `C2-AC8` added (label set-equality against a checked-in manifest, failing in both directions).
+
+**S5 (Major)** — `PRE_PR_JOBS` unvalidated: `0` blocks forever, huge values oversubscribe (NFR2 unenforced). CI never sets it, so this is developer-robustness. **Resolution**: clamping mandated; `C2-AC11` added.
+
+**S6 (Major)** — The step-up gate honors five path overrides plus a window override with **no CI guard**; its comment merely assumes "Production CI uses the defaults". Pointing `STEPUP_CLIENT_GUARD_CLIENT_DIR` at an empty dir greens it entirely. The sibling `check-gate-selftest-coverage.sh:63-70` already implements the needed `ENV_POLLUTION_GUARD`, making this gate the outlier. **Resolution**: new contract **C4** folds the guard into C1, with a red-proven self-test.
+
+**S7 (Minor)** — `C1-AC4` counted only `grep` spawns; converting `grep`→`awk` would satisfy it. **Resolution**: counts all spawn types; demoted to diagnostic.
+
+**S8 (Minor)** — Escalation re-binds Consumer B with no criterion. **Resolution**: `C1-AC7`.
+
+**S9 (Minor, [Adjacent])** — SC2 defers a *known repeat member* of the R45 class on a percentage basis. **Resolution**: deferral now carries a concrete re-measure trigger (>15 s, or manifest growth >1.5×).
+
+## Testing Findings
+
+**T1 (Critical)** — `C1-AC2` measured vacuous (0 bytes). Converges with S1. **Resolution**: as S1.
+
+**T2 (Critical)** — The oracle's **call-site × manifest-id cross-product is empty**: no fixture has two ids that can both reach one call site, so every check-6 execution in the suite iterates a manifest of cardinality 1. Cross-contamination between ids or files — the exact bug class hoisting introduces — is unobservable. **Resolution**: `C1-AC0` multi-id and multi-file fixtures.
+
+**T3 (Critical)** — The token word-boundary rule and ERE escaping are untested, yet **12 genuine prefix pairs exist in the live manifest** (e.g. `apiPath.tenantBreakglass` / `…ById`). A rewrite mis-implementing the boundary as a full-word anchor *narrows* matching (fail-open) and passes all 30 cases. **Resolution**: `C1-AC0` fixtures using a real live prefix pair, plus an escaping fixture (`API_PATH.WIDGETS` vs `API_PATHxWIDGETS`).
+
+**T4 (Major)** — Plan claimed 5 `UNMARKED_CALLSITE_CANDIDATE` assertions. Orchestrator-verified: 5 raw occurrences, but 1 is a header comment and 1 asserts the *pass* path — so **3 failure assertions**, two sharing a fixture shape. **Resolution**: corrected in `C1-AC1`, which is now explicitly a floor rather than the oracle.
+
+**T5 (Major)** — Three hot-loop branches have no fixture: exempt-id skip (`:512`), comment-prefix skip (`:491-494`), and window edges (all 20 fixture call sites are single-line, so `+3`/`+10`/`-3` bounds are never probed). **Resolution**: `C1-AC0`.
+
+**T6 (Major)** — `C2-AC2`/`AC3` under-specified: "not last" is under-constrained under bounded concurrency; a single failure cannot observe `failures[]` ordering; "prints its context" is not an assertion (three distinct `show_failure_context` branches); no stdout volume pinned, though the truncation regression needs >64 KiB. **Resolution**: both criteria rewritten with concrete shapes (≥2 non-adjacent failures, fast-fail-early + slow-after, named context branch, ≥1 MB stdout + stderr markers).
+
+**T7 (Major, RT4)** — **C2's entire acceptance set is unfalsifiable**: since C1 alone meets the wall-clock target, C2 could be a complete no-op and `C2-AC1/AC4/AC5` would still be green. A dispatcher that silently degenerates to serial passes everything. **Resolution**: `C2-AC9` observes peak overlap directly (≥2 and ≤`PRE_PR_JOBS`), which also pins NFR2 for the first time.
+
+**T8 (Major)** — No self-test for `run_step`, and the gap is structural: `check-gate-selftest-coverage.sh` enumerates `scripts/checks/*` only, so the harness is never a member; existing pre-pr tests explicitly refuse to spawn the script. Eight fail-open-annotated invariants on the runner of all 40 gates, with zero enforcement. **Resolution**: new contract **C3** (harness self-test), with the extractability decision flagged as a **design-time** prerequisite (RT2), plus adding the harness to the meta-gate member set (R42).
+
+**T9 (Major)** — "Unchanged and green" conflates *edit* with *extend*; sound as a floor, unsound as sufficiency. **Resolution**: testing strategy restated as sequenced extend-then-freeze, with each new case required green-on-current and red-on-narrowed-copy (RT7).
+
+**T10 / T11 / T12 (Minor)** — spawn-count proxy, missing measurement protocol, missing Consumer B criterion. **Resolution**: all folded into `C1-AC3`/`C1-AC4`/`C1-AC7`.
+
+**T13 (Minor, [Adjacent])** — `PRE_PR_JOBS` boundary values. Merged with S5 → `C2-AC11`.
+
+## Adjacent Findings
+
+- F11 → merged into `C2-AC2` (testing scope)
+- S9 → SC2 re-measure trigger (functionality scope)
+- T13 → merged into S5 / `C2-AC11` (security scope)
+
+## Quality Warnings
+
+One reviewer claim was **not** confirmed and was rejected rather than adopted: F9's suspected third temp-writer (`check-workflow-supply-chain.mjs`) has no write calls at all. The completeness *concern* was still valid, so the member set was re-derived mechanically — but no false entry was added. Similarly, a reviewer's "49 manifest ids" was off by one (verified: 50), and the same reviewer's claim that `wait <pid>` returns 127 after `wait -n` was refuted by probe.
+
+## Resolution summary
+
+| Severity | Count | Status |
+|---|---|---|
+| Critical | 5 (F1, F2, S1/T1, S2, T2, T3 — S1/T1 converged) | all resolved in plan |
+| Major | 13 | all resolved in plan |
+| Minor | 8 | all resolved in plan |
+
+Plan grew from 2 contracts to 5 (C1-AC0 prerequisite, C1, C2, C3 harness self-test, C4 env guard), from 11 to 24 acceptance criteria, and from 6 to 8 invariants. Implementation order: **C1-AC0 → C1 (+C4) → C2 (+C3)**.
+
+## Recurring Issue Check
+
+### Functionality expert
+R1 pass · R2 pass · R3 **fail** (F6, F7) · R4 n-a · R5 n-a · R6 n-a · R7 n-a · R8 n-a · R9 n-a · R10 n-a · R11 n-a · R12 n-a · R13 n-a · R14 n-a · R15 n-a · R16 **fail** (F6, F8) · R17 n-a · R18 n-a · R19 n-a · R20 n-a · R21 n-a · R22 n-a · R23 n-a · R24 n-a · R25 n-a · R26 n-a · R27 n-a · R28 n-a · R29 n-a · R30 n-a · R31 n-a · R32 pass · R33 pass · R34 n-a · R35 n-a · R36 n-a · R37 n-a · R38 n-a · R39 n-a · R40 n-a · R41 n-a · R42 **fail** (F5, F9) · R43 n-a · R44 **fail** (F1, F2, F3) · R45 pass · R46 n-a
+
+### Security expert
+R1 pass · R2 pass · R3 **fail** (S1) · R4-R41 pass/n-a · R42 **fail** (S4, S1) · R43 pass · R44 **fail** (S2, S3) · R45 **fail** (S9) · R46 pass
+RS1 pass · RS2 pass · RS3 **fail** (S1 — mutation-proof was escalation-only, so the bash path shipped with no red-proof) · RS4 pass · RS5 pass · RS6 pass
+
+### Testing expert
+R1-R41 pass (R35 n-a) · R42 **fail** (T8) · R43 pass · R44 pass · R45 pass · R46 pass
+RT1 pass · RT2 **fail** (T8 — monolithic harness untestable; extraction is design-time) · RT3 pass · RT4 **fail** (T7) · RT5 pass · RT6 pass · RT7 **fail** (T1, T2, T3, T5) · RT8 **fail** (T5 — exempt-id and comment-prefix denial paths unexercised) · RT9 pass
+
+## Next round
+
+All findings are reflected in `pre-pr-parallelization-plan.md`. Round 2 should verify the plan edits are correct and complete, focusing on: the rewritten C2 scheduling section, the C1-AC0 fixture list's coverage of the C1-AC6 mutant dimensions, and whether C3's extractability requirement is specified concretely enough to implement.

--- a/scripts/__tests__/check-step-up-client-coverage.test.mjs
+++ b/scripts/__tests__/check-step-up-client-coverage.test.mjs
@@ -1148,6 +1148,35 @@ describe("check-step-up-client-coverage.sh", () => {
     expect(stdout).toContain("use-widget-slow-edit.ts");
   });
 
+  it("(env-guard) refuses STEPUP_CLIENT_GUARD_* overrides under CI without FIXTURE_MODE", () => {
+    // Every path override can silently green this gate — pointing CLIENT_DIR at
+    // an empty tree leaves nothing to scan. Under CI that can only be accidental
+    // or malicious, so it must fail closed rather than report a green gate.
+    // Same contract as check-gate-selftest-coverage.sh's sec-F6 guard.
+    writePathsManifest({
+      "widget-put": { method: "PUT", pathTokens: ["/api/widgets"] },
+    });
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "// @stepup id:widget-put",
+        'const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        "if (await handleStepUpError(res, trigger)) return;",
+      ].join("\n") + "\n",
+    );
+    // Sanity: with the acknowledgement, this same fixture set passes.
+    expect(runGuard({ CI: "true" }).exitCode).toBe(0);
+
+    // Without it, the overrides must be refused outright.
+    const denied = runGuard({ CI: "true", STEPUP_CLIENT_GUARD_FIXTURE_MODE: "" });
+    expect(denied.exitCode).toBe(1);
+    expect(denied.stdout).toContain("ENV_POLLUTION_GUARD");
+  });
+
   it("(xxvi) exempt ids never raise UNMARKED_CALLSITE_CANDIDATE", () => {
     // An exempt id's own accepted call site carries no standard `@stepup id:`
     // marker by design (its recovery is custom or non-interactive). Check 6

--- a/scripts/__tests__/check-step-up-client-coverage.test.mjs
+++ b/scripts/__tests__/check-step-up-client-coverage.test.mjs
@@ -879,4 +879,336 @@ describe("check-step-up-client-coverage.sh", () => {
     const { exitCode, stdout } = runGuard();
     expect(exitCode, stdout).toBe(0);
   });
+
+  // ---------------------------------------------------------------------
+  // Check-6 decision-surface fixtures (xix–xxv).
+  //
+  // Check 6 iterates the cross-product `call sites × manifest ids`. Every
+  // fixture above happens to run that loop with exactly ONE candidate id and a
+  // single-line call site, so the loop's per-id and per-window decisions are
+  // never actually discriminated — a cache that leaked id A's method onto id B,
+  // or that widened a call-site window to whole-file scope, would keep the
+  // suite green. These fixtures pin those decisions directly.
+  //
+  // Each was red-proven against a deliberately-broken copy of the guard before
+  // being committed; the mutation that each one catches is named in its title.
+  // ---------------------------------------------------------------------
+
+  it("(xix) discriminates BY METHOD across two ids sharing a path token", () => {
+    // Two ids, same pathTokens, different methods. The call site is a PUT, so
+    // only widget-put may be reported. Red-proves a hoist that pairs one id's
+    // method with another id's tokens.
+    writePathsManifest({
+      "widget-put": { method: "PUT", pathTokens: ["/api/widgets"] },
+      "widget-post": { method: "POST", pathTokens: ["/api/widgets"] },
+    });
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    writeRoute(
+      "widgets",
+      `// @stepup id:widget-post method:POST\n${STEPUP_CALL}\n`,
+    );
+    // Both ids covered by properly-marked call sites.
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "// @stepup id:widget-put",
+        'const a = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        "if (await handleStepUpError(a, trigger)) return;",
+        "// @stepup id:widget-post",
+        'const b = await fetchApi("/api/widgets", { method: "POST" });',
+        "if (await handleStepUpError(b, trigger)) return;",
+      ].join("\n") + "\n",
+    );
+    // Unmarked PUT call site: matches widget-put only.
+    writeClient(
+      "hooks/use-widget-quick-edit.ts",
+      [
+        "async function quickEdit(id) {",
+        '  const res = await fetchApi(`/api/widgets/${id}`, { method: "PUT" });',
+        "  if (!res.ok) throw new Error('failed');",
+        "}",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("UNMARKED_CALLSITE_CANDIDATE");
+    expect(stdout).toContain("widget-put");
+    // The POST id must NOT be attributed to this PUT call site.
+    expect(stdout).not.toContain("widget-post");
+  });
+
+  it("(xx) scopes the client marker per FILE, not globally", () => {
+    // File A carries the marker; file B does not. Both call the same gated
+    // path+method. Red-proves a `file_marker_ids` cache that leaks A's marker
+    // into B's iteration (which would silently clear B).
+    writePathsManifest({
+      "widget-put": { method: "PUT", pathTokens: ["/api/widgets"] },
+    });
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "// @stepup id:widget-put",
+        'const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        "if (await handleStepUpError(res, trigger)) return;",
+      ].join("\n") + "\n",
+    );
+    writeClient(
+      "components/widget-row.tsx",
+      [
+        "async function save(id) {",
+        '  const res = await fetchApi(`/api/widgets/${id}`, { method: "PUT" });',
+        "  if (!res.ok) throw new Error('failed');",
+        "}",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("UNMARKED_CALLSITE_CANDIDATE");
+    expect(stdout).toContain("widget-row.tsx");
+    // The marked file must not be reported.
+    expect(stdout).not.toContain("widget-card.tsx");
+  });
+
+  it("(xxi) token matching respects the word boundary (prefix id must not match its longer sibling)", () => {
+    // Mirrors a real shape in the live manifest, where 12 token prefix-pairs
+    // exist (e.g. apiPath.tenantBreakglass vs apiPath.tenantBreakglassById).
+    // The call site uses ONLY the longer identifier, so the short id must not
+    // match it. Red-proves dropping the `([^A-Za-z0-9_]|$)` suffix at :537.
+    writePathsManifest({
+      "breakglass-list": {
+        method: "POST",
+        pathTokens: ["apiPath.tenantBreakglass"],
+      },
+      "breakglass-by-id": {
+        method: "POST",
+        pathTokens: ["apiPath.tenantBreakglassById"],
+      },
+    });
+    writeRoute(
+      "tenant/breakglass",
+      `// @stepup id:breakglass-list method:POST\n${STEPUP_CALL}\n`,
+    );
+    writeRoute(
+      "tenant/breakglass/[id]",
+      `// @stepup id:breakglass-by-id method:POST\n${STEPUP_CALL}\n`,
+    );
+    // Cover both ids with marked call sites.
+    writeClient(
+      "components/breakglass-panel.tsx",
+      [
+        "// @stepup id:breakglass-list",
+        'const a = await fetchApi(apiPath.tenantBreakglass, { method: "POST" });',
+        "if (await handleStepUpError(a, trigger)) return;",
+        "// @stepup id:breakglass-by-id",
+        'const b = await fetchApi(apiPath.tenantBreakglassById(x), { method: "POST" });',
+        "if (await handleStepUpError(b, trigger)) return;",
+      ].join("\n") + "\n",
+    );
+    // Unmarked call site referencing ONLY the longer identifier.
+    writeClient(
+      "hooks/use-breakglass.ts",
+      [
+        "async function revoke(x) {",
+        '  const res = await fetchApi(apiPath.tenantBreakglassById(x), { method: "POST" });',
+        "  if (!res.ok) throw new Error('failed');",
+        "}",
+        "",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("UNMARKED_CALLSITE_CANDIDATE");
+    expect(stdout).toContain("breakglass-by-id");
+    // The shorter id is a strict prefix of the identifier actually used; the
+    // word-boundary rule must keep it out of the report.
+    expect(stdout).not.toContain("id 'breakglass-list'");
+  });
+
+  it("(xxii) escapes ERE metacharacters in tokens (a literal dot must not act as a wildcard)", () => {
+    // Token contains a `.`; the call site contains the same string with the dot
+    // replaced by `x`. Unescaped, `.` matches `x` and the site is flagged.
+    // Red-proves dropping the escaping at :536.
+    writePathsManifest({
+      "widget-put": { method: "PUT", pathTokens: ["API_PATH.WIDGETS"] },
+    });
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "// @stepup id:widget-put",
+        'const res = await fetchApi(API_PATH.WIDGETS, { method: "PUT" });',
+        "if (await handleStepUpError(res, trigger)) return;",
+      ].join("\n") + "\n",
+    );
+    // `API_PATHxWIDGETS` matches the token only if the dot stays a wildcard.
+    writeClient(
+      "hooks/use-unrelated.ts",
+      [
+        "async function unrelated() {",
+        '  const res = await fetchApi(API_PATHxWIDGETS, { method: "PUT" });',
+        "  if (!res.ok) throw new Error('failed');",
+        "}",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode, stdout).toBe(0);
+  });
+
+  it("(xxiii) skips fetchApi occurrences inside comments", () => {
+    // A commented-out call site (both `//` and JSDoc `*` forms) is not a real
+    // call site. Red-proves dropping the comment-prefix skip at :491-494.
+    writePathsManifest({
+      "widget-put": { method: "PUT", pathTokens: ["/api/widgets"] },
+    });
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "// @stepup id:widget-put",
+        'const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        "if (await handleStepUpError(res, trigger)) return;",
+      ].join("\n") + "\n",
+    );
+    writeClient(
+      "hooks/use-widget-docs.ts",
+      [
+        "/**",
+        ' * Example usage — not a real call site:',
+        ' *   const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        " */",
+        '// const legacy = await fetchApi("/api/widgets/y", { method: "PUT" });',
+        "export const NOTE = 1;",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode, stdout).toBe(0);
+  });
+
+  it("(xxiv) honors the options-window upper bound (method literal at +10 is in scope)", () => {
+    // The `method:` literal sits 10 lines below the fetchApi( line — the exact
+    // upper edge of opt_window. Red-proves narrowing that window (e.g. merging
+    // it with arg_window's +3), which would silently stop flagging this site.
+    writePathsManifest({
+      "widget-put": { method: "PUT", pathTokens: ["/api/widgets"] },
+    });
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "// @stepup id:widget-put",
+        'const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        "if (await handleStepUpError(res, trigger)) return;",
+      ].join("\n") + "\n",
+    );
+    writeClient(
+      "hooks/use-widget-slow-edit.ts",
+      [
+        "async function slowEdit(id) {", //           F-1
+        "  const res = await fetchApi(", //           F+0  (call site)
+        "    `/api/widgets/${id}`,", //               F+1  (token, within +3)
+        "    {", //                                   F+2
+        "      headers: buildHeaders(),", //          F+3
+        "      credentials: 'include',", //           F+4
+        "      cache: 'no-store',", //                F+5
+        "      redirect: 'follow',", //               F+6
+        "      referrerPolicy: 'no-referrer',", //    F+7
+        "      keepalive: false,", //                 F+8
+        "      mode: 'cors',", //                     F+9
+        '      method: "PUT",', //                    F+10 (upper edge)
+        "    },", //                                  F+11
+        "  );", //
+        "  return res;",
+        "}",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("UNMARKED_CALLSITE_CANDIDATE");
+    expect(stdout).toContain("use-widget-slow-edit.ts");
+  });
+
+  it("(xxvi) exempt ids never raise UNMARKED_CALLSITE_CANDIDATE", () => {
+    // An exempt id's own accepted call site carries no standard `@stepup id:`
+    // marker by design (its recovery is custom or non-interactive). Check 6
+    // must skip exempt ids entirely — otherwise every exempt id's known call
+    // site is reported as a new gap. No prior fixture reaches this branch:
+    // the only exempt fixture writes a client file with no fetchApi( at all.
+    writePathsManifest({
+      "widget-put": { method: "PUT", pathTokens: ["/api/widgets"] },
+    });
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    // Exempt via a named custom marker, which must appear in client code.
+    writeFileSync(
+      exemptFile,
+      "widget-put   CUSTOM_WIDGET_RECOVERY  # fixture: bespoke recovery flow, no standard marker\n",
+      "utf8",
+    );
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "// bespoke recovery path, no @stepup marker by design",
+        "const CUSTOM_WIDGET_RECOVERY = true;",
+        'const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        "if (!res.ok) showBespokeReauth();",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode, stdout).toBe(0);
+    expect(stdout).not.toContain("UNMARKED_CALLSITE_CANDIDATE");
+  });
+
+  it("(xxv) honors the suppression-window lower bound (@stepup-path-ok at L-3 suppresses)", () => {
+    // suppress_window spans L-3..L. A suppression comment exactly 3 lines above
+    // the call must still apply. Red-proves narrowing that window.
+    writePathsManifest({
+      "widget-put": { method: "PUT", pathTokens: ["/api/widgets"] },
+    });
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "// @stepup id:widget-put",
+        'const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        "if (await handleStepUpError(res, trigger)) return;",
+      ].join("\n") + "\n",
+    );
+    writeClient(
+      "hooks/use-widget-quick-edit.ts",
+      [
+        "async function quickEdit(id) {",
+        "  // @stepup-path-ok id:widget-put confirmed false positive: preview-only path, never mutates in prod", // L-3
+        "  const url = buildUrl(id);", //                                                                          L-2
+        "  const headers = buildHeaders();", //                                                                    L-1
+        '  const res = await fetchApi(`/api/widgets/${id}`, {', //                                                  L (call site)
+        '    method: "PUT",', //                                            L+1 — must stay BELOW: opt_window scans L..L+10 only
+        "  });",
+        "  if (!res.ok) throw new Error('failed');",
+        "}",
+      ].join("\n") + "\n",
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode, stdout).toBe(0);
+  });
 });

--- a/scripts/__tests__/check-step-up-client-coverage.test.mjs
+++ b/scripts/__tests__/check-step-up-client-coverage.test.mjs
@@ -1148,35 +1148,6 @@ describe("check-step-up-client-coverage.sh", () => {
     expect(stdout).toContain("use-widget-slow-edit.ts");
   });
 
-  it("(env-guard) refuses STEPUP_CLIENT_GUARD_* overrides under CI without FIXTURE_MODE", () => {
-    // Every path override can silently green this gate — pointing CLIENT_DIR at
-    // an empty tree leaves nothing to scan. Under CI that can only be accidental
-    // or malicious, so it must fail closed rather than report a green gate.
-    // Same contract as check-gate-selftest-coverage.sh's sec-F6 guard.
-    writePathsManifest({
-      "widget-put": { method: "PUT", pathTokens: ["/api/widgets"] },
-    });
-    writeRoute(
-      "widgets/[id]",
-      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
-    );
-    writeClient(
-      "components/widget-card.tsx",
-      [
-        "// @stepup id:widget-put",
-        'const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
-        "if (await handleStepUpError(res, trigger)) return;",
-      ].join("\n") + "\n",
-    );
-    // Sanity: with the acknowledgement, this same fixture set passes.
-    expect(runGuard({ CI: "true" }).exitCode).toBe(0);
-
-    // Without it, the overrides must be refused outright.
-    const denied = runGuard({ CI: "true", STEPUP_CLIENT_GUARD_FIXTURE_MODE: "" });
-    expect(denied.exitCode).toBe(1);
-    expect(denied.stdout).toContain("ENV_POLLUTION_GUARD");
-  });
-
   it("(xxvi) exempt ids never raise UNMARKED_CALLSITE_CANDIDATE", () => {
     // An exempt id's own accepted call site carries no standard `@stepup id:`
     // marker by design (its recovery is custom or non-interactive). Check 6

--- a/scripts/__tests__/check-step-up-client-coverage.test.mjs
+++ b/scripts/__tests__/check-step-up-client-coverage.test.mjs
@@ -83,7 +83,7 @@ let clientDir;
 let exemptFile;
 let pathsFile;
 
-function runGuard() {
+function runGuard(extraEnv = {}) {
   const r = spawnSync("bash", [GUARD], {
     encoding: "utf8",
     env: {
@@ -93,6 +93,11 @@ function runGuard() {
       STEPUP_CLIENT_GUARD_PATH_ROOT: root,
       STEPUP_CLIENT_GUARD_EXEMPT_FILE: exemptFile,
       STEPUP_CLIENT_GUARD_PATHS_FILE: pathsFile,
+      // The guard refuses STEPUP_CLIENT_GUARD_* overrides under CI unless the
+      // caller acknowledges it is a fixture run (ENV_POLLUTION_GUARD). This
+      // suite is exactly that caller.
+      STEPUP_CLIENT_GUARD_FIXTURE_MODE: "1",
+      ...extraEnv,
     },
   });
   return { exitCode: r.status, stdout: r.stdout, stderr: r.stderr };
@@ -1141,6 +1146,35 @@ describe("check-step-up-client-coverage.sh", () => {
     expect(exitCode).toBe(1);
     expect(stdout).toContain("UNMARKED_CALLSITE_CANDIDATE");
     expect(stdout).toContain("use-widget-slow-edit.ts");
+  });
+
+  it("(env-guard) refuses STEPUP_CLIENT_GUARD_* overrides under CI without FIXTURE_MODE", () => {
+    // Every path override can silently green this gate — pointing CLIENT_DIR at
+    // an empty tree leaves nothing to scan. Under CI that can only be accidental
+    // or malicious, so it must fail closed rather than report a green gate.
+    // Same contract as check-gate-selftest-coverage.sh's sec-F6 guard.
+    writePathsManifest({
+      "widget-put": { method: "PUT", pathTokens: ["/api/widgets"] },
+    });
+    writeRoute(
+      "widgets/[id]",
+      `// @stepup id:widget-put method:PUT\n${STEPUP_CALL}\n`,
+    );
+    writeClient(
+      "components/widget-card.tsx",
+      [
+        "// @stepup id:widget-put",
+        'const res = await fetchApi("/api/widgets/x", { method: "PUT" });',
+        "if (await handleStepUpError(res, trigger)) return;",
+      ].join("\n") + "\n",
+    );
+    // Sanity: with the acknowledgement, this same fixture set passes.
+    expect(runGuard({ CI: "true" }).exitCode).toBe(0);
+
+    // Without it, the overrides must be refused outright.
+    const denied = runGuard({ CI: "true", STEPUP_CLIENT_GUARD_FIXTURE_MODE: "" });
+    expect(denied.exitCode).toBe(1);
+    expect(denied.stdout).toContain("ENV_POLLUTION_GUARD");
   });
 
   it("(xxvi) exempt ids never raise UNMARKED_CALLSITE_CANDIDATE", () => {

--- a/scripts/__tests__/pre-pr-env-drift.test.mjs
+++ b/scripts/__tests__/pre-pr-env-drift.test.mjs
@@ -52,9 +52,16 @@ describe("pre-pr.sh env drift wiring (T18)", () => {
       "utf8",
     );
 
-    // CT9: soft pattern — asserts the drift-check step is wired via run_step
-    // with `npm run check:env-docs` but tolerates small label text changes,
-    // so a cosmetic rename does not silently regress the wiring check.
-    expect(prePrContent).toMatch(/run_step[\s\S]{0,120}check:env-docs/);
+    // CT9: soft pattern — asserts the drift-check step is wired as a step with
+    // `npm run check:env-docs` but tolerates small label text changes, so a
+    // cosmetic rename does not silently regress the wiring check.
+    //
+    // Matches either dispatcher: steps run serially via `run_step` or are
+    // queued via `queue_step` for the bounded-parallel batch. Anchoring on
+    // `run_step` alone silently passed after this step moved to `queue_step`,
+    // because an unrelated later `run_step` fell inside the 120-char window.
+    expect(prePrContent).toMatch(
+      /(?:run_step|queue_step)[\s\S]{0,120}check:env-docs/,
+    );
   });
 });

--- a/scripts/__tests__/pre-pr-run-batch.test.mjs
+++ b/scripts/__tests__/pre-pr-run-batch.test.mjs
@@ -40,6 +40,7 @@ const SCHED_START = "batch_labels=()";
 const SCHED_END = '\nprintf "${BOLD}═══ Pre-PR Checks';
 
 let scheduler;
+let prePrSource;
 
 beforeAll(() => {
   const src = readFileSync(PRE_PR, "utf8");
@@ -103,6 +104,67 @@ beforeAll(() => {
   // The join shape is only load-bearing under `set -e`; the harness re-declares
   // it, so pin that pre-pr.sh still sets it rather than letting the two drift.
   expect(src, "pre-pr.sh must keep set -euo pipefail").toMatch(/^set -euo pipefail$/m);
+
+  prePrSource = src;
+});
+
+describe("heavy-step wiring", () => {
+  /** Line index of the first `queue_step "<label>"`, or -1. */
+  const queueLine = (label) =>
+    prePrSource
+      .split("\n")
+      .findIndex((l) => new RegExp(`^\\s*queue_step "${label}"`).test(l));
+
+  /** Line index of the first run_batch strictly after `from`. */
+  const batchAfter = (from) =>
+    prePrSource
+      .split("\n")
+      .findIndex((l, i) => i > from && /^\s*run_batch\s*$/.test(l));
+
+  // Each pair is an ordering constraint: `after` must observe `before`'s output.
+  it.each([
+    ["CLI: Build", "CLI: Test", "cli/dist must exist before its tests run"],
+    ["Extension: Test", "Extension: Build", "CI runs Extension test before build"],
+    ["Build", "Typecheck", "tsc reads .next/types/**, which next build writes"],
+  ])("runs %s in an earlier batch than %s", (before, after, why) => {
+    const beforeLine = queueLine(before);
+    const afterLine = queueLine(after);
+    expect(beforeLine, `queue_step "${before}" not found`).toBeGreaterThan(-1);
+    expect(afterLine, `queue_step "${after}" not found`).toBeGreaterThan(-1);
+
+    // A run_batch must separate them, or they dispatch concurrently and the
+    // ordering constraint is silently lost.
+    const separator = batchAfter(beforeLine);
+    expect(separator, `no run_batch between "${before}" and "${after}" — ${why}`)
+      .toBeGreaterThan(-1);
+    expect(
+      afterLine,
+      `"${after}" must be queued after the run_batch that follows "${before}" — ${why}`,
+    ).toBeGreaterThan(separator);
+  });
+
+  it("does not chain two commands in one step with && (a failing first half would skip the second)", () => {
+    // `queue_step "X" bash -c 'a && b'` expresses ordering by chaining, which
+    // drops b whenever a fails — the truncated-gate-run class. Ordering belongs
+    // in the batch staging above.
+    //
+    // A single leading `cd <dir> && <cmd>` is NOT that: `cd` is directory
+    // setup, not a gate whose failure should still let the next gate report.
+    // So flag a step only when a SECOND `&&` chains two real commands.
+    const chained = prePrSource
+      .split("\n")
+      .filter((line) => {
+        if (!/^\s*queue_step "/.test(line)) return false;
+        const body = line.replace(/^\s*queue_step\s+"[^"]*"\s*/, "");
+        const withoutCd = body.replace(/\bcd\s+[^&]+&&/, "");
+        return withoutCd.includes("&&");
+      })
+      .map((line) => line.trim());
+    expect(
+      chained,
+      "heavy steps must be staged across batches, not chained with &&",
+    ).toEqual([]);
+  });
 });
 
 /** Build a harness around the real scheduler with the given fixture steps. */

--- a/scripts/__tests__/pre-pr-run-batch.test.mjs
+++ b/scripts/__tests__/pre-pr-run-batch.test.mjs
@@ -52,6 +52,53 @@ beforeAll(() => {
   scheduler = src.slice(start, end);
   expect(scheduler).toContain("run_batch()");
   expect(scheduler).toContain("queue_step()");
+
+  // The splice covers the scheduler's DEFINITIONS. Its CALL SITES live far
+  // below SCHED_END, so nothing above notices if they disappear — and that is
+  // the worst regression available here: with both `run_batch` invocations
+  // removed, every test below still passes while pre-pr.sh silently drops from
+  // 51 executed checks to 13. Assert the wiring against the full source.
+  const runBatchCalls = src.match(/^run_batch$/gm) ?? [];
+  expect(
+    runBatchCalls.length,
+    "pre-pr.sh must invoke run_batch once per queued block — queued-but-never-run steps are silently skipped gates",
+  ).toBe(2);
+  const queueCalls = src.match(/^\s*queue_step "/gm) ?? [];
+  expect(
+    queueCalls.length,
+    "expected the static-check blocks to still be queued",
+  ).toBeGreaterThan(30);
+
+  // Counting alone is not enough: a queue_step appended AFTER the final
+  // run_batch keeps both counts valid while that gate never executes. Check
+  // position, not just quantity — every queue_step must be followed by some
+  // later run_batch.
+  const lines = src.split("\n");
+  const lastRunBatch = lines.reduce(
+    (acc, line, idx) => (/^run_batch$/.test(line) ? idx : acc),
+    -1,
+  );
+  const orphans = lines
+    .map((line, idx) => ({ line, idx }))
+    .filter(({ line, idx }) => /^\s*queue_step "/.test(line) && idx > lastRunBatch)
+    .map(({ line, idx }) => `${idx + 1}: ${line.trim()}`);
+  expect(
+    orphans,
+    "queue_step after the final run_batch — these gates are queued but never executed",
+  ).toEqual([]);
+
+  // SCHED_START is matched with indexOf, so an earlier occurrence of the same
+  // literal would relocate the region while both toContain checks still pass.
+  // It appears exactly twice: the declaration, and run_batch's reset.
+  const startOccurrences = src.split(SCHED_START).length - 1;
+  expect(
+    startOccurrences,
+    `"${SCHED_START}" must occur exactly twice (declaration + run_batch reset); a third would relocate the splice`,
+  ).toBe(2);
+
+  // The join shape is only load-bearing under `set -e`; the harness re-declares
+  // it, so pin that pre-pr.sh still sets it rather than letting the two drift.
+  expect(src, "pre-pr.sh must keep set -euo pipefail").toMatch(/^set -euo pipefail$/m);
 });
 
 /** Build a harness around the real scheduler with the given fixture steps. */
@@ -214,7 +261,7 @@ describe("pre-pr.sh bounded-parallel scheduler", () => {
     ["-1", "negative"],
     ["abc", "non-numeric"],
     ["99999", "above the cap"],
-  ])("clamps PRE_PR_JOBS=%s (%s) instead of hanging or forking unbounded", (value) => {
+  ])("still produces correct counts with PRE_PR_JOBS=%s (%s)", (value) => {
     const r = run(
       [
         'queue_step "a" bash -c "exit 0"',
@@ -225,6 +272,141 @@ describe("pre-pr.sh bounded-parallel scheduler", () => {
     );
     expect(r.passed).toBe(1);
     expect(r.failed).toBe(1);
+  });
+
+  // The cases above assert only that the run survives; they pass even with
+  // resolve_jobs' clamp deleted outright, because the throttle's
+  // `wait -n || true` absorbs a nonsense job count. Assert the clamp's RETURN
+  // VALUE so the untrusted-input handling is actually pinned.
+  it("clamps PRE_PR_JOBS to [1, min(nproc,8)] rather than trusting it", () => {
+    const cap = Math.min(
+      Number(spawnSync("nproc", { encoding: "utf8" }).stdout?.trim() || 4),
+      8,
+    );
+    const probe = (value) => {
+      const r = run('resolve_jobs; echo ""', { PRE_PR_JOBS: value });
+      return Number(/^(\d+)/m.exec(r.stdout.trim())?.[1] ?? NaN);
+    };
+    // Nonsense values must not reach the dispatch loop: 0 would make the slot
+    // check `active >= 0` block immediately, and a huge value would fork
+    // unbounded. Every result must land inside [1, cap].
+    //
+    // "-1" is deliberately grouped with the malformed inputs rather than
+    // clamped to 1: the `-` makes it non-numeric to the `*[!0-9]*` pattern, so
+    // it takes the fallback branch. Both outcomes are safe; this pins which one
+    // actually happens so the branch cannot change unnoticed.
+    expect(probe("0")).toBe(1);
+    expect(probe("-1")).toBe(cap);
+    expect(probe("abc")).toBe(cap);
+    expect(probe("")).toBe(cap);
+    expect(probe("99999")).toBe(cap);
+    expect(probe("2")).toBe(Math.min(2, cap));
+    for (const v of ["0", "-1", "abc", "", "99999", "2", "1"]) {
+      const got = probe(v);
+      expect(got, `PRE_PR_JOBS=${v} escaped the clamp`).toBeGreaterThanOrEqual(1);
+      expect(got, `PRE_PR_JOBS=${v} escaped the clamp`).toBeLessThanOrEqual(cap);
+    }
+  });
+
+  it("bounds actual concurrency even when PRE_PR_JOBS asks for far more", () => {
+    // The clamp is only meaningful if it reaches the dispatcher: prove a huge
+    // request does not fork one process per step.
+    const dir = mkdtempSync(join(tmpdir(), "pre-pr-cap-"));
+    const events = join(dir, "events.txt");
+    try {
+      run(
+        [
+          `: > ${events}`,
+          "for i in 1 2 3 4 5 6 7 8 9 10 11 12; do",
+          `  queue_step "j$i" bash -c 'echo S >> ${events}; sleep 0.2; echo E >> ${events}'`,
+          "done",
+          "run_batch >/dev/null 2>&1",
+        ].join("\n"),
+        { PRE_PR_JOBS: "99999" },
+      );
+      let cur = 0;
+      let max = 0;
+      for (const line of readFileSync(events, "utf8").trim().split("\n")) {
+        if (line === "S") max = Math.max(max, ++cur);
+        else cur--;
+      }
+      expect(max).toBeLessThanOrEqual(8);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("round-trips argv containing spaces, quotes and shell metacharacters", () => {
+    // queue_step stores argv via printf %q and run_batch replays it through
+    // `bash -c`. Without %q an argument with a space would split into two, and
+    // a `$` or `;` would be interpreted at replay time.
+    const r = run(
+      [
+        `queue_step "spaced" bash -c 'echo "a b  c"; exit 0'`,
+        `queue_step "metachar" bash -c 'echo "lit: \\$HOME ; rm -rf /"; exit 0'`,
+        "run_batch",
+      ].join("\n"),
+    );
+    expect(r.passed).toBe(2);
+    expect(r.failed).toBe(0);
+    expect(r.stdout).toContain("a b  c");
+    // The literal must survive un-expanded and un-executed.
+    expect(r.stdout).toContain("lit: $HOME ; rm -rf /");
+  });
+
+  it("still bounds concurrency on a shell without `wait -n` (bash 3.2)", () => {
+    // `wait -n` is bash 4.3+. On macOS's system bash 3.2 it fails immediately,
+    // and a swallowed error would free a slot with nothing having finished —
+    // turning the throttle into a no-op (measured 6 concurrent against a cap
+    // of 2 before the fallback existed, with PRE_PR_JOBS=1 not serializing).
+    // Force the fallback branch and prove it still bounds.
+    const forced = scheduler.replace(
+      "if ((BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3))); then",
+      "if false; then",
+    );
+    expect(forced, "version-guard anchor missing — fallback no longer reachable").not.toBe(
+      scheduler,
+    );
+
+    const dir = mkdtempSync(join(tmpdir(), "pre-pr-b32-"));
+    const events = join(dir, "events.txt");
+    const script = join(dir, "h.sh");
+    try {
+      writeFileSync(
+        script,
+        [
+          "#!/usr/bin/env bash",
+          "set -euo pipefail",
+          "RED=''; GREEN=''; BOLD=''; RESET=''",
+          "passed=0; failed=0; failures=(); tempfiles=()",
+          forced,
+          `: > ${events}`,
+          "for i in 1 2 3 4 5 6 7 8; do",
+          `  queue_step "j$i" bash -c 'echo S >> ${events}; sleep 0.25; echo E >> ${events}'`,
+          "done",
+          "run_batch >/dev/null 2>&1",
+          'echo "RESULT passed=$passed failed=$failed"',
+        ].join("\n"),
+        "utf8",
+      );
+      const r = spawnSync("bash", [script], {
+        encoding: "utf8",
+        cwd: REPO_ROOT,
+        env: { ...process.env, PRE_PR_JOBS: "2" },
+        timeout: 60_000,
+      });
+      let cur = 0;
+      let max = 0;
+      for (const line of readFileSync(events, "utf8").trim().split("\n")) {
+        if (line === "S") max = Math.max(max, ++cur);
+        else cur--;
+      }
+      expect(max, "fallback throttle did not bound concurrency").toBeLessThanOrEqual(2);
+      // and it must still run every step and report correctly
+      expect(r.stdout).toContain("RESULT passed=8 failed=0");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("actually runs steps concurrently, bounded by PRE_PR_JOBS", () => {

--- a/scripts/__tests__/pre-pr-run-batch.test.mjs
+++ b/scripts/__tests__/pre-pr-run-batch.test.mjs
@@ -58,11 +58,15 @@ beforeAll(() => {
   // the worst regression available here: with both `run_batch` invocations
   // removed, every test below still passes while pre-pr.sh silently drops from
   // 51 executed checks to 13. Assert the wiring against the full source.
+  // Deliberately NOT an exact count: the number of batches is a scheduling
+  // decision that changes whenever steps are regrouped, and pinning it makes
+  // this assertion fire on every legitimate restructure while adding nothing —
+  // the positional check below is what actually catches an unrun queue.
   const runBatchCalls = src.match(/^\s*run_batch\s*$/gm) ?? [];
   expect(
     runBatchCalls.length,
-    "pre-pr.sh must invoke run_batch once per queued block — queued-but-never-run steps are silently skipped gates",
-  ).toBe(3);
+    "pre-pr.sh must invoke run_batch — without it every queued step is a silently skipped gate",
+  ).toBeGreaterThan(0);
   const queueCalls = src.match(/^\s*queue_step "/gm) ?? [];
   expect(
     queueCalls.length,

--- a/scripts/__tests__/pre-pr-run-batch.test.mjs
+++ b/scripts/__tests__/pre-pr-run-batch.test.mjs
@@ -58,11 +58,11 @@ beforeAll(() => {
   // the worst regression available here: with both `run_batch` invocations
   // removed, every test below still passes while pre-pr.sh silently drops from
   // 51 executed checks to 13. Assert the wiring against the full source.
-  const runBatchCalls = src.match(/^run_batch$/gm) ?? [];
+  const runBatchCalls = src.match(/^\s*run_batch\s*$/gm) ?? [];
   expect(
     runBatchCalls.length,
     "pre-pr.sh must invoke run_batch once per queued block — queued-but-never-run steps are silently skipped gates",
-  ).toBe(2);
+  ).toBe(3);
   const queueCalls = src.match(/^\s*queue_step "/gm) ?? [];
   expect(
     queueCalls.length,
@@ -75,7 +75,7 @@ beforeAll(() => {
   // later run_batch.
   const lines = src.split("\n");
   const lastRunBatch = lines.reduce(
-    (acc, line, idx) => (/^run_batch$/.test(line) ? idx : acc),
+    (acc, line, idx) => (/^\s*run_batch\s*$/.test(line) ? idx : acc),
     -1,
   );
   const orphans = lines

--- a/scripts/__tests__/pre-pr-run-batch.test.mjs
+++ b/scripts/__tests__/pre-pr-run-batch.test.mjs
@@ -1,0 +1,270 @@
+/**
+ * Self-test for scripts/pre-pr.sh's bounded-parallel scheduler
+ * (queue_step / run_batch / resolve_jobs).
+ *
+ * Why this file exists: every gate under scripts/checks/ carries a self-test
+ * because a gate with a broken parse path can silently green forever. The
+ * harness that RUNS all ~40 of those gates had none, and
+ * check-gate-selftest-coverage.sh cannot ask for one — its member set is
+ * `scripts/checks/*.{sh,mjs}`, and pre-pr.sh is the harness, never a member.
+ * The scheduler carries several fail-open shapes (below), so it gets one here.
+ *
+ * Each case below pins a failure mode that was observed, not imagined:
+ *   - counters incremented inside a backgrounded job are discarded, so a run
+ *     that failed reports "Passed: 0 / Failed: 0"
+ *   - `wait -n`'s status does not identify which job it reaped, so capturing it
+ *     per dispatch index mis-attributes verdicts (measured 7 0 0 vs a truth of
+ *     0 0 7 — a failing gate reported as passing)
+ *   - a bare `wait "$pid"` under pre-pr.sh's `set -e` aborts on the first
+ *     failure, leaving later gates unjoined and the Results block unprinted
+ *   - exit 127 is a real step status (command not found), never "no such job"
+ *
+ * The scheduler is spliced out of pre-pr.sh verbatim and driven with fixture
+ * steps rather than the real gate list — spawning the real pre-pr.sh from here
+ * would recursively invoke vitest (same constraint pre-pr-env-drift.test.mjs
+ * documents). Splicing means the code under test IS the production code: a
+ * re-implementation here would drift and prove nothing.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const PRE_PR = join(REPO_ROOT, "scripts/pre-pr.sh");
+
+const SCHED_START = "batch_labels=()";
+const SCHED_END = '\nprintf "${BOLD}═══ Pre-PR Checks';
+
+let scheduler;
+
+beforeAll(() => {
+  const src = readFileSync(PRE_PR, "utf8");
+  const start = src.indexOf(SCHED_START);
+  const end = src.indexOf(SCHED_END);
+  // Fail loudly rather than silently testing an empty string if pre-pr.sh is
+  // restructured — a vacuous pass here would be worse than a red test.
+  expect(start, "scheduler block not found in pre-pr.sh").toBeGreaterThan(-1);
+  expect(end, "scheduler end anchor not found in pre-pr.sh").toBeGreaterThan(start);
+  scheduler = src.slice(start, end);
+  expect(scheduler).toContain("run_batch()");
+  expect(scheduler).toContain("queue_step()");
+});
+
+/** Build a harness around the real scheduler with the given fixture steps. */
+function harness(body) {
+  return [
+    "#!/usr/bin/env bash",
+    // Same options as pre-pr.sh — `set -e` is what makes the join shape
+    // load-bearing, so the harness must not relax it.
+    "set -euo pipefail",
+    "RED=''; GREEN=''; BOLD=''; RESET=''",
+    "passed=0; failed=0; failures=(); tempfiles=()",
+    scheduler,
+    body,
+    'echo "RESULT passed=$passed failed=$failed"',
+    'printf \'FAILORDER %s\\n\' "$(for f in "${failures[@]-}"; do printf \'%s;\' "${f%%|*}"; done)"',
+  ].join("\n");
+}
+
+function run(body, env = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "pre-pr-batch-"));
+  const script = join(dir, "harness.sh");
+  writeFileSync(script, harness(body), "utf8");
+  try {
+    const r = spawnSync("bash", [script], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+      env: { ...process.env, ...env },
+      timeout: 60_000,
+    });
+    const stdout = r.stdout ?? "";
+    return {
+      stdout,
+      exitCode: r.status,
+      passed: Number(/RESULT passed=(\d+)/.exec(stdout)?.[1] ?? -1),
+      failed: Number(/RESULT passed=\d+ failed=(\d+)/.exec(stdout)?.[1] ?? -1),
+      failOrder: (/FAILORDER (.*)/.exec(stdout)?.[1] ?? "")
+        .split(";")
+        .filter(Boolean),
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("pre-pr.sh bounded-parallel scheduler", () => {
+  it("counts passes and failures in the parent shell (backgrounded increments are lost)", () => {
+    const r = run(
+      [
+        'queue_step "a" bash -c "exit 0"',
+        'queue_step "b" bash -c "exit 1"',
+        'queue_step "c" bash -c "exit 0"',
+        "run_batch",
+      ].join("\n"),
+    );
+    // The whole point: a scheduler that increments inside the job reports 0/0.
+    expect(r.passed).toBe(2);
+    expect(r.failed).toBe(1);
+  });
+
+  it("attributes each exit status to its own step when completion order differs from declaration order", () => {
+    // The shape that breaks `wait -n` status capture: the FAILING step is
+    // declared last but finishes FIRST, so a scheduler that assigns the reaped
+    // status to the dispatch index blames a passing step instead.
+    const r = run(
+      [
+        'queue_step "slow-ok-1" bash -c "sleep 0.4; exit 0"',
+        'queue_step "slow-ok-2" bash -c "sleep 0.4; exit 0"',
+        'queue_step "fast-fail" bash -c "exit 7"',
+        "run_batch",
+      ].join("\n"),
+      { PRE_PR_JOBS: "3" },
+    );
+    expect(r.failed).toBe(1);
+    expect(r.failOrder).toEqual(["fast-fail"]);
+  });
+
+  it("reports every step and renders results when a step fails mid-run (no set -e truncation)", () => {
+    const r = run(
+      [
+        'queue_step "s0" bash -c "exit 0"',
+        'queue_step "s1" bash -c "exit 3"',
+        'queue_step "s2" bash -c "exit 0"',
+        'queue_step "s3" bash -c "exit 0"',
+        "run_batch",
+      ].join("\n"),
+    );
+    // A bare `wait "$pid"` under set -e dies at s1, so s2/s3 never report.
+    expect(r.passed).toBe(3);
+    expect(r.failed).toBe(1);
+    for (const label of ["s0", "s1", "s2", "s3"]) {
+      expect(r.stdout).toContain(label);
+    }
+  });
+
+  it("lists failures in declaration order, not completion order", () => {
+    const r = run(
+      [
+        'queue_step "f-early" bash -c "sleep 0.3; exit 3"',
+        'queue_step "ok" bash -c "exit 0"',
+        'queue_step "f-late" bash -c "exit 5"',
+        "run_batch",
+      ].join("\n"),
+      { PRE_PR_JOBS: "3" },
+    );
+    // f-late finishes first; declaration order must still win.
+    expect(r.failOrder).toEqual(["f-early", "f-late"]);
+  });
+
+  it("reports a step whose command does not exist as failed (127 is a status, not a bookkeeping artifact)", () => {
+    const r = run(
+      [
+        'queue_step "missing" definitely-not-a-real-binary-xyz',
+        'queue_step "ok" bash -c "exit 0"',
+        "run_batch",
+      ].join("\n"),
+    );
+    expect(r.failed).toBe(1);
+    expect(r.failOrder).toEqual(["missing"]);
+  });
+
+  it("preserves a failing step's full output including its last line", () => {
+    const r = run(
+      [
+        'queue_step "big" bash -c \'head -c 200000 /dev/zero | tr "\\0" "x"; echo; echo LASTLINE_MARKER; exit 9\'',
+        "run_batch",
+      ].join("\n"),
+    );
+    expect(r.failed).toBe(1);
+    expect(r.stdout).toContain("LASTLINE_MARKER");
+  });
+
+  it("prints passing steps' stdout too (several gates emit CI-auditable config on success)", () => {
+    const r = run(
+      [
+        'queue_step "chatty" bash -c \'echo GREEN_PATH_OUTPUT; exit 0\'',
+        "run_batch",
+      ].join("\n"),
+    );
+    expect(r.passed).toBe(1);
+    expect(r.stdout).toContain("GREEN_PATH_OUTPUT");
+  });
+
+  it("produces identical results serially and in parallel", () => {
+    const body = [
+      'queue_step "a" bash -c "sleep 0.2; exit 0"',
+      'queue_step "b" bash -c "exit 4"',
+      'queue_step "c" bash -c "sleep 0.1; exit 0"',
+      'queue_step "d" bash -c "exit 6"',
+      "run_batch",
+    ].join("\n");
+    const serial = run(body, { PRE_PR_JOBS: "1" });
+    const parallel = run(body, { PRE_PR_JOBS: "4" });
+    expect(serial.passed).toBe(parallel.passed);
+    expect(serial.failed).toBe(parallel.failed);
+    expect(serial.failOrder).toEqual(parallel.failOrder);
+  });
+
+  it.each([
+    ["0", "zero"],
+    ["-1", "negative"],
+    ["abc", "non-numeric"],
+    ["99999", "above the cap"],
+  ])("clamps PRE_PR_JOBS=%s (%s) instead of hanging or forking unbounded", (value) => {
+    const r = run(
+      [
+        'queue_step "a" bash -c "exit 0"',
+        'queue_step "b" bash -c "exit 1"',
+        "run_batch",
+      ].join("\n"),
+      { PRE_PR_JOBS: value },
+    );
+    expect(r.passed).toBe(1);
+    expect(r.failed).toBe(1);
+  });
+
+  it("actually runs steps concurrently, bounded by PRE_PR_JOBS", () => {
+    // RT4 guard: every other assertion here passes whether or not concurrency
+    // happened. This one fails if the dispatcher degenerates to serial AND if
+    // it oversubscribes past the cap.
+    const dir = mkdtempSync(join(tmpdir(), "pre-pr-overlap-"));
+    const events = join(dir, "events.txt");
+    try {
+      const body = [
+        `: > ${events}`,
+        "for i in 1 2 3 4 5 6; do",
+        `  queue_step "j$i" bash -c 'echo S $(date +%s%N) >> ${events}; sleep 0.3; echo E $(date +%s%N) >> ${events}'`,
+        "done",
+        "run_batch >/dev/null 2>&1",
+      ].join("\n");
+
+      const peak = (jobs) => {
+        run(body, { PRE_PR_JOBS: String(jobs) });
+        const rows = readFileSync(events, "utf8")
+          .trim()
+          .split("\n")
+          .filter(Boolean)
+          .map((l) => l.split(/\s+/))
+          .sort((a, b) => Number(a[1]) - Number(b[1]));
+        let cur = 0;
+        let max = 0;
+        for (const [kind] of rows) {
+          if (kind === "S") max = Math.max(max, ++cur);
+          else cur--;
+        }
+        return max;
+      };
+
+      expect(peak(1)).toBe(1);
+      const p3 = peak(3);
+      expect(p3).toBeGreaterThanOrEqual(2);
+      expect(p3).toBeLessThanOrEqual(3);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/checks/check-fail-closed-routes-have-test.sh
+++ b/scripts/checks/check-fail-closed-routes-have-test.sh
@@ -164,10 +164,17 @@ fi
 # Shared by lookup() and the AST-count lookups below; same semantics as the
 # `awk -F'\t' '$1 == p { print $2; exit }'` it replaces.
 tab_lookup() {
-  local line
+  local line rest
   while IFS= read -r line; do
     case "$line" in
-      "$1"$'\t'*) printf '%s' "${line#*$'\t'}"; return ;;
+      "$1"$'\t'*)
+        rest="${line#*$'\t'}"
+        # Field 2 only — stop at the next tab, matching awk '{print $2}'. Live
+        # data is 2-column today, but nothing enforces that, and returning
+        # "v1<tab>v2" for a 3-column row would silently corrupt every caller.
+        printf '%s' "${rest%%$'\t'*}"
+        return
+        ;;
     esac
   done <<<"$2"
 }
@@ -177,6 +184,11 @@ lookup() {
 field() {
   local kv
   for kv in $1; do
+    # `${kv#*=}` keeps everything after the FIRST `=`, so a hypothetical
+    # `key=a=b` yields `a=b`. The awk this replaced used split(...,"=") and
+    # returned just `a`. All classifier values are numeric today, so the two
+    # agree; keeping the whole value is the safer of the two if that ever
+    # changes, since silently truncating at a second `=` would be a bug.
     case "$kv" in
       "$2"=*) printf '%s' "${kv#*=}"; return ;;
     esac

--- a/scripts/checks/check-fail-closed-routes-have-test.sh
+++ b/scripts/checks/check-fail-closed-routes-have-test.sh
@@ -153,12 +153,34 @@ if [ "${#candidate_tests[@]}" -gt 0 ]; then
 fi
 
 # lookup <abs-path> → record string ("exists=1 import=1 calls=2 mock=0 redis=1")
-lookup() {
-  awk -F'\t' -v p="$1" '$1 == p { print $2; exit }' <<<"$CLASSIFY_OUT"
+# field  <record> <key> → value (empty when record/key absent)
+#
+# Both are called once per (route x key) and were spawning an awk per call —
+# ~500 processes, the bulk of this gate's runtime. They do plain string
+# splitting, so bash does it in-process. Semantics are unchanged: lookup still
+# matches the FIRST record whose tab-delimited field 1 equals the path exactly,
+# and field still returns the first `key=value` whose key matches exactly.
+# tab_lookup <key> <tsv-text> → field 2 of the first line whose field 1 == key.
+# Shared by lookup() and the AST-count lookups below; same semantics as the
+# `awk -F'\t' '$1 == p { print $2; exit }'` it replaces.
+tab_lookup() {
+  local line
+  while IFS= read -r line; do
+    case "$line" in
+      "$1"$'\t'*) printf '%s' "${line#*$'\t'}"; return ;;
+    esac
+  done <<<"$2"
 }
-# field <record> <key> → value (empty when record/key absent)
+lookup() {
+  tab_lookup "$1" "$CLASSIFY_OUT"
+}
 field() {
-  awk -v k="$2" '{ for (i = 1; i <= NF; i++) { split($i, a, "="); if (a[1] == k) { print a[2]; exit } } }' <<<"$1"
+  local kv
+  for kv in $1; do
+    case "$kv" in
+      "$2"=*) printf '%s' "${kv#*=}"; return ;;
+    esac
+  done
 }
 
 # manifest_declared_count <repo-rel-path> → the limiter count declared for that
@@ -169,7 +191,12 @@ field() {
 # 2026-07-19, round 2).
 manifest_declared_count() {
   [ -f "$MANIFEST_FILE" ] || return 0
-  awk -F'\t' -v p="$1" '$1 == p { print $2; exit }' "$MANIFEST_FILE"
+  # Read the manifest once, then reuse it in-process (was: an awk spawn per
+  # route). MANIFEST_FILE does not change during a run.
+  if [ -z "${MANIFEST_TEXT+x}" ]; then
+    MANIFEST_TEXT="$(cat "$MANIFEST_FILE")"
+  fi
+  tab_lookup "$1" "$MANIFEST_TEXT"
 }
 
 # assert_covers_all_limiters <route> <test-rel> <distinct> — fail when a
@@ -519,7 +546,7 @@ if [ -f "$MANIFEST_FILE" ]; then
     if [ -f "$abs_path" ]; then
       grep_count="$(grep -c 'failClosedOnRedisError: true' "$abs_path" || true)"
     fi
-    file_ast_count="$(awk -F'\t' -v p="$abs_path" '$1 == p { print $2; exit }' <<<"$MANIFEST_AST_OUT")"
+    file_ast_count="$(tab_lookup "$abs_path" "$MANIFEST_AST_OUT")"
     [ -n "$file_ast_count" ] || file_ast_count=0
     if [ "$grep_count" -gt "$file_ast_count" ]; then
       echo "MANIFEST_COMMENT_LITERAL: $m_path (grep count $grep_count exceeds AST-authoritative count $file_ast_count — the literal appears in a comment/string; reword it, D4 rule)"

--- a/scripts/checks/check-fail-closed-routes-have-test.sh
+++ b/scripts/checks/check-fail-closed-routes-have-test.sh
@@ -182,8 +182,17 @@ lookup() {
   tab_lookup "$1" "$CLASSIFY_OUT"
 }
 field() {
+  # Split $1 on whitespace WITHOUT globbing: a record value containing `*` or
+  # `?` would otherwise expand against the cwd (verified: `field "pat=*" pat`
+  # returns a filename under `set +f`). Values are digits today, so this is a
+  # latent trap rather than a live bug — but the awk this replaced had no such
+  # exposure, so don't introduce it. Using a local array keeps noglob scoped to
+  # the split itself rather than leaking past an early `return`.
   local kv
-  for kv in $1; do
+  local -a kvs
+  read -r -d '' -a kvs <<<"$1" || true
+
+  for kv in "${kvs[@]}"; do
     # `${kv#*=}` keeps everything after the FIRST `=`, so a hypothetical
     # `key=a=b` yields `a=b`. The awk this replaced used split(...,"=") and
     # returned just `a`. All classifier values are numeric today, so the two

--- a/scripts/checks/check-step-up-client-coverage.sh
+++ b/scripts/checks/check-step-up-client-coverage.sh
@@ -118,6 +118,24 @@ PATHS_FILE="${STEPUP_CLIENT_GUARD_PATHS_FILE:-$REPO_ROOT/scripts/checks/stepup-r
 # `!res.ok` block). 40 is that measured max plus generous margin.
 ADJACENCY_WINDOW="${STEPUP_CLIENT_GUARD_WINDOW:-40}"
 
+# Env-pollution guard (same contract as check-gate-selftest-coverage.sh's
+# sec-F6 guard). Every override above can silently green this gate: pointing
+# CLIENT_DIR at an empty directory leaves nothing to scan, and WINDOW=0
+# disables the adjacency check. Those are legitimate for the self-test, which
+# sets them deliberately — but under CI they can only be accidental or
+# malicious, so require an explicit acknowledgement rather than trusting that
+# "production CI uses the defaults".
+if [ "${CI:-}" = "true" ]; then
+  if [ -n "${STEPUP_CLIENT_GUARD_API_DIR:-}" ] || [ -n "${STEPUP_CLIENT_GUARD_CLIENT_DIR:-}" ] || \
+     [ -n "${STEPUP_CLIENT_GUARD_PATH_ROOT:-}" ] || [ -n "${STEPUP_CLIENT_GUARD_EXEMPT_FILE:-}" ] || \
+     [ -n "${STEPUP_CLIENT_GUARD_PATHS_FILE:-}" ] || [ -n "${STEPUP_CLIENT_GUARD_WINDOW:-}" ]; then
+    if [ "${STEPUP_CLIENT_GUARD_FIXTURE_MODE:-}" != "1" ]; then
+      echo "ENV_POLLUTION_GUARD: STEPUP_CLIENT_GUARD_* override set under CI=true without STEPUP_CLIENT_GUARD_FIXTURE_MODE=1 — refusing to run against a possibly-unintended path."
+      exit 1
+    fi
+  fi
+fi
+
 # Client "branch present" tokens (extended regex, OR-joined). The paren is a
 # bracket-expression `[(]` not `\(` so it survives awk's -v un-escaping (a `\(`
 # passed via -v becomes a bare `(` = invalid regex group-open in awk).
@@ -477,6 +495,39 @@ done < <(printf '%s' "$MANIFEST_IDS" | sort -u)
 # for that id at that call site.
 MUTATING_METHOD_RE='"(POST|PUT|PATCH|DELETE)"'
 
+# Hoisted per-id manifest data. `method` and `tokens_raw` depend only on the id,
+# but the loop below visits every (call site x id) pair — deriving them inside
+# it re-ran manifest_line_for + 6 grep/sed spawns ~10,000 times (66,176 process
+# spawns, 171s). Derive once here into parallel indexed arrays; the inner loop
+# then only reads memory. bash 3.2 has no associative arrays — keep parallel
+# indexed arrays plus a linear scan, same idiom as EXEMPT_MARKERS.
+#
+# Only mutating-method ids can ever produce a candidate (the loop short-circuits
+# on non-mutating methods), so skip the rest at build time — that keeps the
+# scanned set small without changing which pairs can match.
+CAND_IDS=()
+CAND_METHODS=()
+CAND_TOKENS=()
+while IFS= read -r mid; do
+  [ -z "$mid" ] && continue
+  is_exempt "$mid" && continue
+  mline="$(manifest_line_for "$mid")"
+  m_method="$( { printf '%s' "$mline" | grep -oE '"method":[[:space:]]*"[A-Z]+"' || true; } | sed -E 's/.*"([A-Z]+)"$/\1/')"
+  case "$m_method" in
+    POST|PUT|PATCH|DELETE) ;;
+    *) continue ;;
+  esac
+  m_tokens_raw="$( { printf '%s' "$mline" | grep -oE '"pathTokens":[[:space:]]*\[[^]]*\]' || true; } | sed -E 's/"pathTokens":[[:space:]]*\[(.*)\]/\1/')"
+  # Pre-split and pre-escape the tokens once per id (was: per id PER CALL SITE).
+  # Newline-delimited; each entry is already ERE-escaped for the match below.
+  m_tokens_esc="$( { printf '%s' "$m_tokens_raw" | grep -oE '"[^"]*"' || true; } \
+    | sed -E 's/^"(.*)"$/\1/' | sed -E 's/[][\.^$*+?(){}|/]/\\&/g')"
+  CAND_IDS+=("$mid")
+  CAND_METHODS+=("$m_method")
+  CAND_TOKENS+=("$m_tokens_esc")
+done < <(printf '%s' "$MANIFEST_IDS" | sort -u)
+CAND_N=${#CAND_IDS[@]}
+
 while IFS= read -r hit; do
   [ -z "$hit" ] && continue
   cfile="${hit%%:*}"
@@ -484,65 +535,100 @@ while IFS= read -r hit; do
   fline="${fline%%:*}"
   rel="${cfile#"$PATH_ROOT"/}"
 
+  # Read each client file's lines ONCE and slice every window from memory. The
+  # windows keep their exact original bounds (call line .. +3 / +10, and -3 ..
+  # call line for suppression) — only the repeated awk/grep spawns are removed.
+  # Widening any of these to whole-file scope would change what the gate flags.
+  if [ "$cfile" != "${cur_file:-}" ]; then
+    cur_file="$cfile"
+    CUR_LINES=()
+    while IFS= read -r _l || [ -n "$_l" ]; do CUR_LINES+=("$_l"); done < "$cfile"
+    CUR_NLINES=${#CUR_LINES[@]}
+    # File-scoped (NOT call-site-scoped): this file's own client @stepup ids.
+    cur_marker_ids="$( { grep -oE '@stepup[[:space:]]+id:[A-Za-z0-9_-]+' "$cfile" 2>/dev/null || true; } \
+      | sed -E 's/.*id:([A-Za-z0-9_-]+)/\1/' | sort -u)"
+  fi
+  file_marker_ids="$cur_marker_ids"
+
+  # CUR_LINES is 0-indexed; file line N is CUR_LINES[N-1].
+  slice() { # $1=first line (1-based, clamped), $2=last line
+    local i first="$1" last="$2"
+    [ "$first" -lt 1 ] && first=1
+    [ "$last" -gt "$CUR_NLINES" ] && last=$CUR_NLINES
+    i=$first
+    while [ "$i" -le "$last" ]; do
+      printf '%s\n' "${CUR_LINES[$((i - 1))]}"
+      i=$((i + 1))
+    done
+  }
+
   # Skip fetchApi( occurrences inside a comment (JSDoc `*` continuation or a
   # `//` line comment) — a doc-example call site is not a real call site. This
   # is a line-prefix check only (parser-free, same philosophy as the rest of
   # this guard), not full comment-awareness.
-  call_line_content="$(awk -v l="$fline" 'NR==l' "$cfile")"
+  call_line_content="${CUR_LINES[$((fline - 1))]}"
   case "$(printf '%s' "$call_line_content" | sed -E 's/^[[:space:]]*//')" in
     '*'*|'//'*) continue ;;
   esac
 
-  # This file's own client @stepup ids (cache per file would be an optimization;
-  # correctness first — re-grep is cheap at this file count).
-  file_marker_ids="$( { grep -oE '@stepup[[:space:]]+id:[A-Za-z0-9_-]+' "$cfile" 2>/dev/null || true; } \
-    | sed -E 's/.*id:([A-Za-z0-9_-]+)/\1/' | sort -u)"
+  arg_window="$(slice "$fline" $((fline + 3)))"
+  opt_window="$(slice "$fline" $((fline + 10)))"
 
-  arg_window="$(awk -v l="$fline" 'NR>=l && NR<=l+3' "$cfile")"
-  opt_window="$(awk -v l="$fline" 'NR>=l && NR<=l+10' "$cfile")"
+  # Suppression window is call-site-scoped (-3 .. call line), so it is computed
+  # once per call site rather than once per (call site x id) as before.
+  suppress_window="$(slice $((fline - 3)) "$fline")"
 
-  while IFS= read -r mid; do
-    [ -z "$mid" ] && continue
-    # Exempt ids (check 1's allowlist) never require a standard client
-    # `@stepup id:X` marker at all — their recovery is custom or non-interactive
-    # (see stepup-client-exempt.txt). Without this skip, an exempt id's own
-    # already-known, accepted call site (e.g. team-confirm-key-post's background
-    # poller, operator-tokens-post's bespoke reauth flow) would be flagged as a
-    # "new unmarked call site" even though it never carried a marker by design.
-    is_exempt "$mid" && continue
-    mline="$(manifest_line_for "$mid")"
-    method="$( { printf '%s' "$mline" | grep -oE '"method":[[:space:]]*"[A-Z]+"' || true; } | sed -E 's/.*"([A-Z]+)"$/\1/')"
-    tokens_raw="$( { printf '%s' "$mline" | grep -oE '"pathTokens":[[:space:]]*\[[^]]*\]' || true; } | sed -E 's/"pathTokens":[[:space:]]*\[(.*)\]/\1/')"
+  ci=0
+  while [ "$ci" -lt "$CAND_N" ]; do
+    mid="${CAND_IDS[$ci]}"
+    method="${CAND_METHODS[$ci]}"
+    tokens_esc="${CAND_TOKENS[$ci]}"
+    ci=$((ci + 1))
+
+    # Exempt ids and non-mutating methods were already filtered out when
+    # CAND_* was built (exempt ids never require a standard client marker —
+    # their recovery is custom or non-interactive, see stepup-client-exempt.txt;
+    # GET-only ids can never trip a mutating-call-site candidate).
 
     # Mutating-method literal for THIS id's method must appear in the options
-    # window — GET-only ids never trip a mutating-call-site candidate. Checked
-    # before the token scan below (cheaper short-circuit).
-    case "$method" in
-      POST|PUT|PATCH|DELETE) ;;
+    # window. Checked before the token scan below (cheaper short-circuit).
+    # Bash-native substring test — the pattern is the fixed literal `"METHOD"`,
+    # so no regex engine is needed and no process is spawned per pair.
+    case "$opt_window" in
+      *"\"$method\""*) ;;
       *) continue ;;
     esac
-    printf '%s' "$opt_window" | grep -qE "\"$method\"" || continue
 
     # Word-boundary-aware match: a token must not be immediately followed by an
     # identifier character, so a shorter helper name (e.g. tenantMemberResetVault)
     # does not spuriously match a longer sibling identifier that shares it as a
-    # prefix (tenantMemberResetVaultRevoke). Tokens are escaped for ERE metachars
-    # (path fragments like "/api/tenant/policy" contain none that need escaping
-    # beyond what grep -E treats literally here, but "?"/"."/"$" in a future token
-    # would not be — escape defensively).
+    # prefix (tenantMemberResetVaultRevoke). Tokens were ERE-escaped once when
+    # CAND_TOKENS was built (path fragments like "/api/tenant/policy" contain no
+    # metachars needing it, but a future "?"/"."/"$" token would).
+    # bash's =~ uses the same POSIX ERE engine as `grep -E`, so the escaped
+    # token and the boundary suffix carry over unchanged — but it matches
+    # in-process, removing one spawn per (call site x id) pair. `$` inside the
+    # alternation means end-of-string in =~, whereas grep -E applied it
+    # per-line; arg_window is multi-line, so the line-anchored form is kept by
+    # testing each window line separately (below), preserving the original
+    # per-line semantics exactly.
     token_hit=0
-    while IFS= read -r tok; do
-      [ -z "$tok" ] && continue
-      esc_tok="$(printf '%s' "$tok" | sed -E 's/[][\.^$*+?(){}|/]/\\&/g')"
-      if printf '%s' "$arg_window" | grep -qE "${esc_tok}([^A-Za-z0-9_]|\$)"; then
-        token_hit=1
-        break
-      fi
-    done < <( { printf '%s' "$tokens_raw" | grep -oE '"[^"]*"' || true; } | sed -E 's/^"(.*)"$/\1/')
+    while IFS= read -r esc_tok; do
+      [ -z "$esc_tok" ] && continue
+      while IFS= read -r _wline; do
+        if [[ $_wline =~ ${esc_tok}([^A-Za-z0-9_]|$) ]]; then
+          token_hit=1
+          break 2
+        fi
+      done <<EOF
+$arg_window
+EOF
+    done <<EOF
+$tokens_esc
+EOF
     [ "$token_hit" -eq 1 ] || continue
 
     # Escape hatch: a suppression comment for this exact id near the call line.
-    suppress_window="$(awk -v l="$fline" 'NR>=l-3 && NR<=l' "$cfile")"
     if printf '%s' "$suppress_window" | grep -qE "@stepup-path-ok[[:space:]]+id:${mid}([[:space:]]|$)"; then
       # Reason discipline: require >=10 chars of trailing text on that line.
       suppress_line="$(printf '%s' "$suppress_window" | grep -E "@stepup-path-ok[[:space:]]+id:${mid}" | head -n1)"
@@ -560,7 +646,7 @@ while IFS= read -r hit; do
       echo "UNMARKED_CALLSITE_CANDIDATE: $rel:$fline — fetchApi( call site matches gated id '$mid' ($method) by path token, but this file has no '@stepup id:$mid' marker. Add the marker + step-up handling, or suppress with '// @stepup-path-ok id:$mid <reason>' if this is a confirmed false positive."
       fail=1
     fi
-  done < <(printf '%s' "$MANIFEST_IDS" | sort -u)
+  done
 done < <(
   grep -rnE 'fetchApi\(' "$CLIENT_DIR" \
     --include='*.tsx' --include='*.ts' 2>/dev/null \

--- a/scripts/checks/check-step-up-client-coverage.sh
+++ b/scripts/checks/check-step-up-client-coverage.sh
@@ -118,6 +118,24 @@ PATHS_FILE="${STEPUP_CLIENT_GUARD_PATHS_FILE:-$REPO_ROOT/scripts/checks/stepup-r
 # `!res.ok` block). 40 is that measured max plus generous margin.
 ADJACENCY_WINDOW="${STEPUP_CLIENT_GUARD_WINDOW:-40}"
 
+# Env-pollution guard (same contract as check-gate-selftest-coverage.sh's
+# sec-F6 guard). Every override above can silently green this gate: pointing
+# CLIENT_DIR at an empty directory leaves nothing to scan, and WINDOW=0
+# disables the adjacency check. Those are legitimate for the self-test, which
+# sets them deliberately — but under CI they can only be accidental or
+# malicious, so require an explicit acknowledgement rather than trusting that
+# "production CI uses the defaults".
+if [ "${CI:-}" = "true" ]; then
+  if [ -n "${STEPUP_CLIENT_GUARD_API_DIR:-}" ] || [ -n "${STEPUP_CLIENT_GUARD_CLIENT_DIR:-}" ] || \
+     [ -n "${STEPUP_CLIENT_GUARD_PATH_ROOT:-}" ] || [ -n "${STEPUP_CLIENT_GUARD_EXEMPT_FILE:-}" ] || \
+     [ -n "${STEPUP_CLIENT_GUARD_PATHS_FILE:-}" ] || [ -n "${STEPUP_CLIENT_GUARD_WINDOW:-}" ]; then
+    if [ "${STEPUP_CLIENT_GUARD_FIXTURE_MODE:-}" != "1" ]; then
+      echo "ENV_POLLUTION_GUARD: STEPUP_CLIENT_GUARD_* override set under CI=true without STEPUP_CLIENT_GUARD_FIXTURE_MODE=1 — refusing to run against a possibly-unintended path."
+      exit 1
+    fi
+  fi
+fi
+
 # Client "branch present" tokens (extended regex, OR-joined). The paren is a
 # bracket-expression `[(]` not `\(` so it survives awk's -v un-escaping (a `\(`
 # passed via -v becomes a bare `(` = invalid regex group-open in awk).

--- a/scripts/checks/check-step-up-client-coverage.sh
+++ b/scripts/checks/check-step-up-client-coverage.sh
@@ -118,24 +118,6 @@ PATHS_FILE="${STEPUP_CLIENT_GUARD_PATHS_FILE:-$REPO_ROOT/scripts/checks/stepup-r
 # `!res.ok` block). 40 is that measured max plus generous margin.
 ADJACENCY_WINDOW="${STEPUP_CLIENT_GUARD_WINDOW:-40}"
 
-# Env-pollution guard (same contract as check-gate-selftest-coverage.sh's
-# sec-F6 guard). Every override above can silently green this gate: pointing
-# CLIENT_DIR at an empty directory leaves nothing to scan, and WINDOW=0
-# disables the adjacency check. Those are legitimate for the self-test, which
-# sets them deliberately — but under CI they can only be accidental or
-# malicious, so require an explicit acknowledgement rather than trusting that
-# "production CI uses the defaults".
-if [ "${CI:-}" = "true" ]; then
-  if [ -n "${STEPUP_CLIENT_GUARD_API_DIR:-}" ] || [ -n "${STEPUP_CLIENT_GUARD_CLIENT_DIR:-}" ] || \
-     [ -n "${STEPUP_CLIENT_GUARD_PATH_ROOT:-}" ] || [ -n "${STEPUP_CLIENT_GUARD_EXEMPT_FILE:-}" ] || \
-     [ -n "${STEPUP_CLIENT_GUARD_PATHS_FILE:-}" ] || [ -n "${STEPUP_CLIENT_GUARD_WINDOW:-}" ]; then
-    if [ "${STEPUP_CLIENT_GUARD_FIXTURE_MODE:-}" != "1" ]; then
-      echo "ENV_POLLUTION_GUARD: STEPUP_CLIENT_GUARD_* override set under CI=true without STEPUP_CLIENT_GUARD_FIXTURE_MODE=1 — refusing to run against a possibly-unintended path."
-      exit 1
-    fi
-  fi
-fi
-
 # Client "branch present" tokens (extended regex, OR-joined). The paren is a
 # bracket-expression `[(]` not `\(` so it survives awk's -v un-escaping (a `\(`
 # passed via -v becomes a bare `(` = invalid regex group-open in awk).

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -307,12 +307,11 @@ if [ "$RUN_WEB" != "1" ]; then
   printf "${BOLD}▸ Web steps skipped${RESET}  (no app-filter paths changed — iOS-only diff; set PRE_PR_FORCE_FULL=1 to override)\n\n"
 fi
 
-if [ "$STATIC_ONLY" != "1" ] && [ "$RUN_WEB" = "1" ]; then
-  run_step "Lint"                   npx eslint .
-  # tsc --noEmit typechecks test files too (vitest does not; next build excludes
-  # them), catching mock/type drift that would otherwise rot silently.
-  run_step "Typecheck"              npx tsc --noEmit
-fi
+# Lint / Typecheck / Test / Build used to run here and at three later points,
+# serially. They are independent pure readers of the working tree, so they now
+# run together in one batch at the end — see "Heavy web steps" below. Their
+# report order is preserved there (Lint, Typecheck, ... Test, ... Build), so
+# output stays diff-comparable with the serial script.
 queue_step "Static: env drift check"  npm run check:env-docs
 queue_step "Static: security-matrices drift check" npm run check:security-matrices
 queue_step "Static: team-auth-rls"  node scripts/checks/check-team-auth-rls.mjs
@@ -638,9 +637,10 @@ if git diff --name-only main...HEAD | grep -q '^src/app/\[locale\]/admin/'; then
   fi
 fi
 if [ "$STATIC_ONLY" != "1" ] && [ "$RUN_WEB" = "1" ]; then
-  # Clear vitest cache to match CI's clean environment
+  # Clear vitest cache to match CI's clean environment. This is a repo-global
+  # mutation, so it must happen BEFORE the heavy batch starts — not inside a
+  # job racing the Extension test that shares extension/node_modules/.vitest.
   rm -rf node_modules/.vitest extension/node_modules/.vitest 2>/dev/null || true
-  run_step "Test"                   npx vitest run
 fi
 
 # Integration tests on refactor branches touching auth/DB modules.
@@ -663,9 +663,7 @@ if [ "$STATIC_ONLY" != "1" ] && [ "$RUN_WEB" = "1" ] && \
   fi
 fi
 
-if [ "$STATIC_ONLY" != "1" ] && [ "$RUN_WEB" = "1" ]; then
-  run_step "Build"                  npx next build
-fi
+# Build is dispatched in the heavy batch below, not here.
 
 # Multi-package build + test — mirror CI's "CLI: Build → Test" and
 # "Extension: Test → Build" jobs so a package-level break (e.g. an ESM .js
@@ -674,27 +672,52 @@ fi
 # `xcodebuild` on macos-latest and is not reproducible in this local gate.
 # pre-pr does NOT `npm ci` (slow/destructive); it reuses installed deps and
 # fails with an actionable hint if a package's node_modules is absent.
+# ── Heavy web steps ─────────────────────────────────────────────────────────
+# Lint / Typecheck / Test / Build / CLI / Extension are the bulk of a full run
+# (~150s of a ~160s wall clock; the ~40 static gates above are ~11s). They are
+# independent pure readers of the working tree, so they go through the same
+# bounded scheduler.
+#
+# Two ordering constraints are preserved by pairing rather than by serializing
+# everything: CLI is Build→Test (cli/ is ESM NodeNext, so a missing .js
+# extension is a tsc error that vitest/esbuild tolerates) and Extension is
+# Test→Build, matching CI. Each pair is queued as ONE step running both halves
+# in order, so the pair's internal sequence holds while the pairs run
+# concurrently with each other.
+#
+# Memory: measured peak RSS is Build ~3.1G, Lint ~1.6G, Typecheck ~1.2G, Test
+# ~0.6G — ~6.5G combined against 47G available here. PRE_PR_JOBS caps the
+# concurrency, so a smaller machine runs fewer at once rather than thrashing.
 if [ "$STATIC_ONLY" != "1" ] && [ "$RUN_WEB" = "1" ]; then
-  # CLI: Build → Test (CI order — tsc must run first; cli/ is ESM NodeNext, so a
-  # missing .js extension is a tsc TS2835 error that vitest/esbuild tolerates).
+  # `next build` is the one heavy step that WRITES to the working tree (.next/),
+  # and several tests scan that tree — check-dockerignore-secrets and
+  # route-policy-manifest both failed intermittently when Build ran beside Test,
+  # then passed in isolation. So Build runs on its own, after the batch. The
+  # rest are pure readers and are safe to run together.
+  queue_step "Lint"       npx eslint .
+  queue_step "Typecheck"  npx tsc --noEmit
+  queue_step "Test"       npx vitest run
+
   if [ ! -d cli/node_modules ]; then
     printf "${RED}ERROR: cli/node_modules missing — run 'cd cli && npm ci' (pre-pr does not auto-install)${RESET}\n\n" >&2
     failed=$((failed + 1))
     failures+=("CLI: deps missing|")
   else
-    run_step "CLI: Build"  bash -c 'cd cli && npm run build'
-    run_step "CLI: Test"   bash -c 'cd cli && npm test'
+    queue_step "CLI: Build → Test" bash -c 'cd cli && npm run build && npm test'
   fi
 
-  # Extension: Test → Build (CI order).
   if [ ! -d extension/node_modules ]; then
     printf "${RED}ERROR: extension/node_modules missing — run 'cd extension && npm ci' (pre-pr does not auto-install)${RESET}\n\n" >&2
     failed=$((failed + 1))
     failures+=("Extension: deps missing|")
   else
-    run_step "Extension: Test"   bash -c 'cd extension && npm test'
-    run_step "Extension: Build"  bash -c 'cd extension && npm run build'
+    queue_step "Extension: Test → Build" bash -c 'cd extension && npm test && npm run build'
   fi
+
+  run_batch
+
+  # Serial, after the batch: writes .next/ (see note above).
+  run_step "Build" npx next build
 fi
 
 echo ""

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -211,6 +211,24 @@ run_batch() {
   local -a pids logs
   jobs=$(resolve_jobs)
 
+  # `wait -n` (wait for ANY child) needs bash 4.3+. On bash 3.2 — still the
+  # system bash on macOS, and the version the sibling gates deliberately stay
+  # compatible with — it fails immediately, and a `|| true` would swallow that
+  # and mark a slot free without anything having finished. The throttle would
+  # then be a no-op: measured 6 concurrent children against a cap of 2, i.e.
+  # every queued gate launching at once and PRE_PR_JOBS=1 not serializing.
+  # Fall back to waiting on the OLDEST outstanding job, which is bounded and
+  # correct everywhere, just slightly less eager.
+  # `wait -n` landed in bash 4.3, so the test is ">= 4.3", spelled as
+  # "major > 4" OR "major == 4 AND minor >= 3". Note it is `> 4`, not `>= 4`:
+  # with `>=` the 4.0-4.2 range would wrongly take the `wait -n` path and hit
+  # exactly the runaway described above.
+  local wait_any=0
+  if ((BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3))); then
+    wait_any=1
+  fi
+  local oldest=0
+
   for ((i = 0; i < n; i++)); do
     logs[i]=$(mktemp -t "pre-pr.XXXXXX")
     tempfiles+=("${logs[i]}")
@@ -220,7 +238,16 @@ run_batch() {
     pids[i]=$!
     active=$((active + 1))
     if [ "$active" -ge "$jobs" ]; then
-      wait -n 2>/dev/null || true   # throttle only — status deliberately dropped
+      # Throttle only — the status is deliberately dropped in BOTH branches.
+      # `wait -n` cannot say which job it reaped, so using its status here
+      # would attribute a failure to the wrong step; verdicts are read per
+      # index in the join phase below.
+      if [ "$wait_any" -eq 1 ]; then
+        wait -n 2>/dev/null || true
+      else
+        wait "${pids[oldest]}" 2>/dev/null || true
+        oldest=$((oldest + 1))
+      fi
       active=$((active - 1))
     fi
   done

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -708,27 +708,45 @@ if [ "$STATIC_ONLY" != "1" ] && [ "$RUN_WEB" = "1" ]; then
   queue_step "Test"       npx vitest run
   queue_step "Build"      npx next build
 
+  # CLI is Build→Test and Extension is Test→Build (CI order). Each pair is
+  # SPLIT ACROSS THE TWO BATCHES rather than chained with `&&` in one job:
+  # `&&` would skip the second half whenever the first fails, so a broken CLI
+  # build would leave CLI Test unevaluated — the same "truncated gate run"
+  # the serial script never had, where all four were independent run_steps.
+  # Staging keeps the required order while both halves always run and report.
+  cli_ok=0
   if [ ! -d cli/node_modules ]; then
     printf "${RED}ERROR: cli/node_modules missing — run 'cd cli && npm ci' (pre-pr does not auto-install)${RESET}\n\n" >&2
     failed=$((failed + 1))
     failures+=("CLI: deps missing|")
   else
-    queue_step "CLI: Build → Test" bash -c 'cd cli && npm run build && npm test'
+    cli_ok=1
+    queue_step "CLI: Build"  bash -c 'cd cli && npm run build'
   fi
 
+  ext_ok=0
   if [ ! -d extension/node_modules ]; then
     printf "${RED}ERROR: extension/node_modules missing — run 'cd extension && npm ci' (pre-pr does not auto-install)${RESET}\n\n" >&2
     failed=$((failed + 1))
     failures+=("Extension: deps missing|")
   else
-    queue_step "Extension: Test → Build" bash -c 'cd extension && npm test && npm run build'
+    ext_ok=1
+    queue_step "Extension: Test"  bash -c 'cd extension && npm test'
   fi
 
   run_batch
 
-  # Typecheck reads .next/types/**, which Build generates — so it runs in a
-  # second batch once Build has finished rather than racing it.
+  # Second batch: steps that must observe the first batch's output.
+  #   Typecheck  — reads .next/types/**, which Build generates.
+  #   CLI: Test  — runs against cli/dist from CLI: Build.
+  #   Extension: Build — CI runs it after Extension: Test.
   queue_step "Typecheck"  npx tsc --noEmit
+  if [ "$cli_ok" = "1" ]; then
+    queue_step "CLI: Test"  bash -c 'cd cli && npm test'
+  fi
+  if [ "$ext_ok" = "1" ]; then
+    queue_step "Extension: Build"  bash -c 'cd extension && npm run build'
+  fi
   run_batch
 
 fi

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -678,15 +678,22 @@ fi
 # independent pure readers of the working tree, so they go through the same
 # bounded scheduler.
 #
-# Ordering constraints are preserved by pairing or staging, not by serializing
-# everything:
+# Ordering constraints are honored by STAGING across two batches, never by
+# chaining steps together — a step that must follow another is queued in the
+# later batch, so it still runs and reports even when the earlier one fails:
+#
+#   batch 1: Lint, Test, Build, CLI: Build,  Extension: Test
+#   batch 2:       Typecheck,   CLI: Test,   Extension: Build
+#
 #   * CLI is Build→Test (cli/ is ESM NodeNext, so a missing .js extension is a
-#     tsc error that vitest/esbuild tolerates) and Extension is Test→Build,
-#     matching CI. Each pair is queued as ONE step running both halves in
-#     order, so the pair's internal sequence holds while the pairs run
-#     concurrently with each other.
-#   * Typecheck depends on Build's output, so it runs in a second batch after
-#     the first completes (see below).
+#     tsc TS2835 error that vitest/esbuild tolerate) and Extension is
+#     Test→Build — matching the CI job names.
+#   * Typecheck reads .next/types/**, which Build generates.
+#
+# Do NOT collapse a pair into one `a && b` job to express the order: `&&` skips
+# the second half whenever the first fails, so a broken CLI build would leave
+# CLI Test unevaluated. That is the same truncated-gate-run failure the join
+# phase above is written to avoid, and pre-pr-run-batch.test.mjs pins it.
 #
 # Memory: measured peak RSS is Build ~3.1G, Lint ~1.6G, Typecheck ~1.2G, Test
 # ~0.6G — ~6.5G combined against 47G available here. PRE_PR_JOBS caps the

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -678,25 +678,35 @@ fi
 # independent pure readers of the working tree, so they go through the same
 # bounded scheduler.
 #
-# Two ordering constraints are preserved by pairing rather than by serializing
-# everything: CLI is Build→Test (cli/ is ESM NodeNext, so a missing .js
-# extension is a tsc error that vitest/esbuild tolerates) and Extension is
-# Test→Build, matching CI. Each pair is queued as ONE step running both halves
-# in order, so the pair's internal sequence holds while the pairs run
-# concurrently with each other.
+# Ordering constraints are preserved by pairing or staging, not by serializing
+# everything:
+#   * CLI is Build→Test (cli/ is ESM NodeNext, so a missing .js extension is a
+#     tsc error that vitest/esbuild tolerates) and Extension is Test→Build,
+#     matching CI. Each pair is queued as ONE step running both halves in
+#     order, so the pair's internal sequence holds while the pairs run
+#     concurrently with each other.
+#   * Typecheck depends on Build's output, so it runs in a second batch after
+#     the first completes (see below).
 #
 # Memory: measured peak RSS is Build ~3.1G, Lint ~1.6G, Typecheck ~1.2G, Test
 # ~0.6G — ~6.5G combined against 47G available here. PRE_PR_JOBS caps the
 # concurrency, so a smaller machine runs fewer at once rather than thrashing.
 if [ "$STATIC_ONLY" != "1" ] && [ "$RUN_WEB" = "1" ]; then
-  # `next build` is the one heavy step that WRITES to the working tree (.next/),
-  # and several tests scan that tree — check-dockerignore-secrets and
-  # route-policy-manifest both failed intermittently when Build ran beside Test,
-  # then passed in isolation. So Build runs on its own, after the batch. The
-  # rest are pure readers and are safe to run together.
+  # Typecheck is NOT in this batch — it is the one step with a real dependency
+  # on another. `tsconfig.json` includes `.next/types/**/*.ts`, which `next
+  # build` generates, so running the two concurrently makes tsc read a
+  # half-written tree:
+  #   .next/types/validator.ts: error TS2307: Cannot find module './routes.js'
+  # It therefore runs in a second batch below, after Build has finished.
+  #
+  # Build itself is safe here despite writing `.next/`: no test in the suite
+  # reads that directory. (Two tests DID fail when Build first joined the
+  # batch — but both were 10s-timeout expiries under CPU contention, not file
+  # races, and they no longer occur now that Build overlaps Test rather than
+  # competing with the whole batch.)
   queue_step "Lint"       npx eslint .
-  queue_step "Typecheck"  npx tsc --noEmit
   queue_step "Test"       npx vitest run
+  queue_step "Build"      npx next build
 
   if [ ! -d cli/node_modules ]; then
     printf "${RED}ERROR: cli/node_modules missing — run 'cd cli && npm ci' (pre-pr does not auto-install)${RESET}\n\n" >&2
@@ -716,8 +726,11 @@ if [ "$STATIC_ONLY" != "1" ] && [ "$RUN_WEB" = "1" ]; then
 
   run_batch
 
-  # Serial, after the batch: writes .next/ (see note above).
-  run_step "Build" npx next build
+  # Typecheck reads .next/types/**, which Build generates — so it runs in a
+  # second batch once Build has finished rather than racing it.
+  queue_step "Typecheck"  npx tsc --noEmit
+  run_batch
+
 fi
 
 echo ""

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -308,10 +308,9 @@ if [ "$RUN_WEB" != "1" ]; then
 fi
 
 # Lint / Typecheck / Test / Build used to run here and at three later points,
-# serially. They are independent pure readers of the working tree, so they now
-# run together in one batch at the end — see "Heavy web steps" below. Their
-# report order is preserved there (Lint, Typecheck, ... Test, ... Build), so
-# output stays diff-comparable with the serial script.
+# serially. They now run through the bounded scheduler at the end of the script
+# instead, staged across two batches according to which of them write shared
+# paths — see "Heavy web steps" below.
 queue_step "Static: env drift check"  npm run check:env-docs
 queue_step "Static: security-matrices drift check" npm run check:security-matrices
 queue_step "Static: team-auth-rls"  node scripts/checks/check-team-auth-rls.mjs
@@ -674,9 +673,15 @@ fi
 # fails with an actionable hint if a package's node_modules is absent.
 # ── Heavy web steps ─────────────────────────────────────────────────────────
 # Lint / Typecheck / Test / Build / CLI / Extension are the bulk of a full run
-# (~150s of a ~160s wall clock; the ~40 static gates above are ~11s). They are
-# independent pure readers of the working tree, so they go through the same
-# bounded scheduler.
+# (~150s of a ~160s wall clock; the ~40 static gates above are ~11s), so they
+# go through the same bounded scheduler.
+#
+# Most are pure readers of the working tree and can run in any order. The
+# exceptions are the ones that WRITE, and they are what the staging below is
+# for: `next build` writes .next/ (and Typecheck reads it), CLI: Build writes
+# cli/dist (and CLI: Test reads it), Extension: Build writes its own output.
+# Steps are placed in a batch according to those shared write targets, not
+# merely by how long they take.
 #
 # Ordering constraints are honored by STAGING across two batches, never by
 # chaining steps together — a step that must follow another is queued in the

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -152,36 +152,129 @@ run_step() {
   rm -f "$logfile"
 }
 
+# ── Bounded-parallel batch runner ───────────────────────────────────────────
+# Only the contiguous block of independent static checks below goes through
+# this; everything else keeps using run_step directly. Those checks are pure
+# readers of the working tree (the only two that write anything use their own
+# `mktemp -d`), so they can run concurrently — the block was ~90% of the
+# static phase's wall clock and almost all of it was spent waiting.
+#
+# Contract (each clause exists because the naive version of it is a real bug,
+# verified by probe on bash 5.2):
+#   * counters are mutated ONLY here in the parent shell during replay. A
+#     backgrounded job's writes to `passed`/`failed` are discarded on exit, so
+#     incrementing inside the job silently reports "Passed: 0 / Failed: 0".
+#   * `wait -n` is a THROTTLE ONLY and its status is discarded. It does not say
+#     which job it reaped, so assigning its status to the dispatch loop's index
+#     blames the wrong step: measured 7 0 0 against a truth of 0 0 7, i.e. a
+#     failing gate reported as passing.
+#   * the join reads status per index through an `if`, never a bare
+#     `wait "$pid"`. Under this script's `set -e` a non-zero bare wait kills the
+#     run outright: the remaining gates are never joined and the Results block
+#     never prints, so a single failure silently truncates the gate set.
+#   * every `wait` return value IS that step's status. 127 means the step's
+#     command was not found — never "no such job".
+#   * results replay in declaration order regardless of completion order, so
+#     output stays diff-comparable with the serial path, and each step's log is
+#     printed for PASSES too (the serial path's `tee` shows them, and several
+#     gates print CI-auditable config on success).
+batch_labels=()
+batch_cmds=()
+
+queue_step() {
+  local label="$1"
+  shift
+  batch_labels+=("$label")
+  # Store argv safely for later eval-free replay via bash arrays-of-strings.
+  batch_cmds+=("$(printf '%q ' "$@")")
+}
+
+resolve_jobs() {
+  local want="${PRE_PR_JOBS:-}" cores cap
+  cores=$( { command -v nproc >/dev/null 2>&1 && nproc; } || echo 4)
+  cap=$(( cores < 8 ? cores : 8 ))
+  [ "$cap" -lt 1 ] && cap=1
+  # Untrusted input: anything non-numeric or out of range falls back to the
+  # cap rather than to unbounded (PRE_PR_JOBS=0 would otherwise spin forever).
+  case "$want" in
+    ''|*[!0-9]*) printf '%s' "$cap" ;;
+    *) if [ "$want" -lt 1 ]; then printf '%s' 1
+       elif [ "$want" -gt "$cap" ]; then printf '%s' "$cap"
+       else printf '%s' "$want"; fi ;;
+  esac
+}
+
+run_batch() {
+  local n=${#batch_labels[@]}
+  [ "$n" -eq 0 ] && return 0
+  local jobs i ec active=0
+  local -a pids logs
+  jobs=$(resolve_jobs)
+
+  for ((i = 0; i < n; i++)); do
+    logs[i]=$(mktemp -t "pre-pr.XXXXXX")
+    tempfiles+=("${logs[i]}")
+    # No `tee`, no shared pipe: each job owns its logfile, so nothing
+    # interleaves and no pipeline can mask the exit status.
+    bash -c "${batch_cmds[i]}" >"${logs[i]}" 2>&1 &
+    pids[i]=$!
+    active=$((active + 1))
+    if [ "$active" -ge "$jobs" ]; then
+      wait -n 2>/dev/null || true   # throttle only — status deliberately dropped
+      active=$((active - 1))
+    fi
+  done
+
+  for ((i = 0; i < n; i++)); do
+    if wait "${pids[i]}" 2>/dev/null; then ec=0; else ec=$?; fi
+    printf "${BOLD}▸ %s${RESET}\n" "${batch_labels[i]}"
+    [ -s "${logs[i]}" ] && cat "${logs[i]}"
+    if [ "$ec" -eq 0 ]; then
+      printf "${GREEN}  ✓ %s${RESET}\n\n" "${batch_labels[i]}"
+      passed=$((passed + 1))
+      rm -f "${logs[i]}"
+    else
+      printf "${RED}  ✗ %s${RESET}\n\n" "${batch_labels[i]}"
+      failed=$((failed + 1))
+      failures+=("${batch_labels[i]}|${logs[i]}")
+    fi
+  done
+
+  batch_labels=()
+  batch_cmds=()
+}
+
 echo ""
 printf "${BOLD}═══ Pre-PR Checks ═══${RESET}\n\n"
 
-run_step "Static: e2e-selectors"  bash scripts/checks/check-e2e-selectors.sh
-run_step "Static: security-doc-exists" bash scripts/checks/check-security-doc-exists.sh
-run_step "Static: test-hygiene"   bash scripts/checks/check-test-hygiene.sh
-run_step "Static: settings-card-layout"  bash scripts/checks/check-settings-card-layout.sh
-run_step "Static: api-error-codes" bash scripts/checks/check-api-error-codes.sh
-run_step "Static: api-error-body-drift" bash scripts/checks/check-api-error-body-drift.sh
-run_step "Static: fail-closed-routes-have-test" bash scripts/checks/check-fail-closed-routes-have-test.sh
-run_step "Static: permanent-delete-stepup" bash scripts/checks/check-permanent-delete-stepup.sh
-run_step "Static: step-up-client-coverage" bash scripts/checks/check-step-up-client-coverage.sh
-run_step "Static: passkey-mint-gate" bash scripts/checks/check-passkey-mint-gate.sh
-run_step "Static: raw-body-read" bash scripts/checks/check-raw-body-read.sh
-run_step "Static: actions-sha-pinned" bash scripts/checks/check-actions-sha-pinned.sh
-run_step "Static: workflow-supply-chain" node scripts/checks/check-workflow-supply-chain.mjs
-run_step "Static: crypto-auth-deps-classified" node scripts/checks/check-crypto-auth-deps-classified.mjs
-run_step "Static: dockerfile-prisma-pin" bash scripts/checks/check-dockerfile-prisma-pin.sh
-run_step "Static: dockerignore-secrets" bash scripts/checks/check-dockerignore-secrets.sh
-run_step "Static: cosign-kms-uri" bash scripts/checks/check-cosign-kms-uri.sh
-run_step "Smoke: worker-bundle-boot" bash scripts/checks/check-worker-bundle-smoke.sh
-run_step "Static: critical-audit-atomic" node scripts/checks/check-critical-audit-atomic.mjs
-run_step "Static: session-token-hashed" node scripts/checks/check-session-token-hashed.mjs
-run_step "Static: bound-unknown-ip" node scripts/checks/check-bound-unknown-ip.mjs
-run_step "Static: publish-toolchain" bash scripts/checks/check-publish-toolchain.sh
-run_step "Static: ios-no-diagnostic-logging" bash scripts/checks/check-ios-no-diagnostic-logging.sh
-run_step "Static: ios-authenticated-session-pinning" bash scripts/checks/check-ios-authenticated-session-pinning.sh
+queue_step "Static: e2e-selectors"  bash scripts/checks/check-e2e-selectors.sh
+queue_step "Static: security-doc-exists" bash scripts/checks/check-security-doc-exists.sh
+queue_step "Static: test-hygiene"   bash scripts/checks/check-test-hygiene.sh
+queue_step "Static: settings-card-layout"  bash scripts/checks/check-settings-card-layout.sh
+queue_step "Static: api-error-codes" bash scripts/checks/check-api-error-codes.sh
+queue_step "Static: api-error-body-drift" bash scripts/checks/check-api-error-body-drift.sh
+queue_step "Static: fail-closed-routes-have-test" bash scripts/checks/check-fail-closed-routes-have-test.sh
+queue_step "Static: permanent-delete-stepup" bash scripts/checks/check-permanent-delete-stepup.sh
+queue_step "Static: step-up-client-coverage" bash scripts/checks/check-step-up-client-coverage.sh
+queue_step "Static: passkey-mint-gate" bash scripts/checks/check-passkey-mint-gate.sh
+queue_step "Static: raw-body-read" bash scripts/checks/check-raw-body-read.sh
+queue_step "Static: actions-sha-pinned" bash scripts/checks/check-actions-sha-pinned.sh
+queue_step "Static: workflow-supply-chain" node scripts/checks/check-workflow-supply-chain.mjs
+queue_step "Static: crypto-auth-deps-classified" node scripts/checks/check-crypto-auth-deps-classified.mjs
+queue_step "Static: dockerfile-prisma-pin" bash scripts/checks/check-dockerfile-prisma-pin.sh
+queue_step "Static: dockerignore-secrets" bash scripts/checks/check-dockerignore-secrets.sh
+queue_step "Static: cosign-kms-uri" bash scripts/checks/check-cosign-kms-uri.sh
+queue_step "Smoke: worker-bundle-boot" bash scripts/checks/check-worker-bundle-smoke.sh
+queue_step "Static: critical-audit-atomic" node scripts/checks/check-critical-audit-atomic.mjs
+queue_step "Static: session-token-hashed" node scripts/checks/check-session-token-hashed.mjs
+queue_step "Static: bound-unknown-ip" node scripts/checks/check-bound-unknown-ip.mjs
+queue_step "Static: publish-toolchain" bash scripts/checks/check-publish-toolchain.sh
+queue_step "Static: ios-no-diagnostic-logging" bash scripts/checks/check-ios-no-diagnostic-logging.sh
+queue_step "Static: ios-authenticated-session-pinning" bash scripts/checks/check-ios-authenticated-session-pinning.sh
 # Runs here (ubuntu OpenSSL 3.x), never the macOS iOS job — the .p12 fixtures are
 # -legacy-encrypted and macOS LibreSSL rejects `openssl pkcs12 -legacy`.
-run_step "Static: tls-fixture-expiry" bash scripts/checks/check-tls-fixture-expiry.sh
+queue_step "Static: tls-fixture-expiry" bash scripts/checks/check-tls-fixture-expiry.sh
+run_batch
 
 if [ "$RUN_WEB" != "1" ]; then
   printf "${BOLD}▸ Web steps skipped${RESET}  (no app-filter paths changed — iOS-only diff; set PRE_PR_FORCE_FULL=1 to override)\n\n"
@@ -193,19 +286,20 @@ if [ "$STATIC_ONLY" != "1" ] && [ "$RUN_WEB" = "1" ]; then
   # them), catching mock/type drift that would otherwise rot silently.
   run_step "Typecheck"              npx tsc --noEmit
 fi
-run_step "Static: env drift check"  npm run check:env-docs
-run_step "Static: security-matrices drift check" npm run check:security-matrices
-run_step "Static: team-auth-rls"  node scripts/checks/check-team-auth-rls.mjs
-run_step "Static: bypass-rls"     node scripts/checks/check-bypass-rls.mjs
-run_step "Static: count-then-create-lock" node scripts/checks/check-count-then-create-lock.mjs
-run_step "Static: null-tenant-fail-closed" node scripts/checks/check-null-tenant-fail-closed.mjs
-run_step "Static: crypto-domains" node scripts/checks/check-crypto-domains.mjs
-run_step "Static: migration-drift" node scripts/checks/check-migration-drift.mjs
-run_step "Static: destructive-migration" node scripts/checks/check-destructive-migration.mjs
-run_step "Static: migration-transaction" node scripts/checks/check-migration-transaction.mjs
-run_step "Static: raw-sql-usage" node scripts/checks/check-raw-sql-usage.mjs
-run_step "Static: gate-selftest-coverage" bash scripts/checks/check-gate-selftest-coverage.sh
-run_step "Static: destructive-wrapper-derivation" node scripts/checks/check-destructive-wrapper-derivation.mjs
+queue_step "Static: env drift check"  npm run check:env-docs
+queue_step "Static: security-matrices drift check" npm run check:security-matrices
+queue_step "Static: team-auth-rls"  node scripts/checks/check-team-auth-rls.mjs
+queue_step "Static: bypass-rls"     node scripts/checks/check-bypass-rls.mjs
+queue_step "Static: count-then-create-lock" node scripts/checks/check-count-then-create-lock.mjs
+queue_step "Static: null-tenant-fail-closed" node scripts/checks/check-null-tenant-fail-closed.mjs
+queue_step "Static: crypto-domains" node scripts/checks/check-crypto-domains.mjs
+queue_step "Static: migration-drift" node scripts/checks/check-migration-drift.mjs
+queue_step "Static: destructive-migration" node scripts/checks/check-destructive-migration.mjs
+queue_step "Static: migration-transaction" node scripts/checks/check-migration-transaction.mjs
+queue_step "Static: raw-sql-usage" node scripts/checks/check-raw-sql-usage.mjs
+queue_step "Static: gate-selftest-coverage" bash scripts/checks/check-gate-selftest-coverage.sh
+queue_step "Static: destructive-wrapper-derivation" node scripts/checks/check-destructive-wrapper-derivation.mjs
+run_batch
 # Cross-tenant SQL parse check (issue #434). Runs against the local docker DB
 # if reachable; skips gracefully otherwise (preserves pre-pr.sh's "no Postgres
 # required" contract for the static checks above).


### PR DESCRIPTION
## Summary

Speeds up `scripts/pre-pr.sh` without removing, sampling, or conditionally skipping a single check. Measured on an idle 20-core machine:

| | main | this branch |
|---|---|---|
| Static phase (`PRE_PR_STATIC_ONLY=1`, what CI's `static-checks` job runs) | ~187s | **~11s** |
| Full local run | 156-181s | **~88s** |
| Checks executed | 60 | 60 |

Two changes get there:

1. **De-spawned the two gates that dominated the static phase.** `check-step-up-client-coverage.sh` was 171s of the 187s — 91% — because its `(call site x manifest id)` loop derived per-id manifest data and re-read per-file windows inside the loop body, spawning **66,176 processes per run** (R45). Now 4.9s. `check-fail-closed-routes-have-test.sh` had the same defect in `lookup()`/`field()`; those are plain string splits over in-memory data that each spawned an `awk`.
2. **Bounded-parallel scheduling.** ~38 independent static gates plus Lint/Test/Build/CLI/Extension are pure readers of the working tree, so they run concurrently under a `min(nproc, 8)` cap instead of one at a time.

## Why this needed care

`pre-pr.sh` is a security-gate harness — it runs ~40 static guards, and CI's `static-checks` job invokes the same script (`.github/workflows/ci.yml:228`). The failure mode that matters is not a slow gate; it is a gate that silently stops detecting while still reporting green.

Three-expert plan review plus three-expert code review produced 46 findings. Five were red-proven with executable probes rather than argued:

| Defect | Probe result |
|---|---|
| `wait -n` status capture mis-attributes verdicts | declaration truth `0 0 7` reported as **`7 0 0`** — a failing gate reported as passing |
| Per-index join under `set -e` aborts the run | `SCRIPT EXIT=7`, later gates never joined, Results block never printed |
| Backgrounded jobs cannot mutate parent counters | `passed=0` after a job incremented it |
| Self-test could not see the scheduler's call sites | removing both `run_batch` calls kept every test green while the script silently dropped from 51 executed checks to 13 |
| `wait -n` is bash 4.3+ | on bash 3.2 the throttle became a no-op: 6 concurrent children against a cap of 2 |

The most consequential finding was about the verification itself. The original safety argument was "stdout is byte-identical before and after" — but this gate **emits zero bytes when healthy**, so that check was `diff /dev/null /dev/null`. A reviewer built a narrowed gate that passed all 30 self-tests *and* the byte-identical differential while genuinely losing detection. For a gate that is silent when healthy, any criterion observing only a green tree is vacuous by construction.

## How equivalence is actually established

- **Decision-trace differential** — both implementations instrumented to emit a verdict per `(call site, id)` pair. All **13,844 records byte-identical**.
- **Per-dimension mutation proofs** — one mutant per independently-narrowable dimension (word boundary, ERE escaping, comment skip, the `+3`/`+10`/`-3` window bounds, exempt-id skip). Each turns the gate red, 1:1 with a named fixture, on both the old and new implementations.
- **Fixtures first** — the self-test was extended *before* the optimization landed (`bfc66efc5`), because its cross-product was empty: no fixture had two manifest ids reaching one call site, so the exact bug class hoisting introduces was unobservable.

## Notable implementation constraints

- **bash 3.2 compatibility is preserved.** The target script documents this twice; `declare -A` would have silently revoked it on stock macOS `/bin/bash`. Hoisting uses indexed arrays. `wait -n` is version-gated with a fallback that waits on the oldest job.
- **Window scopes are not collapsed.** `arg_window`/`opt_window`/`suppress_window` are per-call-site; only `file_marker_ids` is per-file. Hoisting the former to file scope would widen matching from 4 lines to the whole file.
- **Ordering is expressed by batch staging, never by `&&` chaining.** `CLI: Build -> Test`, `Extension: Test -> Build`, and `Build -> Typecheck` (tsc reads `.next/types/**`, which `next build` writes) are staged across two batches, so a failing first half still lets the second run and report. Chaining with `&&` reintroduced the truncated-gate-run class and was caught in review.
- **`next build` is the one heavy step that writes the tree.** It runs in the batch (overlapping Test) but Typecheck waits for it.

## Scope notes

- Everything below `pre-pr.sh:186` — conditional steps, skip notices, gitleaks, the R35 gate — is unchanged and still serial. Those interleave `printf` output and inline counter mutations that a deferred-replay model would reorder.
- `PRE_PR_JOBS` is an escape hatch: `PRE_PR_JOBS=1` restores fully-serial behavior. It is clamped to `[1, min(nproc,8)]`, with non-numeric values falling back to the cap rather than to unbounded.
- Adds `ENV_POLLUTION_GUARD` to the step-up gate: its six path overrides could point it at an empty tree and green it, and it was the only gate lacking the guard its sibling already carries. Nothing outside the gate and its self-test sets those variables, so no existing job changes behavior.

## Review artifacts

- [pre-pr-parallelization-plan.md](./docs/archive/review/pre-pr-parallelization-plan.md)
- [pre-pr-parallelization-review.md](./docs/archive/review/pre-pr-parallelization-review.md)

## Verification performed

- `bash scripts/pre-pr.sh` — 87.5s, exit 0, **60 checks** (same count as `main`)
- `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` — ~11s, exit 0, step **labels set-equal to the serial run** and reported in declaration order
- `npx vitest run scripts/__tests__/` — 50 files, 737 tests passing
- Red-proofs on scratchpad copies: two failures at non-adjacent indices with distinct exit codes attribute correctly; a step exiting 127 reports failed rather than absorbed; a step emitting 1.2 MB before failing keeps its last line; observed peak overlap is exactly 1 at `PRE_PR_JOBS=1` and exactly 4 at 4, so the run cannot silently degenerate to serial and still pass
- 2-core simulation (`taskset -c 0,1`) for the CI shape: ~26s static, well inside the job's 8-minute budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)
