### PR TITLE
chore(deps): hold jsdom on 29.x until the CSS engine regression is fixed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,14 +64,20 @@ updates:
     # ("reading 'Cjs'"); TypeScript majors churn the lib.dom typings the app
     # depends on. undici 8 requires Node >=22.19, but the production image and
     # .nvmrc are on Node 20, so it fails at runtime in the SSRF-guarded HTTP
-    # path (webhook / audit delivery). Ignore these major lines; drop the
-    # entry once the peer deps (or the Node baseline) catch up.
+    # path (webhook / audit delivery). jsdom 30 rewrote the CSS engine and its
+    # getComputedStyle throws "object null is not iterable" out of
+    # living/css/helpers/font-sizes.js, which every @testing-library getByRole
+    # query hits via isSubtreeInaccessible — reproduced on this tree with jsdom
+    # 30.0.0 as the only change. Ignore these major lines; drop the entry once
+    # the peer deps (or the Node baseline) catch up.
     ignore:
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
       - dependency-name: "undici"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jsdom"
         update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 5
 
@@ -113,8 +119,11 @@ updates:
           - "*"
         exclude-patterns:
           - "otpauth"
-    # Keep TypeScript on the 5.x line here too (see /cli note).
+    # Keep TypeScript on the 5.x line here too (see /cli note), and jsdom on
+    # 29.x for the same getComputedStyle regression as the root ecosystem.
     ignore:
       - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jsdom"
         update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Why

`#728` and `#726` both carry `jsdom` 29 → 30, and both fail on it. The failure is upstream:

```
TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator))
  ❯ Object.resolveLengthInPixels  node_modules/jsdom/lib/jsdom/living/css/helpers/font-sizes.js:116:23
  ❯ window.getComputedStyle       node_modules/jsdom/lib/jsdom/browser/Window.js:876:36
  ❯ isSubtreeInaccessible         @testing-library/dom/dist/role-helpers.js:41:14
```

jsdom 30 rewrote the CSS engine and `getComputedStyle` throws inside it. Every
`@testing-library` `getByRole` query reaches that path through
`isSubtreeInaccessible`, so the blast radius is not the two `slider.test.tsx`
cases that happened to surface it — any role query can hit it.

Isolated on this tree, with jsdom as the only variable:

| jsdom | `src/components/ui/slider.test.tsx` |
|---|---|
| 29.1.1 (lockfile) | 3 passed |
| 30.0.0 (installed alone, no other bump) | 2 failed, 1 passed |

So this is upstream, not test drift, and holding the major is the right response
rather than rewriting the tests to avoid `getByRole`.

## What changed

A `version-update:semver-major` ignore for `jsdom` in the two ecosystems that
declare it — root and `/extension`. `/cli` has no jsdom.

This follows the existing convention in this file (`eslint`, `typescript`,
`undici`): pin the major line, record the concrete reason, and drop the entry
once upstream catches up.

With this in place Dependabot will drop jsdom from the `npm-root-general` and
`npm-extension-general` groups on recreate, letting the other 12 root bumps
(including `next` 16.2.12 and `undici` 7.29.0) land on their own.

## Verification

- `bash scripts/pre-pr.sh` — exit 0, 64 steps
- `.github/dependabot.yml` parses; resulting ignore lists are
  root `[eslint, typescript, undici, jsdom]`, `/cli` `[typescript]`,
  `/extension` `[typescript, jsdom]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)