### PR TITLE
refactor(security): route production logging through audited sinks and eliminate `any`

### DIFF
--- a/docs/archive/review/eliminate-prod-any-console-plan.md
+++ b/docs/archive/review/eliminate-prod-any-console-plan.md
@@ -1,0 +1,981 @@
+# Plan: eliminate-prod-any-console
+
+Eliminate every `any` and `console.*` from production source under `src/`, then
+lock the result behind ESLint so the count cannot regress.
+
+## Project context
+
+- **Type**: web app (Next.js 16 App Router) + workers, part of a multi-client
+  security product (web / extension / iOS / CLI).
+- **Test infrastructure**: unit + integration (vitest) + E2E (Playwright) + CI/CD
+  (7 GitHub Actions workflows, 66 bespoke security gates, `scripts/pre-pr.sh`).
+- **Verification environment constraints**:
+  - `VC1` — WebAuthn ceremonies (`navigator.credentials.create/get`) cannot run
+    in unit tests or headless CI; they need a real authenticator or a virtual
+    authenticator (CDP). Classification for the WebAuthn contracts below:
+    type-level changes are `verifiable-CI` (tsc + existing mocked unit tests);
+    runtime ceremony behavior is `blocked-deferred` — but see the Anti-Deferral
+    note under C2, since this change is type-only and emits identical JS.
+  - `VC2` — `ImageCapture` / `getDisplayMedia` require a real browser with screen
+    capture permission. `verifiable-CI` at type level only; runtime is
+    `blocked-deferred` (pre-existing condition, unchanged by this work).
+  - `VC3` — `src/lib/env.ts` runs during module initialization before the pino
+    logger exists. Its behavior is observable only via process boot, covered by
+    existing env tests. `verifiable-CI`.
+
+## Objective
+
+Reduce production-code `any` under `src/` from **22 to 1** — the single remaining
+one being `with-request-log.ts`'s `RouteHandler`, which is provably impossible to
+retype (see `SC3`) and becomes a *documented, config-scoped* exception rather
+than an invisible inline suppression. Reduce production `console.*` under `src/`
+from 13 to 0 (3 relocated into two audited sink modules). Make both counts
+machine-enforced by ESLint rather than by review attention.
+
+**Count provenance** — the honest number moved twice during planning and the
+history matters, because two of the three counts a naive reader would trust were
+wrong:
+
+| Source | `any` | Why it was wrong |
+|--------|------:|------------------|
+| The assessment this work came from | ~1,119 | naive substring grep; counted the English word "any" and words containing it |
+| First measurement here | 24 | included 3-4 comment-prose "any" |
+| First plan draft | 21 | missed both SCIM `Record<string, any>` sites |
+| **Verified** | **22** | `git grep` over `src` excluding tests, then excluding comment lines, then checked file-by-file |
+
+Do not restate the objective as "zero `any`". It is 22 → 1, and the 1 is named.
+
+Non-goal: reducing the counts in test code (82 `any`). Test mocks legitimately
+use `any` and rewriting them would lower test readability without lowering risk.
+
+Non-goal: reducing the counts in test code (82 `any`). Test mocks legitimately
+use `any` and rewriting them would lower test readability without lowering risk.
+
+## Requirements
+
+### Functional
+
+- No behavior change. Every edit is type-level or swaps a `console.*` call for a
+  logger call that writes the same information to the same stream class.
+- The client logger must work in the browser bundle, so it must not import
+  `pino`, `node:async_hooks`, or any other `node:*` module, directly or
+  transitively.
+- The client logger must not degrade the existing server-side structured logging:
+  server modules keep using `@/lib/logger` (pino).
+
+### Non-functional
+
+- `npx tsc --noEmit` clean, `npx next build` succeeds, `npx vitest run` green.
+- ESLint gains two rules scoped to production `src/`, both at `error`.
+- No new **inline** `eslint-disable` comments. File-level overrides in
+  `eslint.config.mjs` are permitted only for the two sites documented in C4/`SC1`
+  (`src/lib/logger/client.ts`, `src/lib/env.ts`); the override list is reviewable
+  in one place, an inline disable is not. Existing inline disables are removed
+  wherever the underlying `any` is removed.
+
+## Technical approach
+
+### Key finding that shapes the design
+
+TypeScript 5.9's `lib.dom.d.ts` defines **most** of the WebAuthn extension types
+this codebase casts around:
+
+- `AuthenticationExtensionsPRFInputs` / `PRFOutputs` / `PRFValues`
+- `AuthenticationExtensionsLargeBlobInputs` / `LargeBlobOutputs`
+- `CredentialPropertiesOutput` (`credProps`)
+- `interface ImageCapture`
+
+**Two exceptions that invalidate a naive "delete the cast" approach.** An earlier
+draft of this plan asserted lib.dom covered everything; security review refuted
+it and the corrections below are load-bearing:
+
+1. **`minPinLength` is NOT on the output side.** `AuthenticationExtensionsClient`
+   `Inputs` has `minPinLength?: boolean` (a request flag), but
+   `AuthenticationExtensionsClientOutputs` has only
+   `{ appid, credProps, hmacCreateSecret, largeBlob, prf }` — **no `minPinLength`**.
+   Verified by reading `lib.dom.d.ts`. `register/verify/route.ts:176` reads
+   `clientExtensionResults.minPinLength`, a CTAP2 authenticator output absent from
+   both lib.dom's Outputs type and SimpleWebAuthn's `RegistrationResponseJSON`.
+   Typing that read against either library type does not compile. It must be read
+   off an `unknown`-valued field and narrowed — which is what the existing runtime
+   guard already does correctly.
+2. **PRF salts cross this wire as hex strings, not `BufferSource`.** Proven by
+   `webauthn-client.test.ts:145-167`, which sends
+   `extensions.prf.eval.first = "a".repeat(64)`.
+   `AuthenticationExtensionsClientInputs` types `first` as `BufferSource`, so the
+   DOM type is the **wrong** type for the wire. The hex→ArrayBuffer conversion at
+   `webauthn-client.ts:361-375` is precisely the boundary between the two, and the
+   wire type must model the hex side.
+
+3. **`@simplewebauthn/server` ships its OWN, narrower DOM declarations.** The
+   server files do not see lib.dom's versions at all. From
+   `node_modules/@simplewebauthn/server/esm/types/dom.d.ts`:
+
+   ```ts
+   export interface AuthenticationExtensionsClientInputs {
+     appid?: string; credProps?: boolean; hmacCreateSecret?: boolean; minPinLength?: boolean;
+   }                                     // no largeBlob, no prf
+   export interface AuthenticationExtensionsClientOutputs {
+     appid?: boolean; credProps?: CredentialPropertiesOutput; hmacCreateSecret?: boolean;
+   }                                     // no minPinLength, no largeBlob, no prf
+   ```
+
+   `RegistrationResponseJSON.clientExtensionResults` is typed with *that*
+   interface. Review compiled the plan's original proposals against the real
+   dependency and got:
+
+   ```
+   TS2339: Property 'minPinLength' does not exist on type 'AuthenticationExtensionsClientOutputs'.
+   TS2339: Property 'largeBlob' does not exist on type 'AuthenticationExtensionsClientOutputs'.
+   TS2353: 'largeBlob' does not exist in type 'AuthenticationExtensionsClientInputs'.
+   ```
+
+   So `webauthn-server.ts:141` needs a **named cast to the library's own
+   `AuthenticationExtensionsClientInputs`** (or an intersection adding
+   `largeBlob`) — not `any`, but not a bare deletion either. This is a certainty,
+   not a contingency.
+
+So the rule is narrower than "the DOM types cover it". Three distinct type
+worlds are in play and must not be conflated:
+
+| World | Applies to | Example |
+|-------|-----------|---------|
+| lib.dom | values the **browser** produced, client-side | `credential.getClientExtensionResults()` in `webauthn-client.ts` |
+| `@simplewebauthn/server`'s dom.d.ts | arguments to library functions, server-side | `verifyRegistration(response)`, `generateRegistrationOptions({extensions})` |
+| repo-local wire types | JSON that **arrived over the network** | `optionsJSON`, `response.clientExtensionResults` reads in the verify route |
+
+The third world is where every remaining runtime guard lives, because the JSON
+came from a client that can lie. F1/F2 below guard against collapsing it into
+either of the first two.
+
+The `any` casts are therefore partly residue from an older DOM-lib generation and
+partly a genuine wire/DOM boundary that was never modeled. This means:
+
+- **No hand-written `.d.ts` augmentation is needed for PRF, largeBlob, credProps,
+  minPinLength, or ImageCapture.** Writing one would shadow the real DOM types
+  and is now the *wrong* fix.
+- The correct fix is to delete the cast and let the existing DOM type apply,
+  adding narrowing only where the value genuinely arrives as untyped JSON.
+
+Two distinct situations remain and must not be conflated:
+
+1. **Browser-API values** — already typed by lib.dom. Delete the cast.
+2. **Wire-format JSON** (server → client options, client → server response) —
+   genuinely `unknown` at the boundary. These need real narrowing, not a cast.
+   `startPasskeyRegistration(optionsJSON: Record<string, unknown>)` receives
+   parsed JSON; `toCreationOptions(json: any)` then reads fields off it. The fix
+   is a typed wire-shape (`PublicKeyCredentialCreationOptionsJSON`-like local
+   type) plus explicit field reads, so a malformed server payload fails at a
+   named boundary instead of propagating `any`.
+
+### C-list overview
+
+Contracts are grouped by the mechanism that removes the `any`/`console`, because
+the risk profile differs sharply between groups.
+
+## Contracts
+
+### C1 — Client-safe logger module
+
+**Signature** (`src/lib/logger/client.ts`, new file):
+
+```ts
+export type ClientLogFields = Record<string, string | number | boolean | null>;
+
+export function clientLogWarn(message: string, fields?: ClientLogFields): void;
+export function clientLogError(message: string, fields?: ClientLogFields): void;
+```
+
+**Design**:
+
+- Zero imports from `node:*`, `pino`, or `@/lib/logger`. Verified by a forbidden
+  -pattern grep (below) and by the fact that the module is imported from client
+  components.
+- Internally calls `console.warn` / `console.error` exactly once each. This is
+  the *only* place in `src/` where `console.*` survives, and it carries a single
+  file-scoped `eslint-disable` with a reason comment — the sink has to exist
+  somewhere, and concentrating it in one audited file is the point of the change.
+- `fields` is a flat scalar record, NOT `unknown`. This makes "someone logs an
+  entire response object" a compile error. But shape is only half the problem —
+  see the denylist below.
+- **Key-name denylist (required, not optional).** The flat-scalar type does NOT
+  stop `clientLogWarn("x", { token: extensionToken })` — a string is a scalar.
+  The server logger (`src/lib/logger.ts:21-42`) redacts 16 key names; the client
+  logger MUST do the same, censoring to `"[REDACTED]"`. Because `ClientLogFields`
+  is flat, this is a single `Object.entries` pass — no traversal.
+
+  The client list is a **superset** of the server's, because a browser console is
+  a lower-trust sink than stdout: any extension with `debugger` permission can
+  read it, and this app allowlists Sentry (`csp-builder.ts:29`), so client console
+  output plausibly leaves the machine. Add `email`, `userId`, `sessionToken`,
+  `credentialId` on top of the server's 16.
+
+  **Single source of truth**: server and client redaction lists must derive from
+  one shared constant. Two hand-maintained copies of one redaction policy is the
+  `feedback_effective_default_distributed_contract` shape — they will drift.
+- No log-level filtering *inside the logger*: `warn`/`error` only, always emitted.
+  **This does not license removing caller-side gates** — see the C1 walkthrough
+  for `use-password-entry-detail.ts`, which keeps its `NODE_ENV` guard.
+
+**Invariants**:
+
+- `I1` (app-enforced): the only modules under `src/` containing a `console.*`
+  call are `src/lib/logger/client.ts` (the audited sink, C1) and `src/lib/env.ts`
+  (pre-logger boot banner, `SC1`). Enforced by ESLint `no-console: error` over
+  `src/**` with exactly these two file overrides — the override list IS the
+  audit surface, so adding a third requires editing the config and is visible
+  in review. Any other `console.*` is a lint error.
+- `I2` (app-enforced): `src/lib/logger/client.ts` imports nothing from `node:*`
+  or `pino`. Enforced by forbidden-pattern grep and by `next build` succeeding
+  with the module reachable from client components.
+- `I3` (type-enforced): callers cannot pass non-scalar values in `fields`.
+  Enforced by the `ClientLogFields` type.
+
+**Member-set derivation for I1 (R42)**:
+
+Defining primitive — a `console.<method>` call expression in production `src/`:
+
+```bash
+git grep -nE 'console\.(log|warn|error|debug|info|trace|table|dir|group|time)' -- 'src' \
+  | grep -vE '(\.test\.|\.spec\.|__tests__)'
+```
+
+Set A (13 members, measured 2026-07-27):
+
+| # | File | Line | Runtime | Replacement |
+|---|------|------|---------|-------------|
+| 1 | `src/app/api/passwords/[id]/attachments/route.ts` | 218 | server | `getLogger().warn` |
+| 2 | `src/components/settings/security/passkey-credentials-card.tsx` | 256 | client | `clientLogError` |
+| 3 | `src/components/team/security/team-rotate-key-button.tsx` | 282 | client | `clientLogError` |
+| 4 | `src/hooks/vault/use-password-entry-detail.ts` | 76 | client | `clientLogError` — **keep the `NODE_ENV` guard at L75** |
+| 5 | `src/i18n/pick-messages.ts` | 16 | both | see C4 |
+| 6 | `src/lib/env.ts` | 44 | server (pre-logger) | move to `boot-stderr.ts` — see C4/`SC1` |
+| 7 | `src/lib/key-provider/base-cloud-provider.ts` | 162 | server | `getLogger().warn` |
+| 8 | `src/lib/proxy/auth-gate.ts` | 139 | server (Node — see note) | `getLogger().warn` |
+| 9 | `src/lib/security/csp-builder.ts` | 37 | both | see C4 |
+| 10 | `src/lib/team/team-vault-core.tsx` | 251 | client | `clientLogWarn` |
+| 11 | `src/lib/team/team-vault-core.tsx` | 268 | client | `clientLogWarn` |
+| 12 | `src/lib/team/team-vault-core.tsx` | 323 | client | `clientLogError` |
+| 13 | `src/lib/url-helpers.ts` | 52 | both | see C4 |
+
+**Note on member 8 (`auth-gate.ts:139`)** — runtime and severity both matter here:
+
+- *Runtime*: the module declares no `export const runtime`, and it imports
+  `resolveUserTenantId` (Prisma) transitively, so it executes on the Node
+  runtime, not Edge. `getLogger()` (pino) is therefore safe. Confirmed by
+  reading the import graph, not assumed — pre-screening flagged Edge-runtime
+  `console` stripping as a risk and this is the check that closes it.
+- *Severity*: this call fires exactly when the session response is missing
+  passkey fields and the code substitutes a **fail-closed** bundle
+  (`requirePasskey: true, hasPasskey: false`). It is the only signal that a
+  fail-closed substitution happened. Losing it would make a security-relevant
+  degradation silent. The replacement MUST preserve both the message and the
+  `missing` field list, and MUST NOT be throttled or level-demoted.
+
+Indirect members the symbol grep misses, checked explicitly:
+- aliased console (`const c = console`) — grep `= console\b` → 0 hits.
+- `globalThis.console` / `window.console` — grep → 0 hits in `src/`.
+- Test-only `console` in `src/**/__tests__` — deliberately out of set A.
+
+**Forbidden patterns**:
+
+- `pattern: from "pino"` in `src/lib/logger/client.ts` — reason: pulls
+  `node:async_hooks` into the browser bundle.
+- `pattern: node:` in `src/lib/logger/client.ts` — reason: same.
+- `pattern: fields\?: unknown` in `src/lib/logger/client.ts` — reason: defeats I3.
+
+**Acceptance criteria**:
+
+- `git grep -c 'console\.' src/lib/logger/client.ts` returns 2 (one warn, one error).
+- Set A above is reduced to exactly the entries C4 declares as KEEP.
+- `next build` succeeds with `clientLogError` imported from a client component.
+
+**Consumer-flow walkthrough** (C1 defines a module API consumed elsewhere):
+
+- Consumer `passkey-credentials-card.tsx` (path:
+  `src/components/settings/security/passkey-credentials-card.tsx:256`) calls
+  `clientLogError("[WebAuthn] Registration failed", { error: <message string> })`
+  and uses nothing from the return value (void). It currently passes the raw
+  `err` object to `console.error`; the new signature forces it to extract
+  `err instanceof Error ? err.message : "unknown"` first — this is the intended
+  tightening, since `err` from a WebAuthn ceremony can carry a `DOMException`
+  whose fields are UA-specific.
+- Consumer `team-rotate-key-button.tsx` (path:
+  `src/components/team/security/team-rotate-key-button.tsx:282`) already narrows
+  to `e instanceof Error ? e.message : "unknown error"` — reads the same shape,
+  no change to its narrowing needed.
+- Consumer `use-password-entry-detail.ts` (path:
+  `src/hooks/vault/use-password-entry-detail.ts:76`) passes a `wrapped` error
+  object, reduced to `{ message }` scalars per I3.
+
+  **The `process.env.NODE_ENV === "development"` guard at line 75 MUST be
+  preserved verbatim around the new call.** This is the only one of the 13
+  members that is production-suppressed today. Dropping it would move a
+  vault-entry-detail decrypt error from dev-only into the production browser
+  console — the highest-sensitivity path in the set. Required-pattern:
+  `NODE_ENV === "development"` must still appear in this file after the change.
+- Consumer `team-vault-core.tsx` — **the three sites are NOT uniform**; an
+  earlier draft characterized all three as flat-scalar object calls, which is
+  wrong for `:323`:
+  - `:251` — `console.warn("[getTeamEncryptionKey] member-key request failed",
+    { teamId, status, error })`. Flat scalars → satisfies I3 directly.
+  - `:268` — same shape, version-mismatch fields. Satisfies I3.
+  - `:323` — **a single interpolated template string, no second argument**:
+    `` console.error(`[getTeamEncryptionKey] failed teamId=${teamId} stage=${stage} error=${errorText}`) ``.
+    It does not fit `(message, fields)` as-is. Decompose it into
+    `clientLogError("[getTeamEncryptionKey] failed", { teamId, stage, error: errorText })`.
+
+    This changes the string the existing test asserts on
+    (`expect.stringContaining("stage=parse_member_key")` at
+    `team-vault-core.test.tsx:335`). The test must move to asserting the
+    **fields** — `objectContaining({ stage: "parse_member_key" })` — which is a
+    strictly stronger assertion than substring-matching an interpolated string.
+    Pre-authorized edit; degrading it to bare `toHaveBeenCalled()` is forbidden.
+
+### C2 — WebAuthn client: replace `any` with DOM types + typed wire shapes
+
+**Files**: `src/lib/auth/webauthn/webauthn-client.ts` (12 sites),
+`src/lib/auth/webauthn/webauthn-server.ts` (1 site).
+
+**Signatures**:
+
+```ts
+// PRF salts cross the wire as HEX STRINGS. This is deliberately NOT
+// AuthenticationExtensionsPRFInputs (which types `first` as BufferSource) —
+// see "Key finding" exception 2. Proven by webauthn-client.test.ts:145-167.
+type PrfInputsWire = {
+  eval?: { first: string; second?: string };
+  evalByCredential?: Record<string, { first: string; second?: string }>;
+};
+type ExtensionsWire = { prf?: PrfInputsWire; [k: string]: unknown };
+
+// Wire shape received from the server (parsed JSON, not browser types).
+type CreationOptionsWire = {
+  rp: PublicKeyCredentialRpEntity;
+  user: { id: string; name: string; displayName: string };
+  challenge: string;
+  pubKeyCredParams: PublicKeyCredentialParameters[];
+  timeout?: number;
+  excludeCredentials?: { id: string; type: string; transports?: string[] }[];
+  authenticatorSelection?: AuthenticatorSelectionCriteria;
+  attestation?: AttestationConveyancePreference;
+  extensions?: ExtensionsWire;
+};
+
+type RequestOptionsWire = {
+  challenge: string;
+  timeout?: number;
+  rpId?: string;
+  allowCredentials?: { id: string; type: string; transports?: string[] }[];
+  userVerification?: UserVerificationRequirement;
+  extensions?: ExtensionsWire;
+};
+
+function toCreationOptions(json: CreationOptionsWire): PublicKeyCredentialCreationOptions;
+function toRequestOptions(json: RequestOptionsWire): PublicKeyCredentialRequestOptions;
+```
+
+**Boundary rule**: `toCreationOptions` / `toRequestOptions` convert hex → ArrayBuffer
+at exactly one place (the existing lines 361-375). Everything upstream of that
+conversion is `*Wire` (hex strings); everything downstream is DOM types
+(`BufferSource`). No type may straddle both.
+
+- `startPasskeyRegistration` / `startPasskeyAuthentication` keep their public
+  `Record<string, unknown>` parameter (callers pass parsed JSON), and narrow to
+  the wire type at the top of the function via an explicit `asCreationOptionsWire`
+  / `asRequestOptionsWire` type-guard-ish reader that throws a named error on a
+  missing required field. This is the R-rule-compliant replacement for
+  `json: any`: `unknown` narrowed explicitly, not cast.
+- `(publicKeyOptions as any).extensions = …` → plain assignment; `extensions` is
+  already `AuthenticationExtensionsClientInputs | undefined` on the DOM type.
+- `credential.getClientExtensionResults() as any` → returns
+  `AuthenticationExtensionsClientOutputs`; read `.prf?.results?.first`, which is
+  `BufferSource | undefined`. `new Uint8Array(prfResults.first as ArrayBuffer)`
+  becomes a `BufferSource` narrowing (`ArrayBuffer` vs `ArrayBufferView`) — this
+  is a real distinction the old cast hid.
+- `(optionsJSON as any).extensions?.prf` → read from the narrowed wire type.
+- `extensions: any = { ...publicKeyOptions.extensions }` →
+  `AuthenticationExtensionsClientInputs`.
+- `webauthn-server.ts:141` `} as any` on the extensions object literal →
+  the object is `{ credProps, minPinLength, largeBlob }`, all present on
+  `AuthenticationExtensionsClientInputs`. Verify against the
+  `@simplewebauthn/server` `GenerateRegistrationOptionsOpts` extension field type;
+  if that library's type is narrower than lib.dom, keep a *narrow* named cast to
+  the library's own exported type rather than `any`.
+
+**Invariants**:
+
+- `I4` (behavior): **enumerated**, not a blanket "emitted JS unchanged" claim —
+  the blanket form was false in an earlier draft and would have made the
+  "existing tests pass" oracle unsound wherever it was violated. The complete
+  list of runtime-behavior changes in C2/C3:
+
+  | # | Site | Change | Test obligation |
+  |---|------|--------|-----------------|
+  | 1 | wire readers in `webauthn-client.ts` | new call frames + a named throw on missing required fields | RT8 table (see Testing strategy) |
+  | 2 | `qr-capture-dialog.tsx:113` | new `"ImageCapture" in window` feature detect | new test stubbing `window` without `ImageCapture` |
+  | 3 | PRF `first` read (`:319`, `:425`) | **none if the `as ArrayBuffer` cast is retained** — preferred | none; if a narrowing is introduced instead, the two-variant mock is mandatory |
+
+  Every other C2/C3 edit is a pure cast erasure with byte-identical emit.
+  Anywhere this table is empty, "existing tests pass unchanged" is a valid
+  oracle; anywhere it has a row, a new test is owed.
+- `I5` (security): the PRF salt path continues to hex-decode the *server-supplied*
+  salt and never derives it client-side. Removing the casts must not change which
+  of the three PRF channels wins (server `extensions.prf` > `evalByCredential` >
+  `prfSalt`).
+
+  **Concretely**: for the exact payload in `webauthn-client.test.ts:145-167`,
+  `serverPrfExt` MUST remain `!== undefined`. If it becomes `undefined`, control
+  falls to the `else if (prfSalt || evalByCredential)` branch at line 376 and a
+  **client-constructed salt silently replaces the server-bound one** — changing
+  the HKDF input at `derivePrfWrappingKey`, hence the vault secret-key wrapping
+  key. That is a security downgrade, not a test failure.
+
+  **Red-proof for I5**: `webauthn-client.test.ts` "(C8 case 1) passes server-built
+  extensions.prf through verbatim" is the designated guard. It asserts the decoded
+  salt round-trips to `SERVER_V1_SALT`. If that test goes red during C2, **the
+  type is wrong, not the test** — do not edit it. See the C5 note on this.
+
+**Forbidden patterns**:
+
+- `pattern: as any` in `src/lib/auth/webauthn/*.ts` — reason: the whole point.
+- `pattern: declare global` in any new file — reason: lib.dom already defines
+  these; augmenting would shadow the real types and silently diverge.
+
+**Acceptance criteria**:
+
+- `git grep -c 'any' src/lib/auth/webauthn/webauthn-client.ts` → 0 type-`any`.
+- All existing webauthn unit tests pass unchanged (no test edits permitted in
+  this contract — a test edit means behavior changed).
+- PRF channel-priority tests still green.
+
+**Anti-Deferral for VC1**: the ceremony itself is `blocked-deferred` in CI, but
+because C2 is type-only and asserts `I4` (identical emitted JS), the residual
+risk is the wire-shape reader's new throw path. That path IS unit-testable
+without an authenticator (feed a malformed options object) and is covered in C5.
+Cost of full runtime verification: a CDP virtual-authenticator E2E harness,
+which does not exist today and is out of scope (`SC2`).
+
+### C3 — Remaining `any` sites outside WebAuthn
+
+| Site | Current | Fix |
+|------|---------|-----|
+| `src/app/api/webauthn/register/verify/route.ts:137` | `verifyRegistration(response as any, …)` | `verifyRegistration` already declares `response: RegistrationResponseJSON` at `webauthn-server.ts:147`, so this cast is **redundant** — deleting it is safe once `response` is narrowed to a compatible shape. This is the ONLY site in this route where a library type applies. |
+| same file :162,170,176,182 | `(response as any).response?.transports` etc. | read off a **locally-declared wire type with `unknown`-valued extension fields**, NOT `RegistrationResponseJSON` and NOT `AuthenticationExtensionsClientOutputs`. `minPinLength` exists on neither (Key finding exception 1). Keep every runtime guard in the I6 table — the narrowing IS the validation, since the Zod schema passes `response` through as `unknown`. |
+| `src/components/passwords/dialogs/qr-capture-dialog.tsx:113` | `new (window as any).ImageCapture(track)` | lib.dom declares `ImageCapture` (incl. the constructor `declare var`), so `new ImageCapture(track)` compiles. **Add `"ImageCapture" in window` but fall through to the EXISTING `qrCaptureFailed` message** — do not introduce a new "unsupported" string. Today's `catch` already maps the Firefox `TypeError` to that localized message, so the user-visible behavior is unchanged and **no new i18n keys are needed**. An earlier draft promised a new "clear unsupported error", which would have been an unlisted `messages/{en,ja}.json` dependency and a user-visible change inside a "no behavior change" contract |
+| `src/components/settings/security/passkey-credentials-card.tsx:206` | `(responseJSON as any).response?.transports` | narrow via the registration-response wire type from C2 |
+| `src/lib/http/with-request-log.ts:25` | `type RouteHandler = (...args: any[]) => Promise<Response>` | **KEEP as the one documented exception (`SC3`) — decided, not contingent.** Review compiled the proposed `readonly unknown[]` form: `TS2345: Type 'unknown' is not assignable to type 'Request'`. Under `strictFunctionTypes` parameter positions are contravariant, so `H extends RouteHandler` requires `H` assignable to `RouteHandler`; widening the param to `unknown` is exactly backwards, and `readonly` constrains the tuple, not element variance. The existing comment at L21-23 is correct. Add a **file-scoped config override**, not an inline disable, so it stays on the reviewable audit surface |
+| `src/app/api/scim/v2/Users/route.ts:45` | `let prismaWhere: Record<string, any>` | `Prisma.TenantMemberWhereInput` |
+| `src/lib/services/scim-user-service.ts:254` | `const updateData: Record<string, any>` | `Prisma.TenantMemberUpdateInput` |
+| `src/workers/audit-outbox-worker.ts:73` | `setBypassRlsGucs(client: any)` | accepts `PrismaClient \| Prisma.TransactionClient`; both expose `$executeRaw`. Type as a structural minimum: `{ $executeRaw: PrismaClient["$executeRaw"] }` |
+
+Four occurrences matched by the audit grep are the English word "any" inside
+comments (`user-session-invalidation.ts:101`, `csrf-gate.ts:10`,
+`team-password-service.ts:385`, `read-api-error-body.ts:29`) — not code, no action.
+
+**Why the SCIM sites were missed, and the lesson.** The first draft's grep was
+`(: any\b|as any\b|<any>|any\[\])`, which does not match `Record<string, any>` —
+the `any` there is a type *argument*, preceded by `, ` and followed by `>`. Two
+live sites were invisible to it. The corrected derivation adds `Record<string, any>`
+and `any>`, and was cross-checked per-file rather than by total count:
+
+```bash
+git grep -nE '\bany\b' -- 'src/**/*.ts' 'src/**/*.tsx' \
+  | grep -vE '(\.test\.|\.spec\.|__tests__|/e2e/)' \
+  | grep -vE '//.*\bany\b|\*.*\bany\b' \
+  | grep -E '(: any|as any|<any>|any\[\]|Record<string, any>|any>)'
+```
+
+This is the R42 failure mode in miniature: a member-set derived from a
+hand-written pattern rather than from every syntactic position the construct can
+occupy. The independent cross-check is the **19 `eslint-disable` comments** (C5)
+— every suppressed site must correspond to a fixed site, so the disable count
+going 19 → 1 catches any member the type-position grep still misses.
+
+**Invariants**:
+
+- `I6` (security, app-enforced): every runtime narrowing currently guarding a
+  client-supplied WebAuthn value survives the retyping. The DOM types describe
+  what a *browser* produces; this route receives a **network payload** from a
+  client that can lie. `response` is `z.record(z.string(), z.unknown())` — nothing
+  is field-validated by the schema, so these inline guards ARE the validation.
+
+  **Member-set (R42), derived from the code, not from prose.** An earlier draft
+  listed 4; the actual set is 10. Security review caught the gap. This table is
+  the implementer checklist:
+
+  | # | Line | Guard | Deleting it causes |
+  |---|------|-------|--------------------|
+  | G1 | 160 | `VALID_TRANSPORTS` allowlist (6 values) | arbitrary transport strings persisted |
+  | G2 | 163-165 | `typeof t === "string" && VALID_TRANSPORTS.has(t)` filter | same |
+  | G3 | 162 | `rawTransports: unknown[] = … ?? []` | `transports: "usb"` (string) → `.filter` throws → 500 |
+  | G4 | 171 | `typeof rawRk === "boolean" ? rawRk : null` | type-confusion write to `discoverable` |
+  | G5 | 178-179 | `typeof rawMinPin === "number" && Number.isInteger && >= PIN_LENGTH_MIN && <= PIN_LENGTH_MAX` | **feeds G10 — see below** |
+  | G6 | 183-184 | `typeof rawLargeBlob === "boolean" ? rawLargeBlob : null` | type-confusion write to `largeBlobSupported` |
+  | G7 | 195 | `PER_CRED_SALT_HEX_RE.test(perCredentialSalt)` | tampered Redis salt persisted |
+  | G8 | 111-119 | Redis challenge envelope shape checks | malformed envelope accepted |
+  | G9 | 226-228 | fail-closed `if (!userInfo.tenant) throw` | PIN policy silently skipped |
+  | G10 | 230-232 | `minPinLength < requireMinPin` → reject | — (it is the consumer) |
+
+  **G5 → G10 is the load-bearing pair.** `minPinLength` is attacker-supplied.
+  G5 constrains it to a sane integer; G10 enforces the tenant's
+  `requireMinPinLength` policy against it. Delete G5 and a client sends
+  `minPinLength: 999`, sailing past G10 — **a tenant authz-policy bypass.** The
+  trap is that after retyping, `clientExtensionResults.minPinLength` does not
+  exist on any library type (see Key finding exception 1), so the cheapest way to
+  make line 176 compile is to delete the read and its guard. Do not. Read it off
+  an `unknown`-typed field and keep every narrowing.
+
+  This is the single highest-risk item in the plan.
+
+**Required patterns** (inverse forbidden-pattern — each MUST still appear in
+`src/app/api/webauthn/register/verify/route.ts` after the change; one grep per
+guard in the I6 table, because a checklist nobody greps is a checklist nobody
+follows):
+
+| Guard | Required literal |
+|-------|------------------|
+| G1/G2 | `VALID_TRANSPORTS` |
+| G3 | `?? []` on the transports read |
+| G4 | `typeof rawRk` |
+| G5 | `Number.isInteger`, `PIN_LENGTH_MIN`, `PIN_LENGTH_MAX` |
+| G6 | `typeof rawLargeBlob` |
+| G7 | `PER_CRED_SALT_HEX_RE` |
+| G9 | `if (!userInfo.tenant)` |
+| G10 | `requireMinPin` |
+
+**Forbidden patterns**:
+
+- `pattern: as any` in this route — reason: the point of the change.
+- `pattern: as RegistrationResponseJSON` applied to the *extension reads* —
+  reason: that type does not carry `minPinLength`/`largeBlob` in the read shape;
+  using it there forces either a delete or a re-cast.
+
+### C4 — `console.*` sites that cannot use either logger
+
+`src/lib/env.ts:44`, `src/lib/security/csp-builder.ts:37`,
+`src/lib/url-helpers.ts:52`, `src/i18n/pick-messages.ts:16`.
+
+Decision per site (to be confirmed during implementation by checking each
+module's actual import graph):
+
+- `env.ts:44` — the banner must still reach stderr before any logger exists
+  (VC3), but a **file-level `no-console: off` on `env.ts` is not acceptable**:
+  that module calls `envSchema.safeParse(process.env)` and therefore has
+  `AUTH_SECRET`, `MASTER_KEY`, DB passwords and `JACKSON_API_KEY` in scope. A
+  permanent blanket exemption on the highest-secret-density file in the repo
+  would leave a future `console.log(result.data)` completely ungated — the exact
+  hole this whole change exists to close.
+
+  **Extract instead**: new `src/lib/boot-stderr.ts`, two lines, takes a `string`
+  and writes it. That file goes on the override list; `env.ts` stays under
+  `no-console: error` with no exception. The secret-bearing module keeps the gate;
+  only a module that cannot see secrets is exempt.
+
+  Also pin the content: the banner is built from `issue.path.join(".")` and
+  `issue.message` only — variable *names*, not values. It MUST never interpolate
+  `process.env` values or `result.data`. (Zod messages for `invalid_literal` /
+  `invalid_enum_value` can embed a received value, so this is a real constraint,
+  not a formality.)
+- `csp-builder.ts:37` — **third permanent KEEP, not a `clientLogWarn` target.**
+  An earlier draft grouped it with the two below; that was wrong. Verified: the
+  call sits at **top-level module scope** (not inside a function), guarded by
+  `if (_isProd && _rawCspMode !== _cspMode)`. It fires during module
+  initialization — structurally the same situation as `env.ts` (VC3) — and it is
+  an *operator* signal about a server env var, so a browser-oriented client
+  logger is the wrong sink even setting aside init ordering. It also fires only
+  when `NODE_ENV === "production"`, the least testable and most damaging path
+  for a logger-init bug. Route it to `boot-stderr.ts` alongside the env banner.
+
+- `url-helpers.ts:52`, `pick-messages.ts:16` — genuinely fine for `clientLogWarn`:
+  both are **inside functions** and both are already env-gated
+  (`NODE_ENV !== "production"` / `=== "development"`). **Those gates must be
+  preserved** — same requirement as member 4 (`use-password-entry-detail.ts`).
+  Dropping `pick-messages`'s gate would start emitting namespace warnings in
+  production browser consoles. Required-pattern: the `NODE_ENV` comparison must
+  still appear in each file after the change.
+
+**Invariant `I7`**: after C4, the only `console.*` in `src/` are the two inside
+`src/lib/logger/client.ts` and the one inside `src/lib/boot-stderr.ts` (which
+serves both the env banner and the CSP-mode warning). ESLint enforces this via
+`no-console: error` with exactly **two** file overrides — the override list IS
+the audit surface.
+
+Because the override list gives *no* protection inside the exempt files, each
+gets a pinned count enforced in CI (a `scripts/checks/` guard), so a second
+console call in either is a red build rather than a silent pass:
+
+- `git grep -c 'console\.' src/lib/logger/client.ts` → exactly 2
+- `git grep -c 'console\.' src/lib/boot-stderr.ts` → exactly 1
+
+`csp-builder.test.ts` currently asserts on a `console.warn` spy; after routing
+through `boot-stderr.ts` it must assert on that module instead (see the C1/C4
+test-edit table). Note the CSP warning fires at module-init under
+`NODE_ENV === "production"`, so the test's existing env manipulation must be
+preserved — this is one of the 6 pre-authorized test edits, not a regression.
+
+### C5 — ESLint enforcement + tests
+
+**Measured starting state — an earlier draft of this contract was wrong about
+it, and the correction changes what the work IS:**
+
+```
+$ npx eslint --print-config src/lib/url-helpers.ts
+@typescript-eslint/no-explicit-any: [2]     ← ALREADY error, repo-wide
+no-console:                         undefined ← genuinely absent
+```
+
+`no-explicit-any` is already enforced at `error` via `eslint-config-next/typescript`.
+The 22 production `any`s survive **because 19 inline `eslint-disable` comments
+suppress them**, not because the rule is missing. So:
+
+- **Only ONE rule is actually new: `no-console`.**
+- The `any` half of this contract is **not "turn on a rule"** — it is **"delete
+  19 suppressions"**, which only succeeds if the underlying `any` is genuinely
+  fixed by C2/C3. That is a strictly stronger obligation and a much better
+  acceptance signal, because it cannot be satisfied by config alone.
+
+**Member-set of the 19 suppressions (R42)** — the defining primitive:
+
+```bash
+git grep -n 'eslint-disable.*no-explicit-any' -- 'src' \
+  | grep -vE '(\.test\.|\.spec\.|__tests__)'
+```
+
+This count must go **19 → 1** (the survivor being `with-request-log.ts`, `SC3`).
+It is red today and green only after C2/C3 land, so it is a real gate.
+
+**ESLint additions** to `eslint.config.mjs`:
+
+```js
+{
+  files: ["src/**/*.{ts,tsx}"],
+  ignores: ["**/*.test.*", "**/*.spec.*", "**/__tests__/**", "src/**/e2e/**"],
+  rules: {
+    // no-explicit-any is NOT re-declared here — it is already error repo-wide
+    // via eslint-config-next/typescript. Re-declaring it under a block that
+    // excludes tests would invite a future "simplification" that drops
+    // enforcement for test code.
+    "no-console": "error",
+  },
+},
+{
+  // The only two modules permitted a raw console sink. Neither can see a
+  // secret: client.ts redacts by denylist, boot-stderr.ts takes a string.
+  files: ["src/lib/logger/client.ts", "src/lib/boot-stderr.ts"],
+  rules: { "no-console": "off" },
+},
+```
+
+Note `src/lib/env.ts` is deliberately **absent** from the override list — see C4.
+
+**Invariants**:
+
+- `I8` (app-enforced): a newly added `any` or `console.*` in production `src/`
+  fails `npm run lint`, hence fails CI.
+
+**Gate wiring — verified, not assumed** (a rule added to a config that no
+authoritative gate runs would enforce nothing):
+
+- CI: `.github/workflows/ci.yml:271` → `run: npm run lint`.
+- Local pre-PR: `scripts/pre-pr.sh:719` → `queue_step "Lint" npx eslint .`.
+
+Both invoke the shipped `eslint.config.mjs`, so the C5 rules take effect in both
+paths. Note `extension/` sits in the config's `globalIgnores`, which is why
+`SC5` defers it rather than claiming coverage.
+
+**RT7 obligation — the gate must be proven able to fail.**
+
+An earlier draft of this contract prescribed copying a file to the **scratchpad**
+(outside the repo) and running eslint on it. That procedure was executed during
+plan review and is **vacuous** — reproduced verbatim:
+
+```
+$ npx eslint <scratchpad>/probe.ts
+  0:0  warning  File ignored because outside of base path
+✖ 1 problem (0 errors, 1 warning)
+EXIT=0
+```
+
+ESLint's flat config refuses to lint outside its base path: a **warning**, and
+**exit 0**. The `files: ["src/**/*.{ts,tsx}"]` glob can never match an
+out-of-tree path. An implementer told to "capture the two error lines" would
+have found none and been tempted to fabricate them. This is exactly
+`feedback_silent_gate_makes_green_tree_diff_vacuous`.
+
+**Correct procedure — must be run in-tree, and the gate's OWN exit status read
+(R44: never through a pipe):**
+
+```bash
+mkdir -p src/lib/__redproof_tmp__
+cp src/lib/url-helpers.ts src/lib/__redproof_tmp__/probe.ts
+printf '\nconst x: any = 1;\nconsole.log(x);\n' >> src/lib/__redproof_tmp__/probe.ts
+npx eslint src/lib/__redproof_tmp__/probe.ts > /tmp/redproof.txt 2>&1
+echo "ESLINT_EXIT=$?"          # MUST be 1
+rm -rf src/lib/__redproof_tmp__ # residue check afterwards (R21)
+```
+
+Verified against the **pre-change** config: `ESLINT_EXIT=1`, with
+`@typescript-eslint/no-explicit-any` firing and **`no-console` NOT firing** —
+which is itself the evidence for the F2 correction above (only `no-console` is
+new). After C5 lands, the same probe must report **both** rule IDs.
+
+Acceptance for the red-proof: the deviation log records (a) the nonzero exit
+status read directly from eslint, and (b) both rule IDs present post-change.
+A capture showing only output lines and no exit status does not satisfy this.
+
+**Scope proof (F8 from review) — the override list must also be proven.** Three
+captures, not one:
+1. a probe under `src/lib/__redproof_tmp__/` → **errors** (rule reaches prod code)
+2. a probe copy of `src/lib/logger/client.ts` with an extra `console.log` →
+   **no `no-console` error** (override is active where intended)
+3. a probe under a `__tests__/` path → **no `no-console` error** (ignores work)
+
+Note the probe path is created and removed inside the same procedure; the real
+source is never mutated (`feedback_mutation_proof_on_throwaway_only`), and a
+residue grep for `__redproof_tmp__` runs afterwards.
+
+**Testing strategy**:
+
+- `src/lib/logger/client.test.ts` (new), three obligations:
+
+  1. **`clientLogWarn` calls `console.warn` exactly once with the message and
+     fields.** Sound and red-provable — spy on `console` directly (legitimate
+     here: `client.ts` is the one file where `console` IS the intended sink).
+  2. **Redaction**: `clientLogWarn("m", { token: "abc" })` emits `[REDACTED]`,
+     never `abc`. Red-proof: delete a denylist entry, confirm red.
+  3. **No `node:*` in the transitive import graph.** An earlier draft specified
+     this as "a static import-graph assertion" — as stated it is **not
+     implementable and cannot fail**: under vitest's Node environment,
+     `import pino from "pino"` resolves fine, so a test that merely imports the
+     module is green either way. And a text grep on one file cannot see the
+     *transitive* edge, which is the actual risk (R-B: pull-in via the
+     `@/lib/logger` barrel).
+
+     Implement it as a real AST walk instead — ts-morph is already used for
+     gates here (`project_ast_guard_tsmorph_no_program`): resolve
+     `src/lib/logger/client.ts`, follow relative imports transitively, and fail
+     on any specifier matching `^node:` or equal to `pino` / `@/lib/logger`.
+
+     **RT7 red-proof (mandatory)**: point the walker at a scratchpad copy with
+     `import "node:async_hooks";` added and confirm it goes red. Without that
+     proof this test is indistinguishable from `expect(true).toBe(true)`.
+- **C2 PRF `BufferSource` branch (RT1 — highest testing risk).** The existing
+  mock at `webauthn-client.test.ts:136-138` returns
+  `first: new Uint8Array([1,2,3,4]).buffer` — an **`ArrayBuffer`**. lib.dom types
+  `first` as `BufferSource = ArrayBuffer | ArrayBufferView`. If the implementer
+  writes the narrowing as
+  `first instanceof ArrayBuffer ? new Uint8Array(first) : new Uint8Array(first.buffer)`,
+  the mock takes branch A and passes — while a **real authenticator returning an
+  `ArrayBufferView` takes branch B, which no test ever executes**. Per `VC1`, CI
+  can never reach a real authenticator, so the unexercised branch stays
+  unverified forever. Failure mode: corrupted PRF-derived wrapping key → **vault
+  fails to unlock after passkey sign-in**.
+
+  **Requirement**: parameterize the mock over BOTH variants — add a fixture
+  returning `first: new Uint8Array([1,2,3,4])` (a view, not `.buffer`) — and
+  assert `Array.from(prfOutput)` equals `[1,2,3,4]` in both cases. This mock
+  edit is **pre-authorized**; it does not trip the "test edit = behavior
+  changed" rule.
+
+  Simpler alternative worth preferring: keep the existing
+  `new Uint8Array(first as ArrayBuffer)` cast, which compiles, emits identical
+  JS, and introduces no branch at all. Review confirmed the uncast form does not
+  compile (`TS2769`), so retaining the cast is the *only* zero-behavior-change
+  option. **Prefer this**; only introduce a narrowing if there is a concrete
+  reason, and then the two-variant mock above is mandatory.
+
+- **C2 wire-shape reader throws (RT8).** The plan must name the required-field
+  set, because existing fixtures constrain it tightly:
+  `webauthn-client.test.ts:356-361` calls `startPasskeyRegistration` with only
+  `{ rp, user, challenge, pubKeyCredParams: [] }`, and lines 173-253 call
+  `startPasskeyAuthentication` with only `{ challenge, rpId, allowCredentials }`.
+  A reader that requires more than that reds six existing tests.
+
+  Specify the throw tests as a table with columns: **(a) malformed input,
+  (b) error today, (c) named error after.** Only rows where (b) ≠ (c) count
+  toward RT8 — `missing challenge` and `missing user` already throw `TypeError`
+  today, so a bare `.rejects.toThrow()` on those passes before AND after and is
+  vacuous. Each qualifying row must be red-proven against the pre-change code.
+**The "existing tests pass unchanged" rule applies to C2/C3 ONLY.** An earlier
+draft applied it to the whole change; that is wrong and would have actively
+misled the implementer. Corrected scoping:
+
+**C2/C3 (type-only)** — existing tests must pass unchanged. A required test edit
+IS the signal that the edit was not type-only. Two pre-authorized exceptions:
+
+- The PRF mock must gain an `ArrayBufferView` fixture (see below) — a legitimate
+  coverage addition, not a symptom.
+- New wire-reader throw tests (see the table requirement below).
+
+**C1/C4 (console replacement)** — the rule is INVERTED: **6 test files spy on
+the global `console` and MUST be edited**, because a spy on `console` cannot
+observe a call routed through a logger module. Enumerated:
+
+| Test file | Asserts | Required new target |
+|-----------|---------|---------------------|
+| `src/lib/url-helpers.test.ts` | `warn` called w/ message | `clientLogWarn` mock |
+| `src/lib/security/csp-builder.test.ts` | `warn` called w/ message | see C4 (stays `console`) |
+| `src/lib/team/team-vault-core.test.tsx` | `warn`/`error` w/ **fields** | `clientLogWarn`/`clientLogError` mock |
+| `src/lib/team/team-vault-context.test.tsx` | console spy | follow core |
+| `src/app/api/passwords/[id]/attachments/route.test.ts` | `warn` called (weak) | `getLogger().warn` mock |
+| `src/hooks/use-travel-mode.test.tsx` | console spy | verify whether in scope |
+
+**Forbidden weakening**: an edit that degrades
+`toHaveBeenCalledWith(msg, objectContaining({...}))` to bare
+`toHaveBeenCalled()` is a coverage regression, not a migration. The
+`team-vault-core` assertions are the only tests pinning the *field contents* of
+that failure log — they must keep asserting fields.
+
+**Coverage reality for the 13 console sites** — stating this because "existing
+tests pass" would otherwise imply coverage that does not exist:
+
+- **asserted today** (5): members 1, 9, 10, 12, 13
+- **executed but NOT asserted** (1): member 8 — `auth-gate.ts:139`, the
+  fail-closed signal the plan calls highest-severity. `auth-gate.test.ts`
+  contains **zero** `spyOn(console)` (verified). Its `it.each` fail-closed block
+  asserts only the returned bundle.
+- **not reachable / not asserted** (7): members 2, 3, 4, 5, 6, 7, 11. Member 7
+  (`base-cloud-provider.ts:162`) sits inside a method the test mocks out
+  entirely, so it is unverifiable by the suite.
+
+**New coverage obligation**: C1 must add an assertion to `auth-gate.test.ts`'s
+existing fail-closed `it.each` that the warn fired with the `missing` array —
+red-proven by deleting the call and confirming red. Shipping the plan's
+highest-severity site with zero verification is not acceptable.
+
+### C6 — Pre-implementation checks and orchestrator verification
+
+**R19 — logger mock shapes.** 95 test files `vi.mock("@/lib/logger", ...)`.
+Three members route to `getLogger().warn` (members 1, 7, 8). A mock returning
+only `{ info, error }` makes the new call throw
+`getLogger(...).warn is not a function` in an unrelated route test, surfacing far
+from its cause. **Before implementing C4**, enumerate the mock shape in the test
+files covering those three sites and add `warn` where absent:
+
+```bash
+git grep -ln 'vi.mock("@/lib/logger"' -- 'src' | xargs grep -L 'warn'
+```
+
+Note member 7 (`base-cloud-provider.ts:162`) sits inside `logStaleWarning`,
+which `base-cloud-provider.test.ts:76` mocks out wholesale — that site is
+**unverifiable by the suite** and must be reviewed by reading, not by running.
+
+**R21 — orchestrator obligations.** If any part of this is delegated to a
+sub-agent, the orchestrator itself re-runs (never delegates, never reads through
+a pipe — R44):
+
+- `npx eslint .` — read exit status directly
+- `npx vitest run`
+- `npx next build`
+- residue greps:
+  - `git grep -n 'console\.' -- src | grep -v test` → only the 3 sanctioned sinks
+  - `git grep -c 'eslint-disable.*no-explicit-any' -- src | grep -v test` → 1
+  - `git grep -rn '__redproof_tmp__' .` → **empty** (red-proof probe removed)
+- confirm no sub-agent mutated a real source file while red-proving
+  (`feedback_r21_subagent_production_mutation_residue_grep`)
+
+## Considerations & constraints
+
+### Scope contract
+
+- `SC1` — the env-validation boot banner keeps a raw stderr write, but moves out
+  of `src/lib/env.ts` into `src/lib/boot-stderr.ts` (C4). Owner: none (permanent,
+  by design). Cost-justification: routing it through pino requires the logger to
+  initialize before env validation, inverting a deliberate dependency order; the
+  failure it reports is a boot-time misconfiguration that must print even if
+  logging is itself misconfigured. The extraction means the permanent exemption
+  lands on a module that cannot see a secret, rather than on the module that
+  holds all of them.
+- `SC2` — CDP virtual-authenticator E2E harness for WebAuthn ceremonies. Owner:
+  future issue. Not created by this work; C2 is type-only so it does not increase
+  the need for one.
+- `SC3` — `with-request-log.ts`'s `RouteHandler` **stays `any`**. Decided, with
+  compiler output as evidence, not deferred:
+  `TS2345: Type 'unknown' is not assignable to type 'Request'`. Under
+  `strictFunctionTypes`, `H extends RouteHandler` requires `H` to be assignable
+  to `RouteHandler`; parameter positions are contravariant, so widening to
+  `unknown` is precisely backwards, and `readonly` constrains the tuple rather
+  than element variance. `never[]` fails on arity for the mirror-image reason.
+  The existing comment at L21-23 already says this and is correct.
+
+  Disposition: a **file-scoped override in `eslint.config.mjs`**, not an inline
+  disable — inline disables are invisible to the audit surface, which is the
+  property C5 exists to establish. The PR reports "**21 removed, 1 documented
+  exception**", never "zero".
+- `SC4` — test-code `any` (82 occurrences) is deliberately untouched.
+- `SC5` — `extension/` is out of scope. Measured 2026-07-27: 6 production
+  `console.*`, **0** production `any`. Of the 6, four are
+  `console.debug` guarded by a `typeof console !== "undefined"` feature check in
+  the autofill select-matching path (`autofill-cc-lib.ts:85-86`,
+  `autofill-identity-lib.ts:49-50`) and log only a select element's target value;
+  two are error `console.warn` in `background/index.ts:724,1026`. Reasons for
+  deferring: (a) `extension/` is in the root ESLint `globalIgnores`, so the C5
+  rules cannot reach it without a separate config — a distinct piece of work;
+  (b) `project_extension_no_eslint` records that the extension has no ESLint
+  setup at all; (c) `project_extension_parallel_impl` means edits there must be
+  applied to both the `.js` production file and its `-lib.ts` twin, which is the
+  RT9 twin-drift hazard and deserves its own reviewed change. Owner: future issue.
+  Not a live secret-leak: none of the 6 sites logs a credential, token, or vault
+  value. Re-verify that claim before closing the future issue.
+- `SC6` — `cli/` is out of scope. Measured 2026-07-27: 48 `console.*`, of which
+  **45 are `console.log`** — a CLI's legitimate stdout, not diagnostic logging.
+  Routing those through a logger would be wrong, not an improvement. The 4
+  `console.error` calls are CLI error output on stderr, also correct. No action.
+
+### Risks
+
+- **R-A (highest)**: deleting a runtime narrowing because the type now looks
+  safe. `credProps.rk` / `minPinLength` / `largeBlob.supported` / `transports`
+  arrive over the network from a client that can lie. Mitigation: I6 +
+  required-pattern greps in C3.
+- **R-B**: the client logger pulls pino transitively via a barrel import
+  (`@/lib/logger` re-export). Mitigation: I2 forbidden-pattern grep + `next build`
+  must succeed; the existing repo memory `project_client_shared_constants_no_node_imports`
+  documents this exact failure mode.
+- **R-C**: `ImageCapture` is absent in Firefox. The current `as any` hid this;
+  using the real type makes the absence visible but does not create it.
+  Mitigation: feature-detect before constructing (the code path already sits in a
+  try/catch, but a `TypeError: ImageCapture is not a constructor` currently
+  surfaces as a generic error).
+- **R-D**: `next build` may typecheck differently from `tsc --noEmit` for client
+  components. Both must be run (project CLAUDE.md already mandates `next build`).
+
+## User operation scenarios
+
+1. User registers a passkey on Chrome with PRF support → registration succeeds,
+   PRF wrapping key derived, vault auto-unlock works. (Exercises C2 happy path.)
+2. User registers a security key without PRF → `prfOutput` is null, fallback
+   passphrase path used. (Exercises the `undefined` branches the casts hid.)
+3. User signs in with a passkey on a second device using per-credential salts →
+   `evalByCredential` channel wins over top-level `eval`. (Exercises I5.)
+4. A hostile client POSTs `clientExtensionResults.credProps.rk = "yes"` (string,
+   not boolean) → server stores `discoverable: null`, does not crash. (Exercises
+   I6 — the check that must survive.)
+5. User captures a QR code on Firefox (no `ImageCapture`) → sees a clear
+   "unsupported" error rather than a stack trace. (Exercises R-C.)
+6. Operator boots the app with an invalid env var → banner prints to stderr
+   before any logger exists. (Exercises SC1.)
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------|--------|
+| C1 | Client-safe logger (`logger/client.ts`) + key-name denylist | locked |
+| C2 | WebAuthn client: wire types (hex) vs DOM types, PRF priority preserved | locked |
+| C3 | Remaining `any` sites incl. SCIM ×2; `RouteHandler` is `SC3` | locked |
+| C4 | `console.*` routing; 3 permanent sinks (`client.ts` ×2, `boot-stderr.ts` ×1) | locked |
+| C5 | `no-console` (the only new rule) + 19→1 disable removal + in-tree red-proof | locked |
+| C6 | Logger-mock enumeration + orchestrator re-verification | locked |
+
+Round 1 closed all findings. Summary of what changed and why it mattered:
+
+| # | Finding | Correction |
+|---|---------|------------|
+| 1 | `@simplewebauthn/server` ships **its own narrower DOM types** — no `minPinLength`/`largeBlob` on Outputs | Three type worlds separated (lib.dom / library / repo wire types) |
+| 2 | PRF salts cross the wire as **hex strings**, not `BufferSource` | `PrfInputsWire` declared; wrong type would have silently downgraded the salt |
+| 3 | I6 listed 4 runtime guards; the code has **10** | Full G1–G10 table + per-guard required-pattern greps |
+| 4 | `no-explicit-any` was **already `error`** repo-wide | Real work is deleting 19 suppressions, not adding a rule |
+| 5 | The red-proof ran **out-of-tree → exit 0, zero errors** | Rewritten in-tree, exit status read directly |
+| 6 | "Existing tests pass unchanged" is **false for C1/C4** — 6 files spy on `console` | Rule scoped to C2/C3; expected test-edit table added |
+| 7 | The `any` count was 21 | Actually **22** — `Record<string, any>` was invisible to the first grep |

--- a/docs/archive/review/eliminate-prod-any-console-review.md
+++ b/docs/archive/review/eliminate-prod-any-console-review.md
@@ -1,0 +1,336 @@
+# Plan Review: eliminate-prod-any-console
+
+Date: 2026-07-27
+Review round: 1
+
+## Changes from Previous Round
+
+Initial review. Three expert sub-agents (functionality, security, testing)
+reviewed the plan in parallel, plus an Ollama pre-screening pass. 7 Critical and
+12 Major findings. Every Critical was independently re-verified by the
+orchestrator against the source before being accepted — see "Orchestrator
+verification" below.
+
+## Verdict
+
+**No-Go as originally written; Go after correction.** The plan's central premise
+— "TypeScript 5.9's `lib.dom.d.ts` already defines the WebAuthn extension types,
+so delete the casts" — is true for lib.dom itself but **does not transfer to the
+server files**, which resolve `@simplewebauthn/server`'s own narrower
+declarations. Two of six `any`-bearing files had no working design. Separately,
+the plan's single verification gate was proven vacuous.
+
+All findings are now reflected in the plan; all six contracts are `locked`.
+
+## Critical Findings
+
+### CF1 — `@simplewebauthn/server` ships its own narrower DOM types (Functionality)
+
+`node_modules/@simplewebauthn/server/esm/types/dom.d.ts` declares:
+
+```ts
+export interface AuthenticationExtensionsClientOutputs {
+  appid?: boolean; credProps?: CredentialPropertiesOutput; hmacCreateSecret?: boolean;
+}   // NO minPinLength, NO largeBlob, NO prf
+```
+
+`RegistrationResponseJSON.clientExtensionResults` uses *that*, not lib.dom's.
+Compiling the plan's proposals produced `TS2339` ×2 and `TS2353`.
+
+**Orchestrator verification**: read the file directly — confirmed. The plan had
+cited `minPinLength?: boolean` on `AuthenticationExtensionsClient**Inputs**` to
+justify an **Outputs**-side read. Wrong side of the wire.
+
+**Correction**: plan now separates three type worlds (lib.dom / library / repo
+wire types) and routes the extension reads through repo-local wire types with
+`unknown`-valued fields.
+
+### CF2 — PRF salts cross the wire as hex strings, not `BufferSource` (Security)
+
+`webauthn-client.test.ts:145-167` sends `extensions.prf.eval.first = "a".repeat(64)`.
+Typing the wire as `AuthenticationExtensionsClientInputs` (`first: BufferSource`)
+makes `hexDecode(serverPrfExt.eval.first)` a type error; the cheapest compile-fix
+drops `serverPrfExt` to `undefined`, falling into the `else if` at
+`webauthn-client.ts:376` — **silently replacing the server-bound salt with a
+client-constructed one**, changing the HKDF input to the vault wrapping key.
+
+**Orchestrator verification**: read the test — confirmed hex string.
+
+**Correction**: `PrfInputsWire` declared with `first: string`; hex→ArrayBuffer
+conversion pinned to the single existing boundary; the C8-case-1 test named as
+the I5 red-proof with an explicit "if this reds, the type is wrong, not the test".
+
+### CF3 — I6's guard checklist listed 4 of 10 (Security)
+
+The verify route's `response` is `z.record(z.string(), z.unknown())` — nothing is
+field-validated by schema, so the inline guards **are** the validation. The
+load-bearing pair: G5 (`Number.isInteger` + range on `minPinLength`) feeds G10
+(tenant `requireMinPinLength` policy). Deleting G5 — the cheapest way to make the
+retyped line 176 compile — lets a client send `minPinLength: 999` and **bypass
+the tenant PIN-length policy**.
+
+**Orchestrator verification**: read `route.ts:222-232` — confirmed G9/G10 exist
+and consume G5's output.
+
+**Correction**: full G1–G10 table added as an implementer checklist, plus a
+required-pattern grep per guard.
+
+### CF4 — `no-explicit-any` was already `error` repo-wide (Testing)
+
+```
+$ npx eslint --print-config src/lib/url-helpers.ts
+@typescript-eslint/no-explicit-any: [2]
+no-console: undefined
+```
+
+The 22 `any`s survive because **19 inline `eslint-disable` comments** suppress
+them. Only `no-console` is genuinely new.
+
+**Orchestrator verification**: ran `--print-config` and counted the disables —
+both confirmed (19).
+
+**Correction**: C5 restated. The `any` half is "delete 19 suppressions", a
+strictly stronger gate than adding a rule, because config alone cannot satisfy it.
+
+### CF5 — The red-proof was vacuous (Testing)
+
+The plan prescribed copying a file to the **scratchpad** and running eslint.
+Reproduced:
+
+```
+$ npx eslint <scratchpad>/probe.ts
+  0:0  warning  File ignored because outside of base path
+✖ 1 problem (0 errors, 1 warning)      EXIT=0
+```
+
+Flat config refuses out-of-tree files. The implementer would have found no error
+lines to capture.
+
+**Orchestrator verification**: ran both forms. Out-of-tree → exit 0. In-tree
+(`src/lib/__redproof_tmp__/probe.ts`) → **exit 1** with `no-explicit-any` firing
+and `no-console` not firing — which independently corroborates CF4.
+
+**Correction**: procedure rewritten in-tree, exit status read directly (R44),
+extended to three captures so the override list and ignore globs are also proven.
+
+### CF6 — "Existing tests pass unchanged" is false for C1/C4 (Testing)
+
+6 test files spy on the global `console`; a spy cannot observe a call routed
+through a logger module. Under the plan's own rule ("a test edit means the edit
+was not type-only"), the implementer would have read 6 expected reds as defect
+signals and been pushed toward keeping `console.*` or deleting assertions.
+
+**Orchestrator verification**: `git grep -ln 'spyOn(console' -- src` → 6 files.
+`auth-gate.test.ts` → **0** console spies.
+
+**Correction**: rule scoped to C2/C3 only; expected test-edit table added with a
+forbidden-weakening clause; coverage reality table (5 asserted / 1 executed-but-
+silent / 7 unreachable) added so the plan stops implying coverage that is absent.
+
+### CF7 — PRF mock covers only the `ArrayBuffer` branch (Testing)
+
+If a `BufferSource` narrowing is introduced, the mock's `ArrayBuffer` takes one
+branch and a real authenticator's `ArrayBufferView` takes the other — which no
+CI test can ever reach (VC1). Failure mode: corrupted wrapping key → vault fails
+to unlock after passkey sign-in.
+
+**Correction**: prefer retaining the `as ArrayBuffer` cast (zero behavior change,
+and the uncast form does not compile — `TS2769`). If a narrowing is introduced
+anyway, a two-variant mock is mandatory.
+
+## Major Findings (all reflected)
+
+| ID | Finding | Correction |
+|----|---------|------------|
+| MF1 | 2 SCIM `Record<string, any>` sites missing from the member set; count is 22 not 21 | Added to C3 with Prisma input types; grep corrected to cover type-argument position; disable-count cross-check added |
+| MF2 | `RouteHandler` retype proven not to typecheck (`TS2345`) | `SC3` promoted from contingency to decision; objective restated "21 removed + 1 documented exception" |
+| MF3 | Client logger has no key-name denylist — `{ token: "..." }` is a scalar and typechecks | Denylist required, superset of the server's 16 paths, single shared constant |
+| MF4 | `use-password-entry-detail.ts:75` `NODE_ENV` gate omitted from the walkthrough | Preservation made explicit + required-pattern; same for `pick-messages.ts`, `url-helpers.ts` |
+| MF5 | `env.ts` file-level `no-console: off` is a permanent hole in the highest-secret-density module | Banner extracted to `boot-stderr.ts`; `env.ts` stays gated |
+| MF6 | `csp-builder.ts:37` is module-init scope, mis-routed to the client logger | Third KEEP, routed to `boot-stderr.ts` |
+| MF7 | `team-vault-core.tsx:323` is a single interpolated string, not a fields call | Decomposition specified; test moves to field assertion (stronger) |
+| MF8 | `auth-gate.ts:139` — the plan's MUST-preserve site — has zero test assertion | New coverage obligation with its own red-proof |
+| MF9 | 95 files mock `@/lib/logger`; mock shapes at the 3 new `getLogger()` sites unchecked | C6 enumeration step added; member 7 declared unverifiable-by-suite |
+| MF10 | RT8 throw tests under-specified; obvious malformed inputs already throw today | (a)/(b)/(c) table required; only rows where behavior differs count |
+| MF11 | `I4` "emitted JS unchanged" false for ≥3 edits | Replaced with an enumerated table, each row carrying a test obligation |
+| MF12 | Extension console leak class unenumerated before deferral | `SC5` added with all 6 sites; 2 emit autofilled card/identity values — flagged as a live pre-existing issue |
+
+## Adjacent Findings
+
+- **Security → Functionality**: `verifyRegistrationSchema.response` is unbounded
+  `z.record(z.string(), z.unknown())`. Pre-existing, not caused by this work, but
+  C3 touches the declaration — the cheapest moment to make I6 schema-enforced
+  rather than grep-enforced. Recorded as a candidate, not adopted (would widen
+  scope beyond a type/logging refactor).
+- **Testing → Functionality**: `qr-capture-dialog.test.tsx` has no `ImageCapture`
+  test; the new feature-detect branch would ship uncovered. Resolved by falling
+  through to the existing `qrCaptureFailed` message (no new i18n keys, no
+  user-visible change) plus a new test.
+
+## Quality Warnings
+
+None. All findings arrived with file:line evidence; the orchestrator
+independently re-verified all 7 Criticals against the source rather than
+accepting the sub-agent reports at face value (R21).
+
+## Orchestrator verification (R21)
+
+Commands run by the orchestrator itself, not delegated:
+
+| Check | Result |
+|-------|--------|
+| `lib.dom.d.ts` `AuthenticationExtensionsClientOutputs` | no `minPinLength`, no `largeBlob` — CF1 confirmed |
+| `@simplewebauthn/server/esm/types/dom.d.ts` | narrower still — CF1 confirmed |
+| `webauthn-client.test.ts:145-167` | hex-string salt — CF2 confirmed |
+| `route.ts:222-232` | G9/G10 present, consume G5 — CF3 confirmed |
+| `npx eslint --print-config` | `no-explicit-any: [2]`, `no-console: undefined` — CF4 confirmed |
+| disable count | 19 — CF4 confirmed |
+| out-of-tree red-proof | exit 0, 0 errors — CF5 confirmed vacuous |
+| in-tree red-proof | exit 1, `no-explicit-any` fires — correct procedure verified |
+| `spyOn(console` in `src` | 6 files; `auth-gate.test.ts` has 0 — CF6 confirmed |
+| `any` recount | 22 production sites — MF1 confirmed |
+| lint wiring | `ci.yml:271`, `pre-pr.sh:719` — C5 is enforceable |
+
+## Recurring Issue Check
+
+### Functionality expert
+- R1 (shared utility reimplementation): PASS — `logger/throttled.ts` imports pino, server-only; C1 does not duplicate it
+- R3 (incomplete pattern propagation): PARTIAL → resolved via `SC5`/`SC6`
+- R17 (helper adoption coverage): FAIL → 4 of 13 sites had wrong/absent specs; all corrected
+- R29 (external spec citation accuracy): PASS — no RFCs cited; PRF channel priority and credProps semantics match source comments and tests
+- R42 (member-set derivation): console PASS (13/13 exact); `any` FAIL → 22 not 21
+
+### Security expert
+- R3: applied — 2 findings (extension class, guard class)
+- R36 (suppression as substitute for fix): applied — `env.ts` override rejected, replaced by extraction
+- R42: console set A confirmed complete; I6 set incomplete (4 of 10) → Critical
+- RS3 (input validation at boundaries): applied — tight-envelope/loose-payload posture documented as the reason I6 exists
+- RS4 (PII in artifacts): clean today; `ClientLogFields` permits `email`/`userId` by construction → folded into the denylist
+- RT9 (twin drift): checked — no drift today; extension `-lib.ts` twins have no `.js` counterparts carrying these calls
+
+### Testing expert
+- R19 (test mock alignment): FAIL → C6 enumeration step added
+- R21 (orchestrator re-verification): FAIL → C6 obligations added
+- R44 (gate exit status through a pipeline): FAIL → red-proof now reads `$?` unpiped
+- RT1 (mock-reality divergence): FAIL → PRF `BufferSource` branch; resolved by preferring the retained cast
+- RT5 (test call-path includes production primitive): PARTIAL → import-graph assertion rewritten as an AST walk
+- RT6 (new exports without test diff): PARTIAL → one of two proposed assertions could not fail; rewritten
+- RT7 (gate proven able to fail): FAIL ×3 → all three now carry red-proofs
+- RT8 (vacuous denial-path test): FAIL → (a)/(b)/(c) table required
+- RT9: PASS
+
+---
+
+# Phase 3 — Implementation Review
+
+Date: 2026-07-27
+
+Three expert sub-agents reviewed the implementation. **3 Critical, 9 Major.**
+Every Critical was independently reproduced by the orchestrator before being
+accepted. All are now fixed and each fix carries its own red-proof.
+
+## Critical
+
+### PF1 — `toCreationOptions` dropped the server's registration extensions
+
+The single most consequential defect of the whole change, and the plan never
+enumerated its class.
+
+The wire/DOM boundary rule ("don't copy `extensions`; the wire carries hex")
+was derived from the **authentication** path, where the server sends only `prf`.
+It was then applied to `toCreationOptions` — but on the **registration** path
+`webauthn-server.ts:141` sends `credProps`, `minPinLength`, and `largeBlob`,
+none of which carry hex. Dropping them meant the browser was never asked for
+them, so `getClientExtensionResults()` returned none:
+
+- three columns (`discoverable`, `minPinLength`, `largeBlobSupported`) null for
+  every newly registered passkey
+- **the tenant `requireMinPinLength` policy became permanently inert** — not
+  bypassed by an attacker, but silently non-enforcing on the honest path
+
+Note what this defeats: all ten I6 guards survived verbatim, and every
+required-pattern grep passed. The guards were not removed, their **input was
+starved one layer upstream**. Guard-focused greps structurally cannot see that.
+
+Fixed by `toDomExtensions()` (strips `prf`, forwards the rest) applied to both
+converters. Red-proved: reverting the fix reds 2 of the 3 new tests.
+
+### PF2 — the bundle guard could not follow `@/` imports
+
+`client.ts -> @/lib/logger/throttled -> @/lib/logger -> pino -> node:async_hooks`
+is a real, one-hop, browser-build-breaking edge. The walker followed only
+relative specifiers, so it reported that edge **clean**. Reproduced directly:
+adding the import left the suite green at 8 passed.
+
+The guard passed for the trivial reason that `client.ts` happens to import one
+relative path. Fixed to resolve `@/` against `SRC_ROOT`; the same probe now
+reds.
+
+### PF3 — the guard's own red-proof covered one regex of three
+
+The positive control pointed at `throttled.ts`, whose only forbidden specifier
+is a plain `… from "…"` import. Deleting the side-effect or dynamic-import
+regex left the suite green — a red-proof that proved a third of what it claimed.
+Replaced with six per-form fixtures (side-effect, dynamic, require, re-export,
+multi-line, default+named), each dying if its regex is removed.
+
+## Major (all fixed)
+
+| # | Finding | Fix |
+|---|---------|-----|
+| PM1 | `message` bypasses redaction entirely; two sites interpolated caller data (`withBasePath`'s `path` can carry a token in a query string) | Both moved to `fields`; the constant-message rule is now enforced by an ESLint `no-restricted-syntax` selector, red-proved |
+| PM2 | C4's pinned-count CI guards were never implemented — the two exempt files had **zero** enforcement inside them | `scripts/checks/check-console-sinks.mjs` checks argument *shape*, not counts (a count passes an unredacted 4th call). Wired into pre-pr → CI. Red-proved 3 ways + a 5-case self-test |
+| PM3 | `no-console` ignored `src/**/e2e/**`; in this repo "E2E" also means end-to-end *encryption*, so `src/lib/e2e/` would be silently exempt production crypto | Ignore entry removed; Playwright specs live in the repo-root `e2e/`, outside the glob |
+| PM4 | The three `WEBAUTHN_OPTIONS_MALFORMED` throws shipped untested (RT8) | 3 tests asserting the **named** error; red-proved against the pre-change form (a bare `.toThrow()` would have passed both sides) |
+| PM5 | `auth-gate` warn→error was an unrecorded deviation from the locked C1 table | Deviation accepted and recorded here: promotion is deliberate, since `LOG_LEVEL=error` would otherwise silence the sole fail-closed signal |
+
+## Confirmed to hold
+
+- **All 10 I6 guards intact**, verified by reading each, not by grep. G3 is
+  *stronger* than before: `Array.isArray(...)` rejects the hostile
+  `transports: "usb"` string that `?? []` let through into a `.filter` 500.
+- **I5 PRF channel priority preserved** — the designated C8-case-1 red-proof is
+  green and round-trips the server salt.
+- **Client denylist is a strict superset of the server's** (16 + 4), now from
+  one shared constant; dropping a key from it reds two files.
+- **All three dev-gates preserved** (`use-password-entry-detail`,
+  `pick-messages`, `url-helpers`).
+- **`env.ts` stays under `no-console: error`** — the exemption landed on
+  `boot-stderr.ts`, which cannot see a secret.
+- **ESLint gate correctly scoped** — overrides do not leak to siblings; the
+  `any` rule still applies to tests.
+
+## Process lesson
+
+Three separate times a gate I wrote was green while not working: the bundle
+guard's regex (missed side-effect imports), the guard's alias traversal, and its
+red-proof's coverage. Each was caught only by *running a mutation and demanding
+red* — never by reading the code or by a green suite. The one Critical the
+mutations did not catch, PF1, was found by a reviewer asking what the pre-image
+read that the post-image does not.
+
+R42's defining primitive for a refactor like this should be **"every property
+access present before and absent after"**, not "every guard the plan listed".
+The guard list was complete and still missed a live regression.
+
+## Final state
+
+| Gate | Result |
+|------|--------|
+| `npx tsc --noEmit` | clean |
+| `npx eslint .` | exit 0 (2 pre-existing warnings) |
+| `npx vitest run` | exit 0 — 985 files, 13,063 passed |
+| `npx next build` | exit 0 |
+| `PRE_PR_STATIC_ONLY=1 pre-pr.sh` | exit 0 — 52 steps |
+| production `console.*` (non-sink) | 0 |
+| production `any` | 1 (`with-request-log.ts`, `SC3`) |
+| inline `no-explicit-any` disables | 0 |
+
+## Next step
+
+Commit and open a PR. Deferred, recorded rather than silently dropped:
+`SC5` (extension/ — 6 console sites, 2 emitting autofilled card/identity values
+to the page console; a live pre-existing issue this work surfaced),
+`SC6` (cli/ — legitimate stdout), and three Minor items: `PrfValuesWire.second`
+is declared but discarded, the wire readers are named casts rather than
+validators, and the `ImageCapture` feature-detect branch is uncovered.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -106,25 +106,6 @@ const eslintConfig = defineConfig([
     },
   },
   {
-    // The client logger redacts `fields` by key name but emits `message`
-    // verbatim, so an interpolated message routes a value around the denylist.
-    // Keep variable data in `fields` — enforced, not just documented.
-    files: ["src/**/*.{ts,tsx}"],
-    ignores: ["**/*.test.*", "**/*.spec.*", "**/__tests__/**"],
-    rules: {
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector:
-            "CallExpression[callee.name=/^clientLog(Warn|Error)$/] > TemplateLiteral:first-child[expressions.length>0]",
-          message:
-            "clientLogWarn/clientLogError take a CONSTANT message; only `fields` is redacted. " +
-            "Move interpolated values into the second argument.",
-        },
-      ],
-    },
-  },
-  {
     // The two sanctioned console sinks. Neither can see a secret: client.ts
     // redacts by denylist before writing; boot-stderr.ts takes a plain string
     // and exists so this exemption does NOT land on src/lib/env.ts, which holds

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,6 +82,69 @@ const eslintConfig = defineConfig([
       ],
     },
   },
+  {
+    // Keep diagnostics out of raw console calls in production source.
+    //
+    // Only `no-console` is added here — `@typescript-eslint/no-explicit-any` is
+    // ALREADY error repo-wide via eslint-config-next/typescript, and
+    // re-declaring it under a test-excluding block would invite a future
+    // "simplification" that quietly drops enforcement for test code.
+    //
+    // Client code routes through `@/lib/logger/client` (which redacts by key
+    // name); server code through `@/lib/logger` (pino). The two overrides below
+    // are the only sanctioned raw sinks, and that list IS the audit surface —
+    // adding a third requires editing this file, which is visible in review.
+    // Note the ignore list deliberately does NOT contain `src/**/e2e/**`: in
+    // this repo "E2E" also means end-to-end *encryption* (see
+    // components/share/share-e2e-entry-view.tsx), so a future `src/lib/e2e/`
+    // would be production crypto code silently exempted. Playwright specs live
+    // in the repo-root `e2e/` directory, outside this glob entirely.
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["**/*.test.*", "**/*.spec.*", "**/__tests__/**"],
+    rules: {
+      "no-console": "error",
+    },
+  },
+  {
+    // The client logger redacts `fields` by key name but emits `message`
+    // verbatim, so an interpolated message routes a value around the denylist.
+    // Keep variable data in `fields` — enforced, not just documented.
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["**/*.test.*", "**/*.spec.*", "**/__tests__/**"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "CallExpression[callee.name=/^clientLog(Warn|Error)$/] > TemplateLiteral:first-child[expressions.length>0]",
+          message:
+            "clientLogWarn/clientLogError take a CONSTANT message; only `fields` is redacted. " +
+            "Move interpolated values into the second argument.",
+        },
+      ],
+    },
+  },
+  {
+    // The two sanctioned console sinks. Neither can see a secret: client.ts
+    // redacts by denylist before writing; boot-stderr.ts takes a plain string
+    // and exists so this exemption does NOT land on src/lib/env.ts, which holds
+    // every secret in process.env.
+    files: ["src/lib/logger/client.ts", "src/lib/boot-stderr.ts"],
+    rules: {
+      "no-console": "off",
+    },
+  },
+  {
+    // Route handlers have varying signatures; TypeScript's contravariant
+    // parameter positions make a non-any constraint impossible here (verified:
+    // `readonly unknown[]` yields TS2345). See the explanatory comment in the
+    // file. A file-scoped override rather than an inline disable, so the
+    // exception stays on the reviewable audit surface.
+    files: ["src/lib/http/with-request-log.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/scripts/__tests__/check-console-sinks.test.mjs
+++ b/scripts/__tests__/check-console-sinks.test.mjs
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Self-test for scripts/checks/check-console-sinks.mjs.
+ *
+ * The gate guards the two files exempted from `no-console` — the one place a
+ * secret could reach a console with nothing to stop it. A gate that only ever
+ * runs green proves nothing, so each case here mutates a real source file into
+ * the shape the gate exists to reject, asserts red, and restores. Originals are
+ * captured in beforeEach and rewritten in afterEach so a failing assertion
+ * cannot leave a mutated tree behind.
+ */
+
+const REPO = resolve(import.meta.dirname, "../..");
+const GATE = "scripts/checks/check-console-sinks.mjs";
+
+const TOUCHED = [
+  "src/lib/logger/client.ts",
+  "src/lib/boot-stderr.ts",
+  "eslint.config.mjs",
+];
+
+function runGate() {
+  try {
+    execFileSync("node", [GATE], { cwd: REPO, stdio: "pipe" });
+    return { code: 0, output: "" };
+  } catch (err) {
+    return { code: err.status ?? 1, output: `${err.stdout}${err.stderr}` };
+  }
+}
+
+function patch(file, from, to) {
+  const path = resolve(REPO, file);
+  const src = readFileSync(path, "utf8");
+  expect(src).toContain(from);
+  writeFileSync(path, src.replace(from, to), "utf8");
+}
+
+describe("check-console-sinks", () => {
+  let originals;
+
+  beforeEach(() => {
+    originals = new Map(
+      TOUCHED.map((f) => [f, readFileSync(resolve(REPO, f), "utf8")]),
+    );
+  });
+
+  afterEach(() => {
+    for (const [file, content] of originals) {
+      writeFileSync(resolve(REPO, file), content, "utf8");
+    }
+  });
+
+  it("passes on the current tree", () => {
+    expect(runGate().code).toBe(0);
+  });
+
+  it("rejects fields reaching console without redact()", () => {
+    patch(
+      "src/lib/logger/client.ts",
+      "console.warn(message, redact(fields))",
+      "console.warn(message, fields)",
+    );
+    const { code, output } = runGate();
+    expect(code).toBe(1);
+    expect(output).toMatch(/not a redact\(\.\.\.\) call/);
+  });
+
+  it("rejects a serialized argument in the boot sink", () => {
+    patch(
+      "src/lib/boot-stderr.ts",
+      "console.error(message)",
+      "console.error(JSON.stringify(process.env))",
+    );
+    const { code, output } = runGate();
+    expect(code).toBe(1);
+    expect(output).toMatch(/must take the bare `message` parameter/);
+  });
+
+  it("rejects a third file joining the no-console override list", () => {
+    patch(
+      "eslint.config.mjs",
+      '["src/lib/logger/client.ts", "src/lib/boot-stderr.ts"]',
+      '["src/lib/logger/client.ts", "src/lib/boot-stderr.ts", "src/lib/env.ts"]',
+    );
+    const { code, output } = runGate();
+    expect(code).toBe(1);
+    expect(output).toMatch(/override list is/);
+  });
+
+  it("rejects the sink disappearing from client.ts entirely", () => {
+    // Guards the inverse failure: a gate that finds nothing must not read as OK.
+    patch(
+      "src/lib/logger/client.ts",
+      "console.warn(message, redact(fields));",
+      "void redact(fields);",
+    );
+    patch("src/lib/logger/client.ts", "console.warn(message);", ";");
+    patch(
+      "src/lib/logger/client.ts",
+      "console.error(message, redact(fields));",
+      "void redact(fields);",
+    );
+    patch("src/lib/logger/client.ts", "console.error(message);", ";");
+    const { code, output } = runGate();
+    expect(code).toBe(1);
+    expect(output).toMatch(/expected at least one console call/);
+  });
+});

--- a/scripts/__tests__/check-console-sinks.test.mjs
+++ b/scripts/__tests__/check-console-sinks.test.mjs
@@ -1,31 +1,68 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdtempSync,
+  mkdirSync,
+  cpSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
 
 /**
  * Self-test for scripts/checks/check-console-sinks.mjs.
  *
  * The gate guards the two files exempted from `no-console` — the one place a
  * secret could reach a console with nothing to stop it. A gate that only ever
- * runs green proves nothing, so each case here mutates a real source file into
- * the shape the gate exists to reject, asserts red, and restores. Originals are
- * captured in beforeEach and rewritten in afterEach so a failing assertion
- * cannot leave a mutated tree behind.
+ * runs green proves nothing, so each case mutates the shape the gate exists to
+ * reject and asserts red.
+ *
+ * The mutations happen in a COPY of the tree under $TMPDIR, never in the repo.
+ * An earlier version patched the real files and restored them in afterEach,
+ * which is safe in isolation and wrong under `pre-pr.sh`: that runner executes
+ * steps concurrently, so another gate reading `src/` during the mutation window
+ * observed a half-broken tree and failed. The failure was real but pointed at
+ * an unrelated check, and it did not reproduce on a solo `vitest run` — the
+ * worst shape a flake can take. Copying removes the shared mutable state
+ * instead of narrowing the window.
  */
 
 const REPO = resolve(import.meta.dirname, "../..");
 const GATE = "scripts/checks/check-console-sinks.mjs";
 
-const TOUCHED = [
+// Only what the gate reads: the two sink modules, the ESLint config, and the
+// gate itself. Copying node_modules would make each case take seconds.
+const TREE_FILES = [
   "src/lib/logger/client.ts",
   "src/lib/boot-stderr.ts",
   "eslint.config.mjs",
+  GATE,
 ];
+
+let sandbox;
+
+beforeEach(() => {
+  sandbox = mkdtempSync(resolve(tmpdir(), "console-sinks-"));
+  for (const rel of TREE_FILES) {
+    const dst = resolve(sandbox, rel);
+    mkdirSync(dirname(dst), { recursive: true });
+    cpSync(resolve(REPO, rel), dst);
+  }
+  // The gate imports ts-morph, which resolves from its own location; a symlink
+  // costs nothing and avoids copying the dependency tree per test case.
+  symlinkSync(resolve(REPO, "node_modules"), resolve(sandbox, "node_modules"), "dir");
+});
+
+afterEach(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
 
 function runGate() {
   try {
-    execFileSync("node", [GATE], { cwd: REPO, stdio: "pipe" });
+    execFileSync("node", [GATE], { cwd: sandbox, stdio: "pipe" });
     return { code: 0, output: "" };
   } catch (err) {
     return { code: err.status ?? 1, output: `${err.stdout}${err.stderr}` };
@@ -33,27 +70,13 @@ function runGate() {
 }
 
 function patch(file, from, to) {
-  const path = resolve(REPO, file);
+  const path = resolve(sandbox, file);
   const src = readFileSync(path, "utf8");
   expect(src).toContain(from);
   writeFileSync(path, src.replace(from, to), "utf8");
 }
 
 describe("check-console-sinks", () => {
-  let originals;
-
-  beforeEach(() => {
-    originals = new Map(
-      TOUCHED.map((f) => [f, readFileSync(resolve(REPO, f), "utf8")]),
-    );
-  });
-
-  afterEach(() => {
-    for (const [file, content] of originals) {
-      writeFileSync(resolve(REPO, file), content, "utf8");
-    }
-  });
-
   it("passes on the current tree", () => {
     expect(runGate().code).toBe(0);
   });

--- a/scripts/__tests__/check-console-sinks.test.mjs
+++ b/scripts/__tests__/check-console-sinks.test.mjs
@@ -61,8 +61,8 @@ describe("check-console-sinks", () => {
   it("rejects fields reaching console without redact()", () => {
     patch(
       "src/lib/logger/client.ts",
-      "console.warn(message, redact(fields))",
-      "console.warn(message, fields)",
+      "console.warn(event, redact(fields))",
+      "console.warn(event, fields)",
     );
     const { code, output } = runGate();
     expect(code).toBe(1);
@@ -95,16 +95,16 @@ describe("check-console-sinks", () => {
     // Guards the inverse failure: a gate that finds nothing must not read as OK.
     patch(
       "src/lib/logger/client.ts",
-      "console.warn(message, redact(fields));",
+      "console.warn(event, redact(fields));",
       "void redact(fields);",
     );
-    patch("src/lib/logger/client.ts", "console.warn(message);", ";");
+    patch("src/lib/logger/client.ts", "console.warn(event);", ";");
     patch(
       "src/lib/logger/client.ts",
-      "console.error(message, redact(fields));",
+      "console.error(event, redact(fields));",
       "void redact(fields);",
     );
-    patch("src/lib/logger/client.ts", "console.error(message);", ";");
+    patch("src/lib/logger/client.ts", "console.error(event);", ";");
     const { code, output } = runGate();
     expect(code).toBe(1);
     expect(output).toMatch(/expected at least one console call/);

--- a/scripts/__tests__/check-console-sinks.test.mjs
+++ b/scripts/__tests__/check-console-sinks.test.mjs
@@ -93,18 +93,17 @@ describe("check-console-sinks", () => {
 
   it("rejects the sink disappearing from client.ts entirely", () => {
     // Guards the inverse failure: a gate that finds nothing must not read as OK.
+    // `fields` is required, so each sink has exactly one console call.
     patch(
       "src/lib/logger/client.ts",
       "console.warn(event, redact(fields));",
       "void redact(fields);",
     );
-    patch("src/lib/logger/client.ts", "console.warn(event);", ";");
     patch(
       "src/lib/logger/client.ts",
       "console.error(event, redact(fields));",
       "void redact(fields);",
     );
-    patch("src/lib/logger/client.ts", "console.error(event);", ";");
     const { code, output } = runGate();
     expect(code).toBe(1);
     expect(output).toMatch(/expected at least one console call/);

--- a/scripts/__tests__/check-console-sinks.test.mjs
+++ b/scripts/__tests__/check-console-sinks.test.mjs
@@ -1,16 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import {
-  readFileSync,
-  writeFileSync,
-  mkdtempSync,
-  mkdirSync,
-  cpSync,
-  rmSync,
-  symlinkSync,
-} from "node:fs";
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, cpSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 /**
  * Self-test for scripts/checks/check-console-sinks.mjs.
@@ -20,49 +12,49 @@ import { dirname, resolve } from "node:path";
  * runs green proves nothing, so each case mutates the shape the gate exists to
  * reject and asserts red.
  *
- * The mutations happen in a COPY of the tree under $TMPDIR, never in the repo.
- * An earlier version patched the real files and restored them in afterEach,
- * which is safe in isolation and wrong under `pre-pr.sh`: that runner executes
- * steps concurrently, so another gate reading `src/` during the mutation window
- * observed a half-broken tree and failed. The failure was real but pointed at
- * an unrelated check, and it did not reproduce on a solo `vitest run` — the
- * worst shape a flake can take. Copying removes the shared mutable state
- * instead of narrowing the window.
+ * The guard is driven against fixtures via CONSOLE_SINKS_ROOT, matching the
+ * MINT_GATE_* / other *_ROOT conventions in this directory. An earlier version
+ * patched the real files and restored them in afterEach, which is safe in
+ * isolation and wrong under `pre-pr.sh`: that runner executes steps
+ * concurrently, so another gate reading `src/` during the mutation window
+ * observed a half-broken tree and failed as an unrelated check. Pointing the
+ * guard at a fixture root removes the shared mutable state instead of narrowing
+ * the window.
  */
 
 const REPO = resolve(import.meta.dirname, "../..");
-const GATE = "scripts/checks/check-console-sinks.mjs";
+const GATE = resolve(REPO, "scripts/checks/check-console-sinks.mjs");
 
-// Only what the gate reads: the two sink modules, the ESLint config, and the
-// gate itself. Copying node_modules would make each case take seconds.
+// Only what the gate reads.
 const TREE_FILES = [
   "src/lib/logger/client.ts",
   "src/lib/boot-stderr.ts",
   "eslint.config.mjs",
-  GATE,
 ];
 
-let sandbox;
+let root;
 
 beforeEach(() => {
-  sandbox = mkdtempSync(resolve(tmpdir(), "console-sinks-"));
+  root = mkdtempSync(join(tmpdir(), "console-sinks-"));
   for (const rel of TREE_FILES) {
-    const dst = resolve(sandbox, rel);
+    const dst = join(root, rel);
     mkdirSync(dirname(dst), { recursive: true });
-    cpSync(resolve(REPO, rel), dst);
+    cpSync(join(REPO, rel), dst);
   }
-  // The gate imports ts-morph, which resolves from its own location; a symlink
-  // costs nothing and avoids copying the dependency tree per test case.
-  symlinkSync(resolve(REPO, "node_modules"), resolve(sandbox, "node_modules"), "dir");
 });
 
 afterEach(() => {
-  rmSync(sandbox, { recursive: true, force: true });
+  rmSync(root, { recursive: true, force: true });
 });
 
 function runGate() {
   try {
-    execFileSync("node", [GATE], { cwd: sandbox, stdio: "pipe" });
+    execFileSync("node", [GATE], {
+      cwd: REPO,
+      env: { ...process.env, CONSOLE_SINKS_ROOT: root },
+      encoding: "utf8",
+      stdio: "pipe",
+    });
     return { code: 0, output: "" };
   } catch (err) {
     return { code: err.status ?? 1, output: `${err.stdout}${err.stderr}` };
@@ -70,7 +62,7 @@ function runGate() {
 }
 
 function patch(file, from, to) {
-  const path = resolve(sandbox, file);
+  const path = join(root, file);
   const src = readFileSync(path, "utf8");
   expect(src).toContain(from);
   writeFileSync(path, src.replace(from, to), "utf8");

--- a/scripts/__tests__/check-console-sinks.test.mjs
+++ b/scripts/__tests__/check-console-sinks.test.mjs
@@ -66,7 +66,43 @@ describe("check-console-sinks", () => {
     );
     const { code, output } = runGate();
     expect(code).toBe(1);
-    expect(output).toMatch(/not a redact\(\.\.\.\) call/);
+    expect(output).toMatch(/the only permitted form is/);
+  });
+
+  it("rejects an unredacted single-argument console call", () => {
+    // The regression this gate missed: `console.warn(fields)` is a one-argument
+    // call, and the check used to wave those through as "nothing to redact".
+    // Now only the exact `(event, redact(fields))` form is accepted.
+    patch(
+      "src/lib/logger/client.ts",
+      "console.warn(event, redact(fields));",
+      "console.warn(fields);",
+    );
+    const { code, output } = runGate();
+    expect(code).toBe(1);
+    expect(output).toMatch(/the only permitted form is/);
+  });
+
+  it("rejects an extra argument appended to a sink call", () => {
+    patch(
+      "src/lib/logger/client.ts",
+      "console.error(event, redact(fields));",
+      "console.error(event, redact(fields), fields);",
+    );
+    const { code, output } = runGate();
+    expect(code).toBe(1);
+    expect(output).toMatch(/the only permitted form is/);
+  });
+
+  it("rejects the arguments being reordered", () => {
+    patch(
+      "src/lib/logger/client.ts",
+      "console.warn(event, redact(fields));",
+      "console.warn(redact(fields), event);",
+    );
+    const { code, output } = runGate();
+    expect(code).toBe(1);
+    expect(output).toMatch(/the only permitted form is/);
   });
 
   it("rejects a serialized argument in the boot sink", () => {

--- a/scripts/checks/check-console-sinks.mjs
+++ b/scripts/checks/check-console-sinks.mjs
@@ -17,19 +17,36 @@
  *   boot-stderr.ts — exactly one console call, taking the bare `message` param
  *
  * Run: node scripts/checks/check-console-sinks.mjs
+ *
+ * CONSOLE_SINKS_ROOT overrides the scan root (self-test fixtures only).
  */
 
 import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
 import { Project, SyntaxKind } from "ts-morph";
+
+const REPO_ROOT = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+
+// Scan root is overridable so the self-test
+// (scripts/__tests__/check-console-sinks.test.mjs) can point the guard at
+// fixtures instead of mutating the real tree — mutating it in place raced with
+// the other gates `pre-pr.sh` runs concurrently. Production CI uses the default.
+const SCAN_ROOT = process.env.CONSOLE_SINKS_ROOT || REPO_ROOT;
 
 const CLIENT = "src/lib/logger/client.ts";
 const BOOT = "src/lib/boot-stderr.ts";
+const ESLINT_CONFIG = "eslint.config.mjs";
+
+const at = (rel) => resolve(SCAN_ROOT, rel);
 
 const project = new Project({ useInMemoryFileSystem: false, skipAddingFilesFromTsConfig: true });
 const failures = [];
 
 function consoleCalls(filePath) {
-  const sf = project.addSourceFileAtPath(filePath);
+  const sf = project.addSourceFileAtPath(at(filePath));
   return sf
     .getDescendantsOfKind(SyntaxKind.CallExpression)
     .filter((call) => {
@@ -88,18 +105,18 @@ for (const call of bootCalls) {
 // ── the override list itself must not grow silently ──────────────────
 // A third exempted file would be a new unguarded sink; this pins the list to
 // the two this script actually checks.
-const eslintConfig = readFileSync("eslint.config.mjs", "utf8");
+const eslintConfig = readFileSync(at(ESLINT_CONFIG), "utf8");
 const overrideBlock = eslintConfig.match(
   /files:\s*\[([^\]]*)\][^}]*?"no-console":\s*"off"/s,
 );
 if (!overrideBlock) {
-  failures.push("eslint.config.mjs: could not locate the no-console override block");
+  failures.push(`${ESLINT_CONFIG}: could not locate the no-console override block`);
 } else {
   const exempted = [...overrideBlock[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]).sort();
   const expected = [BOOT, CLIENT].sort();
   if (JSON.stringify(exempted) !== JSON.stringify(expected)) {
     failures.push(
-      `eslint.config.mjs: no-console override list is [${exempted.join(", ")}], expected [${expected.join(", ")}] — ` +
+      `${ESLINT_CONFIG}: no-console override list is [${exempted.join(", ")}], expected [${expected.join(", ")}] — ` +
         `a new exempt file needs a matching check here`,
     );
   }

--- a/scripts/checks/check-console-sinks.mjs
+++ b/scripts/checks/check-console-sinks.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Guards the two modules exempted from `no-console`.
+ *
+ * `eslint.config.mjs` turns `no-console` off for `src/lib/logger/client.ts` and
+ * `src/lib/boot-stderr.ts` — necessary, since the sink has to live somewhere.
+ * But an exemption gives zero protection *inside* those files: a future
+ * `console.log(fields)` placed before the redact() call, or a
+ * `bootStderr(JSON.stringify(result.data))`, fires no gate at all. The override
+ * list is the audit surface for "which files may sink"; this script is the
+ * audit surface for "what they may sink".
+ *
+ * A plain call count was the first idea and is not enough — it would pass an
+ * unredacted fourth call. So the check is on argument SHAPE:
+ *
+ *   client.ts     — every console call is `(message)` or `(message, redact(fields))`
+ *   boot-stderr.ts — exactly one console call, taking the bare `message` param
+ *
+ * Run: node scripts/checks/check-console-sinks.mjs
+ */
+
+import { readFileSync } from "node:fs";
+import { Project, SyntaxKind } from "ts-morph";
+
+const CLIENT = "src/lib/logger/client.ts";
+const BOOT = "src/lib/boot-stderr.ts";
+
+const project = new Project({ useInMemoryFileSystem: false, skipAddingFilesFromTsConfig: true });
+const failures = [];
+
+function consoleCalls(filePath) {
+  const sf = project.addSourceFileAtPath(filePath);
+  return sf
+    .getDescendantsOfKind(SyntaxKind.CallExpression)
+    .filter((call) => {
+      const expr = call.getExpression();
+      return (
+        expr.getKind() === SyntaxKind.PropertyAccessExpression &&
+        expr.getText().startsWith("console.")
+      );
+    });
+}
+
+// ── client.ts: fields must always pass through redact() ──────────────
+const clientCalls = consoleCalls(CLIENT);
+if (clientCalls.length === 0) {
+  failures.push(`${CLIENT}: expected at least one console call; found none (did the sink move?)`);
+}
+for (const call of clientCalls) {
+  const args = call.getArguments();
+  const line = call.getStartLineNumber();
+  if (args.length === 1) continue; // (message) — nothing to redact
+  if (args.length !== 2) {
+    failures.push(`${CLIENT}:${line}: console call takes ${args.length} args; expected (message) or (message, redact(fields))`);
+    continue;
+  }
+  const second = args[1].getText();
+  if (!/^redact\(/.test(second)) {
+    failures.push(
+      `${CLIENT}:${line}: second argument is \`${second}\`, not a redact(...) call — ` +
+        `fields would reach the console unredacted`,
+    );
+  }
+}
+
+// ── boot-stderr.ts: exactly one call, on the bare message param ───────
+const bootCalls = consoleCalls(BOOT);
+if (bootCalls.length !== 1) {
+  failures.push(`${BOOT}: expected exactly 1 console call, found ${bootCalls.length}`);
+}
+for (const call of bootCalls) {
+  const args = call.getArguments();
+  const line = call.getStartLineNumber();
+  if (args.length !== 1 || args[0].getText() !== "message") {
+    failures.push(
+      `${BOOT}:${line}: console call must take the bare \`message\` parameter, got \`${args
+        .map((a) => a.getText())
+        .join(", ")}\` — an interpolated or serialized argument can carry a secret`,
+    );
+  }
+}
+
+// ── the override list itself must not grow silently ──────────────────
+// A third exempted file would be a new unguarded sink; this pins the list to
+// the two this script actually checks.
+const eslintConfig = readFileSync("eslint.config.mjs", "utf8");
+const overrideBlock = eslintConfig.match(
+  /files:\s*\[([^\]]*)\][^}]*?"no-console":\s*"off"/s,
+);
+if (!overrideBlock) {
+  failures.push("eslint.config.mjs: could not locate the no-console override block");
+} else {
+  const exempted = [...overrideBlock[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]).sort();
+  const expected = [BOOT, CLIENT].sort();
+  if (JSON.stringify(exempted) !== JSON.stringify(expected)) {
+    failures.push(
+      `eslint.config.mjs: no-console override list is [${exempted.join(", ")}], expected [${expected.join(", ")}] — ` +
+        `a new exempt file needs a matching check here`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error("check-console-sinks: FAIL");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log(`check-console-sinks: OK (${clientCalls.length} guarded calls in client.ts, ${bootCalls.length} in boot-stderr.ts)`);

--- a/scripts/checks/check-console-sinks.mjs
+++ b/scripts/checks/check-console-sinks.mjs
@@ -13,7 +13,7 @@
  * A plain call count was the first idea and is not enough — it would pass an
  * unredacted fourth call. So the check is on argument SHAPE:
  *
- *   client.ts     — every console call is `(message)` or `(message, redact(fields))`
+ *   client.ts     — every console call is exactly `(event, redact(fields))`
  *   boot-stderr.ts — exactly one console call, taking the bare `message` param
  *
  * Run: node scripts/checks/check-console-sinks.mjs
@@ -46,19 +46,24 @@ const clientCalls = consoleCalls(CLIENT);
 if (clientCalls.length === 0) {
   failures.push(`${CLIENT}: expected at least one console call; found none (did the sink move?)`);
 }
+// Exactly `(event, redact(fields))` — nothing else.
+//
+// An earlier version waved through any single-argument call as "(message) —
+// nothing to redact". That was true when the payload was optional; once it
+// became required it turned into a hole, because `console.warn(fields)` is also
+// a single-argument call and emits the payload unredacted. The gate reported OK
+// on exactly the shape it exists to prevent. Enumerating the one legal form
+// removes the class rather than the instance.
+const EXPECTED_ARGS = ["event", "redact(fields)"];
+
 for (const call of clientCalls) {
-  const args = call.getArguments();
+  const args = call.getArguments().map((a) => a.getText());
   const line = call.getStartLineNumber();
-  if (args.length === 1) continue; // (message) — nothing to redact
-  if (args.length !== 2) {
-    failures.push(`${CLIENT}:${line}: console call takes ${args.length} args; expected (message) or (message, redact(fields))`);
-    continue;
-  }
-  const second = args[1].getText();
-  if (!/^redact\(/.test(second)) {
+  if (args.length !== EXPECTED_ARGS.length || args.some((a, i) => a !== EXPECTED_ARGS[i])) {
     failures.push(
-      `${CLIENT}:${line}: second argument is \`${second}\`, not a redact(...) call — ` +
-        `fields would reach the console unredacted`,
+      `${CLIENT}:${line}: console call is \`(${args.join(", ")})\`; ` +
+        `the only permitted form is \`(${EXPECTED_ARGS.join(", ")})\` — ` +
+        `anything else can reach the console unredacted`,
     );
   }
 }

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -279,6 +279,7 @@ queue_step "Static: security-doc-exists" bash scripts/checks/check-security-doc-
 queue_step "Static: test-hygiene"   bash scripts/checks/check-test-hygiene.sh
 queue_step "Static: settings-card-layout"  bash scripts/checks/check-settings-card-layout.sh
 queue_step "Static: api-error-codes" bash scripts/checks/check-api-error-codes.sh
+queue_step "Static: console-sinks"  node scripts/checks/check-console-sinks.mjs
 queue_step "Static: api-error-body-drift" bash scripts/checks/check-api-error-body-drift.sh
 queue_step "Static: fail-closed-routes-have-test" bash scripts/checks/check-fail-closed-routes-have-test.sh
 queue_step "Static: permanent-delete-stepup" bash scripts/checks/check-permanent-delete-stepup.sh

--- a/src/app/api/passwords/[id]/attachments/route.test.ts
+++ b/src/app/api/passwords/[id]/attachments/route.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getLogger } from "@/lib/logger";
+
+vi.mock("@/lib/logger", () => {
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return { getLogger: () => logger, default: logger };
+});
 import { NextRequest } from "next/server";
 import { AAD_VERSION } from "@/lib/crypto/crypto-aad";
 
@@ -447,7 +453,8 @@ describe("POST /api/passwords/[id]/attachments", () => {
       createdAt: now,
     });
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warnSpy = vi.mocked(getLogger().warn);
+    warnSpy.mockClear();
 
     const res = await POST(
       await createFormDataRequest("http://localhost:3000/api/passwords/pw-1/attachments", {
@@ -474,8 +481,10 @@ describe("POST /api/passwords/[id]/attachments", () => {
     const createCall = mockPrismaAttachment.create.mock.calls[0][0];
     expect(createCall.data).not.toHaveProperty("keyVersion");
     // Warning log should fire when keyVersion is submitted
-    expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
+    // Tightened from a bare toHaveBeenCalled() while migrating the sink.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("keyVersion field received but ignored"),
+    );
   });
 
   it("stores client-generated id and aadVersion from FormData", async () => {

--- a/src/app/api/passwords/[id]/attachments/route.ts
+++ b/src/app/api/passwords/[id]/attachments/route.ts
@@ -17,6 +17,7 @@ import { rejectOversizedMultipart } from "@/lib/http/parse-body";
 import { assertQuotaAvailable, QuotaExceededError } from "@/lib/quota/resource-quotas";
 import { getAttachmentBlobStore } from "@/lib/blob-store";
 import { withRequestLog } from "@/lib/http/with-request-log";
+import { getLogger } from "@/lib/logger";
 import { AUDIT_TARGET_TYPE, AUDIT_ACTION } from "@/lib/constants";
 import { AAD_VERSION, CURRENT_CEK_WRAP_AAD_VERSION } from "@/lib/crypto/crypto-aad";
 import { withUserTenantRls } from "@/lib/tenant-context";
@@ -215,7 +216,7 @@ async function handlePOST(
 
   // I3.3: keyVersion from request is ignored in mode-2 uploads
   if (keyVersion !== null) {
-    console.warn("[attachment upload] keyVersion field received but ignored — server always sets encryptionMode: 2");
+    getLogger().warn("[attachment upload] keyVersion field received but ignored — server always sets encryptionMode: 2");
   }
 
   // Validate iv/authTag format (hex strings)

--- a/src/app/api/scim/v2/Users/route.ts
+++ b/src/app/api/scim/v2/Users/route.ts
@@ -41,8 +41,7 @@ async function handleGET(req: NextRequest) {
     const count = Math.min(SCIM_PAGE_COUNT_MAX, Math.max(SCIM_PAGE_COUNT_MIN, parseInt(url.searchParams.get("count") ?? String(SCIM_PAGE_COUNT_DEFAULT), 10) || SCIM_PAGE_COUNT_DEFAULT));
     const filterParam = url.searchParams.get("filter");
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let prismaWhere: Record<string, any> = { tenantId, user: { is: { email: { not: null } } } };
+    let prismaWhere: Prisma.TenantMemberWhereInput = { tenantId, user: { is: { email: { not: null } } } };
 
     if (filterParam) {
       try {

--- a/src/app/api/webauthn/register/verify/route.ts
+++ b/src/app/api/webauthn/register/verify/route.ts
@@ -27,6 +27,7 @@ import {
   PER_CRED_SALT_HEX_RE,
   CHALLENGE_ID_RE,
 } from "@/lib/auth/webauthn/webauthn-server";
+import type { RegistrationResponseJSON } from "@simplewebauthn/server";
 import { parseDeviceFromUserAgent } from "@/lib/parse-user-agent";
 import { sendEmail } from "@/lib/email";
 import { passkeyRegisteredEmail } from "@/lib/email/templates/passkey-registered";
@@ -131,10 +132,30 @@ async function handlePOST(req: NextRequest) {
 
   const origin = getRpOrigin(rpId);
 
+  // `response` arrives as z.record(z.string(), z.unknown()) — the schema does NOT
+  // validate its fields, so every `typeof` narrowing below IS the validation.
+  // Two distinct shapes are read off it and they must not be conflated:
+  //   - as a verifyRegistration() argument -> the library's RegistrationResponseJSON
+  //   - as a source of extension outputs   -> a local wire type with `unknown`
+  //     fields, because minPinLength/largeBlob exist on NEITHER lib.dom's
+  //     AuthenticationExtensionsClientOutputs NOR @simplewebauthn's narrower copy.
+  const responseWire = response as {
+    response?: { transports?: unknown };
+    clientExtensionResults?: {
+      credProps?: { rk?: unknown };
+      minPinLength?: unknown;
+      largeBlob?: { supported?: unknown };
+    };
+  };
+
   let verification;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    verification = await verifyRegistration(response as any, challenge, rpId, origin);
+    verification = await verifyRegistration(
+      response as unknown as RegistrationResponseJSON,
+      challenge,
+      rpId,
+      origin,
+    );
   } catch {
     return errorResponseWithMessage(API_ERROR.VALIDATION_ERROR, "Registration verification failed");
   }
@@ -158,28 +179,26 @@ async function handlePOST(req: NextRequest) {
 
   // Extract transports from the response if available (allowlisted per WebAuthn spec)
   const VALID_TRANSPORTS = new Set(["usb", "nfc", "ble", "internal", "hybrid", "smart-card"]);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rawTransports: unknown[] = (response as any).response?.transports ?? [];
+  const rawTransportsRaw = responseWire.response?.transports;
+  // G3: a hostile client can send a non-array here; `.filter` on a string throws.
+  const rawTransports: unknown[] = Array.isArray(rawTransportsRaw) ? rawTransportsRaw : [];
   const transports: string[] = rawTransports.filter(
     (t): t is string => typeof t === "string" && VALID_TRANSPORTS.has(t),
   );
 
   // credProps.rk is a client-supplied value (not authenticator-signed).
   // It is used ONLY for UI display. Never use it for auth/authz decisions.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rawRk = (response as any).clientExtensionResults?.credProps?.rk;
+  const rawRk = responseWire.clientExtensionResults?.credProps?.rk;
   const discoverable: boolean | null = typeof rawRk === "boolean" ? rawRk : null;
 
   // minPinLength is a client-supplied value (not authenticator-signed).
   // Policy enforcement is best-effort; compromised browsers can spoof this value.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rawMinPin = (response as any).clientExtensionResults?.minPinLength;
+  const rawMinPin = responseWire.clientExtensionResults?.minPinLength;
   const minPinLength: number | null =
     typeof rawMinPin === "number" && Number.isInteger(rawMinPin) && rawMinPin >= PIN_LENGTH_MIN && rawMinPin <= PIN_LENGTH_MAX
       ? rawMinPin : null;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rawLargeBlob = (response as any).clientExtensionResults?.largeBlob?.supported;
+  const rawLargeBlob = responseWire.clientExtensionResults?.largeBlob?.supported;
   const largeBlobSupported: boolean | null =
     typeof rawLargeBlob === "boolean" ? rawLargeBlob : null;
 

--- a/src/components/passwords/dialogs/qr-capture-dialog.tsx
+++ b/src/components/passwords/dialogs/qr-capture-dialog.tsx
@@ -109,8 +109,19 @@ export function QRCaptureDialog({
       });
 
       const track = stream.getVideoTracks()[0];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const imageCapture = new (window as any).ImageCapture(track);
+      // Firefox has no ImageCapture. Throwing here lands in the existing catch
+      // below, which already surfaces the localized qrCaptureFailed message —
+      // same user-visible outcome as today's TypeError, no new i18n key.
+      if (!("ImageCapture" in window)) {
+        throw new Error("IMAGE_CAPTURE_UNSUPPORTED");
+      }
+      // lib.dom's ImageCapture declares takePhoto/getPhotoCapabilities but not
+      // grabFrame, which the spec does define and browsers do implement. Widen
+      // locally rather than with a global augmentation, so the gap stays
+      // visible here and disappears when lib.dom catches up.
+      const imageCapture = new ImageCapture(track) as ImageCapture & {
+        grabFrame(): Promise<ImageBitmap>;
+      };
       const bitmap: ImageBitmap = await imageCapture.grabFrame();
 
       const canvas = canvasRef.current;

--- a/src/components/settings/security/passkey-credentials-card.tsx
+++ b/src/components/settings/security/passkey-credentials-card.tsx
@@ -35,7 +35,7 @@ import { DISPLAY_ID_SHORT } from "@/lib/validations/common";
 import { formatDateTime } from "@/lib/format/format-datetime";
 import { useVault } from "@/lib/vault/vault-context";
 import { VAULT_STATUS } from "@/lib/constants";
-import { clientLogError } from "@/lib/logger/client";
+import { clientLogError, CLIENT_LOG_EVENT, toClientErrorCode } from "@/lib/logger/client";
 import {
   isWebAuthnSupported,
   startPasskeyRegistration,
@@ -256,10 +256,10 @@ export function PasskeyCredentialsCard() {
             return;
         }
       }
-      // Narrowed to the message: a WebAuthn DOMException carries UA-specific
-      // fields, and the whole object cannot be redacted key-by-key.
-      clientLogError("[WebAuthn] Registration failed", {
-        error: err instanceof Error ? err.message : "unknown error",
+      // Normalized to a code: a WebAuthn DOMException's message is UA-specific
+      // free text, and a key-name denylist cannot inspect what is inside a value.
+      clientLogError(CLIENT_LOG_EVENT.WEBAUTHN_REGISTRATION_FAILED, {
+        code: toClientErrorCode(err),
       });
       toast.error(t("registerError"));
     } finally {

--- a/src/components/settings/security/passkey-credentials-card.tsx
+++ b/src/components/settings/security/passkey-credentials-card.tsx
@@ -35,6 +35,7 @@ import { DISPLAY_ID_SHORT } from "@/lib/validations/common";
 import { formatDateTime } from "@/lib/format/format-datetime";
 import { useVault } from "@/lib/vault/vault-context";
 import { VAULT_STATUS } from "@/lib/constants";
+import { clientLogError } from "@/lib/logger/client";
 import {
   isWebAuthnSupported,
   startPasskeyRegistration,
@@ -202,8 +203,10 @@ export function PasskeyCredentialsCard() {
       }
 
       // 4. Auto-generate nickname from transports; user can rename after registration.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const transports: string[] = (responseJSON as any).response?.transports ?? [];
+      const regResponse = (responseJSON as { response?: { transports?: unknown } }).response;
+      const transports: string[] = Array.isArray(regResponse?.transports)
+        ? regResponse.transports.filter((t): t is string => typeof t === "string")
+        : [];
       const resolvedNickname = generateDefaultNickname(transports);
 
       // 5. Send to server
@@ -253,7 +256,11 @@ export function PasskeyCredentialsCard() {
             return;
         }
       }
-      console.error("[WebAuthn] Registration failed:", err);
+      // Narrowed to the message: a WebAuthn DOMException carries UA-specific
+      // fields, and the whole object cannot be redacted key-by-key.
+      clientLogError("[WebAuthn] Registration failed", {
+        error: err instanceof Error ? err.message : "unknown error",
+      });
       toast.error(t("registerError"));
     } finally {
       // Defense-in-depth zeroize — covers (a) wrapSecretKeyWithPrf throws,

--- a/src/components/team/security/team-rotate-key-button.tsx
+++ b/src/components/team/security/team-rotate-key-button.tsx
@@ -34,6 +34,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
 import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
+import { clientLogError } from "@/lib/logger/client";
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -279,7 +280,9 @@ export function TeamRotateKeyButton({ teamId, onSuccess }: TeamRotateKeyButtonPr
       setConfirmInput("");
       onSuccess?.();
     } catch (e) {
-      console.error("[TeamRotateKeyButton] rotation failed:", e instanceof Error ? e.message : "unknown error");
+      clientLogError("[TeamRotateKeyButton] rotation failed", {
+        error: e instanceof Error ? e.message : "unknown error",
+      });
       toast.error(t("rotateKeyFailed"));
     } finally {
       setLoading(false);

--- a/src/components/team/security/team-rotate-key-button.tsx
+++ b/src/components/team/security/team-rotate-key-button.tsx
@@ -34,7 +34,7 @@ import { API_ERROR } from "@/lib/http/api-error-codes";
 import { RecentSessionRequiredDialog } from "@/components/auth/recent-session-required-dialog";
 import { PasskeyReauthDialog } from "@/components/auth/passkey-reauth-dialog";
 import { useInlineReauth } from "@/hooks/auth/use-inline-reauth";
-import { clientLogError } from "@/lib/logger/client";
+import { clientLogError, CLIENT_LOG_EVENT, toClientErrorCode } from "@/lib/logger/client";
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -280,8 +280,8 @@ export function TeamRotateKeyButton({ teamId, onSuccess }: TeamRotateKeyButtonPr
       setConfirmInput("");
       onSuccess?.();
     } catch (e) {
-      clientLogError("[TeamRotateKeyButton] rotation failed", {
-        error: e instanceof Error ? e.message : "unknown error",
+      clientLogError(CLIENT_LOG_EVENT.TEAM_KEY_ROTATION_FAILED, {
+        code: toClientErrorCode(e),
       });
       toast.error(t("rotateKeyFailed"));
     } finally {

--- a/src/hooks/vault/use-password-entry-detail.ts
+++ b/src/hooks/vault/use-password-entry-detail.ts
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import type { InlineDetailData } from "@/types/entry";
 import { VAULT_STATUS } from "@/lib/constants";
 import type { VaultStatus } from "@/lib/constants";
+import { clientLogError } from "@/lib/logger/client";
 
 interface UsePasswordEntryDetailOpts {
   getDetail: (id: string) => Promise<InlineDetailData>;
@@ -72,8 +73,12 @@ export function usePasswordEntryDetail(
       .catch((err: unknown) => {
         if (cancelled) return;
         const wrapped = err instanceof Error ? err : new Error(String(err));
+        // Dev-only: this is the vault decrypt path, so the error text must not
+        // reach a production browser console. Keep this gate.
         if (process.env.NODE_ENV === "development") {
-          console.error("[usePasswordEntryDetail] getDetail error:", wrapped);
+          clientLogError("[usePasswordEntryDetail] getDetail error", {
+            error: wrapped.message,
+          });
         }
         setErrorState({ id: entryId, err: wrapped });
       });

--- a/src/hooks/vault/use-password-entry-detail.ts
+++ b/src/hooks/vault/use-password-entry-detail.ts
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import type { InlineDetailData } from "@/types/entry";
 import { VAULT_STATUS } from "@/lib/constants";
 import type { VaultStatus } from "@/lib/constants";
-import { clientLogError } from "@/lib/logger/client";
+import { clientLogError, CLIENT_LOG_EVENT, toClientErrorCode } from "@/lib/logger/client";
 
 interface UsePasswordEntryDetailOpts {
   getDetail: (id: string) => Promise<InlineDetailData>;
@@ -76,8 +76,8 @@ export function usePasswordEntryDetail(
         // Dev-only: this is the vault decrypt path, so the error text must not
         // reach a production browser console. Keep this gate.
         if (process.env.NODE_ENV === "development") {
-          clientLogError("[usePasswordEntryDetail] getDetail error", {
-            error: wrapped.message,
+          clientLogError(CLIENT_LOG_EVENT.VAULT_ENTRY_DETAIL_FAILED, {
+            code: toClientErrorCode(wrapped),
           });
         }
         setErrorState({ id: entryId, err: wrapped });

--- a/src/i18n/pick-messages.ts
+++ b/src/i18n/pick-messages.ts
@@ -1,4 +1,5 @@
 import type { AbstractIntlMessages } from "next-intl";
+import { clientLogWarn } from "@/lib/logger/client";
 
 /**
  * Pick a subset of top-level namespaces from the full messages object.
@@ -13,7 +14,7 @@ export function pickMessages(
     if (ns in messages) {
       picked[ns] = messages[ns];
     } else if (process.env.NODE_ENV === "development") {
-      console.warn(`[pickMessages] namespace "${ns}" not found in messages`);
+      clientLogWarn("[pickMessages] namespace not found in messages", { namespace: ns });
     }
   }
   return picked;

--- a/src/i18n/pick-messages.ts
+++ b/src/i18n/pick-messages.ts
@@ -1,5 +1,5 @@
 import type { AbstractIntlMessages } from "next-intl";
-import { clientLogWarn } from "@/lib/logger/client";
+import { clientLogWarn, CLIENT_LOG_EVENT } from "@/lib/logger/client";
 
 /**
  * Pick a subset of top-level namespaces from the full messages object.
@@ -14,7 +14,7 @@ export function pickMessages(
     if (ns in messages) {
       picked[ns] = messages[ns];
     } else if (process.env.NODE_ENV === "development") {
-      clientLogWarn("[pickMessages] namespace not found in messages", { namespace: ns });
+      clientLogWarn(CLIENT_LOG_EVENT.I18N_NAMESPACE_MISSING, { namespace: ns });
     }
   }
   return picked;

--- a/src/i18n/pick-messages.ts
+++ b/src/i18n/pick-messages.ts
@@ -1,5 +1,5 @@
 import type { AbstractIntlMessages } from "next-intl";
-import { clientLogWarn, CLIENT_LOG_EVENT } from "@/lib/logger/client";
+import { clientLogWarn, CLIENT_LOG_EVENT, opaque } from "@/lib/logger/client";
 
 /**
  * Pick a subset of top-level namespaces from the full messages object.
@@ -14,7 +14,7 @@ export function pickMessages(
     if (ns in messages) {
       picked[ns] = messages[ns];
     } else if (process.env.NODE_ENV === "development") {
-      clientLogWarn(CLIENT_LOG_EVENT.I18N_NAMESPACE_MISSING, { namespace: ns });
+      clientLogWarn(CLIENT_LOG_EVENT.I18N_NAMESPACE_MISSING, { namespace: opaque(ns) });
     }
   }
   return picked;

--- a/src/lib/auth/webauthn/webauthn-client.test.ts
+++ b/src/lib/auth/webauthn/webauthn-client.test.ts
@@ -372,6 +372,127 @@ describe("startPasskeyAuthentication in-flight ceremony guard", () => {
   });
 });
 
+describe("malformed server options are rejected by name", () => {
+  // RT8: these paths previously died as `undefined.replace` deep inside
+  // base64urlDecode — an anonymous TypeError far from its cause. The named
+  // error is the behavior change, so the assertions pin the NAME; a bare
+  // .toThrow() would pass against the pre-change code too and prove nothing.
+  beforeEach(() => {
+    vi.stubGlobal("navigator", {
+      ...globalThis.navigator,
+      credentials: { create: vi.fn(), get: vi.fn() },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("registration rejects options with no challenge", async () => {
+    const { startPasskeyRegistration } = await import("./webauthn-client");
+    await expect(
+      startPasskeyRegistration({ rp: {}, user: { id: "x", name: "u", displayName: "U" } }),
+    ).rejects.toThrow(/WEBAUTHN_OPTIONS_MALFORMED: challenge/);
+  });
+
+  it("registration rejects options whose user is not an object", async () => {
+    const { startPasskeyRegistration } = await import("./webauthn-client");
+    await expect(
+      startPasskeyRegistration({ challenge: "Y2hhbGxlbmdl", user: "nope" }),
+    ).rejects.toThrow(/WEBAUTHN_OPTIONS_MALFORMED: user/);
+  });
+
+  it("authentication rejects options with no challenge", async () => {
+    const { startPasskeyAuthentication } = await import("./webauthn-client");
+    await expect(
+      startPasskeyAuthentication({ rpId: "localhost", allowCredentials: [] }),
+    ).rejects.toThrow(/WEBAUTHN_OPTIONS_MALFORMED: challenge/);
+  });
+});
+
+describe("startPasskeyRegistration forwards server extensions to the browser", () => {
+  // Regression guard. The server sends credProps / minPinLength / largeBlob on
+  // registration (webauthn-server.ts) and the verify route reads all three back
+  // out of clientExtensionResults. A converter that drops them compiles, keeps
+  // every server-side guard intact, and still breaks the contract end-to-end:
+  // the three columns null out and the tenant requireMinPinLength policy stops
+  // rejecting, because its input is starved rather than its check removed.
+  type CapturedCreate = { extensions?: Record<string, unknown> };
+  let captured: CapturedCreate | null = null;
+
+  beforeEach(() => {
+    captured = null;
+    vi.stubGlobal("navigator", {
+      ...globalThis.navigator,
+      credentials: {
+        create: vi.fn(async ({ publicKey }: { publicKey: CapturedCreate }) => {
+          captured = publicKey;
+          return {
+            id: "cred-id",
+            rawId: new Uint8Array(8).buffer,
+            type: "public-key",
+            response: {
+              clientDataJSON: new Uint8Array(8).buffer,
+              attestationObject: new Uint8Array(8).buffer,
+              getTransports: () => ["internal"],
+            },
+            getClientExtensionResults: () => ({}),
+          };
+        }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const REG_OPTIONS = {
+    rp: { id: "localhost", name: "x" },
+    user: { id: "dXNlcg", name: "u", displayName: "U" },
+    challenge: "Y2hhbGxlbmdl",
+    pubKeyCredParams: [],
+    extensions: {
+      credProps: true,
+      minPinLength: true,
+      largeBlob: { support: "preferred" },
+    },
+  };
+
+  it("passes credProps, minPinLength and largeBlob through to credentials.create", async () => {
+    const { startPasskeyRegistration } = await import("./webauthn-client");
+    await startPasskeyRegistration(REG_OPTIONS);
+
+    expect(captured!.extensions).toMatchObject({
+      credProps: true,
+      minPinLength: true,
+      largeBlob: { support: "preferred" },
+    });
+  });
+
+  it("keeps forwarding them when a prf salt is also supplied", async () => {
+    const { startPasskeyRegistration } = await import("./webauthn-client");
+    await startPasskeyRegistration(REG_OPTIONS, "a".repeat(64));
+
+    const ext = captured!.extensions as Record<string, unknown>;
+    expect(ext).toMatchObject({ credProps: true, minPinLength: true });
+    // prf is rebuilt from the hex wire form: a BufferSource here, never the hex
+    // string that crossed the wire. (Matches the existing PRF assertions above,
+    // which observe a Uint8Array view under jsdom.)
+    const first = (ext.prf as { eval: { first: ArrayBufferLike } }).eval.first;
+    expect(typeof first).not.toBe("string");
+    expect(hexEncode(new Uint8Array(first))).toBe("a".repeat(64));
+  });
+
+  it("omits extensions entirely when the server sends none", async () => {
+    const { startPasskeyRegistration } = await import("./webauthn-client");
+    const { extensions: _drop, ...noExt } = REG_OPTIONS;
+    await startPasskeyRegistration(noExt);
+
+    expect(captured!.extensions).toBeUndefined();
+  });
+});
+
 describe("isWebAuthnSupported", () => {
   it("returns true when window.PublicKeyCredential is defined", () => {
     // jsdom does not ship PublicKeyCredential; stub it for this test.

--- a/src/lib/auth/webauthn/webauthn-client.ts
+++ b/src/lib/auth/webauthn/webauthn-client.ts
@@ -38,12 +38,86 @@ import { hexDecode, hexEncode, toArrayBuffer } from "../../crypto/crypto-utils";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 export { hexEncode };
 
+// ─── Wire types ────────────────────────────────────────────
+//
+// These describe JSON that arrived from the server, NOT values the browser
+// produced — so they are deliberately not the lib.dom types. The critical
+// difference: PRF salts cross this wire as HEX STRINGS, whereas
+// `AuthenticationExtensionsPRFValues.first` is a `BufferSource`. The hex →
+// ArrayBuffer conversion happens at exactly one place (buildPrfExtension
+// below); nothing may straddle both sides.
+
+type PrfValuesWire = { first: string; second?: string };
+
+type PrfInputsWire = {
+  eval?: PrfValuesWire;
+  evalByCredential?: Record<string, PrfValuesWire>;
+};
+
+type ExtensionsWire = { prf?: PrfInputsWire } & Record<string, unknown>;
+
+type CredentialDescriptorWire = {
+  id: string;
+  type: PublicKeyCredentialType;
+  transports?: AuthenticatorTransport[];
+};
+
+type CreationOptionsWire = {
+  rp: PublicKeyCredentialRpEntity;
+  user: { id: string; name: string; displayName: string };
+  challenge: string;
+  pubKeyCredParams: PublicKeyCredentialParameters[];
+  timeout?: number;
+  excludeCredentials?: CredentialDescriptorWire[];
+  authenticatorSelection?: AuthenticatorSelectionCriteria;
+  attestation?: AttestationConveyancePreference;
+  extensions?: ExtensionsWire;
+};
+
+type RequestOptionsWire = {
+  challenge: string;
+  timeout?: number;
+  rpId?: string;
+  allowCredentials?: CredentialDescriptorWire[];
+  userVerification?: UserVerificationRequirement;
+  extensions?: ExtensionsWire;
+};
+
+// Narrowing readers. `challenge` is the only field required on both paths —
+// everything else is optional, matching what callers actually send. A missing
+// challenge previously produced `undefined.replace` deep inside
+// base64urlDecode; failing here names the problem instead.
+function asCreationOptionsWire(json: Record<string, unknown>): CreationOptionsWire {
+  if (typeof json.challenge !== "string") {
+    throw new Error("WEBAUTHN_OPTIONS_MALFORMED: challenge must be a string");
+  }
+  if (typeof json.user !== "object" || json.user === null) {
+    throw new Error("WEBAUTHN_OPTIONS_MALFORMED: user must be an object");
+  }
+  return json as CreationOptionsWire;
+}
+
+function asRequestOptionsWire(json: Record<string, unknown>): RequestOptionsWire {
+  if (typeof json.challenge !== "string") {
+    throw new Error("WEBAUTHN_OPTIONS_MALFORMED: challenge must be a string");
+  }
+  return json as RequestOptionsWire;
+}
+
 // ─── Option conversion ─────────────────────────────────────
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+function toCredentialDescriptors(
+  list: CredentialDescriptorWire[] | undefined,
+): PublicKeyCredentialDescriptor[] | undefined {
+  return list?.map((c) => ({
+    id: toArrayBuffer(base64urlDecode(c.id)),
+    type: c.type,
+    transports: c.transports,
+  }));
+}
 
 function toCreationOptions(
-  json: any,
+  json: CreationOptionsWire,
 ): PublicKeyCredentialCreationOptions {
   return {
     rp: json.rp,
@@ -55,31 +129,67 @@ function toCreationOptions(
     challenge: toArrayBuffer(base64urlDecode(json.challenge)),
     pubKeyCredParams: json.pubKeyCredParams,
     timeout: json.timeout,
-    excludeCredentials: json.excludeCredentials?.map((c: any) => ({
-      id: toArrayBuffer(base64urlDecode(c.id)),
-      type: c.type,
-      transports: c.transports,
-    })),
+    excludeCredentials: toCredentialDescriptors(json.excludeCredentials),
     authenticatorSelection: json.authenticatorSelection,
     attestation: json.attestation,
-    extensions: json.extensions,
+    // Forward every extension EXCEPT prf. Only prf carries hex strings that the
+    // DOM type would mis-describe; the rest (credProps, minPinLength,
+    // largeBlob) are plain booleans/enums that the server sends on registration
+    // and the browser must actually receive. Dropping them compiles and keeps
+    // every server-side guard intact, yet silently nulls three columns and
+    // starves the tenant requireMinPinLength policy of its input.
+    extensions: toDomExtensions(json.extensions),
   };
 }
 
+/**
+ * Strip `prf` (hex-string wire form) and pass the remaining extensions through
+ * as DOM types. Returns undefined when nothing is left, so the property is
+ * omitted rather than set to an empty object.
+ */
+function toDomExtensions(
+  wire: ExtensionsWire | undefined,
+): AuthenticationExtensionsClientInputs | undefined {
+  if (!wire) return undefined;
+  const { prf: _prf, ...rest } = wire;
+  return Object.keys(rest).length > 0
+    ? (rest as AuthenticationExtensionsClientInputs)
+    : undefined;
+}
+
 function toRequestOptions(
-  json: any,
+  json: RequestOptionsWire,
 ): PublicKeyCredentialRequestOptions {
   return {
     challenge: toArrayBuffer(base64urlDecode(json.challenge)),
     timeout: json.timeout,
     rpId: json.rpId,
-    allowCredentials: json.allowCredentials?.map((c: any) => ({
-      id: toArrayBuffer(base64urlDecode(c.id)),
-      type: c.type,
-      transports: c.transports,
-    })),
+    allowCredentials: toCredentialDescriptors(json.allowCredentials),
     userVerification: json.userVerification,
-    extensions: json.extensions,
+    // Same rule as the creation path: forward all non-prf extensions. Today the
+    // auth routes only ever send prf, so this keeps the converter structurally
+    // safe rather than incidentally safe — a future auth-side extension will
+    // not be silently dropped.
+    extensions: toDomExtensions(json.extensions),
+  };
+}
+
+/** Convert a wire PRF input (hex strings) into the browser's BufferSource form. */
+function toPrfExtension(wire: PrfInputsWire): AuthenticationExtensionsPRFInputs {
+  return {
+    ...(wire.eval
+      ? { eval: { first: toArrayBuffer(hexDecode(wire.eval.first)) } }
+      : {}),
+    ...(wire.evalByCredential
+      ? {
+          evalByCredential: Object.fromEntries(
+            Object.entries(wire.evalByCredential).map(([credId, value]) => [
+              credId,
+              { first: toArrayBuffer(hexDecode(value.first)) },
+            ]),
+          ),
+        }
+      : {}),
   };
 }
 
@@ -129,8 +239,6 @@ function credentialToAuthenticationJSON(
     clientExtensionResults: credential.getClientExtensionResults(),
   };
 }
-
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 // ─── PRF Key Wrapping ──────────────────────────────────────
 
@@ -274,11 +382,11 @@ export async function startPasskeyRegistration(
   optionsJSON: Record<string, unknown>,
   prfSalt?: string, // hex
 ): Promise<PasskeyRegistrationResult> {
-  const publicKeyOptions = toCreationOptions(optionsJSON);
+  const wire = asCreationOptionsWire(optionsJSON);
+  const publicKeyOptions = toCreationOptions(wire);
 
   if (prfSalt) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (publicKeyOptions as any).extensions = {
+    publicKeyOptions.extensions = {
       ...publicKeyOptions.extensions,
       prf: { eval: { first: toArrayBuffer(hexDecode(prfSalt)) } },
     };
@@ -313,9 +421,12 @@ export async function startPasskeyRegistration(
   if (!credential) throw new Error("REGISTRATION_CANCELLED");
 
   // Extract PRF output from extension results
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const extResults = credential.getClientExtensionResults() as any;
-  const prfResults = extResults?.prf?.results;
+  const extResults = credential.getClientExtensionResults();
+  const prfResults = extResults.prf?.results;
+  // Cast retained deliberately: `first` is typed BufferSource, and the uncast
+  // form does not compile (TS2769). Keeping it emits byte-identical JS and
+  // avoids introducing an ArrayBuffer/ArrayBufferView branch that no test —
+  // and per VC1 no CI test ever could — would exercise.
   const prfOutput = prfResults?.first
     ? new Uint8Array(prfResults.first as ArrayBuffer)
     : null;
@@ -337,7 +448,8 @@ export async function startPasskeyAuthentication(
   prfSalt?: string, // hex — top-level eval (legacy or mixed v1 fallback)
   evalByCredential?: Record<string, string>, // credId base64url → salt hex (A02-8)
 ): Promise<PasskeyAuthenticationResult> {
-  const publicKeyOptions = toRequestOptions(optionsJSON);
+  const wire = asRequestOptionsWire(optionsJSON);
+  const publicKeyOptions = toRequestOptions(wire);
 
   // A02-8: PRF extension input may arrive via three channels (in priority order):
   //   1. Server-built `optionsJSON.extensions.prf` — pass through verbatim
@@ -348,50 +460,36 @@ export async function startPasskeyAuthentication(
   //      or v1 RP-global fallback).
   // Channel (1) is mutually exclusive with (2)/(3). Channels (2) and (3) can
   // coexist and produce { eval, evalByCredential } simultaneously.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const serverPrfExt = (optionsJSON as any).extensions?.prf as
-    | { eval?: { first: string }; evalByCredential?: Record<string, { first: string }> }
-    | undefined;
+  // Read off the WIRE type (hex strings), not the DOM type. Mis-typing this as
+  // AuthenticationExtensionsClientInputs makes the read resolve to undefined,
+  // which silently drops control into the client-salt branch below — a
+  // downgrade of the server-bound salt that governs the vault wrapping key.
+  const serverPrfExt = wire.extensions?.prf;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const extensions: any = { ...publicKeyOptions.extensions };
+  const extensions: AuthenticationExtensionsClientInputs = {
+    ...publicKeyOptions.extensions,
+  };
 
   if (serverPrfExt) {
-    // Convert hex strings back into ArrayBuffers for the browser-side WebAuthn API.
-    extensions.prf = {
-      ...(serverPrfExt.eval
-        ? { eval: { first: toArrayBuffer(hexDecode(serverPrfExt.eval.first)) } }
-        : {}),
-      ...(serverPrfExt.evalByCredential
-        ? {
-            evalByCredential: Object.fromEntries(
-              Object.entries(serverPrfExt.evalByCredential).map(([credId, value]) => [
-                credId,
-                { first: toArrayBuffer(hexDecode(value.first)) },
-              ]),
-            ),
-          }
-        : {}),
-    };
+    extensions.prf = toPrfExtension(serverPrfExt);
   } else if (prfSalt || evalByCredential) {
-    extensions.prf = {
-      ...(prfSalt ? { eval: { first: toArrayBuffer(hexDecode(prfSalt)) } } : {}),
+    extensions.prf = toPrfExtension({
+      ...(prfSalt ? { eval: { first: prfSalt } } : {}),
       ...(evalByCredential
         ? {
             evalByCredential: Object.fromEntries(
               Object.entries(evalByCredential).map(([credId, salt]) => [
                 credId,
-                { first: toArrayBuffer(hexDecode(salt)) },
+                { first: salt },
               ]),
             ),
           }
         : {}),
-    };
+    });
   }
 
   if (extensions.prf || Object.keys(extensions).length > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (publicKeyOptions as any).extensions = extensions;
+    publicKeyOptions.extensions = extensions;
   }
 
   const { abort, timer } = beginCeremony();
@@ -419,9 +517,12 @@ export async function startPasskeyAuthentication(
 
   if (!credential) throw new Error("AUTHENTICATION_CANCELLED");
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const extResults = credential.getClientExtensionResults() as any;
-  const prfResults = extResults?.prf?.results;
+  const extResults = credential.getClientExtensionResults();
+  const prfResults = extResults.prf?.results;
+  // Cast retained deliberately: `first` is typed BufferSource, and the uncast
+  // form does not compile (TS2769). Keeping it emits byte-identical JS and
+  // avoids introducing an ArrayBuffer/ArrayBufferView branch that no test —
+  // and per VC1 no CI test ever could — would exercise.
   const prfOutput = prfResults?.first
     ? new Uint8Array(prfResults.first as ArrayBuffer)
     : null;

--- a/src/lib/auth/webauthn/webauthn-server.ts
+++ b/src/lib/auth/webauthn/webauthn-server.ts
@@ -133,12 +133,18 @@ export async function generateRegistrationOpts(
       // late-reject. "required" surfaces the requirement before the ceremony.
       userVerification: "required",
     },
+    // @simplewebauthn/server ships its OWN AuthenticationExtensionsClientInputs
+    // (types/dom.d.ts), narrower than lib.dom's: it has credProps and
+    // minPinLength but NOT largeBlob. The extension is valid per the WebAuthn
+    // spec and the browser honors it, so widen with a named intersection
+    // rather than erasing the whole object's type with `any`.
     extensions: {
       credProps: true,
       minPinLength: true,
       largeBlob: { support: "preferred" },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any,
+    } as GenerateRegistrationOptionsOpts["extensions"] & {
+      largeBlob?: { support: string };
+    },
   };
 
   return generateRegistrationOptions(opts);

--- a/src/lib/boot-stderr.ts
+++ b/src/lib/boot-stderr.ts
@@ -1,0 +1,27 @@
+/**
+ * Raw stderr writer for boot-time diagnostics that run before any logger exists.
+ *
+ * Two callers, both structurally unable to use pino:
+ *   - `@/lib/env` validates `process.env` during module initialization; the
+ *     logger is constructed after env, so routing this through pino would
+ *     invert a deliberate dependency order — and the failure being reported is
+ *     precisely "the environment is misconfigured", which must still print when
+ *     logging itself is misconfigured.
+ *   - `@/lib/security/csp-builder` warns at module scope when a production
+ *     build ignores `CSP_MODE`.
+ *
+ * This module exists so the `no-console` override lands on a file that cannot
+ * see a secret, rather than on `env.ts`, which holds every secret in the
+ * process.
+ *
+ * Caller contract: a message may name a variable and may echo a *non-secret*
+ * value back to the operator (`CSP_MODE="dev"` is the operator's own setting,
+ * drawn from a two-value enum). It must never carry a credential, key, token,
+ * connection string, or `result.data` from env parsing. The env banner honors
+ * this by building only from Zod issue paths and messages — variable names,
+ * not values.
+ */
+
+export function bootStderr(message: string): void {
+  console.error(message);
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -14,6 +14,7 @@
  */
 
 import { envObject, envSchema, type Env, getSchemaShape } from "@/lib/env-schema";
+import { bootStderr } from "@/lib/boot-stderr";
 
 // Re-export schema surface so existing imports (`from "@/lib/env"`) keep working.
 export { envObject, envSchema, getSchemaShape };
@@ -40,8 +41,13 @@ function parseEnv(): Env {
       "\n" +
       "=".repeat(60);
 
-    // Log to stderr for visibility in container logs
-    console.error(banner);
+    // Log to stderr for visibility in container logs. Routed through
+    // boot-stderr because this runs before the logger exists; keeping the raw
+    // console call out of this module means `no-console` stays enforced here,
+    // where every secret in process.env is in scope.
+    // The banner is built from issue paths (variable NAMES) and Zod messages
+    // only — it must never interpolate a value from process.env or result.data.
+    bootStderr(banner);
 
     throw new Error(`Invalid environment variables:\n${formatted}`);
   }

--- a/src/lib/http/api-error-codes.ts
+++ b/src/lib/http/api-error-codes.ts
@@ -243,6 +243,21 @@ export const API_ERROR = {
 
 export type ApiErrorCode = (typeof API_ERROR)[keyof typeof API_ERROR];
 
+const API_ERROR_VALUES: ReadonlySet<string> = new Set(Object.values(API_ERROR));
+
+/**
+ * Narrow a value read off a response body to a known error code.
+ *
+ * A `typeof x === "string"` check alone leaves free text, which matters when the
+ * value is about to be logged client-side: a browser console is readable by
+ * page scripts and extensions, so an echoed server string is an uncontrolled
+ * sink. Callers that log should fall back to a fixed placeholder rather than
+ * emitting an unrecognized value.
+ */
+export function isKnownApiError(value: unknown): value is ApiErrorCode {
+  return typeof value === "string" && API_ERROR_VALUES.has(value);
+}
+
 /**
  * Default HTTP status for each error code.
  *

--- a/src/lib/http/with-request-log.ts
+++ b/src/lib/http/with-request-log.ts
@@ -21,7 +21,10 @@ import { sanitizeErrorForSentry } from "@/lib/security/sentry-sanitize";
 // TypeScript's contravariant function params prevent a single non-any
 // constraint from accepting both shapes while preserving H's concrete type.
 // The `as unknown as H` cast (L53) is the actual type boundary.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// `no-explicit-any` is disabled for this file in eslint.config.mjs rather than
+// inline, so the exception stays on the reviewable audit surface. Verified:
+// `readonly unknown[]` yields TS2345 — under strictFunctionTypes, parameter
+// positions are contravariant, so widening to unknown is exactly backwards.
 type RouteHandler = (...args: any[]) => Promise<Response>;
 
 export function withRequestLog<H extends RouteHandler>(handler: H): H {

--- a/src/lib/key-provider/base-cloud-provider.ts
+++ b/src/lib/key-provider/base-cloud-provider.ts
@@ -10,6 +10,7 @@ import type { KeyName, KeyProvider } from "./types";
 import { HEX64_RE } from "@/lib/validations/common";
 import { VERIFIER_VERSION } from "@/lib/crypto/verifier-version";
 import { MS_PER_SECOND, MS_PER_MINUTE } from "@/lib/constants/time";
+import { bootStderr } from "@/lib/boot-stderr";
 
 export { HEX64_RE };
 
@@ -158,8 +159,11 @@ export abstract class BaseCloudKeyProvider implements KeyProvider {
         `[key-provider] fetch failed, using stale cached key: ${err instanceof Error ? err.message : err}`
       );
     }).catch(() => {
-      // Fallback if logger unavailable
-      console.warn(`[key-provider] ${this.name} stale key used for "${name}" (${elapsedSec}s old)`);
+      // Fallback when the logger import itself fails — by definition the logger
+      // is unavailable here, so this is the one remaining case for the raw
+      // stderr sink. Key material never appears: only the provider name, the
+      // key's NAME (not its value), and an age in seconds.
+      bootStderr(`[key-provider] ${this.name} stale key used for "${name}" (${elapsedSec}s old)`);
     });
   }
 

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -34,20 +34,18 @@ describe("logger module", () => {
   });
 
   it("uses AUDIT_LOG_APP_NAME env var as app name when set", async () => {
-    process.env.AUDIT_LOG_APP_NAME = "custom-app";
+    vi.stubEnv("AUDIT_LOG_APP_NAME", "custom-app");
     const mod = await import("@/lib/logger");
     // Logger is already created with the env var at module load time.
     // The module exports are not recreated; just assert the module loads cleanly.
     expect(mod.default).toBeDefined();
-    delete process.env.AUDIT_LOG_APP_NAME;
   });
 
   it("uses LOG_LEVEL env var to control minimum log level", async () => {
-    process.env.LOG_LEVEL = "warn";
+    vi.stubEnv("LOG_LEVEL", "warn");
     const mod = await import("@/lib/logger");
     // The level is applied at instantiation; module should load without error.
     expect(mod.default.level).toBe("warn");
-    delete process.env.LOG_LEVEL;
   });
 
   it("requestContext.getStore() returns undefined outside of run()", async () => {

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -54,4 +54,44 @@ describe("logger module", () => {
     const { requestContext } = await import("@/lib/logger");
     expect(requestContext.getStore()).toBeUndefined();
   });
+
+  // The server (pino) and client loggers implement ONE redaction policy. They
+  // derive from a shared constant precisely so they cannot drift; this pins the
+  // wiring, so replacing the shared list with a local copy goes red.
+  it("redacts every shared secret key from the bytes pino actually writes", async () => {
+    const pino = (await import("pino")).default;
+    const { SECRET_REDACT_KEYS, REDACTED } = await import("@/lib/logger/redact-keys");
+
+    // Build an instance with the SAME redact config the module ships, writing
+    // to a capture stream so the assertion sees the serialized output rather
+    // than the pre-redaction arguments.
+    const written: string[] = [];
+    const probe = pino(
+      { redact: { paths: [...SECRET_REDACT_KEYS], censor: REDACTED } },
+      { write: (line: string) => written.push(line) },
+    );
+
+    const fields = Object.fromEntries(
+      SECRET_REDACT_KEYS.map((k) => [k, `leaked-${k}`]),
+    );
+    probe.error(fields, "probe");
+
+    const output = written.join("");
+    expect(output).not.toContain("leaked-");
+    for (const key of SECRET_REDACT_KEYS) {
+      expect(JSON.parse(output)[key]).toBe(REDACTED);
+    }
+  });
+
+  it("the pino instance is configured from the shared key list, not a local copy", async () => {
+    const { SECRET_REDACT_KEYS } = await import("@/lib/logger/redact-keys");
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync("src/lib/logger.ts", "utf8");
+
+    // A hardcoded list here would silently diverge from the client logger.
+    expect(src).toContain("SECRET_REDACT_KEYS");
+    expect(src).not.toMatch(/paths:\s*\[\s*"password"/);
+    expect(SECRET_REDACT_KEYS).toContain("password");
+    expect(SECRET_REDACT_KEYS).toContain("token");
+  });
 });

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -10,6 +10,7 @@
 
 import pino from "pino";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { SECRET_REDACT_KEYS, REDACTED } from "@/lib/logger/redact-keys";
 
 const appName = process.env.AUDIT_LOG_APP_NAME ?? "passwd-sso";
 
@@ -19,26 +20,10 @@ const logger = pino({
   timestamp: pino.stdTimeFunctions.isoTime,
   base: { _logType: "app", _app: appName },
   redact: {
-    paths: [
-      "password",
-      "passphrase",
-      "secret",
-      "secretKey",
-      "authHash",
-      "encryptedBlob",
-      "encryptedOverview",
-      "encryptedData",
-      "encryptedSecretKey",
-      "token",
-      "tokenHash",
-      "codeHash",
-      "accessToken",
-      "refreshToken",
-      "idToken",
-      "authorization",
-      "cookie",
-    ],
-    censor: "[REDACTED]",
+    // Shared with the client logger (@/lib/logger/client) so one redaction
+    // policy cannot exist as two hand-maintained copies that drift apart.
+    paths: [...SECRET_REDACT_KEYS],
+    censor: REDACTED,
   },
   formatters: {
     level(label: string) {

--- a/src/lib/logger/client-events.ts
+++ b/src/lib/logger/client-events.ts
@@ -1,0 +1,89 @@
+/**
+ * The closed vocabulary of client-side log events.
+ *
+ * `clientLogWarn` / `clientLogError` accept only these ids, not `string`. That
+ * is the enforcement: a template literal, a variable, or a concatenation is a
+ * compile error rather than something a lint rule has to notice. An earlier
+ * attempt used an ESLint selector on the callee name and was trivially bypassed
+ * by an aliased import (`import { clientLogError as log }`), a variable, or a
+ * wrapper — a detector always has one more spelling it has not seen, whereas an
+ * unassignable type has none.
+ *
+ * Adding an event means adding a line here, which is visible in review.
+ */
+export const CLIENT_LOG_EVENT = {
+  WEBAUTHN_REGISTRATION_FAILED: "webauthn.registration_failed",
+  TEAM_KEY_ROTATION_FAILED: "team.key_rotation_failed",
+  VAULT_ENTRY_DETAIL_FAILED: "vault.entry_detail_failed",
+  I18N_NAMESPACE_MISSING: "i18n.namespace_missing",
+  TEAM_MEMBER_KEY_REQUEST_FAILED: "team.member_key_request_failed",
+  TEAM_MEMBER_KEY_VERSION_MISMATCH: "team.member_key_version_mismatch",
+  TEAM_ENCRYPTION_KEY_FAILED: "team.encryption_key_failed",
+  BASE_PATH_MALFORMED: "url.base_path_malformed",
+} as const;
+
+export type ClientLogEvent =
+  (typeof CLIENT_LOG_EVENT)[keyof typeof CLIENT_LOG_EVENT];
+
+/**
+ * The closed vocabulary of error causes.
+ *
+ * Free-form exception text must never reach a browser console: `Error.message`
+ * is attacker- or server-influenced, and this codebase's `describeUnknownError`
+ * additionally concatenates `String(e.cause)`. A key-name denylist cannot help,
+ * because it inspects keys and the secret would be inside the *value* — e.g.
+ * `"authentication failed: password=hunter2"` or a URL carrying `?token=…`.
+ *
+ * So exceptions are normalized to one of these codes before logging. The
+ * mapping is deliberately coarse: a client console is for "which branch failed",
+ * not for diagnosing the failure. Full detail stays server-side, where pino
+ * redacts by key and the sink is not readable by page scripts or extensions.
+ */
+export const CLIENT_ERROR_CODE = {
+  ABORTED: "aborted",
+  NOT_ALLOWED: "not_allowed",
+  INVALID_STATE: "invalid_state",
+  NOT_SUPPORTED: "not_supported",
+  NETWORK: "network",
+  DECRYPT: "decrypt",
+  MALFORMED_RESPONSE: "malformed_response",
+  UNKNOWN: "unknown",
+} as const;
+
+export type ClientErrorCode =
+  (typeof CLIENT_ERROR_CODE)[keyof typeof CLIENT_ERROR_CODE];
+
+/**
+ * Classify an unknown throwable into a loggable code.
+ *
+ * Reads only the error's *shape* (constructor, DOMException name) — never its
+ * message, and never `cause`. Anything unrecognized becomes `unknown` rather
+ * than leaking its text, so the default is safe.
+ */
+export function toClientErrorCode(e: unknown): ClientErrorCode {
+  if (e instanceof DOMException) {
+    switch (e.name) {
+      case "AbortError":
+        return CLIENT_ERROR_CODE.ABORTED;
+      case "NotAllowedError":
+        return CLIENT_ERROR_CODE.NOT_ALLOWED;
+      case "InvalidStateError":
+        return CLIENT_ERROR_CODE.INVALID_STATE;
+      case "NotSupportedError":
+        return CLIENT_ERROR_CODE.NOT_SUPPORTED;
+      case "OperationError":
+        return CLIENT_ERROR_CODE.DECRYPT;
+      default:
+        return CLIENT_ERROR_CODE.UNKNOWN;
+    }
+  }
+  if (e instanceof TypeError) {
+    // fetch() rejects with TypeError on network failure.
+    return CLIENT_ERROR_CODE.NETWORK;
+  }
+  if (e instanceof SyntaxError) {
+    // JSON.parse on a malformed response body.
+    return CLIENT_ERROR_CODE.MALFORMED_RESPONSE;
+  }
+  return CLIENT_ERROR_CODE.UNKNOWN;
+}

--- a/src/lib/logger/client-events.ts
+++ b/src/lib/logger/client-events.ts
@@ -54,6 +54,24 @@ export type ClientErrorCode =
   (typeof CLIENT_ERROR_CODE)[keyof typeof CLIENT_ERROR_CODE];
 
 /**
+ * Named steps of the team-key derivation chain.
+ *
+ * Logged so a failure can be located without shipping the exception text. A
+ * closed set rather than a free string, for the same reason as the codes above:
+ * anything assignable from `string` is a channel for an interpolated secret.
+ */
+export const CLIENT_LOG_STAGE = {
+  FETCH_MEMBER_KEY: "fetch_member_key",
+  PARSE_MEMBER_KEY: "parse_member_key",
+  IMPORT_ECDH_PRIVATE_KEY: "import_ecdh_private_key",
+  UNWRAP_TEAM_KEY: "unwrap_team_key",
+  DERIVE_TEAM_ENCRYPTION_KEY: "derive_team_encryption_key",
+} as const;
+
+export type ClientLogStage =
+  (typeof CLIENT_LOG_STAGE)[keyof typeof CLIENT_LOG_STAGE];
+
+/**
  * Classify an unknown throwable into a loggable code.
  *
  * Reads only the error's *shape* (constructor, DOMException name) — never its

--- a/src/lib/logger/client-events.ts
+++ b/src/lib/logger/client-events.ts
@@ -72,6 +72,79 @@ export type ClientLogStage =
   (typeof CLIENT_LOG_STAGE)[keyof typeof CLIENT_LOG_STAGE];
 
 /**
+ * An explicitly bounded string. Construct with {@link opaque}, whose contract
+ * is: the value contains no user input, no server text, and no URL query.
+ *
+ * Branded with a module-private symbol rather than a visible property. An
+ * earlier version used `{ readonly __opaque: string }`, which had three
+ * problems: the emitted log value became an object (contradicting "flat values
+ * only" and changing the field shape downstream consumers see), and the shape
+ * was public, so `{ __opaque: `token=${secret}` }` assigned cleanly and skipped
+ * the truncation entirely. The symbol is not exported, so the brand cannot be
+ * produced structurally — `opaque()` is the only way in — and at runtime the
+ * value stays an ordinary string.
+ */
+declare const opaqueBrand: unique symbol;
+
+export type Opaque = string & { readonly [opaqueBrand]: true };
+
+/**
+ * Mark a string as safe to log. Truncates as a backstop — an id that grew into
+ * a serialized blob still cannot flood the console.
+ */
+export function opaque(value: string, maxLength = 64): Opaque {
+  return value.slice(0, maxLength) as Opaque;
+}
+
+/**
+ * The exact field set each event may carry.
+ *
+ * This is the primary defence, and it is a KEY allowlist — the value-type
+ * restriction alone is not one. `ClientLogValue` narrows what a field may
+ * hold, but says nothing about which fields exist, so `{ otp: 123456 }` and
+ * `{ detail: opaque(secret) }` both typechecked under it. Enumerating the keys
+ * per event closes that: an unlisted key is a compile error, and adding one is
+ * a line in this table that a reviewer sees.
+ *
+ * `CLIENT_REDACT_KEYS` stays as the sink-side layer beneath this. It catches
+ * what the type system cannot see — a cast, a call from untyped JavaScript, a
+ * future widening of these types — and the fact that it grows over time is
+ * fine for a safety net, which is not where the guarantee comes from.
+ */
+export type ClientLogPayloads = {
+  [CLIENT_LOG_EVENT.WEBAUTHN_REGISTRATION_FAILED]: {
+    code: ClientErrorCode;
+  };
+  [CLIENT_LOG_EVENT.TEAM_KEY_ROTATION_FAILED]: {
+    code: ClientErrorCode;
+  };
+  [CLIENT_LOG_EVENT.VAULT_ENTRY_DETAIL_FAILED]: {
+    code: ClientErrorCode;
+  };
+  [CLIENT_LOG_EVENT.I18N_NAMESPACE_MISSING]: {
+    namespace: Opaque;
+  };
+  [CLIENT_LOG_EVENT.TEAM_MEMBER_KEY_REQUEST_FAILED]: {
+    teamId: Opaque;
+    status: number;
+    error: Opaque;
+  };
+  [CLIENT_LOG_EVENT.TEAM_MEMBER_KEY_VERSION_MISMATCH]: {
+    teamId: Opaque;
+    requestedVersion: number;
+    responseVersion: number;
+  };
+  [CLIENT_LOG_EVENT.TEAM_ENCRYPTION_KEY_FAILED]: {
+    teamId: Opaque;
+    stage: ClientLogStage;
+    code: ClientErrorCode;
+  };
+  [CLIENT_LOG_EVENT.BASE_PATH_MALFORMED]: {
+    firstSegment: Opaque;
+  };
+};
+
+/**
  * Classify an unknown throwable into a loggable code.
  *
  * Reads only the error's *shape* (constructor, DOMException name) — never its

--- a/src/lib/logger/client.test.ts
+++ b/src/lib/logger/client.test.ts
@@ -1,32 +1,35 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { readFileSync, existsSync, writeFileSync, rmSync } from "node:fs";
+import { readFileSync, existsSync, writeFileSync, rmSync, readdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { clientLogWarn, clientLogError } from "./client";
 import { CLIENT_REDACT_KEYS, REDACTED } from "./redact-keys";
+import { CLIENT_LOG_EVENT } from "./client-events";
 
 describe("clientLogWarn / clientLogError", () => {
+  // Any member works; the point is the API takes an enumerated id, not a string.
+  const EV = CLIENT_LOG_EVENT.I18N_NAMESPACE_MISSING;
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it("writes the message to console.warn exactly once", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn("boom");
+    clientLogWarn(EV);
     expect(warn).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledWith("boom");
+    expect(warn).toHaveBeenCalledWith(EV);
   });
 
   it("writes the message to console.error exactly once", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    clientLogError("boom");
+    clientLogError(EV);
     expect(error).toHaveBeenCalledOnce();
-    expect(error).toHaveBeenCalledWith("boom");
+    expect(error).toHaveBeenCalledWith(EV);
   });
 
   it("passes non-sensitive fields through untouched", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn("m", { teamId: "team-1", status: 403, ok: false, extra: null });
-    expect(warn).toHaveBeenCalledWith("m", {
+    clientLogWarn(EV, { teamId: "team-1", status: 403, ok: false, extra: null });
+    expect(warn).toHaveBeenCalledWith(EV, {
       teamId: "team-1",
       status: 403,
       ok: false,
@@ -36,8 +39,8 @@ describe("clientLogWarn / clientLogError", () => {
 
   it("redacts a secret passed as a bare string — the flat-scalar type alone does not stop this", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn("m", { token: "super-secret-value" });
-    expect(warn).toHaveBeenCalledWith("m", { token: REDACTED });
+    clientLogWarn(EV, { token: "super-secret-value" });
+    expect(warn).toHaveBeenCalledWith(EV, { token: REDACTED });
     // The point of the assertion: the value must not survive anywhere in the call.
     expect(JSON.stringify(warn.mock.calls)).not.toContain("super-secret-value");
   });
@@ -49,8 +52,8 @@ describe("clientLogWarn / clientLogError", () => {
       CLIENT_REDACT_KEYS.map((k) => [k, `leaked-${k}`]),
     );
 
-    clientLogWarn("m", fields);
-    clientLogError("m", fields);
+    clientLogWarn(EV, fields);
+    clientLogError(EV, fields);
 
     for (const key of CLIENT_REDACT_KEYS) {
       expect(warn.mock.calls[0][1]).toMatchObject({ [key]: REDACTED });
@@ -61,8 +64,88 @@ describe("clientLogWarn / clientLogError", () => {
 
   it("redacts client-only identity keys the server logger does not cover", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn("m", { email: "a@example.test", userId: "u-1" });
-    expect(warn).toHaveBeenCalledWith("m", { email: REDACTED, userId: REDACTED });
+    clientLogWarn(EV, { email: "a@example.test", userId: "u-1" });
+    expect(warn).toHaveBeenCalledWith(EV, { email: REDACTED, userId: REDACTED });
+  });
+});
+
+/**
+ * Guards the two Medium findings from the pre-merge security review.
+ *
+ * 1. A key-name denylist inspects KEYS, so a secret embedded in a VALUE
+ *    ("authentication failed: password=hunter2", "/api?token=…") passes
+ *    straight through. The fix is upstream: no caller may put free-form text
+ *    into a field, so the tests below pin that every production call site emits
+ *    bounded values only.
+ * 2. The message channel is closed by the type system rather than by a lint
+ *    rule — an ESLint selector on the callee name was bypassable by an aliased
+ *    import, a variable, a concatenation, or a wrapper. A type has no such
+ *    spellings left over.
+ */
+describe("client logger value-safety", () => {
+  it("only accepts enumerated event ids, never a free-form string", () => {
+    // A compile-time property, asserted here so the intent survives a refactor
+    // that might otherwise widen the parameter back to `string`.
+    const events: string[] = Object.values(CLIENT_LOG_EVENT);
+    expect(events.length).toBeGreaterThan(0);
+    for (const id of events) {
+      // Every id is a dotted, lowercase, punctuation-free token — no room for
+      // an interpolated value to hide in one.
+      expect(id).toMatch(/^[a-z0-9_]+(\.[a-z0-9_]+)+$/);
+    }
+  });
+
+  it("classifies errors by shape, never by message or cause", async () => {
+    const { toClientErrorCode, CLIENT_ERROR_CODE } = await import("./client-events");
+    const secret = "password=hunter2";
+
+    const err = new Error(`authentication failed: ${secret}`);
+    err.cause = new Error(`inner ${secret}`);
+
+    const code = toClientErrorCode(err);
+    expect(code).toBe(CLIENT_ERROR_CODE.UNKNOWN);
+    // The whole point: no part of the message or cause survives into the code.
+    expect(code).not.toContain("hunter2");
+    expect(Object.values(CLIENT_ERROR_CODE)).toContain(code);
+  });
+
+  it("maps recognized DOMException names without reading their messages", async () => {
+    const { toClientErrorCode, CLIENT_ERROR_CODE } = await import("./client-events");
+    const cases: [string, string][] = [
+      ["AbortError", CLIENT_ERROR_CODE.ABORTED],
+      ["NotAllowedError", CLIENT_ERROR_CODE.NOT_ALLOWED],
+      ["InvalidStateError", CLIENT_ERROR_CODE.INVALID_STATE],
+      ["OperationError", CLIENT_ERROR_CODE.DECRYPT],
+    ];
+    for (const [name, expected] of cases) {
+      expect(toClientErrorCode(new DOMException("leaked-secret", name))).toBe(expected);
+    }
+  });
+
+  it("no production call site passes free-form error text into a field", () => {
+    // The defect class, pinned at its source rather than per-call-site: a
+    // reviewer adding `error: e.message` to any clientLog* call reds this.
+    const SRC = resolve(__dirname, "../..");
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = resolve(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+          walk(full);
+          continue;
+        }
+        if (!/\.tsx?$/.test(entry.name) || /\.test\./.test(entry.name)) continue;
+        const src = readFileSync(full, "utf8");
+        for (const call of src.matchAll(/clientLog(?:Warn|Error)\(([\s\S]{0,400}?)\n\s*\}\);/g)) {
+          if (/\.message\b|String\(\s*e|describeUnknownError/.test(call[1])) {
+            offenders.push(full.replace(`${SRC}/`, ""));
+          }
+        }
+      }
+    };
+    walk(SRC);
+    expect(offenders).toEqual([]);
   });
 });
 

--- a/src/lib/logger/client.test.ts
+++ b/src/lib/logger/client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { readFileSync, existsSync, writeFileSync, rmSync, readdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { clientLogWarn, clientLogError } from "./client";
+import { clientLogWarn, clientLogError, opaque } from "./client";
 import { CLIENT_REDACT_KEYS, REDACTED } from "./redact-keys";
 import { CLIENT_LOG_EVENT } from "./client-events";
 
@@ -28,9 +28,9 @@ describe("clientLogWarn / clientLogError", () => {
 
   it("passes non-sensitive fields through untouched", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn(EV, { teamId: "team-1", status: 403, ok: false, extra: null });
+    clientLogWarn(EV, { teamId: opaque("team-1"), status: 403, ok: false, extra: null });
     expect(warn).toHaveBeenCalledWith(EV, {
-      teamId: "team-1",
+      teamId: opaque("team-1"),
       status: 403,
       ok: false,
       extra: null,
@@ -39,7 +39,7 @@ describe("clientLogWarn / clientLogError", () => {
 
   it("redacts a secret passed as a bare string — the flat-scalar type alone does not stop this", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn(EV, { token: "super-secret-value" });
+    clientLogWarn(EV, { token: opaque("super-secret-value") });
     expect(warn).toHaveBeenCalledWith(EV, { token: REDACTED });
     // The point of the assertion: the value must not survive anywhere in the call.
     expect(JSON.stringify(warn.mock.calls)).not.toContain("super-secret-value");
@@ -49,7 +49,7 @@ describe("clientLogWarn / clientLogError", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     const fields = Object.fromEntries(
-      CLIENT_REDACT_KEYS.map((k) => [k, `leaked-${k}`]),
+      CLIENT_REDACT_KEYS.map((k) => [k, opaque(`leaked-${k}`)]),
     );
 
     clientLogWarn(EV, fields);
@@ -64,7 +64,7 @@ describe("clientLogWarn / clientLogError", () => {
 
   it("redacts client-only identity keys the server logger does not cover", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn(EV, { email: "a@example.test", userId: "u-1" });
+    clientLogWarn(EV, { email: opaque("a@example.test"), userId: opaque("u-1") });
     expect(warn).toHaveBeenCalledWith(EV, { email: REDACTED, userId: REDACTED });
   });
 });
@@ -83,14 +83,32 @@ describe("clientLogWarn / clientLogError", () => {
  *    spellings left over.
  */
 describe("client logger value-safety", () => {
-  it("only accepts enumerated event ids, never a free-form string", () => {
-    // A compile-time property, asserted here so the intent survives a refactor
-    // that might otherwise widen the parameter back to `string`.
+  it("rejects a free-form string as the event — enforced by the compiler", () => {
+    // The load-bearing assertion for the whole design: `@ts-expect-error` fails
+    // the BUILD when the line stops erroring, so widening the parameter back to
+    // `string` breaks typecheck rather than passing silently.
+    //
+    // An earlier version of this test only checked the SHAPE of the enum values
+    // and stayed green through exactly that regression — verified by mutation.
+    // A runtime assertion structurally cannot observe a parameter type.
+
+    // @ts-expect-error arbitrary strings must not be accepted as an event id
+    clientLogWarn("arbitrary.event");
+    // @ts-expect-error the same holds for the error level
+    clientLogError("arbitrary.event", {});
+
+    const interpolated = `injected ${"secret"}`;
+    // @ts-expect-error a template literal is the exact bypass this type closes
+    clientLogWarn(interpolated);
+
+    // Reached only if the three lines above compiled as errors.
+    expect(true).toBe(true);
+  });
+
+  it("keeps event ids free of anywhere an interpolated value could hide", () => {
     const events: string[] = Object.values(CLIENT_LOG_EVENT);
     expect(events.length).toBeGreaterThan(0);
     for (const id of events) {
-      // Every id is a dotted, lowercase, punctuation-free token — no room for
-      // an interpolated value to hide in one.
       expect(id).toMatch(/^[a-z0-9_]+(\.[a-z0-9_]+)+$/);
     }
   });

--- a/src/lib/logger/client.test.ts
+++ b/src/lib/logger/client.test.ts
@@ -1,71 +1,85 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { readFileSync, existsSync, writeFileSync, rmSync, readdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { clientLogWarn, clientLogError, opaque } from "./client";
+import { clientLogWarn, clientLogError, opaque, redact } from "./client";
 import { CLIENT_REDACT_KEYS, REDACTED } from "./redact-keys";
-import { CLIENT_LOG_EVENT } from "./client-events";
+import { CLIENT_LOG_EVENT, CLIENT_ERROR_CODE } from "./client-events";
 
 describe("clientLogWarn / clientLogError", () => {
-  // Any member works; the point is the API takes an enumerated id, not a string.
   const EV = CLIENT_LOG_EVENT.I18N_NAMESPACE_MISSING;
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("writes the message to console.warn exactly once", () => {
+  it("writes the event to console.warn exactly once", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     clientLogWarn(EV);
     expect(warn).toHaveBeenCalledOnce();
     expect(warn).toHaveBeenCalledWith(EV);
   });
 
-  it("writes the message to console.error exactly once", () => {
+  it("writes the event to console.error exactly once", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    clientLogError(EV);
+    clientLogError(CLIENT_LOG_EVENT.WEBAUTHN_REGISTRATION_FAILED, {
+      code: CLIENT_ERROR_CODE.ABORTED,
+    });
     expect(error).toHaveBeenCalledOnce();
-    expect(error).toHaveBeenCalledWith(EV);
   });
 
-  it("passes non-sensitive fields through untouched", () => {
+  it("passes an event's declared fields through untouched", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn(EV, { teamId: opaque("team-1"), status: 403, ok: false, extra: null });
-    expect(warn).toHaveBeenCalledWith(EV, {
+    clientLogWarn(CLIENT_LOG_EVENT.TEAM_MEMBER_KEY_VERSION_MISMATCH, {
       teamId: opaque("team-1"),
+      requestedVersion: 2,
+      responseVersion: 3,
+    });
+    expect(warn).toHaveBeenCalledWith(
+      CLIENT_LOG_EVENT.TEAM_MEMBER_KEY_VERSION_MISMATCH,
+      { teamId: "team-1", requestedVersion: 2, responseVersion: 3 },
+    );
+  });
+});
+
+/**
+ * The sink-side redaction layer, tested directly.
+ *
+ * It is no longer reachable through the public API with an arbitrary key —
+ * per-event payload types see to that — which is exactly why it still earns its
+ * place: it covers what the types cannot, such as a cast or a call from untyped
+ * JavaScript. Testing it here keeps that layer honest rather than assumed.
+ */
+describe("redact (defence in depth beneath the payload types)", () => {
+  it("censors a secret held under a denylisted key", () => {
+    expect(redact({ token: opaque("super-secret-value") })).toEqual({
+      token: REDACTED,
+    });
+  });
+
+  it("censors every key in the shared denylist", () => {
+    const fields = Object.fromEntries(
+      CLIENT_REDACT_KEYS.map((k) => [k, opaque(`leaked-${k}`)]),
+    );
+    const out = redact(fields);
+    for (const key of CLIENT_REDACT_KEYS) {
+      expect(out[key]).toBe(REDACTED);
+    }
+    expect(JSON.stringify(out)).not.toContain("leaked-");
+  });
+
+  it("censors client-only identity keys the server logger does not cover", () => {
+    expect(redact({ email: opaque("a@example.test"), userId: opaque("u-1") })).toEqual({
+      email: REDACTED,
+      userId: REDACTED,
+    });
+  });
+
+  it("leaves non-sensitive keys alone", () => {
+    expect(redact({ status: 403, ok: false, extra: null })).toEqual({
       status: 403,
       ok: false,
       extra: null,
     });
-  });
-
-  it("redacts a secret passed as a bare string — the flat-scalar type alone does not stop this", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn(EV, { token: opaque("super-secret-value") });
-    expect(warn).toHaveBeenCalledWith(EV, { token: REDACTED });
-    // The point of the assertion: the value must not survive anywhere in the call.
-    expect(JSON.stringify(warn.mock.calls)).not.toContain("super-secret-value");
-  });
-
-  it("redacts every key in the shared denylist, on both levels", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    const fields = Object.fromEntries(
-      CLIENT_REDACT_KEYS.map((k) => [k, opaque(`leaked-${k}`)]),
-    );
-
-    clientLogWarn(EV, fields);
-    clientLogError(EV, fields);
-
-    for (const key of CLIENT_REDACT_KEYS) {
-      expect(warn.mock.calls[0][1]).toMatchObject({ [key]: REDACTED });
-      expect(error.mock.calls[0][1]).toMatchObject({ [key]: REDACTED });
-    }
-    expect(JSON.stringify([...warn.mock.calls, ...error.mock.calls])).not.toContain("leaked-");
-  });
-
-  it("redacts client-only identity keys the server logger does not cover", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn(EV, { email: opaque("a@example.test"), userId: opaque("u-1") });
-    expect(warn).toHaveBeenCalledWith(EV, { email: REDACTED, userId: REDACTED });
   });
 });
 
@@ -116,19 +130,19 @@ describe("client logger value-safety", () => {
     // value in `{ __opaque }`, which contradicted "flat values only" and
     // changed the field shape every downstream log consumer sees.
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn(EV, { teamId: opaque("team-1") });
+    clientLogWarn(EV, { namespace: opaque("Settings") });
 
     const fields = warn.mock.calls[0][1] as Record<string, unknown>;
-    expect(fields.teamId).toBe("team-1");
-    expect(typeof fields.teamId).toBe("string");
+    expect(fields.namespace).toBe("Settings");
+    expect(typeof fields.namespace).toBe("string");
   });
 
   it("truncates an opaque value that outgrew its bound", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn(EV, { teamId: opaque("x".repeat(200)) });
+    clientLogWarn(EV, { namespace: opaque("x".repeat(200)) });
 
     const fields = warn.mock.calls[0][1] as Record<string, unknown>;
-    expect(String(fields.teamId)).toHaveLength(64);
+    expect(String(fields.namespace)).toHaveLength(64);
   });
 
   it("keeps event ids free of anywhere an interpolated value could hide", () => {

--- a/src/lib/logger/client.test.ts
+++ b/src/lib/logger/client.test.ts
@@ -14,9 +14,9 @@ describe("clientLogWarn / clientLogError", () => {
 
   it("writes the event to console.warn exactly once", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    clientLogWarn(EV);
+    clientLogWarn(EV, { namespace: opaque("Settings") });
     expect(warn).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledWith(EV);
+    expect(warn).toHaveBeenCalledWith(EV, { namespace: "Settings" });
   });
 
   it("writes the event to console.error exactly once", () => {
@@ -103,26 +103,43 @@ describe("client logger value-safety", () => {
     vi.restoreAllMocks();
   });
 
-  it("rejects a free-form string as the event — enforced by the compiler", () => {
-    // The load-bearing assertion for the whole design: `@ts-expect-error` fails
-    // the BUILD when the line stops erroring, so widening the parameter back to
-    // `string` breaks typecheck rather than passing silently.
+  it("rejects free-form events, unlisted keys, and cross-event payloads", () => {
+    // These are COMPILE-time assertions. `@ts-expect-error` fails the build when
+    // a line stops erroring, so a regression breaks typecheck instead of passing
+    // silently — a runtime assertion structurally cannot observe a parameter
+    // type. Both prior versions of this test were proven inadequate by mutation:
+    // one checked only the shape of the enum VALUES, the next constrained only
+    // the FIRST parameter and stayed green when the payload type was reverted.
     //
-    // An earlier version of this test only checked the SHAPE of the enum values
-    // and stayed green through exactly that regression — verified by mutation.
-    // A runtime assertion structurally cannot observe a parameter type.
+    // The calls live in a never-invoked function so the directives are checked
+    // by tsc while nothing runs — the arguments are deliberately invalid, and
+    // executing them would throw for reasons unrelated to what is being pinned.
+    const typeOnly = () => {
+      // @ts-expect-error arbitrary strings must not be accepted as an event id
+      clientLogWarn("arbitrary.event", {});
+      // @ts-expect-error the same holds for the error level
+      clientLogError("arbitrary.event", {});
 
-    // @ts-expect-error arbitrary strings must not be accepted as an event id
-    clientLogWarn("arbitrary.event");
-    // @ts-expect-error the same holds for the error level
-    clientLogError("arbitrary.event", {});
+      const interpolated = `injected ${"secret"}`;
+      // @ts-expect-error a template literal is the exact bypass this type closes
+      clientLogWarn(interpolated, {});
 
-    const interpolated = `injected ${"secret"}`;
-    // @ts-expect-error a template literal is the exact bypass this type closes
-    clientLogWarn(interpolated);
+      clientLogError(CLIENT_LOG_EVENT.WEBAUTHN_REGISTRATION_FAILED, {
+        code: CLIENT_ERROR_CODE.UNKNOWN,
+        // @ts-expect-error `otp` is not in this event's payload
+        otp: 123456,
+      });
 
-    // Reached only if the three lines above compiled as errors.
-    expect(true).toBe(true);
+      clientLogError(CLIENT_LOG_EVENT.WEBAUTHN_REGISTRATION_FAILED, {
+        // @ts-expect-error this payload belongs to a different event
+        namespace: opaque("Settings"),
+      });
+
+      // @ts-expect-error every payload has a required key, so it cannot be omitted
+      clientLogError(CLIENT_LOG_EVENT.WEBAUTHN_REGISTRATION_FAILED);
+    };
+
+    expect(typeOnly).toBeTypeOf("function");
   });
 
   it("emits opaque values as plain strings, not wrapper objects", () => {

--- a/src/lib/logger/client.test.ts
+++ b/src/lib/logger/client.test.ts
@@ -83,6 +83,12 @@ describe("clientLogWarn / clientLogError", () => {
  *    spellings left over.
  */
 describe("client logger value-safety", () => {
+  const EV = CLIENT_LOG_EVENT.I18N_NAMESPACE_MISSING;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("rejects a free-form string as the event — enforced by the compiler", () => {
     // The load-bearing assertion for the whole design: `@ts-expect-error` fails
     // the BUILD when the line stops erroring, so widening the parameter back to
@@ -103,6 +109,26 @@ describe("client logger value-safety", () => {
 
     // Reached only if the three lines above compiled as errors.
     expect(true).toBe(true);
+  });
+
+  it("emits opaque values as plain strings, not wrapper objects", () => {
+    // The brand is a type-level marker only. An earlier version wrapped the
+    // value in `{ __opaque }`, which contradicted "flat values only" and
+    // changed the field shape every downstream log consumer sees.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    clientLogWarn(EV, { teamId: opaque("team-1") });
+
+    const fields = warn.mock.calls[0][1] as Record<string, unknown>;
+    expect(fields.teamId).toBe("team-1");
+    expect(typeof fields.teamId).toBe("string");
+  });
+
+  it("truncates an opaque value that outgrew its bound", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    clientLogWarn(EV, { teamId: opaque("x".repeat(200)) });
+
+    const fields = warn.mock.calls[0][1] as Record<string, unknown>;
+    expect(String(fields.teamId)).toHaveLength(64);
   });
 
   it("keeps event ids free of anywhere an interpolated value could hide", () => {

--- a/src/lib/logger/client.test.ts
+++ b/src/lib/logger/client.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync, existsSync, writeFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { clientLogWarn, clientLogError } from "./client";
+import { CLIENT_REDACT_KEYS, REDACTED } from "./redact-keys";
+
+describe("clientLogWarn / clientLogError", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes the message to console.warn exactly once", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    clientLogWarn("boom");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith("boom");
+  });
+
+  it("writes the message to console.error exactly once", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    clientLogError("boom");
+    expect(error).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith("boom");
+  });
+
+  it("passes non-sensitive fields through untouched", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    clientLogWarn("m", { teamId: "team-1", status: 403, ok: false, extra: null });
+    expect(warn).toHaveBeenCalledWith("m", {
+      teamId: "team-1",
+      status: 403,
+      ok: false,
+      extra: null,
+    });
+  });
+
+  it("redacts a secret passed as a bare string — the flat-scalar type alone does not stop this", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    clientLogWarn("m", { token: "super-secret-value" });
+    expect(warn).toHaveBeenCalledWith("m", { token: REDACTED });
+    // The point of the assertion: the value must not survive anywhere in the call.
+    expect(JSON.stringify(warn.mock.calls)).not.toContain("super-secret-value");
+  });
+
+  it("redacts every key in the shared denylist, on both levels", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fields = Object.fromEntries(
+      CLIENT_REDACT_KEYS.map((k) => [k, `leaked-${k}`]),
+    );
+
+    clientLogWarn("m", fields);
+    clientLogError("m", fields);
+
+    for (const key of CLIENT_REDACT_KEYS) {
+      expect(warn.mock.calls[0][1]).toMatchObject({ [key]: REDACTED });
+      expect(error.mock.calls[0][1]).toMatchObject({ [key]: REDACTED });
+    }
+    expect(JSON.stringify([...warn.mock.calls, ...error.mock.calls])).not.toContain("leaked-");
+  });
+
+  it("redacts client-only identity keys the server logger does not cover", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    clientLogWarn("m", { email: "a@example.test", userId: "u-1" });
+    expect(warn).toHaveBeenCalledWith("m", { email: REDACTED, userId: REDACTED });
+  });
+});
+
+/**
+ * The bundle guard. pino imports node:async_hooks, so a single transitive edge
+ * from this module to `@/lib/logger` (or to pino directly) would break the
+ * browser build — the failure mode recorded in
+ * project_client_shared_constants_no_node_imports.
+ *
+ * A test that merely imports the module cannot catch this: under vitest's Node
+ * environment `import pino from "pino"` resolves fine and stays green. So the
+ * check walks the real import graph instead.
+ */
+describe("client logger bundle safety", () => {
+  const FORBIDDEN = /^node:|^pino$|^@\/lib\/logger$/;
+  const SRC_ROOT = resolve(__dirname, "../..");
+
+  function collectTransitiveSpecifiers(entry: string): string[] {
+    const seen = new Set<string>();
+    const found: string[] = [];
+
+    const visit = (file: string) => {
+      if (seen.has(file)) return;
+      seen.add(file);
+      const src = readFileSync(file, "utf8");
+      const specifiers = [
+        // `import x from "y"` / `export … from "y"`
+        ...[...src.matchAll(/^\s*(?:import|export)[^'"]*from\s*["']([^"']+)["']/gm)].map((m) => m[1]),
+        // Side-effect imports: `import "node:async_hooks"`. Omitting this form
+        // was a real hole — the red-proof caught it, which is why the proof runs.
+        ...[...src.matchAll(/^\s*import\s*["']([^"']+)["']/gm)].map((m) => m[1]),
+        // `await import("y")` / `require("y")`
+        ...[...src.matchAll(/\b(?:import|require)\s*\(\s*["']([^"']+)["']/g)].map((m) => m[1]),
+      ];
+
+      for (const spec of specifiers) {
+        found.push(spec);
+        // Follow BOTH relative and `@/`-aliased edges. Following only relative
+        // paths was a real hole: this repo imports almost entirely via `@/`, so
+        // `client.ts -> @/lib/logger/throttled -> @/lib/logger -> pino ->
+        // node:async_hooks` — a one-hop, bundle-breaking edge — read as clean.
+        // A bare package specifier stays a leaf; reaching it is the signal.
+        const base = spec.startsWith(".")
+          ? resolve(dirname(file), spec)
+          : spec.startsWith("@/")
+            ? resolve(SRC_ROOT, spec.slice(2))
+            : null;
+        if (base === null) continue;
+        const candidate = [".ts", ".tsx", "/index.ts", "/index.tsx"]
+          .map((ext) => `${base}${ext}`)
+          .find((p) => existsSync(p));
+        if (candidate) visit(candidate);
+      }
+    };
+
+    visit(entry);
+    return found;
+  }
+
+  it("has no node:* or pino anywhere in its transitive import graph", () => {
+    const specifiers = collectTransitiveSpecifiers(
+      resolve(__dirname, "client.ts"),
+    );
+    expect(specifiers.filter((s) => FORBIDDEN.test(s))).toEqual([]);
+  });
+
+  it("the graph walker can actually fail (red-proof for the check above)", () => {
+    // Guards against the check passing because the walker found nothing at all.
+    const specifiers = collectTransitiveSpecifiers(
+      resolve(__dirname, "throttled.ts"),
+    );
+    expect(specifiers).toContain("@/lib/logger");
+    expect(specifiers.filter((s) => FORBIDDEN.test(s)).length).toBeGreaterThan(0);
+  });
+
+  // The control above exercises ONLY the plain `… from "x"` regex, because that
+  // is the single form throttled.ts happens to use. Deleting either of the
+  // other two regexes left the suite green — a red-proof that proved one third
+  // of what it claimed. These fixtures give each form its own assertion, so a
+  // deleted or broken regex dies here.
+  it.each([
+    ['side-effect', 'import "node:async_hooks";', "node:async_hooks"],
+    ['dynamic', 'const l = await import("@/lib/logger");', "@/lib/logger"],
+    ['require', 'const p = require("pino");', "pino"],
+    ['re-export', 'export * from "pino";', "pino"],
+    ['multi-line', 'import {\n  a,\n  b,\n} from "pino";', "pino"],
+    ['default+named', 'import pino, { Logger } from "pino";', "pino"],
+  ])("detects a forbidden specifier in %s form", (_form, source, expected) => {
+    const probe = resolve(SRC_ROOT, "lib/logger/__specifier_probe__.ts");
+    writeFileSync(probe, source, "utf8");
+    try {
+      const specifiers = collectTransitiveSpecifiers(probe);
+      expect(specifiers).toContain(expected);
+      expect(specifiers.filter((s) => FORBIDDEN.test(s)).length).toBeGreaterThan(0);
+    } finally {
+      rmSync(probe, { force: true });
+    }
+  });
+});

--- a/src/lib/logger/client.ts
+++ b/src/lib/logger/client.ts
@@ -13,15 +13,28 @@
  */
 
 import { CLIENT_REDACT_KEYS, REDACTED } from "./redact-keys";
-import type { ClientLogEvent, ClientErrorCode, ClientLogStage } from "./client-events";
+import type {
+  ClientLogEvent,
+  ClientLogPayloads,
+  ClientErrorCode,
+  ClientLogStage,
+  Opaque,
+} from "./client-events";
 
 export {
   CLIENT_LOG_EVENT,
   CLIENT_ERROR_CODE,
   CLIENT_LOG_STAGE,
   toClientErrorCode,
+  opaque,
 } from "./client-events";
-export type { ClientLogEvent, ClientErrorCode, ClientLogStage } from "./client-events";
+export type {
+  ClientLogEvent,
+  ClientLogPayloads,
+  ClientErrorCode,
+  ClientLogStage,
+  Opaque,
+} from "./client-events";
 
 /**
  * A value that cannot smuggle free text into a browser console.
@@ -47,31 +60,6 @@ export type ClientLogValue =
 export type ClientLogEnum = ClientErrorCode | ClientLogStage;
 
 /**
- * An explicitly bounded string. Construct with {@link opaque}, whose contract
- * is: the value contains no user input, no server text, and no URL query.
- *
- * Branded with a module-private symbol rather than a visible property. An
- * earlier version used `{ readonly __opaque: string }`, which had three
- * problems: the emitted log value became an object (contradicting "flat values
- * only" and changing the field shape downstream consumers see), and the shape
- * was public, so `{ __opaque: `token=${secret}` }` assigned cleanly and skipped
- * the truncation entirely. The symbol is not exported, so the brand cannot be
- * produced structurally — `opaque()` is the only way in — and at runtime the
- * value stays an ordinary string.
- */
-declare const opaqueBrand: unique symbol;
-
-export type Opaque = string & { readonly [opaqueBrand]: true };
-
-/**
- * Mark a string as safe to log. Truncates as a backstop — an id that grew into
- * a serialized blob still cannot flood the console.
- */
-export function opaque(value: string, maxLength = 64): Opaque {
-  return value.slice(0, maxLength) as Opaque;
-}
-
-/**
  * Flat values only. A nested object cannot be redacted without traversing it,
  * and traversal is how a whole credential object ends up in a log line — so the
  * type makes "log the entire response" a compile error rather than a runtime
@@ -82,7 +70,12 @@ export type ClientLogFields = Record<string, ClientLogValue>;
 /** Emitted shape: like ClientLogFields, but a censored slot holds REDACTED. */
 type EmittedFields = Record<string, ClientLogValue | typeof REDACTED>;
 
-function redact(fields: ClientLogFields): EmittedFields {
+/**
+ * Exported for tests: the public API now constrains keys per event, so the
+ * sink-side layer can only be exercised directly. That is the point of keeping
+ * it — it defends the paths the types do not reach.
+ */
+export function redact(fields: Record<string, ClientLogValue>): EmittedFields {
   const out: EmittedFields = {};
   for (const [key, value] of Object.entries(fields)) {
     out[key] = CLIENT_REDACT_KEYS.includes(key) ? REDACTED : value;
@@ -91,19 +84,34 @@ function redact(fields: ClientLogFields): EmittedFields {
 }
 
 /**
- * `event` is a `ClientLogEvent`, not a `string`. The message channel is emitted
- * verbatim and is the one thing redaction cannot cover, so it is closed by the
- * type system rather than by a lint rule: a template literal, a variable, or a
- * concatenation simply does not assign. Variable data goes in `fields`, which is
- * redacted by key name.
+ * Two independent restrictions, both at compile time.
+ *
+ * `event` is a `ClientLogEvent`, not a `string`: the id is emitted verbatim and
+ * is the one channel redaction cannot cover, so a template literal, a variable,
+ * or a concatenation simply does not assign. (A lint rule tried this first and
+ * was bypassable by an aliased import.)
+ *
+ * `fields` is `ClientLogPayloads[E]` — the exact key set declared for THAT
+ * event. Restricting the value type alone was not enough: it says nothing about
+ * which fields exist, so `{ otp: 123456 }` and `{ detail: opaque(secret) }`
+ * both typechecked. An unlisted key is now an error.
+ *
+ * `CLIENT_REDACT_KEYS` still runs beneath this as the sink-side layer, for the
+ * cases the types cannot see (a cast, a call from untyped JS, a future widening).
  */
-export function clientLogWarn(event: ClientLogEvent, fields?: ClientLogFields): void {
+export function clientLogWarn<E extends ClientLogEvent>(
+  event: E,
+  fields?: ClientLogPayloads[E],
+): void {
   if (fields) console.warn(event, redact(fields));
   else console.warn(event);
 }
 
-/** See {@link clientLogWarn} on why `event` is not a string. */
-export function clientLogError(event: ClientLogEvent, fields?: ClientLogFields): void {
+/** See {@link clientLogWarn} on why both parameters are constrained. */
+export function clientLogError<E extends ClientLogEvent>(
+  event: E,
+  fields?: ClientLogPayloads[E],
+): void {
   if (fields) console.error(event, redact(fields));
   else console.error(event);
 }

--- a/src/lib/logger/client.ts
+++ b/src/lib/logger/client.ts
@@ -96,22 +96,26 @@ export function redact(fields: Record<string, ClientLogValue>): EmittedFields {
  * which fields exist, so `{ otp: 123456 }` and `{ detail: opaque(secret) }`
  * both typechecked. An unlisted key is now an error.
  *
+ * `fields` is required, not optional. Every declared payload has at least one
+ * required key, so an optional parameter let `clientLogError(EVENT)` compile
+ * with the payload simply absent. If an event ever legitimately carries no
+ * fields, widen this to a conditional rest tuple rather than making the
+ * parameter optional for all of them.
+ *
  * `CLIENT_REDACT_KEYS` still runs beneath this as the sink-side layer, for the
  * cases the types cannot see (a cast, a call from untyped JS, a future widening).
  */
 export function clientLogWarn<E extends ClientLogEvent>(
   event: E,
-  fields?: ClientLogPayloads[E],
+  fields: ClientLogPayloads[E],
 ): void {
-  if (fields) console.warn(event, redact(fields));
-  else console.warn(event);
+  console.warn(event, redact(fields));
 }
 
 /** See {@link clientLogWarn} on why both parameters are constrained. */
 export function clientLogError<E extends ClientLogEvent>(
   event: E,
-  fields?: ClientLogPayloads[E],
+  fields: ClientLogPayloads[E],
 ): void {
-  if (fields) console.error(event, redact(fields));
-  else console.error(event);
+  console.error(event, redact(fields));
 }

--- a/src/lib/logger/client.ts
+++ b/src/lib/logger/client.ts
@@ -13,22 +13,66 @@
  */
 
 import { CLIENT_REDACT_KEYS, REDACTED } from "./redact-keys";
-import type { ClientLogEvent } from "./client-events";
+import type { ClientLogEvent, ClientErrorCode, ClientLogStage } from "./client-events";
 
-export { CLIENT_LOG_EVENT, CLIENT_ERROR_CODE, toClientErrorCode } from "./client-events";
-export type { ClientLogEvent, ClientErrorCode } from "./client-events";
+export {
+  CLIENT_LOG_EVENT,
+  CLIENT_ERROR_CODE,
+  CLIENT_LOG_STAGE,
+  toClientErrorCode,
+} from "./client-events";
+export type { ClientLogEvent, ClientErrorCode, ClientLogStage } from "./client-events";
 
 /**
- * Flat scalars only. A nested object cannot be redacted without traversing it,
+ * A value that cannot smuggle free text into a browser console.
+ *
+ * `string` is deliberately absent. It was the last hole in this design: field
+ * NAMES are redacted, so `{ detail: `token=${secret}` }` typechecked and was
+ * emitted verbatim. What the call sites actually need is narrower than `string`
+ * anyway — an opaque id, a status code, a closed vocabulary, a boolean.
+ *
+ * `Opaque` is the escape hatch for the one legitimate string-ish case: a value
+ * the caller has already bounded (an id, a truncated path segment). Wrapping is
+ * explicit, so a reviewer sees the claim being made and can check it, rather
+ * than a bare template literal sliding through.
+ */
+export type ClientLogValue =
+  | ClientLogEnum
+  | number
+  | boolean
+  | null
+  | Opaque;
+
+/** A member of a closed vocabulary declared in client-events.ts. */
+export type ClientLogEnum = ClientErrorCode | ClientLogStage;
+
+/**
+ * An explicitly bounded string. Construct with {@link opaque}, whose contract
+ * is: the value contains no user input, no server text, and no URL query.
+ */
+export type Opaque = { readonly __opaque: string };
+
+/**
+ * Mark a string as safe to log. Truncates as a backstop — an id that grew into
+ * a serialized blob still cannot flood the console.
+ */
+export function opaque(value: string, maxLength = 64): Opaque {
+  return { __opaque: value.slice(0, maxLength) };
+}
+
+/**
+ * Flat values only. A nested object cannot be redacted without traversing it,
  * and traversal is how a whole credential object ends up in a log line — so the
  * type makes "log the entire response" a compile error rather than a runtime
- * leak. Key-name redaction below covers the other half: a secret passed as a
- * bare string.
+ * leak. Key-name redaction below covers a secret stored under a known key.
  */
-export type ClientLogFields = Record<string, string | number | boolean | null>;
+export type ClientLogFields = Record<string, ClientLogValue>;
 
-function redact(fields: ClientLogFields): ClientLogFields {
-  const out: ClientLogFields = {};
+/** Emitted shape: like ClientLogFields, but a censored slot holds REDACTED. */
+type EmittedFields = Record<string, ClientLogValue | typeof REDACTED>;
+
+function redact(fields: ClientLogFields): EmittedFields {
+  const out: EmittedFields = {};
   for (const [key, value] of Object.entries(fields)) {
     out[key] = CLIENT_REDACT_KEYS.includes(key) ? REDACTED : value;
   }

--- a/src/lib/logger/client.ts
+++ b/src/lib/logger/client.ts
@@ -49,15 +49,26 @@ export type ClientLogEnum = ClientErrorCode | ClientLogStage;
 /**
  * An explicitly bounded string. Construct with {@link opaque}, whose contract
  * is: the value contains no user input, no server text, and no URL query.
+ *
+ * Branded with a module-private symbol rather than a visible property. An
+ * earlier version used `{ readonly __opaque: string }`, which had three
+ * problems: the emitted log value became an object (contradicting "flat values
+ * only" and changing the field shape downstream consumers see), and the shape
+ * was public, so `{ __opaque: `token=${secret}` }` assigned cleanly and skipped
+ * the truncation entirely. The symbol is not exported, so the brand cannot be
+ * produced structurally — `opaque()` is the only way in — and at runtime the
+ * value stays an ordinary string.
  */
-export type Opaque = { readonly __opaque: string };
+declare const opaqueBrand: unique symbol;
+
+export type Opaque = string & { readonly [opaqueBrand]: true };
 
 /**
  * Mark a string as safe to log. Truncates as a backstop — an id that grew into
  * a serialized blob still cannot flood the console.
  */
 export function opaque(value: string, maxLength = 64): Opaque {
-  return { __opaque: value.slice(0, maxLength) };
+  return value.slice(0, maxLength) as Opaque;
 }
 
 /**

--- a/src/lib/logger/client.ts
+++ b/src/lib/logger/client.ts
@@ -13,6 +13,10 @@
  */
 
 import { CLIENT_REDACT_KEYS, REDACTED } from "./redact-keys";
+import type { ClientLogEvent } from "./client-events";
+
+export { CLIENT_LOG_EVENT, CLIENT_ERROR_CODE, toClientErrorCode } from "./client-events";
+export type { ClientLogEvent, ClientErrorCode } from "./client-events";
 
 /**
  * Flat scalars only. A nested object cannot be redacted without traversing it,
@@ -32,18 +36,19 @@ function redact(fields: ClientLogFields): ClientLogFields {
 }
 
 /**
- * `message` MUST be a constant string — it is emitted verbatim and is the one
- * channel redaction cannot cover. Every variable value belongs in `fields`,
- * which is redacted by key name. Interpolating a caller-supplied value into the
- * message (a path, a URL, an error string) routes it around the denylist.
+ * `event` is a `ClientLogEvent`, not a `string`. The message channel is emitted
+ * verbatim and is the one thing redaction cannot cover, so it is closed by the
+ * type system rather than by a lint rule: a template literal, a variable, or a
+ * concatenation simply does not assign. Variable data goes in `fields`, which is
+ * redacted by key name.
  */
-export function clientLogWarn(message: string, fields?: ClientLogFields): void {
-  if (fields) console.warn(message, redact(fields));
-  else console.warn(message);
+export function clientLogWarn(event: ClientLogEvent, fields?: ClientLogFields): void {
+  if (fields) console.warn(event, redact(fields));
+  else console.warn(event);
 }
 
-/** See {@link clientLogWarn} on the constant-message requirement. */
-export function clientLogError(message: string, fields?: ClientLogFields): void {
-  if (fields) console.error(message, redact(fields));
-  else console.error(message);
+/** See {@link clientLogWarn} on why `event` is not a string. */
+export function clientLogError(event: ClientLogEvent, fields?: ClientLogFields): void {
+  if (fields) console.error(event, redact(fields));
+  else console.error(event);
 }

--- a/src/lib/logger/client.ts
+++ b/src/lib/logger/client.ts
@@ -1,0 +1,49 @@
+/**
+ * Browser-safe structured logger.
+ *
+ * The server logger (`@/lib/logger`) is pino, which imports `node:async_hooks`
+ * and therefore cannot be bundled for the browser. Client components need a
+ * diagnostic path that does not drag Node built-ins into the bundle, so this
+ * module is deliberately dependency-free apart from the shared redaction keys.
+ *
+ * This file and `@/lib/boot-stderr` are the only modules under `src/` permitted
+ * a raw `console` call; `no-console` is `error` everywhere else and grants an
+ * override to exactly these two. Concentrating the sink here is what makes the
+ * override list a reviewable audit surface.
+ */
+
+import { CLIENT_REDACT_KEYS, REDACTED } from "./redact-keys";
+
+/**
+ * Flat scalars only. A nested object cannot be redacted without traversing it,
+ * and traversal is how a whole credential object ends up in a log line — so the
+ * type makes "log the entire response" a compile error rather than a runtime
+ * leak. Key-name redaction below covers the other half: a secret passed as a
+ * bare string.
+ */
+export type ClientLogFields = Record<string, string | number | boolean | null>;
+
+function redact(fields: ClientLogFields): ClientLogFields {
+  const out: ClientLogFields = {};
+  for (const [key, value] of Object.entries(fields)) {
+    out[key] = CLIENT_REDACT_KEYS.includes(key) ? REDACTED : value;
+  }
+  return out;
+}
+
+/**
+ * `message` MUST be a constant string — it is emitted verbatim and is the one
+ * channel redaction cannot cover. Every variable value belongs in `fields`,
+ * which is redacted by key name. Interpolating a caller-supplied value into the
+ * message (a path, a URL, an error string) routes it around the denylist.
+ */
+export function clientLogWarn(message: string, fields?: ClientLogFields): void {
+  if (fields) console.warn(message, redact(fields));
+  else console.warn(message);
+}
+
+/** See {@link clientLogWarn} on the constant-message requirement. */
+export function clientLogError(message: string, fields?: ClientLogFields): void {
+  if (fields) console.error(message, redact(fields));
+  else console.error(message);
+}

--- a/src/lib/logger/redact-keys.ts
+++ b/src/lib/logger/redact-keys.ts
@@ -1,0 +1,55 @@
+/**
+ * Field names that must never appear verbatim in a log line.
+ *
+ * Single source of truth for two redaction implementations: the server-side
+ * pino `redact.paths` config (`@/lib/logger`) and the client-side logger
+ * (`@/lib/logger/client`). Two hand-maintained copies of one redaction policy
+ * drift; this file is why they cannot.
+ *
+ * No `node:*` imports — this module is reachable from the browser bundle
+ * through the client logger.
+ */
+
+/** Secret material. Redacted on both server and client. */
+export const SECRET_REDACT_KEYS = [
+  "password",
+  "passphrase",
+  "secret",
+  "secretKey",
+  "authHash",
+  "encryptedBlob",
+  "encryptedOverview",
+  "encryptedData",
+  "encryptedSecretKey",
+  "token",
+  "tokenHash",
+  "codeHash",
+  "accessToken",
+  "refreshToken",
+  "idToken",
+  "authorization",
+  "cookie",
+] as const;
+
+/**
+ * Identity values redacted on the client only.
+ *
+ * A browser console is a lower-trust sink than server stdout: any extension
+ * holding `debugger` permission can read it, and error-reporting SDKs ship it
+ * off the machine. Server logs already correlate by opaque id, so these are
+ * additive rather than a widening of the server policy.
+ */
+export const CLIENT_ONLY_REDACT_KEYS = [
+  "email",
+  "userId",
+  "sessionToken",
+  "credentialId",
+] as const;
+
+/** Client-side redaction set — a superset of the server's. */
+export const CLIENT_REDACT_KEYS: readonly string[] = [
+  ...SECRET_REDACT_KEYS,
+  ...CLIENT_ONLY_REDACT_KEYS,
+];
+
+export const REDACTED = "[REDACTED]";

--- a/src/lib/proxy/auth-gate.test.ts
+++ b/src/lib/proxy/auth-gate.test.ts
@@ -1,4 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getLogger } from "@/lib/logger";
+
+// The fail-closed substitution below emits the ONLY signal that it happened.
+// Mocked so the assertion can pin both the message and the `missing` list.
+vi.mock("@/lib/logger", () => {
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return { getLogger: () => logger, default: logger };
+});
 import { NextRequest } from "next/server";
 
 const { mockGetCachedSession, mockSetCachedSession, mockResolveUserTenantId } =
@@ -266,6 +274,16 @@ describe("getSessionInfo", () => {
       expect(result.hasPasskey).toBe(false);
       expect(result.requirePasskeyEnabledAt).toBeNull();
       expect(result.passkeyGracePeriodDays).toBeNull();
+
+      // The substitution must stay observable. Without this the bundle could be
+      // swapped in silently and the whole suite would still pass — a
+      // security-relevant degradation with no signal.
+      expect(getLogger().error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          msg: expect.stringContaining("substituting fail-closed bundle"),
+          missing: expect.arrayContaining([omittedField]),
+        }),
+      );
     });
   });
 

--- a/src/lib/proxy/auth-gate.ts
+++ b/src/lib/proxy/auth-gate.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/auth/session/session-cache";
 import { resolveUserTenantId } from "@/lib/tenant-context";
 import { ALL_KNOWN_SESSION_COOKIE_NAMES } from "@/lib/auth/session/cookie-name";
+import { getLogger } from "@/lib/logger";
 
 export type { SessionInfo } from "@/lib/auth/session/session-cache";
 export { SESSION_CACHE_TTL_MS } from "@/lib/auth/session/session-cache";
@@ -136,7 +137,11 @@ export async function getSessionInfo(request: NextRequest): Promise<SessionInfo>
         ["hasPasskey", "requirePasskey", "requirePasskeyEnabledAt", "passkeyGracePeriodDays"] as const
       ).filter((field) => data?.user?.[field] === undefined);
       if (missing.length > 0) {
-        console.warn({
+        // .error() not .warn(): this fires only when a fail-closed substitution
+        // has already happened, and it is the sole signal that it did. An
+        // operator setting LOG_LEVEL=error to cut noise would silence a warn
+        // here and make a security-relevant degradation invisible.
+        getLogger().error({
           msg: "auth-gate: session response missing passkey field(s), substituting fail-closed bundle",
           missing,
         });

--- a/src/lib/security/csp-builder.test.ts
+++ b/src/lib/security/csp-builder.test.ts
@@ -9,6 +9,10 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
+// csp-builder warns at MODULE INIT via bootStderr (it runs before any logger
+// exists), so the sink is mocked rather than spied on console.
+vi.mock("@/lib/boot-stderr", () => ({ bootStderr: vi.fn() }));
+
 describe("csp-builder", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -84,7 +88,9 @@ describe("csp-builder", () => {
     it("ignores CSP_MODE=dev in production (forces strict)", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("CSP_MODE", "dev");
-      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { bootStderr } = await import("@/lib/boot-stderr");
+      const warn = vi.mocked(bootStderr);
+      warn.mockClear();
       const { buildCspHeader } = await import("./csp-builder");
       const header = buildCspHeader("p-nonce");
 
@@ -95,7 +101,6 @@ describe("csp-builder", () => {
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining('CSP_MODE="dev" is ignored in production builds'),
       );
-      warn.mockRestore();
     });
   });
 

--- a/src/lib/security/csp-builder.ts
+++ b/src/lib/security/csp-builder.ts
@@ -2,6 +2,8 @@
 // (root) so it can be unit-tested without pulling in the full Next.js
 // middleware import chain (next-intl, etc.).
 
+import { bootStderr } from "@/lib/boot-stderr";
+
 // Pre-compute static CSP parts at module init time to avoid per-request work.
 // Only the nonce value is injected per-request.
 const _isProd = process.env.NODE_ENV === "production";
@@ -34,7 +36,11 @@ function sentryConnectSrc(): string {
 const _rawCspMode = process.env.CSP_MODE ?? (_isProd ? "strict" : "dev");
 const _cspMode = _isProd && _rawCspMode !== "strict" ? "strict" : _rawCspMode;
 if (_isProd && _rawCspMode !== _cspMode) {
-  console.warn(
+  // Module-scope, so this fires during initialization before any logger is
+  // guaranteed to exist — same constraint as the env banner. It is also an
+  // operator signal about a server env var, not a browser-user signal, so the
+  // client logger would be the wrong sink even setting init order aside.
+  bootStderr(
     `[CSP] CSP_MODE="${_rawCspMode}" is ignored in production builds; using "strict"`,
   );
 }

--- a/src/lib/services/scim-user-service.ts
+++ b/src/lib/services/scim-user-service.ts
@@ -250,8 +250,7 @@ export async function patchScimUser(
 
   if (member.role === TENANT_ROLE.OWNER && operations.active === false) throw new ScimOwnerProtectedError();
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const updateData: Record<string, any> = {
+  const updateData: Prisma.TenantMemberUpdateInput = {
     scimManaged: true,
     provisioningSource: "SCIM",
     lastScimSyncedAt: new Date(),

--- a/src/lib/team/team-vault-core.test.tsx
+++ b/src/lib/team/team-vault-core.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { clientLogWarn, clientLogError, CLIENT_LOG_EVENT } from "@/lib/logger/client";
+import { clientLogWarn, clientLogError, CLIENT_LOG_EVENT, opaque } from "@/lib/logger/client";
 
 // Partial mock: the two sink functions are stubbed so calls can be asserted,
 // but CLIENT_LOG_EVENT and toClientErrorCode keep their real values — asserting
@@ -321,7 +321,7 @@ describe("team-vault-core", () => {
     // rather than echoing a server-supplied string into a browser console.
     expect(warnSpy).toHaveBeenCalledWith(
       CLIENT_LOG_EVENT.TEAM_MEMBER_KEY_REQUEST_FAILED,
-      expect.objectContaining({ teamId: "team-1", status: 403, error: "other" }),
+      expect.objectContaining({ teamId: opaque("team-1"), status: 403, error: opaque("other") }),
     );
     expect(Array.from(rawKeyBytes)).toEqual([0, 0, 0, 0]);
   });
@@ -347,7 +347,7 @@ describe("team-vault-core", () => {
     // closed vocabulary — the exception's message and cause never appear.
     expect(errorSpy).toHaveBeenCalledWith(
       CLIENT_LOG_EVENT.TEAM_ENCRYPTION_KEY_FAILED,
-      expect.objectContaining({ teamId: "team-1", stage: "parse_member_key" }),
+      expect.objectContaining({ teamId: opaque("team-1"), stage: "parse_member_key" }),
     );
     const loggedFields = errorSpy.mock.calls[0][1] as Record<string, unknown>;
     expect(Object.keys(loggedFields)).not.toContain("error");

--- a/src/lib/team/team-vault-core.test.tsx
+++ b/src/lib/team/team-vault-core.test.tsx
@@ -2,9 +2,13 @@
 
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { clientLogWarn, clientLogError } from "@/lib/logger/client";
+import { clientLogWarn, clientLogError, CLIENT_LOG_EVENT } from "@/lib/logger/client";
 
-vi.mock("@/lib/logger/client", () => ({
+// Partial mock: the two sink functions are stubbed so calls can be asserted,
+// but CLIENT_LOG_EVENT and toClientErrorCode keep their real values — asserting
+// against a stubbed event id would prove nothing about what production emits.
+vi.mock("@/lib/logger/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/logger/client")>()),
   clientLogWarn: vi.fn(),
   clientLogError: vi.fn(),
 }));
@@ -313,9 +317,11 @@ describe("team-vault-core", () => {
     });
 
     expect(key).toBeNull();
+    // "forbidden" is not in the API_ERROR vocabulary, so it logs as "other"
+    // rather than echoing a server-supplied string into a browser console.
     expect(warnSpy).toHaveBeenCalledWith(
-      "[getTeamEncryptionKey] member-key request failed",
-      expect.objectContaining({ teamId: "team-1", status: 403, error: "forbidden" }),
+      CLIENT_LOG_EVENT.TEAM_MEMBER_KEY_REQUEST_FAILED,
+      expect.objectContaining({ teamId: "team-1", status: 403, error: "other" }),
     );
     expect(Array.from(rawKeyBytes)).toEqual([0, 0, 0, 0]);
   });
@@ -337,12 +343,15 @@ describe("team-vault-core", () => {
       await result.current.getTeamEncryptionKey("team-1");
     });
 
-    // Asserts the FIELD, not a substring of an interpolated string — a
-    // strictly stronger check than the pre-logger form it replaces.
+    // Asserts fields, not a substring of an interpolated string. `code` is a
+    // closed vocabulary — the exception's message and cause never appear.
     expect(errorSpy).toHaveBeenCalledWith(
-      "[getTeamEncryptionKey] failed",
+      CLIENT_LOG_EVENT.TEAM_ENCRYPTION_KEY_FAILED,
       expect.objectContaining({ teamId: "team-1", stage: "parse_member_key" }),
     );
+    const loggedFields = errorSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(Object.keys(loggedFields)).not.toContain("error");
+    expect(loggedFields.code).toBeTypeOf("string");
     expect(Array.from(rawKeyBytes)).toEqual([0, 0, 0, 0]);
   });
 

--- a/src/lib/team/team-vault-core.test.tsx
+++ b/src/lib/team/team-vault-core.test.tsx
@@ -2,6 +2,12 @@
 
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clientLogWarn, clientLogError } from "@/lib/logger/client";
+
+vi.mock("@/lib/logger/client", () => ({
+  clientLogWarn: vi.fn(),
+  clientLogError: vi.fn(),
+}));
 import type { ReactNode } from "react";
 
 const {
@@ -289,7 +295,8 @@ describe("team-vault-core", () => {
 
   it("returns null and logs a warning when member key fetch fails", async () => {
     const rawKeyBytes = new Uint8Array([1, 2, 3, 4]);
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warnSpy = vi.mocked(clientLogWarn);
+    warnSpy.mockClear();
     globalThis.fetch = vi.fn(async () => ({
       ok: false,
       status: 403,
@@ -311,12 +318,12 @@ describe("team-vault-core", () => {
       expect.objectContaining({ teamId: "team-1", status: 403, error: "forbidden" }),
     );
     expect(Array.from(rawKeyBytes)).toEqual([0, 0, 0, 0]);
-    warnSpy.mockRestore();
   });
 
   it("returns null and logs detailed errors for malformed responses", async () => {
     const rawKeyBytes = new Uint8Array([1, 2, 3, 4]);
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = vi.mocked(clientLogError);
+    errorSpy.mockClear();
     globalThis.fetch = vi.fn(async () => ({
       ok: true,
       json: async () => ({ encryptedTeamKey: "cipher" }),
@@ -330,11 +337,13 @@ describe("team-vault-core", () => {
       await result.current.getTeamEncryptionKey("team-1");
     });
 
+    // Asserts the FIELD, not a substring of an interpolated string — a
+    // strictly stronger check than the pre-logger form it replaces.
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("stage=parse_member_key"),
+      "[getTeamEncryptionKey] failed",
+      expect.objectContaining({ teamId: "team-1", stage: "parse_member_key" }),
     );
     expect(Array.from(rawKeyBytes)).toEqual([0, 0, 0, 0]);
-    errorSpy.mockRestore();
   });
 
   describe("getItemEncryptionKey", () => {

--- a/src/lib/team/team-vault-core.tsx
+++ b/src/lib/team/team-vault-core.tsx
@@ -20,6 +20,7 @@ import { buildItemKeyWrapAAD } from "../crypto/crypto-aad";
 import { apiPath, API_PATH } from "@/lib/constants";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 import { fetchApi } from "@/lib/url-helpers";
+import { clientLogWarn, clientLogError } from "@/lib/logger/client";
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -248,7 +249,7 @@ export function TeamVaultProvider({
           } catch {
             // no-op: keep status-based logging
           }
-          console.warn("[getTeamEncryptionKey] member-key request failed", {
+          clientLogWarn("[getTeamEncryptionKey] member-key request failed", {
             teamId,
             status: res.status,
             error: errorCode,
@@ -265,7 +266,7 @@ export function TeamVaultProvider({
         // Version assertion: a server-side version swap must not poison the
         // versioned slot or the latest pointer.
         if (requestedVersion !== undefined && memberKeyData.keyVersion !== requestedVersion) {
-          console.warn("[getTeamEncryptionKey] member-key response version mismatch", {
+          clientLogWarn("[getTeamEncryptionKey] member-key response version mismatch", {
             teamId,
             requestedVersion,
             responseVersion: memberKeyData.keyVersion,
@@ -320,9 +321,13 @@ export function TeamVaultProvider({
         return { key: encryptionKey, keyVersion: memberKeyData.keyVersion };
       } catch (e) {
         const errorText = describeUnknownError(e);
-        console.error(
-          `[getTeamEncryptionKey] failed teamId=${teamId} stage=${stage} error=${errorText}`
-        );
+        // Decomposed from an interpolated string into fields so the values are
+        // redactable and assertable individually.
+        clientLogError("[getTeamEncryptionKey] failed", {
+          teamId,
+          stage,
+          error: errorText,
+        });
         ecdhPrivateKeyBytes.fill(0);
         // Any exception here (network error, malformed response, unwrap
         // failure) is transient, not evidence the version is unavailable.

--- a/src/lib/team/team-vault-core.tsx
+++ b/src/lib/team/team-vault-core.tsx
@@ -20,7 +20,8 @@ import { buildItemKeyWrapAAD } from "../crypto/crypto-aad";
 import { apiPath, API_PATH } from "@/lib/constants";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 import { fetchApi } from "@/lib/url-helpers";
-import { clientLogWarn, clientLogError } from "@/lib/logger/client";
+import { clientLogWarn, clientLogError, CLIENT_LOG_EVENT, toClientErrorCode } from "@/lib/logger/client";
+import { isKnownApiError } from "@/lib/http/api-error-codes";
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -136,14 +137,6 @@ export class TeamKeyVersionUnavailableError extends Error {
   }
 }
 
-function describeUnknownError(e: unknown): string {
-  if (e instanceof Error) {
-    const base = e.message ? `${e.name}: ${e.message}` : `${e.name}: <empty message>`;
-    return e.cause ? `${base} cause=${String(e.cause)}` : base;
-  }
-  return String(e);
-}
-
 function parseTeamMemberKeyResponse(data: unknown): TeamMemberKeyResponse {
   if (!data || typeof data !== "object") {
     throw new Error("invalid member-key response: not an object");
@@ -249,10 +242,15 @@ export function TeamVaultProvider({
           } catch {
             // no-op: keep status-based logging
           }
-          clientLogWarn("[getTeamEncryptionKey] member-key request failed", {
+          clientLogWarn(CLIENT_LOG_EVENT.TEAM_MEMBER_KEY_REQUEST_FAILED, {
             teamId,
             status: res.status,
-            error: errorCode,
+            // errorCode comes from the response body and is only checked for
+            // being a string, so it is free text as far as this sink is
+            // concerned. Bound it to the API_ERROR vocabulary; anything else
+            // logs as "other" rather than echoing a server-supplied value into
+            // a browser console.
+            error: isKnownApiError(errorCode) ? errorCode : "other",
           });
           ecdhPrivateKeyBytes.fill(0);
           // 404 MEMBER_KEY_NOT_FOUND is the "genuinely unavailable" signal;
@@ -266,7 +264,7 @@ export function TeamVaultProvider({
         // Version assertion: a server-side version swap must not poison the
         // versioned slot or the latest pointer.
         if (requestedVersion !== undefined && memberKeyData.keyVersion !== requestedVersion) {
-          clientLogWarn("[getTeamEncryptionKey] member-key response version mismatch", {
+          clientLogWarn(CLIENT_LOG_EVENT.TEAM_MEMBER_KEY_VERSION_MISMATCH, {
             teamId,
             requestedVersion,
             responseVersion: memberKeyData.keyVersion,
@@ -320,13 +318,14 @@ export function TeamVaultProvider({
 
         return { key: encryptionKey, keyVersion: memberKeyData.keyVersion };
       } catch (e) {
-        const errorText = describeUnknownError(e);
-        // Decomposed from an interpolated string into fields so the values are
-        // redactable and assertable individually.
-        clientLogError("[getTeamEncryptionKey] failed", {
+        // A code, not the message. The removed describeUnknownError() helper
+        // concatenated `String(e.cause)` into free text that landed in a
+        // production browser console; a key-name denylist cannot inspect what
+        // is inside a value, so the value itself must not be free-form.
+        clientLogError(CLIENT_LOG_EVENT.TEAM_ENCRYPTION_KEY_FAILED, {
           teamId,
           stage,
-          error: errorText,
+          code: toClientErrorCode(e),
         });
         ecdhPrivateKeyBytes.fill(0);
         // Any exception here (network error, malformed response, unwrap

--- a/src/lib/team/team-vault-core.tsx
+++ b/src/lib/team/team-vault-core.tsx
@@ -20,7 +20,15 @@ import { buildItemKeyWrapAAD } from "../crypto/crypto-aad";
 import { apiPath, API_PATH } from "@/lib/constants";
 import { MS_PER_MINUTE } from "@/lib/constants/time";
 import { fetchApi } from "@/lib/url-helpers";
-import { clientLogWarn, clientLogError, CLIENT_LOG_EVENT, toClientErrorCode } from "@/lib/logger/client";
+import {
+  clientLogWarn,
+  clientLogError,
+  CLIENT_LOG_EVENT,
+  CLIENT_LOG_STAGE,
+  toClientErrorCode,
+  opaque,
+  type ClientLogStage,
+} from "@/lib/logger/client";
 import { isKnownApiError } from "@/lib/http/api-error-codes";
 
 // ─── Types ────────────────────────────────────────────────────
@@ -229,7 +237,7 @@ export function TeamVaultProvider({
         return { failure: "transient" };
       }
 
-      let stage = "fetch_member_key";
+      let stage: ClientLogStage = CLIENT_LOG_STAGE.FETCH_MEMBER_KEY;
       try {
         const res = await fetchApi(apiPath.teamMemberKey(teamId, requestedVersion));
         if (!res.ok) {
@@ -243,14 +251,14 @@ export function TeamVaultProvider({
             // no-op: keep status-based logging
           }
           clientLogWarn(CLIENT_LOG_EVENT.TEAM_MEMBER_KEY_REQUEST_FAILED, {
-            teamId,
+            teamId: opaque(teamId),
             status: res.status,
             // errorCode comes from the response body and is only checked for
             // being a string, so it is free text as far as this sink is
             // concerned. Bound it to the API_ERROR vocabulary; anything else
             // logs as "other" rather than echoing a server-supplied value into
             // a browser console.
-            error: isKnownApiError(errorCode) ? errorCode : "other",
+            error: opaque(isKnownApiError(errorCode) ? errorCode : "other"),
           });
           ecdhPrivateKeyBytes.fill(0);
           // 404 MEMBER_KEY_NOT_FOUND is the "genuinely unavailable" signal;
@@ -258,14 +266,14 @@ export function TeamVaultProvider({
           return { failure: res.status === 404 ? "not_available" : "transient" };
         }
 
-        stage = "parse_member_key";
+        stage = CLIENT_LOG_STAGE.PARSE_MEMBER_KEY;
         const memberKeyData = parseTeamMemberKeyResponse(await res.json());
 
         // Version assertion: a server-side version swap must not poison the
         // versioned slot or the latest pointer.
         if (requestedVersion !== undefined && memberKeyData.keyVersion !== requestedVersion) {
           clientLogWarn(CLIENT_LOG_EVENT.TEAM_MEMBER_KEY_VERSION_MISMATCH, {
-            teamId,
+            teamId: opaque(teamId),
             requestedVersion,
             responseVersion: memberKeyData.keyVersion,
           });
@@ -278,7 +286,7 @@ export function TeamVaultProvider({
         // `.buffer.slice()` ArrayBuffer both fails SubtleCrypto's realm
         // check under jsdom/Node-20 test environments AND leaves an
         // unzeroed intermediate copy on the heap (R39).
-        stage = "import_ecdh_private_key";
+        stage = CLIENT_LOG_STAGE.IMPORT_ECDH_PRIVATE_KEY;
         const ecdhPrivateKey = await crypto.subtle.importKey(
           "pkcs8",
           // Uint8Array default type param is ArrayBufferLike; the vault-context copy is always a plain ArrayBuffer view.
@@ -298,7 +306,7 @@ export function TeamVaultProvider({
         };
 
         // Unwrap team key
-        stage = "unwrap_team_key";
+        stage = CLIENT_LOG_STAGE.UNWRAP_TEAM_KEY;
         const teamKeyBytes = await unwrapTeamKey(
           {
             ciphertext: memberKeyData.encryptedTeamKey,
@@ -312,7 +320,7 @@ export function TeamVaultProvider({
         );
 
         // Derive encryption key from team key, then zero-clear raw bytes
-        stage = "derive_team_encryption_key";
+        stage = CLIENT_LOG_STAGE.DERIVE_TEAM_ENCRYPTION_KEY;
         const encryptionKey = await deriveTeamEncryptionKey(teamKeyBytes);
         teamKeyBytes.fill(0);
 
@@ -323,7 +331,7 @@ export function TeamVaultProvider({
         // production browser console; a key-name denylist cannot inspect what
         // is inside a value, so the value itself must not be free-form.
         clientLogError(CLIENT_LOG_EVENT.TEAM_ENCRYPTION_KEY_FAILED, {
-          teamId,
+          teamId: opaque(teamId),
           stage,
           code: toClientErrorCode(e),
         });

--- a/src/lib/url-helpers.test.ts
+++ b/src/lib/url-helpers.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CLIENT_LOG_EVENT } from "@/lib/logger/client";
 
 /**
  * BASE_PATH is evaluated at module load time from process.env.NEXT_PUBLIC_BASE_PATH.
@@ -62,17 +63,16 @@ describe("url-helpers (no basePath)", () => {
   });
 
   it("withBasePath warns when path does not start with /", async () => {
-    // The offending path travels in `fields`, not interpolated into the
-    // message: only `fields` passes through the redaction denylist, and a path
-    // can carry a token in its query string.
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { withBasePath } = await import("@/lib/url-helpers");
 
     withBasePath("api/test");
 
+    // The path itself is deliberately NOT logged — it is caller-supplied and a
+    // query string can carry a token. Only the leading segment is emitted.
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('path should start with "/"'),
-      { path: "api/test" },
+      CLIENT_LOG_EVENT.BASE_PATH_MALFORMED,
+      { firstSegment: "api" },
     );
   });
 

--- a/src/lib/url-helpers.test.ts
+++ b/src/lib/url-helpers.test.ts
@@ -62,6 +62,9 @@ describe("url-helpers (no basePath)", () => {
   });
 
   it("withBasePath warns when path does not start with /", async () => {
+    // The offending path travels in `fields`, not interpolated into the
+    // message: only `fields` passes through the redaction denylist, and a path
+    // can carry a token in its query string.
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { withBasePath } = await import("@/lib/url-helpers");
 
@@ -69,6 +72,7 @@ describe("url-helpers (no basePath)", () => {
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('path should start with "/"'),
+      { path: "api/test" },
     );
   });
 

--- a/src/lib/url-helpers.test.ts
+++ b/src/lib/url-helpers.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { CLIENT_LOG_EVENT } from "@/lib/logger/client";
+import { CLIENT_LOG_EVENT, opaque } from "@/lib/logger/client";
 
 /**
  * BASE_PATH is evaluated at module load time from process.env.NEXT_PUBLIC_BASE_PATH.
@@ -72,7 +72,7 @@ describe("url-helpers (no basePath)", () => {
     // query string can carry a token. Only the leading segment is emitted.
     expect(warnSpy).toHaveBeenCalledWith(
       CLIENT_LOG_EVENT.BASE_PATH_MALFORMED,
-      { firstSegment: "api" },
+      { firstSegment: opaque("api") },
     );
   });
 

--- a/src/lib/url-helpers.ts
+++ b/src/lib/url-helpers.ts
@@ -1,3 +1,5 @@
+import { clientLogWarn } from "@/lib/logger/client";
+
 export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
 /**
@@ -49,7 +51,7 @@ export const isHttps = (process.env.AUTH_URL ?? "http://localhost:3000").startsW
  */
 export function withBasePath(path: string): string {
   if (process.env.NODE_ENV !== "production" && path && !path.startsWith("/")) {
-    console.warn(`withBasePath: path should start with "/", got "${path}"`);
+    clientLogWarn("withBasePath: path should start with \"/\"", { path });
   }
   return `${BASE_PATH}${path}`;
 }

--- a/src/lib/url-helpers.ts
+++ b/src/lib/url-helpers.ts
@@ -1,4 +1,4 @@
-import { clientLogWarn } from "@/lib/logger/client";
+import { clientLogWarn, CLIENT_LOG_EVENT } from "@/lib/logger/client";
 
 export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
@@ -51,7 +51,12 @@ export const isHttps = (process.env.AUTH_URL ?? "http://localhost:3000").startsW
  */
 export function withBasePath(path: string): string {
   if (process.env.NODE_ENV !== "production" && path && !path.startsWith("/")) {
-    clientLogWarn("withBasePath: path should start with \"/\"", { path });
+    // The path itself is never logged: it is caller-supplied and can carry a
+    // token in its query string. The first segment is enough to locate the
+    // offending call, and it is taken before any "?" so no query survives.
+    clientLogWarn(CLIENT_LOG_EVENT.BASE_PATH_MALFORMED, {
+      firstSegment: path.split(/[?#/]/)[0].slice(0, 32),
+    });
   }
   return `${BASE_PATH}${path}`;
 }

--- a/src/lib/url-helpers.ts
+++ b/src/lib/url-helpers.ts
@@ -1,4 +1,4 @@
-import { clientLogWarn, CLIENT_LOG_EVENT } from "@/lib/logger/client";
+import { clientLogWarn, CLIENT_LOG_EVENT, opaque } from "@/lib/logger/client";
 
 export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
@@ -55,7 +55,7 @@ export function withBasePath(path: string): string {
     // token in its query string. The first segment is enough to locate the
     // offending call, and it is taken before any "?" so no query survives.
     clientLogWarn(CLIENT_LOG_EVENT.BASE_PATH_MALFORMED, {
-      firstSegment: path.split(/[?#/]/)[0].slice(0, 32),
+      firstSegment: opaque(path.split(/[?#/]/)[0], 32),
     });
   }
   return `${BASE_PATH}${path}`;

--- a/src/workers/audit-outbox-worker.ts
+++ b/src/workers/audit-outbox-worker.ts
@@ -69,8 +69,10 @@ interface WorkerConfig {
   pollIntervalMs?: number;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts PrismaClient or TransactionClient
-async function setBypassRlsGucs(client: any): Promise<void> {
+/** Structural minimum shared by PrismaClient and TransactionClient. */
+type RawExecutor = { $executeRaw: PrismaClient["$executeRaw"] };
+
+async function setBypassRlsGucs(client: RawExecutor): Promise<void> {
   await client.$executeRaw`SELECT set_config('app.bypass_rls', 'on', true)`;
   await client.$executeRaw`SELECT set_config('app.bypass_purpose', ${BYPASS_PURPOSE.AUDIT_WRITE}, true)`;
   await client.$executeRaw`SELECT set_config('app.tenant_id', ${NIL_UUID}, true)`;


### PR DESCRIPTION
## Summary

Production `src/` had 13 direct `console.*` calls and 22 `any`. Neither was
enforced: `no-console` was absent from ESLint entirely, and while
`@typescript-eslint/no-explicit-any` was already `error`, 19 inline
`eslint-disable` comments suppressed it. Both counts could grow silently, and
browser-console output is a lower-trust sink than server stdout — readable by
any extension with debugger permission, and this app allowlists Sentry.

- production `console.*`: **13 → 0** (3 relocated into two audited sink modules)
- production `any`: **22 → 1** — not zero; see below
- inline `no-explicit-any` disables: **19 → 0**

## The one remaining `any`

[`src/lib/http/with-request-log.ts:28`](src/lib/http/with-request-log.ts#L28).
`RouteHandler` is contravariant in its parameters, so widening to `unknown`
yields `TS2345` under `strictFunctionTypes` — verified against the compiler, not
assumed. It keeps `any` behind a **file-scoped config override** rather than an
inline disable, so the exception stays on the reviewable audit surface.
Recorded as `SC3`.

## Client logging is typed, not detected

An ESLint rule was the first attempt at forcing constant log messages. It was
bypassable by an aliased import, a variable, a concatenation, and a wrapper —
all four verified to pass it. A detector always has one more spelling it has not
seen, so the constraint moved into the type system:

| Layer | Role |
|---|---|
| `ClientLogPayloads[E]` | primary — exact key set per event; `{ otp }` / `{ detail }` are compile errors |
| `ClientLogValue` | no `string`; a closed vocabulary, a number, a bool, or an `Opaque` |
| `Opaque` (private brand) | explicitly bounded string; cannot be forged structurally |
| `CLIENT_REDACT_KEYS` | defence in depth at the sink — covers casts, untyped JS, future widening |

Exceptions normalize to a `ClientErrorCode` derived from the error's *shape*,
never its message or `cause`. The `describeUnknownError` helper, which
concatenated `String(e.cause)` into text bound for a production browser console,
is removed.

## Review found defects a green suite could not see

- **`toCreationOptions` dropped the server's registration extensions.** The
  wire/DOM boundary rule was derived from the authentication path (only `prf`,
  hex strings) and applied to registration, where `credProps` / `minPinLength` /
  `largeBlob` are sent. Three columns would have nulled out and the tenant
  `requireMinPinLength` policy would have become permanently inert. Every
  runtime guard survived verbatim — the guards were not removed, their **input
  was starved upstream**, which guard-focused greps cannot detect.
- **The bundle-safety guard followed only relative imports**, so the real hazard
  chain through `@/`-aliased modules read as clean, and its own red-proof
  exercised one of its three regexes.
- **The console-sink gate accepted any single-argument call**, which was correct
  while the payload was optional and became a hole once it was required.
- **The self-test mutated the real tree**, which is safe solo and wrong under
  `pre-pr.sh`'s concurrent steps — it surfaced as an unrelated gate failing.

Each is fixed with a regression test red-proved against the defect.

## New gate

[`scripts/checks/check-console-sinks.mjs`](scripts/checks/check-console-sinks.mjs)
— an ESLint exemption gives no protection *inside* the exempted file. It checks
argument **shape** (`(event, redact(fields))` exactly), not call count, since a
count would pass an unredacted call. Wired into `pre-pr.sh` → CI, with an
8-case self-test.

## Verification

All read as exit status directly, never through a pipe:

| Gate | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` | exit 0 — 985 files, 13,074 tests |
| `npx eslint .` | exit 0 |
| `npx next build` | exit 0 |
| `bash scripts/pre-pr.sh` | exit 0 — 61 steps |

## Deferred, recorded rather than dropped

- `SC5` — `extension/` (6 sites, **2 of which emit autofilled card and identity
  values to the page console**; a pre-existing issue this work surfaced)
- `SC6` — `cli/` (45 of 48 are legitimate stdout; no action)

## Review artifacts

- [plan](docs/archive/review/eliminate-prod-any-console-plan.md)
- [review](docs/archive/review/eliminate-prod-any-console-review.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)