### PR TITLE
fix(gates): close four bypasses in the no-pipe-into-grep-q detector

### DIFF
--- a/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
+++ b/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
@@ -225,6 +225,54 @@ describe("check-no-pipe-into-grep-q.sh", () => {
     expect(runGuard().exitCode).toBe(0);
   });
 
+  // A comment-only line is dropped before the continuation test. Joining it
+  // first and then discarding the logical line for starting with `#` let a
+  // comment ending in an operator swallow the violation underneath it.
+  it.each([
+    ["|", "# documented pipeline |"],
+    ["\\", "# documented continuation \\"],
+  ])("FAILS when a comment ending in `%s` precedes the violation", (_op, comment) => {
+    writeScript(
+      "offender",
+      `#!/usr/bin/env bash\nset -euo pipefail\n${comment}\nprintf '%s' "$BODY" | grep -q needle\n`,
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    // Reported against the pipeline, not the comment.
+    expect(stdout).toMatch(/offender\.sh:4:/);
+  });
+
+  it("PASSES a safe pipeline whose LATER stage carries -m", () => {
+    // `sort -m` merges; it reads to EOF. The flag belongs to sort, not to the
+    // grep, so scanning the whole line rather than the grep's own arguments
+    // would reject valid code.
+    writeScript(
+      "clean",
+      '#!/usr/bin/env bash\nset -euo pipefail\nprintf "x\\n" | grep x | sort -m\n',
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode, stdout).toBe(0);
+  });
+
+  it("still FAILS when the grep pattern itself contains a `|`", () => {
+    // The operator scan is quote-aware: the `|` inside the alternation is not
+    // a pipe, and must not truncate the arguments before `-q` is seen.
+    writeScript(
+      "offender",
+      '#!/usr/bin/env bash\nset -euo pipefail\nif cat f | grep -E "a|b" -q; then true; fi\n',
+    );
+    expect(runGuard().exitCode).toBe(1);
+  });
+
+  it("PASSES a quoted `| grep -q` inside a string literal", () => {
+    writeScript(
+      "clean",
+      '#!/usr/bin/env bash\nset -euo pipefail\nmsg="never write: foo | grep -q bar"\nprintf "%s" "$msg"\n',
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode, stdout).toBe(0);
+  });
+
   it("does not trip on the prose that documents the rule", () => {
     writeScript(
       "clean",

--- a/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
+++ b/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
@@ -242,6 +242,24 @@ describe("check-no-pipe-into-grep-q.sh", () => {
     expect(stdout).toMatch(/offender\.sh:4:/);
   });
 
+  // bash lets a pipeline continue across lines that carry no command text.
+  // Ending the logical line on one of them split the pipeline from its grep,
+  // which is precisely the shape being looked for.
+  it.each([
+    ["a comment line", "  # pipeline explanation"],
+    ["a blank line", ""],
+    ["an indented blank line", "   "],
+  ])("FAILS when %s sits between the pipe and the grep", (_name, filler) => {
+    writeScript(
+      "offender",
+      `#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s' "$BODY" |\n${filler}\n  grep -q needle\n`,
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode, stdout).toBe(1);
+    // Still anchored to the line the pipeline starts on.
+    expect(stdout).toMatch(/offender\.sh:3:/);
+  });
+
   it("PASSES a safe pipeline whose LATER stage carries -m", () => {
     // `sort -m` merges; it reads to EOF. The flag belongs to sort, not to the
     // grep, so scanning the whole line rather than the grep's own arguments

--- a/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
+++ b/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
@@ -260,6 +260,37 @@ describe("check-no-pipe-into-grep-q.sh", () => {
     expect(stdout).toMatch(/offender\.sh:3:/);
   });
 
+  // The operator is still the last thing bash sees on the line; only the
+  // scanner saw a comment after it and stopped treating the line as continued.
+  it.each([
+    ["|", `printf '%s' "$BODY" | # pipeline explanation`, "grep -q needle"],
+    ["|&", "producer |& # comment", "grep --silent pattern"],
+  ])(
+    "FAILS when a comment trails the `%s` on the operator's own line",
+    (_op, first, second) => {
+      writeScript(
+        "offender",
+        `#!/usr/bin/env bash\nset -euo pipefail\n${first}\n  ${second}\n`,
+      );
+      const { exitCode, stdout } = runGuard();
+      expect(exitCode, stdout).toBe(1);
+      expect(stdout).toMatch(/offender\.sh:3:/);
+    },
+  );
+
+  it.each([
+    ["a `#` inside a word", 'cat f#1 | grep -q x'],
+    ["a `#` inside a quoted pattern", 'cat f | grep -q "#tag"'],
+    ["a `#` in a parameter expansion", 'cat "${f#pre}" | grep -q x'],
+  ])("still FAILS with %s — that is not a comment", (_name, body) => {
+    writeScript(
+      "offender",
+      `#!/usr/bin/env bash\nset -euo pipefail\n${body}\n`,
+    );
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode, stdout).toBe(1);
+  });
+
   it("PASSES a safe pipeline whose LATER stage carries -m", () => {
     // `sort -m` merges; it reads to EOF. The flag belongs to sort, not to the
     // grep, so scanning the whole line rather than the grep's own arguments

--- a/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
+++ b/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
@@ -278,10 +278,33 @@ describe("check-no-pipe-into-grep-q.sh", () => {
     },
   );
 
+  // A blank is not required before `#`: an unquoted metacharacter ends the
+  // word too, so the operator and the comment can touch.
+  it.each([
+    ["|", "producer |#comment", "grep -q pattern"],
+    ["|&", "producer |&#comment", "grep --silent pattern"],
+  ])(
+    "FAILS when a comment touches the `%s` with no space",
+    (_op, first, second) => {
+      writeScript(
+        "offender",
+        `#!/usr/bin/env bash\nset -euo pipefail\n${first}\n  ${second}\n`,
+      );
+      const { exitCode, stdout } = runGuard();
+      expect(exitCode, stdout).toBe(1);
+      expect(stdout).toMatch(/offender\.sh:3:/);
+    },
+  );
+
+  // Each of these puts a non-comment `#` BEFORE the violation on the same line,
+  // so truncating there would hide the violation rather than merely mangle the
+  // text — the failure mode a passing gate would not show.
   it.each([
     ["a `#` inside a word", 'cat f#1 | grep -q x'],
     ["a `#` inside a quoted pattern", 'cat f | grep -q "#tag"'],
-    ["a `#` in a parameter expansion", 'cat "${f#pre}" | grep -q x'],
+    ["`${f#pre}` (parameter expansion)", 'cat "${f#pre}" | grep -q x'],
+    ["`${#f}` (length expansion)", 'n="${#f}"; cat f | grep -q x'],
+    ["`$#` (positional count)", 'a="$#"; cat f | grep -q x'],
   ])("still FAILS with %s — that is not a comment", (_name, body) => {
     writeScript(
       "offender",

--- a/scripts/checks/check-no-pipe-into-grep-q.sh
+++ b/scripts/checks/check-no-pipe-into-grep-q.sh
@@ -124,11 +124,20 @@ function scan(s,   i, n, j, c, cc, qpos, body, outer, found) {
   outer = outer substr(s, i)
   return (found || offends(outer))
 }
-# Truncates a physical line at the shell comment that starts it, if any. A `#`
-# opens a comment only when it begins a word and is not quoted, so `${x#y}`,
-# `file#1` and `"a # b"` all survive. Everything downstream works on this
-# effective line, which is why a trailing comment can neither hide the operator
-# a continuation depends on nor be mistaken for command text.
+# Truncates a physical line at the shell comment that starts it, if any.
+#
+# A `#` opens a comment when it begins a word and is not quoted. A word begins
+# at the start of the line, after a blank, and after an UNQUOTED metacharacter —
+# blanks are not required, so `producer |#comment` is a comment too. The
+# metacharacter set was measured rather than assumed: with `#zzz` placed
+# directly after each candidate, bash treats it as a comment after
+# `| & ; ( ) < >` and a blank, and as literal text after `$ { } =` or any
+# word character. That is what keeps `${x#y}`, `${#x}`, `$#`, `file#1` and
+# `"#tag"` intact.
+#
+# Everything downstream works on this effective line, which is why a trailing
+# comment can neither hide the operator a continuation depends on nor be
+# mistaken for command text.
 function strip_comment(s,   i, n, c, q, prev) {
   n = length(s); q = ""; prev = ""
   for (i = 1; i <= n; i++) {
@@ -139,9 +148,9 @@ function strip_comment(s,   i, n, c, q, prev) {
       prev = c
       continue
     }
-    if (c == "\\") { i++; prev = ""; continue }
+    if (c == "\\") { i++; prev = "x"; continue }
     if (c == "\047" || c == "\"") { q = c; prev = c; continue }
-    if (c == "#" && (i == 1 || prev == " " || prev == "\t")) return substr(s, 1, i - 1)
+    if (c == "#" && (i == 1 || prev ~ /^[ \t|&;()<>]$/)) return substr(s, 1, i - 1)
     prev = c
   }
   return s

--- a/scripts/checks/check-no-pipe-into-grep-q.sh
+++ b/scripts/checks/check-no-pipe-into-grep-q.sh
@@ -126,10 +126,17 @@ function scan(s,   i, n, j, c, cc, qpos, body, outer, found) {
 }
 {
   raw = $0
-  # A comment-only physical line is dropped BEFORE the continuation test.
-  # Joining it first and discarding the logical line for starting with `#`
-  # would let a comment ending in `|` or `\` swallow the violation below it.
-  if (buf == "" && raw ~ /^[ \t]*#/) next
+  # Physical lines that carry no command text — comment-only and blank — are
+  # dropped BEFORE the continuation test, and WITHOUT ending a logical line
+  # already in progress. Both halves matter, and each was a bypass on its own:
+  #   * joining first and then discarding the logical line for starting with
+  #     `#` let a comment ending in `|` or `\` swallow the violation below it;
+  #   * ending the logical line on them let bash-legal layouts split a pipeline
+  #     from its grep, which is exactly what the gate is looking for:
+  #         printf %s "$BODY" |
+  #           # pipeline explanation      <- or simply a blank line
+  #           grep -q needle
+  if (raw ~ /^[ \t]*#/ || raw ~ /^[ \t]*$/) next
   if (buf == "") { start = FNR; disp = $0 }
   # bash continues a line ending in `\`, and also one ending in a pipe
   # operator (`|` or `|&`) with no backslash at all.

--- a/scripts/checks/check-no-pipe-into-grep-q.sh
+++ b/scripts/checks/check-no-pipe-into-grep-q.sh
@@ -17,7 +17,9 @@
 # No exclusions. A pipeline inside `bash -c '…'` happens to be safe today
 # (a fresh shell has no pipefail), but that is a property of the *caller*, not
 # of the line — one `set -o pipefail` added to such a block would silently arm
-# it. Rejecting the shape outright is what makes this gate cheap to trust.
+# it. Rejecting the shape outright is what makes this gate cheap to trust, and
+# the scanner recurses into those bodies rather than treating the quote around
+# them as data.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "$0")/../.." && pwd))"
@@ -45,10 +47,15 @@ fi
 # Matching is done in awk, not by a line regex, because the shape has several
 # spellings a regex over raw lines gets wrong:
 #   * the early-exit flag can sit anywhere in a short cluster (-q, -qxF, -iqE,
-#     -Eq) or appear long (--quiet, --silent, --max-count);
+#     -Eq, -m1) or appear long (--quiet, --silent, --max-count=1);
 #   * the pipe and the grep can be split across a `\` continuation OR across a
 #     bare trailing `|` / `|&`, which bash continues without a backslash;
-#   * `||` is not a pipe and must not match.
+#   * a comment ending in either of those must NOT swallow the line below it,
+#     so comment-only lines are dropped before continuations are joined;
+#   * `||` is not a pipe, and a `|` inside `grep -qE "a|b"` is not an operator,
+#     so operator splitting is quote-aware;
+#   * the flag must belong to the grep being tested — scanning the whole line
+#     would reject `… | grep x | sort -m`, where -m is sort's and drains.
 #
 # The flag set was derived by measurement, not from the man page: with the
 # needle on line 1 and a body past the pipe buffer, `-q`, `--quiet`, `--silent`
@@ -56,35 +63,84 @@ fi
 # not a member and is deliberately absent.
 detect_awk='
 function has_quiet(seg) {
-  sub(/;.*$/, "", seg)
-  sub(/&&.*$/, "", seg)
   # Trailing digits so `-m1` (and `-im1`) match as well as `-m 1`.
   return (seg ~ /(^|[ \t])-[A-Za-z]*[qm][A-Za-z]*[0-9]*([ \t]|=|$)/ ||
           seg ~ /(^|[ \t])--(quiet|silent|max-count)([ \t]|=|$)/)
 }
-function offends(s,   t, seg) {
-  t = s
-  gsub(/\|\|/, "@@OR@@", t)
-  while (match(t, /\|&?[ \t]*grep([ \t]|$)/)) {
-    seg = substr(t, RSTART + RLENGTH - 1)
-    if (has_quiet(seg)) return 1
-    t = substr(t, RSTART + RLENGTH)
+# Walks the logical line once, tracking quote state, and splits it into
+# commands at UNQUOTED operators. Each grep that a single pipe feeds is then
+# tested on its OWN argument text — so a later `sort -m` is not read as grep
+# is, and a `|` inside `grep -qE "a|b"` is not read as an operator.
+function offends(s,   i, n, c, q, seg, start, piped) {
+  n = length(s); q = ""; start = 1; piped = 0
+  for (i = 1; i <= n + 1; i++) {
+    c = (i <= n) ? substr(s, i, 1) : ""
+    if (q != "") {
+      if (c == "\\" && q == "\"") { i++; continue }
+      if (c == q) q = ""
+      continue
+    }
+    if (c == "\\") { i++; continue }
+    if (c == "\047" || c == "\"") { q = c; continue }
+    if (c != "|" && c != ";" && c != "&" && c != "") continue
+
+    seg = substr(s, start, i - start)
+    if (piped && seg ~ /^[ \t]*grep([ \t]|$)/ && has_quiet(seg)) return 1
+
+    if (c == "|") {
+      if (substr(s, i + 1, 1) == "|") { piped = 0; i++ }        # || is not a pipe
+      else if (substr(s, i + 1, 1) == "&") { piped = 1; i++ }   # |& pipes stderr too
+      else piped = 1
+    } else {
+      piped = 0
+      if (c == "&" && substr(s, i + 1, 1) == "&") i++
+    }
+    start = i + 1
   }
   return 0
 }
+# The argument of `bash -c` / `sh -c` is CODE, not data, so the quote around it
+# must not hide it. Each such body is scanned on its own and then removed from
+# the outer line, which is what keeps quote-awareness from becoming a bypass.
+function scan(s,   i, n, j, c, cc, qpos, body, outer, found) {
+  found = 0; outer = ""; i = 1; n = length(s)
+  while (i <= n) {
+    if (match(substr(s, i), /(^|[ \t;&|(])(bash|sh)[ \t]+-c[ \t]*/) == 0) break
+    qpos = i + RSTART + RLENGTH - 1
+    c = substr(s, qpos, 1)
+    if (c != "\047" && c != "\"") { outer = outer substr(s, i, qpos - i); i = qpos; continue }
+    outer = outer substr(s, i, qpos - i + 1)
+    body = ""; j = qpos + 1
+    while (j <= n) {
+      cc = substr(s, j, 1)
+      if (cc == "\\" && c == "\"") { body = body substr(s, j, 2); j += 2; continue }
+      if (cc == c) break
+      body = body cc; j++
+    }
+    if (scan(body)) found = 1
+    outer = outer substr(s, j, 1)
+    i = j + 1
+  }
+  outer = outer substr(s, i)
+  return (found || offends(outer))
+}
 {
-  if (buf == "") { start = FNR; disp = $0 }
   raw = $0
+  # A comment-only physical line is dropped BEFORE the continuation test.
+  # Joining it first and discarding the logical line for starting with `#`
+  # would let a comment ending in `|` or `\` swallow the violation below it.
+  if (buf == "" && raw ~ /^[ \t]*#/) next
+  if (buf == "") { start = FNR; disp = $0 }
   # bash continues a line ending in `\`, and also one ending in a pipe
   # operator (`|` or `|&`) with no backslash at all.
   cont = (raw ~ /\\[ \t]*$/ || raw ~ /\|&?[ \t]*$/)
   sub(/\\[ \t]*$/, " ", raw)
   buf = buf raw
   if (cont) next
-  if (buf !~ /^[ \t]*#/ && offends(buf)) printf "%d:%s\n", start, disp
+  if (scan(buf)) printf "%d:%s\n", start, disp
   buf = ""
 }
-END { if (buf != "" && buf !~ /^[ \t]*#/ && offends(buf)) printf "%d:%s\n", start, disp }
+END { if (buf != "" && scan(buf)) printf "%d:%s\n", start, disp }
 '
 
 files=$(find "$SCAN_DIR" -name '*.sh' -type f -not -path '*/__tests__/fixtures/*' | sort)

--- a/scripts/checks/check-no-pipe-into-grep-q.sh
+++ b/scripts/checks/check-no-pipe-into-grep-q.sh
@@ -124,19 +124,39 @@ function scan(s,   i, n, j, c, cc, qpos, body, outer, found) {
   outer = outer substr(s, i)
   return (found || offends(outer))
 }
+# Truncates a physical line at the shell comment that starts it, if any. A `#`
+# opens a comment only when it begins a word and is not quoted, so `${x#y}`,
+# `file#1` and `"a # b"` all survive. Everything downstream works on this
+# effective line, which is why a trailing comment can neither hide the operator
+# a continuation depends on nor be mistaken for command text.
+function strip_comment(s,   i, n, c, q, prev) {
+  n = length(s); q = ""; prev = ""
+  for (i = 1; i <= n; i++) {
+    c = substr(s, i, 1)
+    if (q != "") {
+      if (c == "\\" && q == "\"") { i++; prev = ""; continue }
+      if (c == q) q = ""
+      prev = c
+      continue
+    }
+    if (c == "\\") { i++; prev = ""; continue }
+    if (c == "\047" || c == "\"") { q = c; prev = c; continue }
+    if (c == "#" && (i == 1 || prev == " " || prev == "\t")) return substr(s, 1, i - 1)
+    prev = c
+  }
+  return s
+}
 {
-  raw = $0
-  # Physical lines that carry no command text — comment-only and blank — are
-  # dropped BEFORE the continuation test, and WITHOUT ending a logical line
-  # already in progress. Both halves matter, and each was a bypass on its own:
-  #   * joining first and then discarding the logical line for starting with
-  #     `#` let a comment ending in `|` or `\` swallow the violation below it;
-  #   * ending the logical line on them let bash-legal layouts split a pipeline
-  #     from its grep, which is exactly what the gate is looking for:
-  #         printf %s "$BODY" |
-  #           # pipeline explanation      <- or simply a blank line
-  #           grep -q needle
-  if (raw ~ /^[ \t]*#/ || raw ~ /^[ \t]*$/) next
+  # The effective line is what bash would execute. Once comments are gone, a
+  # physical line carrying no command text is simply an empty one — whether it
+  # was blank, a standalone comment, or a comment trailing a pipe operator. It
+  # is dropped WITHOUT ending a logical line already in progress, because bash
+  # continues a pipeline across all three:
+  #     printf %s "$BODY" |   # pipeline explanation
+  #                           <- or a blank line, or a standalone comment
+  #       grep -q needle
+  raw = strip_comment($0)
+  if (raw ~ /^[ \t]*$/) next
   if (buf == "") { start = FNR; disp = $0 }
   # bash continues a line ending in `\`, and also one ending in a pipe
   # operator (`|` or `|&`) with no backslash at all.


### PR DESCRIPTION
Follow-up to `#738`, which was squash-merged. Review findings against the
`check-no-pipe-into-grep-q` detector it introduced, over four rounds.

Every finding was a **bypass**: valid bash that the gate returned `OK` for. Each
was reproduced against a fixture before being fixed, and each fix landed with a
negative test that fails against the previous commit.

## Round 1 — two independent defects

**A comment could swallow the violation below it.** Comment-only lines were
joined into the logical line *before* the "starts with `#`" test ran, so a
comment ending in a continuation absorbed the next line and the combined line
was then discarded as prose:

```bash
# documented pipeline |
printf '%s' "$BODY" | grep -q needle      # ← OK
```

**`sort -m` was read as grep's flag.** `has_quiet` received everything
downstream of the grep, so `printf "x\n" | grep x | sort -m` was rejected — a
false positive in a gate that blocks merges. Operator splitting became
quote-aware and each grep is now tested on its own argument text, which also
fixed a latent miss in the other direction: the `|` inside `grep -qE "a|b"` is
no longer read as an operator.

Quote-awareness then hid `bash -c 'cat f | grep -q x'`. That body is **code, not
data**, so the scanner recurses into `bash -c` / `sh -c` arguments rather than
treating the surrounding quote as opaque — which is what keeps "no exclusions"
true rather than merely stated.

## Round 2 — the skip must not end the logical line

Comment-only lines were skipped only when no logical line was in progress, so a
comment *after* the operator ended it early and the grep was examined alone:

```bash
printf '%s' "$BODY" |
  # pipeline explanation
  grep -q needle                          # ← OK
```

Blank lines split it identically and were **not** reported — the member set is
"physical lines carrying no command text", not "comments". Both are now skipped
regardless of state, and neither terminates a logical line.

## Round 3 — decide on the effective line

`producer | # comment` parses and runs, but the raw line does not end in the
operator, so the scanner stopped treating it as continued.

Patching the continuation regex would have been the fourth patch to that regex.
Instead every physical line is reduced to what bash would execute: a quote-aware
pass truncates it at the `#` that opens a comment. With comments gone, "carries
no command text" is simply "is empty", and the blank / standalone-comment /
trailing-comment cases collapse into one rule instead of three special cases.

## Round 4 — the word boundary comes from the shell

`strip_comment` claimed a `#` opens a comment when it "begins a word" but tested
only for start-of-line or a preceding blank. A blank is not required — an
unquoted metacharacter ends the word too:

```bash
producer |#comment
  grep -q pattern                         # ← OK

producer |&#comment
  grep --silent pattern                   # ← OK
```

The metacharacter set is **measured, not assumed**. Placing `#zzz` directly after
each candidate and asking bash what it did:

| Preceding character | `#` is |
|---|---|
| `\|` `&` `;` `(` `)` `<` `>` blank | a comment |
| `$` `{` `}` `=` word characters | literal |

The first probe appeared to implicate `"` and `'` — an artifact of the probe's
own unbalanced quotes. `( ) < >` needed valid surrounding syntax before they
answered at all: `echo hi >#zzz` errors with "unexpected newline", which is the
redirect losing its target *because* `#zzz` was consumed as a comment.

## Test shape

Getting the comment boundary wrong **hides violations** rather than mangling
text, so those tests put a non-comment `#` — `${f#pre}`, `${#f}`, `$#`,
`file#1`, a quoted `"#tag"` — **before** the violation on the same line, where a
wrong truncation makes the gate pass. A test that only checked the text survived
would not fail for the reason that matters.

## Verification

| Gate | Result |
|---|---|
| `bash scripts/checks/check-no-pipe-into-grep-q.sh` | 45 scripts scanned, exit 0, no false positives |
| `npx vitest run scripts/__tests__/check-no-pipe-into-grep-q.test.mjs` | **49 tests**, exit 0 (was 32 at `#738`) |
| `bash scripts/pre-pr.sh` | exit 0 — 65 steps |

Every bypass above was confirmed to be valid bash (`bash -n` plus execution)
before being treated as a defect, and confirmed to return `OK` from the gate
before the fix.

## Note on scope

`<cmd> | head -N` remains out of scope, unchanged from `#738`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
