### PR TITLE
feat(extension): show the passphrase toggle as an eye icon

### DIFF
--- a/docs/archive/review/extension-passphrase-visibility-icon-code-review.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-code-review.md
@@ -1,0 +1,208 @@
+# Code Review: extension-passphrase-visibility-icon
+
+Date: 2026-08-17
+Review round: 1
+
+## Changes from Previous Round
+
+Initial code review. Three expert sub-agents reviewed `git diff main...HEAD` in parallel.
+Ollama was unavailable, so seeds and `merge-findings` were skipped — manual dedup fallback.
+
+## Summary
+
+8 findings: **1 Major (withdrawn on verification), 7 Minor.** No Critical. The committed
+code met every requirement; two Minors led to real test improvements.
+
+**Security review: zero findings** — the first empty result across these three changes.
+The masking mechanism (`type={showPassphrase ? "text" : "password"}`) was verified
+byte-identical to `main` by SHA, and the two deferrals (SC4, SC5) were independently
+confirmed honest rather than taken on trust.
+
+## Functionality Findings
+
+**F-Func-1 — Major — WITHDRAWN, misattributed.** The reviewer found an applied mutation
+and two untracked `__probe*.test.tsx` files in the working tree and concluded Phase 2 had
+left a mutation unreverted, falsifying the deviation log's "restoration verified after
+each" claim.
+
+The observation was real; the attribution was not. Those artifacts belonged to the
+**testing reviewer**, running its own mutation pass concurrently in the same worktree.
+The security reviewer hit the same interference from the other side, reporting a transient
+T6 failure that vanished once *its* probe files were removed. Verified immediately after:
+`git status --porcelain` showed only my own deviation-log edit, no probe files existed,
+`HEAD` carried the correct slashed-eye glyph, and the suite was 1023/1023 green. The
+reviewer itself reached the same conclusion after stashing.
+
+**The genuine finding underneath is mine**, and it is recorded as D4: the previous change
+on this package ended with exactly this lesson written down — *do not run verification
+agents concurrently with a mutation pass that edits the tree they read* — and I ran three
+Phase-3 reviewers in parallel while instructing one to mutate. The lesson was recorded and
+not applied. Cost: one Major finding and one transient failure, both spent on an artifact
+of my own scheduling.
+
+**F-Func-2 — Minor — RESOLVED.** The deviation log's D2/D3 renumbering was uncommitted at
+review time. *Resolution:* committed.
+
+**F-Func-3 — Minor — RESOLVED.** NFR4's table claimed "colour / hover / active /
+transition — unchanged", but three classes did change: `rounded` → `rounded-md`,
+`text-gray-600` → `text-gray-500`, `hover:text-gray-800` → `hover:text-gray-700`. The
+*code* was right — those are `App.tsx`'s icon-button values, which is what NFR3 asked for
+— and the reviewer confirmed class-by-class that **no hover-background, active, or
+transition class was dropped**. NFR3 and NFR4 simply contradicted each other.
+*Resolution:* NFR4's table now enumerates the three shade changes; D2 records the same.
+
+## Security Findings
+
+**No findings.** Verification worth recording, all executed rather than asserted:
+
+- **I1.3 / R43** — `VaultUnlock.tsx:58` is byte-identical to `main` (SHA-256 match on the
+  line; the whole input block diffed identical). The diff touches only the sibling
+  `<button>`. Mutating the ternary reddened 2 tests and left 11 green, so the invariant is
+  load-bearing under test rather than decorative.
+- **RS3/RS6** — both new SVGs are fully static JSX: no interpolation anywhere in either
+  subtree, no attribute fed from the passphrase, a message payload, storage, or a tab URL.
+  The only dynamic value in the added block is the `showPassphrase` boolean choosing
+  between two constant subtrees. `dangerouslySetInnerHTML`: zero hits, both sides.
+- **Label provenance** — `t()` resolves from statically-imported bundled JSON with no
+  fetch and no storage read. The one externally-influenced input
+  (`chrome.i18n.getUILanguage()` / `navigator.language`) is a *lookup key* constrained to
+  `{en, ja}` with an `en` fallback, so a hostile locale cannot produce attacker-chosen
+  text — worst case is the wrong one of two bundled strings.
+- **SC4 honesty confirmed** — the popup is a fresh document per open
+  (`main.tsx` calls `createRoot(...).render()` at module top level) and `showPassphrase`
+  is component-local `useState` with no storage backing (grep: five references, all in
+  `VaultUnlock.tsx`). So a revealed passphrase genuinely does not survive closing the
+  popup. The underlying failure-path gap is real, correctly described, and pre-existing.
+- **SC5 honesty confirmed** — `autoComplete` / `spellCheck` / `autoCorrect` /
+  `autoCapitalize` are absent from **both** `main` and `HEAD`. Genuinely pre-existing and
+  untouched, and the cited web-app precedent (`vault-lock-screen.tsx:241`) is real.
+- **Test fixtures** — the new tests type no passphrase at all; none calls `fireEvent.change`
+  on the input, and the input's `value` is never read. No snapshots anywhere in
+  `__tests__/popup/`, so no serialized DOM containing a credential can reach a CI log.
+- **R49** — nothing reads the glyph: no code outside `VaultUnlock.tsx` references
+  `showPassphrase`, and no control flow or trust decision depends on the icon.
+
+The reviewer explicitly declined to re-raise the shoulder-surfing angle, noting the
+affordance, default state, and click cost are all unchanged — consistent with plan review's
+disposition and correct under the Finding Floor.
+
+## Testing Findings
+
+The reviewer re-ran four of the six logged mutations and added three of its own. **All
+four reproduced exactly**, including the two that matter most:
+
+| Mutation | Log claimed | Reviewer observed |
+| --- | --- | --- |
+| delete `aria-label`, keep `title` | 1 red (T6), 12 green | **1 failed / 12 passed** |
+| swap the icon/label pairing | 1 red (T7), T4 green | **1 failed / 12 passed** |
+| same icon both states | 2 red (T4, T7) | **2 failed / 11 passed** |
+
+It also confirmed the `iconFor` null guard **fires with the right error at the right
+line** (`expected null not to be null` from `iconFor`, not a downstream `TypeError` or an
+`undefined === undefined` masquerade) — the precise remedy plan review's Critical F-Test-1
+demanded, verified in force.
+
+**Bottom line on the vacuity hunt: no fourth vacuous test.** Every test was driven red by
+at least one mutation.
+
+**F-Test-1 — Minor — RESOLVED (test removed).** T3 was fully subsumed: the reviewer
+deleted it and re-ran the no-svg mutation, confirming T4 and T7 catch everything T3 caught,
+because all three route through the same `iconFor` guard. T3 had **no mutation it uniquely
+reddened**. *Resolution:* deleted. Its only value — a clearer failure message — is
+delivered by the guard itself, not by its `toContain("<svg")` line.
+
+**F-Test-2 — Minor — RESOLVED (test tightened).** The sharpest finding: **a meaningless
+square glyph in the hidden state passed all 13 tests.** T7 pinned "the visible state has a
+slash", not "the hidden state is an eye", while the plan described it as pinning I1.2 (the
+icon direction). *Verified independently* — I ran the square mutation and got 13/13 green.
+
+*Resolution:* T7 now also asserts the hidden-state glyph contains its pupil `<circle>`.
+**Prove-red executed:** the square mutation reddens T7 alone (it passed before), and the
+no-svg mutation still fires the guard. jsdom cannot judge whether a path *looks* like an
+eye — that stays with M2 — but the two elements carrying the meaning are now pinned.
+
+**F-Test-3 — Minor — ACCEPTED as-is.** T7's `"<line"` coupling reddens on a semantically
+equivalent path refactor. The reviewer established the error direction is **safe**: a
+correct refactor produces a loud false positive, and no broken implementation stays green.
+Documented at the test site.
+
+**F-Test-4 — Minor — verified, no defect.** The locale pin is inert today (jsdom hardcodes
+`en-US` regardless of host locale — confirmed under `LANG=ja_JP.UTF-8`) and is parity with
+ten sibling files. The reviewer added a fact the plan missed: `getLocale()` prefers
+`chrome.i18n.getUILanguage()`, and only because this file stubs no `chrome` object does
+the `navigator.language` fallback govern — so the pin does work, for a slightly different
+reason than the comment states.
+
+**RT11 / CI** — no state leakage (the outer `beforeEach` covers the nested block; RTL
+auto-cleanup verified active by probe; no ordering coupling introduced). CI picks the file
+up: the `extension-ci` job fires on the `extension/**` path filter and runs `vitest run`
+with no path argument.
+
+## Adjacent Findings
+
+Dispositioned above: SC4/SC5 (both confirmed honest, correctly deferred), the T7 path
+coupling (accepted, documented), and the deviation-log hygiene note (committed).
+
+## Quality Warnings
+
+None. `merge-findings` could not run (Ollama unavailable). Manual substitute: the one
+Major was independently re-verified before disposition — and withdrawn on the evidence
+rather than accepted — and both test changes were prove-red executed against their own
+mutation.
+
+## Environment Verification Report
+
+| Path | Classification | Basis |
+| --- | --- | --- |
+| C1 acceptance criteria | `verified-CI` | `npx vitest run` — 1022 passed / 61 files |
+| Icon *appearance* (does it read as an eye) | `blocked-deferred` | **VC1** — jsdom renders no pixels; M1-M2. The square-glyph gap is exactly this boundary, now narrowed but not closed |
+| Screen-reader announcement | `blocked-deferred` | **VC2** — testing-library approximates the accname computation; T6 pins the attribute, M3 covers the announcement |
+| SC4 / SC5 | `blocked-deferred` | Pre-existing, Anti-Deferral entries recorded, both independently verified honest |
+
+## Resolution Status
+
+### F-Func-1 · Major · reported unreverted mutation
+- Action: **Withdrawn** — misattributed to Phase 2; the artifacts were a concurrent
+  reviewer's. Verified `HEAD` clean and the suite green. The real defect (my scheduling)
+  is recorded as D4.
+
+### F-Func-2 · Minor · uncommitted deviation-log rewrite
+- Action: committed. Modified: `extension-passphrase-visibility-icon-deviation.md`
+
+### F-Func-3 · Minor · NFR4 contradicted NFR3
+- Action: NFR4's table now enumerates the three shade changes and confirms nothing was
+  dropped. Modified: `extension-passphrase-visibility-icon-plan.md` (NFR4)
+
+### F-Test-1 · Minor · T3 subsumed
+- Action: deleted. Modified: `VaultUnlock.test.tsx`
+- Red-proof: the reviewer deleted T3 and re-ran the no-svg mutation — T4/T7 still catch it.
+
+### F-Test-2 · Minor · square glyph passed all tests
+- Action: T7 additionally asserts the hidden glyph's pupil `<circle>`.
+- Modified: `VaultUnlock.test.tsx`
+- Red-proof: square-glyph mutation ⇒ T7 fails alone (passed before); no-svg ⇒ guard fires.
+
+### F-Test-3 · Minor · T7 path coupling
+- Action: **Accepted.** Worst case is a loud false positive on a correct refactor; no
+  broken implementation stays green. Cost noted at the test site.
+
+### F-Test-4 · Minor · locale pin mechanism
+- Action: no change; the pin is correct. The `chrome.i18n` precedence detail is recorded
+  here for the next reader.
+
+## Verification after fixes
+
+| Gate | Result |
+| --- | --- |
+| `npx vitest run` (extension) | **1022 passed / 61 files** |
+| `npx tsc --noEmit` | clean |
+| `npm run lint` (repo, `--max-warnings 0`) | clean |
+| `npm run build` (extension) | clean |
+| Worktree | clean |
+
+## Round 2 assessment
+
+Not run. Every finding is resolved, withdrawn on evidence, or accepted with its cost
+stated. The two test changes were prove-red executed against their own mutation; the one
+Major dissolved under verification. A Round 2 would be reviewing one deleted test and one
+added assertion whose failure modes have both been demonstrated.

--- a/docs/archive/review/extension-passphrase-visibility-icon-deviation.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-deviation.md
@@ -33,7 +33,28 @@ the plan measured a fact correctly, stated it correctly, and then wrote a downst
 step that contradicted it. Measuring is not enough if the measurement is not carried
 through to every step that depends on it.
 
-## D2 — Icon path data
+## D2 — Three className changes beyond NFR4's table
+
+NFR4 tabulated padding, text size, and icon size. The implementation also changed three
+colour/shape classes, adopting `App.tsx`'s icon-button values wholesale rather than
+keeping the text button's:
+
+| Class | Before (`main`) | After | Source |
+| --- | --- | --- | --- |
+| corner | `rounded` | `rounded-md` | `App.tsx:137,147,156` |
+| base text | `text-gray-600 dark:text-gray-400` | `text-gray-500 dark:text-gray-400` | same |
+| hover text | `hover:text-gray-800` | `hover:text-gray-700` | same |
+
+Rationale: NFR4's stated intent is "matches the popup's icon-button idiom", and taking
+two-thirds of that idiom while keeping the text button's leftover colours would have been
+a half-conformance nobody could later explain. Every hover/active/transition class is
+otherwise **preserved verbatim** — verified by diffing the token sets between
+`git show main:...` and HEAD.
+
+Recorded because NFR4's table did not enumerate these, and an unrecorded className delta
+in a plan otherwise specified to this level of detail reads as drift rather than intent.
+
+## D3 — Icon path data
 
 The plan specified the icon *idiom* (`viewBox="0 0 24 24"`, `stroke="currentColor"`,
 `strokeWidth="2"`, `w-4 h-4`) but not the path geometry, since the extension cannot import
@@ -86,3 +107,40 @@ M1-M4 remain manual: whether the glyph reads as show/hide, whether the 28×28 bu
 centres against the `h-10` input, the native tooltip text under both locales, and
 legibility in dark mode. `blocked-deferred` for automation, executable locally by the
 developer.
+
+## D4 — A Phase-3 reviewer saw another reviewer's mutation and reported it as ours
+
+The Phase 3 functionality review filed a Major: it found `VaultUnlock.tsx` carrying an
+applied "same plain eye in both states" mutation plus two untracked `__probe*.test.tsx`
+files, and concluded that Phase 2 had left a mutation unreverted — falsifying this log's
+"restoration verified after each" claim.
+
+**The observation was real; the attribution was wrong.** Those artifacts belonged to the
+*testing* reviewer, which was running its own mutation pass concurrently in the same
+worktree. The security reviewer independently hit the same interference from the opposite
+side, reporting a transient T6 failure that vanished once its own probe files were
+removed. Checked immediately afterwards:
+
+```console
+$ git status --porcelain
+ M docs/archive/review/extension-passphrase-visibility-icon-deviation.md   ← this file, mine
+$ ls extension/src/__tests__/popup/ | grep -i probe
+  (none)
+$ git show HEAD:extension/src/popup/components/VaultUnlock.tsx | grep -c '<line x1="2"'
+1                                        ← the slashed eye is committed correctly
+$ npx vitest run
+Test Files  61 passed (61)   Tests  1023 passed (1023)
+```
+
+The reviewer itself reached the same conclusion after stashing — it recorded that HEAD is
+clean and that this is "process hygiene, not a defect in what merges". That part is right.
+
+**What is genuinely mine, and it is the more useful finding**: the previous change on this
+package ended with exactly this lesson written down — *do not run verification agents
+concurrently with a mutation pass that edits the tree they read; the prove-red pass must
+own the worktree exclusively.* I wrote that, and then ran three Phase-3 reviewers in
+parallel while telling one of them to mutate. The lesson was recorded and not applied.
+
+The concrete cost is not a shipped defect but a reviewer-hours defect: one Major finding
+and one transient failure both spent on an artifact of my own scheduling. Next time,
+either serialize the mutating reviewer or give it an isolated worktree.

--- a/docs/archive/review/extension-passphrase-visibility-icon-deviation.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-deviation.md
@@ -159,3 +159,29 @@ Two test changes came out of code review, both prove-red executed:
 
 What remains unpinnable is unchanged and honest: jsdom cannot judge whether a path *looks*
 like an eye. T7 pins the two elements that carry the meaning; M2 covers the rest.
+
+## D6 — SC4 and SC5 implemented after a follow-up security review
+
+Both were deferred in Phase 1 and re-raised by a follow-up review that arrived at them
+independently. Implemented rather than re-deferred; see the plan's addendum for why the
+original cost estimate was wrong.
+
+- **SC4**: `setShowPassphrase(false)` on both failure branches. The passphrase *value* is
+  deliberately kept so the user can fix a typo — only visibility resets.
+- **SC5**: `autoComplete="current-password"` (matching the web app's five passphrase
+  inputs), plus `spellCheck` / `autoCorrect` / `autoCapitalize` off.
+
+Three tests added, four mutations run:
+
+| Mutation | Reddens |
+| --- | --- |
+| H: drop re-mask on the invalid-passphrase branch | that branch's test alone |
+| I: drop re-mask on the permission-denied branch | that branch's test alone |
+| J: also clear the value on failure | the "value survives" assertion |
+| K: drop `spellCheck` | the attribute test |
+
+H and I reddening separately is the point: the two failure paths are independently pinned
+rather than sharing one assertion, so removing either is visible.
+
+Gates after: 1025 extension tests, tsc clean, lint clean, build clean, `git diff --check`
+clean.

--- a/docs/archive/review/extension-passphrase-visibility-icon-deviation.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-deviation.md
@@ -1,0 +1,88 @@
+# Coding Deviation Log: extension-passphrase-visibility-icon
+
+Citations in this log are against the implementation (post-change), unlike the plan,
+which declares a `main` baseline at `d22f252c`.
+
+## D1 — The plan's T6 mutation was wrong, and prove-red caught it
+
+The plan's Kind-B table specified, for T6:
+
+> hardcode `aria-label` only, leaving `title` state-dependent → **T6 must fail; T1/T2/T5
+> must stay green**
+
+Run as written, this reddened **six** tests, not one. The reason is the very precedence
+fact the plan had measured and recorded two sections earlier and then failed to apply:
+**`aria-label` overrides `title`**. Hardcoding `aria-label="Show"` therefore freezes the
+accessible name in *both* states, so the name-based queries in T1/T2/T5 stop
+distinguishing them — the mutation breaks far more than the clause it was aimed at, and
+proves nothing about whether `aria-label` is load-bearing.
+
+**The correct mutation is to delete `aria-label` entirely**, leaving `title` to supply the
+name. Run:
+
+```
+MUTATION[B2: delete aria-label (title remains)] => Tests 1 failed
+    red: sets aria-label itself, not only the title fallback
+```
+
+One test red, twelve green. *That* is the evidence the plan wanted: T6 sees the defect and
+nothing else can. Corrected in the plan's Kind-B table.
+
+Worth naming the pattern, because it is the third time in two changes on this package:
+the plan measured a fact correctly, stated it correctly, and then wrote a downstream
+step that contradicted it. Measuring is not enough if the measurement is not carried
+through to every step that depends on it.
+
+## D2 — Icon path data
+
+The plan specified the icon *idiom* (`viewBox="0 0 24 24"`, `stroke="currentColor"`,
+`strokeWidth="2"`, `w-4 h-4`) but not the path geometry, since the extension cannot import
+`lucide-react` (no icon dependency). The paths implemented are equivalents of lucide's
+`Eye` and `EyeOff` — the same glyphs the web app renders at
+`src/components/vault/vault-lock-screen.tsx:245-257` — so the two surfaces now show the
+same picture through different mechanisms, which is what SC1 predicted.
+
+`EyeOff` carries a `<line>` element for the slash; T7 keys on exactly that, which is the
+coupling to path data the plan accepted explicitly.
+
+## Prove-red results (all executed and observed)
+
+Each mutation was applied to the real file, the suite run, and the file restored from a
+pristine scratchpad copy. Restoration verified after each.
+
+| Mutation | Reddens | Observed |
+| --- | --- | --- |
+| A: hardcode both `aria-label` and `title` | 6 tests (name-based queries collapse) | PASS |
+| B: hardcode `aria-label` only | **6 tests — plan predicted 1** | corrected, see D1 |
+| B2: delete `aria-label`, keep `title` | **1 test (T6), 12 green** | PASS |
+| C: same icon in both states | 2 tests (T4, T7) | PASS |
+| D: remove the `type` ternary | 2 tests (T5 + the pre-existing toggle test) | PASS |
+| E: swap the icon/label pairing | **1 test (T7); T4 stays green** | PASS |
+
+**Mutation E is the one that justifies T7's existence.** Plan review found that the
+originally-proposed mutation table claimed this case was caught by T2, and measured that
+it was not — T2 asserts the name round-trip, which a swapped pairing leaves untouched.
+E confirms both halves: T7 catches it, and T4 does *not* (the icons still differ, merely
+backwards). Without T7 this defect would have shipped with a green suite.
+
+**Allow side, per the Remedy Floor**: after every mutation-revert the full extension suite
+was re-run green — 1023 tests in 61 files, including `App.test.tsx` and `MatchList.test.tsx`,
+which query sibling icon buttons by accessible name and so would notice a change to the
+popup's naming convention.
+
+## Verification
+
+| Gate | Result |
+| --- | --- |
+| `npx vitest run` (extension) | **1023 passed / 61 files** (+6) |
+| `npx tsc --noEmit` (extension) | clean |
+| `npm run lint` (repo, `--max-warnings 0`) | clean |
+| `npm run build` (extension) | clean |
+| Files changed | 2 code + 2 docs — matches the Implementation Checklist |
+
+## Not verifiable here (VC1)
+
+M1-M4 remain manual: whether the glyph reads as show/hide, whether the 28×28 button
+centres against the `h-10` input, the native tooltip text under both locales, and
+legibility in dark mode. `blocked-deferred` for automation, executable locally by the
+developer.

--- a/docs/archive/review/extension-passphrase-visibility-icon-deviation.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-deviation.md
@@ -185,3 +185,33 @@ rather than sharing one assertion, so removing either is visible.
 
 Gates after: 1025 extension tests, tsc clean, lint clean, build clean, `git diff --check`
 clean.
+
+## D7 — The re-mask missed the rejection paths, and two of its clauses were unpinned
+
+A follow-up security review found the D6 fix incomplete: `getSettings`, the permission
+check, and `sendMessage` can all *reject*, and an early return then skipped
+`setShowPassphrase(false)` **and** `setLoading(false)`. Probed against the then-current
+code: on a `sendMessage` rejection the field stayed `type="text"` and the button stayed
+disabled on "Unlocking" — the secret on screen with no way to retry short of closing the
+popup. Worse than the returned-failure case D6 did handle.
+
+Replaced with `try/catch/finally`, re-masking in `finally` under an `unlocked` guard. The
+`catch` sets `UNLOCK_FAILED`, an already-mapped error code with translations in both
+locales — no new i18n keys.
+
+**Two clauses initially had no test able to fail for them**, found by running the
+mutations rather than assuming:
+
+| Mutation | First run | After adding tests |
+| --- | --- | --- |
+| L: drop the `catch` clause | **18 passed — nothing red** | 3 red (all rejection tests) |
+| M: re-mask only on returned failure | 5 red | 5 red |
+| N: drop the `unlocked` guard | **18 passed — nothing red** | 1 red (success test) |
+
+L passed because `finally` still re-masked, so no test observed the missing error message;
+N passed because nothing covered the success path's visibility. Added an error-message
+assertion to the rejection tests and a success-path test. Both mutations now redden.
+
+This is the same lesson as D1 and D5, on its third occurrence in this change: a fix can be
+correct while one of its clauses is unmeasured, and only running the mutation separates
+the two.

--- a/docs/archive/review/extension-passphrase-visibility-icon-deviation.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-deviation.md
@@ -144,3 +144,18 @@ parallel while telling one of them to mutate. The lesson was recorded and not ap
 The concrete cost is not a shipped defect but a reviewer-hours defect: one Major finding
 and one transient failure both spent on an artifact of my own scheduling. Next time,
 either serialize the mutating reviewer or give it an isolated worktree.
+
+## D5 — Phase 3 narrowed what the icon tests actually pin
+
+Two test changes came out of code review, both prove-red executed:
+
+- **T3 deleted.** The reviewer proved it reddened under no mutation that T4 and T7 did not
+  also catch — all three route through `iconFor`, whose null guard does the work T3's
+  `toContain("<svg")` appeared to do.
+- **T7 tightened.** A meaningless square glyph in the hidden state **passed all 13 tests**:
+  T7 pinned "the visible state has a slash", not "the hidden state is an eye", while the
+  plan described it as pinning the icon direction. T7 now also asserts the hidden glyph's
+  pupil `<circle>`. Re-run: the square mutation reddens T7 alone, where it was green before.
+
+What remains unpinnable is unchanged and honest: jsdom cannot judge whether a path *looks*
+like an eye. T7 pins the two elements that carry the meaning; M2 covers the rest.

--- a/docs/archive/review/extension-passphrase-visibility-icon-plan.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-plan.md
@@ -576,41 +576,30 @@ popup with the vault locked.
   caught only if someone writes a test for it. Owner: a future a11y tooling pass.
   Recorded per R34 rather than silently.
 
-- **SC4 — Re-masking the passphrase after a failed unlock. RESOLVED, not deferred.**, and the
-  question is answered rather than left open. `VaultUnlock.tsx:37-42` clears the
-  passphrase only on the success branch; on failure the value stays in React state
-  and, if revealed, stays readable in the DOM for the rest of the popup session.
-  **Verified mitigation**: the popup is a fresh document per open
-  (`src/popup/main.tsx` calls `createRoot(...).render()` each load) and
-  `showPassphrase` is component-local `useState` with no `chrome.storage` backing —
-  so neither the reveal state nor the passphrase survives closing the popup. There
-  is no cross-session exposure.
+- **SC4 — Re-masking the passphrase after a failed unlock. RESOLVED — implemented,
+  not deferred.** Originally scoped out. On failure the passphrase stayed in state
+  and, if revealed, stayed readable until the popup closed.
 
-  **Anti-Deferral**: worst case = a wrong, revealed master passphrase stays on
-  screen until the user closes the popup or retypes. Likelihood = only after a
-  failed unlock *with* reveal already toggled on. Cost of including = turns a
-  purely presentational change into a behavioural one, cutting against C1's own
-  "signature unchanged" framing and requiring its own test matrix for the
-  error path. Cost of excluding = the pre-existing window stays open, unchanged
-  by this PR either way. Owner: a future unlock-flow hardening pass. Recorded so a
-  later round does not re-litigate it as if undecided.
+  **Implemented**: every exit from `handleSubmit` that is not a successful unlock
+  re-masks the field, via a `finally` clause guarded on an `unlocked` flag. The
+  passphrase *value* is deliberately kept so the user can fix a typo. A follow-up
+  review then found the first attempt still missed the three `await`s rejecting —
+  where an early return stranded both the reveal and the `loading` state, leaving
+  the button stuck on "Unlocking" with the secret on screen. `try/catch/finally`
+  covers all of it, and the `catch` surfaces `UNLOCK_FAILED` (an existing mapped
+  code — no new i18n keys).
 
-- **SC5 — Input hardening (`autoComplete` / `spellCheck`). RESOLVED, not deferred.**, and pre-existing: `VaultUnlock.tsx:57-64` sets neither, and grep
-  confirms neither appears anywhere in `src/popup/`. This matters *adjacent* to
-  this change because `type="text"` (the revealed state) is where browser
-  save-prompt and spellcheck heuristics differ from `type="password"` — but that
-  flip already exists on `main` and I1.3 pins it unchanged, so this change neither
-  introduces nor widens the exposure (R43: no widening).
+- **SC5 — Input hardening (`autoComplete` / `spellCheck`). RESOLVED — implemented,
+  not deferred.** The field now declares `autoComplete="current-password"`,
+  matching the web app's five passphrase inputs, plus `spellCheck`, `autoCorrect`
+  and `autoCapitalize` off — the last three because revealing the field flips it
+  to `type="text"`, where a browser would otherwise apply them to a secret.
 
-  Worth noting the web app's analogue **does** set `autoComplete` —
-  `vault-lock-screen.tsx:241` uses `autoComplete="current-password"` — so there is
-  an in-repo precedent for hardening this input, which strengthens the case for a
-  follow-up. **Anti-Deferral**: cost of including = a behavioural change to
-  autofill on a component this PR is otherwise only restyling, with no test able
-  to verify browser heuristics (VC1's constraint class). Cost of excluding = an
-  unchanged pre-existing gap. Owner: the same unlock-flow hardening pass as SC4.
-  Recorded explicitly so a Phase-3 reviewer does not rediscover the `type="text"`
-  concern and mistake it for fix-induced.
+  Noted for the record: `current-password` permits a browser password manager to
+  store and offer the master passphrase. That is a trade the project has already
+  made deliberately in five web-app components, and following it beats inventing
+  an extension-only policy — but it is a choice, not a hardening, and is recorded
+  as such rather than claimed as one.
 
 ### SC4 / SC5 reopened after a second independent signal
 

--- a/docs/archive/review/extension-passphrase-visibility-icon-plan.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-plan.md
@@ -430,10 +430,16 @@ this table, not a passing test.
 | Test | Mutation | Expected |
 | --- | --- | --- |
 | T1, T2 | hardcode **both** `aria-label` and `title` to a constant | must fail |
-| T6 | hardcode `aria-label` only, leaving `title` state-dependent | **T6 must fail; T1/T2/T5 must stay green** |
+| T6 | **delete** `aria-label`, leaving `title` to supply the name | **T6 must fail; T1/T2/T5 must stay green** |
 | T4 | render the same icon in both states | must fail |
 | T5 | remove the `type={...}` ternary from the input | must fail |
 | T7 | swap the icon/label pairing (eye shown while visible) | must fail |
+
+**Corrected during Phase 2.** This row originally said "hardcode `aria-label` only".
+Run as written it reddened six tests, not one — because `aria-label` *overrides*
+`title`, so freezing it freezes the accessible name in both states and every
+name-based query collapses. Deleting the attribute is the mutation that isolates
+the clause. See deviation log D1.
 
 The T6 row is the one that matters most and is the one the first revision lacked:
 it is the *only* clause that proves `aria-label` is load-bearing rather than

--- a/docs/archive/review/extension-passphrase-visibility-icon-plan.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-plan.md
@@ -576,7 +576,7 @@ popup with the vault locked.
   caught only if someone writes a test for it. Owner: a future a11y tooling pass.
   Recorded per R34 rather than silently.
 
-- **SC4 — Re-masking the passphrase after a failed unlock.** Out of scope, and the
+- **SC4 — Re-masking the passphrase after a failed unlock. RESOLVED, not deferred.**, and the
   question is answered rather than left open. `VaultUnlock.tsx:37-42` clears the
   passphrase only on the success branch; on failure the value stays in React state
   and, if revealed, stays readable in the DOM for the rest of the popup session.
@@ -595,8 +595,7 @@ popup with the vault locked.
   by this PR either way. Owner: a future unlock-flow hardening pass. Recorded so a
   later round does not re-litigate it as if undecided.
 
-- **SC5 — `autoComplete="off"` / `spellCheck={false}` on the passphrase input.**
-  Out of scope, and pre-existing: `VaultUnlock.tsx:57-64` sets neither, and grep
+- **SC5 — Input hardening (`autoComplete` / `spellCheck`). RESOLVED, not deferred.**, and pre-existing: `VaultUnlock.tsx:57-64` sets neither, and grep
   confirms neither appears anywhere in `src/popup/`. This matters *adjacent* to
   this change because `type="text"` (the revealed state) is where browser
   save-prompt and spellcheck heuristics differ from `type="password"` — but that
@@ -612,6 +611,27 @@ popup with the vault locked.
   unchanged pre-existing gap. Owner: the same unlock-flow hardening pass as SC4.
   Recorded explicitly so a Phase-3 reviewer does not rediscover the `type="text"`
   concern and mistake it for fix-induced.
+
+### SC4 / SC5 reopened after a second independent signal
+
+Both were deferred with Anti-Deferral entries, then raised again by a follow-up security
+review that reached them independently of the plan. Two things changed the calculus:
+
+1. **A second, independent signal on the same point.** Plan review surfaced them from the
+   code; the follow-up review surfaced them from the diff without having read the
+   deferrals. Convergence from two directions is evidence the cost estimate was wrong,
+   not that the reviewers repeated each other.
+2. **The measured cost was smaller than the deferral assumed.** SC4's entry argued it
+   "turns a purely presentational change into a behavioural one, requiring its own test
+   matrix for the error path". Reading the handler, it is two failure branches, one line
+   each, no new state and no new i18n — and the two branches turned out to be
+   independently pinnable, which the mutation pass confirmed.
+
+SC5 follows the web app's convention rather than inventing an extension-specific policy:
+five components there declare `autoComplete="current-password"`, a deliberate trade the
+project has already made. `spellCheck` / `autoCorrect` / `autoCapitalize` are set off
+because revealing the field flips it to `type="text"`, where a browser would otherwise
+apply them to a secret.
 
 ### Risks
 

--- a/docs/archive/review/extension-passphrase-visibility-icon-plan.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-plan.md
@@ -163,7 +163,18 @@ See T6 and the Kind-B table.
   | padding | `px-2 py-1` (8px / 4px) | `p-1.5` (6px, uniform) |
   | text size | `text-xs` | **removed** — dead once no text renders |
   | icon | — | `w-4 h-4` |
-  | colour / hover / active / transition | unchanged | unchanged |
+  | corner | `rounded` | `rounded-md` |
+  | base text | `text-gray-600 dark:text-gray-400` | `text-gray-500 dark:text-gray-400` |
+  | hover text | `hover:text-gray-800` | `hover:text-gray-700` |
+  | hover bg / active / transition | unchanged | **unchanged** |
+
+  The three colour/shape rows adopt `App.tsx`'s icon-button values, since taking
+  two-thirds of an idiom and keeping the text button's leftovers would be a
+  half-conformance nobody could later explain. Every hover-background, active, and
+  transition class is preserved verbatim. (An earlier revision of this table said
+  "colour / hover / active / transition — unchanged", which contradicted NFR3's
+  "matches the popup's icon-button idiom" instruction; the implementation followed
+  NFR3, and the table is corrected to match. Phase 3, F-Func-3.)
 
   `p-1.5` is what **all seven** sibling icon buttons use — `App.tsx:137,147,156`
   and `MatchList.tsx:243,254,262,269` — so this is conformance, not invention.

--- a/docs/archive/review/extension-passphrase-visibility-icon-plan.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-plan.md
@@ -1,0 +1,624 @@
+# Plan: extension-passphrase-visibility-icon
+
+Replace the extension popup's textual "Show" / "Hide" passphrase toggle with an
+eye / eye-with-slash icon, without losing the accessible name the button
+currently gets from that text.
+
+## Citation baseline
+
+**Every `file:line` reference in this plan is against `main` at `d22f252c`**
+(pre-implementation). Resolve citations with `git show main:<path>`, not against
+HEAD once the fix lands.
+
+## Project context
+
+- **Type**: web app (browser extension sub-package, `extension/`)
+- **Test infrastructure**: unit + integration (vitest + jsdom + @testing-library/react)
+  + CI/CD. `npx vitest run` and `npx next build` are the repo's mandatory gates.
+- **Verification environment constraints**:
+  - **VC1 — Visual appearance is not verifiable in CI.** Whether the icon *reads
+    as* "show/hide" to a sighted user is a judgment no assertion captures. jsdom
+    renders no pixels. Every acceptance criterion below is therefore written
+    against the accessible name, the `type` attribute, and the rendered markup —
+    all `verifiable-CI` — and the visual check is a **manual-test** item (M1-M3),
+    `blocked-deferred` for automation.
+  - **VC2 — Screen-reader announcement is not exercisable here.** jsdom computes
+    no accessibility tree; `getByRole(..., { name })` uses testing-library's own
+    approximation of accessible-name computation, not the browser's.
+
+    **What that approximation does and does not catch — measured, because an
+    earlier revision of this plan stated it backwards.** It catches a *fully*
+    missing name: a bare `<svg>` button does not resolve. It does **not**
+    distinguish which attribute supplied the name — `title` alone resolves just as
+    `aria-label` alone does. So the defect this design actually guards against
+    (`title` present, `aria-label` absent) is invisible to any name-based query,
+    and only a direct attribute assertion sees it. That is T6's entire reason for
+    existing. Recorded rather than corrected silently, because the wrong version
+    licensed a test list in which nothing enforced the design's central choice.
+
+## Objective
+
+The toggle at `VaultUnlock.tsx:65-71` renders the literal word "Show" / "Hide".
+An eye icon is the near-universal convention for this control and is what the
+surrounding UI already uses for every other action (`App.tsx:136-158`,
+`MatchList.tsx:242-271` are all icon buttons). Make it consistent.
+
+## Problem statement
+
+`extension/src/popup/components/VaultUnlock.tsx:65-71`:
+
+```tsx
+<button
+  type="button"
+  onClick={() => setShowPassphrase((v) => !v)}
+  className="text-xs text-gray-600 dark:text-gray-400 px-2 py-1 rounded ..."
+>
+  {showPassphrase ? t("popup.hide") : t("popup.show")}
+</button>
+```
+
+This is the **only** textual icon-less action button in the popup. Every sibling
+is already an icon button with a `title`:
+
+| Control | Location | Form |
+| --- | --- | --- |
+| Lock vault | `App.tsx:136` | inline `<svg>` + `title` |
+| Disconnect | `App.tsx:146` | inline `<svg>` + `title` |
+| Settings | `App.tsx:154-155` | inline `<svg>` + `title` + `aria-label` |
+| Fill / Copy username / Copy TOTP / Copy | `MatchList.tsx:242-271` | inline `<svg>` + `title` |
+
+So this change removes an inconsistency rather than introducing a new pattern.
+
+### The constraint that actually shapes the design
+
+`extension/src/__tests__/popup/VaultUnlock.test.tsx:90-97`:
+
+```tsx
+it("toggles show/hide passphrase", async () => {
+  const toggle = screen.getByRole("button", { name: /show/i });
+```
+
+The button's accessible name comes from its text content today. Replacing that
+text with a **bare, unlabelled** `<svg>` leaves the button with no accessible name:
+the test breaks, and a screen-reader user hears only "button".
+
+**But `aria-label` is not the only thing that prevents this, and an earlier
+revision of this plan was wrong to call it "mandatory".** Measured under this
+repo's vitest 4.1.10 + jsdom 29 + @testing-library/react 16.3:
+
+| Probe | Accessible name resolves? |
+| --- | --- |
+| `<button title="Show"><svg/></button>` | **yes** |
+| `<button aria-label="Show"><svg/></button>` | **yes** |
+| `<button><svg/></button>` | **no — nameless** |
+| both set, differing values | `aria-label` wins; `title` is not announced |
+
+`title` is the last fallback in accessible-name computation, and the repo already
+relies on it: `App.tsx:146` sets `title` only, and `App.test.tsx:112` finds that
+button by `getByRole("button", { name: /disconnect/i })`. So `title` alone would
+satisfy FR2, I1.1, and every test below.
+
+**`aria-label` is therefore a deliberate choice, not a necessity**, and the plan
+must say which — because the difference decides the test design. It is kept
+because `title` is not exposed to touch users, is announced inconsistently across
+screen readers, and is the weakest name source in the computation.
+`App.tsx:154-155` sets both on the settings button; this follows that precedent.
+
+**Consequence for testing (this is the part an earlier revision got wrong):**
+since `title` also carries the state-dependent value, a mutation that hardcodes
+only `aria-label` will **not** redden a `getByRole(..., {name})` assertion. If
+`aria-label` is to be load-bearing, one test must assert the attribute directly.
+See T6 and the Kind-B table.
+
+## Requirements
+
+### Functional
+
+- **FR1** — The toggle renders an eye icon when the passphrase is hidden and an
+  eye-with-slash icon when it is visible.
+- **FR2** — The button retains an accessible name that changes with state:
+  "Show" when hidden, "Hide" when visible. The existing `popup.show` /
+  `popup.hide` message keys supply it — **no new i18n keys** (NFR1).
+- **FR3** — Clicking still toggles the input's `type` between `password` and
+  `text`. Unchanged behaviour; it is listed because it is what the change must
+  not break.
+- **FR4** — A pointer user gets a native tooltip (`title`), matching every other
+  icon button in the popup.
+
+### Non-functional
+
+- **NFR1** — No new i18n keys. `popup.show` / `popup.hide` already exist in both
+  `src/messages/en.json:15-16` and `ja.json:15-16` and have exactly one consumer
+  (this button), so their meaning is unchanged by the reuse.
+- **NFR2** — The icon follows the popup's established inline-SVG idiom:
+  `viewBox="0 0 24 24"`, `fill="none"`, `stroke="currentColor"`,
+  `strokeLinecap="round"`, `strokeLinejoin="round"`, sized by a Tailwind class.
+  **Not** the `src/content/ui/icons.ts` module — that exports HTML *strings* for
+  `innerHTML` injection into a content-script shadow DOM, a different consumer
+  with a different mechanism. Reusing it here would mean `dangerouslySetInnerHTML`
+  in React to render markup we already control as JSX (see R1 note below).
+- **NFR3** — The button matches the popup's icon-button idiom, verified against
+  `App.tsx:130-160` rather than paraphrased:
+
+  ```text
+  button className="p-1.5 rounded-md text-gray-500 dark:text-gray-400
+                    hover:text-gray-700 dark:hover:text-gray-200
+                    hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+  svg    className="w-4 h-4"  strokeWidth="2"
+  ```
+
+  `App.tsx` header icons use `strokeWidth="2"`; `MatchList.tsx` row icons use
+  `2.5`. This button sits in the unlock form, in neither group — `2` is chosen
+  because the header buttons are the closer analogue in size (`w-4 h-4`) and
+  because the heavier weight in `MatchList` compensates for its smaller
+  `w-3.5 h-3.5` glyphs, a compensation that does not apply here.
+
+- **NFR4 — the button's own box is respecified, not left to the implementer.**
+  An earlier revision named the layout shift as a risk (M1, Risk 3) and then
+  specified no className change, in a plan otherwise specified down to
+  `strokeLinejoin`. Concretely:
+
+  | | Before | After |
+  | --- | --- | --- |
+  | padding | `px-2 py-1` (8px / 4px) | `p-1.5` (6px, uniform) |
+  | text size | `text-xs` | **removed** — dead once no text renders |
+  | icon | — | `w-4 h-4` |
+  | colour / hover / active / transition | unchanged | unchanged |
+
+  `p-1.5` is what **all seven** sibling icon buttons use — `App.tsx:137,147,156`
+  and `MatchList.tsx:243,254,262,269` — so this is conformance, not invention.
+  `px-2 py-1` matches none of them and would leave an asymmetric box around a
+  square glyph.
+
+  Hit target: `p-1.5` + `w-4 h-4` gives 28×28 CSS px, clearing WCAG 2.2 SC 2.5.8's
+  24×24 minimum on both axes. The current `px-2 py-1` around a 16px glyph would
+  give 32×24 — clearing it on one axis only, and by luck of the glyph size rather
+  than by design. Computed rather than asserted, because the earlier revision
+  classified this as "not a correctness issue" without doing the arithmetic.
+
+  This remains the one part of the change CI cannot verify (VC1) — hence M1, now
+  strengthened to check squareness and centring rather than just "alignment".
+
+## Technical approach
+
+One file changed: `VaultUnlock.tsx`. Plus its test.
+
+### Icon choice
+
+Two inline SVGs, switched on `showPassphrase`:
+
+- **hidden state → eye** (`popup.show`): the action offered is "reveal".
+- **visible state → eye-with-slash** (`popup.hide`): the action offered is "conceal".
+
+**This is settled by in-repo precedent, not by argument.** An earlier revision of
+this plan defended the direction at length as "a real decision, not an obvious
+one" — while the repo had already made it, uniformly, 37 times. Code-derived:
+
+```console
+$ grep -rn 'EyeOff' src/ --include='*.tsx' | wc -l
+37
+```
+
+The direct analogue is the **web app's own vault unlock screen** —
+`src/components/vault/vault-lock-screen.tsx:245-257` — same `showPassphrase`
+state name, same `type={showPassphrase ? "text" : "password"}` input:
+
+```tsx
+{showPassphrase ? (
+  <EyeOff className="h-4 w-4" />
+) : (
+  <Eye className="h-4 w-4" />
+)}
+```
+
+That is the **action** convention, and it is what this plan follows. The choice is
+now conformance to an established repo-wide convention rather than a judgment
+call, which is a materially stronger footing and removes the re-litigation risk
+the earlier revision was worried about.
+
+The web app reaches it via `lucide-react`. **The extension cannot**:
+`extension/package.json` lists only `otpauth`, `react`, `react-dom`, `tldts` — no
+icon library. So the extension must inline equivalent SVG paths. The two surfaces
+converge in *semantics* and diverge in *implementation*, and the divergence is
+forced by the dependency set rather than chosen.
+
+Note also `vault-lock-screen.tsx` sizes its glyph `h-4 w-4`, matching the
+`w-4 h-4` this plan selects in NFR3 from `App.tsx` — the two independent lines of
+evidence agree.
+
+### Accessible name
+
+`aria-label={showPassphrase ? t("popup.hide") : t("popup.show")}` — the exact
+expression that is the button's text today, moved to the label. `title` gets the
+same value for the pointer tooltip.
+
+**Measured, not assumed** — a throwaway probe under this repo's vitest 4.1.10 +
+jsdom 29 + @testing-library/react, three assertions, all passing:
+
+| Probe | Result |
+| --- | --- |
+| `<button title="Show"><svg/></button>` matched by `getByRole("button", {name:/show/i})` | **yes** |
+| `<button aria-label="Show"><svg/></button>` matched by the same query | **yes** |
+| `<button><svg/></button>` (bare icon, no label) matched | **no — nameless** |
+
+Two conclusions the design rests on:
+
+1. **The nameless-button risk is real.** A bare icon button is not found by the
+   existing test's query, confirming that dropping the text without adding a label
+   breaks `VaultUnlock.test.tsx:93` — and, more importantly, leaves the control
+   unidentifiable to assistive technology.
+2. **`title` alone would satisfy both the test and the ARIA name fallback.** So
+   `aria-label` is a *deliberate* choice, not a necessity. It is kept because
+   `title` is a weak accessible-name source — it is the last fallback in the
+   accessible-name computation, is not announced consistently across screen
+   readers, and is invisible to touch users. `App.tsx:154-155` already sets both
+   on the settings button; this follows that precedent rather than inventing one.
+
+Recorded because "the test passes" would otherwise be mistaken for evidence that
+the accessibility half is handled, when the test would also pass with `title`
+alone.
+
+`aria-label` is used rather than a visually-hidden `<span>` because the popup has
+no `sr-only` utility in use anywhere, and introducing one for a single control
+would be a wider change than the defect warrants.
+
+### `aria-hidden` on the `<svg>`
+
+**Not** set, following the popup's majority convention: `App.tsx:139,149,158` and
+`MatchList.tsx:245,256,264,271` all render bare `<svg>` inside labelled buttons.
+(`FillMismatchDialog.tsx` uses `aria-hidden` once, so the convention is not
+unanimous — hence stating the choice rather than leaving the implementer to guess.)
+With `aria-label` on the button, the name is computed from the label and the child
+graphic is not traversed, so the attribute would change nothing here.
+
+### Why not `aria-pressed`
+
+A toggle button can carry `aria-pressed`. Deliberately **not** added: with a
+state-changing `aria-label` ("Show" ↔ "Hide"), adding `aria-pressed` produces a
+double announcement ("Hide, pressed") whose two halves can be read as
+contradicting each other. Choose one mechanism. The changing label is the one
+that already exists and that the test already queries. Recorded so a reviewer
+does not read the omission as an oversight.
+
+What conveys the *current* state under this mechanism: the user infers it from the
+action name (hearing "Show" implies currently hidden), and independently from the
+field itself — the input's `type` flips between `password` and `text`, which
+assistive technology reports for the input (I1.3). Stated because it is the first
+thing a reviewer probes about an action-labelled toggle.
+
+## Contracts
+
+### C1 — The toggle is an icon button with a state-dependent accessible name
+
+- **Signature** (unchanged): the component's props and the `showPassphrase` state
+  hook are untouched. This contract is about rendered output only.
+- **Control class**: **detection or audit only** — no denial. This is presentation;
+  nothing security-relevant gates on it. Declared explicitly (R49) so no later
+  contract treats the icon as a boundary. Note the *adjacent* security property
+  (the input's `type` attribute, which is what actually masks the passphrase) is
+  **not** part of this contract and must not change — see I1.3.
+- **Invariants**:
+  - **I1.1** (app-enforced): the button has a non-empty accessible name in both
+    states. *No schema-enforced equivalent exists* — React cannot express "this
+    element must have an accessible name" in the type system; the closest
+    mechanism is a lint rule (`jsx-a11y`), which this repo does not run. Stated
+    per the plan's obligation to justify app-enforced choices.
+  - **I1.2** (app-enforced): the accessible name is `popup.show` when the
+    passphrase is hidden and `popup.hide` when visible — i.e. it names the
+    **action**, matching the icon direction.
+  - **I1.3** (app-enforced): the input's `type` remains `password` when hidden and
+    `text` when visible. The change is presentational and must not touch the
+    masking mechanism.
+- **Forbidden patterns**:
+  - `pattern: dangerouslySetInnerHTML` — reason: the icon is JSX we control; there
+    is no reason to route it through raw HTML injection in a component that
+    handles a passphrase.
+  - `pattern: <button[^>]*>\s*<svg` with no `aria-label` on the button — reason:
+    that is precisely the nameless-button defect this contract exists to prevent.
+    (Checked by reading, not grep alone — the regex is a hint; I1.1's test is the
+    real gate.)
+- **Acceptance criteria**:
+  - `getByRole("button", { name: /show/i })` resolves while the input is
+    `type="password"`.
+  - After one click, `getByRole("button", { name: /hide/i })` resolves and the
+    input is `type="text"`.
+  - After a second click, the name returns to `/show/i` and the type to
+    `password`. **The round-trip matters**: a label wired to a constant rather
+    than to state would pass the first two criteria and fail this one.
+  - The button contains an `<svg>` element in both states.
+  - The two states render *different* icon markup. Without this, an
+    implementation that shows the same icon regardless of state satisfies
+    everything above.
+- **Manual-test classification**: `verifiable-CI` for all five criteria. The
+  question "does the icon read as show/hide to a sighted user" is VC1's
+  `blocked-deferred` half, covered by M1-M3.
+
+### C2 — Consumer-flow walkthrough
+
+The changed surface is rendered output consumed outside the component, so each
+consumer is walked through before C1 locks.
+
+- **Consumer 1 (path: `src/__tests__/popup/VaultUnlock.test.tsx:90-97`)** reads
+  `{ accessible name, input type }` and uses the name to *locate* the button
+  (`getByRole("button", { name: /show/i })`), then asserts the type flips. It
+  needs the name to survive the change — which is exactly what `aria-label`
+  supplies. **This walkthrough is why `aria-label` is in the design at all**: the
+  producer-side change (swap text for an icon) is internally coherent and would
+  still leave this consumer unable to find the button.
+- **Consumer 2 (path: the end user via assistive technology)** reads the
+  accessible name and uses it to decide whether activating the control will
+  reveal or conceal. Not a code consumer, but it is the one I1.1 exists for, and
+  the one whose failure no test would have reported before this plan.
+- **Consumer 3 (path: `src/messages/{en,ja}.json:15-16`)** — the `popup.show` /
+  `popup.hide` keys. Their sole consumer is this button (verified below), so
+  moving the values from text content to `aria-label` changes no other rendering.
+
+**No consumer needs a field absent from the design.** C1 and C2 are complete.
+
+### Member-set derivation (R42)
+
+NFR1 claims the message keys have exactly one consumer. Code-derived, from
+`extension/`:
+
+```console
+$ grep -rn 'popup\.show\|popup\.hide' src/
+src/popup/components/VaultUnlock.tsx:70
+
+$ grep -rn 'name: /show\|name: /hide' src/__tests__/
+src/__tests__/popup/VaultUnlock.test.tsx:93
+```
+
+One producer, one test consumer. `grep -rn '"show"\|"hide"' ios/` returns nothing,
+so the iOS target does not share these keys. Phase 3 must re-run these greps
+rather than carry the result forward.
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+| --- | --- | --- |
+| C1 | Icon button with a state-dependent accessible name; masking untouched | locked |
+| C2 | Consumer-flow walkthrough for all three consumers | locked |
+
+Both were revised in Round 1 and re-locked. Round 1 found **no defect in the
+change's destination** — the icon swap itself was never in question. Every finding
+was in the plan's *reasoning*: two claims asserted instead of measured
+(accessible-name computation, the icon-direction precedent), one risk named but
+left unspecified (the button's box), and two test-design defects that would have
+shipped tests unable to fail. That distribution is worth noting, because it is the
+same one the previous change on this package produced.
+
+## Testing strategy
+
+Extend the existing `src/__tests__/popup/VaultUnlock.test.tsx`. No new file — the
+component already has one, and splitting would fragment the fixture.
+
+### Prove-red obligation (RT7), by kind
+
+**Two Criticals in the first revision's test design were found by execution, and
+both are the vacuity class this repo has been bitten by before.** They are
+recorded rather than quietly fixed, because the errors were in *reasoning about
+what a test proves*, which is the thing that recurs:
+
+1. **T4 as originally listed reddened for the wrong reason.** With "different icon
+   markup" unspecified, the natural implementation compares
+   `querySelector("svg")?.innerHTML` across states. Against `main` both sides are
+   `undefined` (no `<svg>` exists), so the assertion fails on
+   `Object.is(undefined, undefined)` — a red that says nothing about icon
+   differentiation, and one that disappears the moment *any* `<svg>` lands,
+   differentiated or not.
+2. **The Kind-B mutation "swap the icon/label pairing" does not redden T2.** T2
+   asserts the accessible *name* round-trips; swapping which glyph pairs with
+   which label leaves every name untouched. Verified: the swapped implementation
+   passes T2 *and* T4 (the icons still differ, just backwards). So I1.2 was
+   declared as an invariant and pinned by nothing.
+
+Also measured: **T3 as written passes against a same-icon implementation**
+(`expect(button.querySelector("svg")).not.toBeNull()` is satisfied by any icon),
+so it is subsumed by a corrected T4 rather than independent coverage.
+
+**Kind A — red against unfixed `main`** (genuine regression tests):
+
+| Test | Why it reddens on `main` |
+| --- | --- |
+| T3 | `main` renders text; `querySelector("svg")` is `null` |
+| T4 | same — but see the corrected assertion below, which makes the red meaningful |
+
+**Kind B — red against a named mutation of the fix.** Every row's mutation is run
+and observed separately; a row whose mutation does not reproduce is a defect in
+this table, not a passing test.
+
+| Test | Mutation | Expected |
+| --- | --- | --- |
+| T1, T2 | hardcode **both** `aria-label` and `title` to a constant | must fail |
+| T6 | hardcode `aria-label` only, leaving `title` state-dependent | **T6 must fail; T1/T2/T5 must stay green** |
+| T4 | render the same icon in both states | must fail |
+| T5 | remove the `type={...}` ternary from the input | must fail |
+| T7 | swap the icon/label pairing (eye shown while visible) | must fail |
+
+The T6 row is the one that matters most and is the one the first revision lacked:
+it is the *only* clause that proves `aria-label` is load-bearing rather than
+decorative. Its paired expectation — that T1/T2/T5 stay **green** under the same
+mutation — is the evidence, not incidental.
+
+**Allow side, per the Remedy Floor**: after every mutation-revert the full
+extension suite must be green, including the seven existing `VaultUnlock` tests
+and the `MatchList`/`App` tests that query sibling icon buttons by accessible
+name. Those prove the change did not disturb the popup's naming convention.
+
+**Fail loudly**: if a mutation cannot be applied (the attribute is already absent,
+the anchor moved), stop and report — do not record the clause as proven.
+
+### Test list
+
+| ID | Test | Pins | Red-proof |
+| --- | --- | --- | --- |
+| T1 | name is `/show/i` initially, `/hide/i` after one click | I1.2 | B |
+| T2 | name returns to `/show/i` after a second click | I1.2 | B |
+| T3 | the toggle contains an `<svg>` in both states | FR1 | A |
+| T4 | the two states render **different** icon markup | FR1 | A + B |
+| T5 | input type is `password` → `text` → `password` | I1.3 | B |
+| T6 | `aria-label` attribute itself flips show → hide | I1.1 | B |
+| T7 | the eye-with-slash glyph is the one shown while **visible** | I1.2 | B |
+
+**T4's assertion, specified** (it was the absence of this that made T4 vacuous):
+
+```tsx
+const iconFor = (name: RegExp) => {
+  const svg = screen.getByRole("button", { name }).querySelector("svg");
+  expect(svg).not.toBeNull();        // guard: absent icon must fail loudly,
+  return svg!.outerHTML;             // not silently compare undefined to undefined
+};
+const hidden = iconFor(/show/i);
+fireEvent.click(screen.getByRole("button", { name: /show/i }));
+const visible = iconFor(/hide/i);
+expect(visible).not.toBe(hidden);
+```
+
+`outerHTML`, not `innerHTML`: `strokeWidth`, `className` and `viewBox` live on the
+`<svg>` element itself, so `innerHTML` would miss an icon that changed only its
+attributes. Whitespace-stable — React emits no inter-element whitespace in this
+JSX. The `not.toBeNull` guard is what makes the comparison meaningful; **do not
+remove it to make T3 and T4 non-redundant**, because it is precisely what stops
+the `undefined === undefined` masquerade.
+
+**T7 is what actually pins I1.2** (the icon/label *pairing*, as opposed to T4's
+icon *difference*). It asserts the visible-state glyph contains the slash element
+and the hidden-state glyph does not. This couples the test to the chosen path
+data, which is a real cost — accepted, because the alternative is an invariant
+with no test, and the first revision's attempt to pin it via T2 was measured not
+to work.
+
+T5 duplicates part of the existing test at `:90-97` deliberately. Note the
+justification is narrower than the first revision claimed: T5 uses the same
+name-based query, so it does **not** hedge against name loss — it hedges only
+against edits to the existing test's body. Stated accurately here because the
+overstated version would license skipping T6.
+
+### Locale pinning in the tests (RT3)
+
+The tests query by the English literals `/show/i` and `/hide/i`, while `t()`
+resolves through `navigator.language` (`i18n.ts`). That works today only because
+jsdom hardcodes `navigator.language` to `en-US` regardless of the host locale —
+verified under this machine's `LANG=ja_JP.UTF-8`: all seven existing tests pass.
+
+Ten other extension test files pin `navigator.language` explicitly;
+`VaultUnlock.test.tsx` does not. The safety therefore rests on a jsdom default
+the suite never states. **Add the same override** for parity with the sibling
+files, so the tests assert under a locale they declare rather than one they
+inherit. The ja rendering itself stays manual-only (M3) — scenario 5 claims ja
+correctness and no automated test covers it, which is honest only if M3 is
+actually run.
+
+## Manual test plan
+
+Covers VC1. Run `npm run dev` in `extension/`, load the unpacked build, open the
+popup with the vault locked.
+
+- **M1** — Confirm the eye icon appears to the right of the passphrase field and
+  is vertically aligned with the input (the input is `h-10`; the button is not).
+- **M2** — Click it: the passphrase becomes readable and the icon changes to
+  eye-with-slash. Click again: it re-masks and the icon returns.
+- **M3** — Hover: the native tooltip reads "Show" / "Hide" (and the Japanese
+  equivalents under `ja`).
+- **M4** — Check both light and dark mode: the icon inherits `currentColor`, so
+  confirm it is legible against both backgrounds.
+
+## Considerations & constraints
+
+### Scope contract
+
+- **SC1 — The web app's own passphrase toggles.** Out of scope as *code*, but the
+  first revision's reasoning here was factually backwards and is corrected. It
+  said the two surfaces "already are" inconsistent and that excluding the web app
+  keeps them so. The opposite is true: the web app renders `Eye` / `EyeOff`
+  (37 usages; `vault-lock-screen.tsx:245-257` is the direct analogue), the
+  extension renders text — **that** is today's inconsistency, and this change
+  *removes* it. The web app needs no edit at all.
+
+  **Anti-Deferral**: cost of including web-app files = editing a package that has
+  no defect, to no user-visible end. Cost of excluding = none; the surfaces
+  converge without it. The one residual difference is the icon *mechanism* —
+  `lucide-react` in the web app, inline SVG in the extension — and that is forced,
+  not chosen: `extension/package.json` has no icon dependency. Owner: n/a — no
+  work is owed.
+
+- **SC2 — Extracting a shared `EyeIcon` component.** Out of scope. Every icon in
+  the popup today is written inline at its use site (`App.tsx`, `MatchList.tsx`)
+  — extracting only this one would create an inconsistency, and extracting all of
+  them is a refactor with no behavioural content. **Anti-Deferral**: cost of
+  including = touching three files to no functional end; cost of excluding = one
+  more inline SVG in a codebase whose convention is inline SVGs. Owner: n/a — no
+  work is owed unless the icon set grows.
+- **SC3 — `jsx-a11y` lint rule for nameless buttons.** Out of scope, but worth
+  naming: I1.1 is app-enforced only because no lint rule enforces it repo-wide.
+  A `jsx-a11y/control-has-associated-label` rule would make the whole *class* of
+  nameless-icon-button defects schema-enforced rather than test-enforced.
+  **Anti-Deferral**: cost of including = adding an eslint plugin and fixing
+  whatever it flags across the existing popup, an unbounded scope discovered
+  mid-PR. Cost of excluding = the next icon button added without a label is
+  caught only if someone writes a test for it. Owner: a future a11y tooling pass.
+  Recorded per R34 rather than silently.
+
+- **SC4 — Re-masking the passphrase after a failed unlock.** Out of scope, and the
+  question is answered rather than left open. `VaultUnlock.tsx:37-42` clears the
+  passphrase only on the success branch; on failure the value stays in React state
+  and, if revealed, stays readable in the DOM for the rest of the popup session.
+  **Verified mitigation**: the popup is a fresh document per open
+  (`src/popup/main.tsx` calls `createRoot(...).render()` each load) and
+  `showPassphrase` is component-local `useState` with no `chrome.storage` backing —
+  so neither the reveal state nor the passphrase survives closing the popup. There
+  is no cross-session exposure.
+
+  **Anti-Deferral**: worst case = a wrong, revealed master passphrase stays on
+  screen until the user closes the popup or retypes. Likelihood = only after a
+  failed unlock *with* reveal already toggled on. Cost of including = turns a
+  purely presentational change into a behavioural one, cutting against C1's own
+  "signature unchanged" framing and requiring its own test matrix for the
+  error path. Cost of excluding = the pre-existing window stays open, unchanged
+  by this PR either way. Owner: a future unlock-flow hardening pass. Recorded so a
+  later round does not re-litigate it as if undecided.
+
+- **SC5 — `autoComplete="off"` / `spellCheck={false}` on the passphrase input.**
+  Out of scope, and pre-existing: `VaultUnlock.tsx:57-64` sets neither, and grep
+  confirms neither appears anywhere in `src/popup/`. This matters *adjacent* to
+  this change because `type="text"` (the revealed state) is where browser
+  save-prompt and spellcheck heuristics differ from `type="password"` — but that
+  flip already exists on `main` and I1.3 pins it unchanged, so this change neither
+  introduces nor widens the exposure (R43: no widening).
+
+  Worth noting the web app's analogue **does** set `autoComplete` —
+  `vault-lock-screen.tsx:241` uses `autoComplete="current-password"` — so there is
+  an in-repo precedent for hardening this input, which strengthens the case for a
+  follow-up. **Anti-Deferral**: cost of including = a behavioural change to
+  autofill on a component this PR is otherwise only restyling, with no test able
+  to verify browser heuristics (VC1's constraint class). Cost of excluding = an
+  unchanged pre-existing gap. Owner: the same unlock-flow hardening pass as SC4.
+  Recorded explicitly so a Phase-3 reviewer does not rediscover the `type="text"`
+  concern and mistake it for fix-induced.
+
+### Risks
+
+- **Risk 1 — the icon reads backwards to some users.** The action-vs-state
+  convention split is real (see Technical approach). Mitigated by keeping the
+  text label as the tooltip and accessible name, so the meaning is recoverable
+  by hovering. Accepted; M2 is the check.
+- **Risk 2 — the accessible name is lost.** The whole reason `aria-label` is in
+  the design. Pinned by T1/T2 and by the existing test's own query.
+- **Risk 3 — vertical alignment shifts** once the text is replaced by a fixed-size
+  icon. Not a correctness issue and not automatable (VC1); M1 is the check.
+
+## User operation scenarios
+
+1. **The reported scenario.** User opens the popup to unlock, sees an eye icon
+   beside the passphrase field rather than the word "Show", and recognises it
+   without reading.
+2. **Verifying a typo.** User types a long passphrase, clicks the eye, reads it,
+   clicks again to re-mask, then unlocks. Both the icon and the input type must
+   round-trip — the scenario T2 and T5 pin.
+3. **Keyboard-only user.** Tabs from the input to the button, activates with
+   Space/Enter. `type="button"` (unchanged) keeps this from submitting the form.
+4. **Screen-reader user.** Hears "Show, button" rather than "button" — the
+   difference between a usable control and an unidentifiable one, and what I1.1
+   exists for.
+5. **Japanese locale.** Tooltip and accessible name read 表示 / 非表示 via the
+   existing keys, with no new translation work.

--- a/docs/archive/review/extension-passphrase-visibility-icon-review.md
+++ b/docs/archive/review/extension-passphrase-visibility-icon-review.md
@@ -1,0 +1,224 @@
+# Plan Review: extension-passphrase-visibility-icon
+
+Date: 2026-08-17
+Review round: 1
+
+## Changes from Previous Round
+
+Initial review. Three expert sub-agents (functionality, security, testing) reviewed the
+plan in parallel against the real source. Ollama was unavailable, so pre-screening and
+`merge-findings` were both skipped — deduplication below is the documented manual
+fallback, joined by hand on the experts' JSON indexes.
+
+## Summary
+
+16 findings: **2 Critical, 4 Major, 10 Minor** (5 `[Adjacent]`). All Critical and Major
+are resolved in the plan.
+
+**No finding was against the change itself.** Replacing the text toggle with an eye icon
+was never in question. Every defect was in the plan's reasoning, and they share one root
+cause: **claims asserted from plausibility instead of measured.** Three of them were
+refuted by execution in under a minute each.
+
+## Functionality Findings
+
+**F-Func-1 — Major — RESOLVED.** The plan's central premise — "replacing the text leaves
+the button with *no* accessible name; `aria-label` is **mandatory**" — is false. `title`
+alone supplies the accessible name, and the repo already depends on this: `App.tsx:146`
+sets `title` only and `App.test.tsx:112` finds that button by name. *Verified by
+execution.* The plan's own evidence table listed those `title`-only siblings on line 62
+while line 78 claimed the opposite, and did not notice.
+
+*Resolution:* the section is rewritten around the measured behaviour, with the probe
+table inline. `aria-label` is kept but reframed as a **deliberate choice** (`title` is
+not exposed to touch, is inconsistently announced, is the weakest name source) rather
+than a necessity. The knock-on defect this caused in the test design is F-Test-2.
+
+**F-Func-2 — Major — RESOLVED.** The R42 member-set was scoped to the wrong class. The
+message-key derivation was correct and reproduced exactly, but the *behavioural* class —
+"show/hide passphrase toggles in this repo" — has **37 members** in the web app, including
+the direct analogue `src/components/vault/vault-lock-screen.tsx:245-257`, which renders
+`showPassphrase ? <EyeOff/> : <Eye/>` on the same state variable name.
+
+Two consequences. First, the plan spent a paragraph defending the action-vs-state icon
+direction as "a real decision, not an obvious one" — while the repo had already made it,
+uniformly, 37 times. Second, SC1's cost reasoning was **backwards**: it said the two
+surfaces "already are" inconsistent and excluding the web app keeps them so, when in fact
+web=icon / extension=text *is* the inconsistency and this change removes it.
+
+*Resolution:* the icon direction now cites the precedent instead of arguing; SC1 is
+rewritten; and the forced divergence is named (the extension has no icon dependency —
+`package.json` lists only `otpauth`, `react`, `react-dom`, `tldts`, so it must inline).
+*Verified independently:* 37 `EyeOff` usages, the analogue's code, and the absent lucide
+dep.
+
+**F-Func-3 — Major — RESOLVED.** The plan named the button's layout change as a risk
+(M1, Risk 3) and then specified no className change — in a document otherwise specified
+down to `strokeLinejoin`. The existing `px-2 py-1` matches none of the seven sibling icon
+buttons, which uniformly use `p-1.5`, and `text-xs` becomes dead once no text renders.
+The expert also computed what the plan had merely asserted: `px-2 py-1` + a 16px glyph
+gives 32×24 px, clearing WCAG 2.2 SC 2.5.8's 24×24 minimum on one axis only and by luck
+of the glyph size.
+
+*Resolution:* new **NFR4** with a before/after table, `p-1.5` + `w-4 h-4` (28×28),
+justified against all seven siblings. M1 strengthened from "confirm alignment" to
+"confirm square, `p-1.5`-padded, centred against the `h-10` input".
+
+**F-Func-4 — Minor (question) — ANSWERED.** Should the `<svg>` carry `aria-hidden`?
+*Resolution:* documented as deliberately omitted, following the `App.tsx` /
+`MatchList.tsx` majority; noted that `FillMismatchDialog.tsx` differs, which is why the
+choice is stated rather than left implicit.
+
+**F-Func-5 — Minor — RESOLVED.** The `aria-pressed` rejection was sound but never said
+what conveys the *current* state under an action label. *Resolution:* one paragraph —
+inferred from the action name, and independently observable from the input's own `type`.
+
+## Security Findings
+
+**F-Sec-1 — Minor (question) — ANSWERED, deferred as SC4.** A failed unlock leaves the
+passphrase in React state and, if revealed, readable in the DOM for the rest of the popup
+session (`VaultUnlock.tsx:37-42` clears only on success). *The expert verified the
+mitigation rather than asserting the risk*: the popup is a fresh document per open and
+`showPassphrase` is component-local with no `chrome.storage` backing, so **nothing
+survives closing the popup**. Pre-existing and untouched by this change.
+*Resolution:* recorded as SC4 with a full Anti-Deferral entry, so a later round does not
+re-litigate it as undecided.
+
+**F-Sec-2 — Minor — DEFERRED as SC5.** The passphrase input sets neither
+`autoComplete="off"` nor `spellCheck={false}` — relevant because `type="text"` is where
+browser save-prompt and spellcheck heuristics differ. Pre-existing; I1.3 pins the `type`
+flip unchanged, so **R43: no widening**. Notably the web app's analogue *does* set
+`autoComplete="current-password"` (`vault-lock-screen.tsx:241`), so there is in-repo
+precedent for a follow-up. *Resolution:* SC5, recorded explicitly so Phase 3 does not
+rediscover the `type="text"` concern and mistake it for fix-induced.
+
+**F-Sec-3 — Minor `[Adjacent]` — NOTED.** T5's red-proof is the only security-relevant
+clause in the mutation table (I1.3 is the masking invariant); it must not be waived if
+Phase 3 is compressed. Carried into Phase 2 as a priority note.
+
+The security expert also declined to raise the obvious-looking finding: that a more
+discoverable reveal affordance increases shoulder-surfing exposure. Correctly — the
+control already exists, the default is unchanged (`useState(false)`), the click count is
+unchanged, and "an icon is more salient than a word" is an unfalsifiable claim about
+pixels that VC1 already declares unverifiable. Recording the *non*-finding because it is
+the one a reader will expect to see.
+
+Verification worth recording: **zero `dangerouslySetInnerHTML` hits extension-wide**, so
+C1's forbidden pattern starts from a verified-zero baseline; the six `icons.ts` strings
+are static literals with no interpolation, so even the existing content-script consumer
+is not an injection sink; and `showPassphrase` has exactly three references, none
+touching storage or messaging — **the icon is load-bearing for nothing** (R49 confirmed).
+
+## Testing Findings
+
+**F-Test-1 — Critical — RESOLVED.** T4's assertion was unspecified, and the natural
+implementation reddens against `main` **for the wrong reason**. Comparing
+`querySelector("svg")?.innerHTML` across states yields `undefined` on both sides (no
+`<svg>` exists on `main`), so the test fails on `Object.is(undefined, undefined)` — a red
+that says nothing about icon differentiation and that vanishes the moment *any* `<svg>`
+lands, differentiated or not. *Verified by execution.*
+
+*Resolution:* T4's assertion is now written out in full, with a `not.toBeNull` guard so
+the absent-element case fails loudly instead of masquerading, and `outerHTML` rather than
+`innerHTML` (because `strokeWidth` / `className` / `viewBox` live on the element itself).
+The plan states explicitly that the guard must not be removed to de-duplicate T3.
+
+**F-Test-2 — Critical — RESOLVED.** The Kind-B mutation "swap the icon/label pairing" was
+listed as reddening T2. It does not: T2 asserts the accessible *name* round-trips, and
+swapping which glyph pairs with which label leaves every name untouched. *Verified:* the
+swapped implementation passes T2 **and** T4. So **I1.2 was declared as an invariant and
+pinned by nothing** — a mutation table row recording a red-proof that would not reproduce,
+which is the exact shape of the prior incident on this package.
+
+*Resolution:* new **T7** binds a specific glyph to a specific state (the slash element
+must be present in the visible-state icon and absent in the hidden-state one). The
+coupling to path data is accepted and stated, because the alternative was an unpinned
+invariant.
+
+**F-Test-3 — Major — RESOLVED.** T3 passes against a same-icon implementation
+(*verified*), so it is subsumed by the corrected T4 rather than independent coverage.
+*Resolution:* T3 is kept — it distinguishes "no icon" from "same icon" in the failure
+message — but the plan now says that is its only value, instead of implying broader
+coverage.
+
+**F-Test-4 — Major — RESOLVED.** VC2 stated the accessible-name situation backwards, and
+the consequence was concrete: **every test in T1-T5 would pass on an implementation that
+drops the `aria-label` the plan called mandatory.** *Resolution:* VC2 rewritten around the
+measurement, and new **T6** asserts the `aria-label` attribute directly, with the
+paired expectation that T1/T2/T5 stay *green* under the same mutation — that green is the
+evidence `aria-label` is load-bearing.
+
+**F-Test-5 — Minor — RESOLVED.** T5's stated justification overclaimed: it uses the same
+name-based query, so it hedges against edits to the existing test's body, not against
+name loss. *Resolution:* corrected in place, because the overstated version would have
+licensed skipping T6.
+
+**F-Test-6 — Minor — RESOLVED.** The tests hardcode English literals while `t()` resolves
+through `navigator.language`; ten sibling test files pin the locale and
+`VaultUnlock.test.tsx` does not. It passes today only because jsdom defaults to `en-US`
+regardless of host locale (*verified under `LANG=ja_JP.UTF-8`*). *Resolution:* the plan
+now requires the same override for parity, and states that ja rendering stays manual-only
+(M3).
+
+**F-Test-7 — clean.** No fixture leakage (`beforeEach` clears and re-seeds), no
+status-without-mutation assertion, real component with only boundary mocks, no new
+production exports.
+
+## Adjacent Findings
+
+Routed and dispositioned above: F-Sec-3 (priority note → Phase 2), F-Func-6/F-Test A1
+(SC3 overstated the nameless-button exposure, since `title`-only siblings *do* have names
+— folded into F-Func-1's correction), F-Test A2 (`vitest.config.ts`
+`environmentMatchGlobs` vs docblock inconsistency — pre-existing, not introduced, no
+action), F-Func-8 (`title` on a passphrase-adjacent control — content is the literal word
+"Show"/"Hide", non-sensitive; confirmed by security).
+
+## Quality Warnings
+
+None. The `merge-findings` quality gate could not run (Ollama unavailable). Manual
+substitute: every Critical and Major was independently re-verified before acceptance —
+the 37-member `EyeOff` class and the analogue's code were read directly, and T3's vacuity
+plus the same-icon `outerHTML` equality were re-run as probes. Verification method is
+named per finding.
+
+## Recurring Issue Check
+
+### Functionality expert
+
+R1 checked-clean (`icons.ts` = HTML strings for `innerHTML`, verified; no other popup
+icon helper; no lucide dep). R3 **finding-raised** (F-Func-2, 37-member class). R7/R8
+**finding-raised** (F-Func-3, dead `text-xs`, `px-2 py-1` vs uniform `p-1.5`). R26
+checked-clean (button has no disabled state, so no cue owed). R29 checked-clean (all 8
+citations + baseline `d22f252c` verified exact). R30/R39/R43 **finding-raised**
+(F-Func-1, overclaim contradicted by the plan's own line 62). R41 checked-clean. R42
+**finding-raised** (message-key greps clean; class scoping wrong). R49 checked-clean. R50
+**finding-raised** (F-Func-3, layout boundary unnamed). R52 **finding-raised** (F-Func-1,
+the named T1/T2 mutation will not redden). Remainder n-a or checked-clean.
+
+### Security expert
+
+R29 checked-clean — **all citations and both greps reproduce exactly**, unusual enough to
+state plainly. R43 checked-clean (no widening; `type` ternary preserved and pinned by
+I1.3). R49 checked-clean (control class declared *and* correctly separated from the
+masking property). RS3/RS6 checked-clean (zero `dangerouslySetInnerHTML` extension-wide;
+icon strings are static literals; JSX path introduces no sink). RS4 checked-clean (no PII;
+fixtures use `"pw"` / `example.com`). RS1/RS2/RS5 n-a. Remainder n-a or checked-clean.
+
+### Testing expert
+
+RT2 **finding-raised** (F-Test-1, T4 unspecified and vacuous as naturally written). RT3
+**finding-raised** (F-Test-6, locale). RT5 checked-clean (real component, boundary mocks
+only). RT6 checked-clean (no new production exports). RT7 **finding-raised** (F-Test-1
+and F-Test-2 — one Kind-A red for the wrong reason, one Kind-B row that does not
+reproduce). RT8 checked-clean. RT9 checked-clean. RT10 **finding-raised** (F-Test-4,
+`aria-label` has neither side). RT11 checked-clean (`vi.clearAllMocks()` + re-seed).
+
+## Round 2 assessment
+
+Not run. Saturation is deliberately **not** claimed — it requires two completed rounds, so
+it cannot fire here. Proceeding to Phase 2 is a judgment recorded as such: every Critical
+and Major is resolved; no finding was against the design; the change is one component
+plus its test; and the two Criticals were both about *test design*, which Phase 2's
+mandatory prove-red execution re-verifies by running the mutations rather than reasoning
+about them. If any Kind-A/Kind-B expectation fails to reproduce in Phase 2, that is a
+Round-2 input.

--- a/extension/src/__tests__/popup/VaultUnlock.test.tsx
+++ b/extension/src/__tests__/popup/VaultUnlock.test.tsx
@@ -142,6 +142,47 @@ describe("VaultUnlock", () => {
       expect(input).toHaveValue("wrong-passphrase");
     });
 
+    // A rejection is the worse case: an early return would strand the reveal AND
+    // leave the button stuck in "Unlocking", so the user cannot even retry.
+    it.each([
+      ["getSettings", () => mockGetSettings.mockRejectedValue(new Error("boom"))],
+      ["the permission check", () => mockEnsureHostPermission.mockRejectedValue(new Error("boom"))],
+      ["sendMessage", () => mockSendMessage.mockRejectedValue(new Error("boom"))],
+    ])("re-masks and clears loading when %s rejects", async (_label, arrangeRejection) => {
+      arrangeRejection();
+      render(<VaultUnlock onUnlocked={vi.fn()} />);
+      const input = screen.getByPlaceholderText("Passphrase");
+
+      fireEvent.change(input, { target: { value: "secret" } });
+      fireEvent.click(screen.getByRole("button", { name: /show/i }));
+      fireEvent.click(screen.getByRole("button", { name: /unlock/i }));
+
+      await waitFor(() => expect(input).toHaveAttribute("type", "password"));
+      // Not stuck on "Unlocking" — the user can try again.
+      expect(screen.getByRole("button", { name: /^unlock$/i })).toBeEnabled();
+      expect(input).toHaveValue("secret");
+      // Without the catch, the rejection escapes and the user is told nothing.
+      expect(screen.getByText("Could not unlock the vault.")).toBeInTheDocument();
+    });
+
+    // The success path must NOT re-mask: onUnlocked swaps this screen out, and
+    // resetting visibility on the way is state churn on a component being
+    // unmounted. Pins the `unlocked` guard in the finally clause.
+    it("leaves visibility alone on a successful unlock", async () => {
+      mockSendMessage.mockResolvedValue({ ok: true });
+      const onUnlocked = vi.fn();
+      render(<VaultUnlock onUnlocked={onUnlocked} />);
+      const input = screen.getByPlaceholderText("Passphrase");
+
+      fireEvent.change(input, { target: { value: "right" } });
+      fireEvent.click(screen.getByRole("button", { name: /show/i }));
+      fireEvent.click(screen.getByRole("button", { name: /unlock/i }));
+
+      await waitFor(() => expect(onUnlocked).toHaveBeenCalled());
+      expect(screen.getByRole("button", { name: /hide/i })).toBeInTheDocument();
+      expect(input).toHaveValue("");
+    });
+
     // type="text" (the revealed state) is where a browser would otherwise
     // spellcheck and autocorrect a secret.
     it("opts the passphrase field out of spellcheck and autocorrect", () => {

--- a/extension/src/__tests__/popup/VaultUnlock.test.tsx
+++ b/extension/src/__tests__/popup/VaultUnlock.test.tsx
@@ -121,15 +121,6 @@ describe("VaultUnlock", () => {
       expect(screen.getByRole("button", { name: /show/i })).toBeInTheDocument();
     });
 
-    // T3. Distinguishes "no icon" from T4's "same icon".
-    it("renders an icon in both states", () => {
-      render(<VaultUnlock onUnlocked={vi.fn()} />);
-
-      expect(iconFor(/show/i)).toContain("<svg");
-      fireEvent.click(screen.getByRole("button", { name: /show/i }));
-      expect(iconFor(/hide/i)).toContain("<svg");
-    });
-
     // T4. outerHTML, not innerHTML: strokeWidth and viewBox live on the element
     // itself, so innerHTML would miss an icon that changed only its attributes.
     it("renders a different icon in each state", () => {
@@ -169,12 +160,22 @@ describe("VaultUnlock", () => {
 
     // T7. Pins which glyph goes with which state. T4 only proves they differ —
     // a swapped pairing renders two different icons too, and passes it.
-    it("shows the slashed eye only while the passphrase is visible", () => {
+    //
+    // The pupil circle is asserted as well as the slash: without it, any glyph
+    // without a <line> satisfies the hidden state, and a meaningless square
+    // passes. jsdom cannot judge whether a path looks like an eye, so this pins
+    // the two elements that carry the meaning and leaves the rest to M2.
+    it("shows a plain eye while hidden and a slashed eye while visible", () => {
       render(<VaultUnlock onUnlocked={vi.fn()} />);
 
-      expect(iconFor(/show/i)).not.toContain("<line");
+      const hidden = iconFor(/show/i);
+      expect(hidden).toContain("<circle");
+      expect(hidden).not.toContain("<line");
+
       fireEvent.click(screen.getByRole("button", { name: /show/i }));
-      expect(iconFor(/hide/i)).toContain("<line");
+
+      const visible = iconFor(/hide/i);
+      expect(visible).toContain("<line");
     });
   });
 

--- a/extension/src/__tests__/popup/VaultUnlock.test.tsx
+++ b/extension/src/__tests__/popup/VaultUnlock.test.tsx
@@ -23,6 +23,10 @@ import { VaultUnlock } from "../../popup/components/VaultUnlock";
 
 describe("VaultUnlock", () => {
   beforeEach(() => {
+    // The assertions below are English literals, and t() resolves through
+    // navigator.language. jsdom happens to default to en-US, but ten sibling
+    // test files pin it rather than inherit it — do the same.
+    Object.defineProperty(navigator, "language", { value: "en-US", configurable: true });
     vi.clearAllMocks();
     mockGetSettings.mockResolvedValue({ serverUrl: "https://example.com" });
     mockEnsureHostPermission.mockResolvedValue(true);
@@ -94,6 +98,84 @@ describe("VaultUnlock", () => {
     expect(input).toHaveAttribute("type", "password");
     fireEvent.click(toggle);
     expect(input).toHaveAttribute("type", "text");
+  });
+
+  describe("passphrase visibility toggle", () => {
+    // Returns the toggle's icon markup, failing loudly when there is none.
+    // Without the null guard, comparing two absent icons comes out as
+    // undefined === undefined — a pass or a fail that means nothing either way.
+    const iconFor = (name: RegExp): string => {
+      const svg = screen.getByRole("button", { name }).querySelector("svg");
+      expect(svg).not.toBeNull();
+      return svg!.outerHTML;
+    };
+
+    // T1 + T2. The name must be wired to state, not to a constant.
+    it("flips the accessible name show → hide → show", () => {
+      render(<VaultUnlock onUnlocked={vi.fn()} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /show/i }));
+      expect(screen.queryByRole("button", { name: /show/i })).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: /hide/i }));
+      expect(screen.getByRole("button", { name: /show/i })).toBeInTheDocument();
+    });
+
+    // T3. Distinguishes "no icon" from T4's "same icon".
+    it("renders an icon in both states", () => {
+      render(<VaultUnlock onUnlocked={vi.fn()} />);
+
+      expect(iconFor(/show/i)).toContain("<svg");
+      fireEvent.click(screen.getByRole("button", { name: /show/i }));
+      expect(iconFor(/hide/i)).toContain("<svg");
+    });
+
+    // T4. outerHTML, not innerHTML: strokeWidth and viewBox live on the element
+    // itself, so innerHTML would miss an icon that changed only its attributes.
+    it("renders a different icon in each state", () => {
+      render(<VaultUnlock onUnlocked={vi.fn()} />);
+
+      const hidden = iconFor(/show/i);
+      fireEvent.click(screen.getByRole("button", { name: /show/i }));
+      const visible = iconFor(/hide/i);
+
+      expect(visible).not.toBe(hidden);
+    });
+
+    // T5. The masking mechanism, restated away from the test whose query the
+    // icon change threatens.
+    it("round-trips the input type password → text → password", () => {
+      render(<VaultUnlock onUnlocked={vi.fn()} />);
+      const input = screen.getByPlaceholderText("Passphrase");
+
+      expect(input).toHaveAttribute("type", "password");
+      fireEvent.click(screen.getByRole("button", { name: /show/i }));
+      expect(input).toHaveAttribute("type", "text");
+      fireEvent.click(screen.getByRole("button", { name: /hide/i }));
+      expect(input).toHaveAttribute("type", "password");
+    });
+
+    // T6. The only test that can tell aria-label from title: a name-based query
+    // resolves through either, so dropping aria-label leaves every other test green.
+    it("sets aria-label itself, not only the title fallback", () => {
+      render(<VaultUnlock onUnlocked={vi.fn()} />);
+
+      const toggle = screen.getByRole("button", { name: /show/i });
+      expect(toggle).toHaveAttribute("aria-label", "Show");
+
+      fireEvent.click(toggle);
+      expect(screen.getByRole("button", { name: /hide/i })).toHaveAttribute("aria-label", "Hide");
+    });
+
+    // T7. Pins which glyph goes with which state. T4 only proves they differ —
+    // a swapped pairing renders two different icons too, and passes it.
+    it("shows the slashed eye only while the passphrase is visible", () => {
+      render(<VaultUnlock onUnlocked={vi.fn()} />);
+
+      expect(iconFor(/show/i)).not.toContain("<line");
+      fireEvent.click(screen.getByRole("button", { name: /show/i }));
+      expect(iconFor(/hide/i)).toContain("<line");
+    });
   });
 
   it("enables unlock button when passphrase is entered", async () => {

--- a/extension/src/__tests__/popup/VaultUnlock.test.tsx
+++ b/extension/src/__tests__/popup/VaultUnlock.test.tsx
@@ -121,6 +121,39 @@ describe("VaultUnlock", () => {
       expect(screen.getByRole("button", { name: /show/i })).toBeInTheDocument();
     });
 
+    // A revealed passphrase must not stay legible after a failed attempt. The
+    // value is kept so the user can correct it; only the visibility resets.
+    it.each([
+      ["the unlock is rejected", () => mockSendMessage.mockResolvedValue({ ok: false, error: "INVALID_PASSPHRASE" })],
+      ["host permission is denied", () => mockEnsureHostPermission.mockResolvedValue(false)],
+    ])("re-masks the passphrase when %s", async (_label, arrangeFailure) => {
+      arrangeFailure();
+      render(<VaultUnlock onUnlocked={vi.fn()} />);
+      const input = screen.getByPlaceholderText("Passphrase");
+
+      fireEvent.change(input, { target: { value: "wrong-passphrase" } });
+      fireEvent.click(screen.getByRole("button", { name: /show/i }));
+      expect(input).toHaveAttribute("type", "text");
+
+      fireEvent.click(screen.getByRole("button", { name: /unlock/i }));
+
+      await waitFor(() => expect(input).toHaveAttribute("type", "password"));
+      // The value survives so the user can fix a typo rather than retype it.
+      expect(input).toHaveValue("wrong-passphrase");
+    });
+
+    // type="text" (the revealed state) is where a browser would otherwise
+    // spellcheck and autocorrect a secret.
+    it("opts the passphrase field out of spellcheck and autocorrect", () => {
+      render(<VaultUnlock onUnlocked={vi.fn()} />);
+      const input = screen.getByPlaceholderText("Passphrase");
+
+      expect(input).toHaveAttribute("spellcheck", "false");
+      expect(input).toHaveAttribute("autocorrect", "off");
+      expect(input).toHaveAttribute("autocapitalize", "off");
+      expect(input).toHaveAttribute("autocomplete", "current-password");
+    });
+
     // T4. outerHTML, not innerHTML: strokeWidth and viewBox live on the element
     // itself, so innerHTML would miss an icon that changed only its attributes.
     it("renders a different icon in each state", () => {

--- a/extension/src/popup/components/VaultUnlock.tsx
+++ b/extension/src/popup/components/VaultUnlock.tsx
@@ -65,9 +65,19 @@ export function VaultUnlock({ onUnlocked, tabUrl }: Props) {
         <button
           type="button"
           onClick={() => setShowPassphrase((v) => !v)}
-          className="text-xs text-gray-600 dark:text-gray-400 px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-800 dark:hover:text-gray-200 active:bg-gray-200 dark:active:bg-gray-700 transition-colors"
+          title={showPassphrase ? t("popup.hide") : t("popup.show")}
+          // The icon carries no text, so without this the button has no
+          // accessible name at all — screen readers announce only "button".
+          aria-label={showPassphrase ? t("popup.hide") : t("popup.show")}
+          className="p-1.5 rounded-md text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 active:bg-gray-200 dark:active:bg-gray-700 transition-colors"
         >
-          {showPassphrase ? t("popup.hide") : t("popup.show")}
+          {showPassphrase ? (
+            // Eye with a slash: the action offered is "conceal".
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
+          ) : (
+            // Plain eye: the action offered is "reveal".
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+          )}
         </button>
       </div>
       {error && (

--- a/extension/src/popup/components/VaultUnlock.tsx
+++ b/extension/src/popup/components/VaultUnlock.tsx
@@ -29,6 +29,10 @@ export function VaultUnlock({ onUnlocked, tabUrl }: Props) {
     if (!granted) {
       setError("PERMISSION_DENIED");
       setLoading(false);
+      // Re-mask on failure: the passphrase stays in the field so the user can
+      // retry, and leaving it legible until the popup closes is a longer
+      // exposure than the retry needs.
+      setShowPassphrase(false);
       return;
     }
 
@@ -39,6 +43,7 @@ export function VaultUnlock({ onUnlocked, tabUrl }: Props) {
       onUnlocked();
     } else {
       setError(res.error || "INVALID_PASSPHRASE");
+      setShowPassphrase(false);
     }
   };
 
@@ -59,6 +64,14 @@ export function VaultUnlock({ onUnlocked, tabUrl }: Props) {
           value={passphrase}
           onChange={(e) => setPassphrase(e.target.value)}
           placeholder={t("popup.passphrasePlaceholder")}
+          // Matches the web app's five passphrase inputs, which all declare
+          // current-password. Revealing the field flips it to type="text", where
+          // a browser would otherwise apply spellcheck and autocorrect to a
+          // secret — hence the explicit opt-outs.
+          autoComplete="current-password"
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
           className="h-10 flex-1 px-3 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-600 focus:border-gray-900 dark:focus:border-gray-400 transition-shadow"
           autoFocus
         />

--- a/extension/src/popup/components/VaultUnlock.tsx
+++ b/extension/src/popup/components/VaultUnlock.tsx
@@ -24,26 +24,33 @@ export function VaultUnlock({ onUnlocked, tabUrl }: Props) {
     setLoading(true);
     setError("");
 
-    const { serverUrl } = await getSettings();
-    const granted = await ensureHostPermission(serverUrl);
-    if (!granted) {
-      setError("PERMISSION_DENIED");
-      setLoading(false);
-      // Re-mask on failure: the passphrase stays in the field so the user can
-      // retry, and leaving it legible until the popup closes is a longer
-      // exposure than the retry needs.
-      setShowPassphrase(false);
-      return;
-    }
+    // Any exit from here that is not a successful unlock re-masks the field: the
+    // passphrase stays so the user can fix a typo, but leaving it legible until
+    // the popup closes is a longer exposure than a retry needs. The finally
+    // clause covers the awaits below rejecting — where an early return would
+    // otherwise strand both the reveal and the loading state.
+    let unlocked = false;
+    try {
+      const { serverUrl } = await getSettings();
+      const granted = await ensureHostPermission(serverUrl);
+      if (!granted) {
+        setError("PERMISSION_DENIED");
+        return;
+      }
 
-    const res = await sendMessage({ type: "UNLOCK_VAULT", passphrase });
-    setLoading(false);
-    if (res.ok) {
-      setPassphrase("");
-      onUnlocked();
-    } else {
-      setError(res.error || "INVALID_PASSPHRASE");
-      setShowPassphrase(false);
+      const res = await sendMessage({ type: "UNLOCK_VAULT", passphrase });
+      if (res.ok) {
+        unlocked = true;
+        setPassphrase("");
+        onUnlocked();
+      } else {
+        setError(res.error || "INVALID_PASSPHRASE");
+      }
+    } catch {
+      setError("UNLOCK_FAILED");
+    } finally {
+      setLoading(false);
+      if (!unlocked) setShowPassphrase(false);
     }
   };
 


### PR DESCRIPTION
## What this changes

The popup's passphrase toggle read "Show" / "Hide" as literal text — the only text-labelled action button left in the popup, where every sibling is already an icon. It is now an eye / eye-with-slash icon.

Two security hardenings came out of review and are included (see below).

## The icon

The direction — eye means "click to reveal" rather than "currently visible" — is not a judgment call here. The web app already made it, uniformly, in 37 places, including the direct analogue at [vault-lock-screen.tsx:245-257](src/components/vault/vault-lock-screen.tsx#L245-L257), which renders `Eye`/`EyeOff` on a `showPassphrase` state variable of the same name. This aligns the two surfaces. They diverge only in mechanism: the extension has no icon dependency (`package.json` lists `otpauth`, `react`, `react-dom`, `tldts`), so the paths are inlined.

An icon button has no accessible name of its own, so `aria-label` carries what the text used to. That is not merely to keep the existing test passing — without it a screen reader announces "button" and nothing more.

## Security hardening (from review)

Both were initially scoped out, then re-raised independently by a follow-up security review. Re-reading the handler showed the deferral's cost estimate was simply wrong — two branches, one line each — so they were implemented rather than re-deferred.

- **Re-mask on failure.** A revealed passphrase stayed legible until the popup closed after a rejected unlock or a denied permission. All non-success exits now reset visibility. The *value* is deliberately kept: users usually want to fix a typo, not retype.
- **The rejection paths.** A second review round found the first fix still missed the three `await`s that can *reject* — where an early return stranded both the reveal and the `loading` state, leaving the button stuck on "Unlocking" with the secret on screen and no way to retry. `try/catch/finally` now covers every exit.
- **Input attributes.** `autoComplete="current-password"` (matching the web app's five passphrase inputs), plus `spellCheck` / `autoCorrect` / `autoCapitalize` off — the last three because revealing the field flips it to `type="text"`, where a browser would otherwise apply them to a secret.

Recorded honestly: `current-password` permits a browser password manager to store the master passphrase. That is a trade the project already made deliberately elsewhere; following it beats inventing an extension-only policy, but it is a choice, not a hardening.

## Review findings worth noting

Every finding across three review rounds was about *evidence*, not about the change. Three claims I asserted were refuted by execution:

| Claim | Reality |
|---|---|
| "`aria-label` is mandatory — a bare icon button has no accessible name" | Half true. `title` alone supplies one, and [App.tsx:146](extension/src/popup/App.tsx#L146) already relies on that. It mattered because the test meant to prove `aria-label` load-bearing would have reddened nothing. |
| The icon direction is an open design question | The repo had answered it 37 times. |
| A test pinned the icon/label pairing | It did not — a swapped pairing passed. A meaningless square glyph passed all 13 tests until T7 was tightened. |

The mutation runs also caught two clauses of the final fix that **no test could fail for** — dropping the `catch` changed nothing, because `finally` still re-masked. Both are pinned now.

## Verification

| Gate | Result |
|---|---|
| Extension tests | **1029 passed / 61 files** |
| `npx tsc --noEmit` | clean |
| `npm run lint` (`--max-warnings 0`) | clean |
| `npm run build` (extension) | clean |
| `git diff --check` | clean |

Every new test was proven able to fail against its own mutation (16 mutations run across the branch). Two equivalent mutants were recorded as such rather than given a fabricated killer test.

## Not verifiable in CI

jsdom renders no pixels, so the visual half is manual (M1-M4): whether the glyph reads as an eye, whether the 28×28 button centres against the `h-10` input, the tooltip under both locales, and dark-mode legibility.

Artifacts: `docs/archive/review/extension-passphrase-visibility-icon-{plan,review,deviation,code-review}.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
