### PR TITLE
fix(extension): make the inline suggestion messages dismissible

### DIFF
--- a/docs/archive/review/extension-dropdown-dismiss-code-review.md
+++ b/docs/archive/review/extension-dropdown-dismiss-code-review.md
@@ -55,16 +55,19 @@ the step a future edit would break.
 
 ## Security Findings
 
-**F-Sec-1 — Minor (question) — ANSWERED, deferred as SC7.** `outsideClickHandler` is
-assigned inside a `requestAnimationFrame` callback, but `hideDropdown()` removes it only
+**F-Sec-1 — Minor (question) — deferred as SC7 in this round, then FIXED in Round 2 after
+its premise was refuted. See R2-F2 below.** `outsideClickHandler` is assigned inside a
+`requestAnimationFrame` callback, but `hideDropdown()` removes it only
 `if (outsideClickHandler)`. A dismissal landing between `showDropdown()` returning and
 the rAF firing strands a capture-phase `mousedown` listener on `document` forever.
-**Pre-existing on `main`** (identical rAF and identical guard), and unreachable from the
-timer path — 5000 ms is three orders of magnitude beyond a frame. The reachable paths
-(`suppressInline`, SPA `navigationHandler`) are unchanged from `main`. Recorded as SC7
-with cost-justification rather than fixed, because the fix (`cancelAnimationFrame` plus a
-module-level handle) changes teardown semantics on all 18 external `hideDropdown()` call
-sites — wider than the defect being fixed, in a PR the user framed around three messages.
+**Pre-existing on `main`** (identical rAF and identical guard).
+
+This round deferred it on the argument that the timer path could not reach the window,
+"since 5000 ms is three orders of magnitude beyond a frame". **That argument was wrong** —
+it holds only while rAF is running, and Chrome pauses rAF in background tabs while timers
+keep running. Round 2 reproduced the stranding by probe and fixed it. The reasoning is
+left standing here rather than edited away, because the failure was in the reasoning, and
+hiding it would remove the only evidence of how the deferral got through.
 
 **F-Sec-2 — Minor — RESOLVED.** `hideDropdown` was passed bare to `setTimeout`, so it
 receives whatever arguments the host supplies. Harmless today (`hideDropdown(): void`
@@ -189,6 +192,7 @@ mutation count.
 ## Resolution Status
 
 ### F-Func-1 · Major · FR4's shadow-root-drain clause unpinned
+
 - Action: added T16 (`empties the shadow root, identically to a manual dismiss`), pinning
   auto-dismiss and manual paths against each other with an allow-side assertion. Corrected
   the plan's false FR4 claim.
@@ -197,10 +201,12 @@ mutation count.
 - Red-proof: mutation I (delete the `while (root.firstChild)` loop) ⇒ T16 fails, alone.
 
 ### F-Func-2 · Minor · D4 rationale omits the re-entrancy step
+
 - Action: deviation log D4 now names the `fn()` re-entrancy path as the deciding step.
 - Modified: `docs/archive/review/extension-dropdown-dismiss-deviation.md` (D4)
 
 ### F-Sec-1 · Minor · rAF listener-stranding window
+
 - Action: **Skipped — deferred as SC7** with Anti-Deferral cost-justification.
   Worst case: unbounded accumulation of capture-phase `document` listeners on an SPA that
   navigates repeatedly with an input focused; each adds one `composedPath()` per
@@ -211,11 +217,13 @@ mutation count.
   than the defect this PR fixes. Owner: a future teardown-lifecycle pass.
 
 ### F-Sec-2 · Minor · bare `hideDropdown` as `setTimeout` callback
+
 - Action: wrapped in an arrow, matching `save-banner.ts:84`.
 - Modified: `extension/src/content/ui/suggestion-dropdown.ts:155`
 - Red-proof: mutation E re-run after the change still reddens 3 tests (unchanged).
 
 ### F-Sec-3 · Minor `[Adjacent]` · `role="listbox"` auto-removal (WCAG 2.2.1)
+
 - Action: **Skipped — SC5 scope widened** to name the timing dimension. Worst case: a
   screen-reader user may still be hearing the message announced when it is removed at 5 s;
   affects the three message states only (the entries state arms no timer). Likelihood:
@@ -225,15 +233,18 @@ mutation count.
   a11y pass SC5 already names.
 
 ### F-Test-1 · Minor · `toFake` scoping unpinned
+
 - Action: added `does not install the outside-click listener while the clock advances`.
 - Modified: `extension/src/__tests__/content/ui/suggestion-dropdown.test.ts:277-292`
 - Red-proof: mutation J (bare `vi.useFakeTimers()`) ⇒ that test fails, alone.
 
 ### F-Test-2 · Minor · prove-red table understated mutation E
+
 - Action: corrected 2 → 3 and named the third test.
 - Modified: `docs/archive/review/extension-dropdown-dismiss-deviation.md` (prove-red table)
 
 ### F-Test-3 · Minor · constant absent from wholesale mocks
+
 - Action: added `MESSAGE_AUTO_DISMISS_MS` to both `vi.mock` factories.
 - Modified: `extension/src/__tests__/content/form-detector-inline.test.ts:14`,
   `extension/src/__tests__/content/cc-identity-detector.test.ts:16`
@@ -248,6 +259,79 @@ mutation count.
 | `npm run build` (extension) | clean, dist hygiene passed |
 | Contract greps | combined guard absent; 2 per-case guards; 3 `isTrusted` boundaries |
 | Worktree | clean — every mutation restored and verified |
+
+## Round 2 — external security review
+
+A follow-up security review of `origin/main...HEAD` raised two findings. It confirmed no
+credential leak, XSS, or authorization bypass. **Both findings were valid, and the second
+refuted a claim this review had made.**
+
+### R2-F1 — Medium — RESOLVED: a security notice could expire unseen
+
+The 5 s countdown ran regardless of `document.visibilityState`. A user who switched tabs
+immediately after the notice appeared would return to find "Vault locked" or "Not
+connected" already gone, never having read it. That matters more than ordinary UX here
+for the reason this change's own code comments give: these three messages are the only
+in-page signal that a dropdown is genuinely the extension's. Auto-expiring a genuine
+warning behind a background tab lowers the bar for a look-alike overlay.
+
+*Resolution:* the countdown now measures **visible time only**. `startVisibleCountdown()`
+disarms on `visibilitychange` → hidden, debits the elapsed visible span from `remaining`,
+and re-arms on return. The watcher is removed in `hideDropdown()` so a later visibility
+change cannot resurrect a timer for a dismissed dropdown.
+
+*Tests:* three (one per message state) asserting the notice survives an arbitrarily long
+hidden period and then expires on the *remaining* balance — with the boundary pinned on
+both sides — plus one asserting watcher removal. **Prove-red executed:** mutation L
+(revert to a plain `setTimeout`) reddens all four; mutation M (never remove the watcher)
+reddens all four.
+
+### R2-F2 — Low/Medium — RESOLVED: rAF-vs-timer inversion strands a document listener
+
+`outsideClickHandler` is assigned inside a `requestAnimationFrame` callback, while
+`hideDropdown()` removes it only `if (outsideClickHandler)`. Phase 3 had filed this as
+**SC7, deferred**, on the argument that the timer path could not reach the window because
+"5000 ms is three orders of magnitude beyond a ~16 ms frame."
+
+**That argument was wrong.** The frame-duration comparison only holds while rAF is
+running; Chrome pauses rAF in background tabs while timers keep running. So the ordering
+inverts, and the auto-dismiss is not merely *able* to beat the pending frame — it is the
+*expected* winner whenever a user tabs away from a message state, which is precisely the
+scenario R2-F1 is also about. The two findings compound.
+
+*Reproduced by probe* (fake `setTimeout`, real rAF — the hidden-tab ordering):
+`installed=1, removed=0`. A capture-phase `mousedown` listener survives on `document`
+with nothing able to remove it; on repeat shows they accumulate, and each one calls
+`hideDropdown()` — so a stale listener can dismiss a *later, legitimate* candidate list.
+
+*Resolution:* the frame handle is retained and `cancelAnimationFrame`d in
+`hideDropdown()`. SC7 is corrected from "deferred" to "resolved", with the refuted
+reasoning recorded rather than quietly replaced.
+
+*Tests:* the deny case (dismissal beats the frame ⇒ zero listeners installed) **and** the
+allow case (frame runs first ⇒ listener still installed — the cancellation must not
+disable outside-click). **Prove-red executed:** mutation K (drop the
+`cancelAnimationFrame`) reddens both, confirming the pair brackets the behaviour rather
+than only tightening it.
+
+### What this round changes about the record
+
+The Phase 3 SC7 deferral had a sound *cost* line and an unmeasured *likelihood* line. The
+cost of fixing was correctly assessed as touching teardown across all 18 external
+`hideDropdown()` call sites; what was wrong was the claim that the defect could not be
+reached. This is the same class of defect the plan documents elsewhere — a true
+conclusion resting on a false reason — and it is worth noting that it survived three
+expert reviews before an external one caught it.
+
+### Verification after Round 2
+
+| Gate | Result |
+| --- | --- |
+| `npx vitest run` (extension) | **1015 passed / 61 files** (+6 tests) |
+| `npx tsc --noEmit` | clean |
+| `npm run lint` (repo, `--max-warnings 0`) | clean |
+| `npm run build` (extension) | clean |
+| Prove-red | mutations K, L, M each redden their own tests, executed and observed |
 
 ## Round 2 assessment
 

--- a/docs/archive/review/extension-dropdown-dismiss-code-review.md
+++ b/docs/archive/review/extension-dropdown-dismiss-code-review.md
@@ -1,0 +1,259 @@
+# Code Review: extension-dropdown-dismiss
+
+Date: 2026-08-17
+Review round: 1
+
+## Changes from Previous Round
+
+Initial code review. Three expert sub-agents reviewed `git diff main...HEAD` in parallel,
+as incremental verification on top of the Phase 2 Step 2-5 self-R-check baseline (which
+had returned no code findings). Ollama was unavailable, so seed generation and
+`merge-findings` were both skipped — deduplication below is the documented manual
+fallback, joined by hand on the experts' JSON findings indexes.
+
+The testing expert ran **15 independent mutations** and the functionality expert ran
+several more, all against the real production file with scratchpad restore. Both
+verified the tree clean afterwards.
+
+## Summary
+
+8 findings: **1 Major, 7 Minor** (2 `[Adjacent]`). All resolved. No Critical.
+
+The Major is the notable one, and it is the same defect class this whole change is
+about: **a real behaviour with no test able to fail for it.**
+
+## Functionality Findings
+
+**F-Func-1 — Major — RESOLVED.** FR4's "shadow-root children are removed" clause was
+pinned by nothing, while the plan claimed all four clauses were pinned by T13 and
+T8/T11/T12. Those tests assert only `isDropdownVisible()` and `onDismiss` counts;
+`isDropdownVisible()` reads a module variable (`currentDropdown !== null`) and never
+inspects the shadow root.
+
+*Verified by execution, independently:* deleting the `while (root.firstChild)` drain
+loop from `hideDropdown()` left **all 1007 tests green**. The consequence is not
+cosmetic — `showDropdown` appends a fresh `<style>` and `.psso-dropdown` on every call,
+so a teardown that skips the drain stacks one stale dropdown per show. That is the
+reported bug made worse, and the only thing preventing it was an untested loop.
+
+*Resolution:* added **T16** — asserts the shadow root is drained after auto-dismiss
+**and** after a manual `hideDropdown()`, so the two paths are shown to agree rather than
+the timer path merely doing something. Allow side included (root non-empty while the
+dropdown is up), so the test cannot pass by the dropdown never rendering. VC2 does not
+block it: the test imports `getShadowHost()` directly rather than querying into the
+closed root. **Prove-red executed:** mutation I (delete the drain loop) reddens exactly
+T16 and nothing else. The plan's false FR4 sentence is corrected in the same change.
+
+**F-Func-2 — Minor — RESOLVED.** D4's equivalent-mutant conclusion was correct but its
+stated reason was incomplete: it argued from "one null-assignment site" and "arming
+happens after `currentDropdown` is set", which does not close the case, because
+`hideDropdown()` is re-entrant via `fn()` and that inner entry occurs *after*
+`currentDropdown` has been nulled — exactly the state D4 called unreachable. What
+actually decides it is one step further in (no timer is armed at that inner entry
+either). *Resolution:* the deviation log now names the re-entrancy step, since that is
+the step a future edit would break.
+
+## Security Findings
+
+**F-Sec-1 — Minor (question) — ANSWERED, deferred as SC7.** `outsideClickHandler` is
+assigned inside a `requestAnimationFrame` callback, but `hideDropdown()` removes it only
+`if (outsideClickHandler)`. A dismissal landing between `showDropdown()` returning and
+the rAF firing strands a capture-phase `mousedown` listener on `document` forever.
+**Pre-existing on `main`** (identical rAF and identical guard), and unreachable from the
+timer path — 5000 ms is three orders of magnitude beyond a frame. The reachable paths
+(`suppressInline`, SPA `navigationHandler`) are unchanged from `main`. Recorded as SC7
+with cost-justification rather than fixed, because the fix (`cancelAnimationFrame` plus a
+module-level handle) changes teardown semantics on all 18 external `hideDropdown()` call
+sites — wider than the defect being fixed, in a PR the user framed around three messages.
+
+**F-Sec-2 — Minor — RESOLVED.** `hideDropdown` was passed bare to `setTimeout`, so it
+receives whatever arguments the host supplies. Harmless today (`hideDropdown(): void`
+declares no parameters — verified, and a probe measured zero args passed), but it becomes
+live the moment `hideDropdown` gains an optional parameter. The sibling this change
+imitates, `save-banner.ts:84`, wraps its callback. *Resolution:* wrapped in an arrow.
+Mutation E re-run after the change still reddens 3 tests, so the wrap is red-proof-neutral.
+
+**F-Sec-3 — Minor `[Adjacent]` — DEFERRED, SC5 scope widened.** A `role="listbox"` that
+vanishes after 5 s without user action is a WCAG 2.2.1 (Timing Adjustable) concern on the
+screen-reader path. Unlike SC5's static `role` wart, this dimension *is* introduced here.
+Recorded against SC5, whose named owner (a future a11y pass) is unchanged.
+
+Security verification worth recording, all executed rather than inspected: the `Enter`
+`isTrusted` guard and `isSafeSelectClick` are **byte-identical to `main`** (`git show`
+comparison); the diff contains **zero `innerHTML` lines**, so sanitization is untouched;
+the new Escape guard genuinely closes both exposures it was added for, pinned in all four
+render states. The `ArrowDown` `defaultPrevented` oracle is pre-existing and this change
+*narrows* it (the new per-case guards return before `preventDefault` in message states).
+The timer cannot interfere with a fill: arming (message-only branches) and filling
+(`onSelect`, bound only to entries-branch items) are mutually exclusive by construction.
+
+## Testing Findings
+
+**F-Test-1 — Minor — RESOLVED.** The plan mandated a pin on the `toFake` scoping ("one
+auto-dismiss test asserts `document.addEventListener` was **not** called with
+`mousedown`"); that assertion was never written. *Verified by execution:* replacing the
+helper with a bare `vi.useFakeTimers()` left all 39 tests green — so the regression the
+plan wrote three paragraphs to prevent was invisible to the suite. *Resolution:* added
+that test. **Prove-red executed:** mutation J (bare `useFakeTimers()`) reddens exactly it.
+
+**F-Test-2 — Minor — RESOLVED.** The deviation log's prove-red table recorded mutation E
+as reddening 2 tests; the actual count is 3. The third is the test D4 says was kept on
+its own merit — evidence it earns its place. The count was taken before that test landed
+and not refreshed. *Resolution:* corrected, and the extra test named. This is a
+documentation-accuracy defect in the one record whose purpose is to state what was
+*observed*, which is D6's lesson exactly.
+
+**F-Test-3 — Minor — RESOLVED.** `MESSAGE_AUTO_DISMISS_MS` was absent from the three
+wholesale `vi.mock` factories. No live breakage (no detector imports it — verified), but
+latent drift: the day one does, the mock returns `undefined` and fails far from its
+cause. *Resolution:* added to both factories.
+
+**The headline testing result: no vacuous test was found among the 39.** Given that
+vacuity is this change's central risk — the original bug and two plan-review Criticals
+were all of that class — that conclusion, established by 15 mutations rather than by
+reading, is the most load-bearing thing in this review. Also cleared by execution: each
+of the three `isMessageOnly` branches carries its own coverage (1/2/3 tests reddened
+individually); the ArrowUp per-case guard is independently pinned (3 tests); RT8 is
+satisfied (return value and mutation pinned separately); RT11 holds under three shuffle
+seeds.
+
+## Adjacent Findings
+
+F-Sec-3 (a11y timing → SC5, deferred). The functionality expert also flagged D3's
+constant-derivation tension and the Escape `isTrusted` rationale as `[Adjacent]`; both
+were already resolved in Phase 2 and were confirmed sound.
+
+## Quality Warnings
+
+None. The `merge-findings` quality gate could not run (Ollama unavailable). Manual
+substitute: the Major finding was independently re-verified by execution before
+acceptance — I deleted the drain loop myself and observed 1007 green. Both new tests were
+prove-red executed against their own mutation and confirmed to redden nothing else.
+
+## Environment Verification Report
+
+Phase 1 declared three constraints (VC1-VC3). Classification per contract:
+
+| Path | Classification | Basis |
+| --- | --- | --- |
+| C1 all acceptance criteria | `verified-CI` | `npx vitest run` in `extension/` — 1009 passed / 61 files |
+| C2 timer criteria incl. T13/T16 | `verified-CI` | Same run; fake timers with scoped `toFake`, now itself pinned |
+| C2 real-browser confirmation (M1-M5) | `blocked-deferred` | **VC1** — no Playwright/headless-Chrome extension harness exists in this repo (re-verified this round). Manual test plan M1-M5 is executable locally by the developer; Anti-Deferral cost-justification at VC1 in the plan |
+| SC1 click-to-unlock | `blocked-deferred` | **VC3** — `chrome.action.openPopup()` gesture propagation unmeasured; Anti-Deferral entry at SC1 |
+| SC7 rAF listener-stranding window | `blocked-deferred` | New this round; Anti-Deferral entry at SC7, pre-existing on `main` and unreachable from the timer path |
+
+VC2 (closed Shadow DOM) was **not** limiting after all: T16 reaches the shadow root by
+importing `getShadowHost()` directly. The Phase 1 statement that VC2 constrains the
+*shape* of tests but not their power held up, and this round exercised it.
+
+## Recurring Issue Check
+
+### Functionality expert
+
+R1/R2 checked-clean (`MS_PER_SECOND` reused, constant named + exported). R8 (resource
+leak) **finding-raised** — F-Func-1's untested DOM-drain class. R18 (docs drift)
+**finding-raised** — the false FR4 sentence. R19 checked-clean (4 test files re-derived;
+`passkey-dropdown.test.ts` greps the symbol but is comment-only, not a consumer). R21
+checked-clean (tree verified clean after every mutation). R23/R28 checked-clean (the
+Escape return-value change is discarded by all three callers — verified by reading all
+three). R29 checked-clean (every citation and count re-run; table in the expert output).
+R42 checked-clean (both greps re-run at Phase 3, not carried forward). R43 checked-clean
+(`Enter` guard intact). R52 checked-clean. R57 **finding-raised** — F-Func-2, deviation
+rationale gap. Remainder n-a or checked-clean.
+
+### Security expert
+
+R10/RS3/RS6 checked-clean (zero `innerHTML` lines in the diff; `escapeHtml` wraps every
+interpolation). R16 checked-clean (vault-unlock race traced, benign in both orderings).
+R17 **finding-raised** — F-Sec-1, pre-existing rAF window. R27 **finding-raised** —
+F-Sec-3, a11y timing. R29 checked-clean (all greps and counts reproduced independently).
+R43/R44/R45 checked-clean (both `isTrusted` guards fail closed; three trust boundaries
+now aligned). R49 checked-clean (C1 fail-closed gate, C2 detection-only). R51
+checked-clean (`e.isTrusted` is interpreter-supplied, not a surface heuristic). R53
+checked-clean (Escape's oracle closed; ArrowDown's is pre-existing and narrowed). R54
+checked-clean (closed Shadow DOM, random-token host, visual-safety helpers unchanged; the
+timer *reduces* overlay dwell time). RS1/RS2/RS4/RS5 n-a.
+
+### Testing expert
+
+RT1/RT2 checked-clean. RT3 checked-clean (D3's pin resolves the derivation tension
+without over-coupling — one assertion against twelve derived usages). RT4
+**finding-raised** — F-Test-1, `toFake` unpinned. RT6 checked-clean. RT7 checked-clean
+(prove-red executed; 15 further mutations this round). RT8 checked-clean (cleared by
+three separate mutations). RT9 **finding-raised** — F-Test-3, mock drift. RT10
+checked-clean (every new guard has both sides: Escape trusted/untrusted × 4 states,
+ArrowDown/ArrowUp empty/populated, `isMessageOnly` message/entries). RT11 checked-clean
+(three shuffle seeds, no order dependence). R21 **finding-raised** — F-Test-2, stale
+mutation count.
+
+## Resolution Status
+
+### F-Func-1 · Major · FR4's shadow-root-drain clause unpinned
+- Action: added T16 (`empties the shadow root, identically to a manual dismiss`), pinning
+  auto-dismiss and manual paths against each other with an allow-side assertion. Corrected
+  the plan's false FR4 claim.
+- Modified: `extension/src/__tests__/content/ui/suggestion-dropdown.test.ts:301-320`,
+  `docs/archive/review/extension-dropdown-dismiss-plan.md` (FR4)
+- Red-proof: mutation I (delete the `while (root.firstChild)` loop) ⇒ T16 fails, alone.
+
+### F-Func-2 · Minor · D4 rationale omits the re-entrancy step
+- Action: deviation log D4 now names the `fn()` re-entrancy path as the deciding step.
+- Modified: `docs/archive/review/extension-dropdown-dismiss-deviation.md` (D4)
+
+### F-Sec-1 · Minor · rAF listener-stranding window
+- Action: **Skipped — deferred as SC7** with Anti-Deferral cost-justification.
+  Worst case: unbounded accumulation of capture-phase `document` listeners on an SPA that
+  navigates repeatedly with an input focused; each adds one `composedPath()` per
+  `mousedown`. No credential exposure — the stranded closure only calls `hideDropdown()`.
+  Likelihood: unreachable from the timer path this PR adds (5000 ms vs a ~16 ms frame);
+  reachable only via paths unchanged from `main`. Cost to fix: changes teardown semantics
+  across all 18 external `hideDropdown()` call sites, needing its own test matrix — wider
+  than the defect this PR fixes. Owner: a future teardown-lifecycle pass.
+
+### F-Sec-2 · Minor · bare `hideDropdown` as `setTimeout` callback
+- Action: wrapped in an arrow, matching `save-banner.ts:84`.
+- Modified: `extension/src/content/ui/suggestion-dropdown.ts:155`
+- Red-proof: mutation E re-run after the change still reddens 3 tests (unchanged).
+
+### F-Sec-3 · Minor `[Adjacent]` · `role="listbox"` auto-removal (WCAG 2.2.1)
+- Action: **Skipped — SC5 scope widened** to name the timing dimension. Worst case: a
+  screen-reader user may still be hearing the message announced when it is removed at 5 s;
+  affects the three message states only (the entries state arms no timer). Likelihood:
+  every screen-reader encounter with a message state. Cost to fix: an ARIA semantics
+  change (likely `role="status"` for message states) altering announcement behaviour, needing
+  screen-reader verification that VC1's constraint class also blocks. Owner: the future
+  a11y pass SC5 already names.
+
+### F-Test-1 · Minor · `toFake` scoping unpinned
+- Action: added `does not install the outside-click listener while the clock advances`.
+- Modified: `extension/src/__tests__/content/ui/suggestion-dropdown.test.ts:277-292`
+- Red-proof: mutation J (bare `vi.useFakeTimers()`) ⇒ that test fails, alone.
+
+### F-Test-2 · Minor · prove-red table understated mutation E
+- Action: corrected 2 → 3 and named the third test.
+- Modified: `docs/archive/review/extension-dropdown-dismiss-deviation.md` (prove-red table)
+
+### F-Test-3 · Minor · constant absent from wholesale mocks
+- Action: added `MESSAGE_AUTO_DISMISS_MS` to both `vi.mock` factories.
+- Modified: `extension/src/__tests__/content/form-detector-inline.test.ts:14`,
+  `extension/src/__tests__/content/cc-identity-detector.test.ts:16`
+
+## Verification after fixes
+
+| Gate | Result |
+| --- | --- |
+| `npx vitest run` (extension) | **1009 passed / 61 files** (+2 new tests) |
+| `npx tsc --noEmit` (extension) | clean |
+| `npm run lint` (repo, `--max-warnings 0`) | clean |
+| `npm run build` (extension) | clean, dist hygiene passed |
+| Contract greps | combined guard absent; 2 per-case guards; 3 `isTrusted` boundaries |
+| Worktree | clean — every mutation restored and verified |
+
+## Round 2 assessment
+
+Not run. Every finding is resolved or carries an Anti-Deferral entry; the only Major is
+fixed and red-proven. The two deferrals are Minor, `[Adjacent]`-class, pre-existing or
+a11y-scoped, with named owners. Both fixes that touched code were prove-red executed
+against their own mutation and confirmed to redden nothing else, and the full suite is
+green — so a Round 2 would be reviewing documentation edits and two tests whose failure
+modes have already been demonstrated.

--- a/docs/archive/review/extension-dropdown-dismiss-deviation.md
+++ b/docs/archive/review/extension-dropdown-dismiss-deviation.md
@@ -98,13 +98,44 @@ the dropdown module wholesale (R19 parallel-test-tree check).
 
 ## Verification
 
+All rows below were re-run against clean HEAD (`11fdca80`) after the mutation pass
+finished, not inferred from a run taken during it. See D6 for why that distinction is
+recorded rather than assumed.
+
 | Gate | Result |
 | --- | --- |
 | `npx vitest run` (extension) | 1007 passed / 61 files |
+| `npx vitest run` (repo root) | 14650 passed, 6 skipped / 1009 files |
 | `npx tsc --noEmit` (extension) | clean |
 | `npm run lint` (repo, `--max-warnings 0`) | clean |
+| `npm run build` (extension) | clean, dist hygiene check passed |
+| `npx next build` (repo) | Compiled successfully, 243/243 static pages |
 | Contract conformance greps (4 forbidden patterns) | all absent |
-| Files changed | 2 code + 2 docs — matches the Implementation Checklist exactly |
+| Files changed | 2 code + 2 docs in the implementation commit (plan, deviation); the review artifact landed in the plan commit |
+
+## D6 — A self-check agent observed a live mutation; recorded rather than dismissed
+
+The Phase 2-5 functionality self-check filed an R21 Major: it ran the extension suite
+and saw 3 failures with `MESSAGE_AUTO_DISMISS_MS = 5 * MS_PER_SECOND - 1` live in the
+tree — mutation D, mid-flight.
+
+**Assessment: a true observation of a transient state, not residue.** The agent was
+launched while the prove-red pass was still running, so its suite run fell inside a
+mutation's apply→restore window. The committed state was never affected:
+`git show HEAD:…/suggestion-dropdown.ts` reads `5 * MS_PER_SECOND`, and
+`git diff HEAD -- extension/` is empty. The agent itself observed the tree return to
+green at HEAD minutes later and said so.
+
+**The part that was a real defect**: gate rows were added to the table above while
+that window was open, and a "3 docs" file count was wrong. Both are corrected — every
+row re-run against clean HEAD, and the count fixed. The agent was right that a
+verification record must state what was observed at a known-clean revision rather than
+what was expected to be true.
+
+**Process lesson, since this is the second time the same shape appeared in this
+change**: do not run verification agents concurrently with a mutation pass that edits
+the tree they read. The prove-red pass is destructive by design and must own the
+worktree exclusively for its duration.
 
 No detector file was modified, no message file, no `.js` mirror — as FR6/NFR1/NFR2
 predicted.

--- a/docs/archive/review/extension-dropdown-dismiss-deviation.md
+++ b/docs/archive/review/extension-dropdown-dismiss-deviation.md
@@ -175,3 +175,25 @@ only tightening.
 **The lesson worth keeping**: SC7's cost line was right and its likelihood line rested on
 an assumption nobody measured. Three expert reviews passed over it. When a deferral turns
 on "this path is unreachable", the reachability claim needs a probe, not an argument.
+
+## D8 — Two optional visibility tests added after Round 2 approval
+
+The Round 2 security review approved the fix and noted two further cases as optional:
+"already hidden at show time" and "repeated hidden/visible round-trips". Both were added
+rather than skipped — the second in particular, because `remaining` is an accumulator and
+nothing else pinned its arithmetic across more than one cycle.
+
+Neither was accepted on the strength of passing. Prove-red:
+
+| Mutation | Reddens |
+| --- | --- |
+| N: `arm()` unconditionally, ignoring initial hidden state | the "already hidden" test, alone |
+| O: re-arm with the full interval instead of `remaining` | 4 tests incl. the existing hidden-state trio |
+| P: never debit elapsed visible time when hiding | 4 tests incl. the new round-trip test |
+
+The review's assessment that "the current implementation handles both correctly by
+construction" was right — the tests found no defect. They were still worth writing: the
+structure that makes both cases correct (`arm()` skipped when initially hidden; the
+`else if (autoDismissTimer === null)` branch starting the clock on first reveal) is
+exactly the kind of thing a later edit silently breaks, and mutation N shows the gap it
+would leave.

--- a/docs/archive/review/extension-dropdown-dismiss-deviation.md
+++ b/docs/archive/review/extension-dropdown-dismiss-deviation.md
@@ -1,0 +1,110 @@
+# Coding Deviation Log: extension-dropdown-dismiss
+
+## D1 — Timer arming moved out of the message branches (design refinement, not a contract change)
+
+**Plan text**: "Arming it in the three message branches rather than gating on
+`itemElements.length === 0` after the fact keeps the condition co-located with the
+branch that decides it."
+
+**As implemented**: each message branch sets a local `isMessageOnly = true`; the single
+`setTimeout` call sits after `currentDropdown` / `currentOnDismiss` / `currentOnSelect`
+are assigned.
+
+**Reason**: arming inside the branches would arm before `positionDropdown()` and
+`root.appendChild()` run. A throw in either would leave a live timer pointing at a
+dropdown that was never shown, and the timer would then fire `hideDropdown()` against
+unrelated state. The plan's stated *intent* — the decision lives with the branch that
+makes it — is preserved by the per-branch flag; only the arming point moved, to after
+the dropdown is actually live. I2.1 (armed iff message-only) is unaffected and is
+pinned by T10 plus mutation E.
+
+## D2 — Interval constant uses `MS_PER_SECOND`
+
+The plan said "a named module constant". Step 2-1's shared-utility inventory found
+`MS_PER_SECOND` at `extension/src/lib/time.ts:2`, already used by the auto-dismiss
+sibling (`save-banner.ts:7,11` → `15 * MS_PER_SECOND`). Implemented as
+`5 * MS_PER_SECOND` rather than a bare `5000`, per R1/R2 reuse. Not a deviation from
+intent; recorded because the plan named the constant without naming its unit source.
+
+## D3 — Added a test the plan did not list: the constant's value is pinned directly
+
+**Discovered by prove-red, and it is the reason the mutation pass exists.** Mutation D
+set the interval to `5 * MS_PER_SECOND - 1` and **no test failed**. Cause: T8/T9 derive
+their boundary from `MESSAGE_AUTO_DISMISS_MS` (RT3 — so they never drift from the
+shipped value), which means shrinking the constant moves the assertions with it. The
+two obligations are in genuine tension: importing the constant prevents drift but
+also prevents the tests from detecting a change to it.
+
+Resolution: keep the derived boundaries (RT3 satisfied) and add one test asserting
+`MESSAGE_AUTO_DISMISS_MS === 5000` directly. Re-ran mutation D: now reddens exactly
+that one test. Recorded because the plan's test list would have shipped an unpinned
+constant.
+
+## D4 — Mutation G is an equivalent mutant; no test was added for it
+
+The plan's I2.2 requires the timer clear be unconditional, not nested inside
+`if (currentDropdown)`. I mutated the code to nest it and **no test failed**. Rather
+than invent a test shape to force a failure, I checked reachability: `currentDropdown`
+is assigned `null` at exactly one place (`suggestion-dropdown.ts:188`), inside that same
+block, and the timer is armed only after `currentDropdown` is set (`:147`, `:154-156`).
+So `autoDismissTimer !== null && currentDropdown === null` is unreachable, and the
+nested form is **semantically equivalent** to the unconditional one — not an unpinned
+defect. An equivalent mutant cannot be killed by any test, and adding one that appeared
+to kill it would have been the vacuous-test defect this plan exists to avoid.
+
+Two speculative tests written during this investigation were reverted for exactly that
+reason. One was kept, on its own merit rather than as a mutation-killer: *"does not
+dismiss an entries dropdown put up by an onDismiss callback"* — it pins real behaviour
+(FR3 across the re-entrancy path) and passes honestly.
+
+The unconditional placement is retained regardless: it is the form that stays correct if
+a future edit arms a timer on a path where `currentDropdown` is null, and I2.2's real
+constraint (clear *before* the `fn()` re-entrancy point) **is** pinned — mutation F
+moves the clear after `fn()` and reddens two tests.
+
+## D5 — T13 fakes `requestAnimationFrame` deliberately, against the block default
+
+The plan mandates `toFake: ["setTimeout", "clearTimeout"]` for the auto-dismiss block so
+the outside-click listener is never installed mid-test. T13 is the one test that *needs*
+it installed — it asserts the listener is removed. It therefore adds
+`"requestAnimationFrame"` to its own `toFake` list and drives it with
+`vi.advanceTimersToNextFrame()`.
+
+An earlier attempt kept real timers for the rAF and switched to fake timers afterwards;
+that failed, because switching resets the clock and the already-armed `setTimeout` never
+fired under the new one. Recorded so the next reader does not retry it.
+
+## Prove-red results (Phase 2 obligation, all executed and observed)
+
+Each mutation was applied to a scratchpad-restored copy of the real file, the suite run,
+and the file restored from a pristine copy. No mutation was left in the tree — verified
+by `git diff --stat` after each.
+
+| Mutation | Reddens | Observed |
+| --- | --- | --- |
+| A: drop the Escape `isTrusted` guard | 4 tests (T15 ×3 states + entries state) | PASS |
+| B: trusted Escape returns false without dismissing | 4 tests (T1-T3 + T4) | PASS |
+| C: drop the `ArrowDown` per-case length guard | 3 tests (T5 ×3 states) | PASS |
+| D: interval `− 1` (before D3's fix) | **nothing — gap found** | fixed, see D3 |
+| D2: interval `− 1` (after D3's fix) | 1 test (constant value) | PASS |
+| E: arm the timer unconditionally | 2 tests (T10, T14) | PASS |
+| F: move the clear after the `fn()` re-entrancy point | 2 tests (T11, T14) | PASS |
+| G: nest the clear inside `if (currentDropdown)` | **nothing — equivalent mutant** | see D4 |
+| H: hand-rolled teardown in the timer callback | 1 test (T13) | PASS |
+
+Allow side, per the Remedy Floor: after every mutation-revert the full extension suite
+was re-run green — **1007 tests in 61 files**, including the three test files that mock
+the dropdown module wholesale (R19 parallel-test-tree check).
+
+## Verification
+
+| Gate | Result |
+| --- | --- |
+| `npx vitest run` (extension) | 1007 passed / 61 files |
+| `npx tsc --noEmit` (extension) | clean |
+| `npm run lint` (repo, `--max-warnings 0`) | clean |
+| Contract conformance greps (4 forbidden patterns) | all absent |
+| Files changed | 2 code + 2 docs — matches the Implementation Checklist exactly |
+
+No detector file was modified, no message file, no `.js` mirror — as FR6/NFR1/NFR2
+predicted.

--- a/docs/archive/review/extension-dropdown-dismiss-deviation.md
+++ b/docs/archive/review/extension-dropdown-dismiss-deviation.md
@@ -55,7 +55,20 @@ to kill it would have been the vacuous-test defect this plan exists to avoid.
 Two speculative tests written during this investigation were reverted for exactly that
 reason. One was kept, on its own merit rather than as a mutation-killer: *"does not
 dismiss an entries dropdown put up by an onDismiss callback"* — it pins real behaviour
-(FR3 across the re-entrancy path) and passes honestly.
+(FR3 across the re-entrancy path) and passes honestly. Phase 3 confirmed it earns its
+place independently: it is one of the three tests mutation E reddens.
+
+**Completing the reachability argument.** The two facts above — one null-assignment
+site, arming only after `currentDropdown` is set — are not sufficient on their own,
+because `hideDropdown()` is re-entrant through `fn()` at `:195`, and that inner entry
+happens *after* `:188` has already nulled `currentDropdown`. So the state D4 calls
+unreachable is in fact reached, on that path. What closes the argument is one step
+further in: at that inner entry no timer is armed either, since the outer clear has
+already fired and `showDropdown`'s own arm cannot have run yet. Verified by probe in
+Phase 2 and independently in Phase 3. Recorded because the re-entrancy step is the one
+a future edit would break — an `onDismiss` that arms a timer by some route other than
+`showDropdown` would make the nested form leak while the unconditional form stays
+correct, which is the second reason to keep the unconditional placement.
 
 The unconditional placement is retained regardless: it is the form that stays correct if
 a future edit arms a timer on a path where `currentDropdown` is null, and I2.2's real
@@ -87,7 +100,7 @@ by `git diff --stat` after each.
 | C: drop the `ArrowDown` per-case length guard | 3 tests (T5 ×3 states) | PASS |
 | D: interval `− 1` (before D3's fix) | **nothing — gap found** | fixed, see D3 |
 | D2: interval `− 1` (after D3's fix) | 1 test (constant value) | PASS |
-| E: arm the timer unconditionally | 2 tests (T10, T14) | PASS |
+| E: arm the timer unconditionally | 3 tests (T10, T14, and the onDismiss-reshow case) | PASS |
 | F: move the clear after the `fn()` re-entrancy point | 2 tests (T11, T14) | PASS |
 | G: nest the clear inside `if (currentDropdown)` | **nothing — equivalent mutant** | see D4 |
 | H: hand-rolled teardown in the timer callback | 1 test (T13) | PASS |

--- a/docs/archive/review/extension-dropdown-dismiss-deviation.md
+++ b/docs/archive/review/extension-dropdown-dismiss-deviation.md
@@ -152,3 +152,26 @@ worktree exclusively for its duration.
 
 No detector file was modified, no message file, no `.js` mirror — as FR6/NFR1/NFR2
 predicted.
+
+## D7 — SC7 reopened and fixed after an external security review refuted its premise
+
+Phase 3 deferred the rAF listener-stranding window as SC7, reasoning that the timer path
+could not reach it because 5000 ms ≫ one frame. A follow-up security review pointed out
+that this holds only while rAF is running: **Chrome pauses `requestAnimationFrame` in a
+background tab while timers keep running**, so the auto-dismiss becomes the *expected*
+winner of that race, not an impossible one.
+
+Reproduced by probe (fake `setTimeout`, real rAF — the hidden-tab ordering):
+`installed=1, removed=0`. Fixed by retaining the frame handle and cancelling it in
+`hideDropdown()`. The same review found the countdown ignored `visibilityState`, letting
+a "Vault locked" notice expire unread behind a switched-away tab — fixed by measuring
+visible time only.
+
+Six tests added, three mutations run (K: drop `cancelAnimationFrame`; L: revert to a
+plain timer; M: leak the visibility watcher), each reddening its own tests. Mutation K
+reddens the allow-side test too, confirming the pair brackets the behaviour rather than
+only tightening.
+
+**The lesson worth keeping**: SC7's cost line was right and its likelihood line rested on
+an assumption nobody measured. Three expert reviews passed over it. When a deferral turns
+on "this path is unreachable", the reachability claim needs a probe, not an argument.

--- a/docs/archive/review/extension-dropdown-dismiss-plan.md
+++ b/docs/archive/review/extension-dropdown-dismiss-plan.md
@@ -781,6 +781,56 @@ the unpacked build loaded in Chrome.
 7. **Credit-card and address forms.** Same as 1-2 on a checkout page — covered by
    the singleton, verified by M4.
 
+## Implementation Checklist
+
+Authored in Phase 2 Step 2-1 from impact analysis. Phase 3 reads this as the list of
+files that must appear in the diff.
+
+### Files to modify
+
+| File | Change |
+| --- | --- |
+| `extension/src/content/ui/suggestion-dropdown.ts` | Both production changes: per-case guard split with I1.4 untrusted-Escape denial; exported interval constant + timer arm/clear |
+| `extension/src/__tests__/content/ui/suggestion-dropdown.test.ts` | T1-T15; `disconnectedMessage` added to `makeOptions()` (`:39-54`); `isTrusted` assert inside `trustedKeydown()` (`:136-145`); `vi.useRealTimers()` into the file-level `afterEach` (`:60-63`) |
+
+**No detector file changes** — FR6's member-set derivation confirms the three
+detectors reach the fix through the singleton. **No message-file changes** (NFR2).
+**No `.js` mirror** (NFR1).
+
+### Shared utilities to reuse (R1 / R2)
+
+- `MS_PER_SECOND` from `extension/src/lib/time.ts:2` — the interval is
+  `5 * MS_PER_SECOND`, **not** a bare `5000`. This is the same idiom
+  `save-banner.ts:7,11` uses (`15 * MS_PER_SECOND`). Verified present.
+- `getShadowHost()` from `./shadow-host` — already imported; timer teardown routes
+  through the existing `hideDropdown()`, which already uses it. No new helper.
+- The existing `trustedKeydown()` Proxy helper in the test file — extend it with the
+  `isTrusted` self-assert rather than writing a second one.
+
+### Patterns to follow consistently
+
+- Timer handle typed `ReturnType<typeof setTimeout>`, bare `setTimeout`/`clearTimeout`
+  — matching `save-banner.ts:24,84,92`, the auto-dismiss sibling.
+- Clear-then-arm ordering, and clear before the `fn()` re-entrancy point (I2.2).
+- Every dismissal routes through `hideDropdown()`; no hand-rolled teardown (I2.3).
+
+### Test-tree enumeration (R19)
+
+`grep -rl` across all test roots for the four exported symbols returns four files:
+`suggestion-dropdown.test.ts`, `suggestion-dropdown-entrytype.test.ts`,
+`form-detector-inline.test.ts`, `cc-identity-detector.test.ts`. Only the first is
+modified; the other three mock the module wholesale and must be re-run unchanged to
+confirm no break. There is no co-located `*.test.ts` beside `src/content/ui/` and no
+e2e tree for the extension.
+
+### CI gate parity (Step 2-1 item 7)
+
+15 gates extracted from CI. Relevant to this diff: `npm run lint`, `npm run typecheck`,
+and the extension's own vitest suite. The remaining 12 gate server-side concerns
+(RLS, crypto domains, env docs, migration drift, TLS fixtures, licenses) that this
+extension-only diff cannot affect — no parity gap, no deferred-parity entry needed.
+`scripts/pre-pr.sh` exists and is the aggregate gate; run it before completion.
+
 ## Recurring-rule notes (pre-flagged for review)
 
 Raised proactively so reviewers can confirm rather than rediscover:

--- a/docs/archive/review/extension-dropdown-dismiss-plan.md
+++ b/docs/archive/review/extension-dropdown-dismiss-plan.md
@@ -96,8 +96,12 @@ kind. See `RT10` in §Recurring-rule notes.
   the outside-click listener is removed, shadow-root children are removed, and the
   `onDismiss` callback fires so each detector clears its per-detector state
   (`currentContext` for LOGIN; `activeInput` for CC and IDENTITY — see C3
-  Consumers 4a/4b). All four clauses are pinned: the first by T13, the rest by
-  T8/T11/T12.
+  Consumers 4a/4b). Clause-by-clause pinning: listener removal by T13; shadow-root
+  drain by T16; visibility flip and `onDismiss` by T8/T11/T12. **T16 was added in
+  Phase 3** — the first revision claimed T8/T11/T12 covered the drain, which was
+  false: `isDropdownVisible()` reads a module variable and never inspects the shadow
+  root, so deleting the drain loop left all 1007 tests green. See the Phase 3 code
+  review, F-Func-1.
 - **FR5** — Re-showing the dropdown (a new `showDropdown()` call) cancels any timer
   from the previous invocation. No orphaned timer may fire against a later dropdown.
 - **FR6** — The fix applies to all three detectors (LOGIN, CREDIT_CARD, IDENTITY)
@@ -741,7 +745,7 @@ the unpacked build loaded in Chrome.
   that alters screen-reader announcement behavior and needs its own manual
   verification with a screen reader, which VC1's constraint class also blocks. Cost
   of excluding = a pre-existing, unchanged a11y wart; this PR neither introduces nor
-  worsens it. Owner: a future a11y pass. Noted here rather than silently, per `R34`.
+  worsens it. Owner: a future a11y pass. Noted here rather than silently, per `R34`. **Widened in Phase 3 (F-Sec-3)**: a `listbox` that vanishes after 5 s with no user action is also a WCAG 2.2.1 (Timing Adjustable) concern on the screen-reader path. Unlike the static `role` wart, that dimension *is* introduced by FR2, so it is recorded here rather than carried silently; same owner, same cost-justification — the fix is an ARIA semantics change needing screen-reader verification, which VC1's constraint class also blocks.
 
 - **SC6 — `try`/`catch` around the `onDismiss` invocation.** Out of scope.
   `hideDropdown()` calls `fn()` at `:161-165` unwrapped, while the module's other two
@@ -755,6 +759,24 @@ the unpacked build loaded in Chrome.
   in a page event handler; all three current callbacks are single assignments that
   cannot throw, so the exposure is latent, not live. Owner: a future error-handling
   pass over the module. Verified: all three `onDismiss` bodies are bare assignments.
+
+- **SC7 — The rAF window that can strand the outside-click listener.** Out of scope.
+  `outsideClickHandler` is assigned inside a `requestAnimationFrame` callback, but
+  `hideDropdown()` removes it only `if (outsideClickHandler)`. A dismissal landing
+  between `showDropdown()` returning and the rAF firing therefore skips removal, and
+  the rAF then installs a capture-phase `mousedown` listener that no later
+  `hideDropdown()` will remove. **Pre-existing on `main`** — identical rAF, identical
+  guard — and raised here only because this change adds a fourth dismissal source to
+  that teardown (R52's shape). **Anti-Deferral**: worst case is unbounded accumulation
+  of `document` listeners on an SPA that navigates repeatedly with an input focused,
+  each adding a `composedPath()` call per `mousedown`; no credential exposure, since
+  the stranded closure only calls `hideDropdown()`. Likelihood from the path this PR
+  adds is nil — 5000 ms is three orders of magnitude beyond a ~16 ms frame — and the
+  reachable paths (`suppressInline`, SPA navigation) are unchanged from `main`. Cost of
+  including: `cancelAnimationFrame` plus a module-level frame handle changes teardown
+  semantics on all 18 external `hideDropdown()` call sites and needs its own test
+  matrix — wider than the defect being fixed. Owner: a future teardown-lifecycle pass.
+  Found in Phase 3 review (F-Sec-1).
 
 ### Risks
 

--- a/docs/archive/review/extension-dropdown-dismiss-plan.md
+++ b/docs/archive/review/extension-dropdown-dismiss-plan.md
@@ -760,23 +760,22 @@ the unpacked build loaded in Chrome.
   cannot throw, so the exposure is latent, not live. Owner: a future error-handling
   pass over the module. Verified: all three `onDismiss` bodies are bare assignments.
 
-- **SC7 — The rAF window that can strand the outside-click listener.** Out of scope.
-  `outsideClickHandler` is assigned inside a `requestAnimationFrame` callback, but
-  `hideDropdown()` removes it only `if (outsideClickHandler)`. A dismissal landing
-  between `showDropdown()` returning and the rAF firing therefore skips removal, and
-  the rAF then installs a capture-phase `mousedown` listener that no later
-  `hideDropdown()` will remove. **Pre-existing on `main`** — identical rAF, identical
-  guard — and raised here only because this change adds a fourth dismissal source to
-  that teardown (R52's shape). **Anti-Deferral**: worst case is unbounded accumulation
-  of `document` listeners on an SPA that navigates repeatedly with an input focused,
-  each adding a `composedPath()` call per `mousedown`; no credential exposure, since
-  the stranded closure only calls `hideDropdown()`. Likelihood from the path this PR
-  adds is nil — 5000 ms is three orders of magnitude beyond a ~16 ms frame — and the
-  reachable paths (`suppressInline`, SPA navigation) are unchanged from `main`. Cost of
-  including: `cancelAnimationFrame` plus a module-level frame handle changes teardown
-  semantics on all 18 external `hideDropdown()` call sites and needs its own test
-  matrix — wider than the defect being fixed. Owner: a future teardown-lifecycle pass.
-  Found in Phase 3 review (F-Sec-1).
+- **SC7 — RESOLVED, not deferred (was: the rAF listener-stranding window).** Phase 3
+  filed this as a deferral on the argument that the window was unreachable from the
+  timer path, "since 5000 ms is three orders of magnitude beyond a ~16 ms frame". **A
+  later security review refuted that reasoning, and it was wrong in the direction that
+  matters**: the frame-duration comparison only holds while rAF is *running*. Chrome
+  pauses `requestAnimationFrame` in a background tab while continuing to run timers
+  (throttled), so the ordering inverts — the auto-dismiss is not merely able to beat
+  the frame, it is the *expected* winner whenever the user switches tabs on a message
+  state. Reproduced by probe: dismissal first ⇒ `mousedown` capture listener installed
+  once, removed zero times.
+
+  Fixed rather than deferred: the frame handle is now retained and
+  `cancelAnimationFrame`d in `hideDropdown()`. Recorded here rather than silently
+  corrected, because the deferral's *cost* line was sound while its *likelihood* line
+  rested on an assumption nobody had measured — the same class of defect this plan
+  documents elsewhere (a true conclusion resting on a false reason).
 
 ### Risks
 

--- a/docs/archive/review/extension-dropdown-dismiss-plan.md
+++ b/docs/archive/review/extension-dropdown-dismiss-plan.md
@@ -40,6 +40,15 @@ clicks elsewhere, blurs the field, or navigates. They obscure page content direc
 beneath the focused input, and the ESC key — the reflex every user reaches for — does
 nothing. Make them dismissible by ESC and self-dismissing after 5 s.
 
+## Citation baseline
+
+**Every `file:line` reference in this plan is against `main` (pre-implementation).**
+The plan was written before the fix existed, and the fix moves the very lines it
+cites — `suggestion-dropdown.ts:174`, the guard this document is about, is now a
+different statement. Resolve citations with
+`git show main:extension/src/content/ui/suggestion-dropdown.ts`, not against HEAD.
+The deviation log cites post-implementation lines and says so at its own head.
+
 ## Problem statement (root cause, verified in source)
 
 `extension/src/content/ui/suggestion-dropdown.ts:174`:
@@ -479,11 +488,11 @@ complete.
 
 ## Go/No-Go Gate
 
-| ID  | Subject | Status |
+| ID | Subject | Status |
 | --- | --- | --- |
-| C1  | Escape dismisses in every render state (trusted events only); navigation guards preserved | locked |
-| C2  | 5 s auto-dismiss for message-only states; entries state exempt | locked |
-| C3  | Consumer-flow walkthrough for all seven consumers | locked |
+| C1 | Escape dismisses in every render state (trusted events only); navigation guards preserved | locked |
+| C2 | 5 s auto-dismiss for message-only states; entries state exempt | locked |
+| C3 | Consumer-flow walkthrough for all seven consumers | locked |
 
 All three were revised during Round 1 and re-locked: C1 gained I1.4 (untrusted-Escape
 denial), C2 gained the `fn()`-landmark restatement of I2.2 plus three new acceptance

--- a/docs/archive/review/extension-dropdown-dismiss-plan.md
+++ b/docs/archive/review/extension-dropdown-dismiss-plan.md
@@ -1,0 +1,803 @@
+# Plan: extension-dropdown-dismiss
+
+Fix the browser extension's inline suggestion dropdown so its three message-only
+states (no matches / vault locked / disconnected) can be dismissed: ESC must work,
+and the message must auto-dismiss after 5 s.
+
+## Project context
+
+- **Type**: web app (browser extension sub-package, `extension/`)
+- **Test infrastructure**: unit + integration (vitest, jsdom environment) + CI/CD
+  (`npx vitest run` and `npx next build` are the repo's mandatory gates; the
+  extension has its own vitest suite under `extension/src/__tests__/`)
+- **Verification environment constraints**:
+  - **VC1 — Real-browser inline-autofill behavior is not exercisable in CI.**
+    The suggestion dropdown lives in a content script inside a closed Shadow DOM,
+    injected into third-party pages. There is no Playwright/Puppeteer harness in
+    this repo for the extension, and no headless-Chrome extension-loading job in
+    CI. Classification of each contract's manual-test path is recorded per
+    contract below; paths that need a real browser are `blocked-deferred` for
+    automation and covered by the **manual test plan** (§Manual test plan), which
+    is executable by the developer locally.
+  - **VC2 — Closed Shadow DOM is unreachable from test code.** `shadow-host.ts:20`
+    attaches with `mode: "closed"`, so a test cannot query rendered text or class
+    names from outside the module. Assertions must therefore be made on the
+    module's exported observable surface (`isDropdownVisible()`, the `onDismiss`
+    callback, the return value of `handleDropdownKeydown`) rather than on DOM
+    content. This is a real limit on the shape of the tests, not on their power:
+    every contract below is stated in terms of that observable surface precisely
+    so it stays `verifiable-CI`. **Not deferred.**
+  - **VC3 — `chrome.action.openPopup()` gesture constraints are unmeasured.**
+    Whether a content-script-originated click can open the extension popup via a
+    background relay has not been probed in this environment. This is the sole
+    reason the click-to-unlock affordance is scoped out (see `SC1`), not deferred
+    silently. **Cost-justification recorded at `SC1`.**
+
+## Objective
+
+The three message-only dropdown states currently persist on screen until the user
+clicks elsewhere, blurs the field, or navigates. They obscure page content directly
+beneath the focused input, and the ESC key — the reflex every user reaches for — does
+nothing. Make them dismissible by ESC and self-dismissing after 5 s.
+
+## Problem statement (root cause, verified in source)
+
+`extension/src/content/ui/suggestion-dropdown.ts:174`:
+
+```ts
+export function handleDropdownKeydown(e: KeyboardEvent): boolean {
+  if (!currentDropdown || itemElements.length === 0) return false;
+```
+
+`itemElements` is populated **only** in the `else` branch that renders real entries
+(lines 88, 124). In all three message states — `disconnected` (67-71), `vaultLocked`
+(72-76), `entries.length === 0` (77-81) — `itemElements` is `[]`, so the guard
+returns `false` before control ever reaches `case "Escape"` at line 209.
+
+**ESC is therefore a no-op in exactly the three states the user reported, and only
+in those states.** The guard was written to protect the *navigation* cases
+(ArrowDown/ArrowUp/Enter index into `itemElements`), and Escape was swallowed as
+collateral. This is the whole bug for the ESC half.
+
+For the auto-dismiss half: `showDropdown()` registers no timer. Sibling overlays in
+the same codebase do — `save-banner.ts:11` (`AUTO_DISMISS_MS = 15 * MS_PER_SECOND`,
+armed at `:84-87`) and `form-detector-lib.ts:460-464` (inline notice, 2200 ms) — so
+an auto-dismiss timer is the established idiom here, not a new invention.
+
+### Why the existing test suite did not catch it
+
+`extension/src/__tests__/content/ui/suggestion-dropdown.test.ts:125-132` has a test
+named `dismisses with Escape` that passes. It uses the default `makeOptions()`
+fixture, which supplies **two entries** — so it exercises the item-rendering path,
+where `itemElements.length === 2` and the guard does not fire. The message-only
+states have no ESC test at all, and the `disconnected` branch has no test of any
+kind. See `RT10` in §Recurring-rule notes.
+
+## Requirements
+
+### Functional
+
+- **FR1** — ESC dismisses the dropdown in all four render states (the three message
+  states plus the entries state), not only the entries state.
+- **FR2** — The three message-only states auto-dismiss after 5000 ms.
+- **FR3** — The entries state does **not** auto-dismiss (a timer that fires while
+  the user is choosing a credential would be a regression). Confirmed as the
+  user's explicit choice.
+- **FR4** — Auto-dismiss runs the same teardown as every other dismissal path:
+  the outside-click listener is removed, shadow-root children are removed, and the
+  `onDismiss` callback fires so each detector clears its per-detector state
+  (`currentContext` for LOGIN; `activeInput` for CC and IDENTITY — see C3
+  Consumers 4a/4b). All four clauses are pinned: the first by T13, the rest by
+  T8/T11/T12.
+- **FR5** — Re-showing the dropdown (a new `showDropdown()` call) cancels any timer
+  from the previous invocation. No orphaned timer may fire against a later dropdown.
+- **FR6** — The fix applies to all three detectors (LOGIN, CREDIT_CARD, IDENTITY)
+  without per-detector changes, since all three call the same singleton.
+
+#### FR6 member-set derivation (R42)
+
+FR6 is universally quantified ("**all** detectors are covered by the singleton fix"),
+so the member set is code-derived rather than asserted. Commands and output, run from
+`extension/`:
+
+```console
+$ grep -rn 'showDropdown(' src --include='*.ts' --include='*.tsx' | grep -v '__tests__'
+src/content/identity-form-detector-lib.ts:421
+src/content/cc-form-detector-lib.ts:375
+src/content/form-detector-lib.ts:377
+src/content/ui/suggestion-dropdown.ts:53          ← the definition itself
+
+$ grep -rn 'handleDropdownKeydown' src --include='*.ts' | grep -v '__tests__'
+src/content/form-detector-lib.ts:15 (import), :526 (call)
+src/content/cc-form-detector-lib.ts:25 (import), :440 (call)
+src/content/identity-form-detector-lib.ts:26 (import), :484 (call)
+src/content/ui/suggestion-dropdown.ts:173         ← the definition itself
+```
+
+Member set = exactly the three detectors named in FR6. **No fourth consumer exists**,
+so the set the fix reaches equals the set the requirement quantifies over. Recomputed
+at plan time; Phase 3 must re-run both greps rather than carry these results forward.
+
+**Indirect members**: `hideDropdown` has 18 call sites outside its own module (6 in
+each detector). C2's timer-clearing therefore also runs on every one of those paths —
+blur, SPA navigation, successful fill, unsafe-page detection, teardown. That is the
+intended behavior (any dismissal cancels the timer, per I2.2) and requires no
+per-call-site change, but it is recorded here because it is the widest blast radius in
+the change and a reviewer should confirm it rather than infer it.
+
+### Non-functional
+
+- **NFR1** — No change to the plain-JS / `-lib.ts` mirroring contract.
+  `suggestion-dropdown.ts` is a plain TS module under the CRXJS-bundled entry
+  (`src/content/form-detector.ts`, declared in `manifest.config.ts:63-70`), **not**
+  a `web_accessible_resources` file. The plain-JS restriction that governs
+  `token-bridge.js` / `webauthn-interceptor.js` does not apply, so no `.js` mirror
+  and no sync test are involved. Verified against `manifest.config.ts:71-76`.
+- **NFR2** — No new i18n keys. The strings already exist
+  (`contentScript.vaultLocked`, `.disconnected`, `.noMatches`, `.noCreditCards`,
+  `.noIdentities` in `src/messages/{en,ja}.json`).
+- **NFR3** — The `Enter`-key trusted-event guard (`suggestion-dropdown.ts:192`)
+  must remain in force and must not be weakened by the guard restructuring. This is
+  a credential-disclosure control; see `C2` and §Recurring-rule notes `R43`/`R52`.
+
+## Technical approach
+
+Two changes, both confined to
+`extension/src/content/ui/suggestion-dropdown.ts`. No detector file changes, no
+style changes, no message-file changes.
+
+### 1. Narrow the keydown guard so Escape is always reachable
+
+Split the single early-return into a dropdown-presence check (which Escape needs)
+and a per-case item-list check (which only the navigation cases need). Escape moves
+above the item-list requirement; `ArrowDown`/`ArrowUp`/`Enter` keep theirs.
+
+**Why not simply drop `itemElements.length === 0` from the guard?** Because
+`ArrowDown` on an empty list would then call `setActiveItem(0)` and `Enter` would
+index `itemElements[activeIndex]` on an empty array. The correct shape is per-case,
+not a relaxed global guard.
+
+**Return-value semantics.** `handleDropdownKeydown` returns a boolean meaning
+"handled — the caller may stop". Escape in a message state returns `true` (it *did*
+handle it). The navigation keys in a message state return `false`, unchanged from
+today. The three detector call sites
+(`form-detector-lib.ts:523-528`, `cc-form-detector-lib.ts:437-442`,
+`identity-form-detector-lib.ts:481-486`) ignore the return value entirely —
+they call it for effect — so no caller behavior changes. Verified by reading all
+three call sites.
+
+### 2. Add a 5 s auto-dismiss timer for message-only states
+
+A module-level timer handle alongside the existing module state
+(`currentDropdown`, `itemElements`, `outsideClickHandler`, …), armed in
+`showDropdown()` only on the message-only branches, and cleared unconditionally in
+`hideDropdown()`.
+
+Arming it in the three message branches rather than gating on
+`itemElements.length === 0` after the fact keeps the condition co-located with the
+branch that decides it, so a future fourth message state cannot silently miss the
+timer by forgetting to update a separate predicate.
+
+**Timer handle idiom.** The repo has two: `form-detector-lib.ts:460` uses
+`window.setTimeout` with a `number | null` handle, while `save-banner.ts:24/84/92`
+uses bare `setTimeout` with `ReturnType<typeof setTimeout>` — the type-agnostic form
+that sidesteps the DOM-vs-Node overload question entirely rather than resolving it.
+**Follow `save-banner.ts`**, since this change is an auto-dismiss timer and
+`save-banner.ts` is the auto-dismiss sibling; matching the surrounding idiom of the
+thing being imitated beats matching a different file's. Both behave identically
+under fake timers. (The first revision argued for `window.setTimeout` on the grounds
+of "matching the sibling", while citing the sibling that does the opposite — the
+conclusion was defensible but the reason was false, so it is corrected rather than
+carried.)
+
+**Timer clearing is unconditional in `hideDropdown()`, and must happen before
+control can leave the function.** Two separate requirements, often conflated:
+
+1. *Unconditional* — not nested inside `if (currentDropdown)`, mirroring how
+   `outsideClickHandler` is already cleared at lines 147-150. `showDropdown()` opens
+   with `hideDropdown()` (line 54); that is the mechanism satisfying FR5, and it only
+   works if clearing does not depend on `currentDropdown` being non-null.
+2. *Before any exit from the function* — and the exit that matters is **not** the end
+   of the `if (currentDropdown)` block. `hideDropdown()` ends by invoking the
+   detector-supplied dismiss callback **synchronously**, at lines 161-165:
+
+   ```ts
+   if (currentOnDismiss) {
+     const fn = currentOnDismiss;
+     currentOnDismiss = null;
+     fn();          // ← re-entrant call site: arbitrary detector code runs here
+   }
+   ```
+
+   `fn()` is a re-entrancy point. All three current callbacks are inert (LOGIN sets
+   `currentContext = null`; CC and IDENTITY set `activeInput = null`), so placing the
+   clear anywhere above line 161 is correct **today**. But "above the
+   `currentDropdown` block" is the wrong landmark to write into an invariant: it is
+   correct by accident, and the reason is what licenses the next edit. If any future
+   `onDismiss` synchronously calls `showDropdown` — a re-show-on-dismiss, which is the
+   synchronous analogue of what scenario 5 already does asynchronously via
+   `PSSO_VAULT_STATE_CHANGED` → `requestMatches` — then a clear that ran before
+   `fn()` would not cancel the timer `fn()` just armed. The orphan would then dismiss
+   a *later* dropdown, and because the singleton serves the entries state too, that
+   could be a candidate list the user is mid-selection on: FR3's prohibited outcome
+   reached by a different route.
+
+   **Therefore the invariant binds to `fn()`, not to the `currentDropdown` block**,
+   and `showDropdown` must arm the new timer only after its opening `hideDropdown()`
+   has fully returned (line 54's position already gives this).
+
+### Interaction analysis (why 5 s does not thrash)
+
+The dropdown is re-opened by `focusin` (`form-detector-lib.ts:637`, and the
+identical wiring at `cc:471` / `identity:514`), **not** by `input`. I verified there
+is no `input`-event listener in any of the three detectors. Consequences:
+
+- A user who dismisses the message and keeps typing in the same field does **not**
+  see it return — no refocus occurs. This is the dominant scenario in the user's
+  complaint and it behaves correctly.
+- A user who clicks away and clicks back into the field **does** see it again. That
+  is correct: a fresh focus is a fresh request for suggestions.
+- The 150 ms blur debounce (`form-detector-lib.ts:510-518`) and the auto-dismiss
+  timer cannot conflict — both funnel through `hideDropdown()`, which is idempotent
+  (`isDropdownVisible()` → `false`, second call is a documented no-op tested at
+  `suggestion-dropdown.test.ts:100`).
+- `autofillSuppressUntil` (1500 ms) is unrelated: it suppresses re-open after a
+  *successful fill*, a path that cannot coexist with a message-only state.
+
+### Timer value
+
+5000 ms, per the user's decision. Position among the repo's existing dismissal
+timings: inline notice 2200 ms (`form-detector-lib.ts:460-464`) < **5000 ms** < save
+banner 15000 ms (`AUTO_DISMISS_MS`, `save-banner.ts:11`).
+
+**The constant is `export`ed**, and the tests import it and compute the boundary as
+`CONSTANT` and `CONSTANT - 1` rather than hardcoding `5000` / `4999` (`RT3` — a
+hardcoded literal decouples the assertion from the shipped value the moment anyone
+changes it, leaving the test pinning a number nobody ships). Exporting it is a new
+production export, so under `RT6` it must arrive with the test that consumes it —
+which T8/T9 are.
+
+## Contracts
+
+### C1 — `handleDropdownKeydown` dismisses on Escape in every render state
+
+- **Signature** (unchanged): `handleDropdownKeydown(e: KeyboardEvent): boolean`
+- **Control class**: **fail-closed verification gate**, for the part of this
+  function that gates credential disclosure (the `Enter` case). The Escape case
+  carries no security predicate — it is pure UI dismissal. The declaration matters
+  because C1 *restructures the guard that the `Enter` control sits behind*, and a
+  reader must not infer that loosening the outer guard loosened the `Enter` gate.
+  **Adjudication authority** for the `Enter` predicate: the browser's own
+  `Event.isTrusted` flag — an interpreter-supplied fact, not a surface-form
+  heuristic. Unchanged by this contract.
+- **Invariants**:
+  - **I1.1** (app-enforced): `ArrowDown`, `ArrowUp`, and `Enter` never index
+    `itemElements` when it is empty. *Schema-enforced equivalent: none available —
+    this is control flow inside one function, which no type system in this stack
+    expresses. Stated per the plan's obligation to justify app-enforced choices.*
+  - **I1.2** (app-enforced): the `!e.isTrusted → return false` check on the `Enter`
+    path is preserved verbatim in position and effect. This is `NFR3`.
+  - **I1.3** (app-enforced): when `currentDropdown` is `null`, every key including
+    Escape returns `false`. Escape becoming reachable must not make it reachable
+    with no dropdown on screen.
+  - **I1.4** (app-enforced): the `Escape` case denies untrusted events — an event
+    with `e.isTrusted === false` returns `false` **without** calling
+    `e.preventDefault()` and **without** calling `hideDropdown()`. See the rationale
+    immediately below; this invariant is added by review, not present in the first
+    revision.
+- **Forbidden patterns**:
+  - `pattern: if (!currentDropdown || itemElements.length === 0) return false;` —
+    reason: this exact line is the bug; its survival in the diff means the fix was
+    not applied.
+  - `pattern: case "Enter"` appearing without an `isTrusted` check within the same
+    case block — reason: `NFR3`; a restructure that drops the disclosure guard is a
+    security regression, not a UI fix.
+- **Acceptance criteria**:
+  - Escape returns `true` and `isDropdownVisible()` becomes `false` for each of:
+    `{disconnected: true}`, `{vaultLocked: true}`, `{entries: []}`, and the
+    two-entry default fixture.
+  - `ArrowDown` returns `false` in all three message states (nothing to navigate).
+  - Untrusted `Enter` still returns `false` and still does not invoke `onSelect`,
+    in the entries state.
+  - With no dropdown shown, Escape returns `false`.
+  - **Untrusted Escape returns `false`, leaves the dropdown visible, and leaves
+    `e.defaultPrevented === false`** — in every one of the four render states (I1.4).
+  - `ArrowDown` in a message state leaves `e.defaultPrevented === false`. Asserting
+    only the `false` return cannot distinguish "fell through untouched" from "handled,
+    then returned false" — and the latter would violate I1.1 while passing.
+- **Why Escape must deny untrusted events (I1.4).** Today the `:174` guard makes the
+  `Escape` case unreachable in message states, so this exposure is *created by C1*,
+  not pre-existing there. Once reachable, `case "Escape"` calls `e.preventDefault()`
+  unconditionally and has no `isTrusted` check — unlike the `Enter` case (`:192`) and
+  the mouse path (`isSafeSelectClick`, `:45-51`), both of which already deny
+  untrusted input. Two consequences, both measured:
+  - A page script can `document.dispatchEvent(new KeyboardEvent("keydown", {key:
+    "Escape", cancelable: true}))`. The detector keydown handlers are registered on
+    `document` in capture phase, so it reaches them. That hands a hostile page a
+    reliable **suppression primitive** for the locked / no-match indicators — the
+    user's only in-page signal distinguishing a real dropdown from a page overlay
+    impersonating the password manager.
+  - The page dispatches its own event object, so it can read `e.defaultPrevented`
+    after `dispatchEvent` returns. **Probed and confirmed**: a `preventDefault()` in
+    a capture-phase listener is visible to the dispatcher, and synthetic
+    `KeyboardEvent`s carry `isTrusted === false`. Since C2 arms the timer only on
+    message branches and never on the entries branch, the page gets a state oracle:
+    dispatch, read `defaultPrevented`, learn *extension installed and vault
+    locked / no matches* versus *entries present*. For a password manager that is a
+    fingerprinting and vault-state channel.
+
+  The fix is one line and makes Escape consistent with the module's two existing
+  trust boundaries. It is deliberately **partial**: a page can still blur the input
+  to suppress the dropdown, and other presence inferences remain. The value is
+  consistency — leaving Escape as the single untrusted-reachable branch is the
+  anomaly, and the alternative to fixing it is an explicit written decision, not
+  silence.
+
+  *Boundary and tie*: `e.isTrusted` is a browser-supplied boolean with no equality
+  edge — `true` dismisses, `false` returns `false` unhandled.
+
+- **Test-construction consequence**: T1-T4 must use the `trustedKeydown()` Proxy
+  helper already at `suggestion-dropdown.test.ts:136-145`, **not** a bare
+  `new KeyboardEvent` (which is untrusted and would now be denied). The helper must
+  additionally assert `e.isTrusted === true` before returning, so that if a future
+  jsdom breaks the Proxy workaround the tests go red rather than silently exercising
+  the untrusted path — "examined nothing" must not read the same as "found nothing".
+
+- **Manual-test classification**: `verifiable-CI`. Every criterion is expressible
+  against the module's exported surface under jsdom; VC2 does not block it.
+
+### C2 — Message-only states auto-dismiss after 5000 ms; the entries state does not
+
+- **Signature** (module-internal): a module-level timer handle
+  `number | null`, and a named constant for the interval.
+- **Control class**: **detection or audit only** — no denial. This is a UI
+  convenience timer; nothing security-relevant is gated on it firing or not firing.
+  Declared explicitly so no later contract leans on it as a boundary (`R49`).
+- **Invariants**:
+  - **I2.1** (app-enforced): the timer is armed **iff** the rendered state is one
+    of the three message-only branches. The entries branch never arms it (`FR3`).
+  - **I2.2** (app-enforced): `hideDropdown()` clears the timer **unconditionally**
+    (not nested in `if (currentDropdown)`) and **before invoking `currentOnDismiss`**
+    at `suggestion-dropdown.ts:161-165`. The binding landmark is the `fn()`
+    re-entrancy point, *not* the `currentDropdown` block: `fn()` runs
+    detector-supplied code synchronously, and a callback that re-shows the dropdown
+    would arm a timer that a clear placed earlier in the function has already passed.
+    Correspondingly, `showDropdown` arms its timer only after its opening
+    `hideDropdown()` (line 54) has returned. Together these satisfy `FR5`.
+  - **I2.3** (app-enforced): the timer's callback dismisses via `hideDropdown()`
+    and by no other path, so teardown, listener removal, and `onDismiss` are
+    identical to every other dismissal (`FR4`). No duplicated teardown logic.
+- **Forbidden patterns**:
+  - `pattern: setTimeout(` inside `showDropdown` that is not the auto-dismiss arm —
+    reason: only one timer belongs in this function; a second is a lifecycle leak.
+  - `pattern: currentDropdown = null` inside the timer callback — reason: the
+    callback must delegate to `hideDropdown()`, not hand-roll teardown (I2.3).
+- **Acceptance criteria**:
+  - Under fake timers, advancing 5000 ms from a `{vaultLocked: true}` /
+    `{disconnected: true}` / `{entries: []}` show ⇒ `isDropdownVisible() === false`
+    **and** `onDismiss` called exactly once.
+  - Advancing 4999 ms ⇒ still visible. (Pins the boundary; without it the test
+    passes for any timer ≤ 5000 ms, including 0.)
+  - Advancing 5000 ms from the two-entry default fixture ⇒ still visible,
+    `onDismiss` not called (`FR3`).
+  - `showDropdown(message)` → `showDropdown(message)` → advance 5000 ms ⇒ exactly
+    one further `onDismiss` beyond the one the second `showDropdown`'s internal
+    `hideDropdown()` already fired for the first dropdown. Pins `FR5`: an orphaned
+    first timer would produce an extra dismissal.
+  - `showDropdown(message)` → `hideDropdown()` → advance 5000 ms ⇒ no additional
+    `onDismiss` (timer cleared, not merely outrun).
+  - **Message → entries re-show**: `showDropdown({vaultLocked: true})` → advance
+    2000 ms → `showDropdown(<two-entry fixture>)` → advance 5000 ms ⇒ still visible,
+    no `onDismiss` beyond the one the second `showDropdown`'s internal
+    `hideDropdown()` fired. Pins the transition where an orphaned timer would tear
+    down a list the user is mid-selection on — the `FR3` regression by a different
+    route. Distinct from the message→message case above.
+  - **Re-entrant `onDismiss`**: an `onDismiss` that synchronously calls
+    `showDropdown({vaultLocked: true})` once must leave exactly one armed timer, not
+    two. Advance 5000 ms ⇒ exactly one further dismissal. Pins I2.2's binding to the
+    `fn()` landmark rather than to the `currentDropdown` block.
+  - **Boundary and tie**: the timer fires **at** exactly 5000 ms, not after — measured,
+    see §Fake-timer hygiene. 4999 ms falls on the still-visible side. Two dropdowns
+    can never share the boundary, because arming is always preceded by a clear (I2.2).
+- **Manual-test classification**: `verifiable-CI` via `vi.useFakeTimers()`.
+  Real-browser confirmation is `blocked-deferred` per VC1 and is covered by
+  §Manual test plan M1-M3.
+
+### C3 — Consumer-flow walkthrough
+
+`showDropdown` / `hideDropdown` / `handleDropdownKeydown` are consumed by code
+outside this module, so per the plan obligation each consumer is walked through
+before the contracts lock.
+
+- **Consumer 1 (path: `src/content/form-detector-lib.ts:523-528`, `keydownHandler`)**
+  reads `{ return value of handleDropdownKeydown }` and uses it for **nothing** —
+  the call is `if (isDropdownVisible()) { handleDropdownKeydown(e); }`, result
+  discarded. Therefore C1's change to the return value in message states
+  (`false` → `true` for Escape) is invisible to this consumer. Verified by reading
+  the source.
+- **Consumer 2 (path: `src/content/cc-form-detector-lib.ts:437-442`)** — identical
+  shape to Consumer 1, result discarded. Same conclusion.
+- **Consumer 3 (path: `src/content/identity-form-detector-lib.ts:481-486`)** —
+  identical shape, result discarded. Same conclusion.
+- **Consumer 4a (path: `form-detector-lib.ts:415-417`, LOGIN `onDismiss`)** reads
+  `{}` — it takes no arguments — and uses the *invocation itself* to set
+  `currentContext = null` (the module-level `DropdownContext | null` at `:342`). Its
+  blur handler (`:510-518`) guards on `currentContext` and dereferences
+  `currentContext.input`.
+- **Consumer 4b (paths: `cc-form-detector-lib.ts:406-408` and
+  `identity-form-detector-lib.ts:450-452`)** likewise read `{}` and use the
+  invocation to set **`activeInput = null`** — a bare `HTMLInputElement | null`
+  (`cc:308`, `identity:354`), *not* a `currentContext` object; neither detector has
+  one. Their blur handlers guard on `activeInput` (`cc:426-435`,
+  `identity:470-479`).
+
+  **This pair is the walkthrough that constrains the design.** The shared conclusion
+  holds for all three detectors despite the differing state variable: each clears its
+  per-detector state *only* via `onDismiss`, so any dismissal path that bypasses
+  `hideDropdown()` strands that state — pointing at an input whose dropdown no longer
+  exists — and the next blur handler then acts on it. C2's timer must therefore route
+  through `hideDropdown()`, which I2.3 requires. Caught here, before implementation.
+
+  Recorded as two entries rather than one because an earlier revision asserted
+  `currentContext` for all three; that rationale is false for two of the three, and a
+  reader who went looking for `currentContext` in the CC detector would not find it.
+- **Consumer 5 (path: `src/__tests__/content/ui/suggestion-dropdown.test.ts`,
+  `suggestion-dropdown-entrytype.test.ts`)** reads `isDropdownVisible()`,
+  `onDismiss`, `onSelect`, and `handleDropdownKeydown`'s return value. The existing
+  `afterEach` calls `hideDropdown()` (`:61`), which under C2 also clears the timer —
+  so no timer leaks across test cases. Tests that do **not** use fake timers are
+  unaffected, because a real 5 s timer never elapses within a test.
+- **Consumer 6 (path: `src/__tests__/content/form-detector-inline.test.ts:6-13`)**
+  mocks the whole module wholesale (`showDropdown`, `hideDropdown`,
+  `isDropdownVisible: () => false`, `handleDropdownKeydown: () => false`). Under that
+  mock the real timer-clearing never runs. This test uses no fake timers and never
+  calls the real `showDropdown`, so no timer is ever armed — no impact. Recorded so a
+  reviewer does not have to rediscover it.
+- **Consumer 7 (path: `src/__tests__/content/cc-identity-detector.test.ts:11-16`)**
+  mocks the module the same way, and additionally reads the captured options object
+  to drive `onSelect` (`:129`, `:158`) and to assert `entryType` (`:93`, `:265`) — so
+  it is a genuine behavioural consumer of the option shape C2 touches, not a
+  bystander. Same conclusion: real `showDropdown` never runs, no timer armed, no
+  impact. **This consumer was absent from the first revision**, which enumerated six
+  and asserted completeness; the code-derived set has seven.
+
+**Member-set derivation for C3** (`R42` — the enumeration is code-derived, not
+asserted):
+
+```console
+$ grep -rn -E "showDropdown|handleDropdownKeydown|hideDropdown|isDropdownVisible" src \
+    --include='*.ts' --include='*.tsx' | grep -v '^src/content/ui/suggestion-dropdown.ts:'
+```
+
+yields exactly seven files: the three detectors (Consumers 1-4b) and four test files
+(`suggestion-dropdown.test.ts`, `suggestion-dropdown-entrytype.test.ts`,
+`form-detector-inline.test.ts`, `cc-identity-detector.test.ts` = Consumers 5-7).
+Phase 3 must re-run this grep rather than carry the result forward.
+
+**No consumer requires a field absent from the locked shape.** C1 and C2 are
+complete.
+
+## Go/No-Go Gate
+
+| ID  | Subject | Status |
+| --- | --- | --- |
+| C1  | Escape dismisses in every render state (trusted events only); navigation guards preserved | locked |
+| C2  | 5 s auto-dismiss for message-only states; entries state exempt | locked |
+| C3  | Consumer-flow walkthrough for all seven consumers | locked |
+
+All three were revised during Round 1 and re-locked: C1 gained I1.4 (untrusted-Escape
+denial), C2 gained the `fn()`-landmark restatement of I2.2 plus three new acceptance
+criteria, C3 gained Consumer 7 and the 4a/4b split. Round 1 found no defect in the
+change's *destination* — only in the plan's reasoning, enumeration, and test design.
+
+## Testing strategy
+
+All tests go in the existing
+`extension/src/__tests__/content/ui/suggestion-dropdown.test.ts`. No new test file
+— the module already has one and splitting would fragment the fixture.
+
+### Fixture change required
+
+`makeOptions()` (`:39-54`) currently has no `disconnectedMessage`. The
+`disconnected` branch reads `opts.disconnectedMessage || opts.lockedMessage`
+(`:70`), so it renders today via the fallback, but a test asserting the disconnected
+state should supply the field explicitly to exercise the real path.
+
+### Prove-red obligation (`RT7`) — two distinct kinds, never conflated
+
+A test that cannot fail is worse than no test, because it reads as coverage. **This
+plan's first revision fell into exactly that trap**, and it was caught by execution
+rather than by reasoning: T5, T7, T9 and T10 were run against unfixed `main` and
+**all four passed**, green-on-green. That is the same defect class as the shipped bug
+(`:125` passing vacuously on the entries fixture). Recorded rather than quietly
+corrected, because the failure mode is the plan's own subject matter.
+
+Every new test therefore names which of two kinds of red-proof applies, and each
+mutation is **run and observed separately** — one mutation per clause, never one
+mutation that reddens everything.
+
+**Kind A — red against unfixed `main`.** Genuine regression tests: the test fails
+today and passes after the fix.
+
+| Test | Why it reddens on `main` |
+| --- | --- |
+| T1, T2, T3 | Escape in message states — guard at `:174` returns `false`, dropdown stays visible |
+| T8 | no timer exists on `main`, so nothing dismisses at 5000 ms |
+| T11 | second dropdown is never auto-dismissed on `main` |
+| T12 | vacuously green on `main`; **promoted to Kind B** — see below |
+
+**Kind B — red against a named mutation of the fix.** Guard-preservation tests: they
+pass on `main` *and* after the fix, so their value is that a specific wrong
+implementation reddens them. Each row's mutation is mandatory, not illustrative.
+
+| Test | Mutation that must redden it | Observed |
+| --- | --- | --- |
+| T4 | change the trusted-Escape path to `return false` | must fail |
+| T5 | drop the per-case `itemElements.length` check from the `ArrowDown` case | must fail |
+| T6 | delete the `!e.isTrusted` line from the `Enter` case | must fail |
+| T7 | drop the `!currentDropdown` check from the guard | must fail |
+| T9 | set the interval constant to `4999` | must fail (tie: `5000` ⇒ green) |
+| T10 | arm the timer in the entries branch too | must fail |
+| T12 | move the timer clear to *after* the `fn()` call at `:161-165` | must fail |
+| T13 | replace the timer callback with a hand-rolled teardown (see T13) | must fail |
+| T14 | move the timer clear inside the `if (currentDropdown)` block | must fail |
+
+**Allow side (mandatory after every mutation-revert):** the full `extension/` suite
+must be green — run and observed, not assumed. A remedy that only tightens is
+unmeasured in the direction that gets controls switched off.
+
+**Failing loudly:** if a red-proof cannot be executed (toolchain change, `toFake`
+rejected by a future vitest), the obligation is to stop and say so — "examined
+nothing" must not be recorded the same way as "found nothing".
+
+### What T9 does and does not pin
+
+T9 (`4999 ms ⇒ still visible`) constrains the interval **only from below**. On its
+own it is satisfied by a 60-second timer, or by no timer at all — which is why it
+passed on unfixed `main`. It is meaningful *only in conjunction with* T8
+(`5000 ms ⇒ dismissed`), which supplies the upper bound. The pair is the boundary;
+neither half is a boundary test alone. An earlier revision of this plan claimed T9
+by itself "pins the boundary; without it the test passes for any timer ≤ 5000 ms,
+including 0" — that is backwards, and the correction is recorded here because the
+wrong belief is what licensed listing T9 without a Kind-B mutation.
+
+### Test list
+
+| ID | Test | Pins | Red-proof |
+| --- | --- | --- | --- |
+| T1 | Escape (**trusted**) dismisses when `vaultLocked: true` | C1 | A |
+| T2 | Escape (**trusted**) dismisses when `disconnected: true` | C1 | A |
+| T3 | Escape (**trusted**) dismisses when `entries: []` | C1 | A |
+| T4 | Escape still dismisses with entries present | C1 | B |
+| T5 | `ArrowDown` returns `false` **and leaves `defaultPrevented` false** in each message state | C1 / I1.1 | B |
+| T6 | Untrusted `Enter` still returns `false`, `onSelect` not called | C1 / I1.2, NFR3 | B |
+| T7 | Escape returns `false` when no dropdown is shown | C1 / I1.3 | B |
+| T8 | 5000 ms auto-dismisses each of the three message states, `onDismiss` once | C2 | A |
+| T9 | 4999 ms — still visible (**lower bound only; pairs with T8**) | C2 boundary | B |
+| T10 | 5000 ms with entries present — still visible, no `onDismiss` | C2 / I2.1, FR3 | B |
+| T11 | re-show cancels the prior timer — **per-mock counts**, see below | C2 / I2.2, FR5 | A |
+| T12 | explicit `hideDropdown()` then 5000 ms — no extra `onDismiss` | C2 / I2.2 | B |
+| T13 | auto-dismiss removes the `mousedown` listener, identically to manual dismiss | C2 / I2.3, FR4 | B |
+| T14 | message → entries re-show does not tear down the entries dropdown | C2 / I2.2, FR3 | B |
+| T15 | untrusted Escape is a no-op in every state (`defaultPrevented` stays false) | C1 / I1.4 | B |
+
+T5, T6, T7, T15 are the **paired allow/deny axis coverage** for `RT10` — the rule the
+existing suite violated, and the reason this bug shipped. T6 and T15 are the guards
+against C1's restructure silently widening the page-reachable surface.
+
+**T4 is not a new test.** `suggestion-dropdown.test.ts:125-132` already covers the
+entries axis and already passes; the entries axis was never the untested one. T4 means
+*keep `:125` unchanged and confirm it stays green post-fix* — it is the entries-axis
+half of the `RT10` pair, not a second copy. Do not write a duplicate.
+
+**T11 must assert per-mock counts, not an aggregate.** An aggregate "one further
+`onDismiss`" is satisfied by the buggy implementation too: with an orphaned first
+timer, the second show fires `o1.onDismiss`, then the orphan fires `hideDropdown()`
+which fires `o2.onDismiss` and nulls it, then the second dropdown's own timer fires
+`hideDropdown()` with `currentOnDismiss === null` and fires nothing — **aggregate
+total is two either way**. The discriminator is *when*, not *how many*. Specify T11 as:
+`showDropdown(o1)` → advance 3000 ms → `showDropdown(o2)` → assert `o1.onDismiss`
+once and `o2.onDismiss` zero → advance 4999 ms (t=7999) → assert **still visible** and
+`o2.onDismiss` zero → advance 1 ms (t=8000) → assert dismissed and `o2.onDismiss`
+once. The 3000 ms gap is what separates the orphan's deadline (t=5000) from the
+legitimate one (t=8000); without the gap the two coincide and the test cannot tell
+them apart.
+
+**T13 is what actually pins I2.3.** T8/T10/T11/T12 assert visibility and `onDismiss`,
+both of which a hand-rolled teardown would also satisfy — so the forbidden-pattern
+grep is the only thing standing between the plan and an equivalent hand-roll spelled
+differently. T13 spies on `document.addEventListener`/`removeEventListener` and
+asserts the auto-dismiss path removes the `mousedown` capture listener **exactly
+once**, and that a direct `hideDropdown()` produces the identical call — proving the
+two paths agree rather than merely that the timer path does something. This is
+observable from outside the closed shadow root (it is a `document`-level listener),
+so VC2 does not block it.
+
+### Fake-timer hygiene
+
+`vi.useFakeTimers()` in the auto-dismiss describe block only, with
+`vi.useRealTimers()` in its `afterEach`, so other blocks are unaffected.
+
+**Measured fake-timer semantics (probe, not assumption).** `showDropdown` registers
+the outside-click listener inside a `requestAnimationFrame` callback (`:135-143`), so
+the tests depend on how vitest treats rAF. I probed the actual toolchain rather than
+reasoning about it — a throwaway spec run under this repo's vitest 4.1.10 + jsdom 29,
+`@vitest-environment jsdom`, three assertions, all passing:
+
+| Probe assertion | Result |
+| --- | --- |
+| rAF callback runs after `vi.advanceTimersByTime(5000)` under default `useFakeTimers()` | **true — rAF IS faked and DOES run** |
+| `setTimeout(…, 5000)` fired after `advanceTimersByTime(4999)` | **false — not yet fired** |
+| `setTimeout(…, 5000)` fired after `advanceTimersByTime(5000)` | **true — fires at exactly the delay** |
+
+Vitest 4's default `toFake` set covers every timer key except `nextTick` /
+`queueMicrotask`, and `requestAnimationFrame` is in it. So a bare
+`vi.useFakeTimers()` puts rAF on the same fake clock as `setTimeout`, and
+`advanceTimersByTime(5000)` runs the pending rAF — installing the real
+`outsideClickHandler` on `document` mid-test.
+
+**Required configuration**, therefore, for the auto-dismiss block:
+
+```ts
+vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+```
+
+This leaves rAF real, so the outside-click registration never fires during a clock
+advance and the auto-dismiss tests exercise the timer path and nothing else. Pin it:
+one auto-dismiss test asserts `document.addEventListener` was **not** called with
+`"mousedown"` after `advanceTimersByTime(5000)`. (T13 deliberately does the opposite
+— it needs the listener installed — so T13 arranges that explicitly rather than
+relying on the clock.)
+
+Two further consequences:
+
+1. **Boundary is exact.** T9 (`4999 ⇒ visible`) and T8 (`5000 ⇒ dismissed`) form a
+   genuine pair. The tie falls on the **fire** side at equality: the timer fires *at*
+   5000 ms. Two dropdowns can never share the boundary, because arming is always
+   preceded by a clear (I2.2).
+2. **`useRealTimers()` goes in the FILE-level `afterEach`** at
+   `suggestion-dropdown.test.ts:60-63`, unconditionally and ordered *before*
+   `hideDropdown()` — **not** in a describe-scoped hook. A describe-scoped
+   `useRealTimers()` was measured to leak fake timers into subsequent tests when an
+   auto-dismiss test *fails*, converting one real failure into a cascade across the
+   other describe blocks — `RT11`, fixture outliving its own run on the failure path.
+   `useRealTimers()` is a documented no-op when no fake timers are installed, so it is
+   safe for the whole file. `vitest.config.ts` sets neither `restoreMocks` nor
+   `unstubGlobals`, so there is no config-level safety net to fall back on.
+
+An earlier revision asserted rAF "may not run" under fake timers and put
+`useRealTimers()` in a describe-scoped hook. Both were refuted by execution. Recorded
+rather than silently corrected: the first belief would have licensed tests that
+unknowingly installed a live click handler, and the second would have made the first
+auto-dismiss failure look like five failures.
+
+## Manual test plan
+
+Covers what VC1 blocks from automation. Run with `npm run dev` in `extension/` and
+the unpacked build loaded in Chrome.
+
+- **M1** — On a real login page with the vault locked: focus the password field,
+  confirm the amber "保管庫がロックされています" appears, press ESC, confirm it
+  closes immediately and the text beneath is readable.
+- **M2** — Same, but do not press ESC; confirm it disappears on its own after
+  ~5 s. Confirm typing in the field afterwards does **not** bring it back.
+- **M3** — With the vault unlocked and matching entries present: confirm the
+  candidate list does **not** vanish after 5 s, and that ArrowDown/Enter still fill.
+- **M4** — Repeat M1/M2 on a credit-card form and an address/identity form, to
+  confirm the singleton fix reaches all three detectors (`FR6`).
+- **M5** — Sign out to produce the disconnected state; confirm ESC and the 5 s
+  timer both work there.
+
+## Considerations & constraints
+
+### Scope contract
+
+- **SC1 — Click-to-unlock affordance on the locked / disconnected messages.**
+  Deferred. **Anti-Deferral cost-justification**: making these messages clickable
+  requires opening the extension popup from a content-script-originated click,
+  which needs `chrome.action.openPopup()` behind a background relay. Chrome gates
+  that API on a user gesture whose propagation across the content-script →
+  background → popup boundary is **unmeasured in this environment (VC3)**. Cost of
+  including it now: an unbounded probe of an unverified platform constraint inside
+  a PR whose actual defect is a one-line guard, plus a new failure mode ("looks
+  clickable, does not open") that is worse than the current honest static text.
+  Cost of deferring: the user must open the popup themselves, which is exactly
+  today's behavior — deferring adds no regression. Owner: a future issue, to be
+  filed after a standalone `chrome.action.openPopup()` gesture probe. Decided with
+  the user during Phase 1.
+- **SC2 — `showInlineNotice()` (the 2.2 s black toast).** Out of scope. It already
+  auto-dismisses at `form-detector-lib.ts:460-464` and is `pointer-events:none` by
+  design, so it exhibits neither reported symptom. **Anti-Deferral**: cost of
+  including = touching a second surface with no defect, widening the diff and the
+  review surface for zero user-visible gain. Cost of excluding = none; no symptom
+  is attributable to it. Owner: n/a — no work is owed.
+- **SC3 — `save-banner.ts` / `passkey-save-banner.ts` ESC support.** Out of scope.
+  Both already auto-dismiss (15 s) and both have explicit close buttons, so neither
+  produces the reported "cannot dismiss" symptom. Adding ESC to them is a
+  consistency improvement, not a fix. **Anti-Deferral**: cost of including = two
+  more files and two more test suites in a PR the user framed around three specific
+  messages, against the repo's scope-discipline norm. Cost of excluding = a minor
+  residual inconsistency (banners lack ESC), user-visible only to someone who tries
+  ESC on a banner, and non-blocking because the close button is present. Owner:
+  optional future consistency pass.
+- **SC4 — The orphaned `commands.noMatch` i18n key.** The key exists in both
+  message files with no consumer anywhere in `src/`. **Anti-Deferral**: cost of
+  including = a dead-key deletion is unrelated to this defect and would make the
+  diff span the message files for no behavioral reason. Cost of excluding = one
+  unused translation string, no runtime effect. Owner: a future i18n cleanup.
+- **SC5 — `role="listbox"` set on message-only states.** `suggestion-dropdown.ts:65`
+  sets `role="listbox"` unconditionally, but the message states render no
+  `role="option"` children — an a11y inconsistency. **Anti-Deferral**: cost of
+  including = an a11y semantics change (likely `role="status"` for message states)
+  that alters screen-reader announcement behavior and needs its own manual
+  verification with a screen reader, which VC1's constraint class also blocks. Cost
+  of excluding = a pre-existing, unchanged a11y wart; this PR neither introduces nor
+  worsens it. Owner: a future a11y pass. Noted here rather than silently, per `R34`.
+
+- **SC6 — `try`/`catch` around the `onDismiss` invocation.** Out of scope.
+  `hideDropdown()` calls `fn()` at `:161-165` unwrapped, while the module's other two
+  cross-boundary calls *are* wrapped (`:112-116`, `:199-203`). C2 newly routes a timer
+  callback through that path, where a throw has no originating frame.
+  **Anti-Deferral**: cost of including = changing error-handling semantics on every
+  existing dismissal path (blur, outside-click, keydown, navigation — 18 call sites),
+  which is a wider behavioral change than the defect being fixed and would need its
+  own test matrix for the swallow-vs-propagate decision. Cost of excluding = a throw
+  from a detector `onDismiss` becomes an unhandled error in the timer path rather than
+  in a page event handler; all three current callbacks are single assignments that
+  cannot throw, so the exposure is latent, not live. Owner: a future error-handling
+  pass over the module. Verified: all three `onDismiss` bodies are bare assignments.
+
+### Risks
+
+- **Risk 1 — the guard restructure weakens the `Enter` disclosure control.** This is
+  the only security-relevant risk in the change. Mitigated by I1.2, the C1 forbidden
+  pattern, and T6. Reviewers should read the `Enter` case first.
+- **Risk 2 — a timer outlives its dropdown.** Mitigated by I2.2 (unconditional
+  clear placed before the `currentDropdown` block) and T11/T12.
+- **Risk 3 — 5 s is subjectively wrong for some users.** Accepted; the constant is
+  named and single-sourced, so changing it is a one-line edit. No settings UI is in
+  scope (adding one would need a popup control, an options-storage read in the
+  content script, and a message round-trip — disproportionate to a timing tweak).
+
+## User operation scenarios
+
+1. **The reported scenario.** User focuses a login field on a site with no saved
+   entry. "一致するエントリがありません" appears over the text below. User presses
+   ESC → closes instantly. *Today: nothing happens.*
+2. **Passive user.** Same as 1, but the user does not press ESC and just reads. The
+   message clears itself after 5 s. *Today: it stays until they click elsewhere.*
+3. **Typing through.** User dismisses the message and continues typing in the same
+   field. Because re-show is bound to `focusin` and not `input`, it does not return.
+4. **Deliberate re-check.** User clicks away, then clicks back into the field. The
+   message reappears — correct, a new focus is a new request.
+5. **Locked vault, acting on it.** Message appears, user opens the extension popup
+   from the toolbar and unlocks. `PSSO_VAULT_STATE_CHANGED` triggers
+   `requestMatches` on the active input (`form-detector-lib.ts:611-616`), so
+   candidates appear. Unaffected by this change, but confirms the locked message is
+   informational rather than a dead end — which is what makes `SC1` deferrable.
+6. **Choosing a credential.** Vault unlocked, three candidates listed. User reads
+   them for more than 5 s before choosing. The list does **not** vanish (`FR3`).
+   This is the scenario that makes the entries-state exemption non-negotiable.
+7. **Credit-card and address forms.** Same as 1-2 on a checkout page — covered by
+   the singleton, verified by M4.
+
+## Recurring-rule notes (pre-flagged for review)
+
+Raised proactively so reviewers can confirm rather than rediscover:
+
+- **`RT10` (guard tested only on one side)** — this is the *cause* of the shipped
+  bug. `dismisses with Escape` (`:125`) tested Escape only on the entries axis; the
+  message axis was never combined with it. T1-T5 add the missing axis combinations.
+- **`RT7` (new guard must be proven able to fail)** — the prove-red obligation above
+  is mandatory, not advisory, and its observed output goes in the deviation log.
+- **`R52` (control reach extended without re-auditing the control)** — C1 widens the
+  reach of `handleDropdownKeydown` (it now acts in states where it previously
+  returned early). The `Enter` control inside it must be re-audited, not assumed
+  intact: I1.2, T6.
+- **`R2` (constants hardcoded)** — the 5000 ms interval is a named constant.
+- **`R34` (pre-existing issue in adjacent file)** — `SC5` (`role="listbox"`) and
+  `SC4` (orphaned key) are recorded with cost-justifications rather than silently
+  skipped.
+- **`R49` (undeclared control class)** — C1 and C2 both declare theirs; C2 is
+  explicitly *detection/audit only* so nothing downstream treats the timer as a
+  boundary.

--- a/docs/archive/review/extension-dropdown-dismiss-review.md
+++ b/docs/archive/review/extension-dropdown-dismiss-review.md
@@ -1,0 +1,264 @@
+# Plan Review: extension-dropdown-dismiss
+
+Date: 2026-08-17
+Review round: 1
+
+## Changes from Previous Round
+
+Initial review. Three expert sub-agents (functionality, security, testing) reviewed
+`extension-dropdown-dismiss-plan.md` in parallel against the actual extension source.
+Local LLM pre-screening was skipped — Ollama unavailable at `localhost:11434`; the
+`merge-findings` dedup call was likewise unavailable, so deduplication below is the
+documented manual fallback (the JSON findings indexes from each expert were joined by
+hand on file + root cause).
+
+## Summary
+
+19 findings: 2 Critical, 4 Major, 13 Minor (3 of them `[Adjacent]`). All Critical and
+Major findings are resolved in the plan. **No finding was against the change's
+destination** — the two-part fix (per-case guard split + auto-dismiss timer, confined
+to `suggestion-dropdown.ts`) survived all three reviews intact. Every defect was in
+the plan's reasoning, its enumeration, or its test design.
+
+The two Criticals are the notable result, because both were found *by execution* and
+both are the same defect class the plan was written to fix:
+
+- **T5, T7, T9, T10 passed against unfixed `main`** — four of twelve proposed tests
+  were vacuous. I re-ran this myself and confirmed all four green with no fix applied.
+  The plan diagnosed the shipped bug as "a test that passed vacuously" and then
+  reproduced that exact failure.
+- **The fake-timer/rAF claim was factually inverted.** Vitest 4 fakes
+  `requestAnimationFrame`, so `advanceTimersByTime` runs the pending rAF and installs
+  the real outside-click handler mid-test. I had asserted the opposite from reasoning;
+  a probe refuted it.
+
+## Functionality Findings
+
+**F-Func-1 — Major — RESOLVED.** I2.2's timer-clear ordering invariant was anchored to
+the wrong landmark. `hideDropdown()` does not end at the `if (currentDropdown)` block —
+it ends by invoking `currentOnDismiss()` **synchronously** at `:161-165`, a re-entrancy
+point running detector-supplied code. "Clear before the `currentDropdown` block" is
+correct today only by accident; the binding constraint is "clear before `fn()`".
+*Resolution*: I2.2 restated against the `fn()` landmark; technical approach rewritten
+to separate the two requirements (unconditional vs. before-any-exit); C2 gained a
+re-entrant-`onDismiss` acceptance criterion and test T12's Kind-B mutation.
+
+**F-Func-2 — Major — RESOLVED.** C3 enumerated six consumers and asserted completeness;
+the code-derived set has seven. `src/__tests__/content/cc-identity-detector.test.ts`
+was missing — a genuine behavioural consumer that mocks the module and reads the
+captured options to drive `onSelect`. *Verified independently.* *Resolution*: Consumer 7
+added with the same treatment as Consumer 6; the reproducing grep is now printed in the
+plan so the enumeration is code-derived on its face.
+
+**F-Func-3 — Major — RESOLVED.** Consumer 4's rationale claimed all three detectors
+clear `currentContext` on dismiss. Only LOGIN has `currentContext` (`:342`); CC and
+IDENTITY use `activeInput` (`cc:308`, `identity:354`). *Verified independently.* The
+conclusion was right, the reason false for two of three subjects — R29's "false reason
+under a true conclusion" class, in the one walkthrough the plan called design-
+constraining. *Resolution*: split into Consumers 4a/4b with the shared conclusion
+stated once; FR4 corrected to name both state variables.
+
+**F-Func-4 — Major — RESOLVED.** Six `file:line` citations pointed at the wrong lines.
+*Verified independently:* `makeOptions` is at `:39` not `:97-115` (the range the testing
+strategy told the implementer to edit); `AUTO_DISMISS_MS` at `save-banner.ts:11` not
+`:24`; manifest `content_scripts` at `:63-70` not `:61-68`; `web_accessible_resources`
+at `:71-76` not `:69-74`; `blurHandler` at `:510-518`; LOGIN `onDismiss` at `:415-417`.
+NFR1's *conclusion* was independently confirmed correct despite the wrong citation.
+*Resolution*: all six corrected.
+
+**F-Func-5 — Minor (question) — ANSWERED IN PLAN.** Message branches never reset
+`itemElements`/`activeIndex`; C1's restructure makes `hideDropdown`'s conditional reset
+load-bearing. No reachable path was found where `itemElements` survives into a message
+render. *Resolution*: T5 now asserts `defaultPrevented === false` in message states,
+which distinguishes "fell through untouched" from "handled then returned false" — the
+property that would actually break.
+
+**F-Func-6 — Minor — RESOLVED.** Auto-dismiss tests were blind to FR4's
+listener-removal clause. *Resolution*: T13 added (see F-Test-5, same root cause).
+
+**F-Func-7 — Minor `[Adjacent]` — DEFERRED as SC6.** `hideDropdown` invokes `onDismiss`
+unwrapped while the module's other two cross-boundary calls are wrapped. Cost-
+justification recorded: all three current callbacks are bare assignments that cannot
+throw, so the exposure is latent; wrapping would change error semantics across all 18
+dismissal call sites.
+
+**F-Func-8 — Minor `[Adjacent]` — DEFERRED, SC5 scope widened.** SC5's `role="listbox"`
+deferral addressed the static a11y wart, not the live-region concern FR2's auto-dismiss
+newly introduces. Recorded rather than silently carried.
+
+## Security Findings
+
+**F-Sec-1 — Minor — RESOLVED (upgraded in treatment).** The `Escape` case has no
+`isTrusted` guard, unlike the `Enter` case (`:192`) and the mouse path (`:45-51`). C1
+is what makes it reachable in message states, so the exposure is *created by this
+change*. Two consequences, **both probed and confirmed**: a page script can dispatch a
+synthetic Escape to suppress the locked / no-match indicator (a UI-integrity signal for
+a password manager), and it can read `e.defaultPrevented` on its own event object to
+learn dropdown presence and — given C2's deliberate message-vs-entries timer asymmetry —
+distinguish vault-locked from entries-present. *Resolution*: new invariant I1.4 (Escape
+denies untrusted events without `preventDefault` and without dismissing), two acceptance
+criteria, test T15, and a Kind-B mutation. The plan records that the hardening is
+partial by construction — blur still suppresses the dropdown — and that the value is
+consistency with the module's own two existing trust boundaries.
+
+**F-Sec-2 — Minor (question) — ANSWERED.** Could the timer race a message→entries
+re-show and tear down a list mid-selection? The design handles it via I2.2, but no test
+covered the transition (T11 covered message→message only). *Resolution*: T14 added as
+an explicit acceptance criterion.
+
+**F-Sec-3 — Minor `[Adjacent]` — RESOLVED.** T5 pinned a return value, not I1.1's
+non-indexing invariant. Merged with F-Func-5; same fix.
+
+Clean checks worth recording: the closed shadow root (`mode:"closed"`, random-token
+attribute) means the timer's teardown is not observable as DOM mutation, so the timer
+adds no fingerprinting channel beyond F-Sec-1's; the visual-safety gates
+(`isPageVisuallySafe` / `isElementVisuallySafe` / `isInputHitTestSafe` /
+`hasVisiblePopoverOverlayNear`) run at `requestMatches` time and are untouched;
+auto-dismiss marginally *helps* against overlay attacks by shortening the on-screen
+window; RS3/RS6 clean — `escapeHtml` untouched, messages are i18n-sourced not
+page-controlled.
+
+## Testing Findings
+
+**F-Test-1 — Critical — RESOLVED.** The plan's fake-timer claim was inverted. Vitest 4's
+default `toFake` set includes `requestAnimationFrame`, so `advanceTimersByTime(5000)`
+runs the pending rAF and installs the real `outsideClickHandler` on `document` mid-test.
+**Independently probed and confirmed** (`rafRan after advance: true`). *Resolution*:
+the block now specifies `vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] })`,
+pinned by an assertion that no `mousedown` listener is registered during a clock
+advance; the wrong belief and its correction are both recorded in the plan.
+
+**F-Test-2 — Critical — RESOLVED.** T5, T7, T9, T10 pass on unfixed `main` — vacuous,
+and with no prove-red obligation covering them. **I re-ran all four myself against
+current `main`: all four green.** The plan's own diagnosis of the shipped bug is that
+`:125` passed vacuously; the plan reproduced the class. *Resolution*: the prove-red
+section is split into **Kind A** (red against unfixed `main` — genuine regression tests)
+and **Kind B** (red against a *named mutation of the fix* — guard-preservation tests),
+with a mandatory mutation per Kind-B row, each run and observed separately, plus a
+mandatory full-suite green after every mutation-revert.
+
+**F-Test-3 — Major — RESOLVED.** T11's aggregate `onDismiss` count cannot detect the
+orphaned-timer bug it claims to pin: with an orphan, the second show fires `o1`, the
+orphan fires `o2` and nulls the callback, the legitimate timer fires nothing — aggregate
+is two either way. The discriminator is *when*, not *how many*. *Resolution*: T11
+respecified with per-mock counts, a 3000 ms gap between the two shows (separating the
+orphan's t=5000 deadline from the legitimate t=8000), and a checkpoint at t=7999.
+
+**F-Test-4 — Major — RESOLVED.** A describe-scoped `vi.useRealTimers()` was measured to
+leak fake timers into subsequent tests when an auto-dismiss test *fails* — RT11, fixture
+outliving its own run on the failure path, converting one real failure into a cascade.
+*Resolution*: moved to the file-level `afterEach` at `:60-63`, unconditional and ordered
+before `hideDropdown()`. Noted that `vitest.config.ts` sets neither `restoreMocks` nor
+`unstubGlobals`, so there is no config-level net.
+
+**F-Test-5 — Major — RESOLVED.** Nothing pinned I2.3. A hand-rolled timer teardown
+(`currentDropdown = null; currentOnDismiss?.()`) passes T8/T10/T11/T12 while leaking the
+outside-click listener and the shadow-root children — the exact failure Consumer 4's
+walkthrough identifies as design-constraining, guarded only by a forbidden-pattern grep
+that catches one spelling. *Resolution*: T13 added, spying on
+`document.addEventListener`/`removeEventListener` (observable outside the closed shadow
+root), asserting removal exactly once and that the manual path produces the identical
+call.
+
+**F-Test-6 — Minor — RESOLVED.** T4 duplicated the existing `:125-132` test. The entries
+axis was never the untested one. *Resolution*: T4 restated as "keep `:125` unchanged and
+confirm it stays green post-fix", with an explicit instruction not to write a duplicate.
+
+**F-Test-7 — Minor (question) — ANSWERED.** Would the interval constant be exported so
+tests compute the boundary from it, or hardcoded? *Resolution*: exported; tests import it
+and compute `CONSTANT` / `CONSTANT - 1` (RT3), and the export arrives with its consuming
+tests (RT6).
+
+**F-Test-8 — Minor `[Adjacent]` — RESOLVED.** The `window.setTimeout` rationale cited
+`save-banner.ts` as the sibling to match while that file does the opposite (bare
+`setTimeout` with `ReturnType<typeof setTimeout>`). *Resolution*: the plan now follows
+`save-banner.ts` — the auto-dismiss sibling — and records that the previous conclusion
+was defensible but its stated reason false.
+
+## Adjacent Findings
+
+Routed and dispositioned above: F-Func-7 (→ SC6, deferred), F-Func-8 (→ SC5 scope
+widened), F-Sec-3 (→ merged with F-Func-5, resolved), F-Test-8 (→ resolved).
+
+## Quality Warnings
+
+None. The `merge-findings` quality gate (VAGUE / NO-EVIDENCE / UNTESTED-CLAIM) could not
+run — Ollama unavailable. Manual substitute applied: every Critical and Major finding
+above was independently re-verified against source or by execution before acceptance,
+and the verification method is named per finding. Three findings were re-run as probes
+(`rAF` faking, the four vacuous tests, the `defaultPrevented` oracle); five were checked
+by reading the cited lines (`makeOptions`, `AUTO_DISMISS_MS`, manifest ranges,
+`currentContext`/`activeInput`, the seventh consumer).
+
+## Round 1 disposition
+
+| Severity | Count | Resolved in plan | Deferred with cost-justification |
+| --- | --- | --- | --- |
+| Critical | 2 | 2 | 0 |
+| Major | 4 | 4 | 0 |
+| Minor | 13 | 11 | 2 (SC5 widened, SC6 new) |
+
+No Critical or Major finding is open. Both deferrals are Minor, `[Adjacent]`, and carry
+Anti-Deferral entries naming the owner and the cost on both sides.
+
+## Recurring Issue Check
+
+### Functionality expert
+
+R1-R28 n-a or checked-clean (no dead code, no magic strings, no schema/migration/i18n
+surface, no `any`, no floating promise, `hideDropdown` idempotency verified at test
+`:98-100`). R29 **finding-raised** (F-Func-4 six mis-cited ranges; F-Func-3 false
+rationale). R30-R41 checked-clean (SC1-SC6 carry cost-justifications; NFR1 conclusion
+verified; VC3/SC1 handled honestly). R42 **finding-raised** (F-Func-2: code-derived
+consumer set has 7, plan listed 6). R43 checked-clean (NFR3/I1.2/T6 preserve the `Enter`
+guard). R44-R51 checked-clean (C1/C2 declare control class; decisions bind to the branch
+object). R52 **finding-raised, partial** (plan pre-flagged it; F-Func-5 records the
+residual). R53-R57 checked-clean (`number | null` timer handle cannot collide).
+
+### Security expert
+
+R1-R37 n-a or checked-clean. R38 **finding-raised** (F-Sec-2: timer async state,
+message→entries re-show unpinned). R39-R42 n-a. R43 **finding-raised** (F-Sec-1: Escape
+reachability widens an untrusted-event surface). R44-R46 n-a. R47 checked-clean (`Enter`
+adjudicates on `Event.isTrusted` — interpreter-supplied, not surface-form). R48 n-a.
+R49 checked-clean (C1/C2 control classes verified accurate against source; nothing leans
+on C2 as a boundary). R50 n-a. R51 checked-clean. R52 **finding-raised** (F-Sec-1:
+`Enter` re-audit adequate, Escape's reach extended without re-audit). R53-R54 n-a.
+R55 checked-clean. R56-R57 n-a.
+RS1 n-a. RS2 n-a. RS3 checked-clean. RS4 checked-clean. RS5 checked-clean.
+RS6 checked-clean.
+
+### Testing expert
+
+R1-R57: R2 checked-clean (constant named; scoping raised as F-Test-7). R34 checked-clean.
+R43 checked-clean. R49 checked-clean. R52 checked-clean. Remainder n-a.
+RT1 checked-clean (both wholesale-mocking test files verified to never call the real
+`showDropdown`). RT2 checked-clean (every finding is testable from outside the closed
+shadow root; F-Test-5's remedy uses document-level spies, not shadow-root queries).
+RT3 **finding-raised** (F-Test-7). RT4 checked-clean. RT5 checked-clean (tests call the
+real primitives). RT6 **finding-raised** (F-Test-7: exported constant needs its test
+consumer). RT7 **finding-raised** (F-Test-2: prove-red omitted T5/T7 and conflated
+red-against-main with red-against-mutation). RT8 **finding-raised** (F-Test-3 aggregate
+count; F-Test-5 status-without-mutation). RT9 checked-clean (single singleton, no twin
+to drift). RT10 **finding-raised** (F-Test-2 T5/T7 cannot fail; F-Test-6 T4 duplicates).
+RT11 **finding-raised** (F-Test-4, measured).
+
+## Verification-constraint classification
+
+| Contract | Classification | Basis |
+| --- | --- | --- |
+| C1 (all criteria) | `verifiable-CI` | Expressible against the exported surface under jsdom; the existing suite proves the pattern, including the `isTrusted` Proxy workaround at `:136-145` |
+| C2 (timer criteria) | `verifiable-CI` | Via fake timers with the corrected `toFake` set; T13 closes the FR4 gap that made this partial |
+| C2 real-browser | `blocked-deferred` (VC1) | No Playwright/Puppeteer harness, no headless-Chrome extension job in CI; covered by M1-M5 |
+| SC1 click-to-unlock | deferred (VC3) | `chrome.action.openPopup()` gesture propagation genuinely unmeasured; deferral adds no regression over today |
+
+## Round 2 assessment
+
+Not run. Round 1 resolved every Critical and Major finding, and the saturation criterion
+is deliberately **not** claimed — it requires at least two completed rounds, so it cannot
+fire here. Proceeding to Phase 2 is a judgment call on the evidence, recorded as such:
+all three experts' remaining findings are Minor; no finding was against the design; the
+change is 2 edits in 1 file with 15 tests; and the two Criticals were both about the
+*plan's own test design*, which Phase 2's mandatory prove-red execution will re-verify by
+running the mutations rather than by reasoning about them. Should Phase 2 execution
+contradict any Kind-A/Kind-B expectation in the table, that is a Round-2 input.

--- a/extension/src/__tests__/content/cc-identity-detector.test.ts
+++ b/extension/src/__tests__/content/cc-identity-detector.test.ts
@@ -13,6 +13,7 @@ vi.mock("../../content/ui/suggestion-dropdown", () => ({
   hideDropdown: (...a: unknown[]) => hideDropdownMock(...a),
   isDropdownVisible: () => false,
   handleDropdownKeydown: () => false,
+  MESSAGE_AUTO_DISMISS_MS: 5000,
 }));
 
 vi.mock("../../lib/i18n", () => ({ t: (key: string) => key }));

--- a/extension/src/__tests__/content/form-detector-inline.test.ts
+++ b/extension/src/__tests__/content/form-detector-inline.test.ts
@@ -11,6 +11,7 @@ vi.mock("../../content/ui/suggestion-dropdown", () => ({
   hideDropdown: (...args: unknown[]) => hideDropdownMock(...args),
   isDropdownVisible: () => false,
   handleDropdownKeydown: () => false,
+  MESSAGE_AUTO_DISMISS_MS: 5000,
 }));
 
 vi.mock("../../lib/i18n", () => ({

--- a/extension/src/__tests__/content/ui/suggestion-dropdown.test.ts
+++ b/extension/src/__tests__/content/ui/suggestion-dropdown.test.ts
@@ -7,6 +7,7 @@ import {
   hideDropdown,
   isDropdownVisible,
   handleDropdownKeydown,
+  MESSAGE_AUTO_DISMISS_MS,
   type DropdownOptions,
 } from "../../../content/ui/suggestion-dropdown";
 import { EXT_ENTRY_TYPE } from "../../../lib/constants";
@@ -47,17 +48,47 @@ function makeOptions(overrides?: Partial<DropdownOptions>): DropdownOptions {
     onSelect: vi.fn(),
     onDismiss: vi.fn(),
     lockedMessage: "Vault is locked",
+    disconnectedMessage: "Not connected",
     noMatchesMessage: "No matches",
     headerLabel: "Logins",
     ...overrides,
   };
 }
 
+// jsdom sets Event.isTrusted as a non-configurable own property (false by default).
+// Object.defineProperty cannot override it, so use a Proxy to intercept isTrusted
+// reads. The self-assert below fails loudly if a future jsdom breaks the Proxy —
+// otherwise the trusted-path tests would silently exercise the untrusted path and
+// pass for the wrong reason.
+const trustedKeydown = (key: string): KeyboardEvent => {
+  const e = new KeyboardEvent("keydown", { key, cancelable: true });
+  const proxied = new Proxy(e, {
+    get(target, prop, receiver) {
+      if (prop === "isTrusted") return true;
+      const val = Reflect.get(target, prop, receiver);
+      return typeof val === "function" ? (val as (...a: unknown[]) => unknown).bind(target) : val;
+    },
+  }) as KeyboardEvent;
+  if (!proxied.isTrusted) throw new Error("trustedKeydown: isTrusted override failed");
+  return proxied;
+};
+
+// The three message-only render states, by the option that selects each branch.
+const MESSAGE_STATES: ReadonlyArray<[string, Partial<DropdownOptions>]> = [
+  ["disconnected", { disconnected: true }],
+  ["vaultLocked", { vaultLocked: true }],
+  ["no matches", { entries: [] }],
+];
+
 beforeEach(() => {
   document.body.innerHTML = "";
 });
 
 afterEach(() => {
+  // File-level, unconditional, and before hideDropdown(): a describe-scoped
+  // useRealTimers() leaks the fake clock into later tests when an auto-dismiss test
+  // FAILS, turning one real failure into a cascade across the other blocks.
+  vi.useRealTimers();
   hideDropdown();
   document.body.innerHTML = "";
 });
@@ -122,27 +153,15 @@ describe("handleDropdownKeydown", () => {
     expect(handled).toBe(true);
   });
 
+  // T4: the entries-axis half of the RT10 pair. Pre-existing coverage — kept
+  // unchanged to confirm the guard restructure did not regress the entries path.
   it("dismisses with Escape", () => {
     const opts = makeOptions();
     showDropdown(opts);
-    const e = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
-    const handled = handleDropdownKeydown(e);
+    const handled = handleDropdownKeydown(trustedKeydown("Escape"));
     expect(handled).toBe(true);
     expect(isDropdownVisible()).toBe(false);
   });
-
-  // jsdom sets Event.isTrusted as a non-configurable own property (false by default).
-  // Object.defineProperty cannot override it, so use a Proxy to intercept isTrusted reads.
-  const trustedKeydown = (key: string): KeyboardEvent => {
-    const e = new KeyboardEvent("keydown", { key, cancelable: true });
-    return new Proxy(e, {
-      get(target, prop, receiver) {
-        if (prop === "isTrusted") return true;
-        const val = Reflect.get(target, prop, receiver);
-        return typeof val === "function" ? (val as (...a: unknown[]) => unknown).bind(target) : val;
-      },
-    }) as KeyboardEvent;
-  };
 
   it("selects active item with Enter", () => {
     const opts = makeOptions();
@@ -162,5 +181,269 @@ describe("handleDropdownKeydown", () => {
     );
     expect(handled).toBe(false);
     expect(opts.onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe("Escape in message-only states", () => {
+  // T1-T3. These are the states the guard used to swallow Escape in: nothing to
+  // navigate, so itemElements is empty and the old length check returned early.
+  it.each(MESSAGE_STATES)("dismisses with Escape when %s", (_label, overrides) => {
+    const opts = makeOptions(overrides);
+    showDropdown(opts);
+    expect(isDropdownVisible()).toBe(true);
+
+    const handled = handleDropdownKeydown(trustedKeydown("Escape"));
+
+    expect(handled).toBe(true);
+    expect(isDropdownVisible()).toBe(false);
+    expect(opts.onDismiss).toHaveBeenCalledOnce();
+  });
+
+  // T15. Escape must deny synthetic events like Enter and the mouse path do,
+  // so a page cannot suppress the notice or read defaultPrevented as a state oracle.
+  it.each(MESSAGE_STATES)(
+    "ignores a synthetic (untrusted) Escape when %s, leaving defaultPrevented false",
+    (_label, overrides) => {
+      const opts = makeOptions(overrides);
+      showDropdown(opts);
+
+      const e = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+      const handled = handleDropdownKeydown(e);
+
+      expect(handled).toBe(false);
+      expect(e.defaultPrevented).toBe(false);
+      expect(isDropdownVisible()).toBe(true);
+      expect(opts.onDismiss).not.toHaveBeenCalled();
+    },
+  );
+
+  it("ignores a synthetic Escape in the entries state too", () => {
+    const opts = makeOptions();
+    showDropdown(opts);
+
+    const e = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+
+    expect(handleDropdownKeydown(e)).toBe(false);
+    expect(e.defaultPrevented).toBe(false);
+    expect(isDropdownVisible()).toBe(true);
+  });
+
+  // T5. Asserting the return value alone cannot tell "fell through untouched" from
+  // "handled, then returned false" — defaultPrevented is what distinguishes them.
+  it.each(MESSAGE_STATES)("leaves ArrowDown unhandled when %s", (_label, overrides) => {
+    showDropdown(makeOptions(overrides));
+
+    const e = trustedKeydown("ArrowDown");
+
+    expect(handleDropdownKeydown(e)).toBe(false);
+    expect(e.defaultPrevented).toBe(false);
+    expect(isDropdownVisible()).toBe(true);
+  });
+
+  it.each(MESSAGE_STATES)("leaves ArrowUp unhandled when %s", (_label, overrides) => {
+    showDropdown(makeOptions(overrides));
+
+    const e = trustedKeydown("ArrowUp");
+
+    expect(handleDropdownKeydown(e)).toBe(false);
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  // T7. Escape becoming reachable must not make it reachable with nothing on screen.
+  it("returns false for Escape when no dropdown is shown", () => {
+    const e = trustedKeydown("Escape");
+
+    expect(handleDropdownKeydown(e)).toBe(false);
+    expect(e.defaultPrevented).toBe(false);
+  });
+});
+
+describe("message-only auto-dismiss", () => {
+  // The timing tests below derive their boundary from MESSAGE_AUTO_DISMISS_MS so
+  // they never drift from the shipped value — which means they alone cannot detect
+  // the constant being changed. This pins the value itself: long enough to read the
+  // notice, short enough not to be the nuisance the timer exists to remove.
+  it("dismisses after 5 seconds", () => {
+    expect(MESSAGE_AUTO_DISMISS_MS).toBe(5000);
+  });
+
+  // rAF is on vitest's default fake-timer set, so a bare useFakeTimers() would let
+  // advanceTimersByTime install the real outside-click handler mid-test. Faking only
+  // the timeout pair keeps these tests exercising the timer path and nothing else.
+  const useTimeoutOnlyFakeTimers = () =>
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+
+  // T8.
+  it.each(MESSAGE_STATES)("dismisses %s after the interval", (_label, overrides) => {
+    useTimeoutOnlyFakeTimers();
+    const opts = makeOptions(overrides);
+    showDropdown(opts);
+
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS);
+
+    expect(isDropdownVisible()).toBe(false);
+    expect(opts.onDismiss).toHaveBeenCalledOnce();
+  });
+
+  // T9. Lower bound only — meaningful as a pair with T8, which supplies the upper.
+  it.each(MESSAGE_STATES)("still shows %s one tick before the interval", (_label, overrides) => {
+    useTimeoutOnlyFakeTimers();
+    const opts = makeOptions(overrides);
+    showDropdown(opts);
+
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS - 1);
+
+    expect(isDropdownVisible()).toBe(true);
+    expect(opts.onDismiss).not.toHaveBeenCalled();
+  });
+
+  // T10. The entries list must never expire under a user who is still choosing.
+  it("does not arm a timer in the entries state", () => {
+    useTimeoutOnlyFakeTimers();
+    const opts = makeOptions();
+    showDropdown(opts);
+
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS * 2);
+
+    expect(isDropdownVisible()).toBe(true);
+    expect(opts.onDismiss).not.toHaveBeenCalled();
+  });
+
+  // T13. Visibility and onDismiss alone would also pass for a hand-rolled teardown;
+  // the listener removal is what proves the timer routes through hideDropdown().
+  // rAF is faked here on purpose — it is the only way to install the outside-click
+  // listener synchronously so the removal has something to remove.
+  it("removes the outside-click listener, identically to a manual dismiss", () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "requestAnimationFrame"] });
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+    const mousedownCaptureRemovals = () =>
+      removeSpy.mock.calls.filter(([type, , capture]) => type === "mousedown" && capture === true);
+
+    showDropdown(makeOptions({ vaultLocked: true }));
+    vi.advanceTimersToNextFrame();
+    removeSpy.mockClear();
+
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS);
+
+    expect(isDropdownVisible()).toBe(false);
+    expect(mousedownCaptureRemovals()).toHaveLength(1);
+
+    // The manual path must produce the same call, so the two agree rather than the
+    // timer path merely doing something of its own.
+    showDropdown(makeOptions({ vaultLocked: true }));
+    vi.advanceTimersToNextFrame();
+    removeSpy.mockClear();
+
+    hideDropdown();
+
+    expect(mousedownCaptureRemovals()).toHaveLength(1);
+    removeSpy.mockRestore();
+  });
+
+  // T11. An aggregate onDismiss count cannot detect an orphaned timer — both the
+  // fixed and the buggy version total two. The 3000 ms gap separates the orphan's
+  // deadline from the legitimate one so the checkpoint below can tell them apart.
+  it("cancels the prior timer on re-show, so the second dropdown lives its full interval", () => {
+    useTimeoutOnlyFakeTimers();
+    const first = makeOptions({ vaultLocked: true });
+    const second = makeOptions({ entries: [] });
+
+    showDropdown(first);
+    vi.advanceTimersByTime(3000);
+    showDropdown(second);
+
+    expect(first.onDismiss).toHaveBeenCalledOnce();
+    expect(second.onDismiss).not.toHaveBeenCalled();
+
+    // An orphaned first timer would fire here (t=5000 from the first show).
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS - 1);
+    expect(isDropdownVisible()).toBe(true);
+    expect(second.onDismiss).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(isDropdownVisible()).toBe(false);
+    expect(second.onDismiss).toHaveBeenCalledOnce();
+  });
+
+  // T14. The transition where an orphan would tear down a list mid-selection.
+  it("does not tear down an entries dropdown shown after a message state", () => {
+    useTimeoutOnlyFakeTimers();
+    const message = makeOptions({ vaultLocked: true });
+    const entries = makeOptions();
+
+    showDropdown(message);
+    vi.advanceTimersByTime(2000);
+    showDropdown(entries);
+
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS * 2);
+
+    expect(isDropdownVisible()).toBe(true);
+    expect(entries.onDismiss).not.toHaveBeenCalled();
+  });
+
+  // T12. Cleared, not merely outrun.
+  it("clears the timer on an explicit hideDropdown", () => {
+    useTimeoutOnlyFakeTimers();
+    const opts = makeOptions({ vaultLocked: true });
+
+    showDropdown(opts);
+    hideDropdown();
+    expect(opts.onDismiss).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS);
+
+    expect(opts.onDismiss).toHaveBeenCalledOnce();
+  });
+
+  // An onDismiss that re-shows an entries list must leave it alone: the message
+  // state's timer has already fired, and the entries branch arms none of its own.
+  it("does not dismiss an entries dropdown put up by an onDismiss callback", () => {
+    useTimeoutOnlyFakeTimers();
+    const entries = makeOptions();
+    let reshown = false;
+    const message = makeOptions({
+      vaultLocked: true,
+      onDismiss: () => {
+        if (!reshown) {
+          reshown = true;
+          showDropdown(entries);
+        }
+      },
+    });
+
+    showDropdown(message);
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS);
+
+    expect(isDropdownVisible()).toBe(true);
+    expect(entries.onDismiss).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS * 2);
+
+    expect(isDropdownVisible()).toBe(true);
+    expect(entries.onDismiss).not.toHaveBeenCalled();
+  });
+
+  // I2.2's binding landmark: the clear must precede the onDismiss re-entrancy point,
+  // or a callback that re-shows leaves its freshly-armed timer uncancelled.
+  it("does not orphan a timer when onDismiss re-shows the dropdown", () => {
+    useTimeoutOnlyFakeTimers();
+    const reshown = makeOptions({ entries: [] });
+    let reshowCount = 0;
+    const opts = makeOptions({
+      vaultLocked: true,
+      onDismiss: () => {
+        if (reshowCount++ === 0) showDropdown(reshown);
+      },
+    });
+
+    showDropdown(opts);
+    hideDropdown();
+
+    expect(isDropdownVisible()).toBe(true);
+
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS);
+
+    expect(isDropdownVisible()).toBe(false);
+    expect(reshown.onDismiss).toHaveBeenCalledOnce();
   });
 });

--- a/extension/src/__tests__/content/ui/suggestion-dropdown.test.ts
+++ b/extension/src/__tests__/content/ui/suggestion-dropdown.test.ts
@@ -272,7 +272,7 @@ describe("message-only auto-dismiss", () => {
   // advanceTimersByTime install the real outside-click handler mid-test. Faking only
   // the timeout pair keeps these tests exercising the timer path and nothing else.
   const useTimeoutOnlyFakeTimers = () =>
-    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
 
   // Pins the toFake list above. With a bare useFakeTimers(), vitest also fakes rAF,
   // so advancing the clock would run showDropdown's pending frame and install the
@@ -292,6 +292,42 @@ describe("message-only auto-dismiss", () => {
     addSpy.mockRestore();
   });
 
+  // Chrome pauses rAF in a background tab but keeps timers running, so the
+  // auto-dismiss routinely beats the pending frame. Faking setTimeout while leaving
+  // rAF real reproduces exactly that ordering.
+  it("does not strand a document listener when the dismissal beats the pending frame", () => {
+    useTimeoutOnlyFakeTimers();
+    const addSpy = vi.spyOn(document, "addEventListener");
+    const mousedownInstalls = () =>
+      addSpy.mock.calls.filter(([type, , capture]) => type === "mousedown" && capture === true);
+
+    showDropdown(makeOptions({ vaultLocked: true }));
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS);
+    expect(isDropdownVisible()).toBe(false);
+
+    // Tab becomes visible again: any surviving frame callback would run here.
+    return new Promise<void>((resolve) => requestAnimationFrame(() => resolve())).then(() => {
+      expect(mousedownInstalls()).toHaveLength(0);
+      addSpy.mockRestore();
+    });
+  });
+
+  // The allow side of the same guard: when the frame does run first, the listener
+  // must still be installed — the cancellation must not disable outside-click.
+  it("still installs the outside-click listener when the frame runs first", () => {
+    const addSpy = vi.spyOn(document, "addEventListener");
+
+    showDropdown(makeOptions({ vaultLocked: true }));
+
+    return new Promise<void>((resolve) => requestAnimationFrame(() => resolve())).then(() => {
+      const installs = addSpy.mock.calls.filter(
+        ([type, , capture]) => type === "mousedown" && capture === true,
+      );
+      expect(installs).toHaveLength(1);
+      addSpy.mockRestore();
+    });
+  });
+
   // T8.
   it.each(MESSAGE_STATES)("dismisses %s after the interval", (_label, overrides) => {
     useTimeoutOnlyFakeTimers();
@@ -302,6 +338,61 @@ describe("message-only auto-dismiss", () => {
 
     expect(isDropdownVisible()).toBe(false);
     expect(opts.onDismiss).toHaveBeenCalledOnce();
+  });
+
+  // A notice the user never saw has not been read. These three states are the only
+  // in-page signal that a dropdown is genuinely ours, so expiring one behind a
+  // background tab would silently remove the warning a look-alike has to compete with.
+  const setVisibility = (state: "visible" | "hidden") => {
+    Object.defineProperty(document, "visibilityState", {
+      value: state,
+      configurable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  };
+
+  it.each(MESSAGE_STATES)("does not expire %s while the tab is hidden", (_label, overrides) => {
+    useTimeoutOnlyFakeTimers();
+    const opts = makeOptions(overrides);
+    showDropdown(opts);
+
+    vi.advanceTimersByTime(1000);
+    setVisibility("hidden");
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS * 10);
+
+    expect(isDropdownVisible()).toBe(true);
+    expect(opts.onDismiss).not.toHaveBeenCalled();
+
+    setVisibility("visible");
+    expect(isDropdownVisible()).toBe(true);
+
+    // Only the 1000 ms seen before hiding counts, so the remainder is still owed.
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS - 1000 - 1);
+    expect(isDropdownVisible()).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(isDropdownVisible()).toBe(false);
+    expect(opts.onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("stops watching visibility once dismissed", () => {
+    useTimeoutOnlyFakeTimers();
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    showDropdown(makeOptions({ vaultLocked: true }));
+    hideDropdown();
+
+    expect(
+      removeSpy.mock.calls.filter(([type]) => type === "visibilitychange"),
+    ).toHaveLength(1);
+
+    // A later visibility change must not resurrect a timer for a gone dropdown.
+    setVisibility("hidden");
+    setVisibility("visible");
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS * 2);
+
+    expect(isDropdownVisible()).toBe(false);
+    removeSpy.mockRestore();
   });
 
   // T9. Lower bound only — meaningful as a pair with T8, which supplies the upper.

--- a/extension/src/__tests__/content/ui/suggestion-dropdown.test.ts
+++ b/extension/src/__tests__/content/ui/suggestion-dropdown.test.ts
@@ -10,6 +10,7 @@ import {
   MESSAGE_AUTO_DISMISS_MS,
   type DropdownOptions,
 } from "../../../content/ui/suggestion-dropdown";
+import { getShadowHost } from "../../../content/ui/shadow-host";
 import { EXT_ENTRY_TYPE } from "../../../lib/constants";
 
 // Mock chrome.runtime
@@ -273,6 +274,24 @@ describe("message-only auto-dismiss", () => {
   const useTimeoutOnlyFakeTimers = () =>
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 
+  // Pins the toFake list above. With a bare useFakeTimers(), vitest also fakes rAF,
+  // so advancing the clock would run showDropdown's pending frame and install the
+  // outside-click listener mid-test — leaving these tests exercising a dismissal
+  // path they never meant to involve.
+  it("does not install the outside-click listener while the clock advances", () => {
+    useTimeoutOnlyFakeTimers();
+    const addSpy = vi.spyOn(document, "addEventListener");
+
+    showDropdown(makeOptions({ vaultLocked: true }));
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS);
+
+    const mousedownInstalls = addSpy.mock.calls.filter(
+      ([type, , capture]) => type === "mousedown" && capture === true,
+    );
+    expect(mousedownInstalls).toHaveLength(0);
+    addSpy.mockRestore();
+  });
+
   // T8.
   it.each(MESSAGE_STATES)("dismisses %s after the interval", (_label, overrides) => {
     useTimeoutOnlyFakeTimers();
@@ -307,6 +326,29 @@ describe("message-only auto-dismiss", () => {
 
     expect(isDropdownVisible()).toBe(true);
     expect(opts.onDismiss).not.toHaveBeenCalled();
+  });
+
+  // `isDropdownVisible()` only reads a module variable, so nothing above notices if
+  // the shadow root is never drained. That matters: showDropdown appends a fresh
+  // <style> and dropdown every call, so a teardown that skips the drain stacks one
+  // stale dropdown per show — the reported bug, made worse.
+  it("empties the shadow root, identically to a manual dismiss", () => {
+    useTimeoutOnlyFakeTimers();
+    const { root } = getShadowHost();
+
+    showDropdown(makeOptions({ vaultLocked: true }));
+    expect(root.children.length).toBeGreaterThan(0);
+
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS);
+
+    expect(root.children.length).toBe(0);
+
+    showDropdown(makeOptions({ vaultLocked: true }));
+    expect(root.children.length).toBeGreaterThan(0);
+
+    hideDropdown();
+
+    expect(root.children.length).toBe(0);
   });
 
   // T13. Visibility and onDismiss alone would also pass for a hand-rolled teardown;

--- a/extension/src/__tests__/content/ui/suggestion-dropdown.test.ts
+++ b/extension/src/__tests__/content/ui/suggestion-dropdown.test.ts
@@ -375,6 +375,56 @@ describe("message-only auto-dismiss", () => {
     expect(opts.onDismiss).toHaveBeenCalledOnce();
   });
 
+  // Shown while the tab is already hidden: arm() is skipped entirely, so the first
+  // reveal is what starts the clock — and the user gets the full interval, having
+  // seen none of it yet.
+  it("starts the countdown on first reveal when shown while already hidden", () => {
+    useTimeoutOnlyFakeTimers();
+    setVisibility("hidden");
+    const opts = makeOptions({ vaultLocked: true });
+
+    showDropdown(opts);
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS * 3);
+
+    expect(isDropdownVisible()).toBe(true);
+    expect(opts.onDismiss).not.toHaveBeenCalled();
+
+    setVisibility("visible");
+    vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS - 1);
+    expect(isDropdownVisible()).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(isDropdownVisible()).toBe(false);
+    expect(opts.onDismiss).toHaveBeenCalledOnce();
+  });
+
+  // Several round-trips: the visible spans must sum, so no span is double-counted
+  // (which would expire early) or dropped (which would never expire).
+  it("sums visible time across repeated hide/show cycles", () => {
+    useTimeoutOnlyFakeTimers();
+    const opts = makeOptions({ vaultLocked: true });
+    showDropdown(opts);
+
+    // Four 1000 ms visible spans, each separated by a long hidden stretch.
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(1000);
+      setVisibility("hidden");
+      vi.advanceTimersByTime(MESSAGE_AUTO_DISMISS_MS * 2);
+      setVisibility("visible");
+    }
+
+    // 4000 ms of visible time spent; 1000 ms still owed.
+    expect(isDropdownVisible()).toBe(true);
+    expect(opts.onDismiss).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(999);
+    expect(isDropdownVisible()).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(isDropdownVisible()).toBe(false);
+    expect(opts.onDismiss).toHaveBeenCalledOnce();
+  });
+
   it("stops watching visibility once dismissed", () => {
     useTimeoutOnlyFakeTimers();
     const removeSpy = vi.spyOn(document, "removeEventListener");

--- a/extension/src/content/ui/suggestion-dropdown.ts
+++ b/extension/src/content/ui/suggestion-dropdown.ts
@@ -49,6 +49,8 @@ let currentOnDismiss: (() => void) | null = null;
 let currentOnSelect: ((entryId: string, teamId?: string) => void) | null = null;
 let outsideClickHandler: ((e: MouseEvent) => void) | null = null;
 let autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
+let outsideClickFrame: ReturnType<typeof requestAnimationFrame> | null = null;
+let visibilityWatcher: (() => void) | null = null;
 
 function isSafeSelectClick(e: MouseEvent, item: HTMLDivElement): boolean {
   if (!e.isTrusted) return false;
@@ -152,11 +154,16 @@ export function showDropdown(opts: DropdownOptions): void {
   // running against a dropdown that was never shown. hideDropdown() at the top of
   // this function has already cleared any previous timer.
   if (isMessageOnly) {
-    autoDismissTimer = setTimeout(() => hideDropdown(), MESSAGE_AUTO_DISMISS_MS);
+    startVisibleCountdown();
   }
 
-  // Click outside to dismiss (delayed to avoid triggering on the same click)
-  requestAnimationFrame(() => {
+  // Click outside to dismiss (delayed to avoid triggering on the same click).
+  // The frame handle is kept so hideDropdown() can cancel a still-pending callback:
+  // a hidden tab pauses rAF while timers keep running, so the auto-dismiss can
+  // easily land first and this callback would otherwise install a listener onto an
+  // already-torn-down dropdown, with nothing left to remove it.
+  outsideClickFrame = requestAnimationFrame(() => {
+    outsideClickFrame = null;
     outsideClickHandler = (e: MouseEvent) => {
       const path = e.composedPath();
       if (!path.includes(dropdown)) {
@@ -167,6 +174,35 @@ export function showDropdown(opts: DropdownOptions): void {
   });
 }
 
+// The countdown measures VISIBLE time. A notice the user never saw has not been
+// read, and these three states are the only in-page signal that a dropdown is
+// really ours — expiring one behind a background tab would quietly remove the
+// warning a look-alike overlay has to compete with.
+function startVisibleCountdown(): void {
+  let remaining = MESSAGE_AUTO_DISMISS_MS;
+  let startedAt = performance.now();
+
+  const arm = () => {
+    startedAt = performance.now();
+    autoDismissTimer = setTimeout(() => hideDropdown(), remaining);
+  };
+
+  visibilityWatcher = () => {
+    if (document.visibilityState === "hidden") {
+      if (autoDismissTimer !== null) {
+        clearTimeout(autoDismissTimer);
+        autoDismissTimer = null;
+        remaining = Math.max(0, remaining - (performance.now() - startedAt));
+      }
+    } else if (autoDismissTimer === null) {
+      arm();
+    }
+  };
+  document.addEventListener("visibilitychange", visibilityWatcher);
+
+  if (document.visibilityState !== "hidden") arm();
+}
+
 export function hideDropdown(): void {
   // Cleared unconditionally and before fn() below: that call runs detector-supplied
   // code, and a callback that re-shows the dropdown would arm a timer this clear has
@@ -174,6 +210,17 @@ export function hideDropdown(): void {
   if (autoDismissTimer !== null) {
     clearTimeout(autoDismissTimer);
     autoDismissTimer = null;
+  }
+  if (visibilityWatcher) {
+    document.removeEventListener("visibilitychange", visibilityWatcher);
+    visibilityWatcher = null;
+  }
+  // Cancel before the callback can run. Without this, a dismissal that beats the
+  // frame — routine in a background tab, where rAF is paused and timers are not —
+  // leaves the callback to install a document listener that nothing removes.
+  if (outsideClickFrame !== null) {
+    cancelAnimationFrame(outsideClickFrame);
+    outsideClickFrame = null;
   }
   if (outsideClickHandler) {
     document.removeEventListener("mousedown", outsideClickHandler, true);

--- a/extension/src/content/ui/suggestion-dropdown.ts
+++ b/extension/src/content/ui/suggestion-dropdown.ts
@@ -152,7 +152,7 @@ export function showDropdown(opts: DropdownOptions): void {
   // running against a dropdown that was never shown. hideDropdown() at the top of
   // this function has already cleared any previous timer.
   if (isMessageOnly) {
-    autoDismissTimer = setTimeout(hideDropdown, MESSAGE_AUTO_DISMISS_MS);
+    autoDismissTimer = setTimeout(() => hideDropdown(), MESSAGE_AUTO_DISMISS_MS);
   }
 
   // Click outside to dismiss (delayed to avoid triggering on the same click)

--- a/extension/src/content/ui/suggestion-dropdown.ts
+++ b/extension/src/content/ui/suggestion-dropdown.ts
@@ -2,9 +2,16 @@
 // Rendered inside a closed Shadow DOM to isolate styles.
 
 import type { DecryptedEntry } from "../../types/messages";
+import { MS_PER_SECOND } from "../../lib/time";
 import { getShadowHost } from "./shadow-host";
 import { DROPDOWN_STYLES } from "./styles";
 import { KEY_ICON, LOCK_ICON, USER_ICON, DISCONNECT_ICON, CARD_ICON, ID_ICON } from "./icons";
+
+// Message-only states (disconnected / locked / no matches) carry nothing to pick,
+// so they linger over the page text under the field until the user clicks away.
+// Dismiss them on a timer; the entries list has no timer, since it would expire
+// while the user is still choosing a credential.
+export const MESSAGE_AUTO_DISMISS_MS = 5 * MS_PER_SECOND;
 
 export type DropdownEntryType = "LOGIN" | "CREDIT_CARD" | "IDENTITY";
 
@@ -41,6 +48,7 @@ let itemElements: HTMLDivElement[] = [];
 let currentOnDismiss: (() => void) | null = null;
 let currentOnSelect: ((entryId: string, teamId?: string) => void) | null = null;
 let outsideClickHandler: ((e: MouseEvent) => void) | null = null;
+let autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
 
 function isSafeSelectClick(e: MouseEvent, item: HTMLDivElement): boolean {
   if (!e.isTrusted) return false;
@@ -59,26 +67,35 @@ export function showDropdown(opts: DropdownOptions): void {
   style.textContent = DROPDOWN_STYLES;
   root.appendChild(style);
 
+  // Set by the three message-only branches below; drives the auto-dismiss arm.
+  let isMessageOnly = false;
+
   const dropdown = document.createElement("div");
   dropdown.className = "psso-dropdown";
   dropdown.style.pointerEvents = "auto";
   dropdown.setAttribute("role", "listbox");
 
+  // Armed per message-only branch rather than from a single length check after the
+  // fact, so a future fourth message state cannot miss the timer by forgetting to
+  // update a separate predicate.
   if (opts.disconnected) {
     const disconnected = document.createElement("div");
     disconnected.className = "psso-disconnected";
     disconnected.innerHTML = `${DISCONNECT_ICON}<span>${escapeHtml(opts.disconnectedMessage || opts.lockedMessage)}</span>`;
     dropdown.appendChild(disconnected);
+    isMessageOnly = true;
   } else if (opts.vaultLocked) {
     const locked = document.createElement("div");
     locked.className = "psso-locked";
     locked.innerHTML = `${LOCK_ICON}<span>${escapeHtml(opts.lockedMessage)}</span>`;
     dropdown.appendChild(locked);
+    isMessageOnly = true;
   } else if (opts.entries.length === 0) {
     const empty = document.createElement("div");
     empty.className = "psso-empty";
     empty.textContent = opts.noMatchesMessage;
     dropdown.appendChild(empty);
+    isMessageOnly = true;
   } else {
     const header = document.createElement("div");
     header.className = "psso-dropdown-header";
@@ -131,6 +148,13 @@ export function showDropdown(opts: DropdownOptions): void {
   currentOnDismiss = opts.onDismiss;
   currentOnSelect = opts.onSelect;
 
+  // Armed only after the dropdown is live, so a throw above cannot leave a timer
+  // running against a dropdown that was never shown. hideDropdown() at the top of
+  // this function has already cleared any previous timer.
+  if (isMessageOnly) {
+    autoDismissTimer = setTimeout(hideDropdown, MESSAGE_AUTO_DISMISS_MS);
+  }
+
   // Click outside to dismiss (delayed to avoid triggering on the same click)
   requestAnimationFrame(() => {
     outsideClickHandler = (e: MouseEvent) => {
@@ -144,6 +168,13 @@ export function showDropdown(opts: DropdownOptions): void {
 }
 
 export function hideDropdown(): void {
+  // Cleared unconditionally and before fn() below: that call runs detector-supplied
+  // code, and a callback that re-shows the dropdown would arm a timer this clear has
+  // already passed — orphaning it onto whatever dropdown comes next.
+  if (autoDismissTimer !== null) {
+    clearTimeout(autoDismissTimer);
+    autoDismissTimer = null;
+  }
   if (outsideClickHandler) {
     document.removeEventListener("mousedown", outsideClickHandler, true);
     outsideClickHandler = null;
@@ -171,15 +202,20 @@ export function isDropdownVisible(): boolean {
 }
 
 export function handleDropdownKeydown(e: KeyboardEvent): boolean {
-  if (!currentDropdown || itemElements.length === 0) return false;
+  // Presence-only. The item-list requirement belongs to the navigation cases, which
+  // index itemElements; Escape does not, and gating it here made Escape a no-op in
+  // the three message-only states — the states with nothing to navigate.
+  if (!currentDropdown) return false;
 
   switch (e.key) {
     case "ArrowDown": {
+      if (itemElements.length === 0) return false;
       e.preventDefault();
       setActiveItem(activeIndex < itemElements.length - 1 ? activeIndex + 1 : 0);
       return true;
     }
     case "ArrowUp": {
+      if (itemElements.length === 0) return false;
       e.preventDefault();
       setActiveItem(activeIndex > 0 ? activeIndex - 1 : itemElements.length - 1);
       return true;
@@ -207,6 +243,12 @@ export function handleDropdownKeydown(e: KeyboardEvent): boolean {
       return false;
     }
     case "Escape": {
+      // Trusted-only, matching the Enter case and isSafeSelectClick. A synthetic
+      // Escape would otherwise let a page suppress the locked / no-match notice on
+      // demand — the user's only in-page signal that a dropdown is really ours —
+      // and the resulting defaultPrevented would tell the page whether a message
+      // state is showing. Returning early leaves defaultPrevented false.
+      if (!e.isTrusted) return false;
       e.preventDefault();
       hideDropdown();
       return true;


### PR DESCRIPTION
## What this fixes

Three notices — "no matching entries", "vault is locked", "not connected to server" — could not be dismissed. They sat over the page text directly beneath the focused field, ESC did nothing, and they stayed until the user clicked elsewhere or navigated away.

**Root cause** — the opening guard in `handleDropdownKeydown`:

```ts
if (!currentDropdown || itemElements.length === 0) return false;
```

`itemElements` is populated only in the branch that renders real entries, so it is always empty in the three message-only states and the function returned before ever reaching `case "Escape"`. The guard was written because ArrowDown/ArrowUp/Enter index into `itemElements`; Escape was collateral. That is why ESC failed in exactly the three reported states, and only there.

## Changes

- **Split the guard per case** — presence check stays at the top; the `itemElements.length` requirement moves to ArrowDown/ArrowUp, which are the cases that actually need it.
- **Escape now denies untrusted events**, matching the Enter case and the mouse path. Making Escape reachable would otherwise hand a page a suppression primitive for the locked / no-match notice, and the resulting `defaultPrevented` would tell the page whether the extension is installed and the vault locked.
- **The three message-only states auto-dismiss after 5s.** The candidate list deliberately gets no timer — it would expire while the user is still choosing a credential.
- **The countdown measures visible time only**, pausing while the tab is hidden and resuming on the remaining balance.

All three detectors call the same singleton, so login, credit-card and identity forms are covered. No detector file, message file, or `.js` mirror was touched.

## Review findings worth noting

Plan review and code review each caught this change reproducing the very defect it exists to fix — a test that cannot fail. All three were found by execution, not by reading:

| Where | Finding |
|---|---|
| Plan review | Four of the proposed tests **passed against unfixed `main`** |
| Code review | Deleting the loop that empties the shadow root left **all 1007 tests green** — without it, dropdowns stack one per show, which is the reported bug made worse |
| Code review | The `toFake` scoping pin the plan itself mandated was never written, so dropping the scoping was undetectable |

A security review also refuted the reasoning behind a deferral: the claim that the rAF-vs-dismiss race was unreachable because "5s is three orders of magnitude beyond a frame" holds only while rAF is running, and Chrome pauses rAF in background tabs while timers keep running. Reproduced by probe (`installed=1, removed=0`) and fixed. The refuted reasoning is kept in the record rather than edited away.

## Verification

| Gate | Result |
|---|---|
| Extension tests | **1017 passed / 61 files** |
| Repo tests | **14650 passed, 6 skipped / 1009 files** |
| `npx tsc --noEmit` | clean |
| `npm run lint` (`--max-warnings 0`) | clean |
| `npx next build` | 243/243 static pages |
| `npm run build` (extension) | clean |

Every new test was proven able to fail against its own mutation (14 mutations run in total). Two equivalent mutants were recorded as such, with the reachability argument, rather than given a fabricated test that would appear to kill them.

## Not included (recorded with cost-justification)

- **SC1** — click-to-unlock affordance on the locked notice. `chrome.action.openPopup()` gesture propagation is unmeasured in this environment.
- **SC5** — `role="listbox"` on message states, plus the WCAG 2.2.1 (Timing Adjustable) dimension the timer introduces. Needs screen-reader verification.
- **SC6** — `try`/`catch` around `onDismiss`. Would change error semantics across all 18 dismissal call sites.

Artifacts: `docs/archive/review/extension-dropdown-dismiss-{plan,review,deviation,code-review}.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
