### PR TITLE
fix(extension): make the vitest suite order-independent and gate it with always-on shuffle

### DIFF
--- a/docs/archive/review/extension-test-order-deps-code-review.md
+++ b/docs/archive/review/extension-test-order-deps-code-review.md
@@ -240,3 +240,33 @@ N/A — no environment constraints declared in Phase 1 (all contracts verifiable
 
 Verification after all fixes: `npx tsc --noEmit` clean; 5 shuffled full-suite runs (5 distinct seeds) 1029/1029; A1's 9 recorded seeds re-run green.
 
+
+---
+
+# Code Review — Round 2 (commit b426424f6)
+Date: 2026-08-23
+
+All 9 Round-1 findings verified RESOLVED by all three experts. Security: No findings (R43 check — every hunk tightens: fail-closed reject, guaranteed restores, narrowed cross-describe channel; C1-I4 on the fix diff satisfied — 3 removed expects re-added verbatim in try blocks). Testing: No findings (independent full shuffled run green, seed 1787418987252; CR1 masking check — all non-flow decrypt consumers use ciphertext '11', byte-identical default, net effect strictly stricter since a miss now throws). Functionality: all resolved + ONE new [Adjacent] Minor:
+
+- F6: same failure-unsafe fake-timer restore class as CR2, in non-diff webauthn-bridge-lib.test.ts (last remaining member per a 7-file useFakeTimers sweep).
+
+Disposition: FIXED rather than deferred (close-the-class rule) — commit 1a733a900 adds vi.useRealTimers() to the file's afterEach.
+
+# Code Review — Round 3 (commit 1a733a900)
+Date: 2026-08-23
+
+All three experts: **No findings.**
+- Functionality: F6 resolved exactly per remedy option 2; afterEach ordering harmless (three independent state subsystems); idempotent with the in-body restore; class closed tree-wide (7/7 files failure-safe).
+- Security: 4 additive teardown lines, zero removed; no assertion/suppression change; C3 exclusivity preserved; RS4 clean; tightening only.
+- Testing: ordering/idempotency confirmed by execution; class member set re-derived (7 files) and each member's restore mechanism individually verified. One [Adjacent] non-finding observation recorded below.
+
+## Termination (Step 3-8)
+Natural stop: all experts returned No findings in Round 3.
+R42 expanding-class check: the fake-timer teardown class expanded once (CR2 → F6), below the ≥2-expansion threshold that would mandate a dedicated CI guard; the class was closed by exhaustive execution-derived member enumeration (all 7 useFakeTimers files verified failure-safe by two experts independently), and the standing shuffle gate — itself red-proven in A6 — remains the dynamic adjudicator for the consequence class (any future order-dependence leak).
+
+## Non-finding observation (recorded, no action)
+passkey-save-banner.test.ts / save-banner.test.ts afterEach call hideBanner() BEFORE vi.useRealTimers(); a teardown-throw (not assertion-throw) could skip the restore. Both experts classify this as a narrower, cosmetic class in unchanged files — left for a future hygiene pass.
+
+## Resolution Status — final
+Rounds: 3. Findings: 9 (R1) + 1 Adjacent (R2) = 10; all resolved (dispositions above and in Round-1 Resolution Status). No open findings. No Anti-Deferral entries pending beyond the plan's SC1-SC4 and deviation-log D1/D2 (documented cost-justifications with revisit triggers).
+

--- a/docs/archive/review/extension-test-order-deps-code-review.md
+++ b/docs/archive/review/extension-test-order-deps-code-review.md
@@ -269,4 +269,3 @@ passkey-save-banner.test.ts / save-banner.test.ts afterEach call hideBanner() BE
 
 ## Resolution Status — final
 Rounds: 3. Findings: 9 (R1) + 1 Adjacent (R2) = 10; all resolved (dispositions above and in Round-1 Resolution Status). No open findings. No Anti-Deferral entries pending beyond the plan's SC1-SC4 and deviation-log D1/D2 (documented cost-justifications with revisit triggers).
-

--- a/docs/archive/review/extension-test-order-deps-code-review.md
+++ b/docs/archive/review/extension-test-order-deps-code-review.md
@@ -1,0 +1,242 @@
+# Code Review: extension-test-order-deps
+Date: 2026-08-23
+Review round: 1
+
+## Changes from Previous Round
+Initial review (incremental on top of the Phase 2 self-R-check baseline).
+
+## Merged Findings (convergence-corrected)
+
+| ID | Severity | Title | Convergent |
+|----|----------|-------|------------|
+| CR1 | Major | keyed decryptData install in 1 of 10 describes; impl+map leak across suites (background.test.ts) | func(F1) |
+| CR2 | Major | vi.useFakeTimers restore trailing in-body; assertion throw leaks fake clock (login-detector) | test(1 Major)+func(F2) |
+| CR3 | Major (floored) | getComputedStyle spy restore not failure-safe (form-detector.test.ts) | sec(F1)+func(F4) |
+| CR4 | Major (floored) | deleteTestDb onblocked→resolve fail-open baseline reset (dpop-key) | sec(F2)+func(F5)+test(3) |
+| CR5 | Minor | find-mock overrides persist; no C2 row (login-detector) | test(2) |
+| CR6 | Minor | Stale comment references removed decryptResponses (background.test.ts:1129) | func(F3) |
+| CR7 | Minor | Listener teardown drops registration options (form-detector-entry) | test(4) + sec Adjacent |
+| CR8 | Minor | Seed 52 provenance unrecorded in A3 evidence row | test(5) |
+| CR9 | Minor | C2 contained-table path typo | test(6) |
+
+Convergence per 'Perspective Convergence as a Severity Signal': CR2 max severity Major; CR3/CR4 floored Minor→Major (multi-perspective).
+
+## Ollama merged prose
+
+## Recurring Issue Check
+### Functionality expert
+R1 OK (helper extracted, both consumers import). R2 OK. R3 Finding F1/F2/F4 (fix patterns incompletely propagated within changed files). R17 Finding F1. R19 OK. R21 OK. R29 Finding F3 (stale reference; other citations verified accurate). R33 OK. R34 F2/F4/F5 carry fixes not deferrals. R36 OK. R42 F2 class note (fake-timer state never a Set B bullet) + F1 (fix-introduced state outside derivation). R47 OK. R49 OK. R50 Finding F5. RT1 OK. RT7 OK (verify-not-redo). RT11 Finding F1, F5. Others N/A.
+
+### Security expert
+R1 Pass (helper extracted). R17/R19 Pass. R21 Pass. R29 Pass (dpop constants claim verified; D5 verified against source). R33 Pass. R34 Pass. R36 Pass. R42 Pass. R47/R49 Pass. R44/R50 Pass. RS1-RS3, RS5, RS6 N/A. RS4 Pass. RT1 Pass with F1/F2 notes. RT4 Pass. RT5 Pass. RT7/RT10 Pass. RT9 Pass. RT11 F1, F2 (Minor). Others N/A.
+
+### Testing expert
+R21 clean (name-only diff verified; probe absent). R36/C1-I4 clean (zero suppression spellings; assertions byte-identical or strengthened). RT7 evidence recorded deny/allow; one provenance gap → Finding 5. C3 forbidden patterns clean. R19 twins untouched. R42 counts carry commands; one occurrence-level gap → Finding 2; background.test.ts:2779 verified contained. RT1 keyed mock fidelity increased; fail-loud miss. Gate not vacuous (execution + printed seed; consumers read exit code). Others N/A or owned by siblings.
+
+## Merged Findings
+
+### 1. background.test.ts:236
+- **Severity:** Major
+- **Problem:** Keyed `decryptData` mock installed in only 1 of 10 `describe` blocks; implementation + mutable responses map leak into the other nine suites. `keyedDecrypt.install()` runs only in the "background message flow" `beforeEach`. Other describes run `clearAllMocks` only and never reinstall, causing them to consume either the `vi.hoisted` default or the leaked keyed implementation depending on suite order.
+- **Impact:** Test isolation is violated. Assertions in other suites may pass insensitively to leaked content rather than being properly isolated, breaking the plan's universal invariant and causing flaky or misleading test results.
+- **Recommended action:** Hoist `keyedDecrypt.install()` into a file-level `beforeEach` before the first `describe`. Drop the in-describe call. Add a fail-loud mechanism (named miss-throw) for unmapped ciphertexts to ensure deterministic behavior.
+- **Perspectives flagged:** Functionality
+
+### 2. login-detector.test.ts:695-730
+- **Severity:** Major
+- **Problem:** `vi.useRealTimers()` placed trailing in-body rather than in a failure-safe block; an assertion throw leaks the fake clock state to later tests. This is the sole outlier in the changed set, as every other fake-timer site uses `try/finally`.
+- **Impact:** Frozen `Date.now()` state smears into subsequent tests, causing triage noise on red runs, polluting printed-seed attribution, and potentially causing unrelated tests to fail or pass incorrectly due to mocked time.
+- **Recommended action:** Wrap timer restoration in a `try/finally` or move `vi.useRealTimers()` to an `afterEach` hook (unconditional, idempotent, and covers future fake-timer tests).
+- **Perspectives flagged:** Functionality, Testing
+
+### 3. background.test.ts:1122
+- **Severity:** Minor
+- **Problem:** Stale comment references removed identifier `decryptResponses` (extracted to `keyedDecrypt`/`helpers/keyed-decrypt-mock` by the R1 helper).
+- **Impact:** Documentation drift that confuses maintainers during code review and future refactoring.
+- **Recommended action:** Update the comment to reference the new identifier (`keyedDecrypt` / `helpers/keyed-decrypt-mock`).
+- **Perspectives flagged:** Functionality
+
+### 4. form-detector.test.ts:145-158
+- **Severity:** Minor
+- **Problem:** `getComputedStyle` spy restore is skipped on the failure path (no `try/finally`).
+- **Impact:** Behaviorally transparent today but fragile; assertion failures could leave spy state leaked to sibling tests or subsequent run phases, making future debugging difficult.
+- **Recommended action:** Wrap spy installation/cleanup in `try/finally` to guarantee `mockRestore` on all execution paths, matching the pattern used in `totp-handlers`.
+- **Perspectives flagged:** Functionality, Security
+
+### 5. dpop-key.test.ts:59
+- **Severity:** Minor
+- **Problem:** `deleteTestDb` resolves on `onblocked` instead of rejecting, converting a failed baseline reset into a silent pass.
+- **Impact:** If an IndexedDB connection leaks, the reset appears successful but actually "examined nothing." Subsequent `open()` calls queue behind the pending delete, causing opaque 5-second timeouts without naming the culprit. Violates fail-open/clean-error expectations.
+- **Recommended action:** Reject with a named error on `onblocked` so leaking tests fail loudly by name. The normal path still resolves via `onsuccess`.
+- **Perspectives flagged:** Functionality, Security, Testing
+
+### 6. login-detector.test.ts:673-674
+- **Severity:** Minor
+- **Problem:** `mockFindPasswordInputs`/`mockFindUsernameInput` `mockReturnValue` overrides persist in test bodies; only `clearAllMocks` exists in the outer `beforeEach`.
+- **Impact:** Latent mock pollution across tests. Currently mitigated because every consuming test sets its own values, but violates strict test isolation principles and could cause failures if test execution order changes.
+- **Recommended action:** Add explicit `mockReset()` calls beside other mock resets in the local `beforeEach`, or document as a contained audit row.
+- **Perspectives flagged:** Testing
+
+### 7. form-detector-entry.test.ts:84-105
+- **Severity:** Minor
+- **Problem:** Event listener wrapper tracks only the listener function but not registration options.
+- **Impact:** A future `{ capture: true }` registration would defeat `removeEventListener` silently, leading to memory leaks and unexpected side effects.
+- **Recommended action:** Push `{listener, options}` pairs to the tracking array and pass options through during teardown.
+- **Perspectives flagged:** Testing
+
+### 8. docs/archive/review/extension-test-order-deps-deviation.md
+- **Severity:** Minor
+- **Problem:** Deviation log contains two documentation issues: (1) Seed 52 in A3 row lacks recorded sweep provenance, and (2) contained-table path typo (`totp-handlers/background.test.ts` instead of `background/totp-handlers.test.ts`).
+- **Impact:** Minor documentation inaccuracies affecting audit traceability and file path references for reviewers.
+- **Recommended action:** Annotate the producing command for seed 52 or correct the sweep number. Fix the path typo in the contained table.
+- **Perspectives flagged:** Testing
+
+## Quality Warnings
+No quality warnings triggered. All merged findings contain specific file/line references, concrete root-cause explanations, measurable impacts, and actionable fixes. No findings rely on unverified claims, lack evidence paths, or recommend testing without confirming target testability.
+
+## Expert outputs (verbatim)
+
+# Functionality Code Review R1 — fix/extension-test-order-deps
+
+Checklist cross-check: all nine Implementation Checklist deliverables present in the diff; extra diff files accounted for (context-menu/form-detector C2 rows, helper = R1 remedy). Config single hunk = gate line + comment; no neutralizing key. Forbidden-pattern scan clean (comment-position "shuffled" tokens passed per allow path). C1-I4 holds.
+Verified: keyed-mock first-arg shape matches production decryptData call sites; dpop-key comment IDB semantics accurate; TEST_IDB constants mirror private IDB_NAME/IDB_STORE (L22-23, unexported); 200 ms debounce claim matches context-menu.ts:14; all IDB connections closed on both paths; messaging L18/38/51 converted per C2 row.
+
+## Findings
+
+### F1 — Major — background.test.ts:236 — keyed decryptData mock installed in only 1 of 10 describes; implementation + mutable responses map leak into the other nine
+keyedDecrypt.install() runs only in the "background message flow" beforeEach. The other describes (session persistence 1521, session hydration 1734, token refresh alarm 1850, hydration edge cases 2112, failsafe responses 2163, CHECK_PENDING_SAVE host validation 2372, LOGIN_DETECTED suppresses on own app 2540, PASSKEY handlers 2655) run clearAllMocks only and never reinstall — which decryptData they get depends on suite order: the vi.hoisted default if before any flow test, or the LEAKED keyed implementation whose "11" entry holds whatever the last-run flow test wrote. CHECK_PENDING_SAVE's helper comment premise ("cached entries have urlHost 'example.com' from decryptData mock") is false under the leaked map; green today only because assertions are insensitive to the leaked content, not isolated from it. Violates the plan's universal invariant in a new spelling introduced by the fix; outside the C2 audit (arises from the fix, not a Set B pattern).
+Fix (Remedy Floor): hoist install into a file-level beforeEach before the first describe; drop the in-describe call. Boundary/tie: outer hooks run before inner, so tab-event-badge's inner mockResolvedValue re-establishment still wins deterministically. Allow: recorded seed set stays green (file-level "11" default byte-identical to hoisted default). Deny-proof: scratch copy with sentinel "11" plaintext shows other describes consuming the deterministic install. Fail loudly: unmapped ciphertexts in any describe now hit the named miss-throw.
+
+### F2 — Minor — login-detector.test.ts:696-729 — vi.useFakeTimers restored only by in-body useRealTimers; assertion throw leaks fake clock
+Identical cascade shape D4 fixed for cleanup.destroy() in the same describe. popup/App.test.tsx:204-222 (same diff) shows the correct try/finally. Fix: try/finally or afterEach guard; assertions untouched.
+
+### F3 — Minor — background.test.ts:1122 — stale comment "(see decryptResponses above)" — identifier removed by the R1 helper extraction. Fix: reference keyedDecrypt / helpers/keyed-decrypt-mock.
+
+### F4 — Minor — content/form-detector.test.ts:145-156 — getComputedStyle spy restore not failure-safe (behaviorally transparent today; C2 row notes it). Fix: try/finally like totp-handlers:226-247.
+
+### F5 — Minor — dpop-key.test.ts:52-62 — deleteTestDb resolves on onblocked; fail-open baseline reset. Fix: reject with named error; allow side unaffected (all current connections closed).
+
+Cross-cutting: keyed-decrypt adoption elsewhere = documented contained verdicts (D2); no raw indexedDB.open remains outside dpop-key; form-detector-entry is the only entry-point-importing file; fake-timer global state is a class the Set B derivation never enumerated (F2 the only in-file instance; popup/App's is try/finally-safe).
+
+## Seed Finding Disposition
+Seed empty (No findings) — no dispositions to record.
+
+## Recurring Issue Check
+R1 OK (helper extracted, both consumers import). R2 OK. R3 Finding F1/F2/F4 (fix patterns incompletely propagated within changed files). R17 Finding F1. R19 OK. R21 OK. R29 Finding F3 (stale reference; other citations verified accurate). R33 OK. R34 F2/F4/F5 carry fixes not deferrals. R36 OK. R42 F2 class note (fake-timer state never a Set B bullet) + F1 (fix-introduced state outside derivation). R47 OK. R49 OK. R50 Finding F5. RT1 OK. RT7 OK (verify-not-redo). RT11 Finding F1, F5. Others N/A.
+
+```json
+[
+  {"id":"F1","severity":"Major","title":"Keyed decryptData mock installed in 1 of 10 describes; implementation+map leak across suites in background.test.ts","file":"extension/src/__tests__/background.test.ts","line":236,"adjacent":false,"escalate":null},
+  {"id":"F2","severity":"Minor","title":"vi.useFakeTimers not failure-safe; assertion throw leaks fake clock to later tests","file":"extension/src/__tests__/login-detector.test.ts","line":696,"adjacent":false,"escalate":null},
+  {"id":"F3","severity":"Minor","title":"Stale comment references removed identifier decryptResponses","file":"extension/src/__tests__/background.test.ts","line":1122,"adjacent":false,"escalate":null},
+  {"id":"F4","severity":"Minor","title":"getComputedStyle spy restore skipped if assertion throws (no try/finally)","file":"extension/src/__tests__/content/form-detector.test.ts","line":145,"adjacent":false,"escalate":null},
+  {"id":"F5","severity":"Minor","title":"deleteTestDb resolves on onblocked — fail-open baseline reset","file":"extension/src/__tests__/dpop-key.test.ts","line":60,"adjacent":false,"escalate":null}
+]
+```
+# Security Code Review R1 — fix/extension-test-order-deps
+
+## Seed Finding Disposition
+Seed empty (No findings) — no dispositions to record.
+
+Verification: C3 exclusivity SATISFIED (single hunk, gate line + comment; repro text in comment = allow path). Forbidden-pattern sweep over 350 added lines CLEAN (comment-position shuffle tokens flagged-and-passed). C1-I4 SATISFIED (2 deleted expects re-added verbatim in try block; login-detector deletions are teardown relocation that STRENGTHENS isolation; security-control assertions in dpop-key preserved: JKT format, exactly-one-row, non-extractable key, RFC 9449 no-cnf.jkt; webauthn untouched). D5 triage HOLDS (crypto.ts:145-167 decryptData stateless, pure function; fire-and-forget consumer real at background/index.ts:2215 → getCachedEntries:266 → decryptOverviews:1110, but each call decrypts its own ciphertext — mis-association structurally impossible in production). RS4 CLEAN (canonical fake fixtures; miss error names mock-input ciphertext, not plaintext). RT1 spot checks: schema-safe openTestDb does NOT mask production onupgradeneeded regression (beforeEach deletes DB; most tests hit production openDb() first on version-0). R21 residue clean.
+
+## Findings
+
+### F1 — Minor — content/form-detector.test.ts:145-158 — spy restore skipped on failure path (RT11-shaped; bounded: fallthrough-transparent, fires only when file already red). Fix: try/finally like totp-handlers.
+
+### F2 — Minor — dpop-key.test.ts deleteTestDb onblocked → resolve() — silent no-op if a connection leaks; "examined nothing" spelled as "reset done" (fail-open cleanup the M4 fix depends on; latent — all current tests close connections). Fix: reject with named error so the leaking test reds by name.
+
+[Adjacent] test-quality: form-detector-entry addEventListener wrapper tracks only "error"-type listeners; other types would accumulate — shuffle gate is the standing detector for that class.
+
+No Criticals; no escalations.
+
+## Recurring Issue Check
+R1 Pass (helper extracted). R17/R19 Pass. R21 Pass. R29 Pass (dpop constants claim verified; D5 verified against source). R33 Pass. R34 Pass. R36 Pass. R42 Pass. R47/R49 Pass. R44/R50 Pass. RS1-RS3, RS5, RS6 N/A. RS4 Pass. RT1 Pass with F1/F2 notes. RT4 Pass. RT5 Pass. RT7/RT10 Pass. RT9 Pass. RT11 F1, F2 (Minor). Others N/A.
+
+```json
+[
+  {"id":"F1","severity":"Minor","title":"getComputedStyle spy mockRestore after assertion without try/finally; leaks on assertion failure","file":"extension/src/__tests__/content/form-detector.test.ts","line":145,"adjacent":false,"escalate":null},
+  {"id":"F2","severity":"Minor","title":"deleteTestDb onblocked resolves instead of rejecting — leaked IDB connection silently skips M4 baseline reset","file":"extension/src/__tests__/dpop-key.test.ts","line":59,"adjacent":false,"escalate":null}
+]
+```
+# Testing Code Review R1 — fix/extension-test-order-deps
+
+Spot-checks: keyed-decrypt install/beforeEach interplay sound (install after clearAllMocks in all three consuming scopes; hazardous mockReset sites removed; background.test.ts:2779 persistent override in-beforeEach, race-immune, matches contained row; keying on ciphertext INCREASES fidelity — a blob/overview swap in production would now red where positional was ambiguous). login-detector destroy idempotent (lib:301-309) so afterEach double-destroy safe. form-detector-entry wrapper cannot leak the wrapper itself. Gate CI integration verified (single-hunk config; consumers inherit; path filter extension/** sound for this class; no forbidden patterns in consumers; helper not matched by *.test.* include — 61-file count holds). Acceptance table consistent with A1-A8/A3m; A5 seeds pairwise distinct; A6 both directions; re-seed/exhaustion correctly unneeded; note A8 cites check-pre-pr.sh wrapper (executes the full script — worth one confirming sentence).
+
+## Findings
+
+### 1 — Major — login-detector.test.ts:695-730 — vi.useRealTimers() trailing in-body; the exact skipped-trailing-cleanup class D4 fixed for cleanup.destroy() in the same describe
+Assertion throw at 712/724 leaks fake timers (frozen Date.now) into later tests. Every other fake-timer site in the changed set uses try/finally; this is the sole outlier. Blast radius today: triage noise on a red run (smears frozen-clock state, pollutes printed-seed attribution). Fix (Remedy Floor): try/finally or afterEach vi.useRealTimers() (idempotent); allow side: advanceTimersByTime still under fake timers, test greens as-is; red-proof: scratch copy, force line-724 red + probe expect(vi.isFakeTimers()).toBe(false) in next test — probe reds without fix, greens with; prefer afterEach (unconditional; covers future fake-timer tests); assertions byte-identical; boundary: order vs currentCleanup?.destroy() is a tie with no loser (destroy synchronous, timer-free).
+
+### 2 — Minor — login-detector.test.ts:673-674 (+~8 siblings) — mockFindPasswordInputs/mockFindUsernameInput mockReturnValue in test bodies persist (clearAllMocks-only outer beforeEach); occurrence has no C2 row
+Same M1 shape as the mockSendMessage fix two lines away. Latent (every consuming test sets its own values; 50-seed sweep green). Fix: add both mockReset() calls beside mockSendMessage.mockReset() in the local beforeEach, or add a contained row; the first also closes the latent leak.
+
+### 3 — Minor — dpop-key.test.ts:59 — onblocked → resolve() converts failed baseline reset into silent pass; next open queues behind pending delete → opaque 5 s timeout with nothing naming the culprit. Fix: reject with named error; allow side: normal path resolves via onsuccess.
+
+### 4 — Minor — form-detector-entry.test.ts (~84-105) — wrapper records listener but not options; a future { capture: true } registration would defeat removeEventListener silently. Fix: push {listener, options} pairs and pass options through.
+
+### 5 — Minor — deviation log A3 row + dpop-key comment — seed 52 exceeds both recorded sweeps ({1..8,12345} and 1..50); no entry names the widened per-file sweep. Fix: annotate the producing command or correct the number.
+
+### 6 — Minor — deviation log contained-table — "totp-handlers/background.test.ts" reverses the actual path background/totp-handlers.test.ts.
+
+[Adjacent] environmentMatchGlobs deprecation — already SC3.
+
+## Seed Finding Disposition
+Seed empty (No findings) — no dispositions to record.
+
+## Recurring Issue Check
+R21 clean (name-only diff verified; probe absent). R36/C1-I4 clean (zero suppression spellings; assertions byte-identical or strengthened). RT7 evidence recorded deny/allow; one provenance gap → Finding 5. C3 forbidden patterns clean. R19 twins untouched. R42 counts carry commands; one occurrence-level gap → Finding 2; background.test.ts:2779 verified contained. RT1 keyed mock fidelity increased; fail-loud miss. Gate not vacuous (execution + printed seed; consumers read exit code). Others N/A or owned by siblings.
+
+```json
+[
+  {"id":"1","severity":"Major","title":"Trailing vi.useRealTimers() not exception-safe; same skipped-trailing-cleanup class D4 fixed in same describe","file":"extension/src/__tests__/login-detector.test.ts","line":729,"adjacent":false,"escalate":null},
+  {"id":"2","severity":"Minor","title":"find-mock mockReturnValue overrides persist across tests; no C2 classification row","file":"extension/src/__tests__/login-detector.test.ts","line":673,"adjacent":false,"escalate":null},
+  {"id":"3","severity":"Minor","title":"deleteTestDb onblocked resolves silently — opaque downstream timeout","file":"extension/src/__tests__/dpop-key.test.ts","line":59,"adjacent":false,"escalate":null},
+  {"id":"4","severity":"Minor","title":"Error-listener teardown drops registration options; capture-phase registration would defeat removal","file":"extension/src/__tests__/content/form-detector-entry.test.ts","line":100,"adjacent":false,"escalate":null},
+  {"id":"5","severity":"Minor","title":"Seed 52 in A3 evidence has no recorded sweep provenance","file":"docs/archive/review/extension-test-order-deps-deviation.md","line":9,"adjacent":false,"escalate":null},
+  {"id":"6","severity":"Minor","title":"Contained-table path typo: totp-handlers/background.test.ts","file":"docs/archive/review/extension-test-order-deps-deviation.md","line":199,"adjacent":false,"escalate":null}
+]
+```
+## Environment Verification Report
+N/A — no environment constraints declared in Phase 1 (all contracts verifiable-local). All acceptance paths verified-local; commands and outcomes in the deviation log's Acceptance evidence table (A1-A8, A3m).
+
+## Resolution Status
+
+### CR1 [Major] keyed decryptData install scoped to one describe
+- Action: hoisted `keyedDecrypt.install({ "11": DEFAULT_OVERVIEW_PLAINTEXT })` into a FILE-LEVEL beforeEach (outer hooks run before inner, so describe-local re-establishments still win deterministically); removed the describe-local call; rationale comment added.
+- Modified file: extension/src/__tests__/background.test.ts (file-level hook before first describe)
+
+### CR2 [Major] fake-timer restore not exception-safe
+- Action: wrapped the debounce test body in try/finally with `vi.useRealTimers()` in finally; assertions byte-identical.
+- Modified file: extension/src/__tests__/login-detector.test.ts ("allows LOGIN_DETECTED after debounce period expires")
+
+### CR3 [Major, floored] getComputedStyle spy restore not failure-safe
+- Action: assertion wrapped in try/finally with `mockRestore()` in finally (same shape as totp-handlers' Date.now spy).
+- Modified file: extension/src/__tests__/content/form-detector.test.ts
+
+### CR4 [Major, floored] deleteTestDb onblocked fail-open
+- Action: onblocked now REJECTS with a named error ("a previous test left an IDB connection to psso-ext open") — the leaking test reds by name instead of poisoning a later one; allow path (onsuccess) unchanged.
+- Modified file: extension/src/__tests__/dpop-key.test.ts (deleteTestDb)
+
+### CR5 [Minor] find-mock persistence + missing C2 row
+- Action: `mockFindPasswordInputs.mockReset()` + `mockFindUsernameInput.mockReset()` added beside mockSendMessage.mockReset() in the local beforeEach (closes the latent leak, not just the audit gap); C2 row added to the deviation log.
+- Modified files: extension/src/__tests__/login-detector.test.ts; docs/archive/review/extension-test-order-deps-deviation.md
+
+### CR6 [Minor] stale decryptResponses comment
+- Action: comment now references helpers/keyed-decrypt-mock.
+- Modified file: extension/src/__tests__/background.test.ts:1129
+
+### CR7 [Minor] listener teardown drops options
+- Action: wrapper now records {listener, options} pairs and passes options to removeEventListener; type widened accordingly. (The sec-Adjacent "other event types" note remains future-proofing: production registers only "error", and the standing gate detects any new type's leak.)
+- Modified file: extension/src/__tests__/content/form-detector-entry.test.ts
+
+### CR8 [Minor] seed-52 provenance
+- Action: A3 evidence row now names the per-file discovery sweeps (command shape) that produced seeds > 50.
+- Modified file: docs/archive/review/extension-test-order-deps-deviation.md
+
+### CR9 [Minor] contained-table path typo
+- Action: corrected to "background/totp-handlers.test.ts and background.test.ts".
+- Modified file: docs/archive/review/extension-test-order-deps-deviation.md
+
+Verification after all fixes: `npx tsc --noEmit` clean; 5 shuffled full-suite runs (5 distinct seeds) 1029/1029; A1's 9 recorded seeds re-run green.
+

--- a/docs/archive/review/extension-test-order-deps-deviation.md
+++ b/docs/archive/review/extension-test-order-deps-deviation.md
@@ -1,0 +1,185 @@
+# Coding Deviation Log: extension-test-order-deps
+
+## D0 — A3m executed: M3 VERIFIED (fact 5 upgraded from "hypothesized")
+
+A3m ran on a scratch git worktree (detached, node_modules symlinked, removed
+after): deny = pre-fix positional totp-handlers + steal-window `vi.waitFor`
+flush inserted after `unlockVault()` in "does not include totpCode when totp
+is absent" → RED 3/3 runs with exactly the pre-pr failure shape
+(`{ok:false}` vs `{ok:true}`, NO_PASSWORD); allow = fixed input-keyed file +
+byte-identical flush → GREEN 3/3. The pair differs only in positional-queue
+vs keyed mock, as C1-A3m requires. Logs: scratchpad `a3m-deny-{1..3}.log`,
+`a3m-allow-{1..3}.log`. Consequence: C4's PR body marks M3 "verified".
+
+## D0b — totp-handlers I3 conversion applied by the orchestrator post-batch
+
+Batch 1 fixed totp-handlers' M1/M2 but left its positional decryptData
+queues; since fact 5 diagnoses M3 in this exact file (the pre-pr NO_PASSWORD
+failure), the orchestrator applied the input-keyed conversion (mirroring
+background.test.ts's pattern) before acceptance. 17 shuffle seeds + default
+order + full suite green after conversion.
+
+## D0c — citation-rot gate scope: review artifact excluded
+
+`verify-references.sh --strict` runs over the plan + deviation log (green,
+2/2 ok after annotating pre-fix line citations as historical). The review
+artifact is excluded: it preserves expert outputs verbatim (Step 1-5
+obligation), and their citations (node_modules dist paths, short-path
+file:line evidence) are historical review evidence, not live contracts —
+rewriting them would falsify the record.
+
+## D1 — I3 end-of-test flush not added to M3-fixed tests (deviation from C1-I3 letter)
+
+C1-I3 requires each M3 fix to "deterministically flush the fire-and-forget
+consumer before the test ends" so a keyed-mock miss reds the causing test.
+Neither `background.test.ts` nor `background/totp-handlers.test.ts` adds a
+per-test flush. Rationale: the flush's purpose is miss-ATTRIBUTION (a throw in
+an unawaited consumer would surface as an unhandled rejection on an arbitrary
+test). Both files' `beforeEach` unconditionally map `"11"` — verified by
+reading `background/index.ts` → `invalidateContextMenu` → `doUpdateMenu` →
+`getCachedEntries` → `decryptOverviews` to be the ONLY ciphertext the
+fire-and-forget consumer ever requests — so the consumer structurally cannot
+hit the miss path and the attribution hazard the flush guards against is
+unreachable. The A3m red-proof (deny/allow pair with a steal-window flush on a
+scratch worktree) separately proves the mechanism; see the acceptance
+evidence. Anti-Deferral: cost of adding a `vi.waitFor` flush to every M3 test
+≈ +200 ms × ~40 tests per run for a hazard shown unreachable; benefit none
+while `"11"` is beforeEach-mapped. Revisit if a future fetch stub introduces a
+second consumer-visible ciphertext.
+
+## D2 — C1-I3 member set: inline-matches / team-entries classified `contained`, not converted
+
+`background/inline-matches.test.ts` and `background/team-entries.test.ts` are
+B3 (mockResolvedValueOnce) candidates that import `background/index`. C2
+classification (Batch 3): their helpers reset AND re-queue the decryptData
+mock at the start of every test; 30–60 shuffled seeds green; team-entries'
+one persistent override (L343) resolves to a value identical to the hoisted
+default (no observable escape). I3's conversion obligation applies "in the
+files where M3 is diagnosed" — M3 is diagnosed in `background.test.ts`
+(observed slot-steal: base-default overview leaked into `allowedHosts`) and
+`totp-handlers.test.ts` (issue #784's observed pre-pr NO_PASSWORD); both are
+converted. The two `contained` files retain a theoretical load-axis exposure
+(a stray 200 ms debounce timer from a prior test consuming a queued Once
+mid-test); the standing shuffle gate plus pre-pr (A8 environment) are the
+detection path. Anti-Deferral: converting two more files rewrites their
+helper-based fixture architecture for a mechanism never observed there;
+cost-benefit favors gate coverage. Revisit on the first gate trip in either
+file.
+
+## D3 — Batch-3 process deviations from the delegation contract (both remediated)
+
+(a) A throwaway probe test (`zzz-clearmocks-probe.test.ts`) was briefly
+created inside the real tree instead of the scratchpad (used to verify that
+`vi.clearAllMocks()` does not clear queued `mockXxxOnce` values). Deleted by
+the same agent; orchestrator verified absence (`git status` clean, no `zzz*`
+files) and ran the mandatory R21 residue grep over the full diff — clean.
+(b) `content/form-detector.test.ts`'s red-proof reverted the fix on the real
+file via a captured+reversed patch instead of a scratch copy; the fix was
+restored immediately and the orchestrator verified the final diff contains
+exactly the intended two-line change (spy captured + `mockRestore()`), no
+residue. Both are process violations of the "throwaway copies under the
+scratchpad only" instruction — recorded here so Phase 3 reviews the affected
+files with that knowledge; neither left artifacts in the tree.
+
+## D4 — login-detector mechanism differs from the plan's hypothesis
+
+Plan hypothesized leaked `chrome.runtime.onMessage` listeners. Actual
+diagnosis (Batch 2): (root) `mockSendMessage.mockImplementation(...)` set by
+5 tests, never restored — `clearAllMocks` clears calls, not implementations;
+(cascade) victims' assertion throws skipped their trailing
+`cleanup.destroy()`, leaking document-level submit/click listeners into the
+next test. Fix closes the class: `mockSendMessage.mockReset()` in the local
+beforeEach + afterEach-guaranteed `currentCleanup?.destroy()` so cleanup
+survives assertion failures. No contract change — diagnosis refinement only.
+
+## D5 — SC2 pre-committed triage executed: security hypothesis CLOSED
+
+The M3 fire-and-forget consumer is real production code
+(`background/index.ts`: UNLOCK_VAULT → `invalidateContextMenu()` → 200 ms
+debounce → `doUpdateMenu` → `getCachedEntries()` → `decryptOverviews()`), but
+in production `decryptData` is `crypto.subtle.decrypt` — a pure function of
+its actual ciphertext input. There is no shared position-based response slot
+to race for, so credential/overview mis-association cannot occur; the only
+effect is a possible redundant idempotent fetch+decrypt. Per SC2's
+pre-committed branch: mock-positional only → hypothesis noted and closed; no
+`security`-labeled issue filed.
+
+## D6 — dpop-key culprit is test-fixture schema racing, wider than the plan's M4 sketch
+
+The all-or-nothing failure was NOT cache/order semantics but two ad hoc
+`indexedDB.open("psso-ext", 1)` calls without `onupgradeneeded`: whichever
+connection first bumps 0→1 wins the upgrade event; a bare open winning it
+creates no `dpop-keys` store, and every later open at the same version gets
+`NotFoundError` forever. Fix: schema-safe shared `openTestDb()` helper
+(mirrors production `openDb()`) + awaited per-test `deleteTestDb()` baseline.
+Production `src/lib/dpop-key.ts` untouched (its `openDb()` already carries
+the handler).
+
+## D7 — form-detector-entry: production error handler does not self-remove (report-only)
+
+`content/form-detector.ts` registers `window.addEventListener("error", …)` at
+import with no removal — benign in production (one registration per frame
+load), but it is what leaks across tests sharing one jsdom window. Test-only
+fix (track + remove listeners in afterEach); production untouched per SC2's
+no-unrequested-scope rule.
+
+## C2 classification table (final, all five Set B subsets — reconciled)
+
+Derivations re-run at implementation time from `extension/src/__tests__/`:
+B1 spyOn-without-restore = 3, B2 widened-override hit files = 28, B3
+mockResolvedValueOnce = 12, B4 stubGlobal-without-unstub = 23, B5
+module-scope `let` = 10. Verdicts:
+
+### real-leak (fixed)
+| File | Occurrence | Mechanism | Fix |
+|---|---|---|---|
+| background/totp-handlers.test.ts | `generateTOTPCode.mockReturnValue("654321")` in test body | M1 | `mockReturnValueOnce` |
+| background/totp-handlers.test.ts | `vi.spyOn(Date,"now")` unrestored | M2 | captured spy + `mockRestore()` in `finally` |
+| background/totp-handlers.test.ts | positional decryptData Once queues (6 sites) | M3 (issue #784 pre-pr NO_PASSWORD shape) | input-keyed `setDecryptedPlaintext` + throw-on-miss (orchestrator, post-batch) |
+| background.test.ts | `stubLoginFetch` helper `mockReset()` + Once queues; `"succeeds via sendMessage…"` `mockReset()`; `"still fills a CREDIT_CARD…"` persistent `mockResolvedValue`; 6 Once chains | M1+M3 | input-keyed `setDecryptedPlaintext` + throw-on-miss; hazardous `mockReset()`s removed |
+| dpop-key.test.ts | 2 raw `indexedDB.open` without `onupgradeneeded` | M4 (schema-upgrade race) | schema-safe `openTestDb()` + awaited per-test DB delete |
+| content/form-detector-entry.test.ts | entry-point `window` "error" listeners never removed across tests | M5 (DOM listener leak) | tracked listeners removed in afterEach |
+| login-detector.test.ts | `mockSendMessage.mockImplementation` ×5 in test bodies | M1-shaped | `mockReset()` in local beforeEach |
+| login-detector.test.ts | document submit/click listeners leak when assertion throws before `cleanup.destroy()` | cascade of above | afterEach-guaranteed `currentCleanup?.destroy()` |
+| lib/messaging.test.ts | L18/L38/L51 persistent sendMessage overrides | M1 (latent — no seed reproduces; victim assertion absent) | `…Once` conversions |
+| popup/App.test.tsx | 5 persistent sendMessage overrides incl. never-settling promise | M1 (latent) | `mockSendMessage.mockReset()` in beforeEach |
+| content/form-detector.test.ts | `vi.spyOn(window,"getComputedStyle")` unrestored | M2-shaped (latent — fallthrough transparent) | captured spy + `mockRestore()` |
+| context-menu.test.ts | `tabs.query.mockResolvedValue` persistent ×3, consumed by beforeEach's own `invalidateContextMenu()` | M1-shaped (latent) | `tabs.query.mockResolvedValue([])` re-established in beforeEach |
+
+### m3-race
+None beyond the two converted files: every other B3 file's queue is per-test
+fresh or 1:1-consumed (see D2 for the two `contained` borderline files).
+
+### contained (untouched — one row per remaining candidate)
+api.test.ts (per-test `installChromeMock` factory) · background-commands.test.ts
+(restoreAllMocks afterEach + factory) · background-login-save.test.ts
+(`createDeps()` factory) · background-passkey-provider.test.ts (same) ·
+background/inline-matches.test.ts (helpers reset+re-queue per test; D2) ·
+background/log.test.ts (restoreAllMocks afterEach) ·
+background/start-connect.test.ts (per-test deps) · background/swFetch-dpop.test.ts
+(explicit mockReset + default re-set every beforeEach) ·
+background/team-entries.test.ts (helpers re-queue; L343 value = default; D2) ·
+content/autofill-cc.test.ts, content/autofill-identity.test.ts,
+content/select-diag.test.ts, lib/totp.test.ts (restoreAllMocks afterEach) ·
+content/token-bridge.test.ts, content/token-bridge-user-activation.test.ts
+(per-test mock recreation) · content/ui/suggestion-dropdown.test.ts
+(module-init stub, never mutated) · content/form-detector-inline.test.ts
+(mockReset + fresh stub every beforeEach) · content/cc-identity-detector.test.ts
+(`installChrome()` per test) · lib/storage.test.ts, lib/disconnect-reason.test.ts
+(recreated every beforeEach) · lib/session-storage.test.ts (default impl reset
+in beforeEach) · options/App.test.tsx (all mocks reset every beforeEach) ·
+popup/LoginPrompt.test.tsx (fresh stubGlobal per beforeEach) ·
+popup/MatchList.test.tsx (1:1 Once consumption; 30 seeds green) ·
+popup/VaultUnlock.test.tsx (each reaching test sets its own value; 15 seeds
+green) · webauthn-bridge-lib.test.ts (per-test recreation + restore/unstub
+afterEach) · log.test.ts (describe-scope console spy, uniform for all tests) ·
+content/form-detector.test.ts remaining spyOn sites (per-test-local DOM
+elements) · totp-handlers/background.test.ts chrome mocks (fresh factory every
+beforeEach) · background.test.ts "tab event badge updates" beforeEach
+(unconditional `mockResolvedValue` re-establishment — composes with keyed
+impl in either order).
+
+Additional mechanism note (Batch 3): `vi.clearAllMocks()` does NOT clear
+queued-but-unconsumed `mockXxxOnce` values (only `mockReset()` does). Every
+B3 file was checked for over-provisioned queues; none found. The standing
+gate covers this class dynamically.

--- a/docs/archive/review/extension-test-order-deps-deviation.md
+++ b/docs/archive/review/extension-test-order-deps-deviation.md
@@ -1,5 +1,26 @@
 # Coding Deviation Log: extension-test-order-deps
 
+## Acceptance evidence (executed 2026-08-22; all outputs file-captured per the rtk evidence-capture rule)
+
+| ID | Command / procedure | Result |
+|----|---------------------|--------|
+| A1 | `npx vitest run --sequence.shuffle.files=false --sequence.shuffle.tests=true --sequence.seed=$s` for s ∈ {1..8, 12345} | 9/9 GREEN (1029/1029 each) |
+| A2 | `npx vitest run --sequence.shuffle --sequence.seed=$s` for s ∈ {1..50} | 50/50 GREEN (baseline before fixes: 49/50 RED) |
+| A3 | Per-file pre-fix red seeds recorded before each fix, re-run green after, per batch reports (e.g. totp-handlers seeds 3/9/11/12/14/17/18/20/22/24/25/28; background 28/30 seeds; dpop-key 2/6/7/16/24/28/30/31/40/52; form-detector-entry 12 seeds; login-detector 15 seeds) | all recorded seeds GREEN post-fix |
+| A3m | Scratch worktree; deny = pre-fix positional totp-handlers + steal-window `vi.waitFor` flush after `unlockVault()` in "does not include totpCode when totp is absent" → `{ok:false}` (NO_PASSWORD shape) 3/3 runs; allow = keyed file + byte-identical flush → 3/3 GREEN | deny RED 3/3, allow GREEN 3/3 → **M3 VERIFIED** |
+| A4 | `npx vitest run --sequence.shuffle=false` (CLI override of the config gate) | GREEN, no seed line (shuffle off confirmed) |
+| A5 | 10 consecutive `npx vitest run` (config shuffle, random seeds) | 10/10 GREEN; seeds 1787352720534, 1787352727780, 1787352734668, 1787352742181, 1787352749156, 1787352756253, 1787352763816, 1787352771470, 1787352778721, 1787352785764 — pairwise distinct |
+| A6 | Scratch worktree with the gate config: revert `totp-handlers.test.ts` to its pre-fix state → `--sequence.shuffle --sequence.seed=12345` exits 1, sole failure in that file ("returns TOTP code…"); restore fix → same seed exits 0 (1029/1029) | deny RED / allow GREEN |
+| A7 | Idle-machine like-for-like: before = fact 4 (~6.2–7.2 s, pre-fix); after = A5 walls 6.8–7.7 s (idle, shuffled) | within noise — no material regression (issue `#784`'s perf question answered) |
+| A8 | `bash ~/.claude/hooks/check-pre-pr.sh run` (full parallel batch incl. "Extension: Test" — the environment fact 5 names) | 62/62 checks PASSED |
+
+Post-A-run addition (self-R-check R1 fix): the duplicated keyed-decrypt logic
+was extracted to `extension/src/__tests__/helpers/keyed-decrypt-mock.ts`
+(shared by background.test.ts and totp-handlers.test.ts); after extraction:
+tsc clean, 3 shuffled runs per file GREEN, full suite GREEN (seed
+1787376666155). The helpers/ file is not matched by vitest's test include
+(`*.test.*`), so the 61-file count is unchanged.
+
 ## D0 — A3m executed: M3 VERIFIED (fact 5 upgraded from "hypothesized")
 
 A3m ran on a scratch git worktree (detached, node_modules symlinked, removed

--- a/docs/archive/review/extension-test-order-deps-deviation.md
+++ b/docs/archive/review/extension-test-order-deps-deviation.md
@@ -6,7 +6,7 @@
 |----|---------------------|--------|
 | A1 | `npx vitest run --sequence.shuffle.files=false --sequence.shuffle.tests=true --sequence.seed=$s` for s ∈ {1..8, 12345} | 9/9 GREEN (1029/1029 each) |
 | A2 | `npx vitest run --sequence.shuffle --sequence.seed=$s` for s ∈ {1..50} | 50/50 GREEN (baseline before fixes: 49/50 RED) |
-| A3 | Per-file pre-fix red seeds recorded before each fix, re-run green after, per batch reports (e.g. totp-handlers seeds 3/9/11/12/14/17/18/20/22/24/25/28; background 28/30 seeds; dpop-key 2/6/7/16/24/28/30/31/40/52; form-detector-entry 12 seeds; login-detector 15 seeds) | all recorded seeds GREEN post-fix |
+| A3 | Per-file pre-fix red seeds recorded before each fix, re-run green after, per batch reports (e.g. totp-handlers seeds 3/9/11/12/14/17/18/20/22/24/25/28; background 28/30 seeds; dpop-key 2/6/7/16/24/28/30/31/40/52; form-detector-entry 12 seeds; login-detector 15 seeds). Provenance of seeds > 50 (e.g. dpop-key's 52, login-detector's 53/71/78): the fix batches ran PER-FILE discovery sweeps (`npx vitest run src/__tests__/<file> --sequence.shuffle.tests=true --sequence.seed=N`) beyond the plan's suite-level 1..50 sweep, widening until the failure surfaced repeatedly — commands and logs in the batch scratch logs | all recorded seeds GREEN post-fix |
 | A3m | Scratch worktree; deny = pre-fix positional totp-handlers + steal-window `vi.waitFor` flush after `unlockVault()` in "does not include totpCode when totp is absent" → `{ok:false}` (NO_PASSWORD shape) 3/3 runs; allow = keyed file + byte-identical flush → 3/3 GREEN | deny RED 3/3, allow GREEN 3/3 → **M3 VERIFIED** |
 | A4 | `npx vitest run --sequence.shuffle=false` (CLI override of the config gate) | GREEN, no seed line (shuffle off confirmed) |
 | A5 | 10 consecutive `npx vitest run` (config shuffle, random seeds) | 10/10 GREEN; seeds 1787352720534, 1787352727780, 1787352734668, 1787352742181, 1787352749156, 1787352756253, 1787352763816, 1787352771470, 1787352778721, 1787352785764 — pairwise distinct |
@@ -161,6 +161,7 @@ module-scope `let` = 10. Verdicts:
 | dpop-key.test.ts | 2 raw `indexedDB.open` without `onupgradeneeded` | M4 (schema-upgrade race) | schema-safe `openTestDb()` + awaited per-test DB delete |
 | content/form-detector-entry.test.ts | entry-point `window` "error" listeners never removed across tests | M5 (DOM listener leak) | tracked listeners removed in afterEach |
 | login-detector.test.ts | `mockSendMessage.mockImplementation` ×5 in test bodies | M1-shaped | `mockReset()` in local beforeEach |
+| login-detector.test.ts | `mockFindPasswordInputs`/`mockFindUsernameInput` `mockReturnValue` in test bodies (~8 sites) | M1-shaped (latent — every consuming test sets its own values) | `mockReset()` for both added beside `mockSendMessage.mockReset()` (Phase 3 R1 finding) |
 | login-detector.test.ts | document submit/click listeners leak when assertion throws before `cleanup.destroy()` | cascade of above | afterEach-guaranteed `currentCleanup?.destroy()` |
 | lib/messaging.test.ts | L18/L38/L51 persistent sendMessage overrides | M1 (latent — no seed reproduces; victim assertion absent) | `…Once` conversions |
 | popup/App.test.tsx | 5 persistent sendMessage overrides incl. never-settling promise | M1 (latent) | `mockSendMessage.mockReset()` in beforeEach |
@@ -195,8 +196,8 @@ popup/VaultUnlock.test.tsx (each reaching test sets its own value; 15 seeds
 green) · webauthn-bridge-lib.test.ts (per-test recreation + restore/unstub
 afterEach) · log.test.ts (describe-scope console spy, uniform for all tests) ·
 content/form-detector.test.ts remaining spyOn sites (per-test-local DOM
-elements) · totp-handlers/background.test.ts chrome mocks (fresh factory every
-beforeEach) · background.test.ts "tab event badge updates" beforeEach
+elements) · background/totp-handlers.test.ts and background.test.ts chrome mocks (fresh
+factory every beforeEach) · background.test.ts "tab event badge updates" beforeEach
 (unconditional `mockResolvedValue` re-establishment — composes with keyed
 impl in either order).
 

--- a/docs/archive/review/extension-test-order-deps-plan.md
+++ b/docs/archive/review/extension-test-order-deps-plan.md
@@ -48,13 +48,13 @@ All commands below were run and their outputs recorded; re-run to reproduce (R29
 ## Root-cause mechanisms identified so far
 
 - **M1 — persistent mock override in a test body.**
-  `extension/src/__tests__/background/totp-handlers.test.ts:327`
+  `extension/src/__tests__/background/totp-handlers.test.ts` line 327 as of `af1d00362` (pre-fix; the fix moved this line)
   `totpMock.generateTOTPCode.mockReturnValue("654321")` (no `Once`). The file's
   `beforeEach` runs `vi.clearAllMocks()`, which clears call history but does NOT
   restore return values/implementations. Any test that runs after this one sees
   `"654321"` — matching the seed-12345 failure (`expected "123456", got "654321"`).
 - **M2 — unrestored spy.**
-  `extension/src/__tests__/background/totp-handlers.test.ts:204`
+  `extension/src/__tests__/background/totp-handlers.test.ts` line 204 as of `af1d00362` (pre-fix; the fix moved this line)
   `vi.spyOn(Date, "now").mockReturnValue(59_000)` with no `mockRestore()` /
   `restoreAllMocks` anywhere in the file. Every later test in the file runs at a
   frozen clock.
@@ -130,7 +130,7 @@ the issue's own measurements), so more victims are expected.
   input-derived (`grep -rl 'mockResolvedValueOnce' .` → 12 files at plan
   time), NOT filtered by a name-supplied fire-and-forget module list, because
   such a list under-derives (round-2 found unawaited consumers outside
-  `background/index`, e.g. `content/token-bridge-lib.ts:102`'s
+  `background/index`, e.g. `extension/src/content/token-bridge-lib.ts:102`'s
   `void handlePostMessage(event)`, and React-effect consumers in popup tests).
   Each candidate gets a C2 classification row (`m3-race` / `contained — 
   consumer awaited / no fire-and-forget import`); one-line contained verdicts
@@ -453,6 +453,31 @@ Explicitly rejected:
 | SC2 | Refactoring production `background/index` fire-and-forget async | report-only in this PR; separate issue if confirmed as a production defect. Triage classification is pre-committed: if the Phase 2 diagnosis confirms the race is reachable with real (non-mock) decrypt inputs, the filed issue is labeled `security` and states the credential-mis-delivery hypothesis explicitly (unawaited async consuming decrypt results in a password manager's service worker — OWASP A04 class); if the coupling is mock-positional only, the issue notes that and closes the hypothesis |
 | SC3 | `environmentMatchGlobs` deprecation (vitest 4) migration | untouched here; config modernization is not this fix |
 | SC4 | Root vitest.config.ts shuffle gate for `src/` suite | out of scope; #784 is extension-only |
+
+## Implementation Checklist
+
+Phase 2 Step 2-1 impact analysis (2026-08-22). Baseline 50-seed full-shuffle
+sweep (`--sequence.shuffle --sequence.seed=1..50`): **49/50 seeds red**, 24
+distinct failing tests in **5 files** — same 5 files as the 9-seed Set A
+(no new victim files; per-test seed frequencies recorded in the sweep log).
+
+Files that must change:
+- `extension/src/__tests__/background/totp-handlers.test.ts` — victim ×23 seeds (M1 L327, M2 L204, M3 Once queues)
+- `extension/src/__tests__/background.test.ts` — 8 distinct victim tests, "fetches and decrypts password overviews" red in 48/50 seeds (M1 + M3)
+- `extension/src/__tests__/dpop-key.test.ts` — all 10 tests fail together in 14/50 seeds (M4: shared fake-IDB "psso-ext" DB + in-process key cache; order assumption between clean-boot/delete tests and the rest)
+- `extension/src/__tests__/content/form-detector-entry.test.ts` — victim ×23 seeds (M5 hypothesis: window "error" listeners from prior test's module import accumulate on the shared jsdom window; both handlers fire → destroy counted twice)
+- `extension/src/__tests__/login-detector.test.ts` — 4 victim tests (leaked chrome.onMessage listeners / missing cleanup() in some tests)
+- `extension/src/__tests__/lib/messaging.test.ts` — static real-leak candidate (L18/L38 Once-less overrides, clearAllMocks-only beforeEach)
+- `extension/src/__tests__/popup/App.test.tsx` — static real-leak candidate (L167/L204)
+- `extension/vitest.config.ts` — C3 gate line ONLY (exclusivity clause)
+- C2 classification table → `extension-test-order-deps-deviation.md`
+
+Reuse / patterns:
+- No shared test-helper dir exists in extension; `setupFiles: fake-indexeddb/auto` must stay first. setup.ts contingency only per C3 exclusivity clause.
+- Fix vocabulary: `mockXxxOnce` or beforeEach re-establishment (M1); `mockRestore`/`vi.restoreAllMocks` in afterEach (M2); input-keyed mock with throw-on-miss + steal-window/end-of-test flush (M3, I3); explicit listener/DB teardown (M4/M5).
+- Single test tree (`extension/src/__tests__` only) — no parallel test trees (R19 checked). Production `.js`/`-lib.ts` twins NOT touched (test-only diff).
+
+CI gate parity: extension CI job = `npm test` + `npm run build` (`.github/workflows/ci.yml:373-374` at `af1d00362`); pre-pr runs both ("Extension: Test" batch 1, "Extension: Build" batch 2) — no parity gap. No new files added, so no new-file-pattern gates fire. Config diff is `extension/vitest.config.ts` (inside CI's `extension/**` filter — gate change is exercised by CI).
 
 ## User operation scenarios
 

--- a/docs/archive/review/extension-test-order-deps-plan.md
+++ b/docs/archive/review/extension-test-order-deps-plan.md
@@ -1,0 +1,467 @@
+# Plan: extension-test-order-deps
+
+Fix order-dependent test failures in the `extension/` vitest suite (issue #784).
+
+## Project context
+
+- Type: `mixed` (browser extension — TypeScript, MV3 service worker + content scripts; this task touches only test files and the vitest config)
+- Test infrastructure: `unit tests + CI/CD` (vitest 4.1.10; CI job "Extension: Test → Build"; local gate `scripts/pre-pr.sh` step "Extension: Test" runs `cd extension && npm test`)
+- Verification environment constraints: none — every contract in this plan is `verifiable-local` (all evidence is produced by `npx vitest run` variants inside `extension/`). No paid-tier, hardware, or multi-tenant path is involved.
+
+## Objective
+
+`npx vitest run --sequence.shuffle` must be green for any seed, and stay green:
+the suite must not depend on test execution order, and a regression must be
+detected by the standing gates (dev runs / pre-pr / CI) rather than by an
+unrelated PR author.
+
+## Established facts (measured on this branch, extension/ at af1d00362)
+
+All commands below were run and their outputs recorded; re-run to reproduce (R29).
+
+1. **The failure class is IN-FILE test-order dependence, not cross-file leakage.**
+   - `npx vitest run --sequence.shuffle.files=true --sequence.shuffle.tests=false --sequence.seed=<s>` → green for s ∈ {42, 999, 12345} (1029/1029).
+   - `npx vitest run --sequence.shuffle.files=false --sequence.shuffle.tests=true --sequence.seed=12345` → 3 files / 5 tests fail — the same 5 that fail with full shuffle at that seed.
+2. **`isolate: true` is a no-op.** vitest 4 defaults `isolate` to `true`
+   (verified empirically: `createVitest('test',{}).config.isolate === true` on
+   the installed 4.1.10). The root config's explicit `isolate: true` is
+   documentation, not behavior. Cross-file JS state cannot leak today; the
+   issue's leading hypothesis is refuted.
+3. **vitest prints the seed on every shuffled run** (`Running tests with seed "N"`),
+   so a randomly-seeded gate failure is always reproducible.
+4. **Shuffle does not change suite duration** (measured ~6.2–7.2 s both ways; same
+   1029 tests, same workers).
+5. **The pre-pr plain-run failure is explainable without shuffle — as a
+   hypothesis (M3) until Phase 2 proves it.** pre-pr deletes
+   `extension/node_modules/.vitest` (timing cache → file order changes,
+   harmless per fact 1) and runs the suite concurrently with `next build` etc.
+   Under CPU load, fire-and-forget async work in `background/index` interleaves
+   differently between tests of the SAME file, misaligning `mockResolvedValueOnce`
+   queues (mechanism M3 below) — which yields exactly the observed
+   `NO_PASSWORD` shape. This closure claim is HYPOTHESIZED, not established:
+   the order-axis sweep cannot sample load-dependent interleaving, so C1
+   carries a dedicated M3 derivation + deterministic red-proof (C1-I3/A3m) and
+   C4 carries a full `scripts/pre-pr.sh` green run as evidence. If the
+   deterministic M3 red-proof cannot be built for a file, that is a named
+   deviation-log entry and the claim stays "hypothesized" in the PR body.
+
+## Root-cause mechanisms identified so far
+
+- **M1 — persistent mock override in a test body.**
+  `extension/src/__tests__/background/totp-handlers.test.ts:327`
+  `totpMock.generateTOTPCode.mockReturnValue("654321")` (no `Once`). The file's
+  `beforeEach` runs `vi.clearAllMocks()`, which clears call history but does NOT
+  restore return values/implementations. Any test that runs after this one sees
+  `"654321"` — matching the seed-12345 failure (`expected "123456", got "654321"`).
+- **M2 — unrestored spy.**
+  `extension/src/__tests__/background/totp-handlers.test.ts:204`
+  `vi.spyOn(Date, "now").mockReturnValue(59_000)` with no `mockRestore()` /
+  `restoreAllMocks` anywhere in the file. Every later test in the file runs at a
+  frozen clock.
+- **M3 — positional `mockResolvedValueOnce` queues racing fire-and-forget async.**
+  Tests enqueue exactly-ordered Once values (e.g., `[blob JSON, overview JSON]`)
+  while the background module performs unawaited async work (overview refresh
+  after unlock, alarms) that can consume a queue slot between the intended
+  consumers. Which consumer gets which value depends on interleaving — i.e.,
+  on machine load, not test order. Deterministic fix: key the mock's response
+  on its input (ciphertext → plaintext map) instead of call position.
+- **M4 (dpop-key.test.ts, to be confirmed in Phase 2)** — the whole file (10
+  tests) fails or passes together under in-file shuffle (seeds 2, 6, 7),
+  indicating shared IDB/module-scope key-cache state with an implicit "clean
+  boot first / delete last" order assumption.
+
+Victim tests are downstream of the culprit test; per-file diagnosis in Phase 2
+must name the culprit (the test or setup that leaves state), not just patch the
+victim's assertion.
+
+## Member-set derivation (R42)
+
+The invariant is universally quantified: "no test in `extension/` observes state
+mutated by another test." The class is defined by dynamic behavior, so the
+authoritative member-set derivation is dynamic (execution under permuted order);
+static greps only build the candidate worklist. This ordering is deliberate
+(gate-mechanism over spelling enumeration): the standing gate (C3) adjudicates
+actual execution and therefore also catches spellings no static pattern lists.
+
+**Set A — dynamic victims** (9-seed sweep; command:
+`for s in 1 2 3 4 5 6 7 8 12345; do npx vitest run --sequence.shuffle.files=false --sequence.shuffle.tests=true --sequence.seed=$s; done`, collect `FAIL` lines):
+
+| File | Failing tests observed |
+|---|---|
+| `src/__tests__/background.test.ts` | `fetches and decrypts password overviews` (all 9 seeds), `autofills successfully`, `autofills with blob username fallback…`, `includes text custom fields…` |
+| `src/__tests__/background/totp-handlers.test.ts` | `returns TOTP code when blob contains totp data` |
+| `src/__tests__/content/form-detector-entry.test.ts` | `dispatching 'Extension context invalidated' calls every destroy once…` |
+| `src/__tests__/login-detector.test.ts` | `ignores unrelated messages`, `does not show banner for PSSO_SHOW_SAVE_BANNER with action=none` |
+| `src/__tests__/dpop-key.test.ts` | all 10 tests (file-wide, seeds 2/6/7) |
+
+Phase 2 widens this with a 50-seed sweep (see C1 acceptance) — the 9-seed set is
+a lower bound, not the member set; per-seed failure sets varied (1–14 tests in
+the issue's own measurements), so more victims are expected.
+
+**Set B — static candidates** (commands run from `extension/src/__tests__/`):
+
+- `vi.spyOn` without any `restoreAllMocks|mockRestore` in the same file
+  (`for f in $(grep -rl 'vi\.spyOn(' .); do grep -qE 'restoreAllMocks|mockRestore' "$f" || echo "$f"; done`):
+  `log.test.ts`, `content/form-detector.test.ts`, `background/totp-handlers.test.ts`
+- Persistent (`Once`-less) override inside a test body — ANY handle spelling,
+  not just the object-of-mocks form (review round 1 closed a spelling hole:
+  the narrower `*Mock(s).method.mockX` grep missed direct `vi.fn()` handles).
+  Derivation: `grep -rn --include='*.test.ts*' -E '\.(mockReturnValue|mockResolvedValue|mockRejectedValue|mockImplementation)\(' .`
+  — the include filter is `*.test.ts*` deliberately: it must admit every file
+  vitest's default include admits, and the suite has 7 `.test.tsx` files
+  (popup/, options/) that a `*.test.ts` filter silently drops (round-2 found 5
+  of them carrying hits, incl. M1-shaped test-body overrides in
+  `popup/App.test.tsx` under a clearAllMocks-only beforeEach). Classify each
+  hit by enclosing scope (test body vs. beforeEach/module scope).
+  Object-of-mocks hits: `background-commands.test.ts`,
+  `background/swFetch-dpop.test.ts`, `background/team-entries.test.ts`,
+  `background/totp-handlers.test.ts`, `background.test.ts`. Direct-handle hits
+  verified in round 1: `lib/messaging.test.ts` (lines 18, 38 — M1-shaped,
+  `beforeEach` runs `clearAllMocks` only → real-leak candidate);
+  `lib/session-storage.test.ts` (inside `beforeEach` → contained);
+  `webauthn-bridge-lib.test.ts` (per-test recreation + `afterEach`
+  restore/unstub → contained). Round-2 `.tsx` hits: `popup/LoginPrompt.test.tsx`,
+  `popup/App.test.tsx` (lines 167, 204 — real-leak candidates),
+  `popup/VaultUnlock.test.tsx`, `popup/MatchList.test.tsx`,
+  `options/App.test.tsx`. Phase 2 re-runs the widened grep and classifies
+  every hit.
+- **M3 candidates** (positional Once queues racing fire-and-forget async):
+  EVERY file containing `mockResolvedValueOnce` is a candidate — the set is
+  input-derived (`grep -rl 'mockResolvedValueOnce' .` → 12 files at plan
+  time), NOT filtered by a name-supplied fire-and-forget module list, because
+  such a list under-derives (round-2 found unawaited consumers outside
+  `background/index`, e.g. `content/token-bridge-lib.ts:102`'s
+  `void handlePostMessage(event)`, and React-effect consumers in popup tests).
+  Each candidate gets a C2 classification row (`m3-race` / `contained — 
+  consumer awaited / no fire-and-forget import`); one-line contained verdicts
+  suffice. Reconciliation counts against this grep's own output, which cannot
+  under-derive its left side.
+- `vi.stubGlobal` without `unstubAllGlobals`: 23 files — MOSTLY benign (stubbing
+  in `beforeEach` re-stubs every test; per-file isolation contains the rest).
+  Derivation: `for f in $(grep -rl 'vi\.stubGlobal(' .); do grep -q 'unstubAllGlobals' "$f" || echo "$f"; done | wc -l` → 23.
+  ALL 23 get a C2 classification row (per C2's coverage clause); mid-file
+  stubs are the ones expected to classify as other-than-`contained`.
+- Module-scope `let` in test files: 10 files (candidate shared mutable state).
+  Derivation: `grep -rln --include='*.test.ts*' -E '^let ' .` → 10 files incl.
+  `options/App.test.tsx` (the round-1 count of 9 used the narrower
+  `*.test.ts` filter).
+
+A member in the dynamic set that no static pattern catches is expected (that is
+why the gate is dynamic); a static candidate that never fails dynamically is
+fixed only when the leak is real (see C2), not to satisfy the grep.
+
+## Technical approach
+
+Two legs, in this order:
+
+1. **Root-cause fixes per file (C1, C2)** — diagnose each dynamic victim file,
+   name the culprit test/setup, remove the leak (restore spies, `Once` or
+   `beforeEach`-scoped overrides, input-keyed mock implementations, explicit
+   IDB/module-state reset). No blanket config flags: `restoreMocks: true` /
+   `mockReset: true` at config level would also wipe module-scope defaults set
+   once per file load in `vi.hoisted` factories (e.g., the
+   `mockReturnValue("123456")` default in totp-handlers), breaking
+   currently-green default-order tests — per-file evaluation is required, so
+   the fix stays per-file.
+2. **Standing mechanism-level gate (C3)** — enable `sequence.shuffle` in
+   `extension/vitest.config.ts` so every run (dev, pre-pr, CI — all reach the
+   suite via `npm test` → `vitest run`) executes a fresh random order and
+   prints its seed. This gates the CLASS (any future order dependence),
+   not the instances fixed here. (User decision 2026-08-22: config-level
+   always-on, not CI-only.)
+
+Explicitly rejected:
+- `isolate: true` in extension config — proven no-op (Established fact 2);
+  adding it would misdocument the fix.
+- Config-level `restoreMocks`/`mockReset`/`unstubGlobals` — see leg 1.
+- `.skip`/loosened assertions on victim tests — masking, not fixing (R36).
+
+## Contracts
+
+### C1 — Per-file order-independence fixes for dynamic victims
+
+- **Signature**: edits confined to `extension/src/__tests__/**` test files named
+  in Set A (plus any new victims surfaced by the Phase 2 50-seed sweep).
+  No production source (`extension/src/**` outside `__tests__`) changes.
+- **Invariants** (app-enforced — the enforcing runtime check is the C3 gate):
+  - I1: every test in a fixed file passes with `--sequence.shuffle.files=false
+    --sequence.shuffle.tests=true` for every recorded failing seed of that file.
+  - I2: each fix names its culprit (the state left behind and by whom) in the
+    Phase 2 deviation log; "reordered assertions until green" is not a fix.
+  - I3: mock responses that multiple async consumers race for are keyed on
+    input, not call position (M3), in the files where M3 is diagnosed (M3
+    candidate derivation is in Set B). The keyed mock's MISS behavior is
+    specified, not left open: an unmapped input THROWS with the offending
+    input named in the message (fail loudly — a silent default hides
+    mock-reality divergence), and the key map covers every input the
+    background path can request during the test window INCLUDING the
+    fire-and-forget consumers (overview refresh after unlock). Because a
+    throw inside an unawaited consumer would surface as an unhandled
+    rejection attributed to an arbitrary test, each M3 fix also
+    deterministically flushes the fire-and-forget consumer before the test
+    ends (`await` the observable completion or `vi.waitFor` on an observable
+    condition — never a bare setTimeout sleep), so a miss reds THE test that
+    caused it. NOTE: this end-of-test flush exists for miss-ATTRIBUTION; it
+    is distinct from A3m's steal-window flush (red-proof mechanism) — do not
+    conflate the two.
+  - I4: in every test file edited under C1/C2, assertions are unchanged or
+    strengthened, AND no new early-exit or skip invocation (including
+    destructured `TestContext.skip` — `({ skip }) => { skip(); … }`) is
+    introduced ahead of them — verified by inspection of the PR diff. The
+    early-exit clause exists because an inserted `skip()` leaves every
+    assertion textually unchanged while making them unreachable. Scope is the
+    edited-file set (the diff itself), not just Set A victims: culprit tests
+    are the most-edited tests and their own assertions (e.g., the "654321"
+    expectation at the M1 site) must survive the fix. Weakening or deleting
+    an assertion to get a seed green is suppression, not a fix (R36).
+- **Control class (R49)**: not a control — bug fixes. The controlling gate is C3.
+- **Acceptance**:
+  - A1: for each seed s ∈ {1,2,3,4,5,6,7,8,12345}: in-file-shuffle run at seed s
+    is green (1029/1029).
+  - A2: 50-seed sweep (`--sequence.shuffle` full, seeds 1..50) green.
+  - A3: red-proof per file-level fix (RT7): on a scratch copy (git stash /
+    worktree — never by mutating the working tree's fix), reverting that file's
+    fix re-reds at least one recorded seed. Record seed and failing test name.
+    Re-seed fallback: shuffled order is a function of seed + test set, so if a
+    recorded seed no longer reds after the revert (test count/name changes
+    shifted the permutation), sweep seeds 1..50 for a fresh red and record the
+    new seed — the red-proof is never dropped, only re-seeded. Deny = leak
+    present reds; allow = leak removed greens at the SAME seed; both runs
+    recorded every time. Exhaustion exit: if all 50 seeds green on the
+    reverted copy, widen once (seeds 51..200); if still no red, record a
+    named deviation-log entry with the file, the revert, and the sweep bound
+    (fail loudly) — never a silently assumed proof. A red found at any width
+    still runs both directions at that seed.
+  - A3m: per-MECHANISM red-proof for M3 fixes (order-axis seeds cannot red on
+    interleaving): on the scratch copy, revert to the positional Once queue
+    AND deterministically flush the fire-and-forget consumer AT THE STEAL
+    WINDOW — immediately after the action that schedules the fire-and-forget
+    work (e.g., right after `unlockVault()`), BEFORE the first intended
+    consumer runs — so the background consumer is forced to take a queue slot
+    ahead of the intended one and the misalignment reds EVERY run, not
+    probabilistically → deny. A flush placed after the assertions would find
+    the queue already drained in order and green the deny run for a
+    construction reason, not because M3 is absent. With the input-keyed mock
+    in place, the IDENTICAL test body (same flush, same placement — the pair
+    differs ONLY in positional-queue vs. input-keyed mock) greens → allow.
+    I3's end-of-test flush serves miss-attribution and is not this red-proof.
+    If the deterministic pair cannot be constructed because the fire-and-
+    forget consumer provably never reaches the mocked decrypt, that is the
+    hypothesis DISPROVEN — record it; any other unconstructible case is a
+    named deviation-log entry (and fact 5 stays "hypothesized"), never a
+    silent skip.
+  - A4: default-order run (`npx vitest run`, shuffle disabled via CLI seed
+    equivalence is NOT needed — run BEFORE C3 lands or with
+    `--sequence.shuffle=false`) remains green — fixes must not trade one
+    order's green for another's.
+
+### C2 — Leak-pattern cleanup in static candidates
+
+- **Signature**: for each Set B candidate file, Phase 2 classifies the pattern
+  occurrence as `real-leak` (state escapes the test that created it),
+  `m3-race` (positional queue racing fire-and-forget async), or `contained`
+  (re-established every test by `beforeEach`, or scoped by `mockRestore` in an
+  `afterEach`). `real-leak`/`m3-race` occurrences are fixed like C1;
+  `contained` ones are left untouched (no retrofitting — coding-style rule).
+- **Coverage**: the classification table covers EVERY Set B candidate — all
+  spyOn-without-restore files, all widened-grep persistent-override files, all
+  M3-candidate files, ALL 23 stubGlobal files, and all 10 module-scope-`let`
+  files (a `contained — beforeEach stub` / `contained — reassigned per test`
+  one-liner suffices for the benign majority). The enumeration is the five
+  Set B bullets, each of which now records its derivation command — the
+  reconciliation's left side. A Set B candidate absent from the table is
+  itself a deviation-log entry — a skipped candidate fails loudly instead of
+  silently dropping out of the audit.
+- **Invariant** (app-enforced): a `real-leak`/`m3-race` classification with no
+  fix, or a fix with no classification, is a deviation-log entry, not a silent
+  skip.
+- **Acceptance**: classification table (file × occurrence × verdict × action)
+  in the deviation log, row count reconciled against the Set B derivation
+  commands' output; fixed files inherit C1's A1–A4 (and A3m where `m3-race`)
+  evidence.
+
+### C3 — Standing shuffle gate in vitest config
+
+- **Signature**: `extension/vitest.config.ts` gains `test.sequence.shuffle: true`
+  (shuffles both file order and in-file order; file order additionally guards
+  any future cross-file channel). The diff to `extension/vitest.config.ts` is
+  EXACTLY that single gate line — any other hunk in that file is a named
+  deviation-log entry, whatever its spelling (mechanism-level exclusivity:
+  the check is diff-shape, not key-name, so unenumerated gate-neutralizing
+  keys — `exclude:`, `include:`, `passWithNoTests:`, … — cannot ride along
+  un-adjudicated; the key-enumerated forbidden patterns below remain as
+  high-risk callouts). The single plan-foreseen exception is the
+  Testing-strategy `setupFiles` addition (`src/__tests__/setup.ts`): if that
+  contingency is taken, the hunk is admitted WITH its own red-proof and
+  full-sweep evidence and is still recorded as a named entry — any other
+  hunk remains a deviation. No change to `package.json` scripts, pre-pr, or
+  CI workflows — they inherit via `npm test`.
+- **Control class (R49)**: **best-effort tripwire.** Each run samples ONE
+  ordering from a space of ~1029! permutations; a single green proves nothing
+  about unsampled orders, and load-dependent interleavings (M3) are outside the
+  sampled axis entirely. Known bypasses: (a) an order dependence that fails only
+  under orderings rarer than the sampling rate — quantified: the ~69 shuffled
+  acceptance runs detect (at 95% confidence) only members firing in ≥ ~4.3% of
+  random orderings ((1−p)^69 ≤ 0.05 ⇒ p ≥ 1−0.05^(1/69)); a 1%-firing member
+  escapes with ~50% probability and then reds ~1 in 100 future CI/pre-pr runs.
+  A post-merge tail-trip is therefore EXPECTED behavior of the gate (triage:
+  reproduce via the printed seed, fix the member), not a gate regression. The
+  standing gate keeps accumulating samples — that is the closure mechanism for
+  the tail. (b) a race that needs CPU contention (M3 axis — covered by A3m and
+  the C4 pre-pr run, not by shuffling). (c) an in-band per-suite opt-out:
+  vitest resolves shuffle as `this.shuffle ?? options.shuffle ??
+  currentSuite?.options?.shuffle ?? config.sequence.shuffle`, so
+  `describe("x", { shuffle: false }, …)` or the `describe.shuffle` chainable
+  deterministically exempts a suite from the gate. This spelling is
+  author-controllable and is therefore in the forbidden-pattern list below; it
+  survives only by appearing in a reviewable diff. Recovery path when the gate
+  trips: the printed seed (`Running tests with seed "N"`) reproduces the
+  failure deterministically via `npx vitest run --sequence.shuffle --sequence.seed=N`.
+- **Adjudication authority (R47)**: the vitest runner executing the real test
+  code — execution-based for everything that RUNS. Four surface-form residues
+  remain and are handled as forbidden patterns, because they sit outside the
+  runner's exit-code reach: a test that never runs (suppression spellings), a
+  suite that opts out (bypass (c)), a failure absorbed by re-running
+  (`retry`/`repeats` — the run happens, but the exit code the consumers
+  adjudicate no longer carries it), and a sample space frozen to one
+  permutation (committed seed pinning — the run happens shuffled and prints a
+  seed, but every run samples the SAME ordering, so the accumulating-samples
+  closure mechanism dies invisibly). Runtime suspension is closed by
+  construction: `vi.setConfig`'s RuntimeConfig exposes `sequence.hooks` only —
+  no runtime shuffle opt-out exists (verified against the installed 4.1.10).
+- **Invariants**:
+  - I1 (app-enforced): every standing consumer of the suite (dev `npm test`,
+    `test:watch`, pre-pr "Extension: Test", CI "Extension: Test") runs shuffled
+    with a printed seed. Consumer walkthrough below.
+  - I2: the gate can fail (RT7) — red-proven by mutation (see acceptance).
+- **Consumer-flow walkthrough** (the "shape" consumed here is the config):
+  - Consumer `npm test` / `npm run test:watch` (extension/package.json) reads
+    `vitest.config.ts` `test.sequence` and needs no other field — shuffle and
+    seed-printing are runner-internal.
+  - Consumer pre-pr step "Extension: Test" (`scripts/pre-pr.sh` → `bash -c 'cd
+    extension && npm test'`) consumes only the exit code; the seed line reaches
+    its captured log output for reproduction. No pre-pr edit needed.
+  - Consumer CI job "Extension: Test" runs the same `npm test`; the seed line
+    lands in the job log. No workflow edit needed.
+  - A developer reproducing a red run reads the seed from the log and passes
+    `--sequence.seed=N` — CLI overrides config, no code change needed.
+- **Forbidden patterns** (in this PR's diff):
+  - pattern: `isolate` (in `extension/vitest.config.ts`) — reason: proven no-op for this class; would misdocument the fix
+  - pattern: `--(sequence\.(shuffle|seed)|retry|repeats)` (in `extension/package.json`, `scripts/pre-pr.sh`, `.github/workflows/*`) — reason: the gate lives in vitest.config.ts once; per-consumer flags drift (R33). `--sequence.seed` committed in a consumer file pins every standing run to ONE permutation (vitest generates a random seed only when none is supplied: `resolved.sequence.seed ??= Date.now()`), killing the accumulating-samples closure mechanism while the gate still LOOKS on (shuffled order, seed printed); `--retry`/`--repeats` in the `test` script absorbs failures for every consumer. Allow path: ad-hoc CLI `--sequence.seed=N` on a developer's shell for bisection touches no committed file and is the intended repro flow; the forbidden surface is committed files that standing consumers execute
+  - pattern: `\.(skip|skipIf|todo|fails|runIf|only)\s*\(` newly added under `extension/src/__tests__/` — reason: suppression spellings the execution gate structurally cannot catch (a masked test never runs); `it.fails` is the worst (a red test reports green with no skip marker). Allow path: a genuinely needed conditional skip requires a deviation-log entry naming the condition (R36)
+  - pattern: `(skip|todo|fails|only)\s*:\s*true` newly added under `extension/src/__tests__/` — reason: options-object spelling of the same suppression class (`only: true` narrows the suite; CI's `allowOnly=false` catches it there, but local pre-pr runs without `CI` would not)
+  - pattern: `(retry|repeats)\s*:` newly added under `extension/src/__tests__/` or in `extension/vitest.config.ts` — reason: retry re-runs a failing test until green with no skip marker, laundering exactly the intermittent tail-trips (bypass (a)) and M3-class races the gate exists to accumulate; the standing consumers adjudicate only the exit code, which retry absorbs. Allow path: a genuinely needed retry requires a deviation-log entry naming the nondeterminism source and an issue link. (Verified: current corpus has no `retry:`/`repeats:` occurrences, so no false-positive baseline)
+  - pattern: `shuffle` (bare token) newly added under `extension/src/__tests__/`, plus `(shuffle|seed|sequencer)\s*:` in `extension/vitest.config.ts` outside the single `sequence.shuffle` gate line — reason: per-suite opt-out overrides the config gate in-band (control-class bypass (c)); a config-level `seed:` pins the gate to one frozen permutation (same neutralization as the consumer-file `--sequence.seed` row); and a config-level `sequencer:` silently un-randomizes the FILE-order axis while in-file shuffle and seed printing keep the gate looking on (the boolean-shuffle path assigns RandomSequencer only under `if (!resolved.sequence?.sequencer)`). Corpus verified — zero occurrences of any of the three tokens in tests, config, or package.json today. The bare token is deliberate — the runner reads `options.shuffle` at any key position, so an anchored regex (`\{\s*shuffle`) misses `{ concurrent: true, shuffle: false }`. Deny boundary and allow path: an options-position or chainable occurrence (`{ …shuffle… }`, `describe.shuffle`) is the forbidden thing; a comment/string match (e.g., an optional culprit-naming comment such as "leak surfaced by the shuffle gate at seed N" — the MANDATED location for culprit naming is I2's deviation log, not code comments) is a named false positive, flagged and passed at the same diff inspection C1-I4 performs, never silently ignored and never an automatic reject. Local bisection uses CLI `--sequence.seed=N`, which touches no committed file
+  - pattern: `await new Promise\(\s*\(?r(esolve)?\)?\s*=>\s*setTimeout` newly added under `extension/src/__tests__/` — reason: widening a race window instead of removing the race (common testing rule; use input-keyed mocks or `vi.waitFor` on an observable condition)
+  - Un-greppable residues, covered by C1-I4 diff inspection because no pattern can match an absence or a destructured binding: assertion deletion/weakening in any edited test file, and `TestContext.skip` in destructured form (`it("x", ({ skip }) => { skip(); … })` — no `.skip(` substring; the `ctx.skip()` property-access form does match the dot pattern).
+- **Acceptance**:
+  - A5: 10 consecutive `npx vitest run` (config shuffle active, random seeds)
+    green; seeds recorded from output. The 10 recorded seeds MUST be pairwise
+    distinct — a repeated seed is adjudicated as seed-pinning or a capture
+    failure and fails this acceptance loudly (10 samples of one permutation
+    are vacuous soak evidence), never averaged away.
+  - A6: gate red-proof (RT7, both directions every time): on a scratch copy,
+    revert `totp-handlers.test.ts`'s ENTIRE C1 fix (same mechanics as A3 — a
+    point-mutation could be neutralized by the fix's own afterEach hooks or by
+    a permutation shift) and run with a recorded failing seed (e.g., 12345) →
+    the gate MUST fail; restore the fix → the same seed MUST pass. Both runs
+    executed, both outputs recorded. Re-seed fallback and exhaustion exit as
+    in A3: if no recorded seed reds the reverted copy, sweep seeds 1..50 (then
+    51..200 once) for a fresh red and run both directions at that seed —
+    MUST-fail stays MUST-fail; full exhaustion is a named deviation-log entry,
+    never an assumed proof.
+  - A7: `npm test` wall-clock before/after within noise — LIKE-FOR-LIKE: both
+    numbers from an idle machine. Before = fact 4's idle measurement (or a
+    fresh idle `npx vitest run --sequence.shuffle=false`); after = idle
+    config-shuffled `npm test`. A8's pre-pr step duration is reported
+    separately as contended-environment context, never as an A7 operand
+    (idle-vs-loaded is not a comparison). Report both numbers; if the
+    idle-vs-idle delta is materially worse, report to the user before merging
+    (issue #784 asks for this explicitly).
+
+### C4 — Issue closure evidence
+
+- **Signature**: PR description links issue #784 and carries: the mechanism
+  writeup (M1–M4 as diagnosed; M3 marked "verified" only if A3m ran, else
+  "hypothesized"), the seed-sweep evidence, and the A5–A8 gate evidence.
+  (PR body in English; backtick `#784`.)
+- **Acceptance**:
+  - all acceptance IDs A1–A4, A3m, A5–A8 present with commands and outputs
+    (A3m may instead be a named deviation-log entry per its fallback — the
+    entry, not silence, is what satisfies the clause).
+  - A8: one full `scripts/pre-pr.sh` run green after all fixes — fact 5 names
+    pre-pr's parallel load as the reproducing environment for the M3 axis, so
+    the closure evidence includes that environment, not only idle-machine
+    vitest runs. The "Extension: Test" step duration from this run is recorded
+    as contended-environment context (A7's operands are both idle-machine).
+
+## Go/No-Go Gate
+
+| ID | Subject | Status |
+|----|---------------------------------------------------|--------|
+| C1 | Per-file order-independence fixes (dynamic victims) | locked |
+| C2 | Leak-pattern cleanup in static candidates           | locked |
+| C3 | Standing shuffle gate in vitest config              | locked |
+| C4 | Issue closure evidence                              | locked |
+
+## Testing strategy
+
+- Unit of proof is the (seed, test) pair: every fix is red-proven against a
+  recorded seed on a scratch copy (C1-A3, C3-A6), never by mutating the real
+  working tree (established feedback rule).
+- Sweep breadth: 9 recorded seeds (regression) + 50-seed sweep (discovery)
+  + 10 random-seed runs (gate soak). ~70 runs × ~7 s ≈ 8–9 min locally.
+- Evidence capture: this environment's rtk output proxy compresses Bash
+  output and can strip the `Running tests with seed "N"` line. All acceptance
+  runs redirect output to a file (`> log 2>&1`, or use `rtk proxy`) and grep
+  the FILE for the seed line; a missing seed line is a capture failure to
+  re-run, never "vitest didn't print it". Exit codes pass through rtk
+  unmodified, so pass/fail adjudication is unaffected.
+- Default order must stay green throughout (C1-A4) — checked at each fix batch.
+- No new test infrastructure files unless a shared teardown proves necessary
+  during Phase 2; if one is added (`src/__tests__/setup.ts` +
+  `setupFiles`), it ships with its own red-proof and its effect on all 61
+  files is verified by the full sweep, and fake-indexeddb/auto load order is
+  preserved (it must load first — background SW startup throws
+  `ReferenceError: indexedDB` otherwise, per the existing config comment).
+
+## Considerations & constraints
+
+- **Latent members vs. always-on gate**: enabling C3 with unfixed latent
+  order-dependences would red unrelated PRs at random — the exact pain #784
+  reports. Mitigation: C1/C2 fix everything the 50-seed sweep and the static
+  audit surface BEFORE C3 merges in the same PR; the gate then protects against
+  NEW regressions. Residual risk (rare orderings) is accepted and documented in
+  C3's control class; the printed seed makes any future trip a 1-command repro
+  instead of a lost debugging cycle.
+- **Watch-mode ergonomics**: `test:watch` also shuffles. Accepted — a dev who
+  needs a stable order for bisection passes `--sequence.seed=N`.
+- **Production-code races**: if Phase 2 diagnosis shows a genuine production
+  bug (e.g., an unawaited promise in `background/index` that misbehaves beyond
+  tests), it is reported to the user and filed — NOT fixed in this PR
+  (no unrequested scope; test-side determinism via input-keyed mocks is
+  sufficient for this task).
+- **jsdom files**: `dpop-key.test.ts` and `webauthn-bridge-lib.test.ts` run
+  under jsdom via `environmentMatchGlobs`; fixes must not change their
+  environment assignment.
+
+### Scope contract
+
+| ID | Deferred item | Owner |
+|-----|---------------|-------|
+| SC1 | Root (`src/`) and `cli/` vitest suites' order hygiene | future issue if ever observed (root config already `isolate: true`, different suite) |
+| SC2 | Refactoring production `background/index` fire-and-forget async | report-only in this PR; separate issue if confirmed as a production defect. Triage classification is pre-committed: if the Phase 2 diagnosis confirms the race is reachable with real (non-mock) decrypt inputs, the filed issue is labeled `security` and states the credential-mis-delivery hypothesis explicitly (unawaited async consuming decrypt results in a password manager's service worker — OWASP A04 class); if the coupling is mock-positional only, the issue notes that and closes the hypothesis |
+| SC3 | `environmentMatchGlobs` deprecation (vitest 4) migration | untouched here; config modernization is not this fix |
+| SC4 | Root vitest.config.ts shuffle gate for `src/` suite | out of scope; #784 is extension-only |
+
+## User operation scenarios
+
+1. Developer runs `cd extension && npm test` on a feature branch → order is
+   random; a leak introduced by their new test fails within a few runs locally
+   instead of surfacing on someone else's PR; the log's seed line reproduces it.
+2. pre-pr runs the extension step under full parallel load → M3-class races no
+   longer depend on interleaving because mock responses are input-keyed; a red
+   here prints the seed into the step log pre-pr already captures.
+3. CI "Extension: Test" reds on a PR → author copies the seed from the job log,
+   runs `npx vitest run --sequence.shuffle --sequence.seed=N` locally, gets the
+   same failure deterministically.

--- a/docs/archive/review/extension-test-order-deps-plan.md
+++ b/docs/archive/review/extension-test-order-deps-plan.md
@@ -132,7 +132,7 @@ the issue's own measurements), so more victims are expected.
   such a list under-derives (round-2 found unawaited consumers outside
   `background/index`, e.g. `extension/src/content/token-bridge-lib.ts:102`'s
   `void handlePostMessage(event)`, and React-effect consumers in popup tests).
-  Each candidate gets a C2 classification row (`m3-race` / `contained — 
+  Each candidate gets a C2 classification row (`m3-race` / `contained —
   consumer awaited / no fire-and-forget import`); one-line contained verdicts
   suffice. Reconciliation counts against this grep's own output, which cannot
   under-derive its left side.

--- a/docs/archive/review/extension-test-order-deps-review.md
+++ b/docs/archive/review/extension-test-order-deps-review.md
@@ -619,7 +619,7 @@ All three applied to the plan immediately after Round 4 (C3 signature exclusivit
 **Round-3 fix verification:**
 - **F8 (seed pinning) — fix correct and complete on all three parts.** Consumer-file row + rationale + allow boundary; config-side `(shuffle|seed)\s*:` + corpus-clean; A5 pairwise-distinct with loud failure. Four-residue adjudication paragraph accurate.
 - **F9 (destructured ctx.skip) — fix correct.** I4 early-exit clause; owner's criterion now fires.
-- **Convergent items #3/#4 — no security holes introduced.** Five-subset enumeration with verbatim commands; bare-shuffle deny/allow boundary sound (named-flagged-adjudicated, cannot smuggle options-position occurrence).
+- **Convergent items `#3`/`#4` — no security holes introduced.** Five-subset enumeration with verbatim commands; bare-shuffle deny/allow boundary sound (named-flagged-adjudicated, cannot smuggle options-position occurrence).
 
 **Final class re-derivation over writable surfaces:**
 - In-test options/chainables: closed (dot-form, options-object, retry/repeats options, suite shuffle any position, destructured ctx.skip via I4). expect.soft still fails the task; tags inert without filter flag; no retry chainable.
@@ -676,10 +676,10 @@ No other findings. A5 distinct-seeds has no false-positive path (Date.now()-deri
 # QA/Testing Review — Round 4 (incremental)
 
 ## Verification performed
-- #1 (C2 five-subset enumeration + commands): coverage clause enumerates all five subsets matching the five Set B bullets one-to-one; every bullet records a derivation command. Commands verified: stubGlobal for-loop → 23 (ran it); let-set → 10; M3 → 12; spyOn → 3; widened override grep. Reconciliation's left side exists for every subset. Stale sentence replaced. Resolved.
-- #2 (bare-shuffle deny/allow): overclaim gone; deny boundary + allow path stated. Config-side corpus claim verified: zero `seed` occurrences (case-insensitive) in tests, config, package.json. Resolved (one wording nit — F1).
-- #3 (consumer row + A5 distinctness + four residues): vitest citation verified verbatim (coverage.DM_a_rWm.js:481). A5 false-fail check: seed granularity is ms and each run is a fresh ~7 s process, so pairwise-distinct seeds are guaranteed on legitimate execution — the clause cannot false-fail, and composes with the rtk capture note. Four-residue statement maps one-to-one onto the pattern rows. No forbidden row matches the PR's own planned diff.
-- #4 (I4 early-exit clause): consistent with residue note; destructured skip I4-owned in both places. Resolved.
+- `#1` (C2 five-subset enumeration + commands): coverage clause enumerates all five subsets matching the five Set B bullets one-to-one; every bullet records a derivation command. Commands verified: stubGlobal for-loop → 23 (ran it); let-set → 10; M3 → 12; spyOn → 3; widened override grep. Reconciliation's left side exists for every subset. Stale sentence replaced. Resolved.
+- `#2` (bare-shuffle deny/allow): overclaim gone; deny boundary + allow path stated. Config-side corpus claim verified: zero `seed` occurrences (case-insensitive) in tests, config, package.json. Resolved (one wording nit — F1).
+- `#3` (consumer row + A5 distinctness + four residues): vitest citation verified verbatim (coverage.DM_a_rWm.js:481). A5 false-fail check: seed granularity is ms and each run is a fresh ~7 s process, so pairwise-distinct seeds are guaranteed on legitimate execution — the clause cannot false-fail, and composes with the rtk capture note. Four-residue statement maps one-to-one onto the pattern rows. No forbidden row matches the PR's own planned diff.
+- `#4` (I4 early-exit clause): consistent with residue note; destructured skip I4-owned in both places. Resolved.
 
 ## Findings
 
@@ -776,7 +776,7 @@ Verification: installed source coverage.DM_a_rWm.js:475-477 confirms the ternary
 2. **Testing F1 rewording — no security hole introduced.** Deny boundary unchanged; allow path still named-flagged-passed at C1-I4; rewording narrows, not widens.
 3. **Func F14 (sequencer:) — fix correct, mechanism claim independently verified this round** (supersedes reviewer's Round-2 unconditional-assignment reading). Corpus-clean verified. Layering consistent: exclusivity clause subsumes; pattern = defense-in-depth callout.
 
-Taxonomy note, below finding threshold: adjudication paragraph counts "four surface-form residues" while sequencer: is a partial-freeze variant of residue #4 (freezes the file-order axis only). Member denied by two layers; an undercounted taxonomy does not overstate the control — wording preference, not a defect.
+Taxonomy note, below finding threshold: adjudication paragraph counts "four surface-form residues" while sequencer: is a partial-freeze variant of residue `#4` (freezes the file-order axis only). Member denied by two layers; an undercounted taxonomy does not overstate the control — wording preference, not a defect.
 
 **No findings.**
 
@@ -815,9 +815,9 @@ Taxonomy note, below finding threshold: adjudication paragraph counts "four surf
 # QA/Testing Review — Round 5 (incremental)
 
 ## Verification performed
-- #2 (Round-4 F1): allow-path example now matches I2's actual text exactly. Resolved.
-- #3 (sequencer row): verified against installed vitest (coverage.DM_a_rWm.js ~477-481): `if (!resolved.sequence?.sequencer)` → `sequencer = shuffle ? RandomSequencer : BaseSequencer` — config `sequencer:` preempts RandomSequencer while in-file shuffle and seed printing continue. Corpus-clean verified: zero case-insensitive occurrences of shuffle/seed/sequencer across tests, config, package.json.
-- #1 (exclusivity clause): coexistence with key-enumerated rows coherent (shape check = mechanism, key rows = callouts; both converge on named-deviation adjudication). One internal tension — F1.
+- `#2` (Round-4 F1): allow-path example now matches I2's actual text exactly. Resolved.
+- `#3` (sequencer row): verified against installed vitest (coverage.DM_a_rWm.js ~477-481): `if (!resolved.sequence?.sequencer)` → `sequencer = shuffle ? RandomSequencer : BaseSequencer` — config `sequencer:` preempts RandomSequencer while in-file shuffle and seed printing continue. Corpus-clean verified: zero case-insensitive occurrences of shuffle/seed/sequencer across tests, config, package.json.
+- `#1` (exclusivity clause): coexistence with key-enumerated rows coherent (shape check = mechanism, key rows = callouts; both converge on named-deviation adjudication). One internal tension — F1.
 - No acceptance criterion gained a false-fail path; A5–A8, A1–A4, A3m, four-residue statement, consumer walkthrough mutually consistent.
 
 ## Findings

--- a/docs/archive/review/extension-test-order-deps-review.md
+++ b/docs/archive/review/extension-test-order-deps-review.md
@@ -1,0 +1,841 @@
+# Plan Review: extension-test-order-deps
+Date: 2026-08-22
+Review round: 1
+
+## Changes from Previous Round
+Initial review.
+
+## Merged Findings (convergence-corrected)
+
+Convergence stamps applied per 'Perspective Convergence as a Severity Signal':
+- MF1 (M3 derivation/load-axis acceptance): convergent functionality+testing — Major, fix first.
+- MF6 (A6 red-proof re-seed fallback): convergent functionality+testing — severity floor raised Minor → Major.
+All other findings retain their single-perspective severity.
+
+| ID | Severity | Title | Convergent |
+|----|----------|-------|------------|
+| MF1 | Major | M3 load-race: no member derivation, no load-axis acceptance; fact-5 closure claim unverifiable | func+test |
+| MF2 | Major | Set B Once-less grep misses direct-handle spellings; lib/messaging.test.ts in neither set | — |
+| MF3 | Major | Suppression-spelling member set incomplete (it.fails, skipIf, options-object, assertion deletion) | — |
+| MF4 | Major | Per-suite { shuffle: false } overrides C3 gate in-band; 'no spelling to bypass' overstated | — |
+| MF5 | Major | I3 keyed-mock miss behavior unspecified (silent divergence or unhandled-rejection flake) | — |
+| MF6 | Major (floored) | A3/A6 red-proofs assume ordering stability; no re-seed fallback | func+test |
+| MF7 | Minor | C2 classification coverage ambiguous for 23 stubGlobal candidates | — |
+| MF8 | Minor | SC2 deferral lacks security-triage classification for confirmed production race | — |
+| MF9 | Minor | Residual-risk detection floor unquantified (~4.3% @ 95% over ~69 runs) | — |
+| MF10 | Minor | rtk output proxy strips seed line; evidence capture needs file redirect | — |
+
+## Major Findings
+
+### Severity: Major
+**Problem**: The plan's Established fact 5 claims the pre-pr plain-run failure is M3 (fire-and-forget async load-dependent race), but provides no derivation command for M3 members (e.g., files pairing `mockResolvedValueOnce` with fire-and-forget imports) and no acceptance criterion (A1–A7) runs the suite under CPU contention or reproduces the pre-pr environment. Recorded seeds at a single seed only prove order-dependence, not interleaving-dependence; reverting a file's fix may still red via its order-dependent component while leaving the M3 component unproven.
+**Impact**: The pre-pr failure that partly motivated issue #784 can survive the PR while all acceptance evidence is green. An incomplete or wrong M3 fix passes all acceptance and re-flakes in pre-pr under parallel load later.
+**Recommended action**: Keep shuffled/default suites green, and add: (1) a derivation command for M3 candidates feeding the C2 classification table; (2) an acceptance that runs affected files under the reproducing condition (e.g., concurrent CPU load or pre-pr batch). If unreplicable locally, log it explicitly and downgrade fact 5's closure to "hypothesized". Make red-proof per-mechanism: revert to positional Once queue AND deterministically flush the fire-and-forget consumer (via `await` or `vi.waitFor`) so misalignment reds every run.
+**Flagged by**: Functionality expert, Testing expert
+
+### Severity: Major
+**Problem**: Set B's pattern-2 grep (`*Mock(s).method.mockX`) misses persistent overrides through direct `vi.fn()` handles. Recomputing with a wider pattern (`handle.Mock|Resolved|Implementation(`) surfaces additional files. Specifically, `extension/src/__tests__/lib/messaging.test.ts` (lines 18, 38) has M1-shaped once-less overrides in test bodies with only `vi.clearAllMocks()` in `beforeEach`. This file is absent from both Set A and Set B.
+**Impact**: Under-derived M1 worklist means latent members ship past the 50-seed sweep and surface later as random-red pain. The plan's fallback (dynamic gate as authority) softens but does not remove this risk.
+**Recommended action**: Widen the derivation grep to any handle spelling of `.mock(ReturnValue|ResolvedValue|Implementation)(`. Add every newly matched file to the C2 classification table. Contained occurrences remain untouched, but the classification row is mandatory. Treat a grep that cannot match known spellings as "not-run" until fixed.
+**Flagged by**: Functionality expert
+
+### Severity: Major
+**Problem**: Plan lines 211–215 forbid only `\.skip\(` and `\.todo\(`. Vitest 4.1.10 offers additional suppression spellings that the execution gate cannot catch because masked tests never execute: `it.fails(` / `test.fails(`, options-object forms `{ skip: true }` / `{ fails: true }`, `it.skipIf(cond)(` / `it.runIf(cond)(`, and assertion deletion. Victims in Set A include security-control tests (`dpop-key.test.ts`, `totp-handlers.test.ts`).
+**Impact**: An implementer can neutralize a security-relevant test with a spelling the forbidden list never flags; every standing gate stays green because the masked test does not run.
+**Recommended action**: Widen the forbidden pattern to `\.(skip|skipIf|todo|fails|runIf|only)\s*\(` and options-object `(skip|todo|fails)\s*:\s*true` in test diffs. Pair with an allow path requiring a deviation-log entry for legitimate conditional skips. Add an acceptance clause to C1 requiring victim test assertions to be unchanged or strengthened.
+**Flagged by**: Security expert
+
+### Severity: Major
+**Problem**: Plan line 194 claims the gate has "no spelling enumeration to bypass". However, vitest resolves per-suite shuffle with suite options taking precedence over the config (`this.shuffle ?? options.shuffle ?? currentSuite?.options?.shuffle`). `describe("x", { shuffle: false })` or `describe.shuffle` permanently exempts that suite from the C3 gate. This is deterministic and author-controllable, yet absent from the known-bypass list and forbidden-pattern list.
+**Impact**: The plan's architecture relies on C3 as the controlling gate. A suite-level opt-out makes the gate fail-open per suite with no signal, defeating the control's purpose and allowing flaky security tests to be permanently exempted.
+**Recommended action**: Add `shuffle` (suite/test option or chainable) to the forbidden-pattern list (deny). Pair allow: seed-pinning for local bisection stays available via CLI `--sequence.seed=N`. Amend C3's known-bypass list to honestly name this opt-out and correct the "no spelling enumeration to bypass" claim.
+**Flagged by**: Security expert
+
+### Severity: Major
+**Problem**: C1-I3 dictates input-keyed mocks but leaves miss behavior undefined. Two unbounded shapes exist: (a) miss returns `undefined` → silent default/parsing error, hiding mock-reality divergence; (b) miss throws → the thrower may be the unawaited background consumer, creating an unhandled rejection that vitest attributes to another test, minting a new flake class.
+**Impact**: Either silent divergence (worse than positional queues which fail visibly) or a new nondeterministic failure mode replacing the old one.
+**Recommended action**: Specify that the keyed mock must throw on unmapped input with the input named in the error message (fail loudly). The key map must cover every input the production background path can request during tests, including fire-and-forget consumers. Prove coverage via the deterministic flush described in the M3 action.
+**Flagged by**: Testing expert
+
+---
+
+## Minor Findings
+
+### Severity: Minor
+**Problem**: A6's point-mutation ("restore `totp-handlers.test.ts:327` to persistent `mockReturnValue`") and seed-based red-proofs assume ordering stability. If C1/Phase 2 adds files, renames tests, or alters test counts, seed 12345's permutation changes, potentially placing the culprit after the victim. The mutation may also be neutralized by C1's own `afterEach` restores or permutation shifts. A6's both-directions requirement detects non-red, but no scripted recovery exists.
+**Impact**: The gate red-proof stalls at execution time with no scripted recovery, inviting ad-hoc substitutes or false negatives.
+**Recommended action**: Specify mutation as "revert that file's entire C1 fix on the scratch copy". Add: "if no recorded seed reds after revert, sweep seeds 1..50 for a red and record the new seed". Deny MUST fail on the new seed; allow MUST pass. (Applies to A3/A6).
+**Flagged by**: Functionality expert, Testing expert
+
+### Severity: Minor
+**Problem**: C2's signature says "for each Set B candidate file, Phase 2 classifies the pattern occurrence", but the stubGlobal bullet says "Phase 2 classifies only the ones where a stub is installed mid-file". C2's invariant covers `real-leak`-without-fix and fix-without-classification. A candidate never receiving a classification row trips nothing.
+**Impact**: Up to ~20 files can silently drop out of the audit with no deviation-log trace; intention is undecidable from the plan.
+**Recommended action**: State explicitly which set the classification table must cover. Either "all 23 candidates get a classification row (e.g., `contained — beforeEach stub`)", or amend C2's invariant so that "a Set B candidate absent from the table is itself a deviation-log entry".
+**Flagged by**: Functionality expert
+
+### Severity: Minor
+**Problem**: "Residual risk (rare orderings) is accepted" carries no numerical threshold. The standing gate runs ~69 shuffled iterations. A latent member firing in fraction `p` of orderings escapes all runs with probability `(1-p)^69`. 95% detection requires `p ≥ 4.3%`. Members firing at 1% escape ~50% of the time, surfacing later as random CI reds.
+**Impact**: Post-merge random CI reds from the tail will look like gate regressions unless the accept decision was made with the quantification in view.
+**Recommended action**: Record the ~4.3%/95% detection floor in C3's control-class paragraph so the accepted bypass is quantified. Future tail-trips are triaged as expected behavior, not broken gates. No extra runs needed.
+**Flagged by**: Testing expert
+
+### Severity: Minor
+**Problem**: Vitest's `Running tests with seed "N"` line is stripped by the session's `rtk-compressed` Bash proxy. A5/A6/C4 require "seeds recorded from output", but the Phase-2 executor runs in this environment. Evidence silently comes back empty.
+**Impact**: Acceptance runs fail to capture required seed evidence; executor either blocks incorrectly or skips recording.
+**Recommended action**: Add execution note to Testing strategy: capture acceptance-run output with `> file 2>&1` (or `rtk proxy`) and grep the file for the seed line. Treat a missing seed line as a capture failure. Pass/fail exit codes are unaffected.
+**Flagged by**: Testing expert
+
+### Severity: Minor
+**Problem**: SC2 defers "Refactoring production `background/index` fire-and-forget async" as a routine report-only item. The mechanism (M3) is unawaited async in a password manager's service worker. If Phase 2 confirms it in production, the failure mode is credential/overview mis-association (OWASP A04), not a hygiene refactor. The plan doesn't specify issue classification.
+**Impact**: A confirmed credential-adjacent race filed as an ordinary issue can sit unprioritized, losing the security signal.
+**Recommended action**: Add to SC2: "If Phase 2 confirms the race with real decrypt inputs, the filed issue is labeled security and states the credential-mis-delivery hypothesis; if mock-positional only, note that and close the hypothesis."
+**Flagged by**: Security expert
+
+---
+
+## Recurring Issue Check
+
+### Functionality expert
+| Rule | Status | Note |
+|---|---|---|
+| R1 | N/A | No shared-utility reimplementation; no new infra planned |
+| R2 | N/A | No constants duplicated |
+| R3 | Finding F2 | Once-less-fix pattern must propagate to all member files; spelling hole under-derives the set |
+| R4 | N/A | No event dispatch |
+| R5 | N/A | No DB/transactions |
+| R6 | N/A | No cascade deletes |
+| R7 | N/A | No E2E selectors |
+| R8 | N/A | No UI |
+| R9 | N/A | M3 is a test-mock race, not a tx-boundary fire-and-forget |
+| R10 | N/A | No module graph change |
+| R11 | N/A | — |
+| R12 | N/A | — |
+| R13 | N/A | — |
+| R14 | N/A | No migrations |
+| R15 | OK | Config-level gate makes dev/pre-pr/CI identical; all three consumers verified |
+| R16 | N/A | No helper adoption |
+| R17 | OK | Forbidden patterns block per-consumer `--sequence.shuffle` drift |
+| R18 | N/A | — |
+| R19 | N/A | — |
+| R20 | N/A | Plan review, no subagent output accepted |
+| R21 | N/A | — |
+| R22 | N/A | — |
+| R23 | N/A | — |
+| R24 | N/A | — |
+| R25 | N/A | — |
+| R26 | N/A | — |
+| R27 | N/A | — |
+| R28 | N/A | — |
+| R29 | OK | Isolate default, grep counts, seed-12345 result, duration — all spot-checked and reproduce |
+| R30 | N/A | — |
+| R31 | N/A | No destructive ops |
+| R32 | N/A | No new runtime artifact |
+| R33 | OK | Gate lives in one config; forbidden pattern enforces non-duplication |
+| R34 | OK | SC2 defers the production fire-and-forget with explicit report-only justification; adjacent latent test leak covered under F2 |
+| R35 | N/A | Not production-deployed behavior |
+| R36 | OK | `.skip`/`.todo`/setTimeout-widening explicitly forbidden |
+| R37 | N/A | No user-facing strings |
+| R38 | N/A | No state machine |
+| R39 | N/A | No secrets lifecycle |
+| R40 | N/A | No serialization boundary |
+| R41 | OK | Shuffle, seed printing, and CLI override verified working in the installed vitest — declared capability has a backing path |
+| R42 | Finding F1, F2 | M3 members have no derivation (F1); M1 static worklist misses direct-handle spellings (F2) |
+| R43 | N/A | No security boundary widened |
+| R44 | OK | All consumers read vitest's exit code directly through `npm test` |
+| R45 | OK | No perf regression; duration claim verified (~6.25 s) |
+| R46 | N/A | No analyzer binding resolution |
+| R47 | OK | Adjudication is execution-based (the runner); statics declared as worklist only |
+| R48 | OK | Single adjudicator (one config), all consumers inherit |
+| R49 | Finding F1 | C3's tripwire class is properly declared, but fact 5's "C1 closes the pre-pr failure too" is a claim stronger than any planned verification |
+| R50 | OK | Seeds printed/recorded; red-proofs on scratch copies with both directions executed |
+| R51 | N/A | — |
+| R52 | N/A | — |
+| R53 | N/A | Sweep sizes are discovery breadth, not pass/fail thresholds |
+| R54 | N/A | — |
+| R55 | N/A | — |
+| R56 | N/A | — |
+| R57 | N/A | — |
+
+### Security expert
+| Rule | Status |
+|---|---|
+| R1 | N/A (no shared-utility work) |
+| R2 | N/A |
+| R3 | OK (fix propagation governed by dynamic sweep + C2 classification) |
+| R4 | N/A |
+| R5 | N/A (no DB) |
+| R6 | N/A (no E2E selectors) |
+| R7 | N/A (no UI) |
+| R8 | N/A |
+| R9 | N/A |
+| R10 | N/A |
+| R11 | N/A |
+| R12 | N/A |
+| R13 | N/A |
+| R14 | N/A |
+| R15 | N/A |
+| R16 | OK (same `npm test` path in dev/pre-pr/CI; plan's consumer walkthrough covers parity) |
+| R17 | N/A |
+| R18 | N/A |
+| R19 | OK (mock changes confined to files whose tests adjudicate them) |
+| R20 | N/A (plan stage) |
+| R21 | N/A (no subagent output consumed) |
+| R22 | N/A |
+| R23 | N/A |
+| R24 | N/A |
+| R25 | N/A |
+| R26 | N/A |
+| R27 | N/A |
+| R28 | N/A |
+| R29 | OK — seed-12345 failure count and seed-print claim independently reproduced this review |
+| R30 | N/A |
+| R31 | N/A (no destructive ops; red-proofs on scratch copies) |
+| R32 | N/A |
+| R33 | OK — single-config gate with forbidden pattern against duplication |
+| R34 | OK — SC1–SC4 each carry owner + justification |
+| R35 | N/A |
+| R36 | Finding F1 |
+| R37 | N/A |
+| R38 | N/A |
+| R39 | N/A |
+| R40 | N/A |
+| R41 | OK (seed-repro path verified to exist in installed vitest) |
+| R42 | Finding F1 (suppression-spelling member set), F2 (bypass member set) |
+| R43 | N/A |
+| R44 | OK (pre-pr consumes exit code directly; seed line lands in captured log) |
+| R45 | N/A (no scaling gate; ~70 runs ≈ 9 min, measured) |
+| R46 | N/A |
+| R47 | Finding F1 (forbidden-pattern surface-form list incomplete; C3 itself is genuinely execution-based) |
+| R48 | N/A (one adjudicator — the runner) |
+| R49 | Finding F2 ("no spelling enumeration to bypass" is overstated; per-suite opt-out exists) |
+| R50 | OK (acceptance requires recorded outputs, not proxy signals) |
+| R51 | N/A |
+| R52 | N/A |
+| R53 | N/A |
+| R54 | Finding F2 (in-band per-suite gate suspension) |
+| R55 | N/A |
+| R56 | N/A |
+| R57 | N/A |
+| RS1 | N/A (no comparisons touched) |
+| RS2 | N/A (no routes) |
+| RS3 | N/A (no boundary input) |
+| RS4 | OK — fixtures are canonical fake material; recorded evidence contains seeds/test names only |
+| RS5 | N/A |
+| RS6 | N/A |
+
+### Testing expert
+| Rule | Status | | Rule | Status | | Rule | Status |
+|---|---|---|---|---|---|---|---|
+| R1 | N/A | | R21 | OK (scratch-copy rule stated) | | R41 | OK |
+| R2 | N/A | | R22 | N/A | | R42 | OK (dynamic derivation; F4 quantifies) |
+| R3 | N/A | | R23 | N/A | | R43 | N/A |
+| R4 | N/A | | R24 | N/A | | R44 | Finding F5 |
+| R5 | N/A | | R25 | N/A | | R45 | OK (~7 s suite, no scaling) |
+| R6 | N/A | | R26 | N/A | | R46 | N/A |
+| R7 | N/A | | R27 | N/A | | R47 | OK (vitest execution adjudicates) |
+| R8 | N/A | | R28 | N/A | | R48 | OK (single gate, no parallel adjudicator) |
+| R9 | N/A | | R29 | OK (facts 1,3 reproduced; commands present) | | R49 | OK (tripwire declared; F4 refines) |
+| R10 | N/A | | R30 | N/A | | R50 | Finding F5 (evidence channel) |
+| R11 | N/A | | R31 | N/A | | R51 | N/A |
+| R12 | N/A | | R32 | N/A | | R52 | N/A |
+| R13 | N/A | | R33 | OK (config-once + forbidden per-consumer flags) | | R53 | N/A |
+| R14 | N/A | | R34 | OK (SC1–SC4 owned) | | R54 | N/A |
+| R15 | N/A | | R35 | N/A | | R55 | N/A |
+| R16 | OK (pre-pr/CI/dev all inherit via npm test; verified) | | R36 | OK (.skip forbidden pattern) | | R56 | N/A |
+| R17 | N/A | | R37 | N/A | | R57 | N/A |
+| R18 | OK (CI filter covers extension/vitest.config.ts; verified) | | R38 | N/A | | RS1–RS6 | N/A |
+| R19 | N/A | | R39 | N/A | | | |
+| R20 | N/A | | R40 | | | | |
+
+| RT rule | Status |
+|---|---|
+| RT1 | Finding F2 (keyed-mock miss behavior unbounded) |
+| RT2 | OK (all contracts locally testable) |
+| RT3 | N/A |
+| RT4 | Finding F1 (no acceptance exercises the load axis); F4 (sweep floor quantified) |
+| RT5 | N/A (test-only change) |
+| RT6 | N/A (no production exports) |
+| RT7 | Finding F1 (M3 red-proof cannot fail for the claimed reason); F3 (seed-stability fallback) |
+| RT8 | N/A |
+| RT9 | OK (test-only edits; production twins untouched) |
+| RT10 | OK (A6 runs deny AND allow every time) |
+| RT11 | OK (scratch-copy mutations; no fixture outlives its run) |
+
+## Quality Warnings
+No findings triggered quality flags. All merged findings contain specific file/line references, concrete commands/regexes, or explicit spec amendments, and do not rely on unverified claims or untested test targets.
+
+---
+
+# Plan Review: extension-test-order-deps — Round 2
+Date: 2026-08-22
+Review round: 2
+
+## Changes from Previous Round
+All 10 Round-1 merged findings were applied to the plan (M3 hypothesized + A3m/A8, widened Set B grep, suppression/opt-out forbidden patterns, keyed-mock miss spec, re-seed fallback, C2 full coverage, SC2 triage, detection floor, rtk evidence capture). Round 2 verified those fixes and reviewed the new material.
+
+## Round-2 verdicts on Round-1 fixes
+All three experts confirm every Round-1 finding resolved in substance; all Round-2 findings target construction defects INSIDE the Round-1 remedies or newly re-derived class members.
+
+## Merged Findings (convergence-corrected)
+
+| ID | Severity | Title | Convergent |
+|----|----------|-------|------------|
+| R2-1 | Major | A3m flush placement unspecified/conflated with I3 flush; natural placement greens the deny run | func(F9)+test(F1) |
+| R2-2 | Major | shuffle opt-out regex brace-anchored; misses multi-key option objects | func(F7)+sec(F6) |
+| R2-3 | Major | A7 after-number from pre-pr contended run; cross-environment comparison invalid | func(F8)+test(F4) |
+| R2-4 | Major | Set B commands exclude .test.tsx; 5 files dropped, M1-shaped hits in popup/App.test.tsx | func(F5) |
+| R2-5 | Major | M3 candidate set name-supplied; input-derive from all mockResolvedValueOnce files | func(F6) |
+| R2-6 | Major | retry/repeats options absorb gate trips markerlessly; missing from forbidden patterns | sec(F4) |
+| R2-7 | Major (floored) | C4 'A1–A8' lexically excludes A3m | func(F10)+test(F3) |
+| R2-8 | Minor | Re-seed fallback lacks exhaustion exit | test(F2) |
+| R2-9 | Minor | Options pattern omits only:true; destructured ctx.skip unlisted | sec(F5) |
+| R2-10 | Minor | I4 scoped to victims; culprit tests outside assertion-weakening check | sec(F7) |
+
+Convergence stamps per 'Perspective Convergence as a Severity Signal': R2-1/R2-2/R2-3 take max severity (Major); R2-7 floored Minor→Major (two perspectives).
+
+## Merged Findings
+
+### Major
+
+**Severity**: Major  
+**Problem**: The widened pattern-2 command and the module-scope-`let` count use `--include='*.test.ts'`, excluding 7 `.test.tsx` files. Recomputation reveals 5 dropped files carry `.mock(ReturnValue|ResolvedValue|RejectedValue|Implementation)(` hits (including M1-shaped Once-less overrides in `popup/App.test.tsx`). Reconciliation is self-referential against the same filtered commands.  
+**Impact**: Five candidate files structurally drop out of the C2 audit, and C2's row-count reconciliation cannot notice because it reconciles against the same filtered commands' output.  
+**Recommended action**: Change include filters to `--include='*.test.ts*'` (or drop `--include`), re-run, add new hits to the C2 table. Boundary: the filter must admit every file vitest's default include admits; reconcile counts from corrected commands.  
+*Flagged by*: Functionality
+
+**Severity**: Major  
+**Problem**: The M3 derivation command keys on the literal `background/index`, leaving Phase 2 name-supply to judgment. Recomputation finds 12 files containing `mockResolvedValueOnce`; the command matches only 4. Excluded files (e.g., `content/token-bridge.test.ts`, `popup/App.test.tsx`, `popup/MatchList.test.tsx`) have unawaited consumers by construction. Verdicts are never recorded.  
+**Impact**: An M3-class race in an excluded file stays latent; the shuffle gate cannot sample it (bypass (b)) and A8's single pre-pr run is one sample.  
+**Recommended action**: Make the candidate set input-derived: every `mockResolvedValueOnce` file is an M3-classification candidate (12 rows). Reconciliation then counts against `grep -rl 'mockResolvedValueOnce' .`, which cannot under-derive its own left side.  
+*Flagged by*: Functionality
+
+**Severity**: Major  
+**Problem**: The test-side opt-out regex `\{\s*shuffle\s*:\s*false` is brace-anchored, missing multi-key option objects like `describe("x", { concurrent: true, shuffle: false }, …)`. The companion `shuffle\s*:` is scoped only to `extension/vitests.config.ts`. Zero hits exist under `extension/src/__tests__/`, so a maximally broad pattern carries zero false-positive cost.  
+**Impact**: A suite can opt out of the gate through a spelling the declared residue control does not flag.  
+**Recommended action**: Replace the test-side pattern with unanchored `shuffle\s*:\s*false` (or bare `shuffle`) under `extension/src/__tests__/`. Keep `describe\.shuffle` for readability. Explicitly state the config-side scope.  
+*Flagged by*: Functionality, Security
+
+**Severity**: Major  
+**Problem**: A7 compares `npm test` wall-clock before/after. The before-side is fact 4's idle-machine measurement (~6.2–7.2 s). A8 designates the "Extension: Test" step duration from pre-pr's batch 1 (concurrent with Lint/Test/Build/CLI: Build) as the after-number. This measures CPU contention, not the shuffle delta.  
+**Impact**: Either a spurious "materially worse" report to the user, or a real shuffle regression hidden inside contention noise. Both corrupt C4's closure evidence.  
+**Recommended action**: Derive A7's two numbers from the same idle environment: idle `npx vitest run --sequence.shuffle=false` (before) vs. idle config-shuffled `npm test` (after). Keep A8's step duration as supplementary contended-environment evidence.  
+*Flagged by*: Functionality, QA/Testing
+
+**Severity**: Major  
+**Problem**: A3m's "reds EVERY run" depends on flush placement, but I3 specifies the flush only as "before the test ends". Natural end-of-test placement allows intended consumers to drain the Once queue in order, leaving the fire-and-forget consumer with an exhausted queue. This causes the deny-run to green instead of red, breaking the minimal-pair property.  
+**Impact**: The acceptance criterion built to prove M3 can fail to red for a construction reason, leaving M3 falsely "hypothesized" or requiring ad-hoc executor fixes that break the minimal-pair property.  
+**Recommended action**: Specify in A3m that the red-proof flush sits **at the steal window** — immediately after the fire-and-forget trigger (post-unlock), before intended consumers. The deny/allow pair must use the identical test body, differing only in mock keying. I3's end-of-test flush coexists for miss-attribution.  
+*Flagged by*: Functionality, QA/Testing
+
+**Severity**: Major  
+**Problem**: `TestOptions.retry` (and config-level `retry`/`repeats`) exists on the installed surface but matches no forbidden pattern. `{ retry: 2 }` permanently absorbs the gate's exit-code signal for intermittent members without a skip marker, neutralizing the tail-closure mechanism of C3.  
+**Impact**: The gate stays green while the order-dependence class re-accumulates; the standing gate's closure is bypassed by a socially normal "flaky test fix".  
+**Recommended action**: Add forbidden patterns: `retry\s*:` and `repeats\s*:` under `extension/src/__tests__/` and `extension/vitests.config.ts`. Require a deviation-log entry naming the nondeterminism source and an issue link for genuine retries. Verified zero false positives in current extension tests.  
+*Flagged by*: Security
+
+### Minor
+
+**Severity**: Minor  
+**Problem**: C4's acceptance clause states "all acceptance IDs A1–A8 present with commands and outputs." A3m falls outside the lexical A1..A8 range. A checklist-driven executor can omit A3m's evidence without triggering the clause.  
+**Impact**: The M3 proof — the plan's most fragile evidence item — is at risk of being skipped by strict ID-range checklists.  
+**Recommended action**: Update text to "A1–A4, A3m, A5–A8 present with commands and outputs (A3m may instead be a named deviation-log entry per its fallback)".  
+*Flagged by*: Functionality, QA/Testing
+
+**Severity**: Minor  
+**Problem**: The options-object pattern bans `(skip|todo|fails)\s*:\s*true` but omits `only?: boolean`. `it("x", { only: true }, fn)` narrows suites without a dot-form `.only(`. Additionally, destructured `ctx.skip` contains no `.skip(` substring.  
+**Impact**: Local pre-pr runs without `CI` would silently pass narrowed suites; destructured skip goes uncaught by grep-based residue control.  
+**Recommended action**: Change the options pattern to `(skip|todo|fails|only)\s*:\s*true`. Add destructured `ctx.skip` to the un-greppable-residue sentence so C1-I4's diff inspection explicitly owns it.  
+*Flagged by*: Security
+
+**Severity**: Minor  
+**Problem**: I4 (C1 assertion-weakening check) is scoped to "victim tests", but the plan's fixes typically edit *culprit* tests. Reading I4 literally excludes the actually-edited tests from assertion-strengthening verification.  
+**Impact**: Assertion-weakening in culprit tests escapes adjudication.  
+**Recommended action**: Reword I4 from "victim tests'" to "all tests in files edited under C1/C2" — assertions unchanged or strengthened, verified by PR-diff inspection.  
+*Flagged by*: Security
+
+## Recurring Issue Check
+
+### Functionality expert
+| Rule | Status | Note |
+|---|---|---|
+| R1 | N/A | — |
+| R2 | N/A | — |
+| R3 | OK | Handle-spelling gap closed; residual extension-filter gap tracked as F5 (R42) |
+| R4–R15 | N/A | — |
+| R16 | OK | Consumers unchanged; single-config gate confirmed again |
+| R17 | N/A | — |
+| R18 | OK | Anchoring defect is F7, not a sync gap |
+| R19–R28 | N/A | — |
+| R29 | Finding F10 | Detection-floor math and run counts verified correct; A3m/"A1–A8" cross-reference is the one inaccuracy |
+| R30–R32 | N/A | — |
+| R33 | OK | — |
+| R34 | OK | SC2 triage pre-commitment strengthens Round-1 posture |
+| R35 | N/A | — |
+| R36 | OK | Suppression class widened with an allow path; un-greppable residue handled by C1-I4 |
+| R37–R40 | N/A | — |
+| R41 | OK | Bypass-(c) chain quote matches vitest semantics; CLI overrides re-verified empirically |
+| R42 | Finding F5, F6 | Extension-filter hole; M3 module-set name-supplied |
+| R43 | N/A | — |
+| R44 | OK | Evidence-capture note closes the rtk lossy-channel risk |
+| R45 | OK | — |
+| R46 | N/A | — |
+| R47 | Finding F7 | Brace-anchored opt-out regex misses non-first-property spelling |
+| R48 | OK | — |
+| R49 | OK | Fact 5 hypothesized; honest residues; tail-trip expected behavior |
+| R50 | Finding F8 (and F9) | A7 cross-environment; A3m flush placement underspecified |
+| R51–R57 | N/A | — |
+
+### Security expert
+| Rule | Status |
+|---|---|
+| R1–R2 | N/A |
+| R3 | OK |
+| R4–R15 | N/A |
+| R16 | OK (A8 adds the pre-pr parallel-load environment to the evidence set) |
+| R17–R28 | N/A (R19 OK; R20 N/A plan stage) |
+| R29 | OK — detection-floor math reproduced; resolution-chain quote matches installed runner source |
+| R30–R32 | N/A |
+| R33 | OK |
+| R34 | OK (SC1–SC4 owned; SC2 triage pre-committed) |
+| R35 | N/A |
+| R36 | Finding F4 (retry as markerless weakening), F7 (I4 scope) |
+| R37–R41 | N/A (R41 OK) |
+| R42 | Finding F4 (retry member missed on class re-derivation), F5 (options-`only`, destructured skip) |
+| R43 | N/A |
+| R44 | OK |
+| R45–R46 | N/A |
+| R47 | Finding F6 (test-side opt-out regex weaker than the spelling it bans) |
+| R48 | N/A |
+| R49 | OK — residue: "two surface-form residues" becomes three once F4's retry member is admitted — fold into the F4 fix |
+| R50 | OK (A8; recorded outputs, not proxies) |
+| R51–R57 | N/A (R54: setConfig runtime-suspension vector checked and closed) |
+| RS1–RS3 | N/A |
+| RS4 | OK — keyed-mock throw messages and evidence logs carry fixture data and seeds only |
+| RS5–RS6 | N/A |
+
+### QA/Testing expert
+| Rule | Status | | Rule | Status | | Rule | Status |
+|---|---|---|---|---|---|---|---|
+| R1 | N/A | | R21 | OK | | R41 | OK |
+| R2 | N/A | | R22 | N/A | | R42 | OK (M3-candidate derivation added; widened grep closes the spelling hole) |
+| R3 | N/A | | R23 | N/A | | R43 | N/A |
+| R4 | N/A | | R24 | N/A | | R44 | OK (rtk note: exit codes intact, seed via file capture) |
+| R5 | N/A | | R25 | N/A | | R45 | OK |
+| R6 | N/A | | R26 | N/A | | R46 | N/A |
+| R7 | N/A | | R27 | N/A | | R47 | OK (two-residue statement now accurate; residues pattern-gated) |
+| R8 | N/A | | R28 | N/A | | R48 | OK |
+| R9 | N/A | | R29 | Finding F4 (A7 after-number derivation); bypass-(c) quote verified OK | | R49 | OK (tripwire + quantified floor + named bypasses a/b/c) |
+| R10 | N/A | | R30 | N/A | | R50 | OK |
+| R11 | N/A | | R31 | N/A | | R51 | N/A |
+| R12 | Finding F3 (A1–A8 range excludes A3m) | | R32 | N/A | | R52 | N/A |
+| R13 | N/A | | R33 | OK | | R53 | N/A |
+| R14 | N/A | | R34 | OK | | R54 | N/A |
+| R15 | N/A | | R35 | N/A | | R55 | N/A |
+| R16 | OK | | R36 | OK (suppression spellings + options-object + I4 diff inspection) | | R56 | N/A |
+| R17 | N/A | | R37 | N/A | | R57 | N/A |
+| R18 | OK | | R38 | N/A | | RS1–RS6 | N/A |
+| R19 | N/A | | R39 | N/A | | | |
+| R20 | N/A | | R40 | N/A | | | |
+
+| RT rule | Status |
+|---|---|
+| RT1 | OK (I3 miss-throws with named input; full consumer key map) |
+| RT2 | OK |
+| RT3 | N/A |
+| RT4 | OK (M3 axis covered by A3m + A8; F1 is the RT7 construction defect, not a coverage gap) |
+| RT5 | N/A |
+| RT6 | N/A |
+| RT7 | Finding F1 (A3m flush placement can green the deny run); Finding F2 (re-seed exhaustion has no exit) |
+| RT8 | N/A |
+| RT9 | OK |
+| RT10 | OK (A3, A3m, A6 all state deny AND allow every time) |
+| RT11 | OK (scratch-copy mechanics; A6 whole-file revert) |
+
+## Quality Warnings
+No findings failed the quality gate checks. All merged items contain specific file/line references, concrete recommended actions, and are backed by grep output or interface/runner source verification. No [VAGUE], [NO-EVIDENCE], or [UNTESTED-CLAIM] flags were triggered.
+
+---
+
+# Plan Review: extension-test-order-deps — Round 3
+Date: 2026-08-22
+Review round: 3
+
+## Changes from Previous Round
+All 10 Round-2 merged findings applied (A3m steal-window minimal pair, bare-token shuffle pattern, A7 like-for-like, .tsx include filter, input-derived M3 set, retry/repeats pattern, C4 lattice, exhaustion exit, only:true + ctx.skip residue, I4 rescope). Round 3 verified those fixes: all three experts confirm every Round-2 finding resolved; new findings target residual spelling surfaces and one incompletely-propagated coverage clause.
+
+## Merged Findings (convergence-corrected)
+
+| ID | Severity | Title | Convergent |
+|----|----------|-------|------------|
+| R3-1 | Major | Seed-pinning + consumer-file retry spellings unlisted (--sequence.seed/--retry/--repeats in committed consumer files; seed: in config); A5 lacks pairwise-distinct-seeds clause | sec(F8)+func(F11) |
+| R3-2 | Major | C2 coverage enumeration omits let-subset; stubGlobal bullet stale + two bullets lacked derivation commands | test(F1)+func(F12) |
+| R3-3 | Major (floored) | Bare-token shuffle pattern: no allow path; 'any new match IS forbidden' overclaim (comment/string false positives) | func(F13)+test(F2) |
+| R3-4 | Minor | I4's assertion-only criterion cannot fire on destructured ctx.skip early-exit; needs explicit clause | sec(F9) |
+
+Saturation labels as filed by experts: R3-1 prose-only(R42,R44)/design-level(R47) [func labels design]; R3-2 prose-only (R12/R29); R3-3 prose-only/design-small (R29/R36); R3-4 prose-only (R36).
+
+# Functionality Review — Round 3 (incremental)
+
+## Round-2 resolution verification
+F5 (.tsx filter) resolved — matches recomputation exactly. F6 (M3 input derivation) resolved — 12 files, unfiltered grep admits .tsx, reconciliation self-consistent. F7 (anchored regex) resolved — bare token + config-side scope; residual ergonomic gap = F13. F8 (A7/A8) resolved — like-for-like idle, internally consistent. F9 (flush placement) resolved — steal-window + identical-body pair + DISPROVEN/deviation split; I3 "do not conflate" closes ambiguity. F10 (A1–A8 range) resolved.
+
+New claims verified by execution: `(retry|repeats)\s*:` corpus clean; vi.setConfig RuntimeConfig = `sequence?: { hooks?: SequenceHooks }` only (config.d.A1h_Y6Jt.d.ts:224-228).
+
+## New findings
+
+### F11 — Major (design-level, R47): retry-absorption and order-pinning residues un-forbidden in the consumer-file surface the list already knows about — `--retry`/`--repeats` and `--sequence.seed` in package.json/pre-pr/workflows, and `seed:` in the config
+`"test": "vitest run --retry=3"` in extension/package.json absorbs failures for every standing consumer and matches no pattern; `--sequence.seed=N` committed in any consumer file — or `seed:` in the config's sequence block — pins every run to ONE ordering: the gate still "runs shuffled with a printed seed" (I1 satisfied to the letter) while the accumulating-samples closure mechanism silently dies, and A5's soak becomes 10 samples of the same permutation — vacuous evidence.
+Fix: extend the retry row's scope with `--retry|--repeats` in the consumer files (same file set as the `--sequence.shuffle` row), and add a pinning row: `--sequence.seed` in consumer files and `seed\s*:` in extension/vitest.config.ts. Allow: ad-hoc CLI seed for local bisection (no committed file); committed retry keeps the deviation-log allow path. Boundary: forbidden surface = committed files standing consumers execute.
+
+### F12 — Minor (prose-only, R29): stubGlobal Set B bullet still carries the pre-Round-2 "classifies only mid-file" sentence, contradicting C2's ALL-23 clause, and is the one bullet with no derivation command
+Count re-verified: 23 (unfiltered, .tsx admitted). Fix: replace stale sentence with pointer to C2's coverage clause and paste the derivation command verbatim; let-set bullet likewise wants its command verbatim.
+
+### F13 — Minor (design-level small, R36): bare-token `shuffle` forbidden pattern has no allow path, and this PR's own fix diff is likely to contain the token in comments
+I2 mandates culprit-naming; natural vocabulary is this token ("leak surfaced by the shuffle gate at seed 12345"). Fix: keep the deny; add the allow the sibling rows have — comment-only match acceptable when the hunk shows no `shuffle` token in executable code, adjudicated at C1-I4's diff inspection; code-position match remains forbidden.
+
+## Recurring Issue Check
+R29: Finding F12 (all other quantitative claims re-verified: 12 M3 files, 10 let files, 7 tsx, corpus-clean, RuntimeConfig shape). R36: Finding F13. R47: Finding F11. R18/R33: OK (consumer-file gap filed as F11, not config drift). R42: OK (Round-2 gaps closed; F11 filed under R47). R3/R16/R41/R44/R45/R48/R49/R50/R53: OK. All others N/A.
+
+```json
+[
+  {"id":"F11","severity":"Major","title":"Retry-absorption and seed-pinning spellings un-forbidden in consumer files (--retry/--repeats, --sequence.seed) and config (seed:)","file":"docs/archive/review/extension-test-order-deps-plan.md","line":330,"adjacent":false,"escalate":null},
+  {"id":"F12","severity":"Minor","title":"Stale stubGlobal bullet contradicts C2 ALL-23 coverage clause; only Set B bullet without a derivation command","file":"docs/archive/review/extension-test-order-deps-plan.md","line":141,"adjacent":false,"escalate":null},
+  {"id":"F13","severity":"Minor","title":"Bare-token shuffle forbidden pattern lacks an allow path; mandated culprit-naming comments are a likely false positive","file":"docs/archive/review/extension-test-order-deps-plan.md","line":331,"adjacent":false,"escalate":null}
+]
+```
+# Security Review — Round 3 (incremental)
+
+Verification: no `.spec.*`/`.test.js` files exist under `extension/src` (the `*.test.ts*` include-filter claim holds), the 7 `.test.tsx` and 12 `mockResolvedValueOnce` counts reproduce (R29 clean), and the token `seed` has ZERO occurrences in `extension/src/__tests__`, `vitest.config.ts`, and `package.json`.
+
+**Round-2 fix verification:**
+- **F4 (retry/repeats) — fix correct.** Pattern + deviation-log allow + corpus-clean note present; three-residue adjudication paragraph with vi.setConfig closure. Re-checked chainable surface: `ChainableTestContextMap` has no `retry` member, so the option spelling is the only in-test spelling. One location-axis member remains — F8.
+- **F5 (options-only, destructured skip) — substantially fixed.** One delegation mismatch remains — F9.
+- **F6 (bare shuffle token) — fix correct and complete.**
+- **F7 (I4 rescope) — fix correct.**
+
+## Findings
+
+### F8 — Severity: Major — `sequence.seed` pinning (config `seed:` / script `--sequence.seed`) freezes the gate to one permutation and is unlisted; A5 would not detect it (saturation: prose-only; R42, R44)
+
+**Problem:** The installed vitest only generates a random seed when none is supplied: `node_modules/vitest/dist/chunks/coverage.DM_a_rWm.js:481` — `resolved.sequence.seed ??= Date.now()` — and the in-file shuffle consumes that seed directly (`@vitest/runner/dist/chunk-artifact.js:3155-3156`). So `sequence: { shuffle: true, seed: 42 }` in `extension/vitest.config.ts`, or `--sequence.seed=42` appended to the `test` script in `extension/package.json`, keeps the gate visibly "on" (shuffled order, seed line printed) while sampling the SAME single permutation forever — killing the plan's declared tail-closure mechanism ("the standing gate keeps accumulating samples"). Neither spelling matches any forbidden pattern: the config pattern is `shuffle\s*:` only; the script pattern is `--sequence.shuffle`, which does not match `--sequence.seed` (nor a script-side `--retry`, the same location-axis gap for the F4 member). And A5 requires "10 consecutive runs … seeds recorded" but never requires the recorded seeds to be pairwise distinct — a pinned-seed run satisfies A5's letter with 10 identical recorded seeds.
+
+**Impact:** An in-diff, marker-free spelling neutralizes the gate's only probabilistic guarantee while every acceptance clause still reads green; post-merge, order-dependence members that don't fire at the pinned permutation never fire.
+
+**Recommended action:** (1) Extend the config-side pattern to `(shuffle|seed)\s*:` outside the single gate line — verified corpus-clean: zero `seed` occurrences in tests, config, or package.json. (2) Extend the location pattern to `--(sequence\.(shuffle|seed)|retry|repeats)` in `extension/package.json`, `scripts/pre-pr.sh`, `.github/workflows/*` (closes the script-side `--retry` spelling at the same time). (3) Add to A5: "the 10 recorded seeds are pairwise distinct; a repeated seed is adjudicated as pinning or a capture failure and fails the acceptance loudly." Paired allow stays: seed pinning for local bisection via CLI on a developer's machine, touching no committed file.
+
+### F9 — Severity: Minor — destructured-`ctx.skip` residue delegated to C1-I4, but I4's criterion inspects only assertions, which a destructured `skip()` leaves intact (saturation: prose-only; R36)
+
+**Problem:** The un-greppable-residue sentence says the destructured form is "covered by C1-I4 diff inspection". I4 instructs the inspector to verify "assertions are unchanged or strengthened". A destructured `skip()` inserted as the first statement leaves every assertion textually unchanged — it makes them unreachable. An inspector applying I4's stated criterion faithfully would pass the diff.
+
+**Recommended action:** One clause in I4: "…assertions are unchanged or strengthened, AND no new early-exit or skip invocation (including destructured `TestContext.skip`) is introduced ahead of them." Allow unchanged (deviation-log path).
+
+**No other new holes:** `*.test.ts*` include-filter sound; input-derived M3 set cannot under-derive its left side; exhaustion exits fail loudly (R50-clean); A3m steal-window pair + DISPROVEN branch keep fact 5 honest; no secret material in fixtures/errors/evidence (RS4 clean).
+
+## Recurring Issue Check
+
+| Rule | Status |
+|---|---|
+| R1–R2 | N/A |
+| R3 | OK |
+| R4–R15 | N/A |
+| R16 | OK (A7 idle-vs-idle; A8 contended context separated) |
+| R17–R28 | N/A |
+| R29 | OK — Round-3 spot checks reproduced: 7 .test.tsx, 12 mockResolvedValueOnce files, zero seed corpus hits, no .spec.*/.test.js escapes |
+| R30–R32 | N/A |
+| R33 | OK for shuffle flags; Finding F8 extends the same location set to --sequence.seed/--retry |
+| R34 | OK |
+| R35 | N/A |
+| R36 | Finding F9; F8 secondary |
+| R37–R41 | N/A |
+| R42 | Finding F8 (seed-pinning member missed on neutralization-class re-derivation) |
+| R43 | N/A |
+| R44 | Finding F8 (pinned seed freezes the sampled permutation while appearing random); rtk capture handling OK |
+| R45–R46 | N/A |
+| R47 | OK — bare-token shuffle pattern at least as strong as the spellings it bans |
+| R48 | N/A |
+| R49 | OK — three-residue statement accurate for surfaces enumerated; fold F8's member in as fourth or absorb into bypass (c) when fixed |
+| R50 | OK |
+| R51–R57 | N/A |
+| RS1–RS3 | N/A |
+| RS4 | OK |
+| RS5–RS6 | N/A |
+
+```json
+[
+  {"id":"F8","severity":"Major","title":"sequence.seed pinning (config seed: / script --sequence.seed) freezes the shuffle gate to one permutation; unlisted in forbidden patterns and undetected by A5","file":"docs/archive/review/extension-test-order-deps-plan.md","line":331,"adjacent":false,"escalate":null},
+  {"id":"F9","severity":"Minor","title":"Destructured ctx.skip residue delegated to C1-I4, whose assertion-only criterion cannot fire on it","file":"docs/archive/review/extension-test-order-deps-plan.md","line":333,"adjacent":false,"escalate":null}
+]
+```
+# QA/Testing Review — Round 3 (incremental)
+
+## Verification performed
+A3m steal-window construction verified EXECUTABLE against background.test.ts:705-720 (deny = flush after UNLOCK_VAULT forces overview refresh to take slot 1 → AUTOFILL decrypts slot 2 as blob → NO_PASSWORD, red every run; allow = identical body + keyed mock greens). Coexistence with I3's end-of-test flush consistent. Exhaustion exit present in A3, mirrored in A6, both directions preserved. C4 lattice resolved. A7/A8 internally consistent. All new quantitative claims verified: 7 .test.tsx, 12 mockResolvedValueOnce files, 0 bare-shuffle, 0 retry/repeats, popup/App.test.tsx:167/204 real M1-shaped hits, 10 let-files incl. options/App.test.tsx, RuntimeConfig verbatim. No forbidden pattern matches the planned fix itself.
+
+## Findings
+
+### F1 — Major (prose-only, R12 + R29): C2's coverage enumeration omits the module-scope-`let` subset, and that subset alone has no recorded derivation command
+The em-dash enumeration lists four of Set B's five bullets; the let-set (10 files) is absent, and its derivation command is unrecorded, so the reconciliation has nothing to reconcile for it. Both fail-loud guards (enumeration + reconciliation) miss this subset simultaneously — the round-2 fix incompletely propagated. Candidates unique to this subset: background/inline-matches.test.ts, content/cc-identity-detector.test.ts, lib/disconnect-reason.test.ts, lib/storage.test.ts.
+Fix: add the fifth subset to the enumeration and record the command: `grep -rln --include='*.test.ts*' -E '^let ' .` → exactly 10 files. Allow unchanged: contained one-liners suffice.
+
+### F2 — Minor (prose-only, R29): bare-token `shuffle` pattern claims "any new match IS the thing being forbidden" — false for comment/string matches; the one pattern with no allow path
+Fix: state the boundary — options-position or chainable occurrence is forbidden; comment/string match is a named false positive to note in review, not an automatic reject.
+
+## Round-2 resolution assessment
+All four Round-2 findings correctly and completely resolved (F1 steal-window verified executable; F2 exhaustion exit both directions; F3 C4 lattice; F4 A7 like-for-like). Round-2 revisions from other experts check out against the repo (widened .tsx filter, input-derived 12-file M3 set, bare-token scope, retry/repeats zero baseline, RuntimeConfig closure) — modulo F2's overclaim sentence.
+
+## Recurring Issue Check
+R3: Finding F1 (coverage fix not propagated to fifth subset). R12: Finding F1. R29: Finding F2; all other claims verified OK. R16/R18/R33/R34/R36/R41/R42(dynamic)/R44/R45/R47/R48/R49/R50/R54: OK. RT1/RT2/RT4/RT7/RT9/RT10/RT11: OK. Others N/A.
+
+```json
+[
+  {"id":"F1","severity":"Major","title":"C2 coverage enumeration omits the module-scope-let subset and its derivation command is unrecorded, disarming both fail-loud guards","file":"docs/archive/review/extension-test-order-deps-plan.md","line":259,"adjacent":false,"escalate":null},
+  {"id":"F2","severity":"Minor","title":"Bare-token shuffle pattern overclaims 'any new match IS the thing forbidden' — comment/string false positives unbounded, no allow path","file":"docs/archive/review/extension-test-order-deps-plan.md","line":331,"adjacent":false,"escalate":null}
+]
+```
+---
+
+# Plan Review: extension-test-order-deps — Round 4
+Date: 2026-08-22
+Review round: 4
+
+## Changes from Previous Round
+All 4 Round-3 merged findings applied (consumer-file + config seed/retry patterns with A5 pairwise-distinct clause and four-residue statement; C2 five-subset enumeration with verbatim derivation commands; bare-shuffle deny boundary + allow path; I4 early-exit clause).
+
+## Round-4 verdicts on Round-3 fixes
+All three experts confirm every Round-3 finding fully resolved, with the supporting claims independently re-verified by execution (vitest seed-default line verbatim; corpus-clean claims; command counts 23/10/12/3; A5 distinctness cannot false-fail).
+
+## Merged Findings — Minor only, no Critical/Major
+
+| ID | Severity | Saturation label | Title | By |
+|----|----------|------------------|-------|----|
+| R4-1 | Minor | prose-only (R42) | Config file lacks the exclusivity clause consumer files have (exclude/include/passWithNoTests escape key enumeration) | sec(F10) |
+| R4-2 | Minor | prose-only (R29) | Bare-shuffle allow path misattributes culprit-naming comments to an I2 mandate | test(F1) |
+| R4-3 | Minor | design-level narrow (R47) | Committed sequencer: in config un-randomizes the file-order axis (secondary axis, zero known members) while the gate looks on | func(F14) |
+
+All three applied to the plan immediately after Round 4 (C3 signature exclusivity clause; I2-mandate reword; (shuffle|seed|sequencer) config pattern). Round 5 verifies.
+
+# Security Review — Round 4 (incremental)
+
+**Round-3 fix verification:**
+- **F8 (seed pinning) — fix correct and complete on all three parts.** Consumer-file row + rationale + allow boundary; config-side `(shuffle|seed)\s*:` + corpus-clean; A5 pairwise-distinct with loud failure. Four-residue adjudication paragraph accurate.
+- **F9 (destructured ctx.skip) — fix correct.** I4 early-exit clause; owner's criterion now fires.
+- **Convergent items #3/#4 — no security holes introduced.** Five-subset enumeration with verbatim commands; bare-shuffle deny/allow boundary sound (named-flagged-adjudicated, cannot smuggle options-position occurrence).
+
+**Final class re-derivation over writable surfaces:**
+- In-test options/chainables: closed (dot-form, options-object, retry/repeats options, suite shuffle any position, destructured ctx.skip via I4). expect.soft still fails the task; tags inert without filter flag; no retry chainable.
+- Runtime API: vi.setConfig closed by construction; Math.random stubbing cannot reorder (sequencer's shuffle(tasks, sequence.seed) is seeded, order fixed before any test body runs).
+- Consumer scripts: closed at MECHANISM level — C3 signature forbids any change to those files; the pattern row is defense-in-depth. Every unenumerated flag (--exclude, --testNamePattern, --passWithNoTests, …) already denied wholesale.
+- Config keys: the one surface still guarded by enumeration only — F10.
+
+## Findings
+
+### F10 — Severity: Minor — config file lacks the exclusivity clause its consumer files have; unenumerated config keys (exclude:/include:/passWithNoTests:) ride along un-adjudicated (saturation: prose-only; R42)
+
+**Problem:** Consumer-file surface closed by an exhaustive signature statement ("No change to package.json scripts, pre-pr, or CI workflows"). The config has no equivalent: the signature says the config "gains test.sequence.shuffle: true" — implies but never states that the gain is the ENTIRE diff to that file — and the forbidden list polices it by key enumeration only. Unenumerated gate-neutralizing keys exist: `test.exclude: ['**/dpop-key.test.ts']` removes all 10 DPoP security-control tests from every standing consumer; narrowed `include` + `passWithNoTests: true` shrinks the adjudicated set arbitrarily. Four rounds added config-key spellings one at a time (isolate → shuffle: → retry:/seed:) — the recurring signal that the mechanism, not the member list, should carry the control.
+
+**Impact:** Low — a rogue key must survive PR-diff review of a ~16-line file; but adjudication is implicit where every other surface's is explicit, and the enumeration game has no terminating move.
+
+**Recommended action:** One mechanism-level clause in the C3 signature: "the diff to extension/vitest.config.ts is exactly the single sequence.shuffle: true gate line; any other hunk in that file is a named deviation-log entry, whatever its spelling" (deny = any extra hunk; allow = deviation-log path; fails loudly by construction — diff-shape, not key-name). Keep the existing key-enumerated patterns as high-risk callouts.
+
+No other findings. A5 distinct-seeds has no false-positive path (Date.now()-derived seeds across multi-second runs); comment/string allow path cannot admit options-position occurrences; RS4 unchanged, clean.
+
+## Recurring Issue Check
+
+| Rule | Status |
+|---|---|
+| R1–R2 | N/A |
+| R3 | OK |
+| R4–R15 | N/A |
+| R16 | OK |
+| R17–R28 | N/A |
+| R29 | OK — Round-3 additions carry their own derivation commands and corpus-clean verifications |
+| R30–R32 | N/A |
+| R33 | OK — consumer-flag drift closed at both pattern and signature level |
+| R34 | OK |
+| R35 | N/A |
+| R36 | OK — suppression class closed over dot, options, retry, destructured-skip, assertion-deletion spellings |
+| R37–R41 | N/A |
+| R42 | Finding F10 (config-key surface enumeration-guarded; exclusivity clause missing) |
+| R43 | N/A |
+| R44 | OK — seed-pinning laundering closed |
+| R45–R46 | N/A |
+| R47 | OK — every banned spelling's regex at least as strong as the spelling; residues honestly listed |
+| R48 | N/A |
+| R49 | OK — four-residue statement matches implementation |
+| R50 | OK |
+| R51–R57 | N/A |
+| RS1–RS3 | N/A |
+| RS4 | OK |
+| RS5–RS6 | N/A |
+
+```json
+[
+  {"id":"F10","severity":"Minor","title":"Config file lacks the exclusivity clause consumer files have; unenumerated keys (exclude/include/passWithNoTests) escape the pattern list","file":"docs/archive/review/extension-test-order-deps-plan.md","line":285,"adjacent":false,"escalate":null}
+]
+```
+# QA/Testing Review — Round 4 (incremental)
+
+## Verification performed
+- #1 (C2 five-subset enumeration + commands): coverage clause enumerates all five subsets matching the five Set B bullets one-to-one; every bullet records a derivation command. Commands verified: stubGlobal for-loop → 23 (ran it); let-set → 10; M3 → 12; spyOn → 3; widened override grep. Reconciliation's left side exists for every subset. Stale sentence replaced. Resolved.
+- #2 (bare-shuffle deny/allow): overclaim gone; deny boundary + allow path stated. Config-side corpus claim verified: zero `seed` occurrences (case-insensitive) in tests, config, package.json. Resolved (one wording nit — F1).
+- #3 (consumer row + A5 distinctness + four residues): vitest citation verified verbatim (coverage.DM_a_rWm.js:481). A5 false-fail check: seed granularity is ms and each run is a fresh ~7 s process, so pairwise-distinct seeds are guaranteed on legitimate execution — the clause cannot false-fail, and composes with the rtk capture note. Four-residue statement maps one-to-one onto the pattern rows. No forbidden row matches the PR's own planned diff.
+- #4 (I4 early-exit clause): consistent with residue note; destructured skip I4-owned in both places. Resolved.
+
+## Findings
+
+### F1 — Minor (prose-only, R29): allow-path example misattributes culprit-naming comments to an I2 mandate
+The bare-shuffle row says "the culprit-naming comments I2 mandates". I2 mandates culprit naming IN THE PHASE 2 DEVIATION LOG, not as in-code comments; no clause mandates such comments in test files. Impact: mild executor confusion (harmless extra work, or a reviewer demanding comments). Allow-path function unaffected.
+Fix: reword to "e.g., an optional culprit-naming comment such as 'leak surfaced by the shuffle gate at seed N' (the mandated location for culprit naming is I2's deviation log)". Nothing else changes.
+
+No other findings. Coordinator-flagged hazards checked and clean: A5 distinctness cannot false-fail; five-subset enumeration matches bullets exactly with verified command per subset; no acceptance can false-fail on legitimate execution; four-residue statement / pattern rows / I4 / residue note mutually consistent.
+
+## Round-3 resolution assessment
+Both Round-3 findings fully resolved (F1 fifth subset enumerated + command recorded + fail-loud guard armed; F2 overclaim removed, deny boundary + flagged-not-failed allow path wired to I4).
+
+## Recurring Issue Check
+R29: Finding F1 (I2-mandate misattribution); all other claims verified OK. R3/R12/R16/R18/R21/R33/R34/R36/R41/R42/R44/R45/R47/R48/R49/R50/R54: OK. Others N/A.
+RT1/RT2/RT4/RT7/RT9/RT10/RT11: OK; RT3/RT5/RT6/RT8: N/A. RT4 note: A5 soak now provably samples 10 distinct permutations.
+
+```json
+[
+  {"id":"F1","severity":"Minor","title":"Bare-shuffle allow path misattributes culprit-naming comments to an I2 mandate (I2 mandates the deviation log, not code comments)","file":"docs/archive/review/extension-test-order-deps-plan.md","line":344,"adjacent":false,"escalate":null}
+]
+```# Functionality Review — Round 4 (incremental)
+
+## Round-3 resolution verification
+- F11 resolved: consumer row + config row + A5 distinctness + four residues. Claims verified by execution: `resolved.sequence.seed ??= Date.now()` exists verbatim (coverage.DM_a_rWm.js:481, gated on shuffle active); zero-`seed` corpus claim accurate; new consumer-file regex has zero baseline matches in package.json / pre-pr.sh / workflows. A5 distinctness logic sound (Date.now()-derived seeds per run; a repeat can only mean pinning or capture failure).
+- F12 resolved: stale sentence gone; stubGlobal bullet carries verbatim command (→23, re-verified); let bullet carries command (→10); all five Set B bullets carry commands — claim true.
+- F13 resolved: deny boundary + allow path stated; overclaim removed.
+- Security F9 consistent: I4 early-exit clause closes the unreachable-assertions hole; coheres with residues note.
+
+## New findings
+
+### F14 — Minor (design-level narrow residue, R47): a committed `sequencer:` in the config silently un-randomizes the file-order axis while the gate still looks fully on
+Verified against installed 4.1.10 (coverage.DM_a_rWm.js:470-481): boolean-shuffle assigns RandomSequencer only under `if (!resolved.sequence?.sequencer)` — a user-supplied `sequence: { shuffle: true, sequencer: BaseSequencer }` is respected, so file order reverts to cache/duration sort while shuffle stays truthy: in-file shuffling continues AND the seed line still prints (cli-api:1993 fires on the `|| shuffle` arm). Config-side pattern `(shuffle|seed)\s*:` does not match `sequencer\s*:`. Neutralizes only the SECONDARY axis (cross-file guard; zero known members today — fact 1, isolate default), hence Minor. CLI exposure nil (option takes a class, not a string) — consumer row needs no change.
+Fix: widen config pattern to `(shuffle|seed|sequencer)\s*:` — corpus-clean (none of the three tokens in current config; verified), no false-positive baseline, allow path unchanged; a legitimate custom sequencer takes the sibling rows' deviation-log path.
+
+No other findings: the four revisions are correct and internally consistent; every new quantitative/cited claim reproduced under execution.
+
+## Recurring Issue Check
+R29: OK (all Round-4 claims verified: seed-default line verbatim; zero-seed corpus true; regex baselines clean; five-bullets-with-commands true). R47: Finding F14. R3/R16/R18/R33/R34/R36/R41/R42/R44/R45/R48/R49/R50/R53: OK. Others N/A.
+
+```json
+[
+  {"id":"F14","severity":"Minor","title":"Committed sequencer: in config un-randomizes the file-order axis while seed printing and in-file shuffle keep the gate looking on; config-side pattern misses the spelling","file":"docs/archive/review/extension-test-order-deps-plan.md","line":344,"adjacent":false,"escalate":null}
+]
+```
+---
+
+# Plan Review: extension-test-order-deps — Round 5 (final)
+Date: 2026-08-22
+Review round: 5
+
+## Changes from Previous Round
+All 3 Round-4 Minor findings applied (config-diff exclusivity clause; I2-mandate reword; (shuffle|seed|sequencer) config pattern).
+
+## Round-5 verdicts
+- Functionality expert: No findings (all Round-4 fixes verified; three-token corpus re-verified by execution; exclusivity clause composes with the setup.ts contingency from the functionality reading).
+- Security expert: No findings (all four writable surfaces closed at mechanism level or by construction; reviewer also corrected their own Round-2 isolated-line reading of the sequencer guard).
+- Testing expert: 1 Minor, prose-only (R48) — exclusivity clause vs setup.ts contingency adjudicate one predicate differently. RESOLVED in the plan immediately: the clause now names the setupFiles contingency as the single plan-foreseen exception, admitted with its own red-proof/full-sweep evidence and still recorded as a named entry.
+
+## Saturation call (per Step 1-6 criteria)
+All four conditions hold for Round 5:
+1. Five rounds completed (Round 1 full; Rounds 2-5 incremental).
+2. No Critical or Major finding open in any category (Round-5's single Minor is resolved in the plan file, not dispositioned away).
+3. No finding against the design itself — the sole Round-5 finding was labeled prose-only (R48) by the expert who filed it; the two other experts returned No findings.
+4. Every remaining finding: none remain open. (The resolved Minor was kind (a) prose-only.)
+Per-finding labels as filed: test-F1 = prose-only/R48. No Carried-Forward Plan Findings — nothing is open.
+
+Exit: Phase 1 review loop closes at Round 5. Go/No-Go Gate: C1-C4 all locked (no round after locking materially changed a contract's signature/invariants/forbidden list/acceptance without re-review — every change was itself reviewed in the following round, and Round 5 ends with two No-findings and one resolved prose Minor).
+
+# Functionality Review — Round 5 (incremental)
+
+## Round-4 resolution verification
+- **F14 (sequencer:) — resolved.** Config pattern `(shuffle|seed|sequencer)\s*:` with the exact mechanism in the reason text; `if (!resolved.sequence?.sequencer)` guard matches installed 4.1.10 (coverage.DM_a_rWm.js:476-477). Three-token corpus claim re-verified by execution: zero matching files across tests, config, package.json.
+- **Security F10 (exclusivity clause) — verified from the functionality side.** Diff-shape adjudication closes the unenumerated-key family without spelling enumeration; key patterns correctly demoted to callouts. Checked the one potential collision: the Testing-strategy contingency (shared setup.ts → setupFiles hunk) COMPOSES with the clause — the sanctioned path for that hunk is exactly the named deviation-log adjudication the clause prescribes, not a bypass. Single-gate-line diff shape feasible (`sequence: { shuffle: true },` is one line in the existing test object).
+- **Testing F1 (allow-path rewording) — verified.** Consistent with I2's own wording; no drift.
+
+## Findings
+
+No findings.
+
+Cross-checks this round: exclusivity clause vs every plan section touching vitest.config.ts (isolate/(retry|repeats) rows remain consistent as callouts; SC3 keeps environmentMatchGlobs untouched); three-token corpus by execution; A-ID cross-references (A1–A4, A3m, A5–A8) consistent; new citations match lines independently verified in Round 4. Every quantitative or cited claim now has a reproducing command or verified citation; each control declares class, deny boundary, allow path, fail-loud exit.
+
+## Recurring Issue Check
+R3: OK (all propagation gaps rounds 1-4 closed; exclusivity clause closes the residual key-name class mechanically). R16/R18/R29/R33/R34/R36/R41/R42/R44/R45/R47/R48/R49/R50/R53: OK. R47 note: exclusivity clause converts the config surface from spelling enumeration to diff-shape adjudication — the mechanism-level fix for the class F14 instanced. All others N/A.
+
+```json
+[]
+```
+# Security Review — Round 5 (incremental)
+
+Verification: installed source coverage.DM_a_rWm.js:475-477 confirms the ternary assignment IS guarded by `if (!resolved.sequence?.sequencer)` (corrects the reviewer's own Round-2 isolated-line reading) — the plan's sequencer rationale is accurate. Corpus: zero `sequencer` occurrences in tests, config, package.json — three-token corpus-clean claim holds.
+
+**Round-4 fix verification:**
+1. **F10 (config exclusivity clause) — fix correct and complete.** Config diff pinned to exactly the single gate line, adjudicated by diff-shape; other hunks = named deviation entries "whatever its spelling"; examples carried; key patterns retained as callouts. Config surface closed at MECHANISM level — terminates the per-key enumeration game. All four writable surfaces now closed: config (diff-shape exclusivity), consumer scripts (signature no-change + flag pattern), in-test spellings (patterns + I4 absence-inspection), runtime API (closed by construction).
+2. **Testing F1 rewording — no security hole introduced.** Deny boundary unchanged; allow path still named-flagged-passed at C1-I4; rewording narrows, not widens.
+3. **Func F14 (sequencer:) — fix correct, mechanism claim independently verified this round** (supersedes reviewer's Round-2 unconditional-assignment reading). Corpus-clean verified. Layering consistent: exclusivity clause subsumes; pattern = defense-in-depth callout.
+
+Taxonomy note, below finding threshold: adjudication paragraph counts "four surface-form residues" while sequencer: is a partial-freeze variant of residue #4 (freezes the file-order axis only). Member denied by two layers; an undercounted taxonomy does not overstate the control — wording preference, not a defect.
+
+**No findings.**
+
+## Recurring Issue Check
+
+| Rule | Status |
+|---|---|
+| R1–R2 | N/A |
+| R3 | OK |
+| R4–R15 | N/A |
+| R16 | OK |
+| R17–R28 | N/A |
+| R29 | OK — sequencer guard claim reproduced against installed source; three-token corpus-clean reproduced (0 hits) |
+| R30–R32 | N/A |
+| R33 | OK |
+| R34 | OK |
+| R35 | N/A |
+| R36 | OK — suppression class closed; allow paths fail loudly through the deviation log |
+| R37–R41 | N/A |
+| R42 | OK — config surface converted from enumeration to mechanism; all four writable surfaces closed at mechanism level or by construction |
+| R43 | N/A |
+| R44 | OK — exit-code laundering members (retry, seed pinning, sequencer) all denied; A5 distinct-seeds stands |
+| R45–R46 | N/A |
+| R47 | OK — every pattern at least as strong as its target spelling |
+| R48 | N/A |
+| R49 | OK — control class accurate; taxonomy undercount does not overstate |
+| R50 | OK |
+| R51–R57 | N/A |
+| RS1–RS3 | N/A |
+| RS4 | OK |
+| RS5–RS6 | N/A |
+
+```json
+[]
+```
+# QA/Testing Review — Round 5 (incremental)
+
+## Verification performed
+- #2 (Round-4 F1): allow-path example now matches I2's actual text exactly. Resolved.
+- #3 (sequencer row): verified against installed vitest (coverage.DM_a_rWm.js ~477-481): `if (!resolved.sequence?.sequencer)` → `sequencer = shuffle ? RandomSequencer : BaseSequencer` — config `sequencer:` preempts RandomSequencer while in-file shuffle and seed printing continue. Corpus-clean verified: zero case-insensitive occurrences of shuffle/seed/sequencer across tests, config, package.json.
+- #1 (exclusivity clause): coexistence with key-enumerated rows coherent (shape check = mechanism, key rows = callouts; both converge on named-deviation adjudication). One internal tension — F1.
+- No acceptance criterion gained a false-fail path; A5–A8, A1–A4, A3m, four-residue statement, consumer walkthrough mutually consistent.
+
+## Findings
+
+### F1 — Minor (prose-only, R48): config-diff exclusivity clause contradicts the plan's own setup.ts/setupFiles contingency
+C3 Signature says the config diff "is EXACTLY that single gate line", but the Testing strategy pre-sanctions a second hunk (setupFiles: src/__tests__/setup.ts) with its own evidence protocol and no mention of the deviation entry the clause demands. Two clauses adjudicate the same predicate by different semantics. Bounded impact: both routes fail-loud-adjacent; no key pattern falsely fires on a setupFiles hunk (checked).
+Fix: one sentence in the exclusivity clause naming the setupFiles contingency as the single plan-foreseen exception, admitted WITH its evidence and still recorded as a named entry; any other hunk remains a deviation.
+
+No other findings.
+
+## Round-4 resolution assessment
+Round-4 F1 resolved exactly per remedy. Other two revisions check out against ground truth (sequencer mechanism + three-token corpus verified; exclusivity clause mechanically sound — its one prose conflict is F1).
+
+## Recurring Issue Check
+R29: OK (sequencer guard + three-token corpus verified verbatim). R48: Finding F1. R12/R16/R18/R21/R33/R34/R36/R41/R42/R44/R45/R47/R49/R50/R54: OK. RT1/RT2/RT4/RT7/RT9/RT10/RT11: OK. Others N/A.
+
+```json
+[
+  {"id":"F1","severity":"Minor","title":"Config-diff exclusivity clause contradicts the plan's own sanctioned setupFiles contingency (two clauses adjudicate the same hunk differently)","file":"docs/archive/review/extension-test-order-deps-plan.md","line":287,"adjacent":false,"escalate":null}
+]
+```

--- a/docs/archive/review/extension-test-order-deps-review.md
+++ b/docs/archive/review/extension-test-order-deps-review.md
@@ -297,60 +297,60 @@ Convergence stamps per 'Perspective Convergence as a Severity Signal': R2-1/R2-2
 
 ### Major
 
-**Severity**: Major  
-**Problem**: The widened pattern-2 command and the module-scope-`let` count use `--include='*.test.ts'`, excluding 7 `.test.tsx` files. Recomputation reveals 5 dropped files carry `.mock(ReturnValue|ResolvedValue|RejectedValue|Implementation)(` hits (including M1-shaped Once-less overrides in `popup/App.test.tsx`). Reconciliation is self-referential against the same filtered commands.  
-**Impact**: Five candidate files structurally drop out of the C2 audit, and C2's row-count reconciliation cannot notice because it reconciles against the same filtered commands' output.  
-**Recommended action**: Change include filters to `--include='*.test.ts*'` (or drop `--include`), re-run, add new hits to the C2 table. Boundary: the filter must admit every file vitest's default include admits; reconcile counts from corrected commands.  
+**Severity**: Major
+**Problem**: The widened pattern-2 command and the module-scope-`let` count use `--include='*.test.ts'`, excluding 7 `.test.tsx` files. Recomputation reveals 5 dropped files carry `.mock(ReturnValue|ResolvedValue|RejectedValue|Implementation)(` hits (including M1-shaped Once-less overrides in `popup/App.test.tsx`). Reconciliation is self-referential against the same filtered commands.
+**Impact**: Five candidate files structurally drop out of the C2 audit, and C2's row-count reconciliation cannot notice because it reconciles against the same filtered commands' output.
+**Recommended action**: Change include filters to `--include='*.test.ts*'` (or drop `--include`), re-run, add new hits to the C2 table. Boundary: the filter must admit every file vitest's default include admits; reconcile counts from corrected commands.
 *Flagged by*: Functionality
 
-**Severity**: Major  
-**Problem**: The M3 derivation command keys on the literal `background/index`, leaving Phase 2 name-supply to judgment. Recomputation finds 12 files containing `mockResolvedValueOnce`; the command matches only 4. Excluded files (e.g., `content/token-bridge.test.ts`, `popup/App.test.tsx`, `popup/MatchList.test.tsx`) have unawaited consumers by construction. Verdicts are never recorded.  
-**Impact**: An M3-class race in an excluded file stays latent; the shuffle gate cannot sample it (bypass (b)) and A8's single pre-pr run is one sample.  
-**Recommended action**: Make the candidate set input-derived: every `mockResolvedValueOnce` file is an M3-classification candidate (12 rows). Reconciliation then counts against `grep -rl 'mockResolvedValueOnce' .`, which cannot under-derive its own left side.  
+**Severity**: Major
+**Problem**: The M3 derivation command keys on the literal `background/index`, leaving Phase 2 name-supply to judgment. Recomputation finds 12 files containing `mockResolvedValueOnce`; the command matches only 4. Excluded files (e.g., `content/token-bridge.test.ts`, `popup/App.test.tsx`, `popup/MatchList.test.tsx`) have unawaited consumers by construction. Verdicts are never recorded.
+**Impact**: An M3-class race in an excluded file stays latent; the shuffle gate cannot sample it (bypass (b)) and A8's single pre-pr run is one sample.
+**Recommended action**: Make the candidate set input-derived: every `mockResolvedValueOnce` file is an M3-classification candidate (12 rows). Reconciliation then counts against `grep -rl 'mockResolvedValueOnce' .`, which cannot under-derive its own left side.
 *Flagged by*: Functionality
 
-**Severity**: Major  
-**Problem**: The test-side opt-out regex `\{\s*shuffle\s*:\s*false` is brace-anchored, missing multi-key option objects like `describe("x", { concurrent: true, shuffle: false }, …)`. The companion `shuffle\s*:` is scoped only to `extension/vitests.config.ts`. Zero hits exist under `extension/src/__tests__/`, so a maximally broad pattern carries zero false-positive cost.  
-**Impact**: A suite can opt out of the gate through a spelling the declared residue control does not flag.  
-**Recommended action**: Replace the test-side pattern with unanchored `shuffle\s*:\s*false` (or bare `shuffle`) under `extension/src/__tests__/`. Keep `describe\.shuffle` for readability. Explicitly state the config-side scope.  
+**Severity**: Major
+**Problem**: The test-side opt-out regex `\{\s*shuffle\s*:\s*false` is brace-anchored, missing multi-key option objects like `describe("x", { concurrent: true, shuffle: false }, …)`. The companion `shuffle\s*:` is scoped only to `extension/vitests.config.ts`. Zero hits exist under `extension/src/__tests__/`, so a maximally broad pattern carries zero false-positive cost.
+**Impact**: A suite can opt out of the gate through a spelling the declared residue control does not flag.
+**Recommended action**: Replace the test-side pattern with unanchored `shuffle\s*:\s*false` (or bare `shuffle`) under `extension/src/__tests__/`. Keep `describe\.shuffle` for readability. Explicitly state the config-side scope.
 *Flagged by*: Functionality, Security
 
-**Severity**: Major  
-**Problem**: A7 compares `npm test` wall-clock before/after. The before-side is fact 4's idle-machine measurement (~6.2–7.2 s). A8 designates the "Extension: Test" step duration from pre-pr's batch 1 (concurrent with Lint/Test/Build/CLI: Build) as the after-number. This measures CPU contention, not the shuffle delta.  
-**Impact**: Either a spurious "materially worse" report to the user, or a real shuffle regression hidden inside contention noise. Both corrupt C4's closure evidence.  
-**Recommended action**: Derive A7's two numbers from the same idle environment: idle `npx vitest run --sequence.shuffle=false` (before) vs. idle config-shuffled `npm test` (after). Keep A8's step duration as supplementary contended-environment evidence.  
+**Severity**: Major
+**Problem**: A7 compares `npm test` wall-clock before/after. The before-side is fact 4's idle-machine measurement (~6.2–7.2 s). A8 designates the "Extension: Test" step duration from pre-pr's batch 1 (concurrent with Lint/Test/Build/CLI: Build) as the after-number. This measures CPU contention, not the shuffle delta.
+**Impact**: Either a spurious "materially worse" report to the user, or a real shuffle regression hidden inside contention noise. Both corrupt C4's closure evidence.
+**Recommended action**: Derive A7's two numbers from the same idle environment: idle `npx vitest run --sequence.shuffle=false` (before) vs. idle config-shuffled `npm test` (after). Keep A8's step duration as supplementary contended-environment evidence.
 *Flagged by*: Functionality, QA/Testing
 
-**Severity**: Major  
-**Problem**: A3m's "reds EVERY run" depends on flush placement, but I3 specifies the flush only as "before the test ends". Natural end-of-test placement allows intended consumers to drain the Once queue in order, leaving the fire-and-forget consumer with an exhausted queue. This causes the deny-run to green instead of red, breaking the minimal-pair property.  
-**Impact**: The acceptance criterion built to prove M3 can fail to red for a construction reason, leaving M3 falsely "hypothesized" or requiring ad-hoc executor fixes that break the minimal-pair property.  
-**Recommended action**: Specify in A3m that the red-proof flush sits **at the steal window** — immediately after the fire-and-forget trigger (post-unlock), before intended consumers. The deny/allow pair must use the identical test body, differing only in mock keying. I3's end-of-test flush coexists for miss-attribution.  
+**Severity**: Major
+**Problem**: A3m's "reds EVERY run" depends on flush placement, but I3 specifies the flush only as "before the test ends". Natural end-of-test placement allows intended consumers to drain the Once queue in order, leaving the fire-and-forget consumer with an exhausted queue. This causes the deny-run to green instead of red, breaking the minimal-pair property.
+**Impact**: The acceptance criterion built to prove M3 can fail to red for a construction reason, leaving M3 falsely "hypothesized" or requiring ad-hoc executor fixes that break the minimal-pair property.
+**Recommended action**: Specify in A3m that the red-proof flush sits **at the steal window** — immediately after the fire-and-forget trigger (post-unlock), before intended consumers. The deny/allow pair must use the identical test body, differing only in mock keying. I3's end-of-test flush coexists for miss-attribution.
 *Flagged by*: Functionality, QA/Testing
 
-**Severity**: Major  
-**Problem**: `TestOptions.retry` (and config-level `retry`/`repeats`) exists on the installed surface but matches no forbidden pattern. `{ retry: 2 }` permanently absorbs the gate's exit-code signal for intermittent members without a skip marker, neutralizing the tail-closure mechanism of C3.  
-**Impact**: The gate stays green while the order-dependence class re-accumulates; the standing gate's closure is bypassed by a socially normal "flaky test fix".  
-**Recommended action**: Add forbidden patterns: `retry\s*:` and `repeats\s*:` under `extension/src/__tests__/` and `extension/vitests.config.ts`. Require a deviation-log entry naming the nondeterminism source and an issue link for genuine retries. Verified zero false positives in current extension tests.  
+**Severity**: Major
+**Problem**: `TestOptions.retry` (and config-level `retry`/`repeats`) exists on the installed surface but matches no forbidden pattern. `{ retry: 2 }` permanently absorbs the gate's exit-code signal for intermittent members without a skip marker, neutralizing the tail-closure mechanism of C3.
+**Impact**: The gate stays green while the order-dependence class re-accumulates; the standing gate's closure is bypassed by a socially normal "flaky test fix".
+**Recommended action**: Add forbidden patterns: `retry\s*:` and `repeats\s*:` under `extension/src/__tests__/` and `extension/vitests.config.ts`. Require a deviation-log entry naming the nondeterminism source and an issue link for genuine retries. Verified zero false positives in current extension tests.
 *Flagged by*: Security
 
 ### Minor
 
-**Severity**: Minor  
-**Problem**: C4's acceptance clause states "all acceptance IDs A1–A8 present with commands and outputs." A3m falls outside the lexical A1..A8 range. A checklist-driven executor can omit A3m's evidence without triggering the clause.  
-**Impact**: The M3 proof — the plan's most fragile evidence item — is at risk of being skipped by strict ID-range checklists.  
-**Recommended action**: Update text to "A1–A4, A3m, A5–A8 present with commands and outputs (A3m may instead be a named deviation-log entry per its fallback)".  
+**Severity**: Minor
+**Problem**: C4's acceptance clause states "all acceptance IDs A1–A8 present with commands and outputs." A3m falls outside the lexical A1..A8 range. A checklist-driven executor can omit A3m's evidence without triggering the clause.
+**Impact**: The M3 proof — the plan's most fragile evidence item — is at risk of being skipped by strict ID-range checklists.
+**Recommended action**: Update text to "A1–A4, A3m, A5–A8 present with commands and outputs (A3m may instead be a named deviation-log entry per its fallback)".
 *Flagged by*: Functionality, QA/Testing
 
-**Severity**: Minor  
-**Problem**: The options-object pattern bans `(skip|todo|fails)\s*:\s*true` but omits `only?: boolean`. `it("x", { only: true }, fn)` narrows suites without a dot-form `.only(`. Additionally, destructured `ctx.skip` contains no `.skip(` substring.  
-**Impact**: Local pre-pr runs without `CI` would silently pass narrowed suites; destructured skip goes uncaught by grep-based residue control.  
-**Recommended action**: Change the options pattern to `(skip|todo|fails|only)\s*:\s*true`. Add destructured `ctx.skip` to the un-greppable-residue sentence so C1-I4's diff inspection explicitly owns it.  
+**Severity**: Minor
+**Problem**: The options-object pattern bans `(skip|todo|fails)\s*:\s*true` but omits `only?: boolean`. `it("x", { only: true }, fn)` narrows suites without a dot-form `.only(`. Additionally, destructured `ctx.skip` contains no `.skip(` substring.
+**Impact**: Local pre-pr runs without `CI` would silently pass narrowed suites; destructured skip goes uncaught by grep-based residue control.
+**Recommended action**: Change the options pattern to `(skip|todo|fails|only)\s*:\s*true`. Add destructured `ctx.skip` to the un-greppable-residue sentence so C1-I4's diff inspection explicitly owns it.
 *Flagged by*: Security
 
-**Severity**: Minor  
-**Problem**: I4 (C1 assertion-weakening check) is scoped to "victim tests", but the plan's fixes typically edit *culprit* tests. Reading I4 literally excludes the actually-edited tests from assertion-strengthening verification.  
-**Impact**: Assertion-weakening in culprit tests escapes adjudication.  
-**Recommended action**: Reword I4 from "victim tests'" to "all tests in files edited under C1/C2" — assertions unchanged or strengthened, verified by PR-diff inspection.  
+**Severity**: Minor
+**Problem**: I4 (C1 assertion-weakening check) is scoped to "victim tests", but the plan's fixes typically edit *culprit* tests. Reading I4 literally excludes the actually-edited tests from assertion-strengthening verification.
+**Impact**: Assertion-weakening in culprit tests escapes adjudication.
+**Recommended action**: Reword I4 from "victim tests'" to "all tests in files edited under C1/C2" — assertions unchanged or strengthened, verified by PR-diff inspection.
 *Flagged by*: Security
 
 ## Recurring Issue Check

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../lib/constants";
 import { DISCONNECT_REASON } from "../lib/disconnect-reason";
 import { EXT_API_PATH, extApiPath } from "../lib/api-paths";
+import { createKeyedDecryptMock } from "./helpers/keyed-decrypt-mock";
 import type { SessionState } from "../lib/session-storage";
 
 const PASSWORD_BY_ID_PREFIX = extApiPath.passwordById("");
@@ -84,15 +85,8 @@ const DEFAULT_OVERVIEW_PLAINTEXT = JSON.stringify({
   username: "alice",
   urlHost: "example.com",
 });
-let decryptResponses: Record<string, string> = {};
-
-/** Register the plaintext decryptData resolves to for a given ciphertext. Throws
- * on an unmapped ciphertext (see the mockImplementation below) instead of
- * silently returning undefined, so a coverage gap fails loudly in the test that
- * exposed it rather than diverging silently. */
-function setDecryptedPlaintext(ciphertext: string, plaintext: string): void {
-  decryptResponses[ciphertext] = plaintext;
-}
+const keyedDecrypt = createKeyedDecryptMock(cryptoMocks.decryptData);
+const setDecryptedPlaintext = keyedDecrypt.set;
 
 function installChromeMock() {
   messageHandlers = [];
@@ -238,21 +232,8 @@ describe("background message flow", () => {
     chromeMock = installChromeMock();
 
     // Fresh, input-keyed decryptData for every test regardless of what a
-    // preceding test (in any order) registered — vi.clearAllMocks() clears call
-    // history but not implementations, so without this a persistent override or
-    // a leftover keyed entry from an earlier test would otherwise carry forward.
-    decryptResponses = { "11": DEFAULT_OVERVIEW_PLAINTEXT };
-    cryptoMocks.decryptData.mockImplementation(
-      async (encrypted: { ciphertext: string }) => {
-        const plaintext = decryptResponses[encrypted.ciphertext];
-        if (plaintext === undefined) {
-          throw new Error(
-            `decryptData mock miss: no keyed response registered for ciphertext "${encrypted.ciphertext}"`,
-          );
-        }
-        return plaintext;
-      },
-    );
+    // preceding test (in any order) registered — see helpers/keyed-decrypt-mock.
+    keyedDecrypt.install({ "11": DEFAULT_OVERVIEW_PLAINTEXT });
 
     vi.stubGlobal(
       "fetch",

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -70,6 +70,30 @@ let contextMenuClickHandlers: Array<
   (info: Record<string, unknown>, tab: Record<string, unknown> | undefined) => void
 > = [];
 
+// decryptData is keyed on its input ciphertext rather than call order: UNLOCK_VAULT
+// fires an unawaited context-menu rebuild (invalidateContextMenu -> debounced
+// doUpdateMenu -> getCachedEntries -> decryptOverviews) that also calls decryptData
+// for the overview ciphertext. With a positional mockResolvedValueOnce queue, that
+// extra call can steal the slot a test set up for its own blob/overview decrypt,
+// depending on real-clock timing (the menu rebuild is a real 200ms setTimeout) —
+// an order/timing-dependent failure, not a wrong-but-valid substitution. Keying on
+// the ciphertext removes the race entirely: every caller of decryptData for a given
+// ciphertext gets the same deterministic answer regardless of who called it or when.
+const DEFAULT_OVERVIEW_PLAINTEXT = JSON.stringify({
+  title: "Example",
+  username: "alice",
+  urlHost: "example.com",
+});
+let decryptResponses: Record<string, string> = {};
+
+/** Register the plaintext decryptData resolves to for a given ciphertext. Throws
+ * on an unmapped ciphertext (see the mockImplementation below) instead of
+ * silently returning undefined, so a coverage gap fails loudly in the test that
+ * exposed it rather than diverging silently. */
+function setDecryptedPlaintext(ciphertext: string, plaintext: string): void {
+  decryptResponses[ciphertext] = plaintext;
+}
+
 function installChromeMock() {
   messageHandlers = [];
   alarmHandlers = [];
@@ -212,6 +236,23 @@ describe("background message flow", () => {
     vi.resetModules();
     vi.clearAllMocks();
     chromeMock = installChromeMock();
+
+    // Fresh, input-keyed decryptData for every test regardless of what a
+    // preceding test (in any order) registered — vi.clearAllMocks() clears call
+    // history but not implementations, so without this a persistent override or
+    // a leftover keyed entry from an earlier test would otherwise carry forward.
+    decryptResponses = { "11": DEFAULT_OVERVIEW_PLAINTEXT };
+    cryptoMocks.decryptData.mockImplementation(
+      async (encrypted: { ciphertext: string }) => {
+        const plaintext = decryptResponses[encrypted.ciphertext];
+        if (plaintext === undefined) {
+          throw new Error(
+            `decryptData mock miss: no keyed response registered for ciphertext "${encrypted.ciphertext}"`,
+          );
+        }
+        return plaintext;
+      },
+    );
 
     vi.stubGlobal(
       "fetch",
@@ -644,9 +685,7 @@ describe("background message flow", () => {
   });
 
   it("returns password for COPY_PASSWORD", async () => {
-    cryptoMocks.decryptData.mockResolvedValueOnce(
-      JSON.stringify({ password: "secret" })
-    );
+    setDecryptedPlaintext("aa", JSON.stringify({ password: "secret" }));
     applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
 
@@ -703,9 +742,8 @@ describe("background message flow", () => {
   });
 
   it("autofills successfully", async () => {
-    cryptoMocks.decryptData
-      .mockResolvedValueOnce(JSON.stringify({ password: "secret" }))
-      .mockResolvedValueOnce(JSON.stringify({ username: "alice" }));
+    setDecryptedPlaintext("aa", JSON.stringify({ password: "secret" }));
+    setDecryptedPlaintext("11", JSON.stringify({ username: "alice" }));
 
     applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
@@ -720,11 +758,11 @@ describe("background message flow", () => {
   });
 
   it("autofills with blob username fallback when overview username is missing", async () => {
-    cryptoMocks.decryptData
-      .mockResolvedValueOnce(
-        JSON.stringify({ password: "secret", loginId: "fallback-user" }),
-      )
-      .mockResolvedValueOnce(JSON.stringify({ username: null }));
+    setDecryptedPlaintext(
+      "aa",
+      JSON.stringify({ password: "secret", loginId: "fallback-user" }),
+    );
+    setDecryptedPlaintext("11", JSON.stringify({ username: null }));
 
     applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
@@ -739,18 +777,18 @@ describe("background message flow", () => {
   });
 
   it("includes text custom fields in autofill payload", async () => {
-    cryptoMocks.decryptData
-      .mockResolvedValueOnce(
-        JSON.stringify({
-          password: "secret",
-          customFields: [
-            { label: "brchNum", value: "001", type: "text" },
-            { label: "apiKey", value: "sk-123", type: "hidden" },
-            { label: "https://example.com", value: "https://example.com", type: "url" },
-          ],
-        }),
-      )
-      .mockResolvedValueOnce(JSON.stringify({ username: "alice" }));
+    setDecryptedPlaintext(
+      "aa",
+      JSON.stringify({
+        password: "secret",
+        customFields: [
+          { label: "brchNum", value: "001", type: "text" },
+          { label: "apiKey", value: "sk-123", type: "hidden" },
+          { label: "https://example.com", value: "https://example.com", type: "url" },
+        ],
+      }),
+    );
+    setDecryptedPlaintext("11", JSON.stringify({ username: "alice" }));
 
     applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
@@ -768,7 +806,8 @@ describe("background message flow", () => {
   });
 
   it("suppresses inline matches on passwd-sso origin", async () => {
-    cryptoMocks.decryptData.mockResolvedValueOnce(
+    setDecryptedPlaintext(
+      "11",
       JSON.stringify({
         title: "Local entry",
         username: "local-user",
@@ -920,10 +959,8 @@ describe("background message flow", () => {
 
   it("succeeds via sendMessage even when executeScript injection fails", async () => {
     chromeMock?.scripting.executeScript.mockRejectedValue(new Error("CSP"));
-    cryptoMocks.decryptData.mockReset();
-    cryptoMocks.decryptData
-      .mockResolvedValueOnce(JSON.stringify({ password: "secret" }))
-      .mockResolvedValueOnce(JSON.stringify({ username: "alice" }));
+    setDecryptedPlaintext("aa", JSON.stringify({ password: "secret" }));
+    setDecryptedPlaintext("11", JSON.stringify({ username: "alice" }));
 
     applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
@@ -934,9 +971,8 @@ describe("background message flow", () => {
   });
 
   it("retries direct inject without hint when args are unserializable", async () => {
-    cryptoMocks.decryptData
-      .mockResolvedValueOnce(JSON.stringify({ password: "secret" }))
-      .mockResolvedValueOnce(JSON.stringify({ username: "alice", urlHost: "example.com" }));
+    setDecryptedPlaintext("aa", JSON.stringify({ password: "secret" }));
+    setDecryptedPlaintext("11", JSON.stringify({ username: "alice", urlHost: "example.com" }));
 
     // Message-based autofill must fail so direct fallback runs.
     chromeMock?.tabs.sendMessage.mockRejectedValueOnce(
@@ -1014,19 +1050,19 @@ describe("background message flow", () => {
       }),
     );
 
-    cryptoMocks.decryptData
-      .mockResolvedValueOnce(
-        JSON.stringify({
-          givenName: "Jane",
-          familyName: "Doe",
-          addressLine1: "123 Main St",
-          city: "Springfield",
-          state: "CA",
-          postalCode: "90210",
-          country: "US",
-        }),
-      )
-      .mockResolvedValueOnce(JSON.stringify({ username: "Jane Doe" }));
+    setDecryptedPlaintext(
+      "aa",
+      JSON.stringify({
+        givenName: "Jane",
+        familyName: "Doe",
+        addressLine1: "123 Main St",
+        city: "Springfield",
+        state: "CA",
+        postalCode: "90210",
+        country: "US",
+      }),
+    );
+    setDecryptedPlaintext("11", JSON.stringify({ username: "Jane Doe" }));
 
     applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
@@ -1102,13 +1138,11 @@ describe("background message flow", () => {
         return { ok: false, json: async () => ({}) };
       }),
     );
-    // Reset the once-queue: vi.clearAllMocks() (beforeEach) does not clear
-    // mockResolvedValueOnce values, and the sender-host fail-closed tests
-    // reject before consuming their two decrypts, leaving stale queue entries.
-    cryptoMocks.decryptData.mockReset();
-    cryptoMocks.decryptData
-      .mockResolvedValueOnce(JSON.stringify({ password: "secret", username: "alice" }))
-      .mockResolvedValueOnce(JSON.stringify(overview));
+    // Keyed by ciphertext (see decryptResponses above), so the sender-host
+    // fail-closed tests below — which reject before consuming either decrypt —
+    // never leave a stale entry for a later test to trip over.
+    setDecryptedPlaintext("aa", JSON.stringify({ password: "secret", username: "alice" }));
+    setDecryptedPlaintext("11", JSON.stringify(overview));
   };
 
   it("rejects a content-driven LOGIN fill when the sender host does not match the entry host", async () => {
@@ -1350,7 +1384,8 @@ describe("background message flow", () => {
     );
     applyToken("t", Date.now() + 60_000, "");
     await sendMessage({ type: "UNLOCK_VAULT", passphrase: "pw" });
-    cryptoMocks.decryptData.mockResolvedValue(
+    setDecryptedPlaintext(
+      "aa",
       JSON.stringify({ title: "Card", cardNumber: "4111111111111111", cvv: "123" }),
     );
 

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -225,15 +225,22 @@ function sendMessageWithSender(message: unknown, sender: unknown): Promise<unkno
   });
 }
 
+// FILE-LEVEL hook, deliberately outside every describe: the keyed decryptData
+// implementation and its response map are module-scope state, so installing
+// them from only one describe's beforeEach would leak the last flow test's
+// map entries into the other nine describes (which run clearAllMocks only —
+// call history, not implementations). Outer hooks run before inner ones, so
+// a describe that re-establishes its own decryptData (e.g. "tab event badge
+// updates") deterministically wins over this default.
+beforeEach(() => {
+  keyedDecrypt.install({ "11": DEFAULT_OVERVIEW_PLAINTEXT });
+});
+
 describe("background message flow", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
     chromeMock = installChromeMock();
-
-    // Fresh, input-keyed decryptData for every test regardless of what a
-    // preceding test (in any order) registered — see helpers/keyed-decrypt-mock.
-    keyedDecrypt.install({ "11": DEFAULT_OVERVIEW_PLAINTEXT });
 
     vi.stubGlobal(
       "fetch",
@@ -1119,7 +1126,7 @@ describe("background message flow", () => {
         return { ok: false, json: async () => ({}) };
       }),
     );
-    // Keyed by ciphertext (see decryptResponses above), so the sender-host
+    // Keyed by ciphertext (see helpers/keyed-decrypt-mock), so the sender-host
     // fail-closed tests below — which reject before consuming either decrypt —
     // never leave a stale entry for a later test to trip over.
     setDecryptedPlaintext("aa", JSON.stringify({ password: "secret", username: "alice" }));

--- a/extension/src/__tests__/background/totp-handlers.test.ts
+++ b/extension/src/__tests__/background/totp-handlers.test.ts
@@ -3,6 +3,7 @@ import {
   EXT_ENTRY_TYPE,
 } from "../../lib/constants";
 import { EXT_API_PATH, extApiPath } from "../../lib/api-paths";
+import { createKeyedDecryptMock } from "../helpers/keyed-decrypt-mock";
 
 const PASSWORD_BY_ID_PREFIX = extApiPath.passwordById("");
 
@@ -32,34 +33,15 @@ const DEFAULT_OVERVIEW_PLAINTEXT = JSON.stringify({
   username: "alice",
   urlHost: "example.com",
 });
-let decryptResponses: Record<string, string> = {};
-
-/** Register the plaintext decryptData resolves to for a given ciphertext.
- * Input-keyed, not positional: UNLOCK_VAULT schedules a fire-and-forget
- * context-menu refresh (real 200 ms debounce) whose overview decrypt would
- * steal a positional Once slot under load — the pre-pr NO_PASSWORD flake in
- * issue #784. An unmapped ciphertext throws so a coverage gap fails loudly in
- * the test that exposed it instead of diverging silently. */
-function setDecryptedPlaintext(ciphertext: string, plaintext: string): void {
-  decryptResponses[ciphertext] = plaintext;
-}
+const keyedDecrypt = createKeyedDecryptMock(cryptoMocks.decryptData);
+const setDecryptedPlaintext = keyedDecrypt.set;
 
 function installKeyedDecryptData(): void {
   // "11" is the overview ciphertext every fetch stub in this file returns —
   // the only input the fire-and-forget consumer ever requests, so it is
-  // always mapped and the consumer can never hit the miss path.
-  decryptResponses = { "11": DEFAULT_OVERVIEW_PLAINTEXT };
-  cryptoMocks.decryptData.mockImplementation(
-    async (encrypted: { ciphertext: string }) => {
-      const plaintext = decryptResponses[encrypted.ciphertext];
-      if (plaintext === undefined) {
-        throw new Error(
-          `decryptData mock miss: no keyed response registered for ciphertext "${encrypted.ciphertext}"`,
-        );
-      }
-      return plaintext;
-    },
-  );
+  // always mapped and the consumer can never hit the miss path
+  // (see helpers/keyed-decrypt-mock for the rationale).
+  keyedDecrypt.install({ "11": DEFAULT_OVERVIEW_PLAINTEXT });
 }
 
 type MessageHandler = (

--- a/extension/src/__tests__/background/totp-handlers.test.ts
+++ b/extension/src/__tests__/background/totp-handlers.test.ts
@@ -27,6 +27,41 @@ const cryptoMocks = vi.hoisted(() => ({
 
 vi.mock("../../lib/crypto", () => cryptoMocks);
 
+const DEFAULT_OVERVIEW_PLAINTEXT = JSON.stringify({
+  title: "Example",
+  username: "alice",
+  urlHost: "example.com",
+});
+let decryptResponses: Record<string, string> = {};
+
+/** Register the plaintext decryptData resolves to for a given ciphertext.
+ * Input-keyed, not positional: UNLOCK_VAULT schedules a fire-and-forget
+ * context-menu refresh (real 200 ms debounce) whose overview decrypt would
+ * steal a positional Once slot under load — the pre-pr NO_PASSWORD flake in
+ * issue #784. An unmapped ciphertext throws so a coverage gap fails loudly in
+ * the test that exposed it instead of diverging silently. */
+function setDecryptedPlaintext(ciphertext: string, plaintext: string): void {
+  decryptResponses[ciphertext] = plaintext;
+}
+
+function installKeyedDecryptData(): void {
+  // "11" is the overview ciphertext every fetch stub in this file returns —
+  // the only input the fire-and-forget consumer ever requests, so it is
+  // always mapped and the consumer can never hit the miss path.
+  decryptResponses = { "11": DEFAULT_OVERVIEW_PLAINTEXT };
+  cryptoMocks.decryptData.mockImplementation(
+    async (encrypted: { ciphertext: string }) => {
+      const plaintext = decryptResponses[encrypted.ciphertext];
+      if (plaintext === undefined) {
+        throw new Error(
+          `decryptData mock miss: no keyed response registered for ciphertext "${encrypted.ciphertext}"`,
+        );
+      }
+      return plaintext;
+    },
+  );
+}
+
 type MessageHandler = (
   message: unknown,
   sender: unknown,
@@ -132,6 +167,7 @@ describe("COPY_TOTP handler", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    installKeyedDecryptData();
     chromeMock = installChromeMock();
 
     vi.stubGlobal(
@@ -201,29 +237,36 @@ describe("COPY_TOTP handler", () => {
   });
 
   it("returns TOTP code when blob contains totp data", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(59_000);
-    cryptoMocks.decryptData.mockResolvedValueOnce(
-      JSON.stringify({ totp: { secret: "JBSWY3DPEHPK3PXP", algorithm: "SHA1", digits: 6, period: 30 } }),
-    );
-    await unlockVault();
+    // Date.now is spied (not stubbed globally), so it must be restored on this
+    // spy specifically — restoreAllMocks would also wipe the vi.hoisted
+    // generateTOTPCode/decryptData default implementations set once at file
+    // load, breaking default-order tests that rely on them.
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(59_000);
+    try {
+      setDecryptedPlaintext(
+        "aa",
+        JSON.stringify({ totp: { secret: "JBSWY3DPEHPK3PXP", algorithm: "SHA1", digits: 6, period: 30 } }),
+      );
+      await unlockVault();
 
-    const res = await sendMsg({ type: "COPY_TOTP", entryId: "pw-1" });
-    expect(res).toEqual({
-      type: "COPY_TOTP",
-      code: "123456",
-    });
-    expect(totpMock.generateTOTPCode).toHaveBeenCalledWith({
-      secret: "JBSWY3DPEHPK3PXP",
-      algorithm: "SHA1",
-      digits: 6,
-      period: 30,
-    });
+      const res = await sendMsg({ type: "COPY_TOTP", entryId: "pw-1" });
+      expect(res).toEqual({
+        type: "COPY_TOTP",
+        code: "123456",
+      });
+      expect(totpMock.generateTOTPCode).toHaveBeenCalledWith({
+        secret: "JBSWY3DPEHPK3PXP",
+        algorithm: "SHA1",
+        digits: 6,
+        period: 30,
+      });
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 
   it("returns NO_TOTP when blob has no totp data", async () => {
-    cryptoMocks.decryptData.mockResolvedValueOnce(
-      JSON.stringify({ password: "secret" }),
-    );
+    setDecryptedPlaintext("aa", JSON.stringify({ password: "secret" }));
     await unlockVault();
 
     const res = await sendMsg({ type: "COPY_TOTP", entryId: "pw-1" });
@@ -235,7 +278,8 @@ describe("COPY_TOTP handler", () => {
   });
 
   it("returns INVALID_TOTP when generateTOTPCode throws", async () => {
-    cryptoMocks.decryptData.mockResolvedValueOnce(
+    setDecryptedPlaintext(
+      "aa",
       JSON.stringify({ totp: { secret: "JBSWY3DPEHPK3PXP", digits: 99 } }),
     );
     totpMock.generateTOTPCode.mockImplementationOnce(() => {
@@ -256,6 +300,7 @@ describe("AUTOFILL with TOTP", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    installKeyedDecryptData();
     chromeMock = installChromeMock();
 
     vi.stubGlobal(
@@ -316,15 +361,15 @@ describe("AUTOFILL with TOTP", () => {
   });
 
   it("includes totpCode in content-script message when totp exists", async () => {
-    cryptoMocks.decryptData
-      .mockResolvedValueOnce(
-        JSON.stringify({
-          password: "secret",
-          totp: { secret: "JBSWY3DPEHPK3PXP" },
-        }),
-      )
-      .mockResolvedValueOnce(JSON.stringify({ username: "alice" }));
-    totpMock.generateTOTPCode.mockReturnValue("654321");
+    setDecryptedPlaintext(
+      "aa",
+      JSON.stringify({
+        password: "secret",
+        totp: { secret: "JBSWY3DPEHPK3PXP" },
+      }),
+    );
+    setDecryptedPlaintext("11", JSON.stringify({ username: "alice" }));
+    totpMock.generateTOTPCode.mockReturnValueOnce("654321");
 
     await unlockVault();
 
@@ -342,9 +387,8 @@ describe("AUTOFILL with TOTP", () => {
   });
 
   it("does not include totpCode when totp is absent", async () => {
-    cryptoMocks.decryptData
-      .mockResolvedValueOnce(JSON.stringify({ password: "secret" }))
-      .mockResolvedValueOnce(JSON.stringify({ username: "alice" }));
+    setDecryptedPlaintext("aa", JSON.stringify({ password: "secret" }));
+    setDecryptedPlaintext("11", JSON.stringify({ username: "alice" }));
 
     await unlockVault();
 
@@ -357,14 +401,14 @@ describe("AUTOFILL with TOTP", () => {
   });
 
   it("continues autofill without totpCode when generateTOTPCode throws", async () => {
-    cryptoMocks.decryptData
-      .mockResolvedValueOnce(
-        JSON.stringify({
-          password: "secret",
-          totp: { secret: "JBSWY3DPEHPK3PXP", digits: 99 },
-        }),
-      )
-      .mockResolvedValueOnce(JSON.stringify({ username: "alice" }));
+    setDecryptedPlaintext(
+      "aa",
+      JSON.stringify({
+        password: "secret",
+        totp: { secret: "JBSWY3DPEHPK3PXP", digits: 99 },
+      }),
+    );
+    setDecryptedPlaintext("11", JSON.stringify({ username: "alice" }));
     totpMock.generateTOTPCode.mockImplementationOnce(() => {
       throw new Error("INVALID_TOTP");
     });

--- a/extension/src/__tests__/content/form-detector-entry.test.ts
+++ b/extension/src/__tests__/content/form-detector-entry.test.ts
@@ -58,7 +58,10 @@ const GUARD_KEY = "__passwdSsoFormDetector";
 // listener and its own fresh one, double-counting destroy() calls. Wrapping
 // addEventListener here lets afterEach explicitly detach every listener the
 // entry point registered during the test, closing the leak at its source.
-let errorListeners: EventListenerOrEventListenerObject[] = [];
+let errorListeners: Array<{
+  listener: EventListenerOrEventListenerObject;
+  options?: boolean | AddEventListenerOptions;
+}> = [];
 let realAddEventListener: typeof window.addEventListener;
 
 beforeEach(() => {
@@ -92,15 +95,19 @@ beforeEach(() => {
     listener: EventListenerOrEventListenerObject,
     options?: boolean | AddEventListenerOptions,
   ) => {
-    if (type === "error") errorListeners.push(listener);
+    // Record the options too: removeEventListener only matches a listener
+    // registered with the same capture flag, so dropping the options here
+    // would silently defeat the teardown if the entry point ever registers
+    // with { capture: true }. (Today it registers "error" with no options.)
+    if (type === "error") errorListeners.push({ listener, options });
     realAddEventListener(type, listener, options);
   }) as typeof window.addEventListener;
 });
 
 afterEach(() => {
   delete (window as unknown as Record<string, unknown>)[GUARD_KEY];
-  for (const listener of errorListeners) {
-    window.removeEventListener("error", listener);
+  for (const { listener, options } of errorListeners) {
+    window.removeEventListener("error", listener, options);
   }
   errorListeners = [];
   window.addEventListener = realAddEventListener;

--- a/extension/src/__tests__/content/form-detector-entry.test.ts
+++ b/extension/src/__tests__/content/form-detector-entry.test.ts
@@ -48,6 +48,19 @@ vi.mock("../../content/webauthn-bridge", () => ({}));
 
 const GUARD_KEY = "__passwdSsoFormDetector";
 
+// M5 fix: the entry point registers a window "error" listener at import time
+// and never removes it (correct for a real page, which loads it once). The
+// jsdom `window` is shared across every test in this file, and vi.resetModules()
+// only clears the MODULE cache — it does not detach already-registered DOM
+// listeners. Without tracking, a test that imports the entry point but never
+// dispatches the invalidation event (e.g. "double-injection guard...") leaves
+// its listener attached; a later test's dispatch then fires BOTH that leftover
+// listener and its own fresh one, double-counting destroy() calls. Wrapping
+// addEventListener here lets afterEach explicitly detach every listener the
+// entry point registered during the test, closing the leak at its source.
+let errorListeners: EventListenerOrEventListenerObject[] = [];
+let realAddEventListener: typeof window.addEventListener;
+
 beforeEach(() => {
   destroyCC.mockReset();
   destroyIdentity.mockReset();
@@ -71,10 +84,26 @@ beforeEach(() => {
       session: { setAccessLevel: vi.fn() },
     },
   });
+
+  errorListeners = [];
+  realAddEventListener = window.addEventListener.bind(window);
+  window.addEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ) => {
+    if (type === "error") errorListeners.push(listener);
+    realAddEventListener(type, listener, options);
+  }) as typeof window.addEventListener;
 });
 
 afterEach(() => {
   delete (window as unknown as Record<string, unknown>)[GUARD_KEY];
+  for (const listener of errorListeners) {
+    window.removeEventListener("error", listener);
+  }
+  errorListeners = [];
+  window.addEventListener = realAddEventListener;
 });
 
 describe("M5: entry-point error-handler teardown (F6 invariant)", () => {

--- a/extension/src/__tests__/content/form-detector.test.ts
+++ b/extension/src/__tests__/content/form-detector.test.ts
@@ -154,8 +154,13 @@ describe("clickjacking hardening guards", () => {
       return realGetComputedStyle(el, pseudo ?? undefined);
     });
 
-    expect(hasVisiblePopoverOverlayNear(input)).toBe(true);
-    getComputedStyleSpy.mockRestore();
+    // finally, not a trailing restore: an assertion throw would otherwise
+    // leak the spy into later tests sharing this jsdom window.
+    try {
+      expect(hasVisiblePopoverOverlayNear(input)).toBe(true);
+    } finally {
+      getComputedStyleSpy.mockRestore();
+    }
   });
 });
 

--- a/extension/src/__tests__/content/form-detector.test.ts
+++ b/extension/src/__tests__/content/form-detector.test.ts
@@ -142,7 +142,7 @@ describe("clickjacking hardening guards", () => {
     // jsdom applies the UA popover stylesheet (display:none until shown) but does
     // not implement showPopover(), so simulate a shown popover's computed style.
     const realGetComputedStyle = window.getComputedStyle.bind(window);
-    vi.spyOn(window, "getComputedStyle").mockImplementation((el, pseudo) => {
+    const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle").mockImplementation((el, pseudo) => {
       if (el === popover) {
         return {
           display: "block",
@@ -155,6 +155,7 @@ describe("clickjacking hardening guards", () => {
     });
 
     expect(hasVisiblePopoverOverlayNear(input)).toBe(true);
+    getComputedStyleSpy.mockRestore();
   });
 });
 

--- a/extension/src/__tests__/context-menu.test.ts
+++ b/extension/src/__tests__/context-menu.test.ts
@@ -73,6 +73,12 @@ describe("context-menu", () => {
     // pending forever — a hang rather than a legible failure.
     chromeMock.contextMenus.create.mockImplementation((_props: unknown, cb?: () => void) => cb?.());
     chromeMock.contextMenus.removeAll.mockImplementation((cb?: () => void) => cb?.());
+    // Some tests override tabs.query to a specific tab so their own
+    // invalidateContextMenu() call rebuilds against it; without resetting it
+    // back here, that leaked resolution would drive THIS beforeEach's own
+    // invalidateContextMenu() (below) to rebuild the menu asynchronously in
+    // the background of whatever test runs next.
+    chromeMock.tabs.query.mockResolvedValue([]);
     deps = createDeps();
     initContextMenu(deps);
     invalidateContextMenu();

--- a/extension/src/__tests__/dpop-key.test.ts
+++ b/extension/src/__tests__/dpop-key.test.ts
@@ -55,8 +55,16 @@ function deleteTestDb(): Promise<void> {
     r.onsuccess = () => resolve();
     r.onerror = () => reject(r.error);
     // No connection should still be open at this point (every test closes
-    // what it opens), but resolve rather than hang if one ever is.
-    r.onblocked = () => resolve();
+    // what it opens). Fail LOUDLY if one ever is: resolving here would skip
+    // the baseline reset silently and the next versioned open would queue
+    // behind the pending delete — an opaque timeout blamed on the wrong
+    // test. Rejecting names the culprit in the beforeEach that hit it.
+    r.onblocked = () =>
+      reject(
+        new Error(
+          "deleteTestDb blocked: a previous test left an IDB connection to psso-ext open",
+        ),
+      );
   });
 }
 

--- a/extension/src/__tests__/dpop-key.test.ts
+++ b/extension/src/__tests__/dpop-key.test.ts
@@ -18,12 +18,19 @@ import { JKT_RE } from "../lib/constants";
 // production's, which never sees onupgradeneeded again at the same version)
 // permanently failed with "NotFoundError: No objectStore named dpop-keys" —
 // the whole-file all-or-nothing failure seen at seeds 2/6/7/16/24/28/30/31/40/52.
+// Mirror the private IDB_NAME / IDB_STORE constants in ../lib/dpop-key.ts
+// (not exported there; exporting them for tests alone would widen the
+// production surface). If the production schema names change, the golden
+// tests below fail loudly on the mismatch.
+const TEST_IDB_NAME = "psso-ext";
+const TEST_IDB_STORE = "dpop-keys";
+
 function openTestDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
-    const r = indexedDB.open("psso-ext", 1);
+    const r = indexedDB.open(TEST_IDB_NAME, 1);
     r.onupgradeneeded = () => {
-      if (!r.result.objectStoreNames.contains("dpop-keys")) {
-        r.result.createObjectStore("dpop-keys");
+      if (!r.result.objectStoreNames.contains(TEST_IDB_STORE)) {
+        r.result.createObjectStore(TEST_IDB_STORE);
       }
     };
     r.onsuccess = () => resolve(r.result);
@@ -33,8 +40,8 @@ function openTestDb(): Promise<IDBDatabase> {
 
 async function getAllKeys(db: IDBDatabase): Promise<unknown[]> {
   return new Promise((resolve, reject) => {
-    const tx = db.transaction("dpop-keys", "readonly");
-    const req = tx.objectStore("dpop-keys").getAll();
+    const tx = db.transaction(TEST_IDB_STORE, "readonly");
+    const req = tx.objectStore(TEST_IDB_STORE).getAll();
     req.onsuccess = () => { db.close(); resolve(req.result as unknown[]); };
     req.onerror = () => { db.close(); reject(req.error); };
   });
@@ -44,7 +51,7 @@ async function getAllKeys(db: IDBDatabase): Promise<unknown[]> {
 // key row/state depends on execution order (M4 baseline reset).
 function deleteTestDb(): Promise<void> {
   return new Promise((resolve, reject) => {
-    const r = indexedDB.deleteDatabase("psso-ext");
+    const r = indexedDB.deleteDatabase(TEST_IDB_NAME);
     r.onsuccess = () => resolve();
     r.onerror = () => reject(r.error);
     // No connection should still be open at this point (every test closes
@@ -119,10 +126,10 @@ describe("dpop-key (C6)", () => {
     // this was one of the two M4 culprits when it ran first in shuffled order.
     const db = await openTestDb();
     await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction("dpop-keys", "readwrite");
+      const tx = db.transaction(TEST_IDB_STORE, "readwrite");
       tx.oncomplete = () => { db.close(); resolve(); };
       tx.onerror = () => { db.close(); reject(tx.error); };
-      tx.objectStore("dpop-keys").clear();
+      tx.objectStore(TEST_IDB_STORE).clear();
     });
 
     const jktNew = await getDpopThumbprint();
@@ -131,8 +138,8 @@ describe("dpop-key (C6)", () => {
     // Verify exactly one IDB row was written.
     const db2 = await openTestDb();
     const all = await new Promise<unknown[]>((resolve, reject) => {
-      const tx = db2.transaction("dpop-keys", "readonly");
-      const req = tx.objectStore("dpop-keys").getAll();
+      const tx = db2.transaction(TEST_IDB_STORE, "readonly");
+      const req = tx.objectStore(TEST_IDB_STORE).getAll();
       req.onsuccess = () => resolve(req.result as unknown[]);
       req.onerror = () => reject(req.error);
     });
@@ -215,8 +222,8 @@ describe("dpop-key (C6)", () => {
 
     const record = await new Promise<{ privateKey: CryptoKey; publicJwk: JsonWebKey } | null>(
       (resolve, reject) => {
-        const tx = db.transaction("dpop-keys", "readonly");
-        const req = tx.objectStore("dpop-keys").get("current");
+        const tx = db.transaction(TEST_IDB_STORE, "readonly");
+        const req = tx.objectStore(TEST_IDB_STORE).get("current");
         req.onsuccess = () => resolve(req.result as { privateKey: CryptoKey; publicJwk: JsonWebKey } | null);
         req.onerror = () => reject(req.error);
       },
@@ -246,8 +253,8 @@ describe("dpop-key (C6)", () => {
     // Verify IDB row is gone
     const db = await openTestDb();
     const row = await new Promise<unknown>((resolve, reject) => {
-      const tx = db.transaction("dpop-keys", "readonly");
-      const req = tx.objectStore("dpop-keys").get("current");
+      const tx = db.transaction(TEST_IDB_STORE, "readonly");
+      const req = tx.objectStore(TEST_IDB_STORE).get("current");
       req.onsuccess = () => resolve(req.result ?? null);
       req.onerror = () => reject(req.error);
     });

--- a/extension/src/__tests__/dpop-key.test.ts
+++ b/extension/src/__tests__/dpop-key.test.ts
@@ -8,9 +8,24 @@ import "fake-indexeddb/auto";
 import { describe, it, expect, beforeEach } from "vitest";
 import { JKT_RE } from "../lib/constants";
 
+// M4 fix: this open MUST create the "dpop-keys" store on first touch, same as
+// production's openDb() in lib/dpop-key.ts. IndexedDB only fires
+// onupgradeneeded on the request that first bumps the DB from version 0 to 1;
+// whichever test runs first in shuffled order owns that bump. The previous
+// version of this helper (and two ad hoc inline opens below) omitted the
+// handler, so whenever one of them ran first, "psso-ext" was created at
+// version 1 with no object store, and every later open (including
+// production's, which never sees onupgradeneeded again at the same version)
+// permanently failed with "NotFoundError: No objectStore named dpop-keys" —
+// the whole-file all-or-nothing failure seen at seeds 2/6/7/16/24/28/30/31/40/52.
 function openTestDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const r = indexedDB.open("psso-ext", 1);
+    r.onupgradeneeded = () => {
+      if (!r.result.objectStoreNames.contains("dpop-keys")) {
+        r.result.createObjectStore("dpop-keys");
+      }
+    };
     r.onsuccess = () => resolve(r.result);
     r.onerror = () => reject(r.error);
   });
@@ -22,6 +37,19 @@ async function getAllKeys(db: IDBDatabase): Promise<unknown[]> {
     const req = tx.objectStore("dpop-keys").getAll();
     req.onsuccess = () => { db.close(); resolve(req.result as unknown[]); };
     req.onerror = () => { db.close(); reject(req.error); };
+  });
+}
+
+// Delete the shared fake-IDB database between tests so no test's leftover
+// key row/state depends on execution order (M4 baseline reset).
+function deleteTestDb(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const r = indexedDB.deleteDatabase("psso-ext");
+    r.onsuccess = () => resolve();
+    r.onerror = () => reject(r.error);
+    // No connection should still be open at this point (every test closes
+    // what it opens), but resolve rather than hang if one ever is.
+    r.onblocked = () => resolve();
   });
 }
 
@@ -37,7 +65,10 @@ async function importFresh() {
 
 describe("dpop-key (C6)", () => {
   beforeEach(async () => {
-    // Drop in-memory cache between tests (simulates SW restart).
+    // Reset both persistence layers so every test starts from a known state
+    // regardless of shuffled order (M4): delete the shared fake-IDB "psso-ext"
+    // database, then drop the in-process key cache (simulates SW restart).
+    await deleteTestDb();
     const mod = await import("../lib/dpop-key");
     mod.resetInMemoryKeyCache();
   });
@@ -80,16 +111,13 @@ describe("dpop-key (C6)", () => {
     // After cache reset and IDB clear, a new key must be generated and persisted.
     // This covers the "regenerate on missing IDB row" path that also fires when
     // the SW was killed between generateKey() and idbPut() completing.
-    const openFn = indexedDB.open.bind(indexedDB);
     const { getDpopThumbprint, resetInMemoryKeyCache } = await importFresh();
     resetInMemoryKeyCache();
 
     // Clear IDB to simulate clean-boot / partial-write after SW kill.
-    const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const r = openFn("psso-ext", 1);
-      r.onsuccess = () => resolve(r.result);
-      r.onerror = () => reject(r.error);
-    });
+    // Uses openTestDb() (schema-safe) rather than a raw indexedDB.open() —
+    // this was one of the two M4 culprits when it ran first in shuffled order.
+    const db = await openTestDb();
     await new Promise<void>((resolve, reject) => {
       const tx = db.transaction("dpop-keys", "readwrite");
       tx.oncomplete = () => { db.close(); resolve(); };
@@ -101,11 +129,7 @@ describe("dpop-key (C6)", () => {
     expect(jktNew).toMatch(JKT_RE);
 
     // Verify exactly one IDB row was written.
-    const db2 = await new Promise<IDBDatabase>((resolve, reject) => {
-      const r = openFn("psso-ext");
-      r.onsuccess = () => resolve(r.result);
-      r.onerror = () => reject(r.error);
-    });
+    const db2 = await openTestDb();
     const all = await new Promise<unknown[]>((resolve, reject) => {
       const tx = db2.transaction("dpop-keys", "readonly");
       const req = tx.objectStore("dpop-keys").getAll();
@@ -182,11 +206,9 @@ describe("dpop-key (C6)", () => {
     // We cannot directly access the CryptoKey from the public API,
     // but we can verify that the sign() function works (proving the key exists)
     // and that a raw export of the key stored in IDB rejects.
-    const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const r = indexedDB.open("psso-ext", 1);
-      r.onsuccess = () => resolve(r.result);
-      r.onerror = () => reject(r.error);
-    });
+    // Uses openTestDb() (schema-safe) — this was the other M4 culprit when it
+    // ran first in shuffled order (its raw open had no onupgradeneeded).
+    const db = await openTestDb();
 
     // Trigger key generation
     await getOrGenerateDpopKeyPair();
@@ -222,11 +244,7 @@ describe("dpop-key (C6)", () => {
     await deleteIdbKey();
 
     // Verify IDB row is gone
-    const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const r = indexedDB.open("psso-ext", 1);
-      r.onsuccess = () => resolve(r.result);
-      r.onerror = () => reject(r.error);
-    });
+    const db = await openTestDb();
     const row = await new Promise<unknown>((resolve, reject) => {
       const tx = db.transaction("dpop-keys", "readonly");
       const req = tx.objectStore("dpop-keys").get("current");

--- a/extension/src/__tests__/helpers/keyed-decrypt-mock.ts
+++ b/extension/src/__tests__/helpers/keyed-decrypt-mock.ts
@@ -1,0 +1,46 @@
+import type { Mock } from "vitest";
+
+/**
+ * Input-keyed decryptData mock, shared by the background-module test files
+ * (issue #784). Positional mockResolvedValueOnce queues are forbidden for
+ * decryptData in files that load background/index: UNLOCK_VAULT schedules a
+ * fire-and-forget context-menu refresh (real 200 ms debounce) whose overview
+ * decrypt would steal a positional slot under load. Keying the response on
+ * the ciphertext makes the result independent of call interleaving.
+ *
+ * An unmapped ciphertext THROWS with the offending input named, so a
+ * coverage gap fails loudly in the test that exposed it instead of
+ * diverging silently (plan C1-I3). Callers must keep every ciphertext the
+ * fire-and-forget consumer can request (the overview ciphertext) mapped in
+ * the install() defaults so that consumer can never hit the miss path.
+ */
+export function createKeyedDecryptMock(decryptData: Mock): {
+  install: (defaults: Record<string, string>) => void;
+  set: (ciphertext: string, plaintext: string) => void;
+} {
+  let responses: Record<string, string> = {};
+  return {
+    /** Reset the map to `defaults` and (re)install the keyed implementation.
+     * Call from beforeEach — vi.clearAllMocks() clears call history but not
+     * implementations, so without the per-test reinstall a leftover keyed
+     * entry from an earlier test would carry forward. */
+    install(defaults: Record<string, string>): void {
+      responses = { ...defaults };
+      decryptData.mockImplementation(
+        async (encrypted: { ciphertext: string }) => {
+          const plaintext = responses[encrypted.ciphertext];
+          if (plaintext === undefined) {
+            throw new Error(
+              `decryptData mock miss: no keyed response registered for ciphertext "${encrypted.ciphertext}"`,
+            );
+          }
+          return plaintext;
+        },
+      );
+    },
+    /** Register the plaintext decryptData resolves to for a ciphertext. */
+    set(ciphertext: string, plaintext: string): void {
+      responses[ciphertext] = plaintext;
+    },
+  };
+}

--- a/extension/src/__tests__/lib/messaging.test.ts
+++ b/extension/src/__tests__/lib/messaging.test.ts
@@ -15,7 +15,7 @@ import { sendMessage } from "../../lib/messaging";
 
 describe("sendMessage", () => {
   it("sends a typed message and returns the response", async () => {
-    mockSendMessage.mockResolvedValue({
+    mockSendMessage.mockResolvedValueOnce({
       type: "GET_STATUS",
       hasToken: true,
       expiresAt: 1700000000000,
@@ -35,7 +35,7 @@ describe("sendMessage", () => {
   });
 
   it("passes message payload to chrome.runtime.sendMessage", async () => {
-    mockSendMessage.mockResolvedValue({ type: "COPY_PASSWORD", ok: true });
+    mockSendMessage.mockResolvedValueOnce({ type: "COPY_PASSWORD", ok: true });
 
     await sendMessage({
       type: "COPY_PASSWORD",
@@ -48,7 +48,7 @@ describe("sendMessage", () => {
   });
 
   it("propagates rejection from chrome.runtime.sendMessage", async () => {
-    mockSendMessage.mockRejectedValue(new Error("Extension context invalidated"));
+    mockSendMessage.mockRejectedValueOnce(new Error("Extension context invalidated"));
 
     await expect(sendMessage({ type: "GET_TOKEN" })).rejects.toThrow(
       "Extension context invalidated",

--- a/extension/src/__tests__/login-detector.test.ts
+++ b/extension/src/__tests__/login-detector.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock chrome API
 const messageListeners: Array<(message: unknown) => void> = [];
@@ -39,6 +39,7 @@ import {
   extractCredentials,
   extractCredentialsFromPage,
   initLoginDetector,
+  type LoginDetectorCleanup,
 } from "../content/login-detector-lib";
 import { showSaveBanner, hideSaveBanner } from "../content/ui/save-banner";
 import { findPasswordInputs, findUsernameInput } from "../content/form-detector-lib";
@@ -311,8 +312,32 @@ describe("login-detector-lib", () => {
     const mockSendMessage = vi.mocked(chrome.runtime.sendMessage);
     const mockShowSaveBanner = vi.mocked(showSaveBanner);
 
+    // Root-cause fix: mockSendMessage.mockImplementation(...) is set by several
+    // tests below (CHECK_PENDING_SAVE / action response callbacks) and never
+    // restored — the outer beforeEach's vi.clearAllMocks() clears call history
+    // but NOT a custom implementation. Left in place, a later test's own
+    // initLoginDetector() call fires the leftover implementation's callback
+    // (e.g. the "pulled-user"/save response), making it call showSaveBanner
+    // unexpectedly. mockReset() here clears both, so every test starts from
+    // the same no-op sendMessage baseline.
     beforeEach(() => {
       document.body.innerHTML = "";
+      mockSendMessage.mockReset();
+    });
+
+    // Every test below assigns its initLoginDetector() handle to this instead
+    // of a local `const cleanup`, so afterEach can destroy it unconditionally.
+    // Without this, a test whose OWN assertion throws (e.g. the two victims
+    // above, before the mockReset fix) returns before reaching its trailing
+    // `cleanup.destroy()`, leaking that test's document-level submit/click
+    // listeners into every later test in the file — which is exactly how
+    // "stops listening after destroy()" / "removes click listener after
+    // destroy()" observed a second, stale LOGIN_DETECTED call.
+    let currentCleanup: LoginDetectorCleanup | undefined;
+
+    afterEach(() => {
+      currentCleanup?.destroy();
+      currentCleanup = undefined;
     });
 
     it("sends LOGIN_DETECTED on form submit with credentials", () => {
@@ -326,7 +351,7 @@ describe("login-detector-lib", () => {
       mockFindPasswordInputs.mockReturnValue([pw]);
       mockFindUsernameInput.mockReturnValue(user);
 
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       form.dispatchEvent(new Event("submit", { bubbles: true }));
 
@@ -338,8 +363,6 @@ describe("login-detector-lib", () => {
         }),
         expect.any(Function),
       );
-
-      cleanup.destroy();
     });
 
     it("does not send message for forms without credentials", () => {
@@ -350,7 +373,7 @@ describe("login-detector-lib", () => {
 
       mockFindPasswordInputs.mockReturnValue([pw]);
 
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       form.dispatchEvent(new Event("submit", { bubbles: true }));
 
@@ -358,8 +381,6 @@ describe("login-detector-lib", () => {
         expect.objectContaining({ type: "LOGIN_DETECTED" }),
         expect.any(Function),
       );
-
-      cleanup.destroy();
     });
 
     it("shows save banner when background responds with save action", () => {
@@ -380,7 +401,7 @@ describe("login-detector-lib", () => {
         }
       });
 
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       form.dispatchEvent(new Event("submit", { bubbles: true }));
 
@@ -390,8 +411,6 @@ describe("login-detector-lib", () => {
           username: "bob",
         }),
       );
-
-      cleanup.destroy();
     });
 
     it("shows update banner when background responds with update action", () => {
@@ -416,7 +435,7 @@ describe("login-detector-lib", () => {
         }
       });
 
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       form.dispatchEvent(new Event("submit", { bubbles: true }));
 
@@ -427,8 +446,6 @@ describe("login-detector-lib", () => {
           username: "bob",
         }),
       );
-
-      cleanup.destroy();
     });
 
     it("does not show banner when background responds with none action", () => {
@@ -448,13 +465,11 @@ describe("login-detector-lib", () => {
         }
       });
 
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       form.dispatchEvent(new Event("submit", { bubbles: true }));
 
       expect(mockShowSaveBanner).not.toHaveBeenCalled();
-
-      cleanup.destroy();
     });
 
     it("stops listening after destroy()", () => {
@@ -468,8 +483,8 @@ describe("login-detector-lib", () => {
       mockFindPasswordInputs.mockReturnValue([pw]);
       mockFindUsernameInput.mockReturnValue(user);
 
-      const cleanup = initLoginDetector();
-      cleanup.destroy();
+      currentCleanup = initLoginDetector();
+      currentCleanup.destroy();
 
       form.dispatchEvent(new Event("submit", { bubbles: true }));
 
@@ -481,25 +496,24 @@ describe("login-detector-lib", () => {
 
     it("calls hideSaveBanner on destroy()", () => {
       const mockHideSaveBanner = vi.mocked(hideSaveBanner);
-      const cleanup = initLoginDetector();
-      cleanup.destroy();
+      currentCleanup = initLoginDetector();
+      currentCleanup.destroy();
       expect(mockHideSaveBanner).toHaveBeenCalled();
     });
 
     it("registers onMessage listener for PSSO_SHOW_SAVE_BANNER", () => {
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
       expect(chrome.runtime.onMessage.addListener).toHaveBeenCalled();
-      cleanup.destroy();
     });
 
     it("removes onMessage listener on destroy()", () => {
-      const cleanup = initLoginDetector();
-      cleanup.destroy();
+      currentCleanup = initLoginDetector();
+      currentCleanup.destroy();
       expect(chrome.runtime.onMessage.removeListener).toHaveBeenCalled();
     });
 
     it("shows save banner when PSSO_SHOW_SAVE_BANNER message received", () => {
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       // Simulate background pushing save banner
       for (const listener of messageListeners) {
@@ -519,12 +533,10 @@ describe("login-detector-lib", () => {
           action: "save",
         }),
       );
-
-      cleanup.destroy();
     });
 
     it("does not show banner for PSSO_SHOW_SAVE_BANNER with action=none", () => {
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       for (const listener of messageListeners) {
         listener({
@@ -537,31 +549,25 @@ describe("login-detector-lib", () => {
       }
 
       expect(mockShowSaveBanner).not.toHaveBeenCalled();
-
-      cleanup.destroy();
     });
 
     it("ignores unrelated messages", () => {
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       for (const listener of messageListeners) {
         listener({ type: "UNRELATED_MESSAGE" });
       }
 
       expect(mockShowSaveBanner).not.toHaveBeenCalled();
-
-      cleanup.destroy();
     });
 
     it("sends CHECK_PENDING_SAVE on init", () => {
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       expect(mockSendMessage).toHaveBeenCalledWith(
         { type: "CHECK_PENDING_SAVE" },
         expect.any(Function),
       );
-
-      cleanup.destroy();
     });
 
     it("shows save banner when CHECK_PENDING_SAVE returns save action", () => {
@@ -578,7 +584,7 @@ describe("login-detector-lib", () => {
         }
       });
 
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       expect(mockShowSaveBanner).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -587,8 +593,6 @@ describe("login-detector-lib", () => {
           action: "save",
         }),
       );
-
-      cleanup.destroy();
     });
 
     it("does not show banner when CHECK_PENDING_SAVE returns none", () => {
@@ -602,11 +606,9 @@ describe("login-detector-lib", () => {
         }
       });
 
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       expect(mockShowSaveBanner).not.toHaveBeenCalled();
-
-      cleanup.destroy();
     });
 
     it("sends LOGIN_DETECTED when a submit-like button is clicked near password fields", () => {
@@ -623,7 +625,7 @@ describe("login-detector-lib", () => {
       mockFindPasswordInputs.mockReturnValue([pw]);
       mockFindUsernameInput.mockReturnValue(user);
 
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       button.click();
 
@@ -635,8 +637,6 @@ describe("login-detector-lib", () => {
         }),
         expect.any(Function),
       );
-
-      cleanup.destroy();
     });
 
     it("does not send LOGIN_DETECTED for non-submit-like buttons", () => {
@@ -652,7 +652,7 @@ describe("login-detector-lib", () => {
       mockFindPasswordInputs.mockReturnValue([pw]);
       mockFindUsernameInput.mockReturnValue(user);
 
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       button.click();
 
@@ -660,8 +660,6 @@ describe("login-detector-lib", () => {
         expect.objectContaining({ type: "LOGIN_DETECTED" }),
         expect.any(Function),
       );
-
-      cleanup.destroy();
     });
 
     it("debounces duplicate LOGIN_DETECTED within 2 seconds", () => {
@@ -675,7 +673,7 @@ describe("login-detector-lib", () => {
       mockFindPasswordInputs.mockReturnValue([pw]);
       mockFindUsernameInput.mockReturnValue(user);
 
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       // First submit — should send
       form.dispatchEvent(new Event("submit", { bubbles: true }));
@@ -692,8 +690,6 @@ describe("login-detector-lib", () => {
         expect.objectContaining({ type: "LOGIN_DETECTED" }),
         expect.any(Function),
       );
-
-      cleanup.destroy();
     });
 
     it("allows LOGIN_DETECTED after debounce period expires", () => {
@@ -709,7 +705,7 @@ describe("login-detector-lib", () => {
       mockFindPasswordInputs.mockReturnValue([pw]);
       mockFindUsernameInput.mockReturnValue(user);
 
-      const cleanup = initLoginDetector();
+      currentCleanup = initLoginDetector();
 
       // First submit — should send (CHECK_PENDING_SAVE + LOGIN_DETECTED)
       form.dispatchEvent(new Event("submit", { bubbles: true }));
@@ -730,7 +726,6 @@ describe("login-detector-lib", () => {
         expect.any(Function),
       );
 
-      cleanup.destroy();
       vi.useRealTimers();
     });
 
@@ -747,8 +742,8 @@ describe("login-detector-lib", () => {
       mockFindPasswordInputs.mockReturnValue([pw]);
       mockFindUsernameInput.mockReturnValue(user);
 
-      const cleanup = initLoginDetector();
-      cleanup.destroy();
+      currentCleanup = initLoginDetector();
+      currentCleanup.destroy();
 
       button.click();
 

--- a/extension/src/__tests__/login-detector.test.ts
+++ b/extension/src/__tests__/login-detector.test.ts
@@ -323,6 +323,11 @@ describe("login-detector-lib", () => {
     beforeEach(() => {
       document.body.innerHTML = "";
       mockSendMessage.mockReset();
+      // Same M1 shape as mockSendMessage: several tests set persistent
+      // mockReturnValue on these, and the outer clearAllMocks clears call
+      // history only — reset so no test reads a sibling's detached elements.
+      mockFindPasswordInputs.mockReset();
+      mockFindUsernameInput.mockReset();
     });
 
     // Every test below assigns its initLoginDetector() handle to this instead
@@ -694,39 +699,44 @@ describe("login-detector-lib", () => {
 
     it("allows LOGIN_DETECTED after debounce period expires", () => {
       vi.useFakeTimers();
+      // try/finally, not a trailing restore: an assertion throw above a bare
+      // vi.useRealTimers() would leak fake timers (frozen Date.now) into every
+      // later test in the file — the same skipped-trailing-cleanup class the
+      // afterEach-guaranteed destroy() fixes for listeners.
+      try {
+        const form = createForm();
+        const pw = createPasswordInput("secret");
+        const user = createTextInput("bob");
+        form.appendChild(user);
+        form.appendChild(pw);
+        document.body.appendChild(form);
 
-      const form = createForm();
-      const pw = createPasswordInput("secret");
-      const user = createTextInput("bob");
-      form.appendChild(user);
-      form.appendChild(pw);
-      document.body.appendChild(form);
+        mockFindPasswordInputs.mockReturnValue([pw]);
+        mockFindUsernameInput.mockReturnValue(user);
 
-      mockFindPasswordInputs.mockReturnValue([pw]);
-      mockFindUsernameInput.mockReturnValue(user);
+        currentCleanup = initLoginDetector();
 
-      currentCleanup = initLoginDetector();
+        // First submit — should send (CHECK_PENDING_SAVE + LOGIN_DETECTED)
+        form.dispatchEvent(new Event("submit", { bubbles: true }));
+        expect(mockSendMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ type: "LOGIN_DETECTED" }),
+          expect.any(Function),
+        );
 
-      // First submit — should send (CHECK_PENDING_SAVE + LOGIN_DETECTED)
-      form.dispatchEvent(new Event("submit", { bubbles: true }));
-      expect(mockSendMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ type: "LOGIN_DETECTED" }),
-        expect.any(Function),
-      );
+        vi.clearAllMocks();
 
-      vi.clearAllMocks();
+        // Advance past debounce period (2 seconds)
+        vi.advanceTimersByTime(2_001);
 
-      // Advance past debounce period (2 seconds)
-      vi.advanceTimersByTime(2_001);
-
-      // Submit again — should send (debounce expired)
-      form.dispatchEvent(new Event("submit", { bubbles: true }));
-      expect(mockSendMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ type: "LOGIN_DETECTED" }),
-        expect.any(Function),
-      );
-
-      vi.useRealTimers();
+        // Submit again — should send (debounce expired)
+        form.dispatchEvent(new Event("submit", { bubbles: true }));
+        expect(mockSendMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ type: "LOGIN_DETECTED" }),
+          expect.any(Function),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("removes click listener after destroy()", () => {

--- a/extension/src/__tests__/popup/App.test.tsx
+++ b/extension/src/__tests__/popup/App.test.tsx
@@ -39,6 +39,11 @@ import { App } from "../../popup/App";
 describe("App tab URL handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks only wipes call history; mockSendMessage is a module-scope
+    // const (not recreated per test) so a persistent mockResolvedValue/
+    // mockRejectedValue/mockReturnValue set by one test's body would otherwise
+    // survive as the base implementation for whatever test runs next.
+    mockSendMessage.mockReset();
     const chromeMock = {
       tabs: {
         query: vi.fn(),

--- a/extension/src/__tests__/webauthn-bridge-lib.test.ts
+++ b/extension/src/__tests__/webauthn-bridge-lib.test.ts
@@ -55,6 +55,10 @@ describe("webauthn-bridge-lib handleWebAuthnMessage", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    // Unconditional timer restore: an assertion throw between useFakeTimers()
+    // and a trailing in-body useRealTimers() would otherwise leak the fake
+    // clock into later tests in this file (issue #784 teardown class).
+    vi.useRealTimers();
   });
 
   it("ignores events where source !== window", () => {

--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -8,6 +8,11 @@ export default defineConfig({
     // (hydrateFromSession → getDpopThumbprint) does not throw on
     // ReferenceError("indexedDB") in node-env tests.
     setupFiles: ["fake-indexeddb/auto"],
+    // Standing order-independence gate (issue #784): every run — dev, pre-pr,
+    // CI — samples a fresh random permutation of file and in-file order. On
+    // failure the seed line ("Running tests with seed ...") reproduces it via
+    // `npx vitest run --sequence.shuffle --sequence.seed=N`.
+    sequence: { shuffle: true },
     environmentMatchGlobs: [
       ["**/__tests__/webauthn-bridge-lib.test.ts", "jsdom"],
       ["**/__tests__/dpop-key.test.ts", "jsdom"],


### PR DESCRIPTION
## Summary
- Fixes order-dependent and load-dependent test failures in the `extension/` vitest suite (issue `#784`).
- Replaces positional mock queues with input-keyed mocks to eliminate fire-and-forget async races.
- Makes all test teardowns exception-safe, resolving leaked state across spies, fake timers, and IDB fixtures.
- Enforces a standing `sequence.shuffle` gate in `extension/vitest.config.ts` to detect future test-order regressions.

## Motivation
Before this branch, 49 of 50 shuffled seeds failed (24 distinct tests across 5 files), and pre-pr's parallel batch hit the same class as a `NO_PASSWORD` flake on an unrelated PR. The suite was failing due to mock state leakage (`vi.clearAllMocks()` clears call history, not implementations), persistent overrides without restoration, and positional `Once` queues racing a real 200 ms fire-and-forget consumer in `background/index`. This PR fixes the diagnosed root causes (M1–M5) and installs a mechanism-level gate so any future order dependence is caught deterministically by standing gates rather than surfacing as random flakes. Note: `isolate` is untouched — vitest 4 defaults it to `true`, so the issue's leading hypothesis was a no-op; the failures were in-file order dependence, which isolation cannot address.

## Implementation notes
- **Mock state isolation**: positional `mockResolvedValueOnce` queues in `background.test.ts` / `background/totp-handlers.test.ts` converted to an input-keyed helper (`extension/src/__tests__/helpers/keyed-decrypt-mock.ts`); unmapped ciphertext throws with the input named. The M3 mechanism (the pre-pr flake) is verified by a deterministic steal-window red/green minimal pair, not just seed sampling.
- **Exception-safe teardowns**: fake-timer restoration, spy cleanup, and the IDB baseline reset now use `try/finally`, unconditional `afterEach`, or a loud reject — closing the review rounds' CR1–CR4 classes plus the round-2 tree-wide class closure in `webauthn-bridge-lib.test.ts`.
- **Standing gate**: `test.sequence.shuffle: true` in `extension/vitest.config.ts`; the config diff is strictly the gate line (+ comment) per a diff-shape exclusivity clause; forbidden-pattern rows block opt-outs (`shuffle: false`, `seed:` pinning, `retry:` absorption, `sequencer:` swap). A failing run prints its seed; `npx vitest run --sequence.shuffle --sequence.seed=N` reproduces it deterministically.
- **Deviation handling**: cost-justified tradeoffs recorded in the deviation log (D1 flush omission, D2 contained M3 candidates, D5 production-hypothesis closure — production `decryptData` is `crypto.subtle.decrypt`, a pure function, so credential mis-association is structurally impossible; no security issue filed per the pre-committed triage).

## Review artifacts
`docs/archive/review/extension-test-order-deps-{plan,review,deviation,code-review}.md` (plan: 5 review rounds; code: 3 rounds ending in unanimous No findings)

## Test plan
- [x] A1: all recorded failing seeds green in-file shuffle
- [x] A2: 50-seed full shuffle sweep green (baseline: 49/50 red)
- [x] A3m: M3 verified via deterministic steal-window minimal pair (deny 3/3 red / allow 3/3 green)
- [x] A4: default-order run green (1029/1029)
- [x] A5: 10 consecutive shuffled runs green, pairwise-distinct seeds
- [x] A6: gate red-proof (revert fix → seed 12345 red; restore → green)
- [x] A7: no material duration regression (6.8–7.7 s vs 6.2–7.2 s baseline, idle vs idle)
- [x] A8: full pre-pr run green (62/62), including the parallel-load environment that originally flaked

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)