### PR TITLE
fix(gates): stop reading a successful grep match as a gate failure

### DIFF
--- a/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
+++ b/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
@@ -63,23 +63,33 @@ describe("the defect this guard exists for", () => {
   const NEEDLE = "needle";
   const BUILD = `block=$'filler-line\\n'; for _ in $(seq 1 18); do block="$block$block"; done; big=$'${NEEDLE}\\n'"$block";`;
 
+  // grep's own stdout is discarded: -m1 and -l print their match, which would
+  // otherwise land in the FOUND/MISSED capture.
   function runShape(condition) {
     return spawnSync(
       "bash",
       [
         "-c",
-        `set -euo pipefail; ${BUILD} if ${condition}; then echo FOUND; else echo "MISSED(rc=$?)"; fi`,
+        `set -euo pipefail; ${BUILD} if ${condition} >/dev/null 2>&1; then echo FOUND; else echo "MISSED(rc=$?)"; fi`,
       ],
       { encoding: "utf8", maxBuffer: 1 << 20 },
     );
   }
 
-  it("reports a SUCCESSFUL match as failure when piped into grep -q", () => {
-    const r = runShape(`printf '%s' "$big" | grep -qxF '${NEEDLE}'`);
-    // The needle IS on the first line — "MISSED" here is the inversion itself,
-    // not a matching failure. If a future bash/coreutils stops reporting it,
-    // this assertion is the tripwire that says so.
-    expect(r.stdout.trim()).toMatch(/^MISSED\(rc=\d+\)$/);
+  // The needle IS on the first line — "MISSED" here is the inversion itself,
+  // not a matching failure. These four flags are the gate's member set, and
+  // this is the measurement it was derived from; `-l` is excluded below.
+  it.each([["-q"], ["--quiet"], ["--silent"], ["-m1"]])(
+    "reports a SUCCESSFUL match as failure when piped into grep %s",
+    (flag) => {
+      const r = runShape(`printf '%s' "$big" | grep ${flag} '${NEEDLE}'`);
+      expect(r.stdout.trim()).toMatch(/^MISSED\(rc=\d+\)$/);
+    },
+  );
+
+  it("does NOT invert for grep -l, which is why the gate leaves it alone", () => {
+    const r = runShape(`printf '%s' "$big" | grep -l '${NEEDLE}'`);
+    expect(r.stdout.trim()).toBe("FOUND");
   });
 
   it("reports the same match correctly through a herestring", () => {
@@ -123,6 +133,10 @@ describe("check-no-pipe-into-grep-q.sh", () => {
     ["-iqE (q in the middle)", 'cat f | grep -iqE "^x"'],
     ["-Eq (q last)", 'cat f | grep -Eq "^x"'],
     ["--quiet", 'cat f | grep --quiet "^x"'],
+    ["--silent", 'cat f | grep --silent "^x"'],
+    ["-m1", 'cat f | grep -m1 "^x"'],
+    ["-m 1 (separated)", 'cat f | grep -m 1 "^x"'],
+    ["--max-count=1", 'cat f | grep --max-count=1 "^x"'],
   ])("FAILS on the %s spelling", (_name, body) => {
     writeScript(
       "offender",
@@ -131,7 +145,7 @@ describe("check-no-pipe-into-grep-q.sh", () => {
     expect(runGuard().exitCode).toBe(1);
   });
 
-  it("FAILS when the pipe and the grep are split by a line continuation", () => {
+  it("FAILS when the pipe and the grep are split by a `\\` continuation", () => {
     writeScript(
       "offender",
       '#!/usr/bin/env bash\nset -euo pipefail\nif cat f | \\\n  grep -qxF "$1"; then true; fi\n',
@@ -140,6 +154,30 @@ describe("check-no-pipe-into-grep-q.sh", () => {
     expect(exitCode).toBe(1);
     // Reported against the line the pipeline starts on, not the continuation.
     expect(stdout).toMatch(/offender\.sh:3:/);
+  });
+
+  it.each([["|"], ["|&"]])(
+    "FAILS when the line simply ends in `%s` — bash needs no backslash there",
+    (op) => {
+      writeScript(
+        "offender",
+        `#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s' "$value" ${op}\n  grep -q needle\n`,
+      );
+      const { exitCode, stdout } = runGuard();
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/offender\.sh:3:/);
+    },
+  );
+
+  it("PASSES `grep -l`, which measurement shows does not invert", () => {
+    // Pinning the derivation: the member set is "flags that make grep exit
+    // before draining stdin", and -l is not one of them. If that ever changes,
+    // this test is where the claim gets revisited.
+    writeScript(
+      "clean",
+      '#!/usr/bin/env bash\nset -euo pipefail\ncat f | grep -l needle\n',
+    );
+    expect(runGuard().exitCode).toBe(0);
   });
 
   it("FAILS on a three-stage pipeline whose last reader is quiet", () => {

--- a/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
+++ b/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
@@ -115,10 +115,37 @@ describe("check-no-pipe-into-grep-q.sh", () => {
     expect(runGuard().exitCode).toBe(1);
   });
 
-  it("FAILS on combined short flags (-qxF, -qiE)", () => {
+  // The quiet flag is what makes the reader exit early, so every spelling of it
+  // has to match. Matching `grep -q…` by prefix missed four of these five.
+  it.each([
+    ["-q", 'cat f | grep -q "^x"'],
+    ["-qiE (q first)", 'cat f | grep -qiE "^x"'],
+    ["-iqE (q in the middle)", 'cat f | grep -iqE "^x"'],
+    ["-Eq (q last)", 'cat f | grep -Eq "^x"'],
+    ["--quiet", 'cat f | grep --quiet "^x"'],
+  ])("FAILS on the %s spelling", (_name, body) => {
     writeScript(
       "offender",
-      '#!/usr/bin/env bash\nset -euo pipefail\ncat f | grep -qiE "^x"\n',
+      `#!/usr/bin/env bash\nset -euo pipefail\nif ${body}; then true; fi\n`,
+    );
+    expect(runGuard().exitCode).toBe(1);
+  });
+
+  it("FAILS when the pipe and the grep are split by a line continuation", () => {
+    writeScript(
+      "offender",
+      '#!/usr/bin/env bash\nset -euo pipefail\nif cat f | \\\n  grep -qxF "$1"; then true; fi\n',
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    // Reported against the line the pipeline starts on, not the continuation.
+    expect(stdout).toMatch(/offender\.sh:3:/);
+  });
+
+  it("FAILS on a three-stage pipeline whose last reader is quiet", () => {
+    writeScript(
+      "offender",
+      '#!/usr/bin/env bash\nset -euo pipefail\nif cat f | grep -v skip | grep -q .; then true; fi\n',
     );
     expect(runGuard().exitCode).toBe(1);
   });

--- a/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
+++ b/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
@@ -1,0 +1,200 @@
+/**
+ * Self-test for scripts/checks/check-no-pipe-into-grep-q.sh — the CI guard that
+ * forbids `<writer> | grep -q …` in shell scripts.
+ *
+ * The first block is not a test of the guard but of the defect the guard exists
+ * for: it reproduces the SIGPIPE inversion in a real bash process, so the rest
+ * of this file is not defending a rule nobody can show is real.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const GUARD = join(REPO_ROOT, "scripts/checks/check-no-pipe-into-grep-q.sh");
+
+let root;
+
+function runGuard(extraEnv = {}) {
+  const r = spawnSync("bash", [GUARD], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NO_PIPE_GREP_Q_ROOT: root,
+      NO_PIPE_GREP_Q_FIXTURE_MODE: "1",
+      ...extraEnv,
+    },
+  });
+  return { exitCode: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+
+/** Writes scripts/<name>.sh under the fixture root. */
+function writeScript(name, body) {
+  writeFileSync(join(root, "scripts", `${name}.sh`), body, "utf8");
+}
+
+/** The guard needs >= MIN_FILES scripts before it will report at all. */
+function padScripts(n = 25) {
+  for (let i = 0; i < n; i++) {
+    writeScript(`pad-${i}`, "#!/usr/bin/env bash\nset -euo pipefail\ntrue\n");
+  }
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "no-pipe-grep-q-"));
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  padScripts();
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("the defect this guard exists for", () => {
+  // A needle on the FIRST line and a body far larger than the 64 KiB pipe
+  // buffer: grep matches and exits while printf still has data to write, so
+  // printf takes SIGPIPE and pipefail reports the successful match as failure.
+  // The haystack is built inside bash by string doubling — passing ~3 MB as an
+  // argv entry hits E2BIG.
+  const NEEDLE = "needle";
+  const BUILD = `block=$'filler-line\\n'; for _ in $(seq 1 18); do block="$block$block"; done; big=$'${NEEDLE}\\n'"$block";`;
+
+  function runShape(condition) {
+    return spawnSync(
+      "bash",
+      [
+        "-c",
+        `set -euo pipefail; ${BUILD} if ${condition}; then echo FOUND; else echo "MISSED(rc=$?)"; fi`,
+      ],
+      { encoding: "utf8", maxBuffer: 1 << 20 },
+    );
+  }
+
+  it("reports a SUCCESSFUL match as failure when piped into grep -q", () => {
+    const r = runShape(`printf '%s' "$big" | grep -qxF '${NEEDLE}'`);
+    // The needle IS on the first line — "MISSED" here is the inversion itself,
+    // not a matching failure. If a future bash/coreutils stops reporting it,
+    // this assertion is the tripwire that says so.
+    expect(r.stdout.trim()).toMatch(/^MISSED\(rc=\d+\)$/);
+  });
+
+  it("reports the same match correctly through a herestring", () => {
+    const r = runShape(`grep -qxF '${NEEDLE}' <<<"$big"`);
+    expect(r.stdout.trim()).toBe("FOUND");
+  });
+});
+
+describe("check-no-pipe-into-grep-q.sh", () => {
+  it("FAILS on a pipeline into grep -q", () => {
+    writeScript(
+      "offender",
+      '#!/usr/bin/env bash\nset -euo pipefail\nif printf "%s" "$LIST" | grep -qxF "$1"; then true; fi\n',
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("offender.sh");
+  });
+
+  it("FAILS on the echo spelling too — the writer is not part of the rule", () => {
+    writeScript(
+      "offender",
+      '#!/usr/bin/env bash\nset -euo pipefail\nif echo "$LIST" | grep -q foo; then true; fi\n',
+    );
+    expect(runGuard().exitCode).toBe(1);
+  });
+
+  it("FAILS when the writer is a command rather than printf/echo", () => {
+    writeScript(
+      "offender",
+      '#!/usr/bin/env bash\nset -euo pipefail\nif git diff --name-only | grep -q "^src/"; then true; fi\n',
+    );
+    expect(runGuard().exitCode).toBe(1);
+  });
+
+  it("FAILS on combined short flags (-qxF, -qiE)", () => {
+    writeScript(
+      "offender",
+      '#!/usr/bin/env bash\nset -euo pipefail\ncat f | grep -qiE "^x"\n',
+    );
+    expect(runGuard().exitCode).toBe(1);
+  });
+
+  it("FAILS on a pipeline nested inside bash -c, which no exclusion spares", () => {
+    // Safe today only because a fresh `bash -c` has no pipefail — a property of
+    // the caller, not the line. The gate rejects the shape regardless.
+    writeScript(
+      "offender",
+      "#!/usr/bin/env bash\nset -euo pipefail\nbash -c 'if cat f | grep -q x; then true; fi'\n",
+    );
+    expect(runGuard().exitCode).toBe(1);
+  });
+
+  it("PASSES the herestring form", () => {
+    writeScript(
+      "clean",
+      '#!/usr/bin/env bash\nset -euo pipefail\nif grep -qxF "$1" <<<"$LIST"; then true; fi\n',
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("no pipeline into grep -q");
+  });
+
+  it("PASSES `|| grep -q` — logical OR is not a pipe", () => {
+    writeScript(
+      "clean",
+      '#!/usr/bin/env bash\nset -euo pipefail\n(( ec == 0 )) || grep -qE "x" <<<"$out"\n',
+    );
+    expect(runGuard().exitCode).toBe(0);
+  });
+
+  it("PASSES a pipeline into a reader that drains its input", () => {
+    // grep -v / sort read to EOF, so the writer never sees a closed pipe.
+    writeScript(
+      "clean",
+      '#!/usr/bin/env bash\nset -euo pipefail\nhits=$(grep -rn x src/ | grep -v test || true)\n',
+    );
+    expect(runGuard().exitCode).toBe(0);
+  });
+
+  it("does not trip on the prose that documents the rule", () => {
+    writeScript(
+      "clean",
+      "#!/usr/bin/env bash\nset -euo pipefail\n# NOTE: never write `foo | grep -q bar` here.\ntrue\n",
+    );
+    expect(runGuard().exitCode).toBe(0);
+  });
+
+  it("EMPTY_SCAN: fails when the scan finds implausibly few scripts", () => {
+    rmSync(join(root, "scripts"), { recursive: true, force: true });
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    writeScript("only-one", "#!/usr/bin/env bash\ntrue\n");
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("EMPTY_SCAN");
+  });
+
+  it("fails when the scan directory is absent rather than passing vacuously", () => {
+    rmSync(join(root, "scripts"), { recursive: true, force: true });
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("not found");
+  });
+
+  it("ENV_POLLUTION_GUARD: refuses an override under CI without fixture mode", () => {
+    const { exitCode, stdout } = runGuard({
+      CI: "true",
+      NO_PIPE_GREP_Q_FIXTURE_MODE: "",
+    });
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("ENV_POLLUTION_GUARD");
+  });
+
+  it("passes against the real repo", () => {
+    const r = spawnSync("bash", [GUARD], { encoding: "utf8", env: process.env });
+    expect(r.status, r.stdout + r.stderr).toBe(0);
+  });
+});

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -57,10 +57,10 @@ suggest_bump() {
   fi
 
   # Check for breaking changes (highest priority)
-  if echo "$commits" | grep -qiE '^[a-z]+!:|BREAKING CHANGE'; then
+  if grep -qiE '^[a-z]+!:|BREAKING CHANGE' <<<"$commits"; then
     bump="major"
   # Check for new features
-  elif echo "$commits" | grep -qE '^feat(\(.+\))?:'; then
+  elif grep -qE '^feat(\(.+\))?:' <<<"$commits"; then
     bump="minor"
   fi
 

--- a/scripts/checks/check-cosign-kms-uri.sh
+++ b/scripts/checks/check-cosign-kms-uri.sh
@@ -77,7 +77,7 @@ OUT=$(
 # every other failure mode — a `awskms:/<arn>` (one slash) URI produced neither
 # known string and the gate reported OK, and a timeout or a future cosign error
 # message would do the same.
-if echo "$OUT" | grep -qE "UnrecognizedClientException|InvalidClientTokenId|SignatureDoesNotMatch|AccessDenied|NotFoundException"; then
+if grep -qE "UnrecognizedClientException|InvalidClientTokenId|SignatureDoesNotMatch|AccessDenied|NotFoundException" <<<"$OUT"; then
   echo "check-cosign-kms-uri: OK ($URI reached AWS KMS as a key reference)"
   exit 0
 fi
@@ -86,13 +86,13 @@ echo "ERROR: cosign did not resolve this KMS URI to a key." >&2
 echo "       URI: $URI" >&2
 echo "       Expected the dummy credentials to be rejected BY AWS, which proves" >&2
 echo "       cosign parsed the URI and issued the KMS call. Instead:" >&2
-echo "$OUT" | head -3 | sed 's/^/         /' >&2
+head -3 | sed 's/^/         /' >&2 <<<"$OUT"
 echo "" >&2
-if echo "$OUT" | grep -q "Failed to parse uri"; then
+if grep -q "Failed to parse uri" <<<"$OUT"; then
   echo "       cosign treated the ARN as an ENDPOINT HOST. The URI grammar is" >&2
   echo "       awskms://[ENDPOINT]/[ID]; with no endpoint the ARN goes in the" >&2
   echo "       path — THREE slashes: awskms:///<arn>." >&2
-elif echo "$OUT" | grep -q "should be in the format"; then
+elif grep -q "should be in the format" <<<"$OUT"; then
   echo "       cosign rejected the URI at parse time — check the slash count and" >&2
   echo "       that the ARN is well formed." >&2
 else

--- a/scripts/checks/check-e2e-selectors.sh
+++ b/scripts/checks/check-e2e-selectors.sh
@@ -115,7 +115,7 @@ if [ -n "$e2e_class_selectors" ]; then
       for cls in $classes; do
         [ -z "$cls" ] && continue
         # Check if this class appears in removed lines but NOT in added lines
-        if echo "$removed_classes" | grep -q "\b${cls}\b" 2>/dev/null; then
+        if grep -q "\b${cls}\b" 2>/dev/null <<<"$removed_classes"; then
           # Verify it's actually gone (not just moved)
           added_with_class=$(git diff "${BASE}...HEAD" -- $changed_src \
             | grep -E '^\+.*className=.*\b'"${cls}"'\b' \
@@ -191,7 +191,7 @@ added_exports=$(git diff "${BASE}...HEAD" -- 'src/**/*.tsx' 'src/**/*.ts' \
 
 for name in $removed_exports; do
   # Skip if re-exported under the same name
-  if echo "$added_exports" | grep -qx "$name"; then
+  if grep -qx "$name" <<<"$added_exports"; then
     continue
   fi
   # Look for the symbol inside an actual import statement only — not local
@@ -239,7 +239,7 @@ if [ -n "$e2e_aria_names" ] && [ -n "$changed_src" ]; then
   if [ -n "$removed_aria" ]; then
     for name in $e2e_aria_names; do
       [ ${#name} -lt 3 ] && continue
-      if echo "$removed_aria" | grep -qi "$name" 2>/dev/null; then
+      if grep -qi "$name" 2>/dev/null <<<"$removed_aria"; then
         added_aria=$(git diff "${BASE}...HEAD" -- $changed_src \
           | grep -E '^\+.*aria-label=.*'"$name" \
           | grep -v '^\+\+\+' || true)
@@ -272,7 +272,7 @@ if [ -n "$e2e_ids" ] && [ -n "$changed_src" ]; then
   if [ -n "$removed_ids" ]; then
     for id in $e2e_ids; do
       [ ${#id} -lt 2 ] && continue
-      if echo "$removed_ids" | grep -q "\"${id}\"" 2>/dev/null; then
+      if grep -q "\"${id}\"" 2>/dev/null <<<"$removed_ids"; then
         added_id=$(git diff "${BASE}...HEAD" -- $changed_src \
           | grep -E '^\+.*\bid=.*"'"${id}"'"' \
           | grep -v '^\+\+\+' || true)
@@ -349,12 +349,12 @@ if [ -n "$i18n_removed_ja" ] && [ -d "$E2E_DIR" ]; then
       [ "$(echo -n "$ja_pattern" | wc -m)" -lt 2 ] && continue
 
       # Check if this E2E Japanese pattern matches any removed i18n value
-      if echo "$i18n_removed_ja" | grep -qF "$ja_pattern"; then
+      if grep -qF "$ja_pattern" <<<"$i18n_removed_ja"; then
         # Verify it's NOT in the added side (i.e. the string was truly removed, not just moved)
         i18n_added_ja=$(git diff "${BASE}...HEAD" -- 'messages/ja/*.json' \
           | grep -E '^\+\s*"[^"]+"\s*:\s*"' \
           | grep -v '^\+\+\+' || true)
-        if ! echo "$i18n_added_ja" | grep -qF "$ja_pattern"; then
+        if ! grep -qF "$ja_pattern" <<<"$i18n_added_ja"; then
           ref_files=$(grep -rl "$ja_pattern" "$E2E_DIR/" 2>/dev/null | tr '\n' ', ' | sed 's/,$//')
           warn "i18n value '$ja_pattern' was changed in messages/ja/ but is still used in E2E regex: $ref_files"
         fi

--- a/scripts/checks/check-fail-closed-routes-have-test.sh
+++ b/scripts/checks/check-fail-closed-routes-have-test.sh
@@ -105,8 +105,10 @@ LEGACY_LIST="$(read_manifest "$LEGACY_FILE")"
 # pipelines — `grep -q` closes the pipe on first match, and under load
 # (parallel vitest workers) printf then dies with SIGPIPE (141), which
 # `set -o pipefail` turns into a spurious gate failure. No pipe, no race.
-is_debt()   { grep -qxF "$1" <<<"$DEBT_LIST"; }
-is_legacy() { grep -qxF "$1" <<<"$LEGACY_LIST"; }
+# The `[ -n "$1" ]` guard keeps an empty needle fail-CLOSED: a herestring feeds
+# grep one empty line, so `grep -qxF ""` would report every caller as exempt.
+is_debt()   { [ -n "$1" ] && grep -qxF "$1" <<<"$DEBT_LIST"; }
+is_legacy() { [ -n "$1" ] && grep -qxF "$1" <<<"$LEGACY_LIST"; }
 
 # manifest_count <list> — number of non-empty entries in a read_manifest
 # output string. Herestring, not a pipe (same SIGPIPE rationale as above).

--- a/scripts/checks/check-gate-selftest-coverage.sh
+++ b/scripts/checks/check-gate-selftest-coverage.sh
@@ -108,7 +108,7 @@ if [ "$DEBT_PARSE_FAIL" -ne 0 ]; then
 fi
 
 is_debt() {
-  printf '%s' "$DEBT_LIST" | grep -qxF "$1"
+  [ -n "$1" ] && grep -qxF "$1" <<<"$DEBT_LIST"
 }
 
 # ---------------------------------------------------------------------------
@@ -190,13 +190,13 @@ while IFS= read -r debt_entry; do
   case "$debt_entry" in
     pre-pr:*)
       inline_label="${debt_entry#pre-pr:}"
-      if ! printf '%s' "$inline_keys" | grep -qxF "$debt_entry"; then
+      if ! grep -qxF "$debt_entry" <<<"$inline_keys"; then
         echo "STALE_DEBT_ENTRY: $debt_entry (no inline \"$inline_label\" bash -c gate found in $PREPR_FILE)"
         DEBT_DRIFT=1
       fi
       ;;
     *)
-      if ! printf '%s' "$check_keys" | grep -qxF "$debt_entry"; then
+      if ! grep -qxF "$debt_entry" <<<"$check_keys"; then
         echo "STALE_DEBT_ENTRY: $debt_entry (no such file under $CHECKS_DIR)"
         DEBT_DRIFT=1
       else

--- a/scripts/checks/check-no-pipe-into-grep-q.sh
+++ b/scripts/checks/check-no-pipe-into-grep-q.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Forbid `<writer> | grep -q …` in shell scripts.
+#
+# `grep -q` exits the moment it matches. Under load the writer is still writing
+# when the pipe closes, takes SIGPIPE (141), and `set -o pipefail` reports the
+# whole pipeline as failed — so a SUCCESSFUL match is observed as a failure.
+# Every such pipeline is therefore a coin flip whose bias runs the wrong way:
+# the more matches there are, the sooner grep exits, and the likelier the
+# inversion. In a condition that inverts the decision, and roughly half of the
+# call sites in this repo skipped a check when it fired (`RUN_WEB=0`, "not a
+# refactor branch", "no admin changes") — a green that proved nothing.
+#
+# The fix is to remove the writer process, not to retry: `grep -q PAT <<<"$VAR"`
+# has no second process, so there is no race. Where the input comes from a
+# command, capture it first (`v=$(cmd || true)`) and feed the herestring.
+#
+# No exclusions. A pipeline inside `bash -c '…'` happens to be safe today
+# (a fresh shell has no pipefail), but that is a property of the *caller*, not
+# of the line — one `set -o pipefail` added to such a block would silently arm
+# it. Rejecting the shape outright is what makes this gate cheap to trust.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "$0")/../.." && pwd))"
+FIXTURE_ROOT="${NO_PIPE_GREP_Q_ROOT:-$REPO_ROOT}"
+cd "$FIXTURE_ROOT"
+
+SCAN_DIR="scripts"
+
+echo "check-no-pipe-into-grep-q: FIXTURE_ROOT=$FIXTURE_ROOT SCAN_DIR=$SCAN_DIR"
+
+# Env-pollution guard: an override under CI needs an explicit acknowledgement,
+# so a stray export cannot point the gate at an empty tree and green it.
+if [ "${CI:-}" = "true" ] && [ -n "${NO_PIPE_GREP_Q_ROOT:-}" ]; then
+  if [ "${NO_PIPE_GREP_Q_FIXTURE_MODE:-}" != "1" ]; then
+    echo "ENV_POLLUTION_GUARD: NO_PIPE_GREP_Q_ROOT override set under CI=true without NO_PIPE_GREP_Q_FIXTURE_MODE=1 — refusing to run against a possibly-unintended path."
+    exit 1
+  fi
+fi
+
+if [ ! -d "$SCAN_DIR" ]; then
+  echo "ERROR: $SCAN_DIR/ not found under $FIXTURE_ROOT"
+  exit 1
+fi
+
+# `[^|]` before the pipe keeps `||  grep -q` (logical OR — no pipe, no race)
+# out of the match. `-q` may carry other short flags (`-qxF`, `-qiE`).
+PATTERN='[^|]\|[[:space:]]*grep[[:space:]]+-q'
+
+files=$(find "$SCAN_DIR" -name '*.sh' -type f -not -path '*/__tests__/fixtures/*' | sort)
+file_count=$(grep -c . <<<"$files" || true)
+
+# EMPTY_SCAN: a gate that inspects nothing passes vacuously. The floor is set
+# below today's count so an ordinary deletion does not trip it, but a broken
+# path or a bad glob does.
+MIN_FILES=20
+if [ "${file_count:-0}" -lt "$MIN_FILES" ]; then
+  echo "EMPTY_SCAN: only ${file_count:-0} shell scripts found under $SCAN_DIR/ (expected >= $MIN_FILES) — the scan path is wrong, not the tree."
+  exit 1
+fi
+
+violations=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  # Strip comment-only lines so the prose that documents this rule does not
+  # trip it.
+  hits=$(grep -nE "$PATTERN" "$f" | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+  if [ -n "$hits" ]; then
+    while IFS= read -r h; do
+      [ -z "$h" ] && continue
+      violations="${violations}${f}:${h}
+"
+    done <<<"$hits"
+  fi
+done <<<"$files"
+
+if [ -n "$violations" ]; then
+  echo "ERROR: pipeline into 'grep -q' found — under pipefail a successful match can be reported as failure (SIGPIPE on the writer)."
+  printf '%s' "$violations"
+  echo "Use a herestring instead: grep -q PAT <<<\"\$VAR\""
+  echo "If the input comes from a command, capture it first: v=\$(cmd || true)"
+  exit 1
+fi
+
+echo "OK ($file_count shell scripts scanned, no pipeline into grep -q)"

--- a/scripts/checks/check-no-pipe-into-grep-q.sh
+++ b/scripts/checks/check-no-pipe-into-grep-q.sh
@@ -42,24 +42,30 @@ if [ ! -d "$SCAN_DIR" ]; then
   exit 1
 fi
 
-# Matching is done in awk, not by a line regex, because the shape has three
+# Matching is done in awk, not by a line regex, because the shape has several
 # spellings a regex over raw lines gets wrong:
-#   * the quiet flag can sit anywhere in a short cluster (-q, -qxF, -iqE, -Eq)
-#     or appear as --quiet;
-#   * the pipe and the grep can be split across a `\` continuation;
+#   * the early-exit flag can sit anywhere in a short cluster (-q, -qxF, -iqE,
+#     -Eq) or appear long (--quiet, --silent, --max-count);
+#   * the pipe and the grep can be split across a `\` continuation OR across a
+#     bare trailing `|` / `|&`, which bash continues without a backslash;
 #   * `||` is not a pipe and must not match.
-# So: join continuations into logical lines, mask `||`, then for each piped
-# `grep` test its own argument segment for a quiet flag.
+#
+# The flag set was derived by measurement, not from the man page: with the
+# needle on line 1 and a body past the pipe buffer, `-q`, `--quiet`, `--silent`
+# and `-m1` all report the match as rc=141, while `-l` does not — so `-l` is
+# not a member and is deliberately absent.
 detect_awk='
 function has_quiet(seg) {
-  sub(/[;&].*$/, "", seg)
-  return (seg ~ /(^|[ \t])-[A-Za-z]*q[A-Za-z]*([ \t]|$)/ ||
-          seg ~ /(^|[ \t])--quiet([ \t]|$)/)
+  sub(/;.*$/, "", seg)
+  sub(/&&.*$/, "", seg)
+  # Trailing digits so `-m1` (and `-im1`) match as well as `-m 1`.
+  return (seg ~ /(^|[ \t])-[A-Za-z]*[qm][A-Za-z]*[0-9]*([ \t]|=|$)/ ||
+          seg ~ /(^|[ \t])--(quiet|silent|max-count)([ \t]|=|$)/)
 }
 function offends(s,   t, seg) {
   t = s
   gsub(/\|\|/, "@@OR@@", t)
-  while (match(t, /\|[ \t]*grep([ \t]|$)/)) {
+  while (match(t, /\|&?[ \t]*grep([ \t]|$)/)) {
     seg = substr(t, RSTART + RLENGTH - 1)
     if (has_quiet(seg)) return 1
     t = substr(t, RSTART + RLENGTH)
@@ -69,7 +75,9 @@ function offends(s,   t, seg) {
 {
   if (buf == "") { start = FNR; disp = $0 }
   raw = $0
-  cont = (raw ~ /\\[ \t]*$/)
+  # bash continues a line ending in `\`, and also one ending in a pipe
+  # operator (`|` or `|&`) with no backslash at all.
+  cont = (raw ~ /\\[ \t]*$/ || raw ~ /\|&?[ \t]*$/)
   sub(/\\[ \t]*$/, " ", raw)
   buf = buf raw
   if (cont) next

--- a/scripts/checks/check-no-pipe-into-grep-q.sh
+++ b/scripts/checks/check-no-pipe-into-grep-q.sh
@@ -42,9 +42,42 @@ if [ ! -d "$SCAN_DIR" ]; then
   exit 1
 fi
 
-# `[^|]` before the pipe keeps `||  grep -q` (logical OR — no pipe, no race)
-# out of the match. `-q` may carry other short flags (`-qxF`, `-qiE`).
-PATTERN='[^|]\|[[:space:]]*grep[[:space:]]+-q'
+# Matching is done in awk, not by a line regex, because the shape has three
+# spellings a regex over raw lines gets wrong:
+#   * the quiet flag can sit anywhere in a short cluster (-q, -qxF, -iqE, -Eq)
+#     or appear as --quiet;
+#   * the pipe and the grep can be split across a `\` continuation;
+#   * `||` is not a pipe and must not match.
+# So: join continuations into logical lines, mask `||`, then for each piped
+# `grep` test its own argument segment for a quiet flag.
+detect_awk='
+function has_quiet(seg) {
+  sub(/[;&].*$/, "", seg)
+  return (seg ~ /(^|[ \t])-[A-Za-z]*q[A-Za-z]*([ \t]|$)/ ||
+          seg ~ /(^|[ \t])--quiet([ \t]|$)/)
+}
+function offends(s,   t, seg) {
+  t = s
+  gsub(/\|\|/, "@@OR@@", t)
+  while (match(t, /\|[ \t]*grep([ \t]|$)/)) {
+    seg = substr(t, RSTART + RLENGTH - 1)
+    if (has_quiet(seg)) return 1
+    t = substr(t, RSTART + RLENGTH)
+  }
+  return 0
+}
+{
+  if (buf == "") { start = FNR; disp = $0 }
+  raw = $0
+  cont = (raw ~ /\\[ \t]*$/)
+  sub(/\\[ \t]*$/, " ", raw)
+  buf = buf raw
+  if (cont) next
+  if (buf !~ /^[ \t]*#/ && offends(buf)) printf "%d:%s\n", start, disp
+  buf = ""
+}
+END { if (buf != "" && buf !~ /^[ \t]*#/ && offends(buf)) printf "%d:%s\n", start, disp }
+'
 
 files=$(find "$SCAN_DIR" -name '*.sh' -type f -not -path '*/__tests__/fixtures/*' | sort)
 file_count=$(grep -c . <<<"$files" || true)
@@ -61,9 +94,7 @@ fi
 violations=""
 while IFS= read -r f; do
   [ -z "$f" ] && continue
-  # Strip comment-only lines so the prose that documents this rule does not
-  # trip it.
-  hits=$(grep -nE "$PATTERN" "$f" | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+  hits=$(awk "$detect_awk" "$f" || true)
   if [ -n "$hits" ]; then
     while IFS= read -r h; do
       [ -z "$h" ] && continue

--- a/scripts/checks/check-passkey-mint-gate.sh
+++ b/scripts/checks/check-passkey-mint-gate.sh
@@ -111,7 +111,7 @@ if [ "$EXEMPT_PARSE_FAIL" -ne 0 ]; then
 fi
 
 is_exempt() {
-  printf '%s' "$EXEMPT_LIST" | grep -qxF "$1"
+  [ -n "$1" ] && grep -qxF "$1" <<<"$EXEMPT_LIST"
 }
 
 # Token-mint and token-refresh primitives (extended regex). Trigger on the
@@ -180,7 +180,7 @@ while read -r lib_rel fn_name; do
     LIB_GATE_FAIL=1
     continue
   fi
-  if ! printf '%s' "$fn_body" | grep -qE '(^|[^A-Za-z0-9_])passkeyEnforcementBlocks\(' 2>/dev/null; then
+  if ! grep -qE '(^|[^A-Za-z0-9_])passkeyEnforcementBlocks\(' 2>/dev/null <<<"$fn_body"; then
     echo "MISSING_LIB_PASSKEY_GATE: $lib_rel function $fn_name() does not call passkeyEnforcementBlocks (gate moved from route into this lib fn — removing it leaves this token-mint path unguarded)."
     LIB_GATE_FAIL=1
   fi

--- a/scripts/checks/check-permanent-delete-stepup.sh
+++ b/scripts/checks/check-permanent-delete-stepup.sh
@@ -110,7 +110,7 @@ if [ "$EXEMPT_PARSE_FAIL" -ne 0 ]; then
 fi
 
 is_exempt() {
-  printf '%s' "$EXEMPT_LIST" | grep -qxF "$1"
+  [ -n "$1" ] && grep -qxF "$1" <<<"$EXEMPT_LIST"
 }
 
 # Irreversible vault-data delete primitives (extended regex). Keep table-name

--- a/scripts/checks/check-publish-toolchain.sh
+++ b/scripts/checks/check-publish-toolchain.sh
@@ -53,7 +53,7 @@ ver_ge "$npm_pin" "11.5.1" || fail "release.yml: PUBLISH_NPM_VERSION=$npm_pin is
 # PUBLISH_NODE_VERSION must be an EXACT patch (X.Y.Z), so the bundled npm is
 # deterministic. (The grep above already required the X.Y.Z shape; assert the
 # captured value has no trailing `.x`/range and is a full three-part semver.)
-printf '%s' "$node_pin" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' \
+grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' <<<"$node_pin" \
   || fail "release.yml: PUBLISH_NODE_VERSION=$node_pin must be an exact patch (X.Y.Z), not a partial or floating version"
 
 # Every setup-node in release.yml MUST resolve node-version from the pinned env —

--- a/scripts/checks/check-raw-body-read.sh
+++ b/scripts/checks/check-raw-body-read.sh
@@ -68,7 +68,7 @@ if [ -f "$ALLOWLIST" ]; then
 fi
 
 is_allowed() {
-  printf '%s' "$ALLOW_LIST" | grep -qxF "$1"
+  [ -n "$1" ] && grep -qxF "$1" <<<"$ALLOW_LIST"
 }
 
 fail=0

--- a/scripts/checks/check-step-up-client-coverage.sh
+++ b/scripts/checks/check-step-up-client-coverage.sh
@@ -386,7 +386,7 @@ while IFS= read -r line; do
   #     as the route file) must exist and contain the literal
   #     `@browser-redirect-recovery-test` marker, pinning a regression test.
   if [ "$emarker" = "@browser-redirect" ]; then
-    route_rel="$(printf '%s' "$SERVER_ID_FILES" | grep -m1 "^${eid} " | cut -d' ' -f2-)"
+    route_rel="$(grep -m1 "^${eid} " <<<"$SERVER_ID_FILES" | cut -d' ' -f2-)"
     if [ -z "$route_rel" ]; then
       echo "STALE_EXEMPT: exempt id '$eid' has no matching server route file on record — remove it from stepup-client-exempt.txt."
       fail=1

--- a/scripts/checks/check-step-up-client-coverage.sh
+++ b/scripts/checks/check-step-up-client-coverage.sh
@@ -209,7 +209,7 @@ if [ "$EXEMPT_PARSE_FAIL" -ne 0 ]; then
 fi
 
 is_exempt() {
-  printf '%s' "$EXEMPT_IDS" | grep -qxF "$1"
+  [ -n "$1" ] && grep -qxF "$1" <<<"$EXEMPT_IDS"
 }
 
 # ── Collect SERVER markers (set S) and enforce completeness ──────────────────
@@ -247,7 +247,7 @@ while IFS= read -r route; do
     sid="$(printf '%s' "$marker_line" | sed -E 's/.*id:([A-Za-z0-9_-]+).*/\1/')"
 
     # Per-file id uniqueness (a marker must not cover two distinct calls).
-    if printf '%s' "$file_ids" | grep -qxF "$sid"; then
+    if grep -qxF "$sid" <<<"$file_ids"; then
       echo "SERVER_MARKER_DUP_ID: $route:$H — id '$sid' is used by more than one requireRecentCurrentAuthMethod call in this file; each gated call needs a distinct id."
       fail=1
     fi
@@ -255,7 +255,7 @@ while IFS= read -r route; do
 "
 
     # Global id uniqueness across all server files.
-    if printf '%s' "$declare_ids_seen" | grep -qxF "$sid"; then
+    if grep -qxF "$sid" <<<"$declare_ids_seen"; then
       echo "SERVER_MARKER_DUP_ID_GLOBAL: $route:$H — id '$sid' is already declared by another route file; ids must be globally unique."
       fail=1
     fi
@@ -315,7 +315,7 @@ done < <(
 # ── Check 1: Coverage (S \ C) ────────────────────────────────────────────────
 while IFS= read -r sid; do
   [ -z "$sid" ] && continue
-  if printf '%s' "$CLIENT_IDS" | grep -qxF "$sid"; then
+  if grep -qxF "$sid" <<<"$CLIENT_IDS"; then
     continue
   fi
   if is_exempt "$sid"; then
@@ -328,7 +328,7 @@ done < <(printf '%s' "$SERVER_IDS" | sort -u)
 # ── Check 3: Anti-orphan (C \ S) ─────────────────────────────────────────────
 while IFS= read -r cid; do
   [ -z "$cid" ] && continue
-  if printf '%s' "$SERVER_IDS" | grep -qxF "$cid"; then
+  if grep -qxF "$cid" <<<"$SERVER_IDS"; then
     continue
   fi
   if is_exempt "$cid"; then
@@ -362,7 +362,7 @@ while IFS= read -r line; do
   [ -z "$eid" ] && continue
 
   # The exempt id must still be a real server id (else the exemption is stale).
-  if ! printf '%s' "$SERVER_IDS" | grep -qxF "$eid"; then
+  if ! grep -qxF "$eid" <<<"$SERVER_IDS"; then
     echo "STALE_EXEMPT: exempt id '$eid' has no matching server @stepup marker — remove it from stepup-client-exempt.txt."
     fail=1
     continue
@@ -461,7 +461,7 @@ manifest_line_for() {
 
 while IFS= read -r sid; do
   [ -z "$sid" ] && continue
-  if ! printf '%s' "$MANIFEST_IDS" | grep -qxF "$sid"; then
+  if ! grep -qxF "$sid" <<<"$MANIFEST_IDS"; then
     echo "MANIFEST_ID_MISSING: server id '$sid' has no entry in $PATHS_FILE — add \"$sid\": { \"method\": \"<M>\", \"pathTokens\": [...] }."
     fail=1
     continue
@@ -476,7 +476,7 @@ done < <(printf '%s' "$SERVER_IDS" | sort -u)
 
 while IFS= read -r mid; do
   [ -z "$mid" ] && continue
-  if ! printf '%s' "$SERVER_IDS" | grep -qxF "$mid"; then
+  if ! grep -qxF "$mid" <<<"$SERVER_IDS"; then
     echo "MANIFEST_ID_STALE: manifest id '$mid' (in $PATHS_FILE) has no matching server @stepup marker — remove it or the route was renamed/removed."
     fail=1
   fi
@@ -629,7 +629,7 @@ EOF
     [ "$token_hit" -eq 1 ] || continue
 
     # Escape hatch: a suppression comment for this exact id near the call line.
-    if printf '%s' "$suppress_window" | grep -qE "@stepup-path-ok[[:space:]]+id:${mid}([[:space:]]|$)"; then
+    if grep -qE "@stepup-path-ok[[:space:]]+id:${mid}([[:space:]]|$)" <<<"$suppress_window"; then
       # Reason discipline: require >=10 chars of trailing text on that line.
       suppress_line="$(printf '%s' "$suppress_window" | grep -E "@stepup-path-ok[[:space:]]+id:${mid}" | head -n1)"
       reason="$(printf '%s' "$suppress_line" | sed -E "s/.*@stepup-path-ok[[:space:]]+id:${mid}//")"
@@ -642,7 +642,7 @@ EOF
       continue
     fi
 
-    if ! printf '%s' "$file_marker_ids" | grep -qxF "$mid"; then
+    if ! grep -qxF "$mid" <<<"$file_marker_ids"; then
       echo "UNMARKED_CALLSITE_CANDIDATE: $rel:$fline — fetchApi( call site matches gated id '$mid' ($method) by path token, but this file has no '@stepup id:$mid' marker. Add the marker + step-up handling, or suppress with '// @stepup-path-ok id:$mid <reason>' if this is a confirmed false positive."
       fail=1
     fi

--- a/scripts/manual-tests/test-codebase-review-fixes.sh
+++ b/scripts/manual-tests/test-codebase-review-fixes.sh
@@ -112,8 +112,8 @@ sleep 2  # avoid rate limit
 echo ""
 echo "▸ Finding 4: Audit download CSV — actorType in header"
 BODY=$(api GET "/api/audit-logs/download?format=csv&from=$DATE_FROM&to=$DATE_TO" 2>/dev/null || echo "")
-HEADER=$(echo "$BODY" | head -1)
-if echo "$HEADER" | grep -q "actorType"; then
+HEADER=$(head -1) <<<"$BODY"
+if grep -q "actorType" <<<"$HEADER"; then
   pass "CSV header includes actorType"
 else
   fail "CSV header missing actorType: $HEADER"

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -386,7 +386,7 @@ run_step "Static: prf-salt-migration-script-readonly" bash -c '
   # Extract just the SQL block(s) between `<<EOF` markers and the closing tag.
   # Any of UPDATE/INSERT/DELETE/TRUNCATE inside that block fails the check.
   SQL_BODY=$(awk "/^psql /,/^SQL\$/" "$SCRIPT")
-  if echo "$SQL_BODY" | grep -iqE "\\b(UPDATE|INSERT|DELETE|TRUNCATE)\\b"; then
+  if grep -iqE "\\b(UPDATE|INSERT|DELETE|TRUNCATE)\\b" <<<"$SQL_BODY"; then
     echo "ERROR: forbidden write verb inside SQL body of $SCRIPT (A02-8 C9 immutable)"
     exit 1
   fi

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -43,13 +43,19 @@ detect_web_changes() {
   diff=$(git diff --name-only "$base"...HEAD 2>/dev/null) || return 0
   # Empty diff (e.g. nothing committed yet) ⇒ run all, can't prove iOS-only.
   [ -z "$diff" ] && return 0
-  printf '%s\n' "$diff" | grep -qE "$app_paths"
+  grep -qE "$app_paths" <<<"$diff"
 }
 if detect_web_changes; then
   RUN_WEB=1
 else
   RUN_WEB=0
 fi
+
+# Captured once, and fed to the branch-shape tests below as a herestring rather
+# than piped: `git … | grep -q` dies with SIGPIPE when grep matches and exits
+# first, and pipefail turns that into "no match" — silently skipping the very
+# steps the match was supposed to enable.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 
 passed=0
 failed=0
@@ -116,7 +122,7 @@ show_failure_context() {
       start_line=$(( fail_summary_line > 3 ? fail_summary_line - 3 : 1 ))
       end_line=$(( start_line + 60 ))
     else
-      first_line=$(printf "%s\n" "$matches" | head -1 | cut -d: -f1)
+      first_line=$(head -1 | cut -d: -f1) <<<"$matches"
       start_line=$(( first_line > 5 ? first_line - 5 : 1 ))
       end_line=$(( start_line + 24 ))
     fi
@@ -331,6 +337,7 @@ queue_step "Static: destructive-migration" node scripts/checks/check-destructive
 queue_step "Static: migration-transaction" node scripts/checks/check-migration-transaction.mjs
 queue_step "Static: raw-sql-usage" node scripts/checks/check-raw-sql-usage.mjs
 queue_step "Static: gate-selftest-coverage" bash scripts/checks/check-gate-selftest-coverage.sh
+queue_step "Static: no-pipe-into-grep-q" bash scripts/checks/check-no-pipe-into-grep-q.sh
 queue_step "Static: destructive-wrapper-derivation" node scripts/checks/check-destructive-wrapper-derivation.mjs
 run_batch
 # Cross-tenant SQL parse check (issue #434). Runs against the local docker DB
@@ -354,7 +361,7 @@ if command -v docker >/dev/null 2>&1 && docker exec passwd-sso-db-1 pg_isready -
 else
   printf "  [skip: rls-cross-tenant SQL parse — local docker DB not running (npm run docker:up to enable)]\n\n"
 fi
-run_step "Static: no-deprecated-logAudit" bash -c 'if grep -rn "logAudit(" src/ --include="*.ts" --include="*.tsx" | grep -v "logAuditAsync\|logAuditInTx" | grep -v "\.test\." | grep -v "^\s*//" | grep -v "^\s*\*" | grep -q .; then echo "Residual logAudit() calls found:"; grep -rn "logAudit(" src/ --include="*.ts" --include="*.tsx" | grep -v "logAuditAsync\|logAuditInTx" | grep -v "\.test\." | grep -v "^\s*//" | grep -v "^\s*\*"; exit 1; fi'
+run_step "Static: no-deprecated-logAudit" bash -c 'hits=$(grep -rn "logAudit(" src/ --include="*.ts" --include="*.tsx" | grep -v "logAuditAsync\|logAuditInTx" | grep -v "\.test\." | grep -v "^\s*//" | grep -v "^\s*\*" || true); if [ -n "$hits" ]; then echo "Residual logAudit() calls found:"; printf "%s\n" "$hits"; exit 1; fi'
 
 # C21 / C10: forbid imports of Auth.js builtin WebAuthn providers. The project
 # uses Auth.js Credentials provider with a custom authorize() flow that calls
@@ -404,11 +411,11 @@ run_step "Static: no-argon2-browser-reintroduce" bash -c '
   # of argon2-browser to catch accidental re-introduction (left-pad scenario
   # for an unmaintained dep). Also forbid hash-wasm imports outside the crypto
   # lib + tests + cli (CLI keeps its own argon2 dep).
-  if grep -rnE "(from\s+[\x22\x27]argon2-browser[\x22\x27]|require\([\x22\x27]argon2-browser[\x22\x27]\))" \
-    src/ 2>/dev/null | grep -v "\\.test\\." | grep -q .; then
+  argon2_hits=$(grep -rnE "(from\s+[\x22\x27]argon2-browser[\x22\x27]|require\([\x22\x27]argon2-browser[\x22\x27]\))" \
+    src/ 2>/dev/null | grep -v "\\.test\\." || true)
+  if [ -n "$argon2_hits" ]; then
     echo "ERROR: argon2-browser import detected — A06-2 forbids re-introduction; use hash-wasm."
-    grep -rnE "(from\s+[\x22\x27]argon2-browser[\x22\x27]|require\([\x22\x27]argon2-browser[\x22\x27]\))" \
-      src/ | grep -v "\\.test\\."
+    printf "%s\n" "$argon2_hits"
     exit 1
   fi
   if grep -qF "argon2-browser" package.json; then
@@ -621,10 +628,11 @@ fi
 # local run isn't false-failed by a stale, git-ignored
 # .refactor-phase-verify-baseline; CI's refactor-phase-verify.yml keeps using
 # --force WITHOUT the flag, so its behavior is unchanged.
-if [ "$STATIC_ONLY" != "1" ] && git rev-parse --abbrev-ref HEAD | grep -q "^refactor/"; then
+if [ "$STATIC_ONLY" != "1" ] && grep -q "^refactor/" <<<"$CURRENT_BRANCH"; then
   # two-dot -M main (working tree) mirrors verify-move-only-diff.mjs:194; do NOT
   # change to main...HEAD — the gate's rename detector must match the verifier.
-  if git diff --name-status -M main -- src | grep -qE '^[RC]'; then
+  src_rename_status=$(git diff --name-status -M main -- src 2>/dev/null || true)
+  if grep -qE '^[RC]' <<<"$src_rename_status"; then
     run_step "Refactor phase verify" node scripts/refactor-phase-verify.mjs --skip-merge-queue-guards
   else
     printf "${BOLD}▸ Refactor phase verify${RESET}\n  (skipped — content-only refactor: 0 src renames; CI's Refactor Phase Verify workflow is authoritative)\n\n"
@@ -633,8 +641,10 @@ fi
 
 # Manual-test artifact gate (R35 Tier-1) — fails if admin-IA changes ship
 # without an accompanying docs/archive/review/*-manual-test.md.
-if git diff --name-only main...HEAD | grep -q '^src/app/\[locale\]/admin/'; then
-  if ! git diff --name-only --diff-filter=A main...HEAD | grep -q '^docs/archive/review/.*-manual-test\.md$'; then
+branch_changed_files=$(git diff --name-only main...HEAD 2>/dev/null || true)
+branch_added_files=$(git diff --name-only --diff-filter=A main...HEAD 2>/dev/null || true)
+if grep -q '^src/app/\[locale\]/admin/' <<<"$branch_changed_files"; then
+  if ! grep -q '^docs/archive/review/.*-manual-test\.md$' <<<"$branch_added_files"; then
     printf "${RED}ERROR: admin/ changes detected but no docs/archive/review/*-manual-test.md added (R35 Tier-1)${RESET}\n" >&2
     failed=$((failed + 1))
     failures+=("Manual-test artifact gate (R35 Tier-1)|")
@@ -655,10 +665,9 @@ fi
 # T22 (CI via ci-integration.yml is authoritative; this local run is a preview).
 # Set PREPR_SKIP_INTEGRATION=1 to defer to CI.
 if [ "$STATIC_ONLY" != "1" ] && [ "$RUN_WEB" = "1" ] && \
-   git rev-parse --abbrev-ref HEAD | grep -q "^refactor/" && \
-   git diff --name-only main...HEAD | \
-     grep -E '^src/lib/(prisma|redis|tenant-(context|rls)|auth/.+-token)\.ts$|^src/lib/(prisma|tenant|auth)/' \
-     > /dev/null; then
+   grep -q "^refactor/" <<<"$CURRENT_BRANCH" && \
+   grep -qE '^src/lib/(prisma|redis|tenant-(context|rls)|auth/.+-token)\.ts$|^src/lib/(prisma|tenant|auth)/' \
+     <<<"$branch_changed_files"; then
   if [ "${PREPR_SKIP_INTEGRATION:-0}" = "1" ]; then
     printf "${BOLD}▸ Integration tests${RESET}\n"
     printf "  (skipped — PREPR_SKIP_INTEGRATION=1; CI ci-integration.yml is authoritative)\n\n"


### PR DESCRIPTION
## The flake

`#730` failed CI with:

```
MANIFEST_ID_STALE: manifest id 'mcp-client-id-put' has no matching server @stepup marker
scripts/checks/check-step-up-client-coverage.sh: line 479: printf: write error: Broken pipe
```

The marker exists. Re-running the job with no code change turned it green. `#725`
failed the same way on a different gate, with the same broken-pipe line.

## The mechanism

`grep -q` exits the moment it matches. Under load the writer is still writing when
the pipe closes, takes SIGPIPE, and `set -o pipefail` reports the pipeline as
failed — so a **successful match is observed as a failure**. The bias runs the
wrong way: the more matches there are, the sooner grep exits, and the likelier the
inversion.

This repo had already diagnosed it. `check-fail-closed-routes-have-test.sh` carries
the note verbatim — and the fix, for its own two helpers only. The rest of the tree
kept the shape.

## Why this is not just noise

A spurious failure inverts a decision, and roughly half the call sites invert in the
**fail-silent** direction. In `pre-pr.sh` alone:

| Site | What a spurious failure did |
|---|---|
| `detect_web_changes` | `RUN_WEB=0` — **Lint, Test and Build skipped**, run still green |
| refactor-branch test | branch looks like a non-refactor branch → Refactor phase verify skipped |
| `-M main` rename test | looks content-only → verify step skipped |
| admin-IA test | admin/ changes look absent → manual-test artifact gate skipped |
| integration-test gate | refactor+auth/DB changes look absent → integration tests skipped |

A red gate announces itself and gets re-run. These do not.

## What changed

**40 pipelines across 12 files** converted to herestrings — no second process, so no
race. Where the writer was a command, its output is captured first
(`v=$(cmd || true)`) so a genuine command failure still cannot be confused with a
non-match.

The `printf '%s'` sites also needed an `[ -n "$1" ]` guard on the membership helpers
to stay equivalent: a herestring feeds grep one empty line, so `grep -qxF ""` would
have reported **every** caller as exempt — a fail-open the pipe form did not have.
The `echo` sites need no guard (`echo ""` and `<<<""` both emit one empty line).

`scripts/checks/check-no-pipe-into-grep-q.sh` keeps the shape out, wired into
`pre-pr.sh` (and therefore the `Static: security check guards` CI job).

## How the gate decides

The member set is **derived by measurement, not from the man page**. With the needle
on line 1 and a body past the pipe buffer:

| grep flag | Result |
|---|---|
| `-q`, `--quiet`, `--silent` | `MISSED(rc=141)` — inverts |
| `-m1` / `--max-count` | `MISSED(rc=141)` — inverts |
| `-l` | `FOUND` — does **not** invert |

`-l` is therefore deliberately absent, and a test pins that it does not invert, so
the exclusion is a recorded measurement rather than an oversight.

That measurement added a member nobody had reported — `-m` — and with it a real
site: `check-step-up-client-coverage.sh` resolved a route path through
`printf … | grep -m1 …` **inside a command substitution**, where a SIGPIPE aborts
the gate under `set -e` rather than inverting a decision.

Detection runs in awk rather than as a line regex, because the shape has spellings a
raw-line pattern gets wrong:

- the flag can sit anywhere in a short cluster (`-q`, `-qxF`, `-iqE`, `-Eq`, `-m1`)
  or appear long (`--quiet`, `--silent`, `--max-count=1`);
- the pipe and the grep can be split across a `\` continuation **or** across a bare
  trailing `|` / `|&`, which bash continues with no backslash at all;
- `||` is not a pipe and must not match.

So: join continuations into logical lines, mask `||`, then for each piped `grep`
test that grep's own argument segment.

There are **no exclusions**. A pipeline inside `bash -c '…'` is safe only because
that fresh shell has no `pipefail` — a property of the caller, not of the line. One
`set -o pipefail` added to such a block would silently arm it.

## Review history

The gate was rewritten twice under review, and both rewrites were the same mistake:
matching the spelling in front of me rather than the property.

1. First cut matched `grep -q…` as a literal prefix. It missed `-iqE`, `-Eq`,
   `--quiet` and `\` continuations — including a real site, `pre-pr.sh`'s SQL-body
   write-verb check, left unflagged **in the commit that introduced the gate**.
2. Second cut still missed a bare trailing `|` and `--silent`. Re-deriving the set by
   running the shape then surfaced `-m`, which nobody had reported.

## Scope note

`<cmd> | head -N` shares the root property but a different failure mode (the pipeline
aborts rather than inverting a decision) and needs per-site judgement; 21 such sites
remain and are **not** addressed here.

## Verification

| Gate | Result |
|---|---|
| `bash scripts/checks/check-no-pipe-into-grep-q.sh` | 45 scripts scanned, exit 0, no false positives |
| `npx vitest run scripts/__tests__/check-no-pipe-into-grep-q.test.mjs` | 32 tests, exit 0 |
| every converted gate, run directly | 9/9 exit 0 |
| those gates' own self-tests | exit 0 |
| `bash scripts/pre-pr.sh` | exit 0 — 65 steps |

Five of the 32 self-tests are not tests of the guard but of the defect: they
reproduce the inversion in a real bash process for each member flag, and assert that
`-l` does **not** invert. Without them the rule — and its one exclusion — would rest
on argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
