### PR TITLE
fix(ci): audit the published package, not only its dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,10 +281,15 @@ jobs:
             # NOT --no-save: `npm audit signatures` walks the dependency graph, and
             # an unsaved install leaves the package in neither the manifest nor the
             # lockfile's root deps, so it has no edge to reach. The audit then
-            # covers only the CLI's own 8 dependencies and reports "8 verified"
-            # while never touching the package this job exists to verify — which is
-            # how both 0.4.73 and 0.4.74 failed the identity check below with
+            # covers only the installed dependencies that carry registry signatures
+            # and never the package this job exists to verify — which is how both
+            # 0.4.73 and 0.4.74 failed the identity check below with
             # PACKAGE_NOT_VERIFIED despite publishing correctly.
+            #
+            # Those runs reported "8 verified", and the CLI happens to declare 8
+            # direct dependencies — the match is a coincidence. The audited set is
+            # "signed packages in the tree", mostly transitive, so the count is not
+            # a completeness signal and must not be used as one when checking this.
             if npm install --ignore-scripts "passwd-sso-cli@${VERSION}" >/dev/null 2>&1; then
               installed=true
               break

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,7 +278,14 @@ jobs:
           # report the published package as verified when it was never fetched).
           installed=false
           for attempt in 1 2 3 4 5; do
-            if npm install --no-save --ignore-scripts "passwd-sso-cli@${VERSION}" >/dev/null 2>&1; then
+            # NOT --no-save: `npm audit signatures` walks the dependency graph, and
+            # an unsaved install leaves the package in neither the manifest nor the
+            # lockfile's root deps, so it has no edge to reach. The audit then
+            # covers only the CLI's own 8 dependencies and reports "8 verified"
+            # while never touching the package this job exists to verify — which is
+            # how both 0.4.73 and 0.4.74 failed the identity check below with
+            # PACKAGE_NOT_VERIFIED despite publishing correctly.
+            if npm install --ignore-scripts "passwd-sso-cli@${VERSION}" >/dev/null 2>&1; then
               installed=true
               break
             fi
@@ -315,9 +322,23 @@ jobs:
           npm audit signatures --json --include-attestations > "$AUDIT_JSON"
           node -e '
             const j = require(process.argv[1]);
-            const v = (j.verified || []).length, m = (j.missing || []).length, i = (j.invalid || []).length;
+            const verified = j.verified || [];
+            const v = verified.length, m = (j.missing || []).length, i = (j.invalid || []).length;
             console.log(`npm audit signatures: ${v} verified, ${m} missing, ${i} invalid`);
             if (i > 0 || m > 0) { console.error("::error::signature verification reported missing/invalid entries"); process.exit(1); }
+            // The subject of this whole job must be IN the audited set. Counting
+            // only verified/missing/invalid cannot tell "verified the package"
+            // from "verified everything except the package" — the latter is what
+            // shipped twice, reporting a healthy "8 verified" that was entirely
+            // the CLI dependencies. Assert presence explicitly so a future change
+            // that drops the package out of the graph reds here, naming the cause,
+            // rather than further down with an opaque PACKAGE_NOT_VERIFIED.
+            const pkg = "passwd-sso-cli", ver = process.env.VERSION;
+            if (!verified.some((e) => e && e.name === pkg && e.version === ver)) {
+              console.error(`::error::${pkg}@${ver} is absent from the audited set (${v} verified) — the audit did not cover the published package`);
+              console.error(`::error::audited: ${verified.map((e) => e && e.name).join(", ") || "(none)"}`);
+              process.exit(1);
+            }
           ' "$AUDIT_JSON"
           # Bind the published bytes to the bytes build-cli produced: compare the
           # registry's dist.integrity for this version against the integrity we

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,23 +322,9 @@ jobs:
           npm audit signatures --json --include-attestations > "$AUDIT_JSON"
           node -e '
             const j = require(process.argv[1]);
-            const verified = j.verified || [];
-            const v = verified.length, m = (j.missing || []).length, i = (j.invalid || []).length;
+            const v = (j.verified || []).length, m = (j.missing || []).length, i = (j.invalid || []).length;
             console.log(`npm audit signatures: ${v} verified, ${m} missing, ${i} invalid`);
             if (i > 0 || m > 0) { console.error("::error::signature verification reported missing/invalid entries"); process.exit(1); }
-            // The subject of this whole job must be IN the audited set. Counting
-            // only verified/missing/invalid cannot tell "verified the package"
-            // from "verified everything except the package" — the latter is what
-            // shipped twice, reporting a healthy "8 verified" that was entirely
-            // the CLI dependencies. Assert presence explicitly so a future change
-            // that drops the package out of the graph reds here, naming the cause,
-            // rather than further down with an opaque PACKAGE_NOT_VERIFIED.
-            const pkg = "passwd-sso-cli", ver = process.env.VERSION;
-            if (!verified.some((e) => e && e.name === pkg && e.version === ver)) {
-              console.error(`::error::${pkg}@${ver} is absent from the audited set (${v} verified) — the audit did not cover the published package`);
-              console.error(`::error::audited: ${verified.map((e) => e && e.name).join(", ") || "(none)"}`);
-              process.exit(1);
-            }
           ' "$AUDIT_JSON"
           # Bind the published bytes to the bytes build-cli produced: compare the
           # registry's dist.integrity for this version against the integrity we

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -1010,6 +1010,50 @@ jobs:
     expect(resolveSaveFlag(`npm install ${flag} pkg@1.0.0`)).toBe(expected);
   });
 
+  // Quoted space-separated values, npm's `-S` short form, and the neighbouring
+  // `--save-exact` family. Each value measured with `npm config get save`; the
+  // last two rows are the FALSE-POSITIVE direction, where flagging a correct
+  // command is what gets a gate switched off.
+  it.each([
+    ['--save "false"', false],
+    ["--save 'false'", false],
+    ["-S=false", false],
+    ["-S false", false],
+    ["-S", true],
+    ['--no-save "false"', true],
+    ["--no-save-exact", true],
+    ["--save-exact", true],
+  ])("resolveSaveFlag(%s) === %s, matching real npm", (flag, expected) => {
+    expect(resolveSaveFlag(`npm install ${flag} pkg@1.0.0`)).toBe(expected);
+  });
+
+  it.each([
+    '--save "false"',
+    "-S=false",
+    "-S false",
+  ])("flags the unsaved form: %s", (flag) => {
+    expect(
+      findUnsavedAuditSubjectViolations(
+        withAudit(`npm install ${flag} "passwd-sso-cli@1.0.0"`),
+        "release.yml",
+      ),
+    ).toHaveLength(1);
+  });
+
+  // --no-save-exact is a DIFFERENT option; its prefix must not read as --no-save.
+  it.each([
+    "--no-save-exact",
+    '--no-save "false"',
+    "-S",
+  ])("stays silent for the saving form: %s", (flag) => {
+    expect(
+      findUnsavedAuditSubjectViolations(
+        withAudit(`npm install ${flag} "passwd-sso-cli@1.0.0"`),
+        "release.yml",
+      ),
+    ).toEqual([]);
+  });
+
   it("flags a conflicting-flag install whose last flag is --no-save", () => {
     expect(
       findUnsavedAuditSubjectViolations(

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -996,6 +996,38 @@ jobs:
     ).toEqual([]);
   });
 
+  // npm takes the LAST save flag. A parser that lets a space-separated value
+  // swallow the following token reads `--save --no-save` as `--save=--no-save`
+  // and reports true, where npm reports false — so a conflicting-flag install
+  // would walk past the guard. Values measured with `npm config get save`.
+  it.each([
+    ["--save --no-save", false],
+    ["--no-save --save", true],
+    ["--no-save --save=true", true],
+    ["--save false", false],
+    ["--save true", true],
+  ])("resolveSaveFlag(%s) === %s — last flag wins, as npm does", (flag, expected) => {
+    expect(resolveSaveFlag(`npm install ${flag} pkg@1.0.0`)).toBe(expected);
+  });
+
+  it("flags a conflicting-flag install whose last flag is --no-save", () => {
+    expect(
+      findUnsavedAuditSubjectViolations(
+        withAudit('npm install --save --no-save "passwd-sso-cli@1.0.0"'),
+        "release.yml",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("stays silent when the last flag re-enables saving", () => {
+    expect(
+      findUnsavedAuditSubjectViolations(
+        withAudit('npm install --no-save --save "passwd-sso-cli@1.0.0"'),
+        "release.yml",
+      ),
+    ).toEqual([]);
+  });
+
   it.each([
     ["--no-save", false],
     ["--save=false", false],

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -12,6 +12,7 @@ import {
   findMaskedVerifierViolations,
   findPublishJobIsolationViolation,
   findTrustedPublishNodeViolation,
+  findUnsavedAuditSubjectViolations,
   isTrustedPublishingNodeVersion,
   parseTopLevelEnv,
 } from "../checks/check-workflow-supply-chain.mjs";
@@ -905,5 +906,67 @@ describe("isTrustedPublishingNodeVersion", () => {
     for (const v of ["20", "18.19.0"]) {
       expect(isTrustedPublishingNodeVersion(v), v).toBe(false);
     }
+  });
+});
+
+describe("findUnsavedAuditSubjectViolations", () => {
+  // Releases 0.4.73 and 0.4.74 both failed the provenance identity check because
+  // `npm install --no-save` kept the published package out of the dependency
+  // graph, so `npm audit signatures` covered only its 8 dependencies. The gate
+  // that would have caught it only runs on a real publish, so the regression was
+  // invisible in PR CI — which is what this guard fixes.
+  const withAudit = (install) => `
+jobs:
+  verify:
+    steps:
+      - name: Verify published package signature
+        run: |
+          npm init -y
+          ${install}
+          npm audit signatures --json --include-attestations > "$AUDIT_JSON"
+`;
+
+  it("flags a versioned install with --no-save alongside npm audit signatures", () => {
+    const v = findUnsavedAuditSubjectViolations(
+      withAudit('npm install --no-save --ignore-scripts "passwd-sso-cli@${VERSION}"'),
+      "release.yml",
+    );
+    expect(v).toHaveLength(1);
+    expect(v[0]).toContain("--no-save");
+    expect(v[0]).toContain("never the package itself");
+  });
+
+  it("flags it regardless of flag order", () => {
+    const v = findUnsavedAuditSubjectViolations(
+      withAudit('npm install --ignore-scripts --no-save "passwd-sso-cli@1.2.3"'),
+      "release.yml",
+    );
+    expect(v).toHaveLength(1);
+  });
+
+  // The allow side: this is the shape the fix ships, and it must stay silent.
+  it("accepts the saved install the verification job now uses", () => {
+    expect(
+      findUnsavedAuditSubjectViolations(
+        withAudit('npm install --ignore-scripts "passwd-sso-cli@${VERSION}"'),
+        "release.yml",
+      ),
+    ).toEqual([]);
+  });
+
+  // --no-save is unremarkable outside a verification context; only an install
+  // whose package the audit is supposed to cover matters.
+  it("ignores --no-save in a workflow that does not audit signatures", () => {
+    expect(
+      findUnsavedAuditSubjectViolations(
+        `jobs:\n  x:\n    steps:\n      - run: npm install --no-save "some-pkg@1.0.0"\n`,
+        "ci.yml",
+      ),
+    ).toEqual([]);
+  });
+
+  it("passes against the real release.yml", () => {
+    const content = readFileSync(".github/workflows/release.yml", "utf8");
+    expect(findUnsavedAuditSubjectViolations(content, "release.yml")).toEqual([]);
   });
 });

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -944,6 +944,28 @@ jobs:
     expect(v).toHaveLength(1);
   });
 
+  // A guard that recognises one spelling of what it forbids is a tripwire, not a
+  // boundary: every alias below reintroduces the identical defect, so each needs
+  // its own fixture or the guard is bypassable by a routine refactor.
+  it.each([
+    ['npm i --no-save "passwd-sso-cli@1.0.0"', "install alias `i`"],
+    ['npm add --no-save "passwd-sso-cli@1.0.0"', "install alias `add`"],
+    ['npm install --save=false "passwd-sso-cli@1.0.0"', "--save=false"],
+    ['npm i --save=false "passwd-sso-cli@${VERSION}"', "alias + --save=false"],
+  ])("flags the equivalent form: %s", (install) => {
+    expect(findUnsavedAuditSubjectViolations(withAudit(install), "release.yml")).toHaveLength(1);
+  });
+
+  // The allow side of the same axis: --no-save is only a problem when it applies
+  // to a versioned package the audit is meant to cover.
+  it.each([
+    ["npm ci", "no install of a versioned spec"],
+    ["npm install --no-save", "unversioned — installs the manifest, not a subject"],
+    ["npm i --no-save eslint", "unversioned package name"],
+  ])("stays silent for: %s", (install) => {
+    expect(findUnsavedAuditSubjectViolations(withAudit(install), "release.yml")).toEqual([]);
+  });
+
   // The allow side: this is the shape the fix ships, and it must stay silent.
   it("accepts the saved install the verification job now uses", () => {
     expect(

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -1027,6 +1027,16 @@ jobs:
     expect(resolveSaveFlag(`npm install ${flag} pkg@1.0.0`)).toBe(expected);
   });
 
+  // Empty values. Measured by actually installing with each flag and checking
+  // whether package.json gained a dependency, not by `npm config get` — which
+  // reports undefined for both and so cannot distinguish them.
+  it.each([
+    ["--save=", true],
+    ["--no-save=", false],
+  ])("resolveSaveFlag(%s) === %s, matching a real install", (flag, expected) => {
+    expect(resolveSaveFlag(`npm install ${flag} pkg@1.0.0`)).toBe(expected);
+  });
+
   it.each([
     '--save "false"',
     "-S=false",

--- a/scripts/__tests__/check-workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/check-workflow-supply-chain.test.mjs
@@ -13,6 +13,7 @@ import {
   findPublishJobIsolationViolation,
   findTrustedPublishNodeViolation,
   findUnsavedAuditSubjectViolations,
+  resolveSaveFlag,
   isTrustedPublishingNodeVersion,
   parseTopLevelEnv,
 } from "../checks/check-workflow-supply-chain.mjs";
@@ -945,15 +946,66 @@ jobs:
   });
 
   // A guard that recognises one spelling of what it forbids is a tripwire, not a
-  // boundary: every alias below reintroduces the identical defect, so each needs
-  // its own fixture or the guard is bypassable by a routine refactor.
+  // boundary. npm resolves ELEVEN aliases to `install` (its own cmd-list.js,
+  // typo-tolerant ones included), and each installs identically — so every one
+  // gets a fixture rather than a representative sample.
   it.each([
-    ['npm i --no-save "passwd-sso-cli@1.0.0"', "install alias `i`"],
-    ['npm add --no-save "passwd-sso-cli@1.0.0"', "install alias `add`"],
-    ['npm install --save=false "passwd-sso-cli@1.0.0"', "--save=false"],
-    ['npm i --save=false "passwd-sso-cli@${VERSION}"', "alias + --save=false"],
-  ])("flags the equivalent form: %s", (install) => {
-    expect(findUnsavedAuditSubjectViolations(withAudit(install), "release.yml")).toHaveLength(1);
+    "install",
+    "add",
+    "i",
+    "in",
+    "ins",
+    "inst",
+    "insta",
+    "instal",
+    "isnt",
+    "isnta",
+    "isntal",
+    "isntall",
+  ])("flags the install alias: npm %s", (alias) => {
+    const v = findUnsavedAuditSubjectViolations(
+      withAudit(`npm ${alias} --no-save "passwd-sso-cli@1.0.0"`),
+      "release.yml",
+    );
+    expect(v).toHaveLength(1);
+  });
+
+  // Quoted booleans survive into the workflow text unshelled, so a bare
+  // `--save=false` match misses them. Values measured against real npm 11.
+  it.each([
+    "--save=false",
+    "--save='false'",
+    '--save="false"',
+  ])("flags the quoted boolean form: %s", (flag) => {
+    const v = findUnsavedAuditSubjectViolations(
+      withAudit(`npm install ${flag} "passwd-sso-cli@1.0.0"`),
+      "release.yml",
+    );
+    expect(v).toHaveLength(1);
+  });
+
+  // The false-positive direction, and the one that matters most: npm reads
+  // `--no-save=false` as save=TRUE — the explicit value negates the prefix. A
+  // guard that blocks a correct command is how a gate ends up switched off.
+  it("does not flag --no-save=false, which npm resolves to save=true", () => {
+    expect(
+      findUnsavedAuditSubjectViolations(
+        withAudit('npm install --no-save=false "passwd-sso-cli@1.0.0"'),
+        "release.yml",
+      ),
+    ).toEqual([]);
+  });
+
+  it.each([
+    ["--no-save", false],
+    ["--save=false", false],
+    ["--save='false'", false],
+    ['--save="false"', false],
+    ["--no-save=false", true],
+    ["--save", true],
+    ["", true],
+  ])("resolveSaveFlag(%s) === %s, matching real npm", (flag, expected) => {
+    expect(resolveSaveFlag(`npm install ${flag} pkg@1.0.0`)).toBe(expected);
   });
 
   // The allow side of the same axis: --no-save is only a problem when it applies

--- a/scripts/__tests__/verify-npm-provenance-source.test.mjs
+++ b/scripts/__tests__/verify-npm-provenance-source.test.mjs
@@ -78,6 +78,31 @@ describe("verifyProvenanceSource", () => {
     expect(r).toMatchObject({ ok: false, reason: "PACKAGE_NOT_VERIFIED" });
   });
 
+  // Releases 0.4.73 and 0.4.74 both failed here, and the bare reason code could
+  // not say why: `npm install --no-save` had kept the package out of the
+  // dependency graph, so the audit covered only the CLI's own dependencies and
+  // reported a healthy-looking "8 verified" that contained none of the subject.
+  // The detail line is what turns that into an immediately diagnosable failure,
+  // so it gets a fixture per shape.
+  it("names the audited packages when the audit covered the wrong dependency graph", () => {
+    const wrongGraph = {
+      verified: ["chalk", "commander", "zod"].map((name) => ({ name, version: "1.0.0" })),
+    };
+    const r = verifyProvenanceSource(wrongGraph, EXPECTED);
+    expect(r).toMatchObject({ ok: false, reason: "PACKAGE_NOT_VERIFIED" });
+    expect(r.detail).toContain("3 entries");
+    expect(r.detail).toContain("chalk@1.0.0");
+    // The subject the audit was supposed to cover is named, so the log says what
+    // was looked for as well as what was found.
+    expect(r.detail).toContain(`${EXPECTED.package}@${EXPECTED.version}`);
+  });
+
+  it("distinguishes an empty audit from one that covered the wrong packages", () => {
+    const r = verifyProvenanceSource({ verified: [] }, EXPECTED);
+    expect(r).toMatchObject({ ok: false, reason: "PACKAGE_NOT_VERIFIED" });
+    expect(r.detail).toContain("empty");
+  });
+
   it("rejects a commit-SHA mismatch (same repo)", () => {
     const r = verifyProvenanceSource(audit([{ payload: payload({ sha: "0".repeat(40) }) }]), EXPECTED);
     expect(r).toMatchObject({ ok: false, reason: "SHA_MISMATCH" });

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -560,8 +560,12 @@ export function resolveSaveFlag(invocation) {
     const token = unquote(tokens[i]);
     const withValue = token.match(SAVE_WITH_VALUE);
     if (withValue) {
-      // `--no-save=false` is save=TRUE: the explicit value is what npm reads and
-      // the `no-` prefix inverts it. An empty value (`--save=`) is falsy to npm.
+      // Only the literal string "false" is falsy here; the `no-` prefix then
+      // inverts it. That gives npm's answers for both edge cases, measured by
+      // installing with each flag and checking whether package.json gained a
+      // dependency: `--no-save=false` saves (the explicit value beats the
+      // prefix), and `--save=` saves while `--no-save=` does not (an empty value
+      // is not "false", so each behaves like its bare form).
       const value = unquote(withValue[2]) !== "false";
       save = withValue[1] ? !value : value;
       continue;

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -543,10 +543,15 @@ const INSTALL_INVOCATION_RE = new RegExp(
  */
 export function resolveSaveFlag(invocation) {
   let save = true;
-  const flag = /--(no-)?save(?:[=\s]+("[^"]*"|'[^']*'|[^\s]+))?/g;
+  // `=`-attached values bind unconditionally; a SPACE-separated value binds only
+  // when the next token is literally true/false (quoted or not). Consuming any
+  // next token would let `--save --no-save` read `--no-save` as `--save`'s value
+  // and return true, where npm returns false — npm takes the LAST flag, and the
+  // loop below reproduces that by simply overwriting `save` each time.
+  const flag = /--(no-)?save(?:=("[^"]*"|'[^']*'|[^\s]*)|\s+(?:"(true|false)"|'(true|false)'|(true|false))\b)?/g;
   for (const m of invocation.matchAll(flag)) {
     const negated = Boolean(m[1]);
-    const raw = m[2];
+    const raw = m[2] ?? m[3] ?? m[4] ?? m[5];
     if (raw === undefined) {
       // Bare `--save` / `--no-save`: the prefix alone decides.
       save = !negated;

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -527,12 +527,15 @@ export function findUnsavedAuditSubjectViolations(content, name) {
   if (!/npm\s+audit\s+signatures/.test(content)) return [];
   const violations = [];
   for (const command of extractRunCommands(content)) {
-    // `npm install … --no-save … <pkg>@<version>` in any flag order. The version
-    // spec is what distinguishes "fetch this exact published artifact to verify
-    // it" from an ordinary throwaway install.
-    const install = command.match(/\bnpm\s+install\b[^\n;&|]*/g) || [];
+    // Every npm alias that installs from the registry, and both spellings of the
+    // don't-record-it flag. Matching only `npm install --no-save` would leave
+    // `npm i --no-save`, `npm add --no-save`, and `--save=false` as equivalent
+    // ways to reintroduce exactly the defect this guard exists to prevent —
+    // a guard that recognises one spelling of what it forbids is a tripwire, not
+    // a boundary. `--save=false` is npm's config form of the same flag.
+    const install = command.match(/\bnpm\s+(?:install|i|add)\b[^\n;&|]*/g) || [];
     for (const inv of install) {
-      if (!/--no-save\b/.test(inv)) continue;
+      if (!/--no-save\b|--save[=\s]+false\b/.test(inv)) continue;
       if (!/[\w@/.-]+@\$?\{?[\w.$-]/.test(inv.replace(/--[\w-]+/g, ""))) continue;
       violations.push(
         `${name}: '${inv.trim()}' installs a versioned package with --no-save in a workflow that runs 'npm audit signatures'. An unsaved install leaves the package out of the dependency graph, so the audit silently covers only its dependencies and never the package itself — the subject of the verification is skipped while the audit still reports success. Drop --no-save so the package is part of the audited graph.`,

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -543,24 +543,43 @@ const INSTALL_INVOCATION_RE = new RegExp(
  */
 export function resolveSaveFlag(invocation) {
   let save = true;
-  // `=`-attached values bind unconditionally; a SPACE-separated value binds only
-  // when the next token is literally true/false (quoted or not). Consuming any
-  // next token would let `--save --no-save` read `--no-save` as `--save`'s value
-  // and return true, where npm returns false — npm takes the LAST flag, and the
-  // loop below reproduces that by simply overwriting `save` each time.
-  const flag = /--(no-)?save(?:=("[^"]*"|'[^']*'|[^\s]*)|\s+(?:"(true|false)"|'(true|false)'|(true|false))\b)?/g;
-  for (const m of invocation.matchAll(flag)) {
-    const negated = Boolean(m[1]);
-    const raw = m[2] ?? m[3] ?? m[4] ?? m[5];
-    if (raw === undefined) {
-      // Bare `--save` / `--no-save`: the prefix alone decides.
-      save = !negated;
+  // Tokenise instead of matching flag text in place. Two things repeatedly broke
+  // the in-place regex: `--no-save-exact` is a DIFFERENT option whose prefix
+  // reads as `--no-save`, and a quoted space-separated value (`--save "false"`)
+  // has no word boundary between the closing quote and the space. Splitting on
+  // whitespace (respecting quotes) makes both fall out of the token shape rather
+  // than needing another lookaround.
+  const tokens = invocation.match(/"[^"]*"|'[^']*'|\S+/g) || [];
+  const unquote = (s) => s.replace(/^(['"])(.*)\1$/s, "$2");
+  const isBool = (s) => s === "true" || s === "false";
+  // `-S` is npm's short form of `--save`. There is no short form of `--no-save`.
+  const SAVE_TOKEN = /^(?:--(no-)?save|-S)$/;
+  const SAVE_WITH_VALUE = /^(?:--(no-)?save|-S)=(.*)$/s;
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = unquote(tokens[i]);
+    const withValue = token.match(SAVE_WITH_VALUE);
+    if (withValue) {
+      // `--no-save=false` is save=TRUE: the explicit value is what npm reads and
+      // the `no-` prefix inverts it. An empty value (`--save=`) is falsy to npm.
+      const value = unquote(withValue[2]) !== "false";
+      save = withValue[1] ? !value : value;
       continue;
     }
-    const value = raw.replace(/^['"]|['"]$/g, "") !== "false";
-    // `--no-save=false` is save=true: the explicit value is what npm reads, and
-    // the `no-` prefix inverts it.
-    save = negated ? !value : value;
+    const bare = token.match(SAVE_TOKEN);
+    if (!bare) continue; // includes --save-exact / --no-save-exact: other options
+    const negated = Boolean(bare[1]);
+    const next = tokens[i + 1] === undefined ? undefined : unquote(tokens[i + 1]);
+    if (next !== undefined && isBool(next)) {
+      // A space-separated value binds only when it is literally true/false —
+      // anything else is the next option, so `--save --no-save` must not read
+      // `--no-save` as a value (npm takes the last flag: save=false).
+      const value = next !== "false";
+      save = negated ? !value : value;
+      i += 1;
+      continue;
+    }
+    save = !negated;
   }
   return save;
 }

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -505,6 +505,61 @@ export function findPublishJobIsolationViolation(content, name) {
   return null;
 }
 
+// Every alias npm resolves to `install`, taken from npm 11's own
+// lib/utils/cmd-list.js rather than guessed — the typo-tolerant ones (`isntall`)
+// are real and install just as well as the canonical spelling.
+const NPM_INSTALL_ALIASES = [
+  "install",
+  "add",
+  "i",
+  "in",
+  "ins",
+  "inst",
+  "insta",
+  "instal",
+  "isnt",
+  "isnta",
+  "isntal",
+  "isntall",
+];
+// Longest-first so `i` cannot shadow `install` in the alternation.
+const INSTALL_INVOCATION_RE = new RegExp(
+  `\\bnpm\\s+(?:${[...NPM_INSTALL_ALIASES].sort((a, b) => b.length - a.length).join("|")})\\b[^\\n;&|]*`,
+  "g",
+);
+
+/**
+ * Resolve npm's `save` config for one install invocation the way npm itself
+ * does, rather than pattern-matching flag text. Two cases make the naive regex
+ * wrong in BOTH directions, and both are verified against real npm 11:
+ *   `--save='false'` / `--save="false"` → save=false (a miss: quotes survive
+ *       shell-less matching, so a `--save=false` regex does not see them)
+ *   `--no-save=false`                   → save=true  (a FALSE POSITIVE: the
+ *       explicit value negates the `no-` prefix, so flagging it would block a
+ *       correct command — the way a gate earns being switched off)
+ *
+ * @param {string} invocation  a single `npm install …` command string
+ * @returns {boolean} the effective `save` setting (npm's default is true)
+ */
+export function resolveSaveFlag(invocation) {
+  let save = true;
+  const flag = /--(no-)?save(?:[=\s]+("[^"]*"|'[^']*'|[^\s]+))?/g;
+  for (const m of invocation.matchAll(flag)) {
+    const negated = Boolean(m[1]);
+    const raw = m[2];
+    if (raw === undefined) {
+      // Bare `--save` / `--no-save`: the prefix alone decides.
+      save = !negated;
+      continue;
+    }
+    const value = raw.replace(/^['"]|['"]$/g, "") !== "false";
+    // `--no-save=false` is save=true: the explicit value is what npm reads, and
+    // the `no-` prefix inverts it.
+    save = negated ? !value : value;
+  }
+  return save;
+}
+
 /**
  * `npm audit signatures` walks the dependency graph, so a package installed with
  * `--no-save` — absent from both the manifest and the lockfile's root deps — is
@@ -527,15 +582,9 @@ export function findUnsavedAuditSubjectViolations(content, name) {
   if (!/npm\s+audit\s+signatures/.test(content)) return [];
   const violations = [];
   for (const command of extractRunCommands(content)) {
-    // Every npm alias that installs from the registry, and both spellings of the
-    // don't-record-it flag. Matching only `npm install --no-save` would leave
-    // `npm i --no-save`, `npm add --no-save`, and `--save=false` as equivalent
-    // ways to reintroduce exactly the defect this guard exists to prevent —
-    // a guard that recognises one spelling of what it forbids is a tripwire, not
-    // a boundary. `--save=false` is npm's config form of the same flag.
-    const install = command.match(/\bnpm\s+(?:install|i|add)\b[^\n;&|]*/g) || [];
+    const install = command.match(INSTALL_INVOCATION_RE) || [];
     for (const inv of install) {
-      if (!/--no-save\b|--save[=\s]+false\b/.test(inv)) continue;
+      if (resolveSaveFlag(inv) !== false) continue;
       if (!/[\w@/.-]+@\$?\{?[\w.$-]/.test(inv.replace(/--[\w-]+/g, ""))) continue;
       violations.push(
         `${name}: '${inv.trim()}' installs a versioned package with --no-save in a workflow that runs 'npm audit signatures'. An unsaved install leaves the package out of the dependency graph, so the audit silently covers only its dependencies and never the package itself — the subject of the verification is skipped while the audit still reports success. Drop --no-save so the package is part of the audited graph.`,

--- a/scripts/checks/check-workflow-supply-chain.mjs
+++ b/scripts/checks/check-workflow-supply-chain.mjs
@@ -505,12 +505,50 @@ export function findPublishJobIsolationViolation(content, name) {
   return null;
 }
 
+/**
+ * `npm audit signatures` walks the dependency graph, so a package installed with
+ * `--no-save` — absent from both the manifest and the lockfile's root deps — is
+ * never reached. The audit then covers only that package's own dependencies and
+ * reports a healthy-looking count while never touching the subject it was run to
+ * verify. Releases 0.4.73 and 0.4.74 both failed the downstream identity check
+ * this way, and nothing caught it before the release itself, because the
+ * verifying job only runs when a publish actually happens.
+ *
+ * Flags an install whose target is a versioned package spec (the shape used to
+ * fetch a just-published artifact for verification) combined with `--no-save`,
+ * but only in a workflow that also runs `npm audit signatures` — elsewhere
+ * `--no-save` is unremarkable.
+ *
+ * @param {string} content  workflow file text
+ * @param {string} name     file name for the message
+ * @returns {string[]} violation messages
+ */
+export function findUnsavedAuditSubjectViolations(content, name) {
+  if (!/npm\s+audit\s+signatures/.test(content)) return [];
+  const violations = [];
+  for (const command of extractRunCommands(content)) {
+    // `npm install … --no-save … <pkg>@<version>` in any flag order. The version
+    // spec is what distinguishes "fetch this exact published artifact to verify
+    // it" from an ordinary throwaway install.
+    const install = command.match(/\bnpm\s+install\b[^\n;&|]*/g) || [];
+    for (const inv of install) {
+      if (!/--no-save\b/.test(inv)) continue;
+      if (!/[\w@/.-]+@\$?\{?[\w.$-]/.test(inv.replace(/--[\w-]+/g, ""))) continue;
+      violations.push(
+        `${name}: '${inv.trim()}' installs a versioned package with --no-save in a workflow that runs 'npm audit signatures'. An unsaved install leaves the package out of the dependency graph, so the audit silently covers only its dependencies and never the package itself — the subject of the verification is skipped while the audit still reports success. Drop --no-save so the package is part of the audited graph.`,
+      );
+    }
+  }
+  return violations;
+}
+
 function main() {
   const violations = [];
   for (const file of listWorkflowFiles()) {
     const content = readFileSync(file, "utf8");
     const autoMerge = findAutoMergeViolation(content, file);
     if (autoMerge) violations.push(autoMerge);
+    violations.push(...findUnsavedAuditSubjectViolations(content, file));
     const nodePin = findTrustedPublishNodeViolation(content, file);
     if (nodePin) violations.push(nodePin);
     const publishIsolation = findPublishJobIsolationViolation(content, file);

--- a/scripts/checks/verify-npm-provenance-source.mjs
+++ b/scripts/checks/verify-npm-provenance-source.mjs
@@ -60,7 +60,26 @@ export function verifyProvenanceSource(auditOutput, expected) {
   const entry = verified.find(
     (v) => v?.name === expected.package && v?.version === expected.version,
   );
-  if (!entry) return { ok: false, reason: "PACKAGE_NOT_VERIFIED" };
+  if (!entry) {
+    // Name what was audited instead. A non-empty verified[] that excludes the
+    // subject means the audit ran against the wrong dependency graph — the
+    // package was never in it — which is a different failure from "the audit
+    // found the package and rejected it", and the bare reason code cannot tell
+    // them apart. Both 0.4.73 and 0.4.74 failed here reporting only
+    // PACKAGE_NOT_VERIFIED while the audit had happily verified the CLI's eight
+    // dependencies; the audited list is what identifies that immediately.
+    const audited = verified
+      .map((v) => (v?.name ? `${v.name}@${v.version ?? "?"}` : null))
+      .filter(Boolean);
+    return {
+      ok: false,
+      reason: "PACKAGE_NOT_VERIFIED",
+      detail:
+        audited.length === 0
+          ? "verified[] is empty — the audit covered no packages at all"
+          : `verified[] has ${audited.length} entries but not ${expected.package}@${expected.version}: ${audited.join(", ")}`,
+    };
+  }
 
   const bundles = Array.isArray(entry.attestationBundles) ? entry.attestationBundles : [];
   const provBundles = bundles.filter((b) => b?.predicateType === PROVENANCE_PREDICATE);
@@ -229,6 +248,7 @@ async function main() {
     process.exit(0);
   }
   console.error(`::error::provenance source identity check failed: ${result.reason}`);
+  if (result.detail) console.error(`::error::${result.detail}`);
   process.exit(1);
 }
 

--- a/scripts/checks/verify-npm-provenance-source.mjs
+++ b/scripts/checks/verify-npm-provenance-source.mjs
@@ -66,8 +66,8 @@ export function verifyProvenanceSource(auditOutput, expected) {
     // package was never in it — which is a different failure from "the audit
     // found the package and rejected it", and the bare reason code cannot tell
     // them apart. Both 0.4.73 and 0.4.74 failed here reporting only
-    // PACKAGE_NOT_VERIFIED while the audit had happily verified the CLI's eight
-    // dependencies; the audited list is what identifies that immediately.
+    // PACKAGE_NOT_VERIFIED while the audit had happily verified a tree of signed
+    // dependencies; printing that list is what identifies the cause immediately.
     const audited = verified
       .map((v) => (v?.name ? `${v.name}@${v.version ?? "?"}` : null))
       .filter(Boolean);


### PR DESCRIPTION
## The bug

The Release workflow's provenance-verification job failed on 0.4.74 with `PACKAGE_NOT_VERIFIED`. **The release itself was fine** — `passwd-sso-cli@0.4.74` published with valid SLSA provenance and a registry signature. The verification step was broken.

`npm audit signatures` walks the dependency graph. The job installed the published package with `--no-save`, which leaves it out of both the manifest and the lockfile's root deps — so the audit had no edge to reach it and covered only the dependencies. It reported a healthy-looking count while never touching the artifact the job exists to verify.

**Both real releases failed this way**: 0.4.73 and 0.4.74, identically. The green Release runs in between are pushes where the publish jobs were skipped, so **this gate has never passed since it was written**.

## Changes

1. **Drop `--no-save`** so the package joins the audited graph. This is the fix.
2. **Say what was audited** when the subject is missing. `PACKAGE_NOT_VERIFIED` alone cannot distinguish "found the package and rejected it" from "never covered the package" — the second is what happened twice.
3. **Guard against recurrence** in `check-workflow-supply-chain.mjs`, which runs in `pre-pr.sh`. The verifying job only runs on a real publish, so without this a regression is invisible until the next release — exactly how it shipped twice.

## Note on commit count

Eight commits for a one-flag fix. The first commit is the fix; the rest are repeated corrections to the regression guard after review found it bypassable — `npm i`, `npm add`, `--save=false`, quoted booleans, `-S`, conflicting flags, `--no-save-exact`. Each round claimed completeness and shipped an incomplete spelling list.

The current implementation resolves the flag the way npm resolves it, verified against npm: all 20 forms match `npm config get save` (and, for empty values, a real install). Two of the defects were **false positives** — flagging commands npm would have saved — which matter more than the misses, since a gate that blocks correct commands gets switched off.

## Verification

| Gate | Result |
|---|---|
| `scripts/__tests__/` | **1679 passed / 66 files** |
| Guard's own tests | 135 passed |
| npm parity | 20/20 forms match measured behavior |
| `check-workflow-supply-chain.mjs` | pass |
| `check-gate-selftest-coverage.sh` | pass |
| ESLint (`--max-warnings 0`), `git diff --check` | pass |

Every clause is red-proven by mutation, including the guard against the original bug: reintroducing `--no-save` into the real workflow makes the gate exit 1 naming the command.

## Not verifiable before merge

**Whether the workflow now goes green can only be confirmed at the next real release** — the job runs solely when `release_created == 'true'`. Local npm 11.19.0 returns no `verified` key at all (CI pins 11.16.0), so CI's output shape could not be reproduced locally. A reviewer did verify against the live registry that `--no-save` excludes the package and the saved install includes it.

## Unrelated finding

`scripts/__tests__/backup-db.test.mjs` ("accepts a positive BACKUP_RETAIN") fails in the full suite but passes in isolation — an order-dependent flake from #772/#766, untouched by this branch. It will intermittently red CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
