### PR TITLE
docs(security): align CSP and fail-closed manifest comments with implementation

### DIFF
--- a/scripts/checks/fail-closed-manifest.txt
+++ b/scripts/checks/fail-closed-manifest.txt
@@ -26,7 +26,7 @@
 # comment that discusses the flag (e.g. writing "the fail-closed opt-in
 # flag" instead of the literal) is the required fix, not a manifest change.
 #
-# 65 entries: 62 route files under src/app/api + 3 non-route lib members
+# 66 entries: 63 route files under src/app/api + 3 non-route lib members
 # (src/auth.config.ts, src/lib/scim/rate-limit.ts,
 # src/lib/security/rate-limiters.ts). Each non-route member is covered by a
 # tier-appropriate shared helper — silent-drop (auth.config magic-link),
@@ -40,7 +40,7 @@
 # (MAPPING_MOCKED_CONTRACT_TEST), or leaving a stale legacy entry after
 # migration (STALE_LEGACY_ENTRY) all fail the gate, not just an edit to the
 # manifest count. Sum of all counts here
-# is 72 (69 across the 62 route files, matching AC4.4's
+# is 74 (71 across the 63 route files, matching AC4.4's
 # EXPECTED_LIMITER_COUNT, + 3 for the lib members) — the gate cross-checks
 # the src/app/api subset sum against EXPECTED_LIMITER_COUNT so the two
 # primitives cannot drift apart silently.

--- a/src/lib/security/csp-builder.ts
+++ b/src/lib/security/csp-builder.ts
@@ -13,8 +13,7 @@ const _isProd = process.env.NODE_ENV === "production";
  *   https://<publicKey>@<host>/<projectId>
  * where <host> is org-specific (e.g. `o123456.ingest.us.sentry.io`).
  * Falling back to the broad wildcard is acceptable when the DSN is
- * unparseable — fail-open is safer than CSP-blocking error reports —
- * but we log so misconfig is visible.
+ * unparseable — fail-open is safer than CSP-blocking error reports.
  */
 function sentryConnectSrc(): string {
   const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;


### PR DESCRIPTION
## Summary
Two long-form comments had drifted from the code they describe. Both fixes are
documentation-only: no behavior, gate threshold, or test expectation changes.

## Motivation
Found while verifying an external security review of this codebase. The review
itself raised two issues that did not survive checking against the source — a
claimed CSP weakness and a claimed set of fail-open rate limiters (three of the
five routes it named are in fact `failClosedOnRedisError: true`). But tracing
those claims surfaced two genuine prose/implementation mismatches.

Neither is a vulnerability. Both matter because these comments are what the next
reader audits the security class from, and both currently assert something the
code does not do.

## Changes

**`src/lib/security/csp-builder.ts`** — the comment claimed the malformed-DSN
path logs "so misconfig is visible", but `sentryConnectSrc()` has no warning
there. The wildcard fallback itself is the intended fail-open (a broken DSN must
not silently disable error capture) and is pinned by an existing test, so the
accurate fix is to drop the false claim rather than change the behavior it
misdescribes. Adding a `console.warn` would be a defensible hardening, but it is
an operational-observability decision, not a documentation fix — deliberately
left out of scope.

**`scripts/checks/fail-closed-manifest.txt`** — the header still described the
pre-expansion class size. Measured against the current file:

| | comment said | actual |
|---|---|---|
| entries | 65 | 66 |
| route files under `src/app/api` | 62 | 63 |
| total sum | 72 | 74 |
| `src/app/api` subset sum | 69 | 71 |

The machine-checked invariants never drifted — the gate's
`EXPECTED_LIMITER_COUNT=71` already matches the subset sum, and the three
non-route lib members were described correctly. Only the prose was stale, which
is precisely what makes it misleading.

## Test plan
Verified before commit:

- `scripts/checks/check-fail-closed-routes-have-test.sh` — exit 0 (checked via
  exit status; this gate prints no PASS line, so a text match would be a false
  green)
- `npx vitest run src/lib/security/csp-builder.test.ts` — 18/18 passed
- `scripts/pre-pr.sh` — 60/60 checks passed, including the Extension build

`next build` skipped per the project rule for comment-only changes; `pre-pr.sh`
covers the build surface.

## Not addressed
The fail-closed gate pins *which* files opted in, but does not derive which
routes *should* be fail-closed — `EXPECTED_LIMITER_COUNT=71` is a frozen
inventory, not a rule. A new unauthenticated token-guessing route added
fail-open would pass CI as long as it never enters the manifest. Current
mitigations are strong (zero debt, AST-based classification, bidirectional set
equality), so this is residual drift risk rather than a defect, and belongs in
its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)