### PR TITLE
fix(scripts,hooks): repair macOS-inert security gates and the credential guard

### DIFF
--- a/.claude/hooks/block-bare-decrypt.sh
+++ b/.claude/hooks/block-bare-decrypt.sh
@@ -1,23 +1,29 @@
 #!/usr/bin/env bash
-# Pre-tool-use hook for the Bash tool: refuses vault decrypt commands, whose
-# stdout is captured into Claude's conversation context.
+# Pre-tool-use hook for the Bash tool: a LINT against the common way a vault
+# credential ends up in the conversation — a decrypt whose stdout is transcribed.
 #
-# Deny by default. There is no "safe shape" of decrypt-via-Bash to allow: where a
-# process's stdout ends up depends on redirections, the pipeline's last stage,
-# command substitution and the surrounding shell — none of which can be
-# recovered by matching the command string. An earlier version allowed a leading
-# "(" or a "|" after the subcommand, and both a bare subshell and a pipe into
-# `cat` satisfied those checks while printing the credential to stdout.
+# Scope, stated plainly because an overstated guard is worse than none:
 #
-# The two failure modes this must not have, both of which it did have:
-#   - allowing on a heuristic that proves nothing. Fixed by removing the
-#     heuristics, not by refining them: a wrong "allowed" is read as
-#     "checked and safe".
-#   - allowing because the guard could not evaluate its own input or matcher.
-#     Both now route to a refusal.
+#   This is not a security boundary. It matches the command STRING before
+#   execution, and a shell string does not determine the argv the process sees.
+#   Quoting the subcommand, splitting it across quotes, or passing it through a
+#   variable all reach the same program unseen by this matcher. A determined
+#   caller — including the model — evades it trivially.
 #
-# Credential use goes through the /use-credential skill instead, which consumes
-# the value without routing it through a shell whose output is transcribed.
+#   The boundary would be a decrypt that is not a Bash command at all: a tool or
+#   MCP surface that consumes the credential and never returns plaintext to the
+#   model. This hook is the stopgap for accidents until that exists.
+#
+# It allows the shape .claude/skills/use-credential/SKILL.md documents (_CRED
+# assigned inside a subshell, consumed in place, never printed) and refuses the
+# shapes that put plaintext on stdout. Two failure modes it must not have, both
+# of which earlier revisions did:
+#
+#   - allowing on a heuristic that proves nothing. A leading "(" or a trailing
+#     pipe say nothing about where stdout lands; `(<cli> <sub> x)` and
+#     `<cli> <sub> x | cat` both satisfied those and both printed the value.
+#   - refusing the sanctioned pattern, which made the workflow its own error
+#     message recommends impossible to run.
 
 set -euo pipefail
 
@@ -69,25 +75,36 @@ if ! matches 'passwd-sso[[:space:]]+decrypt\b|index\.ts[[:space:]]+decrypt\b'; t
   exit 0
 fi
 
-# It is a decrypt command: refuse.
+# It looks like a decrypt command. Decide by the SHAPE the skill documents.
 #
-# This used to allow two "safe" shapes — a leading `(` (subshell) or a `|` after
-# `decrypt`. Neither proves anything about where the plaintext ends up, and both
-# are trivially satisfied by a command that dumps it straight to stdout:
+# What this hook is: a lint against the common accident — running a decrypt whose
+# stdout lands in the transcript. What it is NOT: a security boundary. It matches
+# the pre-execution command STRING, and a shell string does not determine the
+# argv the process will see. All three of these reach the same program and this
+# matcher does not see any of them:
 #
-#   (passwd-sso decrypt item)        <- subshell, output still goes to stdout
-#   passwd-sso decrypt item | cat    <- piped, `cat` writes it to stdout
+#   <cli> \'"'"'<sub>\'"'"' item          quoted subcommand
+#   <cli> <su>"<b>" item        split across quotes
+#   s=<sub>; <cli> "$s" item    variable expansion
 #
-# Both were accepted by the old heuristics and both put the credential in the
-# transcript. A regex over shell text cannot decide where a process's stdout
-# lands: that depends on redirections, the pipeline's last stage, command
-# substitution, and the surrounding shell — none of which are recoverable from
-# the string. Deciding it wrongly is worse than not deciding, because a guard
-# that says "allowed" is read as "checked and safe".
+# Closing that gap needs the decrypt to stop being a Bash command at all — a
+# dedicated tool or MCP surface that consumes the credential and never returns
+# plaintext to the model. Until then this catches the accident, not the evasion,
+# and it should not be read as more than that.
 #
-# So the answer is not a better pattern; it is to stop adjudicating. Every
-# Bash-issued decrypt is refused, and credential use goes through the
-# /use-credential skill, which consumes the value without routing it through a
-# shell whose output is captured into the conversation.
-echo '{"error": "BLOCKED: passwd-sso decrypt must not run via the Bash tool — its stdout is captured into the conversation. A subshell or a pipe does not change that. Use the /use-credential skill, which consumes the credential without exposing it."}' >&2
+# The allowed shape is the one .claude/skills/use-credential/SKILL.md specifies:
+# assignment to _CRED inside a subshell, so the value is consumed by the command
+# that needs it and never printed. An earlier revision of this hook refused that
+# shape too, which broke the workflow its own error message recommends.
+if matches '_CRED=\$\(' && matches '^[[:space:]]*\('; then
+  # Inside the sanctioned subshell. Still refuse if it prints the credential —
+  # that is the accident the skill's own rules forbid.
+  if matches 'echo[[:space:]]+[^|]*\$_CRED|printf[^|]*\$_CRED|cat[^|]*\$_CRED'; then
+    echo '{"error": "BLOCKED: do not echo/print the credential variable. Pass $_CRED directly to the command that consumes it."}' >&2
+    exit 2
+  fi
+  exit 0
+fi
+
+echo '{"error": "BLOCKED: a vault decrypt run this way puts its stdout in the conversation. Use the /use-credential skill pattern: assign to _CRED inside a subshell and pass it straight to the consuming command."}' >&2
 exit 2

--- a/.claude/hooks/block-bare-decrypt.sh
+++ b/.claude/hooks/block-bare-decrypt.sh
@@ -96,6 +96,28 @@ fi
 # into a consuming sink, is what makes the allow mean anything.
 DECRYPT_RE='(passwd-sso|index\.ts)[[:space:]]+decrypt\b'
 
+# COUNT the occurrences before judging any of them.
+#
+# A `grep -q` answers "does a safe form exist?", and that is the wrong question:
+# a command can hold a safe decrypt and an unsafe one at once, and existence is
+# satisfied by the safe one alone. All three of these passed while exposing the
+# second credential:
+#
+#   _CRED=$(<cli> <sub> safe); <cli> <sub> exposed
+#   <cli> <sub> safe | pbcopy; <cli> <sub> exposed
+#   echo '<cli> <sub> x | pbcopy'; <cli> <sub> exposed     <- decoy inside quotes
+#
+# The right question is "is EVERY occurrence safe?", which a regex cannot ask.
+# So: require exactly one occurrence, then judge that one. Every documented
+# /use-credential pattern has exactly one, so this costs nothing real; a command
+# with two is refused with a message saying to split it, which is both easy to
+# act on and impossible to satisfy accidentally.
+occurrences=$(printf '%s' "$COMMAND" | grep -oE "$DECRYPT_RE" | wc -l | tr -d '[:space:]')
+if [ "$occurrences" != "1" ]; then
+  echo "{\"error\": \"BLOCKED: found $occurrences decrypt invocations in one command. This lint can only vouch for a single one — run each in its own Bash call using a /use-credential pattern.\"}" >&2
+  exit 2
+fi
+
 # Shape 1 — captured: _CRED=$( ... decrypt ... ). The value lands in a variable
 # and is consumed in place. This is /use-credential Patterns A, B and C.
 if matches "_CRED=\\\$\\([^)]*${DECRYPT_RE}"; then
@@ -109,12 +131,18 @@ if matches "_CRED=\\\$\\([^)]*${DECRYPT_RE}"; then
 fi
 
 # Shape 2 — piped into a sink that consumes without printing. This is
-# /use-credential Patterns D and E (clipboard). The sink list is deliberately a
-# closed set: `| cat`, `| tee`, `| head` all print, and a decrypt piped into an
-# unknown command is not something this lint can vouch for.
-if matches "${DECRYPT_RE}[^|]*\\|[[:space:]]*(pbcopy|xclip|xsel|wl-copy)\\b"; then
+# /use-credential Patterns D and E (clipboard).
+#
+# The sink is matched as a WHOLE INVOCATION, not by name, because several of
+# these have flags that turn them back into filters — `xclip -filter` and
+# `xsel --output` both write stdin straight to stdout, so name-only matching
+# allowed the credential into the transcript through a sanctioned-looking sink.
+# Each alternative below pins the exact argument shape Pattern D/E documents and
+# nothing else; an unrecognised flag falls through to the refusal.
+CLIP_RE='(pbcopy|wl-copy)[[:space:]]*$|xclip[[:space:]]+-selection[[:space:]]+(clipboard|primary|secondary)[[:space:]]*$|xclip[[:space:]]*$|xsel[[:space:]]+(--clipboard|--primary|--secondary)?[[:space:]]*(--input|-i)[[:space:]]*$'
+if matches "${DECRYPT_RE}[^|]*\\|[[:space:]]*(${CLIP_RE})"; then
   exit 0
 fi
 
-echo '{"error": "BLOCKED: this decrypt puts its stdout in the conversation. Use a /use-credential pattern: capture it with _CRED=$(...) and pass $_CRED to the consuming command, or pipe it straight into a clipboard sink (pbcopy/xclip/xsel/wl-copy)."}' >&2
+echo '{"error": "BLOCKED: this decrypt puts its stdout in the conversation. Use a /use-credential pattern: capture it with _CRED=$(...) and pass $_CRED to the consuming command, or pipe it into a clipboard sink in its documented form (pbcopy, wl-copy, xclip -selection clipboard, xsel --input). Sink flags that re-emit stdin (xclip -filter, xsel --output) are refused."}' >&2
 exit 2

--- a/.claude/hooks/block-bare-decrypt.sh
+++ b/.claude/hooks/block-bare-decrypt.sh
@@ -1,30 +1,46 @@
 #!/usr/bin/env bash
-# Pre-tool-use hook for Bash tool: blocks bare `passwd-sso decrypt` commands
-# that would expose credentials in Claude's conversation context.
+# Pre-tool-use hook for the Bash tool: refuses vault decrypt commands, whose
+# stdout is captured into Claude's conversation context.
 #
-# Allowed patterns:
-#   - Inside subshell: ( _CRED=$(...decrypt...) && ... )
-#   - Piped: ...decrypt... | curl ...
-#   - Variable assignment inside subshell: $(...decrypt...)
+# Deny by default. There is no "safe shape" of decrypt-via-Bash to allow: where a
+# process's stdout ends up depends on redirections, the pipeline's last stage,
+# command substitution and the surrounding shell — none of which can be
+# recovered by matching the command string. An earlier version allowed a leading
+# "(" or a "|" after the subcommand, and both a bare subshell and a pipe into
+# `cat` satisfied those checks while printing the credential to stdout.
 #
-# Blocked patterns:
-#   - Bare execution: passwd-sso decrypt ... (stdout visible to Claude)
-#   - Echo after decrypt: PASS=$(...decrypt...); echo $PASS
+# The two failure modes this must not have, both of which it did have:
+#   - allowing on a heuristic that proves nothing. Fixed by removing the
+#     heuristics, not by refining them: a wrong "allowed" is read as
+#     "checked and safe".
+#   - allowing because the guard could not evaluate its own input or matcher.
+#     Both now route to a refusal.
+#
+# Credential use goes through the /use-credential skill instead, which consumes
+# the value without routing it through a shell whose output is transcribed.
 
 set -euo pipefail
 
 # Read tool input from stdin
 INPUT=$(cat)
 
-# Extract the command from the Bash tool input
-COMMAND=$(echo "$INPUT" | python3 -c "
+# Extract the command from the Bash tool input.
+#
+# Parse failure is NOT "no command". Swallowing a JSON error into an empty
+# string made every malformed payload — `{bad json`, a missing tool_input, a
+# non-string command — take the "not a decrypt command" path and exit 0. A guard
+# that cannot read its input has not cleared the input; it has failed to look.
+COMMAND=$(printf '%s' "$INPUT" | python3 -c "
 import sys, json
-try:
-    data = json.load(sys.stdin)
-    print(data.get('tool_input', {}).get('command', ''))
-except:
-    print('')
-" 2>/dev/null)
+data = json.load(sys.stdin)                      # raises on malformed JSON
+cmd = data.get('tool_input', {}).get('command')
+if not isinstance(cmd, str):                     # missing, null, or non-string
+    raise SystemExit(3)
+print(cmd)
+" 2>/dev/null) || {
+  echo '{"error": "BLOCKED: credential guard could not read tool_input.command (malformed JSON, missing key, or non-string value). Refusing rather than allowing."}' >&2
+  exit 2
+}
 
 # Patterns are POSIX ERE, not PCRE. `grep -P` does not exist on BSD grep, which
 # is what macOS ships: it exits 2, and `! grep -qP ...` turned that failure into
@@ -53,22 +69,25 @@ if ! matches 'passwd-sso[[:space:]]+decrypt\b|index\.ts[[:space:]]+decrypt\b'; t
   exit 0
 fi
 
-# Block if the command is not wrapped in a safe pattern
-# Safe patterns: starts with '(' (subshell) or has pipe '|' after decrypt
-if matches '^[[:space:]]*\('; then
-  # Subshell — check it doesn't echo/print the credential
-  if matches 'echo[[:space:]]+.*\$_CRED|printf.*\$_CRED|cat.*\$_CRED'; then
-    echo '{"error": "BLOCKED: Do not echo/print credential variables. Use the /use-credential skill instead."}' >&2
-    exit 2
-  fi
-  exit 0
-fi
-
-if matches 'decrypt.*\|'; then
-  # Piped to another command — OK
-  exit 0
-fi
-
-# Not a safe pattern — block
-echo '{"error": "BLOCKED: passwd-sso decrypt must be wrapped in a subshell to prevent credential exposure. Use the /use-credential skill instead."}' >&2
+# It is a decrypt command: refuse.
+#
+# This used to allow two "safe" shapes — a leading `(` (subshell) or a `|` after
+# `decrypt`. Neither proves anything about where the plaintext ends up, and both
+# are trivially satisfied by a command that dumps it straight to stdout:
+#
+#   (passwd-sso decrypt item)        <- subshell, output still goes to stdout
+#   passwd-sso decrypt item | cat    <- piped, `cat` writes it to stdout
+#
+# Both were accepted by the old heuristics and both put the credential in the
+# transcript. A regex over shell text cannot decide where a process's stdout
+# lands: that depends on redirections, the pipeline's last stage, command
+# substitution, and the surrounding shell — none of which are recoverable from
+# the string. Deciding it wrongly is worse than not deciding, because a guard
+# that says "allowed" is read as "checked and safe".
+#
+# So the answer is not a better pattern; it is to stop adjudicating. Every
+# Bash-issued decrypt is refused, and credential use goes through the
+# /use-credential skill, which consumes the value without routing it through a
+# shell whose output is captured into the conversation.
+echo '{"error": "BLOCKED: passwd-sso decrypt must not run via the Bash tool — its stdout is captured into the conversation. A subshell or a pipe does not change that. Use the /use-credential skill, which consumes the credential without exposing it."}' >&2
 exit 2

--- a/.claude/hooks/block-bare-decrypt.sh
+++ b/.claude/hooks/block-bare-decrypt.sh
@@ -75,30 +75,32 @@ if ! matches 'passwd-sso[[:space:]]+decrypt\b|index\.ts[[:space:]]+decrypt\b'; t
   exit 0
 fi
 
-# It looks like a decrypt command. Decide by the SHAPE the skill documents.
+# It looks like a decrypt command. Decide on the ONE property that matters:
+# is that command's stdout consumed, or does it reach the transcript?
 #
-# What this hook is: a lint against the common accident — running a decrypt whose
-# stdout lands in the transcript. What it is NOT: a security boundary. It matches
-# the pre-execution command STRING, and a shell string does not determine the
-# argv the process will see. All three of these reach the same program and this
-# matcher does not see any of them:
+# What this hook is: a lint against the common accident. What it is NOT: a
+# security boundary. It matches the pre-execution command STRING, and a shell
+# string does not determine the argv the process will see — a quoted, split, or
+# variable-passed subcommand reaches the same program unseen. Closing that needs
+# the decrypt to stop being a Bash command at all: a tool or MCP surface that
+# consumes the credential and never returns plaintext to the model.
 #
-#   <cli> \'"'"'<sub>\'"'"' item          quoted subcommand
-#   <cli> <su>"<b>" item        split across quotes
-#   s=<sub>; <cli> "$s" item    variable expansion
+# The check is anchored on the decrypt OCCURRENCE, not on unrelated features of
+# the line. Two independent tests ("starts with (" AND "contains _CRED=$(")
+# accepted a decoy:
 #
-# Closing that gap needs the decrypt to stop being a Bash command at all — a
-# dedicated tool or MCP surface that consumes the credential and never returns
-# plaintext to the model. Until then this catches the accident, not the evasion,
-# and it should not be read as more than that.
+#   (_CRED=$(true); <cli> <sub> item)
 #
-# The allowed shape is the one .claude/skills/use-credential/SKILL.md specifies:
-# assignment to _CRED inside a subshell, so the value is consumed by the command
-# that needs it and never printed. An earlier revision of this hook refused that
-# shape too, which broke the workflow its own error message recommends.
-if matches '_CRED=\$\(' && matches '^[[:space:]]*\('; then
-  # Inside the sanctioned subshell. Still refuse if it prints the credential —
-  # that is the accident the skill's own rules forbid.
+# — the assignment captured something else entirely while the real decrypt ran
+# bare. Requiring the decrypt itself to sit inside the capture, or inside a pipe
+# into a consuming sink, is what makes the allow mean anything.
+DECRYPT_RE='(passwd-sso|index\.ts)[[:space:]]+decrypt\b'
+
+# Shape 1 — captured: _CRED=$( ... decrypt ... ). The value lands in a variable
+# and is consumed in place. This is /use-credential Patterns A, B and C.
+if matches "_CRED=\\\$\\([^)]*${DECRYPT_RE}"; then
+  # Still refuse if the captured value is then printed — the accident the
+  # skill's own rules forbid.
   if matches 'echo[[:space:]]+[^|]*\$_CRED|printf[^|]*\$_CRED|cat[^|]*\$_CRED'; then
     echo '{"error": "BLOCKED: do not echo/print the credential variable. Pass $_CRED directly to the command that consumes it."}' >&2
     exit 2
@@ -106,5 +108,13 @@ if matches '_CRED=\$\(' && matches '^[[:space:]]*\('; then
   exit 0
 fi
 
-echo '{"error": "BLOCKED: a vault decrypt run this way puts its stdout in the conversation. Use the /use-credential skill pattern: assign to _CRED inside a subshell and pass it straight to the consuming command."}' >&2
+# Shape 2 — piped into a sink that consumes without printing. This is
+# /use-credential Patterns D and E (clipboard). The sink list is deliberately a
+# closed set: `| cat`, `| tee`, `| head` all print, and a decrypt piped into an
+# unknown command is not something this lint can vouch for.
+if matches "${DECRYPT_RE}[^|]*\\|[[:space:]]*(pbcopy|xclip|xsel|wl-copy)\\b"; then
+  exit 0
+fi
+
+echo '{"error": "BLOCKED: this decrypt puts its stdout in the conversation. Use a /use-credential pattern: capture it with _CRED=$(...) and pass $_CRED to the consuming command, or pipe it straight into a clipboard sink (pbcopy/xclip/xsel/wl-copy)."}' >&2
 exit 2

--- a/.claude/hooks/block-bare-decrypt.sh
+++ b/.claude/hooks/block-bare-decrypt.sh
@@ -26,23 +26,45 @@ except:
     print('')
 " 2>/dev/null)
 
+# Patterns are POSIX ERE, not PCRE. `grep -P` does not exist on BSD grep, which
+# is what macOS ships: it exits 2, and `! grep -qP ...` turned that failure into
+# "this is not a decrypt command", so the hook exited 0 and allowed the very
+# command it exists to block. An unusable matcher must deny, never allow.
+matches() {
+  local pattern="$1" status
+  set +e
+  printf '%s' "$COMMAND" | grep -qE "$pattern"
+  status=$?
+  set -e
+  case "$status" in
+    0) return 0 ;;   # matched
+    1) return 1 ;;   # did not match
+    *)
+      # grep could not evaluate the pattern at all (bad option, unusable regex).
+      # "Could not decide" is not "safe" — refuse, and name the reason.
+      echo "{\"error\": \"BLOCKED: credential guard could not evaluate its matcher (grep exit $status). Refusing rather than allowing.\"}" >&2
+      exit 2
+      ;;
+  esac
+}
+
 # Skip if not a decrypt command
-if ! echo "$COMMAND" | grep -qP 'passwd-sso\s+decrypt\b|index\.ts\s+decrypt\b'; then
+if ! matches 'passwd-sso[[:space:]]+decrypt\b|index\.ts[[:space:]]+decrypt\b'; then
   exit 0
 fi
 
 # Block if the command is not wrapped in a safe pattern
 # Safe patterns: starts with '(' (subshell) or has pipe '|' after decrypt
-if echo "$COMMAND" | grep -qP '^\s*\('; then
+if matches '^[[:space:]]*\('; then
   # Subshell — check it doesn't echo/print the credential
-  if echo "$COMMAND" | grep -qP 'echo\s+.*\$_CRED|printf.*\$_CRED|cat.*\$_CRED'; then
+  if matches 'echo[[:space:]]+.*\$_CRED|printf.*\$_CRED|cat.*\$_CRED'; then
     echo '{"error": "BLOCKED: Do not echo/print credential variables. Use the /use-credential skill instead."}' >&2
     exit 2
   fi
   exit 0
 fi
 
-if echo "$COMMAND" | grep -qP 'decrypt.*\|'; then
+if matches 'decrypt.*\|'; then
   # Piped to another command — OK
   exit 0
 fi

--- a/docs/architecture/machine-identity.md
+++ b/docs/architecture/machine-identity.md
@@ -269,12 +269,12 @@ sequenceDiagram
 
     Agent ->> AI: 9. Credential consumed in pipe (pipe to curl)
 
-    Note over AI: 10. Only result reaches AI<br/>"HTTP 200" (no password)
+    Note over AI: 10. Only result reaches AI<br/>"HTTP 200" (no password)<br/>— cooperative use only
 
     Note over Human: Sees: everything (owner)
     Note over Server: Sees: metadata, entryIds<br/>NO passwords, NO vault key
     Note over Agent: Sees: plaintext<br/>(in memory only)
-    Note over AI: Sees: metadata, HTTP results<br/>NO passwords
+    Note over AI: Sees: metadata, HTTP results<br/>NO passwords — cooperative use only<br/>(lint, not a boundary — see below)
 ```
 
 > **Security boundaries:**
@@ -355,7 +355,7 @@ Credential usage requires the CLI agent daemon running on the same machine as th
 |-------|----------|--------|
 | Phase 3 | Encrypted data only — AI agents receive ciphertext | Implemented |
 | Phase 5 | Delegated Decryption — browser relays metadata to MCP session | Implemented |
-| Phase 7 | Zero-Knowledge CLI Decrypt — agent daemon, no plaintext to server or AI | Implemented |
+| Phase 7 | Zero-Knowledge CLI Decrypt — agent daemon; no plaintext to the server (cryptographic), none to the AI under cooperative use (convention + lint) | Implemented |
 
 **Why not decrypt server-side?** The server has never had access to plaintext passwords — that is the core security guarantee, and it is cryptographic: the server holds only wrapped keys and ciphertext, so no server-side bug or operator can recover a password.
 

--- a/docs/architecture/machine-identity.md
+++ b/docs/architecture/machine-identity.md
@@ -290,7 +290,7 @@ sequenceDiagram
 | Human (Delegation UI) | Decides which entries to allow, for how long | Full vault access | — |
 | Server (DelegationSession) | Answers "is this request authorized?" | Metadata + entryIds allowlist | Vault key, plaintext passwords |
 | Agent daemon (CLI) | Decrypts when authorized | Vault key in memory | Authorization decisions |
-| AI (Claude Code) | Uses credentials via Skill/hook | Metadata + operation results | Plaintext passwords |
+| AI (Claude Code) | Uses credentials via Skill/hook | Metadata + operation results | Plaintext passwords *(by convention — see the caveat below; not enforced against the AI itself)* |
 
 #### Credential Usage Flow (Claude Code)
 
@@ -300,14 +300,38 @@ sequenceDiagram
 4. `passwd-sso decrypt --mcp-client mcpc_xxx` → connects to agent daemon via Unix socket
 5. Agent checks authorization with server (`GET /api/vault/delegation/check?clientId=mcpc_xxx&entryId=...`)
 6. If authorized: agent fetches encrypted blob → decrypts locally with vault key + AAD
-7. Credential is consumed in pipe (e.g., `| curl --config -`) → **never appears in Claude's context**
+7. Credential is consumed in pipe (e.g., `| curl --config -`) → does not appear in Claude's context **when the documented pattern is followed**
 8. Claude sees only the operation result (e.g., "HTTP 200")
+
+> **What this flow does and does not guarantee.** Steps 1-6 are enforced
+> server-side and by the agent daemon: the authorization decision, the entryId
+> allowlist, and the vault key's confinement to the daemon are real boundaries,
+> and no prompt talks its way past them.
+>
+> Step 7 is not in that category. It holds because the caller follows the
+> `/use-credential` pattern, and the `block-bare-decrypt` hook is a **lint that
+> catches the common accident, not a boundary**. The hook matches the Bash
+> command string before execution, and a shell string does not determine the
+> argv a process will see — a quoted, split, or variable-passed subcommand
+> reaches the same program unseen. The model the hook constrains is also the
+> party that writes the command, so it can evade the hook by construction.
+> `scripts/__tests__/block-bare-decrypt-hook.test.mjs` pins those evasions as
+> known limitations rather than leaving them implied.
+>
+> The honest statement: **this design keeps plaintext out of the transcript in
+> the cooperative case, and shrinks the blast radius in the hostile one** — the
+> daemon still enforces per-entry authorization, so a misbehaving caller reaches
+> only entries a human already allowed, for as long as the delegation lasts. It
+> is not a defence against prompt injection or a deliberately hostile model.
+> That would require the decrypt to stop being a Bash command at all: a tool or
+> MCP surface that consumes the credential and returns only the operation
+> result, never plaintext, to the model.
 
 #### Protection Mechanisms
 
 | Mechanism | Purpose |
 |-----------|---------|
-| `block-bare-decrypt` hook | Blocks direct `passwd-sso decrypt` in Bash (must use Skill subshell pattern) |
+| `block-bare-decrypt` hook | **Lint, not a boundary.** Catches the common accident of a decrypt whose stdout is transcribed; evadable by quoting or variable expansion (see the caveat above) |
 | `/use-credential` Skill | Generates safe subshell commands that consume credentials in pipe |
 | `credentials:list` scope | Grants metadata access only — no decrypt capability |
 | `credentials:use` scope | Authorizes agent to respond to decrypt requests |
@@ -319,7 +343,7 @@ sequenceDiagram
 
 | Client | Metadata (list/search) | Credential Usage | Notes |
 |--------|:---------------------:|:----------------:|-------|
-| Claude Code (CLI) | Yes | Yes (Skill + agent) | Full zero-knowledge flow via `/use-credential` Skill and `block-bare-decrypt` hook |
+| Claude Code (CLI) | Yes | Yes (Skill + agent) | Decrypt happens in the agent daemon, never server-side. Plaintext stays out of the transcript when the `/use-credential` pattern is followed; the `block-bare-decrypt` hook lints for the common accident but is not a boundary |
 | Claude Desktop | Yes | No | No Skill/hook mechanism; metadata-only access |
 | Other MCP clients | Yes | No | Standard MCP protocol — no agent socket integration |
 
@@ -333,7 +357,9 @@ Credential usage requires the CLI agent daemon running on the same machine as th
 | Phase 5 | Delegated Decryption — browser relays metadata to MCP session | Implemented |
 | Phase 7 | Zero-Knowledge CLI Decrypt — agent daemon, no plaintext to server or AI | Implemented |
 
-**Why not decrypt server-side?** The server has never had access to plaintext passwords — that's the core security guarantee. Phase 7 extends this: even the MCP client (AI) never sees plaintext. Decryption happens in the CLI agent daemon process, and credentials are consumed in Unix pipes without reaching the LLM context.
+**Why not decrypt server-side?** The server has never had access to plaintext passwords — that is the core security guarantee, and it is cryptographic: the server holds only wrapped keys and ciphertext, so no server-side bug or operator can recover a password.
+
+Phase 7 extends the *shape* of that to the AI: decryption happens in the CLI agent daemon, and credentials are consumed in Unix pipes rather than returned to the model. But the two guarantees are not the same strength, and it is worth being precise about which is which. Zero-knowledge against the **server** is enforced by cryptography. Keeping plaintext out of the **model's** context is enforced by convention plus a lint the model itself can bypass (see the caveat under "Credential Usage Flow"). Treat the first as a property of the system and the second as a property of cooperative use.
 
 ## Unified Audit
 

--- a/docs/architecture/machine-identity.md
+++ b/docs/architecture/machine-identity.md
@@ -277,11 +277,16 @@ sequenceDiagram
     Note over AI: Sees: metadata, HTTP results<br/>NO passwords — cooperative use only<br/>(lint, not a boundary — see below)
 ```
 
-> **Security boundaries:**
+> **Security boundaries** — enforced independently of how the caller behaves:
 > - Server ↔ AI: HTTPS + MCP OAuth 2.1 (metadata only)
 > - Agent ↔ Server: HTTPS + Bearer token (auth check, encrypted blob)
 > - Agent ↔ Hook: Unix socket 0600 (plaintext, same-user only)
-> - Hook ↔ AI: stdout pipe (result only, credential consumed in subshell)
+>
+> **Cooperative-use control** — depends on the caller following the pattern:
+> - Hook ↔ AI: stdout pipe (result only, credential consumed in subshell). The
+>   `block-bare-decrypt` hook lints for the common accident here; it is not a
+>   boundary, because the model it constrains is also the party writing the
+>   command. See the caveat under "Credential Usage Flow".
 
 #### Actor Responsibility Matrix
 
@@ -347,7 +352,9 @@ sequenceDiagram
 | Claude Desktop | Yes | No | No Skill/hook mechanism; metadata-only access |
 | Other MCP clients | Yes | No | Standard MCP protocol — no agent socket integration |
 
-Credential usage requires the CLI agent daemon running on the same machine as the MCP client. Claude Desktop and other MCP clients can browse entry metadata but cannot decrypt or use credentials. This is a deliberate security boundary — extending credential usage to other clients would require equivalent Skill/hook protections to prevent plaintext exposure to the LLM context.
+Credential usage requires the CLI agent daemon running on the same machine as the MCP client. Claude Desktop and other MCP clients can browse entry metadata but cannot decrypt or use credentials.
+
+That restriction *is* a boundary, and a real one: it rests on the agent's 0600 Unix socket, which a client on another machine simply cannot reach. What it does not rest on is the Skill/hook pair — those are cooperative-use controls, so extending credential usage to another client would need a way to consume the credential without returning plaintext to the model (a dedicated tool or MCP surface), not a port of the hook.
 
 ### E2E Encryption Strategy
 

--- a/docs/architecture/machine-identity.md
+++ b/docs/architecture/machine-identity.md
@@ -280,7 +280,12 @@ sequenceDiagram
 > **Security boundaries** — enforced independently of how the caller behaves:
 > - Server ↔ AI: HTTPS + MCP OAuth 2.1 (metadata only)
 > - Agent ↔ Server: HTTPS + Bearer token (auth check, encrypted blob)
-> - Agent ↔ Hook: Unix socket 0600 (plaintext, same-user only)
+> - Agent daemon ↔ local CLI process: Unix socket 0600 (plaintext, same-user
+>   only). The connecting party is the CLI's decrypt command, not the hook — the
+>   hook never opens the socket. Note what this separates and what it does not:
+>   it excludes other machines and other OS users, but any process running as the
+>   same user can speak the protocol, since the handler authorizes on the
+>   request's `clientId` rather than authenticating the caller.
 >
 > **Cooperative-use control** — depends on the caller following the pattern:
 > - Hook ↔ AI: stdout pipe (result only, credential consumed in subshell). The
@@ -354,7 +359,13 @@ sequenceDiagram
 
 Credential usage requires the CLI agent daemon running on the same machine as the MCP client. Claude Desktop and other MCP clients can browse entry metadata but cannot decrypt or use credentials.
 
-That restriction *is* a boundary, and a real one: it rests on the agent's 0600 Unix socket, which a client on another machine simply cannot reach. What it does not rest on is the Skill/hook pair — those are cooperative-use controls, so extending credential usage to another client would need a way to consume the credential without returning plaintext to the model (a dedicated tool or MCP surface), not a port of the hook.
+Three separate things are worth keeping apart here, because the restriction is real but narrower than "other clients cannot decrypt":
+
+- **Enforced boundary.** The agent socket is `0600` on the local filesystem, so it is reachable only from the same machine and only by the same OS user. A remote host or another user cannot connect at all.
+- **Product status, not a guarantee.** Claude Desktop and other MCP clients cannot use credentials today because none of them implements the agent protocol — not because anything stops them. That is a matter of what has been built.
+- **Not guaranteed.** The socket does not distinguish *which* client is calling. `handleConnection` reads a `clientId` from the request and checks authorization with the server; it does not authenticate the connecting process or bind a Unix peer credential to a particular MCP client. Any process running as the same OS user can speak the protocol.
+
+So extending credential usage to another client is a product decision, and the thing it would need is a way to consume the credential without returning plaintext to the model (a dedicated tool or MCP surface) — not a port of the Skill/hook pair, which are cooperative-use controls.
 
 ### E2E Encryption Strategy
 

--- a/scripts/__tests__/backup-db.test.mjs
+++ b/scripts/__tests__/backup-db.test.mjs
@@ -21,7 +21,7 @@
  * inherited HOME would let a test of default behaviour delete the developer's
  * real backups.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { spawnSync, spawn } from "node:child_process";
 import {
   mkdtempSync, mkdirSync, rmSync, writeFileSync, chmodSync, readFileSync,
@@ -32,15 +32,6 @@ import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tmpdir, hostname, homedir } from "node:os";
 
-// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
-// is subprocess startup, not assertion work — 1-3s each measured in isolation.
-// That fits the 10s default alone but not under the full suite, where ~1000 test
-// files compete for CPU and the slowest of these crosses the line; which one
-// crosses varies per run, so it presents as an unattributable flake.
-//
-// Raised for this file only. A global testTimeout bump would buy the same green
-// by hiding genuinely-hung tests everywhere else.
-vi.setConfig({ testTimeout: 60_000 });
 
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/scripts/__tests__/backup-db.test.mjs
+++ b/scripts/__tests__/backup-db.test.mjs
@@ -21,7 +21,7 @@
  * inherited HOME would let a test of default behaviour delete the developer's
  * real backups.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync, spawn } from "node:child_process";
 import {
   mkdtempSync, mkdirSync, rmSync, writeFileSync, chmodSync, readFileSync,
@@ -31,6 +31,17 @@ import {
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tmpdir, hostname, homedir } from "node:os";
+
+// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
+// is subprocess startup, not assertion work — 1-3s each measured in isolation.
+// That fits the 10s default alone but not under the full suite, where ~1000 test
+// files compete for CPU and the slowest of these crosses the line; which one
+// crosses varies per run, so it presents as an unattributable flake.
+//
+// Raised for this file only. A global testTimeout bump would buy the same green
+// by hiding genuinely-hung tests everywhere else.
+vi.setConfig({ testTimeout: 60_000 });
+
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..", "..");

--- a/scripts/__tests__/block-bare-decrypt-hook.test.mjs
+++ b/scripts/__tests__/block-bare-decrypt-hook.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * Tests for .claude/hooks/block-bare-decrypt.sh — the pre-tool-use lint that
+ * keeps a vault credential's stdout out of the conversation.
+ *
+ * Read the hook's own header first: it is a lint, NOT a security boundary. It
+ * matches the command string before execution, and a shell string does not
+ * determine the argv the process will see. The "known evasions" block below
+ * pins that limitation as a fact rather than leaving it as a comment nobody
+ * re-checks — if one of those ever starts being refused, the hook gained reach
+ * and the header should be re-read, not silently trusted further.
+ *
+ * The regression this file exists for: two earlier revisions each shipped a
+ * failure the other did not have. One allowed `(<cli> <sub> x)` and
+ * `<cli> <sub> x | cat` on shape heuristics that prove nothing about where
+ * stdout lands. The next refused everything — including the /use-credential
+ * pattern its own error message recommends, which made the sanctioned workflow
+ * impossible to run. Both directions are asserted here.
+ */
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const HOOK = resolve(REPO_ROOT, ".claude/hooks/block-bare-decrypt.sh");
+
+// Built from fragments so this file's own source does not contain the literal
+// command — the hook is installed on this repo, and a test fixture that spells
+// it out would be flagged when the test file itself is edited via the Bash tool.
+const CLI = "npx tsx " + REPO_ROOT + "/cli/src/index.ts";
+const SUB = "dec" + "rypt";
+
+/** Run the hook with a tool_input payload; returns its exit status. */
+function runHook(command) {
+  const payload = JSON.stringify({ tool_input: { command } });
+  const r = spawnSync("bash", [HOOK], { input: payload, encoding: "utf8" });
+  return r.status;
+}
+
+/** Run the hook with a raw (possibly malformed) stdin payload. */
+function runHookRaw(payload) {
+  const r = spawnSync("bash", [HOOK], { input: payload, encoding: "utf8" });
+  return r.status;
+}
+
+const ALLOW = 0;
+const BLOCK = 2;
+
+describe("block-bare-decrypt hook", () => {
+  describe("allows the /use-credential pattern", () => {
+    // These are the shapes .claude/skills/use-credential/SKILL.md documents. If
+    // the hook refuses them the skill cannot be used at all, which is what the
+    // error message tells the caller to do — a contradiction that shipped once.
+    it("allows _CRED assigned in a subshell and consumed by curl", () => {
+      const cmd = `(\n  _CRED=$(${CLI} ${SUB} ID --field password)\n  curl -s -u "user:\${_CRED}" https://example.test\n) 2>/dev/null`;
+      expect(runHook(cmd)).toBe(ALLOW);
+    });
+
+    it("allows the bearer-token variant", () => {
+      const cmd = `(\n  _CRED=$(${CLI} ${SUB} ID --field password)\n  curl -s -H "Authorization: Bearer \${_CRED}" https://example.test\n) 2>/dev/null`;
+      expect(runHook(cmd)).toBe(ALLOW);
+    });
+  });
+
+  describe("blocks shapes that put the credential on stdout", () => {
+    it("blocks a bare run", () => {
+      expect(runHook(`passwd-sso ${SUB} item`)).toBe(BLOCK);
+    });
+
+    it("blocks a subshell that does not capture into _CRED", () => {
+      // A leading paren was once treated as proof of safety. It is not: stdout
+      // still goes to stdout.
+      expect(runHook(`(passwd-sso ${SUB} item)`)).toBe(BLOCK);
+    });
+
+    it("blocks a pipe whose last stage prints", () => {
+      // A pipe was once treated as proof of safety. `cat` writes it out.
+      expect(runHook(`passwd-sso ${SUB} item | cat`)).toBe(BLOCK);
+    });
+
+    it("blocks a sanctioned subshell that echoes the credential", () => {
+      const cmd = `(\n  _CRED=$(${CLI} ${SUB} ID)\n  echo $_CRED\n)`;
+      expect(runHook(cmd)).toBe(BLOCK);
+    });
+  });
+
+  describe("refuses rather than allowing when it cannot read its input", () => {
+    // A guard that cannot parse its input has not cleared that input. Each of
+    // these once mapped to an empty command and took the "not a decrypt" path.
+    it("blocks malformed JSON", () => {
+      expect(runHookRaw("{bad json")).toBe(BLOCK);
+    });
+
+    it("blocks a missing command key", () => {
+      expect(runHookRaw(JSON.stringify({ tool_input: {} }))).toBe(BLOCK);
+    });
+
+    it("blocks a null command", () => {
+      expect(runHookRaw(JSON.stringify({ tool_input: { command: null } }))).toBe(BLOCK);
+    });
+
+    it("blocks a non-string command", () => {
+      expect(runHookRaw(JSON.stringify({ tool_input: { command: 123 } }))).toBe(BLOCK);
+    });
+  });
+
+  describe("does not block unrelated commands", () => {
+    // The over-blocking direction. A hook that refuses everything gets disabled,
+    // which is strictly worse than one with known gaps.
+    it("allows an unrelated command", () => {
+      expect(runHook("git status")).toBe(ALLOW);
+    });
+
+    it("allows a different subcommand of the same CLI", () => {
+      expect(runHook("passwd-sso list")).toBe(ALLOW);
+    });
+
+    it("allows prose that merely contains the word", () => {
+      expect(runHook("echo decrypting files")).toBe(ALLOW);
+    });
+  });
+
+  describe("known evasions — pinned as limitations, not as coverage", () => {
+    // These reach the same program and the hook does not see them, because it
+    // matches the pre-execution string rather than the runtime argv. They are
+    // asserted as ALLOW deliberately: the hook is documented as a lint against
+    // accidents, and this is the evidence for that claim rather than a promise
+    // it is safe. Closing them requires moving the decrypt off Bash entirely
+    // (a dedicated tool or MCP surface that never returns plaintext).
+    //
+    // If one of these flips to BLOCK, do not simply update the expectation —
+    // the hook's reach changed, and its header's scope statement needs revising.
+    it("does not see a quoted subcommand", () => {
+      expect(runHook(`passwd-sso '${SUB}' item`)).toBe(ALLOW);
+    });
+
+    it("does not see a subcommand split across quotes", () => {
+      expect(runHook(`passwd-sso decr"ypt" item`)).toBe(ALLOW);
+    });
+
+    it("does not see a subcommand passed through a variable", () => {
+      expect(runHook(`sub=${SUB}; passwd-sso "$sub" item`)).toBe(ALLOW);
+    });
+  });
+});

--- a/scripts/__tests__/block-bare-decrypt-hook.test.mjs
+++ b/scripts/__tests__/block-bare-decrypt-hook.test.mjs
@@ -121,6 +121,54 @@ describe("block-bare-decrypt hook", () => {
     });
   });
 
+  describe("requires EVERY decrypt in the command to be safe, not just one", () => {
+    // The allow once answered "does a safe form exist?", which a command holding
+    // one safe and one unsafe decrypt satisfies with the safe one alone. Grep
+    // cannot ask "is every occurrence safe?", so the hook requires exactly one
+    // occurrence and judges that. Every documented pattern has exactly one.
+    it("blocks a capture followed by a bare decrypt", () => {
+      expect(runHook(`_CRED=$(passwd-sso ${SUB} safe); passwd-sso ${SUB} exposed`)).toBe(BLOCK);
+    });
+
+    it("blocks a clipboard sink followed by a bare decrypt", () => {
+      expect(runHook(`passwd-sso ${SUB} safe | pbcopy; passwd-sso ${SUB} exposed`)).toBe(BLOCK);
+    });
+
+    it("blocks a quoted decoy used to justify a bare decrypt", () => {
+      // The decoy is inside a string literal and never runs, but it was enough
+      // to satisfy the existence check for the real one beside it.
+      const cmd = `echo 'passwd-sso ${SUB} x | pbcopy'; passwd-sso ${SUB} exposed`;
+      expect(runHook(cmd)).toBe(BLOCK);
+    });
+  });
+
+  describe("pins the clipboard sink's argument shape, not just its name", () => {
+    // Several clipboard tools have flags that turn them back into filters, so
+    // matching the sink by NAME let the credential through a sanctioned-looking
+    // pipe. xclip -filter and xsel --output both write stdin to stdout.
+    it("blocks xclip -filter after a selection argument", () => {
+      expect(runHook(`passwd-sso ${SUB} item | xclip -selection clipboard -filter`)).toBe(BLOCK);
+    });
+
+    it("blocks a bare xclip -filter", () => {
+      expect(runHook(`passwd-sso ${SUB} item | xclip -filter`)).toBe(BLOCK);
+    });
+
+    it("blocks xsel --output", () => {
+      expect(runHook(`passwd-sso ${SUB} item | xsel --output`)).toBe(BLOCK);
+    });
+
+    it("still allows xsel in its documented input form", () => {
+      // The allow side of the same clause: pinning the shape must not break the
+      // legitimate one.
+      expect(runHook(`${CLI} ${SUB} ID | xsel --clipboard --input`)).toBe(ALLOW);
+    });
+
+    it("still allows wl-copy", () => {
+      expect(runHook(`${CLI} ${SUB} ID | wl-copy`)).toBe(ALLOW);
+    });
+  });
+
   describe("refuses rather than allowing when it cannot read its input", () => {
     // A guard that cannot parse its input has not cleared that input. Each of
     // these once mapped to an empty command and took the "not a decrypt" path.

--- a/scripts/__tests__/block-bare-decrypt-hook.test.mjs
+++ b/scripts/__tests__/block-bare-decrypt-hook.test.mjs
@@ -60,6 +60,25 @@ describe("block-bare-decrypt hook", () => {
       const cmd = `(\n  _CRED=$(${CLI} ${SUB} ID --field password)\n  curl -s -H "Authorization: Bearer \${_CRED}" https://example.test\n) 2>/dev/null`;
       expect(runHook(cmd)).toBe(ALLOW);
     });
+
+    it("allows the generic consuming-command variant (Pattern C)", () => {
+      const cmd = `(\n  _CRED=$(${CLI} ${SUB} ID --field password)\n  some-tool --token "\${_CRED}"\n) 2>/dev/null`;
+      expect(runHook(cmd)).toBe(ALLOW);
+    });
+
+    // Patterns D and E do NOT use _CRED — they pipe straight into a clipboard
+    // sink. An earlier revision keyed the allow on "_CRED=$(" being present
+    // anywhere, so both were refused and the documented macOS/Linux clipboard
+    // flows could not run.
+    it("allows the macOS clipboard pattern (Pattern D)", () => {
+      const cmd = `(\n  ${CLI} ${SUB} ID --field password | pbcopy\n  echo "Copied to clipboard"\n) 2>/dev/null`;
+      expect(runHook(cmd)).toBe(ALLOW);
+    });
+
+    it("allows the Linux clipboard pattern (Pattern E)", () => {
+      const cmd = `(\n  ${CLI} ${SUB} ID --field password | xclip -selection clipboard\n  echo "Copied to clipboard"\n) 2>/dev/null`;
+      expect(runHook(cmd)).toBe(ALLOW);
+    });
   });
 
   describe("blocks shapes that put the credential on stdout", () => {
@@ -81,6 +100,24 @@ describe("block-bare-decrypt hook", () => {
     it("blocks a sanctioned subshell that echoes the credential", () => {
       const cmd = `(\n  _CRED=$(${CLI} ${SUB} ID)\n  echo $_CRED\n)`;
       expect(runHook(cmd)).toBe(BLOCK);
+    });
+
+    it("blocks a decoy _CRED that captures something else", () => {
+      // The allow must be anchored on the decrypt OCCURRENCE. Testing "starts
+      // with (" and "contains _CRED=$(" independently accepted this: the
+      // assignment captured `true` while the real decrypt ran bare beside it.
+      expect(runHook(`(_CRED=$(true); passwd-sso ${SUB} item)`)).toBe(BLOCK);
+    });
+
+    it("blocks a pipe into a sink that prints", () => {
+      // The clipboard allow is a closed set. `tee` writes to stdout, so it is
+      // not a consuming sink even though it looks like one.
+      expect(runHook(`${CLI} ${SUB} ID | tee /tmp/x`)).toBe(BLOCK);
+    });
+
+    it("blocks a pipe into an unknown command", () => {
+      // A decrypt piped into something this lint cannot vouch for.
+      expect(runHook(`${CLI} ${SUB} ID | some-unknown-tool`)).toBe(BLOCK);
     });
   });
 

--- a/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
+++ b/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
@@ -11,12 +11,20 @@
  * executeVaultReset/deleteTeamPassword wrapper functions just to avoid a
  * spurious STALE_DELETE_SIGNAL_NAME.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+
+// Shells out to the real guard over the whole repo source tree, so its cost is
+// subprocess startup rather than assertion work — ~1.1s measured in isolation.
+// That fits the 10s default alone but not under the full suite, where ~1000 test
+// files compete for CPU. Raised for this file only; a global testTimeout bump
+// would buy the same green by hiding genuinely-hung tests everywhere else.
+vi.setConfig({ testTimeout: 60_000 });
+
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..", "..");

--- a/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
+++ b/scripts/__tests__/check-destructive-wrapper-derivation.test.mjs
@@ -11,19 +11,13 @@
  * executeVaultReset/deleteTeamPassword wrapper functions just to avoid a
  * spurious STALE_DELETE_SIGNAL_NAME.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// Shells out to the real guard over the whole repo source tree, so its cost is
-// subprocess startup rather than assertion work — ~1.1s measured in isolation.
-// That fits the 10s default alone but not under the full suite, where ~1000 test
-// files compete for CPU. Raised for this file only; a global testTimeout bump
-// would buy the same green by hiding genuinely-hung tests everywhere else.
-vi.setConfig({ testTimeout: 60_000 });
 
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/scripts/__tests__/check-env-docs.test.mjs
+++ b/scripts/__tests__/check-env-docs.test.mjs
@@ -4,20 +4,11 @@
  * Each case uses a fixture directory under scripts/__tests__/fixtures/env-drift/.
  * The drift-checker accepts --root <path> to resolve all files relative to the fixture.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
-// is subprocess startup, not assertion work — 1-3s each measured in isolation.
-// That fits the 10s default alone but not under the full suite, where ~1000 test
-// files compete for CPU and the slowest of these crosses the line; which one
-// crosses varies per run, so it presents as an unattributable flake.
-//
-// Raised for this file only. A global testTimeout bump would buy the same green
-// by hiding genuinely-hung tests everywhere else.
-vi.setConfig({ testTimeout: 60_000 });
 
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/scripts/__tests__/check-env-docs.test.mjs
+++ b/scripts/__tests__/check-env-docs.test.mjs
@@ -4,10 +4,21 @@
  * Each case uses a fixture directory under scripts/__tests__/fixtures/env-drift/.
  * The drift-checker accepts --root <path> to resolve all files relative to the fixture.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+
+// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
+// is subprocess startup, not assertion work — 1-3s each measured in isolation.
+// That fits the 10s default alone but not under the full suite, where ~1000 test
+// files compete for CPU and the slowest of these crosses the line; which one
+// crosses varies per run, so it presents as an unattributable flake.
+//
+// Raised for this file only. A global testTimeout bump would buy the same green
+// by hiding genuinely-hung tests everywhere else.
+vi.setConfig({ testTimeout: 60_000 });
+
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..", "..");

--- a/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
+++ b/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
@@ -87,10 +87,29 @@ describe("the defect this guard exists for", () => {
     },
   );
 
-  it("does NOT invert for grep -l, which is why the gate leaves it alone", () => {
-    const r = runShape(`printf '%s' "$big" | grep -l '${NEEDLE}'`);
-    expect(r.stdout.trim()).toBe("FOUND");
-  });
+  // -l was once asserted NOT to invert, measured on GNU grep, which keeps
+  // draining stdin. BSD grep (macOS) exits on first match and takes SIGPIPE
+  // exactly like -q, so the claim was platform-specific and the gate that rested
+  // on it under-covered on macOS. Asserted as a member on both platforms: the
+  // gate runs in CI and locally, so the union is the only safe member set.
+  it.each([["-q"], ["--quiet"], ["--silent"], ["-m1"], ["-l"]])(
+    "reports a SUCCESSFUL match as failure when piped into grep %s (member)",
+    (flag) => {
+      const r = runShape(`printf '%s' "$big" | grep ${flag} '${NEEDLE}'`);
+      expect(r.stdout.trim()).toMatch(/^MISSED\(rc=\d+\)$/);
+    },
+  );
+
+  // The non-members, measured on the same haystack: these consume their input,
+  // so the writer never takes SIGPIPE. They bound the widening — without them a
+  // later edit could keep adding flags with nothing to say it had gone too far.
+  it.each([["-c"], ["-o"], ["-n"]])(
+    "does NOT invert for grep %s, which is why the gate leaves it alone",
+    (flag) => {
+      const r = runShape(`printf '%s' "$big" | grep ${flag} '${NEEDLE}' >/dev/null`);
+      expect(r.stdout.trim()).toBe("FOUND");
+    },
+  );
 
   it("reports the same match correctly through a herestring", () => {
     const r = runShape(`grep -qxF '${NEEDLE}' <<<"$big"`);
@@ -169,13 +188,23 @@ describe("check-no-pipe-into-grep-q.sh", () => {
     },
   );
 
-  it("PASSES `grep -l`, which measurement shows does not invert", () => {
+  it("FAILS on `grep -l`, which inverts on BSD grep", () => {
     // Pinning the derivation: the member set is "flags that make grep exit
-    // before draining stdin", and -l is not one of them. If that ever changes,
-    // this test is where the claim gets revisited.
+    // before draining stdin". -l does on BSD (macOS) though not on GNU, and the
+    // gate runs on both, so it is a member.
+    writeScript(
+      "offender",
+      '#!/usr/bin/env bash\nset -euo pipefail\ncat f | grep -l needle\n',
+    );
+    expect(runGuard().exitCode).toBe(1);
+  });
+
+  it("PASSES `grep -c`, a measured non-member", () => {
+    // The over-blocking direction: widening the class must not sweep in flags
+    // that were measured as safe, or the gate starts flagging correct code.
     writeScript(
       "clean",
-      '#!/usr/bin/env bash\nset -euo pipefail\ncat f | grep -l needle\n',
+      '#!/usr/bin/env bash\nset -euo pipefail\ncat f | grep -c needle\n',
     );
     expect(runGuard().exitCode).toBe(0);
   });

--- a/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
+++ b/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
@@ -76,24 +76,21 @@ describe("the defect this guard exists for", () => {
     );
   }
 
-  // The needle IS on the first line — "MISSED" here is the inversion itself,
-  // not a matching failure. These four flags are the gate's member set, and
-  // this is the measurement it was derived from; `-l` is excluded below.
-  it.each([["-q"], ["--quiet"], ["--silent"], ["-m1"]])(
-    "reports a SUCCESSFUL match as failure when piped into grep %s",
-    (flag) => {
-      const r = runShape(`printf '%s' "$big" | grep ${flag} '${NEEDLE}'`);
-      expect(r.stdout.trim()).toMatch(/^MISSED\(rc=\d+\)$/);
-    },
-  );
+  // 128 + SIGPIPE(13). Pinned exactly rather than as /rc=\d+/: a loose pattern
+  // also accepts rc=1 (needle genuinely absent), rc=2 (grep rejected its own
+  // arguments) and rc=127 (grep not found) — three ways for this test to pass
+  // while measuring something other than the inversion it exists to measure.
+  const SIGPIPE = "MISSED(rc=141)";
 
-  // These four invert on BOTH platforms — they stop reading as soon as the
-  // verdict is known, so the writer takes SIGPIPE regardless of implementation.
+  // The needle IS on the first line, so "MISSED" here is the inversion itself,
+  // not a matching failure. These four invert on BOTH platforms — they stop
+  // reading as soon as the verdict is known, so the writer takes SIGPIPE
+  // regardless of implementation. `-l` is the platform-dependent one, below.
   it.each([["-q"], ["--quiet"], ["--silent"], ["-m1"]])(
     "reports a SUCCESSFUL match as failure when piped into grep %s (member)",
     (flag) => {
       const r = runShape(`printf '%s' "$big" | grep ${flag} '${NEEDLE}'`);
-      expect(r.stdout.trim()).toMatch(/^MISSED\(rc=\d+\)$/);
+      expect(r.stdout.trim()).toBe(SIGPIPE);
     },
   );
 
@@ -117,7 +114,7 @@ describe("the defect this guard exists for", () => {
     const r = runShape(`printf '%s' "$big" | grep -l '${NEEDLE}'`);
     const out = r.stdout.trim();
     expect(
-      out === "FOUND" || /^MISSED\(rc=\d+\)$/.test(out),
+      out === "FOUND" || out === SIGPIPE,
       `grep -l produced an unexpected outcome: ${out}`,
     ).toBe(true);
   });

--- a/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
+++ b/scripts/__tests__/check-no-pipe-into-grep-q.test.mjs
@@ -87,18 +87,40 @@ describe("the defect this guard exists for", () => {
     },
   );
 
-  // -l was once asserted NOT to invert, measured on GNU grep, which keeps
-  // draining stdin. BSD grep (macOS) exits on first match and takes SIGPIPE
-  // exactly like -q, so the claim was platform-specific and the gate that rested
-  // on it under-covered on macOS. Asserted as a member on both platforms: the
-  // gate runs in CI and locally, so the union is the only safe member set.
-  it.each([["-q"], ["--quiet"], ["--silent"], ["-m1"], ["-l"]])(
+  // These four invert on BOTH platforms — they stop reading as soon as the
+  // verdict is known, so the writer takes SIGPIPE regardless of implementation.
+  it.each([["-q"], ["--quiet"], ["--silent"], ["-m1"]])(
     "reports a SUCCESSFUL match as failure when piped into grep %s (member)",
     (flag) => {
       const r = runShape(`printf '%s' "$big" | grep ${flag} '${NEEDLE}'`);
       expect(r.stdout.trim()).toMatch(/^MISSED\(rc=\d+\)$/);
     },
   );
+
+  // -l is PLATFORM-DEPENDENT, and that is the whole reason it belongs in the
+  // gate's member set. BSD grep (macOS) exits on first match and takes SIGPIPE
+  // exactly like -q; GNU grep keeps draining stdin and does not invert. The gate
+  // must flag it because it runs on both, but this test cannot assert one
+  // outcome for both — an earlier revision did, and CI (GNU) reddened on the
+  // BSD-measured claim. Assert the behaviour the running grep actually has, and
+  // require the pair to be exhaustive so an unexpected third outcome fails.
+  it("either inverts for grep -l or does not, depending on the implementation", () => {
+    // Deliberately NOT branching on `grep --version`: BSD grep reports itself as
+    // "grep (BSD grep, GNU compatible)", so a substring test for "GNU" picks the
+    // wrong branch on exactly the platform that inverts. There is no reliable
+    // name to key on here — only the behaviour.
+    //
+    // So assert the pair is EXHAUSTIVE rather than picking a side: -l either
+    // drains (FOUND, GNU) or exits early and SIGPIPEs the writer (MISSED, BSD).
+    // Any third outcome is a real finding. The gate's member set includes -l
+    // because one of these two platforms inverts, and the gate runs on both.
+    const r = runShape(`printf '%s' "$big" | grep -l '${NEEDLE}'`);
+    const out = r.stdout.trim();
+    expect(
+      out === "FOUND" || /^MISSED\(rc=\d+\)$/.test(out),
+      `grep -l produced an unexpected outcome: ${out}`,
+    ).toBe(true);
+  });
 
   // The non-members, measured on the same haystack: these consume their input,
   // so the writer never takes SIGPIPE. They bound the widening — without them a

--- a/scripts/__tests__/check-session-token-hashed.test.mjs
+++ b/scripts/__tests__/check-session-token-hashed.test.mjs
@@ -7,22 +7,13 @@
  * catches. Green fixtures cover every SAFE form (hashSessionToken call, a
  * *Digest variable bound to a producer, a DB-selected `.sessionToken`, `true`).
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
-// is subprocess startup, not assertion work — 1-3s each measured in isolation.
-// That fits the 10s default alone but not under the full suite, where ~1000 test
-// files compete for CPU and the slowest of these crosses the line; which one
-// crosses varies per run, so it presents as an unattributable flake.
-//
-// Raised for this file only. A global testTimeout bump would buy the same green
-// by hiding genuinely-hung tests everywhere else.
-vi.setConfig({ testTimeout: 60_000 });
 
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/scripts/__tests__/check-session-token-hashed.test.mjs
+++ b/scripts/__tests__/check-session-token-hashed.test.mjs
@@ -7,12 +7,23 @@
  * catches. Green fixtures cover every SAFE form (hashSessionToken call, a
  * *Digest variable bound to a producer, a DB-selected `.sessionToken`, `true`).
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+
+// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
+// is subprocess startup, not assertion work — 1-3s each measured in isolation.
+// That fits the 10s default alone but not under the full suite, where ~1000 test
+// files compete for CPU and the slowest of these crosses the line; which one
+// crosses varies per run, so it presents as an unattributable flake.
+//
+// Raised for this file only. A global testTimeout bump would buy the same green
+// by hiding genuinely-hung tests everywhere else.
+vi.setConfig({ testTimeout: 60_000 });
+
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..", "..");

--- a/scripts/__tests__/check-tls-fixture-expiry.test.mjs
+++ b/scripts/__tests__/check-tls-fixture-expiry.test.mjs
@@ -52,7 +52,16 @@ const OPENSSL = (() => {
       const help = execFileSync("bash", ["-c", `${bin} pkcs12 -help 2>&1`], {
         encoding: "utf8",
       });
-      if (help.includes("-legacy")) return bin;
+      if (!help.includes("-legacy")) continue;
+      // Resolve to an ABSOLUTE path before returning. On Linux the first
+      // candidate is the bare name `openssl`, and the stub below delegates with
+      // `exec "${OPENSSL}" "$@"` while the stub's own directory is first on
+      // PATH — so a bare name would resolve back to the stub and recurse until
+      // the process dies. macOS hides this: the resolver lands on the Homebrew
+      // absolute path instead.
+      return execFileSync("bash", ["-c", `command -v ${bin}`], {
+        encoding: "utf8",
+      }).trim();
     } catch {
       // candidate absent or unusable — try the next
     }

--- a/scripts/__tests__/check-tls-fixture-expiry.test.mjs
+++ b/scripts/__tests__/check-tls-fixture-expiry.test.mjs
@@ -36,8 +36,41 @@ beforeEach(() => {
 });
 afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
+// These fixtures are generated with `openssl pkcs12 -legacy`, and macOS ships
+// LibreSSL as /usr/bin/openssl, which has no `-legacy` flag at all. Resolve an
+// openssl whose pkcs12 accepts it and run every generation command through that
+// one, so the self-test does not depend on how a developer ordered their PATH.
+// (The gate under test resolves its own openssl the same way.)
+const OPENSSL = (() => {
+  const candidates = [
+    "openssl",
+    "/opt/homebrew/opt/openssl@3/bin/openssl",
+    "/usr/local/opt/openssl@3/bin/openssl",
+  ];
+  for (const bin of candidates) {
+    try {
+      const help = execFileSync("bash", ["-c", `${bin} pkcs12 -help 2>&1`], {
+        encoding: "utf8",
+      });
+      if (help.includes("-legacy")) return bin;
+    } catch {
+      // candidate absent or unusable — try the next
+    }
+  }
+  return null;
+})();
+
 function sh(cmd) {
-  execFileSync("bash", ["-c", cmd], { stdio: ["ignore", "ignore", "ignore"] });
+  if (!OPENSSL) {
+    throw new Error(
+      "no openssl with `pkcs12 -legacy` found — install OpenSSL 3 (brew install openssl@3)",
+    );
+  }
+  // PATH-prefix the resolved binary's directory so the bare `openssl` tokens in
+  // the generation commands below resolve to it.
+  const dirOf = OPENSSL.includes("/") ? OPENSSL.slice(0, OPENSSL.lastIndexOf("/")) : null;
+  const env = dirOf ? { ...process.env, PATH: `${dirOf}:${process.env.PATH}` } : process.env;
+  execFileSync("bash", ["-c", cmd], { stdio: ["ignore", "ignore", "ignore"], env });
 }
 
 // Build a CA + one leaf p12 (`tlsLeaf<label>.p12`) into `dir`.
@@ -154,7 +187,7 @@ describe("check-tls-fixture-expiry", () => {
       "bash",
       [
         "-c",
-        `openssl pkcs12 -in "${join(dir, "tlsLeafA.p12")}" -nokeys -clcerts ` +
+        `"${OPENSSL}" pkcs12 -in "${join(dir, "tlsLeafA.p12")}" -nokeys -clcerts ` +
           `-passin pass:${PASS} -legacy 2>/dev/null`,
       ],
       { encoding: "utf8" },
@@ -167,8 +200,12 @@ describe("check-tls-fixture-expiry", () => {
     writeFileSync(
       join(stubDir, "openssl"),
       `#!/usr/bin/env bash
+# The gate probes \`pkcs12 -help\` to find an openssl that supports -legacy, so
+# the stub must answer that probe truthfully or the gate skips it and resolves a
+# real binary instead — which would silently defeat this test.
+if [ "$1" = "pkcs12" ] && [ "$2" = "-help" ]; then exec "${OPENSSL}" pkcs12 -help; fi
 if [ "$1" = "pkcs12" ]; then cat "${pemFile}"; exit 1; fi
-exec /usr/bin/openssl "$@"
+exec "${OPENSSL}" "$@"
 `,
       { mode: 0o755 },
     );

--- a/scripts/__tests__/deploy-rollback.test.mjs
+++ b/scripts/__tests__/deploy-rollback.test.mjs
@@ -157,11 +157,13 @@ exit 0`,
         .join("\n")
     : "";
 
+  // Assign rather than echo: these arms are no longer inside a $( ) capture
+  // (see the stub body — bash 3.2 cannot parse `;;` in command substitution).
   const oldTdCases = Object.entries(OLD_TD_FOR_SERVICE)
-    .map(([svc, td]) => `    ${svc}) echo "${td}";;`)
+    .map(([svc, td]) => `    ${svc}) CURRENT_TD="${td}";;`)
     .join("\n");
   const newTdCases = Object.entries(NEW_TD_FOR_SERVICE)
-    .map(([svc, td]) => `    ${svc}) echo "${td}";;`)
+    .map(([svc, td]) => `    ${svc}) CURRENT_TD="${td}";;`)
     .join("\n");
 
   stub(
@@ -240,14 +242,19 @@ case "$1 $2" in
       esac
       shift
     done
+    # The case statements assign directly instead of being captured with $( ):
+    # bash 3.2 (what macOS ships) cannot parse \`;;\` inside command
+    # substitution, so \`CURRENT_TD=$(case ... esac)\` is a syntax error there and
+    # the whole stub fails to run. Assigning inside the case is equivalent and
+    # parses on 3.2 and 5.x alike.
     if [ -f "${tmpDir}/updated_\${SVC}" ]; then
-      CURRENT_TD=$(case "$SVC" in
+      case "$SVC" in
 ${newTdCases}
-      esac)
+      esac
     else
-      CURRENT_TD=$(case "$SVC" in
+      case "$SVC" in
 ${oldTdCases}
-      esac)
+      esac
     fi
     case "$QUERY" in
       *deployments*)
@@ -431,6 +438,18 @@ describe("deploy.sh --rollback-to validation", () => {
     // Nothing may have been deployed or even queried.
     expect(logLines("ecs update-service")).toHaveLength(0);
     expect(logLines("terraform").filter((l) => l.includes("apply"))).toHaveLength(0);
+    // The three assertions above are all negative, and a suite whose every
+    // assertion is an absence cannot tell "rejected correctly" from "never ran".
+    // This one is positive: the rejection message quotes the offending image, so
+    // it only appears if deploy.sh actually parsed the argument.
+    //
+    // Note what this does and does not prove. deploy.sh rejects a foreign
+    // registry at the argument-shape `case` (deploy.sh:166), before any aws
+    // call, so this test legitimately does not exercise the stub and stays green
+    // even when the stub is unparseable — verified by mutation. It is a test of
+    // the pre-AWS validation path, not a canary for stub health; the other ten
+    // tests are what depend on the stub working.
+    expect(result.stderr).toContain("evil.example/image:git-abc123def456");
   });
 
   it("accepts a rollback image in the configured ECR repo and skips the migration", () => {

--- a/scripts/__tests__/generate-env-example.test.mjs
+++ b/scripts/__tests__/generate-env-example.test.mjs
@@ -10,7 +10,7 @@
  * ['İ','I','i','a','Z'] — so a regression that swapped the comparator for
  * String.prototype.localeCompare() (LANG-dependent) would fail this test.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
 import { readFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -18,15 +18,6 @@ import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { makeEnvKeyCollator } from "../lib/env-sort.ts";
 
-// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
-// is subprocess startup, not assertion work — 1-3s each measured in isolation.
-// That fits the 10s default alone but not under the full suite, where ~1000 test
-// files compete for CPU and the slowest of these crosses the line; which one
-// crosses varies per run, so it presents as an unattributable flake.
-//
-// Raised for this file only. A global testTimeout bump would buy the same green
-// by hiding genuinely-hung tests everywhere else.
-vi.setConfig({ testTimeout: 60_000 });
 
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/scripts/__tests__/generate-env-example.test.mjs
+++ b/scripts/__tests__/generate-env-example.test.mjs
@@ -10,13 +10,24 @@
  * ['İ','I','i','a','Z'] — so a regression that swapped the comparator for
  * String.prototype.localeCompare() (LANG-dependent) would fail this test.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import { readFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { makeEnvKeyCollator } from "../lib/env-sort.ts";
+
+// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
+// is subprocess startup, not assertion work — 1-3s each measured in isolation.
+// That fits the 10s default alone but not under the full suite, where ~1000 test
+// files compete for CPU and the slowest of these crosses the line; which one
+// crosses varies per run, so it presents as an unattributable flake.
+//
+// Raised for this file only. A global testTimeout bump would buy the same green
+// by hiding genuinely-hung tests everywhere else.
+vi.setConfig({ testTimeout: 60_000 });
+
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..", "..");

--- a/scripts/__tests__/lint-extension.test.mjs
+++ b/scripts/__tests__/lint-extension.test.mjs
@@ -13,12 +13,23 @@
  * nothing and a run that linted and found nothing are otherwise indistinguishable,
  * which is the exact vacuity this self-test exists to rule out.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+
+// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
+// is subprocess startup, not assertion work — 1-3s each measured in isolation.
+// That fits the 10s default alone but not under the full suite, where ~1000 test
+// files compete for CPU and the slowest of these crosses the line; which one
+// crosses varies per run, so it presents as an unattributable flake.
+//
+// Raised for this file only. A global testTimeout bump would buy the same green
+// by hiding genuinely-hung tests everywhere else.
+vi.setConfig({ testTimeout: 60_000 });
+
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const CONFIG = "eslint.extension.config.mjs";

--- a/scripts/__tests__/lint-extension.test.mjs
+++ b/scripts/__tests__/lint-extension.test.mjs
@@ -13,22 +13,13 @@
  * nothing and a run that linted and found nothing are otherwise indistinguishable,
  * which is the exact vacuity this self-test exists to rule out.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
-// is subprocess startup, not assertion work — 1-3s each measured in isolation.
-// That fits the 10s default alone but not under the full suite, where ~1000 test
-// files compete for CPU and the slowest of these crosses the line; which one
-// crosses varies per run, so it presents as an unattributable flake.
-//
-// Raised for this file only. A global testTimeout bump would buy the same green
-// by hiding genuinely-hung tests everywhere else.
-vi.setConfig({ testTimeout: 60_000 });
 
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");

--- a/scripts/__tests__/pre-pr-run-batch.test.mjs
+++ b/scripts/__tests__/pre-pr-run-batch.test.mjs
@@ -25,12 +25,23 @@
  * documents). Splicing means the code under test IS the production code: a
  * re-implementation here would drift and prove nothing.
  */
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+
+// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
+// is subprocess startup, not assertion work — 1-3s each measured in isolation.
+// That fits the 10s default alone but not under the full suite, where ~1000 test
+// files compete for CPU and the slowest of these crosses the line; which one
+// crosses varies per run, so it presents as an unattributable flake.
+//
+// Raised for this file only. A global testTimeout bump would buy the same green
+// by hiding genuinely-hung tests everywhere else.
+vi.setConfig({ testTimeout: 60_000 });
+
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..", "..");

--- a/scripts/__tests__/pre-pr-run-batch.test.mjs
+++ b/scripts/__tests__/pre-pr-run-batch.test.mjs
@@ -25,22 +25,13 @@
  * documents). Splicing means the code under test IS the production code: a
  * re-implementation here would drift and prove nothing.
  */
-import { describe, it, expect, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// These tests shell out to real processes (npx tsx, eslint, bash), so their cost
-// is subprocess startup, not assertion work — 1-3s each measured in isolation.
-// That fits the 10s default alone but not under the full suite, where ~1000 test
-// files compete for CPU and the slowest of these crosses the line; which one
-// crosses varies per run, so it presents as an unattributable flake.
-//
-// Raised for this file only. A global testTimeout bump would buy the same green
-// by hiding genuinely-hung tests everywhere else.
-vi.setConfig({ testTimeout: 60_000 });
 
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/scripts/checks/check-e2e-selectors.sh
+++ b/scripts/checks/check-e2e-selectors.sh
@@ -234,7 +234,7 @@ printf "${BOLD}▸ Checking aria-label changes vs E2E selectors${RESET}\n"
 
 # Extract aria-label values used in E2E (from { name: "..." } or { name: /.../ })
 e2e_aria_names=$(grep -rohE 'name:[[:space:]]*["'"'"'/][^"'"'"'/]+["'"'"'/]' "$E2E_DIR/" \
-  | sed -E "s/name:\s*[\"'/]//; s/[\"'/]$//" \
+  | sed -E "s/name:[[:space:]]*[\"'/]//; s/[\"'/]$//" \
   | grep -v '|' \
   | sort -u || true)
 
@@ -335,7 +335,7 @@ printf "${BOLD}▸ Checking i18n value changes vs E2E regex selectors${RESET}\n"
 i18n_removed_ja=$(git diff "${BASE}...HEAD" -- 'messages/ja/*.json' \
   | grep -E '^\-\s*"[^"]+"\s*:\s*"' \
   | grep -v '^\-\-\-' \
-  | sed -E 's/^\-\s*"[^"]+"\s*:\s*"([^"]+)".*/\1/' \
+  | sed -E 's/^\-[[:space:]]*"[^"]+"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' \
   | sort -u || true)
 
 if [ -n "$i18n_removed_ja" ] && [ -d "$E2E_DIR" ]; then

--- a/scripts/checks/check-e2e-selectors.sh
+++ b/scripts/checks/check-e2e-selectors.sh
@@ -98,8 +98,8 @@ printf "${BOLD}▸ Checking CSS class selectors in E2E vs source changes${RESET}
 
 # Extract unique CSS class patterns from E2E locator() calls
 # Matches patterns like: .locator(".px-4.py-3") or .locator('.border.rounded-md')
-e2e_class_selectors=$(grep -roPhE '\.locator\(\s*["\x27](\.[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*)["\x27]' "$E2E_DIR/" 2>/dev/null \
-  | sed -E "s/.*\.locator\([\"']//; s/[\"']\)$//" \
+e2e_class_selectors=$(grep -rohE '\.locator\([[:space:]]*["'"'"'](\.[a-zA-Z0-9_-]+)+["'"'"']' "$E2E_DIR/" \
+  | sed -E "s/.*\.locator\([[:space:]]*[\"']//; s/[\"']$//" \
   | sort -u || true)
 
 # Get the full list of changed .tsx source files (reused by checks 2, 5, 6)
@@ -143,7 +143,7 @@ fi
 
 printf "${BOLD}▸ Checking data-testid attributes vs source changes${RESET}\n"
 
-e2e_testids=$(grep -roPhE "data-testid=[\"'][^\"']+[\"']" "$E2E_DIR/" 2>/dev/null \
+e2e_testids=$(grep -rohE "data-testid=[\"'][^\"']+[\"']" "$E2E_DIR/" \
   | sed -E "s/data-testid=[\"']//; s/[\"']$//" \
   | sort -u || true)
 
@@ -233,7 +233,7 @@ done
 printf "${BOLD}▸ Checking aria-label changes vs E2E selectors${RESET}\n"
 
 # Extract aria-label values used in E2E (from { name: "..." } or { name: /.../ })
-e2e_aria_names=$(grep -roPhE 'name:\s*["\x27/]([^"\x27/]+)["\x27/]' "$E2E_DIR/" 2>/dev/null \
+e2e_aria_names=$(grep -rohE 'name:[[:space:]]*["'"'"'/][^"'"'"'/]+["'"'"'/]' "$E2E_DIR/" \
   | sed -E "s/name:\s*[\"'/]//; s/[\"'/]$//" \
   | grep -v '|' \
   | sort -u || true)
@@ -267,7 +267,7 @@ fi
 printf "${BOLD}▸ Checking id attribute changes vs E2E selectors${RESET}\n"
 
 # Extract #id selectors from E2E (from locator("#foo") or page.locator("#foo"))
-e2e_ids=$(grep -roPhE '#[a-zA-Z][a-zA-Z0-9_-]+' "$E2E_DIR/" 2>/dev/null \
+e2e_ids=$(grep -rohE '#[a-zA-Z][a-zA-Z0-9_-]+' "$E2E_DIR/" \
   | sed 's/^#//' \
   | sort -u || true)
 
@@ -299,7 +299,7 @@ fi
 
 printf "${BOLD}▸ Checking data-slot attribute changes vs E2E selectors${RESET}\n"
 
-e2e_slots=$(grep -roPhE "data-slot=[\"'][^\"']+[\"']" "$E2E_DIR/" 2>/dev/null \
+e2e_slots=$(grep -rohE "data-slot=[\"'][^\"']+[\"']" "$E2E_DIR/" \
   | sed -E "s/data-slot=[\"']//; s/[\"']$//" \
   | sort -u || true)
 

--- a/scripts/checks/check-fail-closed-routes-have-test.sh
+++ b/scripts/checks/check-fail-closed-routes-have-test.sh
@@ -724,11 +724,17 @@ EOF
       # the offending `TOKEN<TAB>relpath` lines; the bash loop below then
       # iterates findings (usually zero), not every file. `FROZEN_STUB_EXEMPTIONS`
       # and `SETUP_FILE_SET` are passed in as newline sets for O(1) membership.
-      STUB_FINDINGS="$(awk -F'\t' \
-        -v root="$FIXTURE_ROOT/" \
-        -v exempt="$FROZEN_STUB_EXEMPTIONS" \
-        -v setups="$SETUP_FILE_SET" '
+      # `exempt` and `setups` are newline-separated sets. They are passed through
+      # the ENVIRONMENT rather than `-v`: POSIX awk processes escape sequences in
+      # a -v value, and BSD awk (macOS) rejects a raw newline there outright with
+      # "awk: newline in string", which surfaces as a non-zero exit under the
+      # pre-PR harness's `set -o pipefail`. gawk happens to tolerate it, so this
+      # only ever failed on macOS. ENVIRON is POSIX and does no such processing.
+      STUB_FINDINGS="$(AWK_EXEMPT="$FROZEN_STUB_EXEMPTIONS" AWK_SETUPS="$SETUP_FILE_SET" \
+        awk -F'\t' \
+        -v root="$FIXTURE_ROOT/" '
         BEGIN {
+          exempt = ENVIRON["AWK_EXEMPT"]; setups = ENVIRON["AWK_SETUPS"]
           n = split(exempt, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") EX[a[i]] = 1
           m = split(setups, b, "\n"); for (i = 1; i <= m; i++) if (b[i] != "") SU[b[i]] = 1
         }

--- a/scripts/checks/check-no-pipe-into-grep-q.sh
+++ b/scripts/checks/check-no-pipe-into-grep-q.sh
@@ -58,14 +58,25 @@ fi
 #     would reject `… | grep x | sort -m`, where -m is sort's and drains.
 #
 # The flag set was derived by measurement, not from the man page: with the
-# needle on line 1 and a body past the pipe buffer, `-q`, `--quiet`, `--silent`
-# and `-m1` all report the match as rc=141, while `-l` does not — so `-l` is
-# not a member and is deliberately absent.
+# needle on line 1 and a body past the pipe buffer, `-q`, `--quiet`, `--silent`,
+# `-m1` AND `-l` all report the match as rc=141.
+#
+# `-l` was previously excluded on a GNU-grep measurement, where it keeps draining
+# stdin and so does not invert. BSD grep (macOS) exits on first match and takes
+# SIGPIPE exactly like `-q` — re-measured at rc=141 on a 3 MB haystack. Since the
+# gate runs on both platforms, the member set is the UNION: excluding `-l` left
+# the guard under-covering on every macOS developer's machine.
+#
+# Non-members, also measured, so the widening stops here: `-c`, `-o`, `-n` all
+# return rc=0 on both platforms — they consume their input.
 detect_awk='
 function has_quiet(seg) {
   # Trailing digits so `-m1` (and `-im1`) match as well as `-m 1`.
-  return (seg ~ /(^|[ \t])-[A-Za-z]*[qm][A-Za-z]*[0-9]*([ \t]|=|$)/ ||
-          seg ~ /(^|[ \t])--(quiet|silent|max-count)([ \t]|=|$)/)
+  # `l` is in the cluster class alongside `q`/`m`, so `-ql`, `-il`, `-rl` match
+  # too. Case-sensitive by construction: `-L` (files-WITHOUT-match) is a
+  # different flag and is deliberately not a member.
+  return (seg ~ /(^|[ \t])-[A-Za-z]*[qml][A-Za-z]*[0-9]*([ \t]|=|$)/ ||
+          seg ~ /(^|[ \t])--(quiet|silent|max-count|files-with-matches)([ \t]|=|$)/)
 }
 # Walks the logical line once, tracking quote state, and splits it into
 # commands at UNQUOTED operators. Each grep that a single pipe feeds is then

--- a/scripts/checks/check-tls-fixture-expiry.sh
+++ b/scripts/checks/check-tls-fixture-expiry.sh
@@ -37,6 +37,39 @@ CHECKEND_DAYS="${TLS_FIXTURE_CHECKEND_DAYS:-30}"
 # wrong-passphrase (unreadable) branch.
 export TLS_FIXTURE_PASS="${TLS_FIXTURE_PASS:-passwd-sso-test}"
 
+# Resolve an openssl that can read these fixtures.
+#
+# macOS ships LibreSSL as /usr/bin/openssl, and LibreSSL has no `-legacy` flag —
+# which these p12 files need, because they use the RC2 encryption OpenSSL 3
+# moved to the legacy provider. With LibreSSL first on PATH the extraction below
+# fails and the gate reports TLS_FIXTURE_UNREADABLE against perfectly healthy
+# fixtures. That is a false alarm on the developer's PATH, not a fixture
+# problem, and it should not depend on each developer having ordered their PATH
+# a particular way.
+#
+# Prefer an openssl whose `pkcs12` accepts `-legacy`; fall back to whatever is
+# on PATH so a GNU/CI environment (OpenSSL 3 as `openssl`) is unaffected.
+OPENSSL_BIN=""
+for candidate in openssl /opt/homebrew/opt/openssl@3/bin/openssl /usr/local/opt/openssl@3/bin/openssl; do
+  command -v "$candidate" >/dev/null 2>&1 || continue
+  # Capture first, then match on the variable. Piping into `grep -q` is the
+  # SIGPIPE-under-pipefail shape check-no-pipe-into-grep-q.sh forbids: grep exits
+  # on the first match while the writer is still writing, and the writer's 141
+  # becomes the pipeline's status.
+  help_out="$("$candidate" pkcs12 -help 2>&1 || true)"
+  if grep -q -- '-legacy' <<<"$help_out"; then
+    OPENSSL_BIN="$candidate"
+    break
+  fi
+done
+if [ -z "$OPENSSL_BIN" ]; then
+  echo "ERROR: no openssl with pkcs12 -legacy support found." >&2
+  echo "  These fixtures use RC2, which OpenSSL 3 gates behind the legacy provider" >&2
+  echo "  and LibreSSL (macOS /usr/bin/openssl) does not implement at all." >&2
+  echo "  Install OpenSSL 3 (macOS: brew install openssl@3) and re-run." >&2
+  exit 1
+fi
+
 checkend_secs=$(( CHECKEND_DAYS * 86400 ))
 fail=0
 found=0
@@ -52,7 +85,7 @@ for p12 in "$FIXTURE_ROOT"/tlsLeaf*.p12; do
   # as healthy. `|| true` here would re-hide exactly that, so the exit status is
   # captured explicitly instead.
   extract_ok=1
-  leaf_pem="$(openssl pkcs12 -in "$p12" -nokeys -clcerts \
+  leaf_pem="$("$OPENSSL_BIN" pkcs12 -in "$p12" -nokeys -clcerts \
     -passin env:TLS_FIXTURE_PASS -legacy 2>/dev/null)" || extract_ok=0
 
   if [ "$extract_ok" -eq 0 ] || [ -z "$leaf_pem" ]; then
@@ -62,11 +95,11 @@ for p12 in "$FIXTURE_ROOT"/tlsLeaf*.p12; do
     continue
   fi
 
-  if printf '%s\n' "$leaf_pem" | openssl x509 -checkend "$checkend_secs" -noout >/dev/null 2>&1; then
-    enddate="$(printf '%s\n' "$leaf_pem" | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)"
+  if printf '%s\n' "$leaf_pem" | "$OPENSSL_BIN" x509 -checkend "$checkend_secs" -noout >/dev/null 2>&1; then
+    enddate="$(printf '%s\n' "$leaf_pem" | "$OPENSSL_BIN" x509 -noout -enddate 2>/dev/null | cut -d= -f2)"
     echo "TLS_FIXTURE_OK: $name valid past ${CHECKEND_DAYS}d (until ${enddate})"
   else
-    enddate="$(printf '%s\n' "$leaf_pem" | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)"
+    enddate="$(printf '%s\n' "$leaf_pem" | "$OPENSSL_BIN" x509 -noout -enddate 2>/dev/null | cut -d= -f2)"
     echo "TLS_FIXTURE_EXPIRING: $name expires within ${CHECKEND_DAYS}d (at ${enddate:-unknown})" >&2
     echo "    Regenerate with: ios/scripts/generate-tls-test-fixtures.sh" >&2
     fail=1

--- a/scripts/checks/check-tls-fixture-expiry.sh
+++ b/scripts/checks/check-tls-fixture-expiry.sh
@@ -51,14 +51,20 @@ export TLS_FIXTURE_PASS="${TLS_FIXTURE_PASS:-passwd-sso-test}"
 # on PATH so a GNU/CI environment (OpenSSL 3 as `openssl`) is unaffected.
 OPENSSL_BIN=""
 for candidate in openssl /opt/homebrew/opt/openssl@3/bin/openssl /usr/local/opt/openssl@3/bin/openssl; do
-  command -v "$candidate" >/dev/null 2>&1 || continue
+  # Store the ABSOLUTE path, not the candidate as written. The first candidate is
+  # a bare name, and the self-test drives this gate with a stub `openssl` first on
+  # PATH — a bare name would resolve back to that stub when the stub delegates,
+  # recursing until the process dies. Linux hits it (bare name wins there);
+  # macOS does not (resolution lands on the Homebrew absolute path).
+  candidate_path="$(command -v "$candidate" 2>/dev/null)" || continue
+  [ -n "$candidate_path" ] || continue
   # Capture first, then match on the variable. Piping into `grep -q` is the
   # SIGPIPE-under-pipefail shape check-no-pipe-into-grep-q.sh forbids: grep exits
   # on the first match while the writer is still writing, and the writer's 141
   # becomes the pipeline's status.
-  help_out="$("$candidate" pkcs12 -help 2>&1 || true)"
+  help_out="$("$candidate_path" pkcs12 -help 2>&1 || true)"
   if grep -q -- '-legacy' <<<"$help_out"; then
-    OPENSSL_BIN="$candidate"
+    OPENSSL_BIN="$candidate_path"
     break
   fi
 done

--- a/scripts/checks/check-worker-bundle-smoke.sh
+++ b/scripts/checks/check-worker-bundle-smoke.sh
@@ -32,7 +32,16 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 # invocation from the Dockerfile, joining its backslash-continued lines into one.
 # Using the Dockerfile as the source of truth means a change to the bundle format
 # (e.g. adding --format=esm) is re-smoke-tested automatically.
-mapfile -t ESBUILD_CMDS < <(
+# Collected with `while read` rather than `mapfile`: macOS ships bash 3.2, where
+# mapfile/readarray do not exist, and this gate runs from the local pre-PR hook as
+# well as from CI. An esbuild invocation cannot contain a newline (it is one
+# logical line, already joined by the awk below), so IFS= read -r round-trips it
+# without loss.
+ESBUILD_CMDS=()
+while IFS= read -r _cmd; do
+  [ -z "$_cmd" ] && continue
+  ESBUILD_CMDS+=("$_cmd")
+done < <(
   awk '
     /npx esbuild scripts\/.*-worker\.ts/ { collecting=1; line="" }
     collecting {

--- a/scripts/checks/check-worker-bundle-smoke.sh
+++ b/scripts/checks/check-worker-bundle-smoke.sh
@@ -66,6 +66,23 @@ fi
 # opening a connection.
 FAKE_DB_URL="postgresql://app:app@127.0.0.1:5432/passwd_sso"
 
+# `timeout` is GNU coreutils and is NOT present on stock macOS; Homebrew installs
+# it as `gtimeout` (and as `timeout` when coreutils is linked). Resolve it, and
+# refuse if neither exists rather than letting the boot run unbounded — or, worse,
+# letting a missing binary surface as exit 127, which this gate would report as
+# "the shipped artifact does not boot". A missing tool is a gate that could not
+# run, not a failing subject.
+TIMEOUT_BIN=""
+for candidate in timeout gtimeout; do
+  if command -v "$candidate" >/dev/null 2>&1; then TIMEOUT_BIN="$candidate"; break; fi
+done
+if [ -z "$TIMEOUT_BIN" ]; then
+  echo "ERROR: neither 'timeout' nor 'gtimeout' is on PATH."
+  echo "This gate bounds each worker boot so a hang cannot stall the run."
+  echo "Install GNU coreutils (macOS: brew install coreutils) and re-run."
+  exit 1
+fi
+
 fail=0
 for raw in "${ESBUILD_CMDS[@]}"; do
   # Normalise whitespace and strip the leading `npx ` so we invoke the repo-local
@@ -104,7 +121,7 @@ for raw in "${ESBUILD_CMDS[@]}"; do
   # COPYed alongside the bundle; NODE_PATH reproduces that reachability here.
   echo "  booting $(basename "$bundle") --validate-env-only"
   set +e
-  out="$(timeout 30 env \
+  out="$("$TIMEOUT_BIN" 30 env \
     NODE_ENV=production \
     NODE_PATH="$REPO_ROOT/node_modules" \
     RETENTION_GC_DATABASE_URL="$FAKE_DB_URL" \

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -500,11 +500,20 @@ run_step "Static: no-authjs-builtin-webauthn-provider" bash -c '
   # Anchor the match with a closing string-delimiter so future siblings like
   # @auth/core/providers/webauthn-safe (or webauthn2) do not get caught by a
   # prefix-loose pattern. The two literal provider paths below are exactly
-  # the v9-shape ones we keep dead-coded. Delimiters in the character class
-  # are spelled as hex escapes so the regex survives nested bash -c quoting:
-  # \x22 = ", \x27 = single quote, \x60 = backtick.
-  if grep -rPn --include="*.ts" --include="*.tsx" \
-    "@auth/core/providers/(passkey|webauthn)[\x22\x27\x60]" \
+  # the v9-shape ones we keep dead-coded.
+  #
+  # POSIX ERE, not PCRE: grep -P does not exist on BSD grep (macOS), where it
+  # exits 2 — and the "if grep ...; then <fail>; fi" shape reads that as
+  # "no match", so this gate printed PASS while never running.
+  #
+  # ERE has no hex escape, so \x22/\x27/\x60 would match the LETTERS x,2,7,6,0 and
+  # the anchor would silently become a no-op. The delimiters must be real
+  # characters — and because this whole block is inside bash -c with a
+  # single-quoted body, a literal single quote cannot appear anywhere in it,
+  # comments included. Q carries the quote in via printf \047.
+  Q=$(printf "\047")
+  if grep -rEn --include="*.ts" --include="*.tsx" \
+    "@auth/core/providers/(passkey|webauthn)[\"${Q}\`]" \
     src/; then
     echo "ERROR: @auth/core builtin WebAuthn provider imports are forbidden (C21/C10)."
     echo "These providers still pin @simplewebauthn/server@^9 and are incompatible"

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,5 +1,19 @@
-import { vi, beforeEach, afterEach } from "vitest";
+import { vi, beforeEach, afterEach, expect } from "vitest";
 import { _resetKeyProvider, getKeyProvider } from "@/lib/key-provider";
+
+// Gate self-tests under scripts/__tests__/ shell out to real processes — node,
+// bash, npx tsx, eslint, openssl — so their cost is subprocess startup, not
+// assertion work. Measured in isolation they run 1-3s against the 10s default,
+// which is ample alone and not under the full suite, where ~1000 test files
+// compete for CPU. The symptom is a contention flake that picks a different
+// file each run, so budgeting them one at a time only moves the failure.
+//
+// Scoped to that directory rather than raised globally: the src/ suites are
+// in-process and a hang there is a real defect that should surface as a
+// timeout, which a global bump would mask.
+if (expect.getState().testPath?.includes("/scripts/__tests__/")) {
+  vi.setConfig({ testTimeout: 60_000 });
+}
 
 // Passthrough mock for withRequestLog — prevents wrapper from accessing
 // request.headers when tests call handlers without arguments.


### PR DESCRIPTION
## Summary

The pre-PR gate blocked a macOS push with 2 gate failures and 13 test failures. Fixing them turned up something worse than the blockage: **four security gates were reporting green while running nothing at all**, and one credential guard was allowing exactly what it exists to block.

Every defect is a GNU-vs-BSD tooling difference. CI runs `ubuntu-latest` (bash 5, gawk, GNU grep) and is green on all of it; macOS ships bash 3.2.57, BSD awk and BSD grep, where each construct degrades to "no opinion" rather than an error — so the gate passes and nobody looks again.

### Gates that were inert

| Gate | What it did | Proven by |
|---|---|---|
| `check-fail-closed-routes-have-test.sh` | `awk -v` with a newline-separated set; BSD awk aborts before the check runs | Adding `vi.mock("@/lib/security/rate-limiters")` to a setup file is reported after the fix, **not detected** before |
| `pre-pr.sh` webauthn-provider | `grep -rPn`; BSD grep exits 2, `if grep …; then <fail>; fi` reads that as "no match" and prints ✓ PASS | Planting a forbidden `@auth/core` import: 61/61 before, **60/1** after |
| `check-e2e-selectors.sh` | Five PCRE extractions wrapped `2>/dev/null … \|\| true` — diagnostic and status both erased | Printed "No E2E selector issues detected" while capturing **0 of 159** selectors |
| `block-bare-decrypt.sh` | `! grep -qP …` inverted exit-2 into "not a decrypt command" | Bare decrypt exited **0 (allowed)** |

### The credential guard

That last one blocks a vault decrypt whose stdout lands in the AI's transcript, so it took several rounds of review to get right. Each round found a real defect in my previous attempt:

1. **Fail-open on `grep -P`** — an unusable matcher was read as "no match".
2. **Then it refused everything**, including the `/use-credential` skill it points users toward — a guard that blocks the sanctioned path is broken, not strict.
3. **Trivially bypassable** — `(<cli> <sub> x)` and `<cli> <sub> x | cat` both satisfied the "subshell or pipe" heuristics while printing the credential.
4. **Decoy capture** — `(_CRED=$(true); <cli> <sub> item)` passed, because the allow was anchored on unrelated features of the line rather than on the decrypt itself.
5. **Existential, not universal** — the check asked "does a safe form exist?", so `_CRED=$(<cli> <sub> safe); <cli> <sub> exposed` passed on the safe one. A decoy inside a string literal, which never runs, was also enough.
6. **Sink matched by name** — `xclip -filter` and `xsel --output` write stdin back to stdout, so the credential reached the transcript through a sanctioned-looking pipe.

It now counts occurrences, requires exactly one, judges *that* one, and pins each clipboard sink to its documented argument shape. All five `/use-credential` patterns (A–E) work; every shape above is refused.

### Blockers

- **`mapfile`** is bash 4+; replaced with `while read`. Five other scripts mention it only in comments explaining they avoid it — this was the one real use.
- **`$(case … ;; … esac)`** cannot be parsed by bash 3.2, so the deploy-rollback `aws` stub never ran and its 10 assertions failed on unrelated-looking messages.
- **`grep -l`** was excluded from the pipe-into-grep-q member set on a GNU measurement. BSD grep exits on first match and takes SIGPIPE like `-q` — re-measured at rc=141. The gate runs on both platforms, so the member set has to be the union.

## Docs

`machine-identity.md` claimed credentials "never appear in Claude's context" and listed the AI as never seeing plaintext — resting on a hook the same file now describes as evadable. Corrected to separate the guarantees by strength:

- **Cryptographic:** the server never holds plaintext. Unchanged, and deliberately not weakened.
- **Convention + lint:** plaintext stays out of the model's context when the documented pattern is followed. The model the hook constrains is also the party writing the command.

The `Agent ↔ Hook` boundary label was also wrong on two counts, both verified against `agent-decrypt.ts`: the hook never opens the socket (the CLI's decrypt command does), and `0600` separates **OS users**, not client types — `handleConnection` authorizes on a `clientId` from the request payload and never authenticates the caller. "Other MCP clients cannot decrypt" is product status, not a guarantee.

## Test plan

- `scripts/__tests__/`: **1639 passed, 0 failed** (was 13 failing), twice consecutively
- `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh`: **61 passed, 0 failed**, with no PATH manipulation
- New `block-bare-decrypt-hook.test.mjs`: **30 cases**, previously verified only in commit messages

Every fix proven able to fail, on scratch copies, production files never left mutated:

| Mutation | Result |
|---|---|
| plant a forbidden `@auth/core` import | 61 → 60/1, names the file |
| break the decrypt hook's matcher | `BLOCKED: … could not evaluate its matcher` instead of allowing |
| remove a class from source that E2E references | warns, naming the three E2E files |
| disable `deploy.sh`'s compensating rollback | 4 of 11 deploy tests redden |
| drop `-l` from the grep-q member set | 1 test reddens (under-coverage) |
| add `-c` to it | 2 tests redden (over-coverage) |
| remove the hook's occurrence count | 1 test reddens |
| revert sinks to name-only matching | 3 tests redden |

The grep-q member set is bounded in both directions, not merely widened: `-c`, `-o`, `-n` are measured non-members with their own test, so a later edit cannot keep adding flags with nothing to say it went too far.

Three known hook evasions (quoted, split, variable-passed subcommand) are pinned as **ALLOW on purpose** — they are the evidence for the lint-not-boundary claim, with a note that a flip to BLOCK means the scope statement needs revising rather than the expectation.

## Two traps worth recording

A naive `-P`→`-E` swap leaves `\x22\x27\x60` in the character class. ERE has no hex escape, so the delimiter anchor silently matches the letters `x,2,7,6,0` — the same no-op in a new spelling.

That gate's body lives inside `bash -c '…'`, so an apostrophe in a **comment** closes the string and breaks the script. I hit that while writing the comment explaining the first trap.

## Corrections to my own claims

- I described the awk defect as "silently exited 0". Measured, it exits **2** — a loud fail-closed that reads as a broken harness. The detection claim held; the exit-code claim did not.
- A review finding called the foreign-registry deploy test vacuous. It is not: `deploy.sh` rejects the argument shape at `deploy.sh:166` before any AWS call, so it legitimately never reaches the stub. Added a positive assertion with a comment saying what it does and does not prove.

## One more tool resolution, found by installing the prerequisite

The TLS fixture gate reported `TLS_FIXTURE_UNREADABLE` against healthy fixtures, and I had recorded that as a macOS limitation. That was wrong on the second half: OpenSSL 3 was already installed and `/usr/bin/openssl` (LibreSSL 3.3.6) simply won the PATH lookup. The fixtures read fine and are valid until 2027-08-15.

So it was the same defect as `timeout` — a gate depending on how a developer ordered their PATH — and it is now resolved the same way: probe candidates for `pkcs12 -legacy`, refuse with the install command if none has it. Verified against a LibreSSL-only PATH. The self-test needed it too, since it *generates* its fixtures with `-legacy`; that failure predates this branch.

Three things my own change broke there, all caught by running rather than reading:

- The self-test injects a stub `openssl` on PATH to drive one branch. My capability probe called `pkcs12 -help`, the stub did not answer it, so the gate skipped the stub and resolved a real binary — silently defeating the test.
- The probe was `… | grep -q -- '-legacy'`, which `check-no-pipe-into-grep-q` flagged immediately: the exact SIGPIPE-under-pipefail shape this branch exists to fix. Captured first, matched with a herestring, per the gate's own advice.
- **The resolver stored the candidate as written, and the first candidate is the bare name `openssl`.** On Linux that one wins, so the stub's `exec "${OPENSSL}" "$@"` would resolve back through a PATH headed by the stub directory — infinite recursion. macOS hides it completely: LibreSSL fails the `-legacy` probe, so resolution falls through to the Homebrew absolute path. Both resolvers now store `command -v` output.

That last one is the mirror image of this whole PR. The branch exists because CI is green on defects that only bite macOS; here I wrote one that only bites Linux, on the platform I cannot run. It was reproduced with a self-delegating stub, then verified by simulating the Linux condition — a bare `openssl` on PATH that *does* support `-legacy` — where the self-test now passes 5/5 instead of hanging. Verified in three environments: normal macOS PATH, LibreSSL-only PATH, and the simulated Linux PATH.

## Environment prerequisites — now cleared

With `libpq` installed, `PRE_PR_STATIC_ONLY=1 bash scripts/pre-pr.sh` is **61 passed / 0 failed with no PATH manipulation**, and `backup-db` is **237/237**. `pg_restore` was a genuine missing dependency; the openssl half was mine to fix and now is.

The one thing still not addressed is **machine oversubscription**: the subprocess-spawning suites got per-file budgets sized to measured work (1–3s each) rather than a global `testTimeout` bump, which would hide genuinely-hung tests everywhere else.

The durable fix for the whole defect class is a macOS CI runner. None exists, so this class is invisible to CI by construction and will recur silently — worth filing separately, as it is an infrastructure decision rather than a bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
