### PR TITLE
fix(security): clear the container scan's HIGH findings (brace-expansion, ip-address)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,9 +117,12 @@ COPY --from=builder /app/node_modules/dotenv ./node_modules/dotenv
 #   WebSocket → DoS). npm 11.16.0 bundles 6.26.0. The app's own top-level undici
 #   is already 7.28.0 (also fixed); this patches npm's bundled copy, which Trivy
 #   reports separately.
-# - brace-expansion >=5.0.8: closes CVE-2026-13149 (exponential-time DoS) AND
-#   GHSA-mh99-v99m-4gvg (unbounded expansion → OOM), whose range is <=5.0.7 —
-#   so the previous 5.0.7 pin was itself affected once that advisory landed.
+# - brace-expansion >=5.0.9: closes CVE-2026-13149 (exponential-time DoS),
+#   GHSA-mh99-v99m-4gvg (unbounded expansion → OOM, range <=5.0.7) AND
+#   GHSA-rgw5-rvv9-x895 / CVE-2026-69152, whose range is 4.0.0 – 5.0.8
+#   INCLUSIVE — so each pin in turn has been inside the next advisory's band.
+#   That has now happened twice; the version here is a floor to raise, not a
+#   value to trust because it was once correct.
 #   npm 11.16.0 bundles 5.0.6, so this patch is doing real work. The app's own
 #   copy is pinned separately via the package.json overrides block; this patches
 #   npm's bundled copy, which Trivy scans as part of the image.
@@ -135,7 +138,7 @@ COPY --from=builder /app/node_modules/dotenv ./node_modules/dotenv
 RUN TAR_VER=7.5.19 && \
     PICOMATCH_VER=4.0.4 && \
     SIGSTORE_VER=4.1.1 && \
-    BE_VER=5.0.8 && \
+    BE_VER=5.0.9 && \
     UNDICI_VER=6.28.0 && \
     NPM_VER=11.16.0 && \
     npm install -g "npm@${NPM_VER}" --loglevel=error --ignore-scripts && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -140,6 +140,7 @@ RUN TAR_VER=7.5.19 && \
     SIGSTORE_VER=4.1.1 && \
     BE_VER=5.0.9 && \
     UNDICI_VER=6.28.0 && \
+    IPADDR_VER=10.4.0 && \
     NPM_VER=11.16.0 && \
     npm install -g "npm@${NPM_VER}" --loglevel=error --ignore-scripts && \
     TAR_DIR=/usr/local/lib/node_modules/npm/node_modules/tar && \
@@ -202,6 +203,21 @@ RUN TAR_VER=7.5.19 && \
     else \
       echo "ERROR: brace-expansion directory not found at ${BE_DIR}; npm layout changed, re-verify patch path" >&2 && exit 1; \
     fi && \
+    IPADDR_DIR=/usr/local/lib/node_modules/npm/node_modules/ip-address && \
+    if [ -d "$IPADDR_DIR" ]; then \
+      CURRENT=$(node -p "require('${IPADDR_DIR}/package.json').version") && \
+      if [ "$(printf '%s\n' "$IPADDR_VER" "$CURRENT" | sort -V | head -n1)" != "$IPADDR_VER" ]; then \
+        cd "$IPADDR_DIR" && \
+        npm pack "ip-address@${IPADDR_VER}" --quiet && \
+        tar xzf "ip-address-${IPADDR_VER}.tgz" --strip-components=1 && \
+        rm -f "ip-address-${IPADDR_VER}.tgz" && \
+        node -e "const v=require('./package.json').version;if(v!=='${IPADDR_VER}'){console.error('ip-address patch failed: got '+v);process.exit(1)}"; \
+      else \
+        echo "ip-address ${CURRENT} already >= ${IPADDR_VER}, skipping patch"; \
+      fi; \
+    else \
+      echo "ERROR: ip-address directory not found at ${IPADDR_DIR}; npm layout changed, re-verify patch path" >&2 && exit 1; \
+    fi && \
     UNDICI_DIR=/usr/local/lib/node_modules/npm/node_modules/undici && \
     if [ -d "$UNDICI_DIR" ]; then \
       CURRENT=$(node -p "require('${UNDICI_DIR}/package.json').version") && \
@@ -226,7 +242,8 @@ RUN TAR_VER=7.5.19 && \
     node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch/package.json').version,c=v.split('.').map(Number),m='${PICOMATCH_VER}'.split('.').map(Number);for(let i=0;i<m.length;i++){const a=c[i]||0;if(a>m[i])break;if(a<m[i]){console.error('picomatch still '+v);process.exit(1)}}" && \
     node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/sigstore/package.json').version,c=v.split('.').map(Number),m='${SIGSTORE_VER}'.split('.').map(Number);for(let i=0;i<m.length;i++){const a=c[i]||0;if(a>m[i])break;if(a<m[i]){console.error('sigstore still '+v);process.exit(1)}}" && \
     node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/brace-expansion/package.json').version,c=v.split('.').map(Number),m='${BE_VER}'.split('.').map(Number);for(let i=0;i<m.length;i++){const a=c[i]||0;if(a>m[i])break;if(a<m[i]){console.error('brace-expansion still '+v);process.exit(1)}}" && \
-    node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/undici/package.json').version,c=v.split('.').map(Number),m='${UNDICI_VER}'.split('.').map(Number);for(let i=0;i<m.length;i++){const a=c[i]||0;if(a>m[i])break;if(a<m[i]){console.error('undici still '+v);process.exit(1)}}"
+    node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/undici/package.json').version,c=v.split('.').map(Number),m='${UNDICI_VER}'.split('.').map(Number);for(let i=0;i<m.length;i++){const a=c[i]||0;if(a>m[i])break;if(a<m[i]){console.error('undici still '+v);process.exit(1)}}" && \
+    node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/ip-address/package.json').version,c=v.split('.').map(Number),m='${IPADDR_VER}'.split('.').map(Number);for(let i=0;i<m.length;i++){const a=c[i]||0;if(a>m[i])break;if(a<m[i]){console.error('ip-address still '+v);process.exit(1)}}"
 
 # Prisma CLI: COPY the self-contained closure from the dedicated `prisma-cli`
 # stage (isolated npm install with .npmrc), NOT a runner-side `npm install`

--- a/package-lock.json
+++ b/package-lock.json
@@ -16119,9 +16119,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10991,9 +10991,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11475,9 +11475,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15612,9 +15612,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -21290,9 +21290,9 @@
       }
     },
     "node_modules/shadcn/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "postcss": ">=8.5.12",
     "brace-expansion@1": "^1.1.17",
     "brace-expansion@2": "^2.1.3",
-    "brace-expansion@>=3.0.0 <5.0.8": "^5.0.8",
+    "brace-expansion@>=3.0.0 <5.0.9": "^5.0.9",
     "find-my-way": "^9.7.0",
     "js-yaml@>=3.0.0 <3.15.0": "^3.15.0",
     "js-yaml@>=4.0.0 <4.3.0": "^4.3.0",

--- a/scripts/__tests__/check-dockerfile-prisma-pin.test.mjs
+++ b/scripts/__tests__/check-dockerfile-prisma-pin.test.mjs
@@ -48,6 +48,28 @@ function writeLockfile(version) {
   );
 }
 
+// The gate has a THIRD input now: brace-expansion is pinned both in the app
+// tree's overrides and in the Dockerfile's BE_VER, and it asserts the second is
+// at least the first. A fixture that omits package.json therefore describes a
+// repository the gate cannot exist in, so every fixture writes one.
+function writeManifest(overrideFloor = "^5.0.9") {
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({
+      name: "fixture",
+      overrides: { "brace-expansion@>=3.0.0 <5.0.9": overrideFloor },
+    }),
+    "utf8",
+  );
+}
+
+/** A Dockerfile carrying both pins; `be` omitted writes no BE_VER at all. */
+function writeDockerfile(prismaVer, be = "5.0.9") {
+  const lines = [`ARG PRISMA_VER=${prismaVer}`];
+  if (be !== null) lines.push(`    BE_VER=${be} && \\`);
+  writeFileSync(join(root, "Dockerfile"), lines.join("\n") + "\n", "utf8");
+}
+
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), "dockerfile-prisma-pin-"));
 });
@@ -59,7 +81,8 @@ afterEach(() => {
 describe("check-dockerfile-prisma-pin.sh", () => {
   it("FAILS when the Dockerfile PRISMA_VER floats/mismatches the lockfile version", () => {
     writeLockfile("7.2.0");
-    writeFileSync(join(root, "Dockerfile"), "ARG PRISMA_VER=7.1.0\n", "utf8");
+    writeManifest();
+    writeDockerfile("7.1.0");
     const { exitCode, stdout } = runGuard();
     expect(exitCode).toBe(1);
     expect(stdout).toContain(
@@ -69,15 +92,69 @@ describe("check-dockerfile-prisma-pin.sh", () => {
 
   it("passes when the Dockerfile PRISMA_VER exactly matches the lockfile version", () => {
     writeLockfile("7.2.0");
-    writeFileSync(join(root, "Dockerfile"), "ARG PRISMA_VER=7.2.0\n", "utf8");
+    writeManifest();
+    writeDockerfile("7.2.0");
     const { exitCode, stdout } = runGuard();
     expect(exitCode).toBe(0);
     expect(stdout).toContain("OK (Dockerfile PRISMA_VER=7.2.0 matches lockfile)");
   });
 
+  // ─── The second pin: npm's bundled brace-expansion ─────────
+  //
+  // brace-expansion is pinned twice — the app tree via `overrides`, and npm's
+  // own bundled copy via BE_VER, which the runner stage unpacks over npm's.
+  // Nothing tied them together, and GHSA-rgw5-rvv9-x895 (4.0.0 – 5.0.8
+  // inclusive) found both stale at once: `npm audit` went green while the image
+  // still shipped 5.0.8 and Trivy stayed red.
+
+  it("FAILS when BE_VER is below the app tree's override floor", () => {
+    writeLockfile("7.2.0");
+    writeManifest("^5.0.9");
+    writeDockerfile("7.2.0", "5.0.8");
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain(
+      "ERROR: Dockerfile BE_VER=5.0.8 is below the package.json brace-expansion override floor 5.0.9",
+    );
+  });
+
+  it("passes when BE_VER is ABOVE the floor (paired allow case)", () => {
+    // Higher is fine — the Dockerfile patches npm's copy UP to BE_VER, so the
+    // gate is a floor, not an equality. Without this the fix could be "always
+    // deny" and satisfy every other case here.
+    writeLockfile("7.2.0");
+    writeManifest("^5.0.9");
+    writeDockerfile("7.2.0", "5.1.0");
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK (Dockerfile BE_VER=5.1.0 >= override floor 5.0.9)");
+  });
+
+  it("FAILS when the Dockerfile pins no BE_VER at all", () => {
+    writeLockfile("7.2.0");
+    writeManifest("^5.0.9");
+    writeDockerfile("7.2.0", null);
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("no pinned 'BE_VER=X.Y.Z' found");
+  });
+
+  it("FAILS when the app tree carries no brace-expansion override", () => {
+    // "Examined nothing" must not be spelled like "found nothing": with the
+    // override gone there is no floor to compare against, and the gate refuses
+    // rather than passing an unconstrained BE_VER.
+    writeLockfile("7.2.0");
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "fixture" }), "utf8");
+    writeDockerfile("7.2.0", "5.0.9");
+    const { exitCode, stdout } = runGuard();
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("no 'brace-expansion@>=3...' override found");
+  });
+
   it("FAILS when the Dockerfile has no pinned PRISMA_VER at all", () => {
     writeLockfile("7.2.0");
-    writeFileSync(join(root, "Dockerfile"), "ARG PRISMA_VER=latest\n", "utf8");
+    writeManifest();
+    writeDockerfile("latest");
     const { exitCode, stdout } = runGuard();
     expect(exitCode).toBe(1);
     expect(stdout).toContain("prisma must be version-pinned, not floating");
@@ -93,7 +170,8 @@ describe("check-dockerfile-prisma-pin.sh", () => {
   describe("env-pollution guard (sec-F6)", () => {
     it("FAILS when CI=true and an override is set without DOCKERFILE_PRISMA_PIN_FIXTURE_MODE=1", () => {
       writeLockfile("7.2.0");
-      writeFileSync(join(root, "Dockerfile"), "ARG PRISMA_VER=7.2.0\n", "utf8");
+      writeManifest();
+      writeDockerfile("7.2.0");
       const { exitCode, stdout } = runGuard({ CI: "true", DOCKERFILE_PRISMA_PIN_FIXTURE_MODE: "" });
       expect(exitCode).toBe(1);
       expect(stdout).toContain("ENV_POLLUTION_GUARD");
@@ -101,7 +179,8 @@ describe("check-dockerfile-prisma-pin.sh", () => {
 
     it("passes under CI=true when DOCKERFILE_PRISMA_PIN_FIXTURE_MODE=1 is set and the fixture is clean", () => {
       writeLockfile("7.2.0");
-      writeFileSync(join(root, "Dockerfile"), "ARG PRISMA_VER=7.2.0\n", "utf8");
+      writeManifest();
+      writeDockerfile("7.2.0");
       const { exitCode } = runGuard({ CI: "true", DOCKERFILE_PRISMA_PIN_FIXTURE_MODE: "1" });
       expect(exitCode).toBe(0);
     });

--- a/scripts/checks/check-dockerfile-prisma-pin.sh
+++ b/scripts/checks/check-dockerfile-prisma-pin.sh
@@ -55,3 +55,36 @@ if [ "$docker_ver" != "$lock_ver" ]; then
 fi
 
 echo "OK (Dockerfile PRISMA_VER=$docker_ver matches lockfile)"
+
+# brace-expansion is pinned TWICE — the app tree via package.json `overrides`,
+# and npm's own bundled copy via BE_VER in the Dockerfile. Nothing tied them
+# together, and GHSA-rgw5-rvv9-x895 (4.0.0 – 5.0.8 inclusive) found both stale
+# at once: the override said ^5.0.8 and BE_VER said 5.0.8, and the image
+# shipped the vulnerable version while `npm audit` had been made green. That is
+# the second time a brace-expansion pin has been inside the next advisory's
+# band, so the floor is asserted rather than remembered.
+be_override=$(node -p "
+  const o = require('./package.json').overrides || {};
+  const k = Object.keys(o).find((k) => /^brace-expansion@>=3/.test(k));
+  k ? String(o[k]).replace(/^[\\^~]/, '') : ''
+")
+be_docker=$( (grep -oE 'BE_VER=[0-9]+\.[0-9]+\.[0-9]+' "$DOCKERFILE" || true) | head -1 | cut -d= -f2)
+
+if [ -z "$be_override" ]; then
+  echo "ERROR: no 'brace-expansion@>=3...' override found in package.json — the app-tree pin this gate compares against is gone"
+  exit 1
+fi
+if [ -z "$be_docker" ]; then
+  echo "ERROR: no pinned 'BE_VER=X.Y.Z' found in $DOCKERFILE — npm's bundled brace-expansion must be version-pinned, not floating"
+  exit 1
+fi
+# The Dockerfile patches npm's bundled copy UP to BE_VER, so it must be at
+# least the app tree's floor. Higher is fine; lower means the image ships a
+# version the app tree has already rejected.
+if [ "$(printf '%s\n%s\n' "$be_override" "$be_docker" | sort -V | head -n1)" != "$be_override" ]; then
+  echo "ERROR: Dockerfile BE_VER=$be_docker is below the package.json brace-expansion override floor $be_override"
+  echo "Raise BE_VER in $DOCKERFILE to at least $be_override — npm's bundled copy is scanned separately by Trivy."
+  exit 1
+fi
+
+echo "OK (Dockerfile BE_VER=$be_docker >= override floor $be_override)"


### PR DESCRIPTION
`Audit: App dependencies` is red on main with one high finding, and no
Dependabot PR can clear it.

`GHSA-rgw5-rvv9-x895` covers brace-expansion 4.0.0 – 5.0.8 **inclusive**, and
this repository's own override pinned `^5.0.8`. The version we force is the
vulnerable one. Because an override decides the resolution, a dependency bump
changes nothing about what installs — the key itself has to move. It is the
stale-override shape `docs/security/dependency-cve-response.md` records for
`GHSA-3jxr-9vmj-r5cp`, arriving a second time.

```diff
-    "brace-expansion@>=3.0.0 <5.0.8": "^5.0.8",
+    "brace-expansion@>=3.0.0 <5.0.9": "^5.0.9",
```

**Both halves move, and that is the part worth reviewing.** Raising the floor
alone would not have worked: npm matches an override key against the range the
*depending package asks for*, so a parent requesting `^5.0.8` (`>=5.0.8 <6.0.0`)
does not intersect a selector ending at `<5.0.8` — the key would not apply to
that edge and 5.0.8 would install unoverridden. The selector has to cover the
newly-vulnerable version for the floor to reach it.

## Verified

| Check | Result |
|---|---|
| `npm audit --omit=dev --audit-level=high` | exit 0 (was 1, one high) |
| `node scripts/checks/check-override-key-disjointness.mjs` | passed, 3 manifests |
| `npm audit signatures` | exit 0 |

Every 5.x resolution in the lockfile is now 5.0.9. The 1.x and 2.x keys are
untouched and stay disjoint from this one.

## What this does not fix

Two moderate findings remain, and neither reds the gate (`--audit-level=high`):
postcss `GHSA-fxqj-rqcc-2cmp`, which #758 fixes by bumping to 8.5.25, and one in
next. Merging this and #758 clears both the audit and Trivy jobs on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
