### PR TITLE
fix(extension): declare @testing-library/dom instead of relying on peer auto-install

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "passwd-sso-extension",
-  "version": "0.4.70",
+  "version": "0.4.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "passwd-sso-extension",
-      "version": "0.4.70",
+      "version": "0.4.71",
       "dependencies": {
         "otpauth": "^9.5.1",
         "react": "^19.2.8",
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.7.1",
         "@tailwindcss/vite": "^4.3.3",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.0",
         "@types/chrome": "^0.2.2",
@@ -95,7 +96,6 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -111,7 +111,6 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1432,7 +1431,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1521,8 +1519,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1782,7 +1779,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1793,7 +1789,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1977,8 +1972,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -2195,8 +2189,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -2548,7 +2541,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -2741,7 +2733,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -2787,8 +2778,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.7.1",
     "@tailwindcss/vite": "^4.3.3",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.0",
     "@types/chrome": "^0.2.2",


### PR DESCRIPTION
## Why

Every Dependabot PR touching `extension/` has failed `npm ci`:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json are in sync.
npm error Missing: @testing-library/dom@10.4.1 from lock file
npm error Missing: dom-accessibility-api@0.5.16 from lock file
...
```

This survived a full `@dependabot recreate` with the jsdom bump excluded, so the
bumps were never the cause. `#726` and `#734` both failed on it.

`@testing-library/dom` is declared nowhere in `extension/package.json` — it is
only a peerDependency:

| Package | Constraint |
|---|---|
| `@testing-library/react` | `peerDependencies: { "@testing-library/dom": "^10.0.0" }` |
| `@testing-library/jest-dom` | `peerDependencies: { "@testing-library/dom": ">=10 <11" }` |

Our npm auto-installs peers and writes the subtree into the lock. Dependabot
regenerates the lock without it, and the result no longer satisfies
`package.json` — so `npm ci` refuses, correctly.

The root `package.json` already declares `@testing-library/dom": "^10.4.1"`
explicitly, which is exactly why root Dependabot PRs never hit this. This change
makes `extension/` match.

## What changed

One devDependency added, and the lockfile regenerated. In the lock,
`@testing-library/dom` and its subtree stop being `peer: true` derivations and
become direct entries, so no resolver can drop them.

The lockfile's own `version` field also catches up `0.4.70` → `0.4.71` — a
pre-existing drift npm corrected on regeneration, not a version bump.

## Verification

| Gate | Result |
|---|---|
| `cd extension && npm ci` | exit 0 (fails on `#734`'s lock) |
| `cd extension && npx tsc --noEmit` | clean |
| `cd extension && npm test` | 59 files, 940 tests, exit 0 |
| `bash scripts/pre-pr.sh` | exit 0 — 64 steps |

## Follow-up

Once this lands, `#734` needs `@dependabot recreate` so its lock is regenerated
on top of the explicit declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)